### PR TITLE
Fixed #20 column_constraint REFERENCES for accepting empty column list

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -3225,7 +3225,7 @@ column_constraint
     :(CONSTRAINT constraint=id)?
       ((PRIMARY KEY | UNIQUE) clustered? with_index_options?
       | CHECK for_replication? LR_BRACKET search_condition RR_BRACKET
-      | (FOREIGN KEY)? REFERENCES table_name LR_BRACKET pk = column_name_list RR_BRACKET (on_update | on_delete)*
+      | (FOREIGN KEY)? REFERENCES table_name (LR_BRACKET pk = column_name_list RR_BRACKET)? (on_update | on_delete)*
       | DEFAULT expression
       | null_notnull
       | WITH VALUES 

--- a/test/JDBC/expected/BABEL-COLUMN-CONSTRAINT.out
+++ b/test/JDBC/expected/BABEL-COLUMN-CONSTRAINT.out
@@ -1,0 +1,49 @@
+USE master;
+GO
+
+CREATE SCHEMA [Babelfish_COLCONST];
+GO
+
+create table [Babelfish_COLCONST].[a] (
+  id int identity primary key,
+  texto varchar(50) NOT NULL
+);
+GO
+
+create table [Babelfish_COLCONST].[b] (
+  id int identity primary key,
+  foreign_id int not null references [Babelfish_COLCONST].[a],
+  texto varchar(50) NOT NULL
+);
+GO
+
+create table [Babelfish_COLCONST].[c] (
+    id int identity primary key,
+    foreign_id int not null,
+    foreign key(foreign_id) references [Babelfish_COLCONST].[a](id),
+    texto varchar(50) NOT NULL
+);
+GO
+
+SET IDENTITY_INSERT [Babelfish_COLCONST].[a] ON;
+insert into [Babelfish_COLCONST].[a](id,texto) values(1, 'some text');
+SET IDENTITY_INSERT [Babelfish_COLCONST].[a] OFF;
+GO
+~~ROW COUNT: 1~~
+
+
+insert into [Babelfish_COLCONST].[b](foreign_id, texto) values(1,'insert text');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into [Babelfish_COLCONST].[c](foreign_id, texto) values(1,'insert text');
+GO
+~~ROW COUNT: 1~~
+
+
+DROP TABLE [Babelfish_COLCONST].[c];
+DROP TABLE [Babelfish_COLCONST].[b];
+DROP TABLE [Babelfish_COLCONST].[a];
+DROP SCHEMA [Babelfish_COLCONST];
+GO

--- a/test/JDBC/input/BABEL-COLUMN-CONSTRAINT.sql
+++ b/test/JDBC/input/BABEL-COLUMN-CONSTRAINT.sql
@@ -1,0 +1,43 @@
+USE master;
+GO
+
+CREATE SCHEMA [Babelfish_COLCONST];
+GO
+
+create table [Babelfish_COLCONST].[a] (
+  id int identity primary key,
+  texto varchar(50) NOT NULL
+);
+GO
+
+create table [Babelfish_COLCONST].[b] (
+  id int identity primary key,
+  foreign_id int not null references [Babelfish_COLCONST].[a],
+  texto varchar(50) NOT NULL
+);
+GO
+
+create table [Babelfish_COLCONST].[c] (
+    id int identity primary key,
+    foreign_id int not null,
+    foreign key(foreign_id) references [Babelfish_COLCONST].[a](id),
+    texto varchar(50) NOT NULL
+);
+GO
+
+SET IDENTITY_INSERT [Babelfish_COLCONST].[a] ON;
+insert into [Babelfish_COLCONST].[a](id,texto) values(1, 'some text');
+SET IDENTITY_INSERT [Babelfish_COLCONST].[a] OFF;
+GO
+
+insert into [Babelfish_COLCONST].[b](foreign_id, texto) values(1,'insert text');
+GO
+
+insert into [Babelfish_COLCONST].[c](foreign_id, texto) values(1,'insert text');
+GO
+
+DROP TABLE [Babelfish_COLCONST].[c];
+DROP TABLE [Babelfish_COLCONST].[b];
+DROP TABLE [Babelfish_COLCONST].[a];
+DROP SCHEMA [Babelfish_COLCONST];
+GO


### PR DESCRIPTION
Signed-off-by: Emanuel Calvo <emanuel@ongres.com>

### Description

It looks like that all tests are around either table constraints or by using `references a(column)`. So I wrote a small test following @spencercw's concept:

```sql
create table a (
  id int identity primary key,
  texto varchar(50) NOT NULL
);

-- column_constraints
create table b (
  id int identity primary key,
  foreign_id int not null references a, -- no column specified
  texto varchar(50) NOT NULL
);
GO

SET IDENTITY_INSERT dbo.a ON;
GO

insert into a(id,texto) values(1, 'some text');
GO

insert into b(foreign_id, texto) values(1,'insert text');
GO

```

```
1> SELECT * FROM a;
2> SELECT * FROM b;
3> GO
id      texto
1       some text
(1 row affected)
id      foreign_id      texto
1       1       insert text
(1 row affected)
```

Tested also the FK reference functionality:

```
1> insert into b (foreign_id, texto) values (10,'fail?');
2> GO
Msg 547 (severity 16, state 1) from BABELFISH Line 1:
        "insert or update on table "b" violates foreign key constraint "b_foreign_id_fkey""
```

### Issues Resolved

- #20 


### External references

Reported the issue to [antlr grammars-v4](https://github.com/antlr/grammars-v4/issues/2396).

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).