### PR TITLE
Update build instructions to address issue #12

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -189,8 +189,11 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     CREATE DATABASE babelfish_db OWNER babelfish_user;
     \c babelfish_db
     CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE;
+    GRANT ALL ON SCHEMA sys to babelfish_user;
     ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';
+    ALTER SYSTEM SET babelfishpg_tds.set_db_session_property = true;
     ALTER DATABASE babelfish_db SET babelfishpg_tsql.migration_mode = 'single-db'|'multi-db';
+    SELECT pg_reload_conf();
     CALL SYS.INITIALIZE_BABELFISH('babelfish_user');
     ```
       - If you run into errors connecting to psql such as `psql: error: could not connect to server: No such file or directory` try giving permissions by using this command instead:


### PR DESCRIPTION
### Description

This PR adds a few extra steps to the build instructions, specifically the Postgres script that is run when first connecting with psql. If the current instructions are followed, sqlcmd will fail with a communication link failure.
 
### Issues Resolved

[Issue 12](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/12)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).