### PR TITLE
Truncate precision of DATETIME[2] to 6

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -1658,6 +1658,10 @@ ReadParameters(TDSRequestSP request, uint64_t offset, StringInfo message, int *p
 				uint8_t scale = message->data[offset++];
 				temp->len = message->data[offset++];
 
+				/* PostgreSQL's timestamp is limited to scale 6 */
+				if (scale != 255 && scale > 6)
+					scale = 6;
+
 				if (temp->len == 0)
 					temp->isNull = true;
 


### PR DESCRIPTION
PostgreSQL only supports 6 digits of precision (scale)
for TIMESTAMP. The Babelfish types for DATETIME and
DATETIME2 are based on PostgreSQL's TIMESTAMP type. Some
client drivers (like JDBC) transmit the default precision
of 7 for TDS/TSQL. We need to truncate that to avoid
flooding of the logs with WARN level messages.

### Description

Limit the number of digits for fractional seconds to 6 if a client application sends the default of 7 for DATETIME or DATETIME2. 
 
### Issues Resolved

Eliminate WARNING messages on every datum sent by the client application.

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).