### PR TITLE
Fix ERRORS undefined symbol and schema 'sys' does not exists during pg_upgrade

### DIFF
--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -70,6 +70,15 @@ ifeq ($(GE91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(UPGRADES)
 endif
 
+install: install-lib link-lib
+uninstall: uninstall-lib unlink-lib
+
+link-lib:
+	ln -sf $(pkglibdir)/$(EXTENSION).so $(libdir)/$(EXTENSION).so
+
+unlink-lib:
+	rm -f $(libdir)/$(EXTENSION).so
+
 $(EXTENSION).control: $(EXTENSION).control.in
 	cat $< \
 		| sed -e 's|@EXTVERSION@|$(EXTVERSION)|g' \

--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -73,11 +73,16 @@ endif
 install: install-lib link-lib
 uninstall: uninstall-lib unlink-lib
 
+# Also add .so file to libdir so that other extensions can link to it.
 link-lib:
+ifneq ($(pkglibdir), $(libdir))
 	ln -sf $(pkglibdir)/$(EXTENSION).so $(libdir)/$(EXTENSION).so
+endif
 
 unlink-lib:
+ifneq ($(pkglibdir), $(libdir))
 	rm -f $(libdir)/$(EXTENSION).so
+endif
 
 $(EXTENSION).control: $(EXTENSION).control.in
 	cat $< \

--- a/contrib/babelfishpg_common/src/typecode.c
+++ b/contrib/babelfishpg_common/src/typecode.c
@@ -97,7 +97,11 @@ init_tcode_trans_tab(PG_FUNCTION_ARGS)
                                         HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
     }
 
-    sys_nspoid = get_namespace_oid("sys", false);
+    sys_nspoid = get_namespace_oid("sys", true);
+
+    if (!OidIsValid(sys_nspoid))
+	PG_RETURN_INT32(0);
+
     /* retrieve oid and setup hashtable*/
     for (int i=0; i<TOTAL_TYPECODE_COUNT; i++)
     {

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -112,7 +112,7 @@ DATA_built = \
 # Get Postgres version, as well as major (9.4, etc) version. Remove '.' from MAJORVER.
 VERSION 	 = $(shell $(PG_CONFIG) --version | awk '{print $$2}' | sed -e 's/devel$$//')
 MAJORVER 	 = $(shell echo $(VERSION) | cut -d . -f1,2 | tr -d .)
-pkglibdir 	 = $(shell $(PG_CONFIG) --pkglibdir)
+
 # Function for testing a condition
 test		 = $(shell test $(1) $(2) $(3) && echo yes || echo no)
 

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -79,7 +79,7 @@ PG_CXXFLAGS += -I$(ANTLR4_RUNTIME_INCLUDE_DIR)
 PG_CFLAGS += -g
 PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -DFAULT_INJECTOR
 
-SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto
+SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto -L$(pkglibdir) -l:babelfishpg_common.so
 
 UPGRADES = $(patsubst sql/upgrades/%.sql,sql/%.sql,$(wildcard sql/upgrades/*.sql))
 
@@ -112,7 +112,7 @@ DATA_built = \
 # Get Postgres version, as well as major (9.4, etc) version. Remove '.' from MAJORVER.
 VERSION 	 = $(shell $(PG_CONFIG) --version | awk '{print $$2}' | sed -e 's/devel$$//')
 MAJORVER 	 = $(shell echo $(VERSION) | cut -d . -f1,2 | tr -d .)
-
+pkglibdir 	 = $(shell $(PG_CONFIG) --pkglibdir)
 # Function for testing a condition
 test		 = $(shell test $(1) $(2) $(3) && echo yes || echo no)
 

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -92,7 +92,10 @@ PG_FUNCTION_INFO_V1(init_catalog);
 Datum init_catalog(PG_FUNCTION_ARGS)
 {
 	/* sys schema */
-	sys_schema_oid = get_namespace_oid("sys", false);
+	sys_schema_oid = get_namespace_oid("sys", true);
+
+	if (!OidIsValid(sys_schema_oid))
+	       	PG_RETURN_INT32(0);
 
 	/* sysdatabases */
 	sysdatabases_oid = get_relname_relid(SYSDATABASES_TABLE_NAME, sys_schema_oid);

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -647,7 +647,10 @@ init_collid_trans_tab(PG_FUNCTION_ARGS)
 
 	// locale_pos = find_locale(pltsql_default_locale);
 
-	nspoid = get_namespace_oid("sys", false);
+	nspoid = get_namespace_oid("sys", true);
+
+	if (!OidIsValid(nspoid))
+		PG_RETURN_INT32(0);
 
 	/* retrieve oid and setup hashtable */
 	for (int i=0; i<TOTAL_COLL_COUNT; i++)


### PR DESCRIPTION
pg_upgrade tries to LOAD extension libraries without creating the
extension. But while loading  babelfishpg_tsql/babelfishpg_common
libraries pg_upgrade throws ERROR undefined symbol or ERROR schema "sys"
does not exists.

This commit fixes the above errors as following:
1. The reason for ERROR undefined symbol is that babelfishpg_tsql library
was not able to find objects defined in babelfishpg_common library.
So we will link babelfishpg_common to babelfishpg_tsql library.

2. The reason for ERROR "schema 'sys' does not exists" is that during
LOAD we are searching for 'sys' schema to do the initialization without
creating the extension. So we will skip the initialization if schema
'sys' does not exists.

Task: BABEL-3106
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).