### PR TITLE
Fix buffer overrun in CREATE LOGIN

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -85,6 +85,7 @@ create_bbf_authid_login_ext(CreateRoleStmt *stmt)
 	Oid			roleid;
 	ListCell	*option;
 	char		*default_database = NULL;
+	NameData	rolname;
 
 	/* Extract options from the statement node tree */
 	foreach(option, stmt->options)
@@ -116,8 +117,9 @@ create_bbf_authid_login_ext(CreateRoleStmt *stmt)
 	/* Build a tuple to insert */
 	MemSet(new_record_login_ext, 0, sizeof(new_record_login_ext));
 	MemSet(new_record_nulls_login_ext, false, sizeof(new_record_nulls_login_ext));
+	namestrcpy(&rolname, stmt->role);
 
-	new_record_login_ext[LOGIN_EXT_ROLNAME] = CStringGetDatum(stmt->role);
+	new_record_login_ext[LOGIN_EXT_ROLNAME] = NameGetDatum(&rolname);
 	new_record_login_ext[LOGIN_EXT_IS_DISABLED] = Int32GetDatum(0);
 	new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("S");
 	new_record_login_ext[LOGIN_EXT_CREDENTIAL_ID] = Int32GetDatum(-1); /* placeholder */


### PR DESCRIPTION
### Description

Attribute `rolname` of table `sys.babelfish_authid_login_ext` is of type `name`, but `create_bbf_authid_login_ext()` did not use a variable of type `NameData` for the value.
Now `heap_form_tuple()` assumes that `new_record_login_ext[0]` is a `name` and will happily copy NAMEDATALEN bytes, reading past the end of the string.

This is like #39.

valgrind log:

```none
Invalid read of size 8
   at 0x484A21F: memmove (vg_replace_strmem.c:1382)
   by 0x490F47: fill_val (heaptuple.c:287)
   by 0x491088: heap_fill_tuple (heaptuple.c:336)
   by 0x492AC4: heap_form_tuple (heaptuple.c:1090)
   by 0x14D3CF97: create_bbf_authid_login_ext (rolecmds.c:132)
   by 0x14CF3F6D: bbf_ProcessUtility (pl_handler.c:1675)
   by 0x93E5FF: ProcessUtility (utility.c:521)
   by 0x76FA3E: _SPI_execute_plan (spi.c:2373)
   by 0x76C7BD: SPI_execute_plan_with_paramlist (spi.c:588)
   by 0x14D12A7B: exec_stmt_execsql (pl_exec.c:4704)
   by 0x14D0AEA8: dispatch_stmt (iterative_exec.c:660)
   by 0x14D0BAF2: dispatch_stmt_handle_error (iterative_exec.c:1072)
 Address 0x15ace9c8 is 776 bytes inside a block of size 1,024 alloc'd
   at 0x484086F: malloc (vg_replace_malloc.c:381) 
   by 0xAEE06D: AllocSetContextCreateInternal (aset.c:468)
   by 0xAA5E15: BuildCachedPlan (plancache.c:965)
   by 0xAA63BE: GetCachedPlan (plancache.c:1187)
   by 0x76EDD9: SPI_plan_get_cached_plan (spi.c:1842)
   by 0x14D125F3: exec_stmt_execsql (pl_exec.c:4595)
   by 0x14D0AEA8: dispatch_stmt (iterative_exec.c:660)
   by 0x14D0BAF2: dispatch_stmt_handle_error (iterative_exec.c:1072)
   by 0x14D0C75B: exec_stmt_iterative (iterative_exec.c:1356)
   by 0x14D00595: pltsql_exec_function (pl_exec.c:657)
   by 0x14CF7657: pltsql_inline_handler (pl_handler.c:2818)
   by 0x14939631: ExecuteSQLBatch (tdssqlbatch.c:86)
```

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).