### PR TITLE
Update lock_timeout in fk-deadlock isolation test

### DIFF
--- a/test/python/input/isolation/fk-deadlock.spec
+++ b/test/python/input/isolation/fk-deadlock.spec
@@ -19,7 +19,7 @@ teardown
 }
 
 session s1
-setup		{ BEGIN TRAN; SET lock_timeout '100'; }
+setup		{ BEGIN TRAN; SET lock_timeout '500'; }
 step s1i	{ INSERT INTO child VALUES (1, 1); }
 step s1u	{ UPDATE parent SET aux = 'bar'; }
 step s1c	{ COMMIT; }


### PR DESCRIPTION
### Description

Previously, this test was failing while testing on remote instances; 100ms was not sufficient for running the test on a remote instance. This commit increases lock_timeout for session s1 to 500ms from 100ms.

Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>
 
### Issues Resolved

It will resolve the failure of fk-deadlock isolation test when running it on remote Babelfish instance.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).