### PR TITLE
Fix buffer overrun in CREATE SCHEMA

### DIFF
--- a/contrib/babelfishpg_tsql/src/schemacmds.c
+++ b/contrib/babelfishpg_tsql/src/schemacmds.c
@@ -30,6 +30,7 @@ add_ns_ext_info(CreateSchemaStmt *stmt, const char *queryString, const char *ori
 	bool        *new_record_nulls;
 	HeapTuple	tuple;
 	int16        db_id = get_cur_db_id();
+	NameData	nspname;
 
 	/* orig_name will be provided only when queryString is not valid. e.g CREATE LOGICLA DATABASE */
 	if (!orig_name)
@@ -48,7 +49,8 @@ add_ns_ext_info(CreateSchemaStmt *stmt, const char *queryString, const char *ori
 	new_record = palloc0(sizeof(Datum) * namespace_ext_num_cols);
 	new_record_nulls = palloc0(sizeof(bool) * namespace_ext_num_cols);
 
-	new_record[0] = CStringGetDatum(stmt->schemaname);
+	namestrcpy(&nspname, stmt->schemaname);
+	new_record[0] = NameGetDatum(&nspname);
 	new_record[1] = Int16GetDatum(db_id);
 	new_record[2] = CStringGetTextDatum(orig_name);
 	new_record[3] = CStringGetTextDatum("{}"); /* place holder */


### PR DESCRIPTION
### Description

Attribute `nspname` of table `sys.babelfish_namespace_ext` is of type `name`, but `add_ns_ext_info()` did not use a variable of type `NameData` for the value.
Now `heap_form_tuple()` assumes that `new_record[0]` is a `name` and will happily copy NAMEDATALEN bytes, reading past the end of the string.

This was found by valgrind:

```none
Invalid read of size 8
   at 0x484A22F: memmove (vg_replace_strmem.c:1382) 
   by 0x490F47: fill_val (heaptuple.c:287) 
   by 0x491088: heap_fill_tuple (heaptuple.c:336)
   by 0x492AC4: heap_form_tuple (heaptuple.c:1090)
   by 0x15588311: add_ns_ext_info (schemacmds.c:56)
   by 0x154F4B1A: bbf_ProcessUtility (pl_handler.c:1896)
   by 0x93E5FF: ProcessUtility (utility.c:521)
   by 0x76FA3E: _SPI_execute_plan (spi.c:2373)
   by 0x76C7BD: SPI_execute_plan_with_paramlist (spi.c:588)
   by 0x15512A7B: exec_stmt_execsql (pl_exec.c:4704)
   by 0x1550AEA8: dispatch_stmt (iterative_exec.c:660)
   by 0x1550BAF2: dispatch_stmt_handle_error (iterative_exec.c:1072)
 Address 0x173e10b8 is 792 bytes inside a block of size 1,024 alloc'd
   at 0x484086F: malloc (vg_replace_malloc.c:381)
   by 0xAEE06D: AllocSetContextCreateInternal (aset.c:468)
   by 0xAA5E15: BuildCachedPlan (plancache.c:965)
   by 0xAA63BE: GetCachedPlan (plancache.c:1187)
   by 0x76EDD9: SPI_plan_get_cached_plan (spi.c:1842)
   by 0x15537041: exec_simple_check_plan (prepare.c:490)
   by 0x15536E0C: exec_prepare_plan (prepare.c:391)
   by 0x155362D8: prepare_stmt_execsql (prepare.c:50)
   by 0x155125C9: exec_stmt_execsql (pl_exec.c:4585)
   by 0x1550AEA8: dispatch_stmt (iterative_exec.c:660)
   by 0x1550BAF2: dispatch_stmt_handle_error (iterative_exec.c:1072)
   by 0x1550C75B: exec_stmt_iterative (iterative_exec.c:1356)
```

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).