### PR TITLE
Fix bug template issue where multiple entries had the same ID

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -36,10 +36,10 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: version
+    id: extension
     attributes:
-      label: Version
-      description: What version of our software are you running?
+      label: Extension
+      description: What extension is the problem occurring with?
       options:
         - babelfishpg_tsql (Default)
         - babelfishpg_tds


### PR DESCRIPTION
### Description

- Two entries in the bug template have "version" set as the id. This is not allowed for bug templates. Resolving by changing one of the entry id's
 
### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).