### PR TITLE
Escape curly brace in regex to avoid make errors

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/include.pl
+++ b/contrib/babelfishpg_tsql/src/backend_parser/include.pl
@@ -144,7 +144,7 @@ sub simple_parse {
 			$_[2] = 1;
 			next;
 		}
-		elsif ($arr[$fieldIndexer] =~ /^<.*>{$/) # special handling for lex grammar "<...>{" not to add #line directive
+		elsif ($arr[$fieldIndexer] =~ /^<.*>\{$/) # special handling for lex grammar "<...>{" not to add #line directive
 		{
 			$_[3]++; # $brace_indent
 			next;


### PR DESCRIPTION
Signed-off-by: Michael Haynes <mf.haynes@gmail.com>

### Description

While attempting to build Babelfish from source on a Ubuntu 18.04 box, I got the following errors while trying to  `make` the `babelfishpg_tsql` extension:

```'/usr/bin/perl' src/backend_parser/include.pl src/backend_parser gram.y < /babelfish/postgresql_modified_for_babelfish/src/backend/parser/gram.y > src/backend_parser/gram-backend.y
Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/^<.*>{ <-- HERE $/ at src/backend_parser/include.pl line 147.
Makefile:182: recipe for target 'src/backend_parser/gram-backend.y' failed
make: *** [src/backend_parser/gram-backend.y] Error 255
make: *** Deleting file 'src/backend_parser/gram-backend.y'
```

I modified the file locally to escape the curly brace with a backslash and my `make` then succeeded.

fix #32 
 
### Issues Resolved

#32 


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).