### PR TITLE
Minor fix in README.md to fix the compile command for antlr

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,7 +81,7 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     unzip -d antlr4 antlr4-cpp-runtime-4.9.2-source.zip 
     cd antlr4
     mkdir build && cd build 
-    cmake .. -D ANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.2-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
+    cmake .. -DANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.2-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
     make
     sudo make install
     ```
@@ -101,7 +101,7 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
         /usr/local/share/cmake-3.21/Modules/FindPkgConfig.cmake:776 (_pkg_check_modules_internal)
         CMakeLists.txt:44 (pkg_check_modules)
     ```
-    Check that you have `uuid-devel` installed. If so, go to `antlr4/CMakeLists.txt` and comment out the line `pkg_check_modules(UUID REQUIRED uuid)`.
+    Check that you have `uuid-devel` installed. If so, go to `antlr4/CMakeLists.txt` and comment out the line `pkg_check_modules(UUID REQUIRED uuid)` using # at the beginning of the line.
 
     More information about installing ANTLR4 can be found [at this link](https://www.cs.upc.edu/~padro/CL/practica/install.html).
 


### PR DESCRIPTION
### Description

Cutting and pasting from the README.md failed for the antlr step. This small change fixes that space that caused the issue. Also added a clarification on how to comment in the CMakeList.txt.
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).