### PR TITLE
Adjust babelfish_extensions Makefiles for submodule

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -4,6 +4,10 @@ ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = babelfish_extensions/contrib
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
 endif
 
 SUBDIRS = \

--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -37,8 +37,18 @@ OBJS += src/datetimeoffset.o
 OBJS += src/sqlvariant.o
 OBJS += src/coerce.o
 
+ifdef USE_PGXS
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+VERSION = $(shell $(PG_CONFIG) --version | awk '{print $$2}' | sed -e 's/devel$$//')
+CFLAGS = `$(PG_CONFIG) --includedir-server`
+else
+subdir = babelfish_extensions/contrib/babelfishpg_common
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+PG_SRC=$(top_srcdir)
+endif
 
 MODULEPATH = $$libdir/$(EXTENSION)-$(BBFPGCMN_MAJOR_VERSION)
 
@@ -54,17 +64,13 @@ DATA_built = \
 
 #include ../Makefile.common
 
-# Get Postgres version, as well as major (9.4, etc) version. Remove '.' from MAJORVER.
-VERSION 	 = $(shell $(PG_CONFIG) --version | awk '{print $$2}' | sed -e 's/devel$$//')
+# Get Postgres major (9.4, etc) version. Remove '.' from MAJORVER.
 MAJORVER 	 = $(shell echo $(VERSION) | cut -d . -f1,2 | tr -d .)
 
 # Function for testing a condition
 test		 = $(shell test $(1) $(2) $(3) && echo yes || echo no)
 
 GE91		 = $(call test, $(MAJORVER), -ge, 91)
-
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)
 
 ifeq ($(GE91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(UPGRADES)
@@ -82,8 +88,5 @@ sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).in
 
 sql/%.sql: sql/upgrades/%.sql
 	cp $< $@
-
-
-CFLAGS = `$(PG_CONFIG) --includedir-server`
 
 $(recurse)

--- a/contrib/babelfishpg_money/Makefile
+++ b/contrib/babelfishpg_money/Makefile
@@ -3,37 +3,38 @@ OBJS = fixeddecimal.o
 
 EXTENSION = babelfishpg_money
 
-#subdir = contrib/babelfishpg_money
-
 DATA = fixeddecimal--1.0.0--1.1.0.sql
 DATA_built = babelfishpg_money--1.1.0.sql
 
-#include ../Makefile.common
-
-CFLAGS = `$(PG_CONFIG) --includedir-server`
+ifdef USE_PGXS
+VERSION = $(shell $(PG_CONFIG) --version)
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = babelfish_extensions/contrib/babelfishpg_money
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 TESTS = $(wildcard test/sql/*.sql)
 
-REGRESS_BRIN := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL 9\.[5-9]| 10\.0| 11\.[0-9]| 12\.[0-9]" && echo brin-xl)
-REGRESS_BRIN += $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -E "9\.[5-9]| 10\.0| 11\.[0-9]| 12\.[0-9]" | grep -qEv "XL" && echo brin)
-REGRESS_VERSION_SPECIFIC := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL" && echo index-xl || echo index)
+REGRESS_BRIN := $(shell echo $(VERSION) | grep -qE "XL 9\.[5-9]| 10\.0| 11\.[0-9]| 12\.[0-9]| 13\.[0-9]" && echo brin-xl)
+REGRESS_BRIN += $(shell echo $(VERSION) | grep -E "9\.[5-9]| 10\.0| 11\.[0-9]| 12\.[0-9]| 13\.[0-9]" | grep -qEv "XL" && echo brin)
+REGRESS_VERSION_SPECIFIC := $(shell echo $(VERSION) | grep -qE "XL" && echo index-xl || echo index)
 REGRESS = $(shell echo aggregate cast comparison overflow $(REGRESS_BRIN) $(REGRESS_VERSION_SPECIFIC))
 
 REGRESS_OPTS = --inputdir=test --outputdir=test --load-extension=babelfishpg_money
 
-#PG_CONFIG = pg_config
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)
+AGGSTATESQL := $(shell echo $(VERSION) | grep -qE "XL" && echo fixeddecimalaggstate.sql)
+AGGFUNCSSQL := $(shell echo $(VERSION) | grep -qE "XL" && echo fixeddecimal--xlaggs.sql)
 
-AGGSTATESQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL" && echo fixeddecimalaggstate.sql)
-AGGFUNCSSQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL" && echo fixeddecimal--xlaggs.sql)
+AGGFUNCSSQL := $(shell echo $(VERSION) | grep -qE "9\.[6-9]| 10\.[0-9]| 11\.[0-9]| 12\.[0-9]| 13\.[0-9]" && echo fixeddecimal--parallelaggs.sql || echo fixeddecimal--aggs.sql)
 
-AGGFUNCSSQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "9\.[6-9]| 10\.[0-9]| 11\.[0-9]| 12\.[0-9]" && echo fixeddecimal--parallelaggs.sql || echo fixeddecimal--aggs.sql)
-
-BRINSQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "9\.[5-9]| 10\.[0-9]| 11\.[0-9]| 12\.[0-9]" && echo fixeddecimal--brin.sql)
+BRINSQL := $(shell echo $(VERSION) | grep -qE "9\.[5-9]| 10\.[0-9]| 11\.[0-9]| 12\.[0-9]| 13\.[0-9]" && echo fixeddecimal--brin.sql)
 
 # 9.6 was the dawn of parallel query, so we'll use the parallel enabled .sql file from then on.
-BASESQL := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "9\.[6-9]| 10\.[0-9]| 11\.[0-9]| 12\.[0-9]" && echo fixeddecimal--1.1.0_base_parallel.sql || echo fixeddecimal--1.1.0_base.sql)
+BASESQL := $(shell echo $(VERSION) | grep -qE "9\.[6-9]| 10\.[0-9]| 11\.[0-9]| 12\.[0-9]| 13\.[0-9]" && echo fixeddecimal--1.1.0_base_parallel.sql || echo fixeddecimal--1.1.0_base.sql)
 
 OBJECTS := $(addprefix $(srcdir)/, $(AGGSTATESQL) $(BASESQL) $(AGGFUNCSSQL) $(BRINSQL))
 

--- a/contrib/babelfishpg_tds/Makefile
+++ b/contrib/babelfishpg_tds/Makefile
@@ -10,6 +10,9 @@ tds_backend = $(tds_top_dir)/src/backend
 tds_include = $(tds_top_dir)/src/include
 TSQL_SRC = ../babelfishpg_tsql
 
+ifndef USE_PGXS
+PG_SRC = ../../..
+endif
 PG_CPPFLAGS += -I$(TSQL_SRC) -I$(PG_SRC) -I$(tds_top_dir) -DFAULT_INJECTOR
 
 # Exclude the following files from the build (sometimes these
@@ -28,11 +31,15 @@ $(tds_include)/error_mapping.h: error_mapping.txt generate_error_mapping.pl
 	$(PERL) generate_error_mapping.pl $< > $@
 $(tds_backend)/tds/err_handler.o: $(tds_include)/error_mapping.h
 
-# Disable for now
-#NO_PGXS = 1
-
+ifdef USE_PGXS
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = babelfish_extensions/contrib/babelfishpg_tds
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 #include ../Makefile.common
 

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -76,6 +76,9 @@ PG_CXXFLAGS += -Wno-undef -Wall -Wcpp
 PG_CXXFLAGS += -Wno-register # otherwise C++17 gags on PostgreSQL headers
 PG_CXXFLAGS += -I$(ANTLR4_RUNTIME_INCLUDE_DIR)
 PG_CFLAGS += -g
+ifndef USE_PGXS
+PG_SRC = ../../..
+endif
 PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -DFAULT_INJECTOR
 
 SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto
@@ -108,17 +111,22 @@ DATA_built = \
 
 #include ../Makefile.common
 
-# Get Postgres version, as well as major (9.4, etc) version. Remove '.' from MAJORVER.
+ifdef USE_PGXS
 VERSION 	 = $(shell $(PG_CONFIG) --version | awk '{print $$2}' | sed -e 's/devel$$//')
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = babelfish_extensions/contrib/babelfishpg_tsql
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 MAJORVER 	 = $(shell echo $(VERSION) | cut -d . -f1,2 | tr -d .)
 
 # Function for testing a condition
 test		 = $(shell test $(1) $(2) $(3) && echo yes || echo no)
 
 GE91		 = $(call test, $(MAJORVER), -ge, 91)
-
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)
 
 ifeq ($(GE91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(UPGRADES)
@@ -154,8 +162,11 @@ GEN_KEYWORDLIST = $(PERL) -I $(TOOLSDIR) $(TOOLSDIR)/gen_keywordlist.pl
 GEN_KEYWORDLIST_DEPS = $(TOOLSDIR)/gen_keywordlist.pl $(TOOLSDIR)/PerfectHash.pm
 TSQLSRC = .
 
+ifndef USE_PGXS
+cmake = cmake
+endif
 antlr/Makefile: antlr/CMakeLists.txt antlr/TSqlLexer.g4 antlr/TSqlLexer.g4
-	cd antlr && $(cmake) . && cd ..
+	cd antlr && CFLAGS="$(shell echo $(CFLAGS) | sed -e 's/-fexcess-precision=[^ ]*//' -e 's/-Wmissing-prototypes//' -e 's/-Wdeclaration-after-statement//')" $(cmake) . && cd ..
 
 .PHONY: antlr/libantlr_tsql.a  # to allow CMake's make check the build
 antlr/libantlr_tsql.a: antlr/Makefile


### PR DESCRIPTION
### Description

Fix all the babelfish_extensions Makefiles so that the
extensions build inside the submodule and without setting
environment variables PG_SRC and PG_CONFIG or the need to
have a binary installation present.


By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).