### PR TITLE
Change has_dbaccess to always return 1

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -655,17 +655,14 @@ LANGUAGE plpgsql
 VOLATILE
 RETURNS NULL ON NULL INPUT;
 
+-- This procedure is deliberately short-circuited to always return 1.
+-- Babelfish does not currently have full support for permissions, 
+-- because the Babelfish table names might not match the unerlying
+-- Postgres table names, so previous implementation threw an exception
+-- on the underlying psql, and thus always returned NULL.
 CREATE OR REPLACE FUNCTION sys.has_dbaccess(database_name PG_CATALOG.TEXT) RETURNS INTEGER AS $$
-DECLARE has_access BOOLEAN;
 BEGIN
-	has_access = has_database_privilege(database_name, 'CONNECT');
-	IF has_access THEN
-		RETURN 1;
-	ELSE
-		RETURN 0;
-	END IF;
-EXCEPTION WHEN others THEN
-	RETURN NULL;
+	RETURN 1;
 END;
 $$
 STRICT


### PR DESCRIPTION
### Description

The existing HAS_DBACCESS() implementation always returned NULL due to an exception thrown by the Psql call, because the Babelfish table names do not agree with the Postgres table names.

This is a temporary change to the HAS_DBACCESS() procedure to always return 1.  Expected functionality will be implemented along with a larger piece of work to implement the permissions/ownership of tables and databases in Babelfish.
 
### Issues Resolved

None

### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).