### PR TITLE
feat: Allow extensions to compile under top_builddir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
         run: |
+          export USE_PGXS=1
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           export cmake=$(which cmake)

--- a/.github/workflows/dotnet-framework.yml
+++ b/.github/workflows/dotnet-framework.yml
@@ -35,6 +35,7 @@ jobs:
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
         run: |
+          export USE_PGXS=1
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           export cmake=$(which cmake)

--- a/.github/workflows/odbc-framework.yml
+++ b/.github/workflows/odbc-framework.yml
@@ -35,6 +35,7 @@ jobs:
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
         run: |
+          export USE_PGXS=1
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           export cmake=$(which cmake)

--- a/.github/workflows/python-framework.yml
+++ b/.github/workflows/python-framework.yml
@@ -35,6 +35,7 @@ jobs:
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
         run: |
+          export USE_PGXS=1
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           export cmake=$(which cmake)

--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -37,8 +37,15 @@ OBJS += src/datetimeoffset.o
 OBJS += src/sqlvariant.o
 OBJS += src/coerce.o
 
+ifdef USE_PGXS
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/babelfishpg_common
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 MODULEPATH = $$libdir/$(EXTENSION)-$(BBFPGCMN_MAJOR_VERSION)
 

--- a/contrib/babelfishpg_money/Makefile
+++ b/contrib/babelfishpg_money/Makefile
@@ -21,9 +21,15 @@ REGRESS = $(shell echo aggregate cast comparison overflow $(REGRESS_BRIN) $(REGR
 
 REGRESS_OPTS = --inputdir=test --outputdir=test --load-extension=babelfishpg_money
 
-#PG_CONFIG = pg_config
+ifdef USE_PGXS
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/babelfishpg_money
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 AGGSTATESQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL" && echo fixeddecimalaggstate.sql)
 AGGFUNCSSQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL" && echo fixeddecimal--xlaggs.sql)

--- a/contrib/babelfishpg_tds/Makefile
+++ b/contrib/babelfishpg_tds/Makefile
@@ -28,11 +28,15 @@ $(tds_include)/error_mapping.h: error_mapping.txt generate_error_mapping.pl
 	$(PERL) generate_error_mapping.pl $< > $@
 $(tds_backend)/tds/err_handler.o: $(tds_include)/error_mapping.h
 
-# Disable for now
-#NO_PGXS = 1
-
+ifdef USE_PGXS
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/babelfishpg_tds
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 #include ../Makefile.common
 

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -100,8 +100,15 @@ test		 = $(shell test $(1) $(2) $(3) && echo yes || echo no)
 
 GE91		 = $(call test, $(MAJORVER), -ge, 91)
 
+ifdef USE_PGXS
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/babelfishpg_tsql
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 ifeq ($(GE91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(UPGRADES)


### PR DESCRIPTION
Signed-off-by: 3manuek <emanuel@ongres.com>

### Description

Allow building the Babelfish extensions by copying them into the `/contrib` directory of Postgres source code, in addition to supporting PGXS. Add a simple test of non-PGXS builds.
 
### Issues Resolved

#76 


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).