### PR TITLE
Fix buffer overrun in CREATE DATABASE

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -286,6 +286,7 @@ do_create_bbf_db(const char *dbname, List *options, const char *owner)
 	const char 	*dbo_role;
 	const char  *db_owner_role;
 	NameData 	default_collation;
+	NameData 	owner_name;
 	const char  *guest;
 	const char	*prev_current_user;
 
@@ -367,12 +368,12 @@ do_create_bbf_db(const char *dbname, List *options, const char *owner)
 	/* Write catalog entry */
 	new_record = palloc0(sizeof(Datum) * SYSDATABASES_NUM_COLS);
 	new_record_nulls = palloc0(sizeof(bool) * SYSDATABASES_NUM_COLS);
-
+	namestrcpy(&owner_name, owner);
 
 	new_record[0] = Int16GetDatum(dbid);
 	new_record[1] = Int32GetDatum(0);
 	new_record[2] = Int32GetDatum(0);
-	new_record[3] = CStringGetDatum(owner);
+	new_record[3] = NameGetDatum(&owner_name);
 	new_record[4] = NameGetDatum(&default_collation);
 	new_record[5] = CStringGetTextDatum(dbname);
 	new_record[6] = TimestampGetDatum(GetSQLLocalTimestamp(0));


### PR DESCRIPTION
### Description

Fix this bug:
Attribute `owner` of table `sys.babelfish_sysdatabases` is of type `name`, but `do_create_bbf_db()` did not use a variable of type `NameData` for the value.
Now `heap_form_tuple()` assumes that `new_record[3]` is a `name` and will happily copy NAMEDATALEN bytes, reading past the end of the string.

This is the same kind of problem as in #39.

Bug was dicovered using valgrind:

```none
Invalid read of size 2
   at 0x484A2C0: memmove (vg_replace_strmem.c:1382)
   by 0x490F47: fill_val (heaptuple.c:287)
   by 0x491088: heap_fill_tuple (heaptuple.c:336)
   by 0x492AC4: heap_form_tuple (heaptuple.c:1090)
   by 0x14D82314: do_create_bbf_db (dbcmds.c:381)
   by 0x14D81BE5: create_bbf_db (dbcmds.c:245)
   by 0x14CF4D00: bbf_ProcessUtility (pl_handler.c:1937)
   by 0x93E5FF: ProcessUtility (utility.c:521)
   by 0x76FA3E: _SPI_execute_plan (spi.c:2373)
   by 0x76C7BD: SPI_execute_plan_with_paramlist (spi.c:588)
   by 0x14D12A7B: exec_stmt_execsql (pl_exec.c:4704)
   by 0x14D0AEA8: dispatch_stmt (iterative_exec.c:660)
 Address 0x7019ee2 is 578 bytes inside a recently re-allocated block of size 8,192 alloc'd
   at 0x484086F: malloc (vg_replace_malloc.c:381) 
   by 0xAEE06D: AllocSetContextCreateInternal (aset.c:468)
   by 0x14CFBDEB: pltsql_compile_inline (pl_comp.c:1047)
   by 0x14CF70D7: pltsql_inline_handler (pl_handler.c:2725)
   by 0x14939631: ExecuteSQLBatch (tdssqlbatch.c:86)
   by 0x1492AA2C: TdsSendLoginAck (tdslogin.c:2049)
   by 0x14925ED4: pe_send_ready_for_query (tds_srv.c:369)
   by 0x93AA17: PostgresMain (postgres.c:4306)
   by 0x14925E40: pe_mainfunc (tds_srv.c:341)
   by 0x8891F5: BackendRun (postmaster.c:4688)
   by 0x8889CC: BackendStartup (postmaster.c:4371)
   by 0x88507E: ServerLoop (postmaster.c:1898)
```

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).