### PR TITLE
Implement HAS_PERMS_BY_NAME

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -2672,17 +2672,38 @@ end
 $body$
 language 'plpgsql';
 
--- Remove closing square brackets at both ends, otherwise do nothing.
-CREATE OR REPLACE FUNCTION sys.babelfish_single_unbracket_name(IN name TEXT)
+-- Remove single pair of either square brackets or double-quotes from outer ends if present
+-- If name begins with a delimiter but does not end with the matching delimiter return NULL
+-- Otherwise, return the name unchanged
+CREATE OR REPLACE FUNCTION sys.babelfish_remove_delimiter_pair(IN name TEXT)
 RETURNS TEXT AS
 $BODY$
 BEGIN
-    IF length(name) >= 2 AND left(name, 1) = '[' AND right(name, 1) = ']' THEN
+    IF name IN('[', ']', '"') THEN
+        RETURN NULL;
+
+    ELSIF length(name) >= 2 AND left(name, 1) = '[' AND right(name, 1) = ']' THEN
         IF length(name) = 2 THEN
             RETURN '';
         ELSE
             RETURN substring(name from 2 for length(name)-2);
         END IF;
+    ELSIF length(name) >= 2 AND left(name, 1) = '[' AND right(name, 1) != ']' THEN
+        RETURN NULL;
+    ELSIF length(name) >= 2 AND left(name, 1) != '[' AND right(name, 1) = ']' THEN
+        RETURN NULL;
+
+    ELSIF length(name) >= 2 AND left(name, 1) = '"' AND right(name, 1) = '"' THEN
+        IF length(name) = 2 THEN
+            RETURN '';
+        ELSE
+            RETURN substring(name from 2 for length(name)-2);
+        END IF;
+    ELSIF length(name) >= 2 AND left(name, 1) = '"' AND right(name, 1) != '"' THEN
+        RETURN NULL;
+    ELSIF length(name) >= 2 AND left(name, 1) != '"' AND right(name, 1) = '"' THEN
+        RETURN NULL;
+
     END IF;
     RETURN name;
 END;
@@ -10061,6 +10082,157 @@ $BODY$
                                                       )/1000::numeric);
 $BODY$
 LANGUAGE SQL;
+
+-- valid names are
+-- db_name.schema_name.object_name or schema_name.object_name or object_name
+CREATE OR REPLACE FUNCTION sys.babelfish_split_object_name(
+    name TEXT,
+    OUT db_name TEXT,
+    OUT schema_name TEXT,
+    OUT object_name TEXT)
+AS $$
+DECLARE
+    lower_object_name text;
+    names text[2];
+    counter int;
+    cur_pos int;
+BEGIN
+    lower_object_name = lower(rtrim(name));
+
+    counter = 1;
+    cur_pos = sys.babelfish_get_name_delimiter_pos(lower_object_name);
+
+    -- Parse user input into names split by '.'
+    WHILE cur_pos > 0 LOOP
+        IF counter > 3 THEN
+            -- Too many names provided
+            RETURN;
+        END IF;
+
+        names[counter] = sys.babelfish_remove_delimiter_pair(rtrim(left(lower_object_name, cur_pos - 1)));
+
+        -- invalid name
+        IF names[counter] IS NULL THEN
+            RETURN;
+        END IF;
+
+        lower_object_name = substring(lower_object_name from cur_pos + 1);
+        counter = counter + 1;
+        cur_pos = sys.babelfish_get_name_delimiter_pos(lower_object_name);
+    END LOOP;
+
+    CASE counter
+        WHEN 1 THEN
+            db_name = NULL;
+            schema_name = NULL;
+        WHEN 2 THEN
+            db_name = NULL;
+            schema_name = sys.babelfish_truncate_identifier(names[1]);
+        WHEN 3 THEN
+            db_name = sys.babelfish_truncate_identifier(names[1]);
+            schema_name = sys.babelfish_truncate_identifier(names[2]);
+        ELSE
+            RETURN;
+    END CASE;
+
+    -- Assign each name accordingly
+    object_name = sys.babelfish_truncate_identifier(sys.babelfish_remove_delimiter_pair(rtrim(lower_object_name)));
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_name_delimiter_pos(name TEXT)
+RETURNS INTEGER
+AS $$
+DECLARE
+    pos int;
+BEGIN
+    IF (length(name) <= 2 AND (position('"' IN name) != 0 OR position(']' IN name) != 0 OR position('[' IN name) != 0))
+        -- invalid name
+        THEN RETURN 0;
+    ELSIF left(name, 1) = '[' THEN
+        pos = position('].' IN name);
+        IF pos = 0 THEN
+            -- invalid name
+            RETURN 0;
+        ELSE
+            RETURN pos + 1;
+        END IF;
+    ELSIF left(name, 1) = '"' THEN
+        -- search from position 1 in case name starts with ".
+        pos = position('".' IN right(name, length(name) - 1));
+        IF pos = 0 THEN
+            -- invalid name
+            RETURN 0;
+        ELSE
+            RETURN pos + 2;
+        END IF;
+    ELSE
+        RETURN position('.' IN name);
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sys.has_any_privilege(
+    perm_target_type text,
+    schema_name text,
+    object_name text,
+    sub_securable text DEFAULT NULL)
+RETURNS INTEGER
+AS
+$BODY$
+DECLARE
+    relevant_permissions text[];
+    namespace_id oid;
+    function_signature text;
+    qualified_name text;
+    permission text;
+BEGIN
+	IF perm_target_type IS NULL OR perm_target_type NOT IN('table', 'column', 'function', 'procedure')
+        THEN RETURN NULL;
+    ELSIF perm_target_type = 'column' AND sub_securable IS NULL
+        THEN RETURN NULL;
+    END IF;
+
+    relevant_permissions := (
+        SELECT CASE
+            WHEN perm_target_type = 'table'
+                THEN '{"select", "insert", "update", "delete", "references"}'
+            WHEN perm_target_type = 'column'
+                THEN '{"select", "update", "references"}'
+            WHEN perm_target_type IN('function', 'procedure')
+                THEN '{"execute"}'
+        END
+    );
+
+    SELECT oid INTO namespace_id FROM pg_catalog.pg_namespace WHERE nspname = schema_name;
+
+    IF perm_target_type IN('function', 'procedure')
+        THEN SELECT oid::regprocedure
+                INTO function_signature
+                FROM pg_catalog.pg_proc
+                WHERE proname = object_name
+                    AND pronamespace = namespace_id;
+    END IF;
+
+    -- Surround with double-quotes to handle names that contain periods/spaces
+    qualified_name := concat('"', schema_name, '"."', object_name, '"');
+
+    FOREACH permission IN ARRAY relevant_permissions
+    LOOP
+        IF perm_target_type = 'table' AND has_table_privilege(qualified_name, permission)::integer = 1
+            THEN RETURN 1;
+        ELSIF perm_target_type = 'column' AND has_column_privilege(qualified_name, sub_securable, permission)::integer = 1
+            THEN RETURN 1;
+        ELSIF perm_target_type IN('function', 'procedure') AND has_function_privilege(function_signature, permission)::integer = 1
+            THEN RETURN 1;
+        END IF;
+    END LOOP;
+    RETURN 0;
+END
+$BODY$
+LANGUAGE plpgsql;
 
 -- internal table function for sp_cursor_list and sp_decribe_cursor
 CREATE OR REPLACE FUNCTION sys.babelfish_cursor_list(cursor_source integer)

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -454,156 +454,94 @@ RETURNS INTEGER AS
 $BODY$
 DECLARE
         id oid;
-        lower_object_name text;
-        names text[2];
-        counter int;
-        cur_pos int;
         db_name text;
-        input_schema_name text;
+        bbf_schema_name text;
 		schema_name text;
         schema_oid oid;
         obj_name text;
         is_temp_object boolean;
 BEGIN
         id = null;
-        lower_object_name = lower(trim(object_name));
-        counter = 1;
-        cur_pos = position('.' in lower_object_name);
         schema_oid = NULL;
 
-        -- Parse user input into names split by '.'
-        WHILE cur_pos > 0 LOOP
-            IF counter > 3 THEN
-                -- Too many names provided
-                RETURN NULL;
-            END IF;
-            names[counter] = sys.babelfish_single_unbracket_name(left(lower_object_name, cur_pos - 1));
-            lower_object_name = substring(lower_object_name from cur_pos + 1);
-            counter = counter + 1;
-            cur_pos = position('.' in lower_object_name);
-        END LOOP;
+        SELECT s.db_name, s.schema_name, s.object_name INTO db_name, bbf_schema_name, obj_name
+        FROM sys.babelfish_split_object_name(object_name) s;
 
-        -- Assign each name accordingly
-        obj_name = sys.babelfish_truncate_identifier(sys.babelfish_single_unbracket_name(lower_object_name));
-        CASE counter
-            WHEN 1 THEN
-                db_name = NULL;
-                schema_name = NULL;
-            WHEN 2 THEN
-                db_name = NULL;
-                input_schema_name = sys.babelfish_truncate_identifier(names[1]);
-				schema_name = sys.bbf_get_current_physical_schema_name(input_schema_name);
-            WHEN 3 THEN
-                db_name = sys.babelfish_truncate_identifier(names[1]);
-                input_schema_name = sys.babelfish_truncate_identifier(names[2]);
-				schema_name = sys.bbf_get_current_physical_schema_name(input_schema_name);
-            ELSE
-                RETURN NULL;
-        END CASE;
+        -- Invalid object_name
+        IF obj_name IS NULL OR obj_name = '' THEN
+            RETURN NULL;
+        END IF;
+
+        IF bbf_schema_name IS NULL OR bbf_schema_name = '' THEN
+            bbf_schema_name := sys.schema_name();
+        END IF;
+
+        schema_name := sys.bbf_get_current_physical_schema_name(bbf_schema_name);
 
         -- Check if looking for temp object.
         is_temp_object = left(obj_name, 1) = '#';
 
         -- Can only search in current database. Allowing tempdb for temp objects.
-        IF db_name IS NOT NULL AND db_name <> current_database() AND db_name <> 'tempdb' THEN
+        IF db_name IS NOT NULL AND db_name <> db_name() AND db_name <> 'tempdb' THEN
             RAISE EXCEPTION 'Can only do lookup in current database.';
         END IF;
 
-        IF schema_name IS NOT NULL AND schema_name <> '' THEN
-            -- Searching within a schema. Get schema oid.
-            schema_oid = (SELECT oid FROM pg_namespace WHERE nspname = schema_name);
-            IF schema_oid IS NULL THEN
-                RETURN NULL;
-            END IF;
-
-            if object_type <> '' then
-                case
-                    -- Schema does not apply as much to temp objects.
-                    when upper(object_type) in ('S', 'U', 'V', 'IT', 'ET', 'SO') and is_temp_object then
-	                id := (select reloid from sys.babelfish_get_enr_list() where lower(relname) = obj_name limit 1);
-
-                    when upper(object_type) in ('S', 'U', 'V', 'IT', 'ET', 'SO') and not is_temp_object then
-	                id := (select oid from pg_class where lower(relname) = obj_name 
-                                and relnamespace = schema_oid limit 1);
-
-                    when upper(object_type) in ('C', 'D', 'F', 'PK', 'UQ') then
-	                id := (select oid from pg_constraint where lower(conname) = obj_name 
-                                and connamespace = schema_oid limit 1);
-
-                    when upper(object_type) in ('AF', 'FN', 'FS', 'FT', 'IF', 'P', 'PC', 'TF', 'RF', 'X') then
-	                id := (select oid from pg_proc where lower(proname) = obj_name 
-                                and pronamespace = schema_oid limit 1);
-
-                    when upper(object_type) in ('TR', 'TA') then
-	                id := (select oid from pg_trigger where lower(tgname) = obj_name limit 1);
-
-                    -- Throwing exception as a reminder to add support in the future.
-                    when upper(object_type) in ('R', 'EC', 'PG', 'SN', 'SQ', 'TT') then
-                        RAISE EXCEPTION 'Object type currently unsupported.';
-
-                    -- unsupported object_type
-                    else id := null;
-                end case;
-            else
-                if not is_temp_object then id := (
-                                                select oid from pg_class where lower(relname) = obj_name
-                                                    and relnamespace = schema_oid
-					            union
-				                select oid from pg_constraint where lower(conname) = obj_name
-					            and connamespace = schema_oid
-                                                    union
-				                select oid from pg_proc where lower(proname) = obj_name
-					            and pronamespace = schema_oid
-                                                    union
-				                select oid from pg_trigger where lower(tgname) = obj_name
-				                limit 1);
-                else
-                    -- temp object without "object_type" in-argument
-                    id := (select reloid from sys.babelfish_get_enr_list() where lower(relname) = obj_name limit 1);
-                end if;
-            end if;
-        ELSE 
-            -- Schema not specified.
-            if object_type <> '' then
-                case
-                    when upper(object_type) in ('S', 'U', 'V', 'IT', 'ET', 'SO') and is_temp_object then
-	                id := (select reloid from sys.babelfish_get_enr_list() where lower(relname) = obj_name limit 1);
-
-                    when upper(object_type) in ('S', 'U', 'V', 'IT', 'ET', 'SO') and not is_temp_object then
-	                id := (select oid from pg_class where lower(relname) = obj_name limit 1);
-
-                    when upper(object_type) in ('C', 'D', 'F', 'PK', 'UQ') then
-	                id := (select oid from pg_constraint where lower(conname) = obj_name limit 1);
-
-                    when upper(object_type) in ('AF', 'FN', 'FS', 'FT', 'IF', 'P', 'PC', 'TF', 'RF', 'X') then
-	                id := (select oid from pg_proc where lower(proname) = obj_name limit 1);
-
-                    when upper(object_type) in ('TR', 'TA') then
-	                id := (select oid from pg_trigger where lower(tgname) = obj_name limit 1);
-
-                    -- Throwing exception as a reminder to add support in the future.
-                    when upper(object_type) in ('R', 'EC', 'PG', 'SN', 'SQ', 'TT') then
-                        RAISE EXCEPTION 'Object type currently unsupported.';
-
-                    -- unsupported object_type
-                    else id := null;
-                end case;
-            else
-                if not is_temp_object then id := (
-                                                select oid from pg_class where lower(relname) = obj_name
-					            union
-				                select oid from pg_constraint where lower(conname) = obj_name
-					            union
-				                select oid from pg_proc where lower(proname) = obj_name
-					            union
-				                select oid from pg_trigger where lower(tgname) = obj_name
-				                limit 1);
-                else
-                    -- temp object without "object_type" in-argument
-                    id := (select reloid from sys.babelfish_get_enr_list() where lower(relname) = obj_name limit 1);
-                end if;
-            end if;
+        IF schema_name IS NULL OR schema_name = '' THEN
+            RETURN NULL;
         END IF;
+
+        -- Searching within a schema. Get schema oid.
+        schema_oid = (SELECT oid FROM pg_namespace WHERE nspname = schema_name);
+        IF schema_oid IS NULL THEN
+            RETURN NULL;
+        END IF;
+
+        if object_type <> '' then
+            case
+                -- Schema does not apply as much to temp objects.
+                when upper(object_type) in ('S', 'U', 'V', 'IT', 'ET', 'SO') and is_temp_object then
+	            id := (select reloid from sys.babelfish_get_enr_list() where lower(relname) = obj_name limit 1);
+
+                when upper(object_type) in ('S', 'U', 'V', 'IT', 'ET', 'SO') and not is_temp_object then
+	            id := (select oid from pg_class where lower(relname) = obj_name
+                            and relnamespace = schema_oid limit 1);
+
+                when upper(object_type) in ('C', 'D', 'F', 'PK', 'UQ') then
+	            id := (select oid from pg_constraint where lower(conname) = obj_name
+                            and connamespace = schema_oid limit 1);
+
+                when upper(object_type) in ('AF', 'FN', 'FS', 'FT', 'IF', 'P', 'PC', 'TF', 'RF', 'X') then
+	            id := (select oid from pg_proc where lower(proname) = obj_name
+                            and pronamespace = schema_oid limit 1);
+
+                when upper(object_type) in ('TR', 'TA') then
+	            id := (select oid from pg_trigger where lower(tgname) = obj_name limit 1);
+
+                -- Throwing exception as a reminder to add support in the future.
+                when upper(object_type) in ('R', 'EC', 'PG', 'SN', 'SQ', 'TT') then
+                    RAISE EXCEPTION 'Object type currently unsupported.';
+
+                -- unsupported object_type
+                else id := null;
+            end case;
+        else
+            if not is_temp_object then id := (
+                                            select oid from pg_class where lower(relname) = obj_name
+                                                and relnamespace = schema_oid
+				            union
+			                select oid from pg_constraint where lower(conname) = obj_name
+				            and connamespace = schema_oid
+                                                union
+			                select oid from pg_proc where lower(proname) = obj_name
+				            and pronamespace = schema_oid
+                                                union
+			                select oid from pg_trigger where lower(tgname) = obj_name
+			                limit 1);
+            else
+                -- temp object without "object_type" in-argument
+                id := (select reloid from sys.babelfish_get_enr_list() where lower(relname) = obj_name limit 1);
+            end if;
+        end if;
 
         RETURN id::integer;
 END;
@@ -1860,6 +1798,231 @@ EXCEPTION
 END;
 $$;
 GRANT EXECUTE ON FUNCTION sys.trigger_nestlevel() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.has_perms_by_name(
+    securable SYS.SYSNAME,
+    securable_class SYS.NVARCHAR(60),
+    permission SYS.SYSNAME,
+    sub_securable SYS.SYSNAME DEFAULT NULL,
+    sub_securable_class SYS.NVARCHAR(60) DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    db_name text;
+    bbf_schema_name text;
+    pg_schema text;
+    object_name text;
+    database_id smallint;
+    namespace_id oid;
+    perm_target_type text;
+    function_signature text;
+    qualified_name text;
+    return_value integer;
+BEGIN
+    return_value := NULL;
+
+    -- Lower-case to avoid case issues, remove trailing whitespace to match SQL SERVER behavior
+    -- Objects created in Babelfish are stored in lower-case in pg_class/pg_proc
+    securable = lower(rtrim(securable));
+    securable_class = lower(rtrim(securable_class));
+    permission = lower(rtrim(permission));
+    sub_securable = lower(rtrim(sub_securable));
+    sub_securable_class = lower(rtrim(sub_securable_class));
+
+    -- Validate inputs
+    IF permission IS NULL THEN
+        RETURN NULL;
+
+    -- Assert that securable_class is NULL, object, database, or server
+    ELSIF securable_class IS NOT NULL AND securable_class NOT IN('object', 'database', 'server') THEN
+        RETURN NULL;
+
+    -- Assert that sub_securable and sub_securable_class are either both NULL or both defined
+    ELSIF sub_securable IS NOT NULL AND sub_securable_class IS NULL THEN
+        RETURN NULL;
+    ELSIF sub_securable IS NULL AND sub_securable_class IS NOT NULL THEN
+        RETURN NULL;
+    -- If they are both defined, sub_securable_class must be set to 'column' and securable_class to 'object'
+    ELSIF sub_securable IS NOT NULL
+            AND (sub_securable_class != 'column' OR securable_class IS NULL OR securable_class != 'object') THEN
+        RETURN NULL;
+
+    -- If securable is null, securable_class must be null or server
+    ELSIF securable IS NULL AND securable_class IS NOT NULL AND securable_class != 'server' THEN
+        RETURN NULL;
+    -- If securable_class is null or server, securable must be null
+    ELSIF (securable_class IS NULL OR securable_class = 'server') AND securable IS NOT NULL THEN
+        RETURN NULL;
+
+    -- Assert that permission type is compatible with the securable class
+    ELSIF securable_class = 'object' AND permission NOT IN('select', 'insert', 'update', 'delete', 'references', 'execute', 'any') THEN
+        RETURN NULL;
+    ELSIF securable_class = 'database' AND permission NOT IN('create schema', 'create table') THEN
+        RETURN NULL;
+    ELSIF (securable_class IS NULL OR securable_class = 'server') AND permission != 'view server state' THEN
+        RETURN NULL;
+    END IF;
+
+
+    IF securable_class IS NULL OR securable_class = 'server' THEN
+        IF CURRENT_USER IN('dbo', 'master_dbo', 'tempdb_dbo', 'msdb_dbo') THEN
+            RETURN 1;
+        ELSE
+            RETURN 0;
+        END IF;
+    END IF;
+
+    IF securable_class = 'database' THEN
+        IF CURRENT_USER IN('dbo', 'master_dbo', 'tempdb_dbo', 'msdb_dbo')
+                AND (SELECT count(name) FROM sys.databases WHERE name = securable) = 1
+            THEN RETURN 1;
+        ELSE
+            RETURN 0;
+        END IF;
+    END IF;
+
+    SELECT s.db_name, s.schema_name, s.object_name INTO db_name, bbf_schema_name, object_name
+    FROM sys.babelfish_split_object_name(securable) s;
+
+    -- Invalid securable name
+    IF object_name IS NULL OR object_name = '' THEN
+        RETURN NULL;
+    END IF;
+
+    database_id := (
+        SELECT CASE
+            WHEN db_name IS NULL OR db_name = '' THEN (sys.db_id())
+            ELSE (sys.db_id(db_name))
+        END);
+
+    IF bbf_schema_name IS NULL OR bbf_schema_name = '' THEN
+        bbf_schema_name := sys.schema_name();
+    END IF;
+
+     -- Translate schema name from bbf to postgres, e.g. dbo -> master_dbo
+    pg_schema := (SELECT nspname
+                    FROM sys.babelfish_namespace_ext ext
+                    WHERE ext.orig_name = bbf_schema_name
+                        AND ext.dbid::oid = database_id::oid);
+
+    -- Surround with double-quotes to handle names that contain periods/spaces
+    qualified_name := concat('"', pg_schema, '"."', object_name, '"');
+
+    SELECT oid INTO namespace_id FROM pg_catalog.pg_namespace WHERE nspname = pg_schema;
+
+    IF sub_securable IS NOT NULL THEN
+        sub_securable := sys.babelfish_remove_delimiter_pair(sub_securable);
+        IF sub_securable IS NULL THEN
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    perm_target_type := (
+        SELECT CASE
+            WHEN sub_securable_class = 'column'
+                THEN CASE
+                    WHEN (SELECT count(name)
+                        FROM sys.all_columns
+                        WHERE name = sub_securable
+                            -- Use V as the object type to specify that the securable is table-like.
+                            -- We don't know that the securable is a view, but object_id behaves the
+                            -- same for differint table-like types, so V can be arbitrarily chosen.
+                            AND object_id = sys.object_id(securable, 'V')) = 1
+                                THEN 'column'
+                    ELSE NULL
+                END
+
+            WHEN (SELECT count(relname)
+                    FROM pg_catalog.pg_class
+                    WHERE relname = object_name
+                        AND relnamespace = namespace_id) = 1
+                THEN 'table'
+
+            WHEN (SELECT count(proname)
+                    FROM pg_catalog.pg_proc
+                    WHERE proname = object_name
+                        AND pronamespace = namespace_id
+                        AND prokind = 'f') = 1
+                THEN 'function'
+
+            WHEN (SELECT count(proname)
+                    FROM pg_catalog.pg_proc
+                    WHERE proname = object_name
+                        AND pronamespace = namespace_id
+                        AND prokind = 'p') = 1
+                THEN 'procedure'
+            ELSE NULL
+        END
+    );
+
+    -- Object wasn't found
+    IF perm_target_type IS NULL THEN
+        RETURN 0;
+    END IF;
+
+    -- Get signature for function-like objects
+    IF perm_target_type IN('function', 'procedure') THEN
+        SELECT oid::regprocedure
+            INTO function_signature
+            FROM pg_catalog.pg_proc
+            WHERE proname = object_name
+                AND pronamespace = namespace_id;
+    END IF;
+
+	return_value := (
+        SELECT CASE
+            WHEN permission = 'any' THEN sys.has_any_privilege(perm_target_type, pg_schema, object_name, sub_securable)
+
+            WHEN perm_target_type = 'column'
+                THEN CASE
+                    WHEN permission IN('insert', 'delete', 'execute') THEN NULL
+                    ELSE has_column_privilege(qualified_name, sub_securable, permission)::integer
+                END
+
+            WHEN perm_target_type = 'table'
+                THEN CASE
+                    WHEN permission = 'execute' THEN 0
+                    ELSE has_table_privilege(qualified_name, permission)::integer
+                END
+
+            WHEN perm_target_type = 'function'
+                THEN CASE
+                    WHEN permission IN('select', 'execute')
+                        THEN has_function_privilege(function_signature, 'execute')::integer
+                    WHEN permission IN('update', 'insert', 'delete', 'references')
+                        THEN 0
+                    ELSE NULL
+                END
+
+            WHEN perm_target_type = 'procedure'
+                THEN CASE
+                    WHEN permission = 'execute'
+                        THEN has_function_privilege(function_signature, 'execute')::integer
+                    WHEN permission IN('select', 'update', 'insert', 'delete', 'references')
+                        THEN 0
+                    ELSE NULL
+                END
+
+            ELSE NULL
+		END
+	);
+
+	RETURN return_value;
+	EXCEPTION WHEN OTHERS THEN RETURN NULL;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION sys.has_perms_by_name(
+    securable sys.SYSNAME,
+    securable_class sys.nvarchar(60),
+    permission sys.SYSNAME,
+    sub_securable sys.SYSNAME,
+    sub_securable_class sys.nvarchar(60)) TO PUBLIC;
+
+COMMENT ON FUNCTION sys.has_perms_by_name
+IS 'This function returns permission information. Currently only works with tables, views, columns, functions, and procedures. Otherwise returns NULL.';
 
 CREATE OR REPLACE FUNCTION sys.schema_name()
 RETURNS sys.sysname

--- a/test/JDBC/expected/BABEL-1044.out
+++ b/test/JDBC/expected/BABEL-1044.out
@@ -48,32 +48,7 @@ int
 ~~END~~
 
 
--- object_id(<table_name>) for both original namd shortend name
-select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') is not null then 'exists' else 'error' end) result;
-GO
-~~START~~
-text
-exists
-~~END~~
-
-
-select (case when object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') is not null then 'exists' else 'error' end) result;
-GO
-~~START~~
-text
-exists
-~~END~~
-
-
-select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') = object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') then 'correct' else 'error' end) result;
-GO
-~~START~~
-text
-correct
-~~END~~
-
-
--- object_id(<schema_name>.<table_name>) for both original namd shortend name
+-- object_id(<schema_name>.<table_name>) for both original name and shortened name
 select (case when object_id('schema_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij.table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') is not null then 'exists' else 'error' end) result;
 GO
 ~~START~~
@@ -111,6 +86,31 @@ GO
 insert into table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij values (42);
 GO
 ~~ROW COUNT: 1~~
+
+
+-- object_id(<table_name>) for both original name and shortened name
+select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') is not null then 'exists' else 'error' end) result;
+GO
+~~START~~
+text
+exists
+~~END~~
+
+
+select (case when object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') is not null then 'exists' else 'error' end) result;
+GO
+~~START~~
+text
+exists
+~~END~~
+
+
+select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') = object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') then 'correct' else 'error' end) result;
+GO
+~~START~~
+text
+correct
+~~END~~
 
 
 -- char/varchar/text -> name casting

--- a/test/JDBC/expected/BABEL-OBJECT-FUNCTIONS.out
+++ b/test/JDBC/expected/BABEL-OBJECT-FUNCTIONS.out
@@ -4,7 +4,7 @@ GO
 CREATE TABLE obj_funcs.t1(id INT, c1 NVARCHAR);
 GO
 
-SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N't1 ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'obj_funcs.t1 ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
 GO
 ~~START~~
 text
@@ -16,7 +16,7 @@ SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'  t1', N'U')) = 't1' THEN 'true' ELSE 
 GO
 ~~START~~
 text
-true
+false
 ~~END~~
 
 
@@ -24,11 +24,11 @@ SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'  t1  ')) = 't1' THEN 'true' ELSE 'fal
 GO
 ~~START~~
 text
-true
+false
 ~~END~~
 
 
-SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N' [t1] ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'[obj_funcs].[t1] ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
 GO
 ~~START~~
 text
@@ -40,7 +40,23 @@ SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'   [obj_funcs].[t1]  ', N'U')) = 't1' 
 GO
 ~~START~~
 text
+false
+~~END~~
+
+
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'"obj_funcs"."t1" ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+GO
+~~START~~
+text
 true
+~~END~~
+
+
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'   "obj_funcs"."t1"  ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+GO
+~~START~~
+text
+false
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-has_perms_by_name.out
+++ b/test/JDBC/expected/sys-has_perms_by_name.out
@@ -1,0 +1,2116 @@
+
+-- tsql
+-- =============== Setup ===============
+DROP TABLE IF EXISTS t_perms_by_name;
+GO
+
+CREATE TABLE t_perms_by_name (col1 INT, col2 VARCHAR(16));
+GO
+
+CREATE LOGIN user_perms_by_name WITH PASSWORD='test';
+GO
+
+CREATE DATABASE db_perms_by_name;
+GO
+
+USE db_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS t_perms_by_name;
+GO
+
+CREATE TABLE t_perms_by_name (col1 INT, col2 VARCHAR(16));
+GO
+
+CREATE SCHEMA s_perms_by_name;
+GO
+
+CREATE TABLE s_perms_by_name.t_perms_by_name (col1 INT, col2 VARCHAR(16));
+GO
+
+DROP TABLE IF EXISTS [.t perms.by.name.];
+GO
+
+CREATE TABLE [.t perms.by.name.] ([.column perms.by.name.] INT);
+GO
+
+DROP TABLE IF EXISTS [ t.perms by name ];
+GO
+
+CREATE TABLE [ t.perms by name ] ([ column perms.by.name ] INT);
+GO
+
+DROP VIEW IF EXISTS v_perms_by_name;
+GO
+
+CREATE VIEW v_perms_by_name AS
+	SELECT * FROM t_perms_by_name;
+GO
+
+DROP FUNCTION IF EXISTS scalar_function_perms_by_name;
+GO
+
+CREATE FUNCTION scalar_function_perms_by_name()
+RETURNS int
+AS
+BEGIN
+   DECLARE @retval int
+   SELECT @retval = COUNT(*) FROM t_perms_by_name
+   RETURN @retval
+END;
+GO
+
+DROP FUNCTION IF EXISTS table_function_perms_by_name;
+GO
+
+CREATE FUNCTION table_function_perms_by_name(@empid int)
+RETURNS table
+AS
+RETURN
+(
+	SELECT * FROM t_perms_by_name WHERE col1 = @empid
+);
+GO
+
+DROP PROCEDURE IF EXISTS proc_perms_by_name;
+GO
+
+CREATE procedure proc_perms_by_name AS
+	SELECT * FROM t_perms_by_name
+GO
+
+DROP USER IF EXISTS user_perms_by_name;
+GO
+
+CREATE USER user_perms_by_name FOR LOGIN user_perms_by_name;
+GO
+
+GRANT ALL ON t_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON [.t perms.by.name.] TO user_perms_by_name;
+GO
+
+GRANT ALL ON [ t.perms by name ] TO user_perms_by_name;
+GO
+
+GRANT ALL ON v_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON table_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON proc_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT CURRENT_USER;
+GO
+~~START~~
+varchar
+user_perms_by_name
+~~END~~
+
+
+
+
+
+-- =============== Tables ===============
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'INSERT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'DELETE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'REFERENCES');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+SELECT CURRENT_USER
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+REVOKE SELECT ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+REVOKE ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+GRANT REFERENCES ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('"db_perms_by_name".[dbo]."t_perms_by_name"','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+GRANT ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+-- =============== Views ===============
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'INSERT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'DELETE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'REFERENCES');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+REVOKE SELECT ON OBJECT::v_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+REVOKE ALL ON OBJECT::v_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+GRANT REFERENCES ON OBJECT::v_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+GRANT ALL ON OBJECT::v_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+-- =============== Columns ===============
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'INSERT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'DELETE', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'REFERENCES', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'EXECUTE', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+REVOKE SELECT ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GRANT SELECT (col2) ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col2', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+REVOKE ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+GRANT REFERENCES (col1) ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('"db_perms_by_name".[dbo]."t_perms_by_name"','OBJECT', 'ANY', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+GRANT ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+-- =============== Scalar-valued functions ===============
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'INSERT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'DELETE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'REFERENCES');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+REVOKE EXECUTE ON OBJECT::scalar_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+REVOKE ALL ON OBJECT::scalar_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+GRANT EXECUTE ON OBJECT::scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+GRANT ALL ON OBJECT::scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+-- =============== Table-valued functions ===============
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'INSERT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'DELETE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'REFERENCES');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+REVOKE EXECUTE ON OBJECT::table_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+REVOKE ALL ON OBJECT::table_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+GRANT EXECUTE ON OBJECT::table_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+GRANT ALL ON OBJECT::table_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+-- =============== Procedures ===============
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'INSERT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'DELETE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'REFERENCES');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+REVOKE EXECUTE ON OBJECT::proc_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+REVOKE ALL ON OBJECT::proc_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+GRANT EXECUTE ON OBJECT::proc_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'ANY');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+GRANT ALL ON OBJECT::proc_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'EXECUTE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+-- =============== Database permissions ================
+SELECT HAS_PERMS_BY_NAME(db_name(),'DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME(db_name(),'DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CONNECT REPLICATION');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+USE msdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+USE tempdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- tsql user=user_perms_by_name password=test
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+
+-- tsql
+-- =============== Server permissions ================
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, 'DATABASE', 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name', NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name', 'SERVER', 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Unsupported permission for server
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER ANY ENDPOINT');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME(NULL, 'SERVER', 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE tempdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE msdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=user_perms_by_name password=test
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+
+-- =============== Object name splitting ================
+-- invalid table spec (five part name or more)
+SELECT HAS_PERMS_BY_NAME('invalid.server.db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('server.db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].[dbo].[t_perms_by_name]','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].[dbo].[t_perms_by_name]','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master.dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[dbo].[t_perms_by_name]','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[dbo].[t_perms_by_name]','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('s_perms_by_name.t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[t_perms_by_name]','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[t_perms_by_name]','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].[dbo].[t_perms_by_name]','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo.[t_perms_by_name]','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.[dbo].[t_perms_by_name]','OBJECT', 'UPDATE', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.[dbo.t_perms_by_name','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo.[t_perms_by_name]','OBJECT', 'SELECT', 'col1]', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo.[t_perms_by_name]','OBJECT', 'SELECT', '[col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name]','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('"db_perms_by_name".dbo."t_perms_by_name"','OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name"','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('"t_perms_by_name','OBJECT', 'SELECT');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo."t_perms_by_name"', 'OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.."t_perms_by_name"', 'OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('master..t_perms_by_name', 'OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+
+
+
+-- =============== Special handling ================
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'non_existing_sub_securable_class');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'non_existing_column', 'COLUMN');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'non_existing_permission');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','non_existing_securable_class', 'SELECT');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('non_existing_table','OBJECT', 'UPDATE');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- test permission type that only exists in SQL Server
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ALTER');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- test permission type that only exists in Postgres
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'TRUNCATE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- test unsupported securable class
+SELECT HAS_PERMS_BY_NAME(db_name(), 'SEARCH PROPERTY LIST', 'CONTROL');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- test invalid sub-securable_class
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'TABLE');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- test invalid securable class for sub-securable_class
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','DATABASE', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', NULL);
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', NULL, 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', NULL, 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name', NULL, 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME(NULL, 'OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'SELECT', 'col1', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('dbo.t_perms_by_name     ','OBJECT    ', 'SELECT   ', 'col2   ', 'COLUMN ');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('dBo.t_PeRmS_bY_nAmE','oBjEcT', 'sElEcT', 'CoL2', 'cOlUmN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('  t_perms_by_name','OBJECT', 'SELECT', 'col2', 'COLUMN');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name',' OBJECT', 'SELECT', 'col2', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', ' SELECT', 'col2', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', ' col2', 'COLUMN');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col2', ' COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[.t perms.by.name.]', 'OBJECT', 'SELECT')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('".t perms.by.name."', 'OBJECT', 'SELECT')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[ t.perms by name ]', 'OBJECT', 'SELECT')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('" t.perms by name "', 'OBJECT', 'SELECT')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[.t perms.by.name.]', 'OBJECT', 'SELECT', '".column perms.by.name."', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('".t perms.by.name."', 'OBJECT', 'SELECT', '[.column perms.by.name.]', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[.t perms.by.name.]', 'OBJECT', 'ANY', '".column perms.by.name."', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('".t perms.by.name."', 'OBJECT', 'ANY', '[.column perms.by.name.]', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[ t.perms by name ]', 'OBJECT', 'SELECT', '" column perms.by.name "', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('" t.perms by name "', 'OBJECT', 'SELECT', '[ column perms.by.name ]', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[ t.perms by name ]', 'OBJECT', 'ANY', '" column perms.by.name "', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('" t.perms by name "', 'OBJECT', 'ANY', '[ column perms.by.name ]', 'COLUMN');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT HAS_PERMS_BY_NAME('[ non.existent.db ].".non existent.schema.".[non .. existent table]', 'OBJECT', 'SELECT', '[. non. existent.column]', 'COLUMN');
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+USE master;
+GO
+
+
+
+
+-- tsql
+-- =============== Cleanup ===============
+USE db_perms_by_name;
+GO
+
+DROP PROCEDURE proc_perms_by_name;
+GO
+
+DROP FUNCTION table_function_perms_by_name;
+GO
+
+DROP FUNCTION scalar_function_perms_by_name;
+GO
+
+DROP VIEW IF EXISTS v_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS t_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS s_perms_by_name.t_perms_by_name;
+GO
+
+DROP SCHEMA s_perms_by_name
+GO
+
+DROP TABLE IF EXISTS [.t perms.by.name.];
+GO
+
+DROP TABLE IF EXISTS [ t.perms by name ];
+GO
+
+USE master;
+GO
+
+DROP DATABASE db_perms_by_name;
+GO
+
+DROP LOGIN user_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS t_perms_by_name;
+GO

--- a/test/JDBC/input/BABEL-1044.sql
+++ b/test/JDBC/input/BABEL-1044.sql
@@ -26,17 +26,7 @@ GO
 select count(*) from pg_catalog.pg_class where relname = 'table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf';
 GO
 
--- object_id(<table_name>) for both original namd shortend name
-select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') is not null then 'exists' else 'error' end) result;
-GO
-
-select (case when object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') is not null then 'exists' else 'error' end) result;
-GO
-
-select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') = object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') then 'correct' else 'error' end) result;
-GO
-
--- object_id(<schema_name>.<table_name>) for both original namd shortend name
+-- object_id(<schema_name>.<table_name>) for both original name and shortened name
 select (case when object_id('schema_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij.table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') is not null then 'exists' else 'error' end) result;
 GO
 
@@ -57,6 +47,16 @@ create table table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcde
 GO
 
 insert into table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij values (42);
+GO
+
+-- object_id(<table_name>) for both original name and shortened name
+select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') is not null then 'exists' else 'error' end) result;
+GO
+
+select (case when object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') is not null then 'exists' else 'error' end) result;
+GO
+
+select (case when object_id('table_longer_than_63_0abcdefgij1abcdefgij2abcdefgij3abcdefgij4abcdefgij5abcdefgij6abcdefgij7abcdefgij8abcdefghij9abcdefghij') = object_id('table_longer_than_63_0abcdefgijc2ed7b983a352405e4e26c711bd071bf') then 'correct' else 'error' end) result;
 GO
 
 -- char/varchar/text -> name casting

--- a/test/JDBC/input/BABEL-OBJECT-FUNCTIONS.sql
+++ b/test/JDBC/input/BABEL-OBJECT-FUNCTIONS.sql
@@ -4,7 +4,7 @@ GO
 CREATE TABLE obj_funcs.t1(id INT, c1 NVARCHAR);
 GO
 
-SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N't1 ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'obj_funcs.t1 ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
 GO
 
 SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'  t1', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
@@ -13,10 +13,16 @@ GO
 SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'  t1  ')) = 't1' THEN 'true' ELSE 'false' END) result;
 GO
 
-SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N' [t1] ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'[obj_funcs].[t1] ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
 GO
 
 SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'   [obj_funcs].[t1]  ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+GO
+
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'"obj_funcs"."t1" ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
+GO
+
+SELECT (CASE WHEN OBJECT_NAME(OBJECT_ID(N'   "obj_funcs"."t1"  ', N'U')) = 't1' THEN 'true' ELSE 'false' END) result;
 GO
 
 DROP TABLE obj_funcs.t1;

--- a/test/JDBC/input/functions/sys-has_perms_by_name.mix
+++ b/test/JDBC/input/functions/sys-has_perms_by_name.mix
@@ -1,0 +1,1071 @@
+-- =============== Setup ===============
+
+-- tsql
+DROP TABLE IF EXISTS t_perms_by_name;
+GO
+
+CREATE TABLE t_perms_by_name (col1 INT, col2 VARCHAR(16));
+GO
+
+CREATE LOGIN user_perms_by_name WITH PASSWORD='test';
+GO
+
+CREATE DATABASE db_perms_by_name;
+GO
+
+USE db_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS t_perms_by_name;
+GO
+
+CREATE TABLE t_perms_by_name (col1 INT, col2 VARCHAR(16));
+GO
+
+CREATE SCHEMA s_perms_by_name;
+GO
+
+CREATE TABLE s_perms_by_name.t_perms_by_name (col1 INT, col2 VARCHAR(16));
+GO
+
+DROP TABLE IF EXISTS [.t perms.by.name.];
+GO
+
+CREATE TABLE [.t perms.by.name.] ([.column perms.by.name.] INT);
+GO
+
+DROP TABLE IF EXISTS [ t.perms by name ];
+GO
+
+CREATE TABLE [ t.perms by name ] ([ column perms.by.name ] INT);
+GO
+
+DROP VIEW IF EXISTS v_perms_by_name;
+GO
+
+CREATE VIEW v_perms_by_name AS
+	SELECT * FROM t_perms_by_name;
+GO
+
+DROP FUNCTION IF EXISTS scalar_function_perms_by_name;
+GO
+
+CREATE FUNCTION scalar_function_perms_by_name()
+RETURNS int
+AS
+BEGIN
+   DECLARE @retval int
+   SELECT @retval = COUNT(*) FROM t_perms_by_name
+   RETURN @retval
+END;
+GO
+
+DROP FUNCTION IF EXISTS table_function_perms_by_name;
+GO
+
+CREATE FUNCTION table_function_perms_by_name(@empid int)
+RETURNS table
+AS
+RETURN
+(
+	SELECT * FROM t_perms_by_name WHERE col1 = @empid
+);
+GO
+
+DROP PROCEDURE IF EXISTS proc_perms_by_name;
+GO
+
+CREATE procedure proc_perms_by_name AS
+	SELECT * FROM t_perms_by_name
+GO
+
+DROP USER IF EXISTS user_perms_by_name;
+GO
+
+CREATE USER user_perms_by_name FOR LOGIN user_perms_by_name;
+GO
+
+GRANT ALL ON t_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON [.t perms.by.name.] TO user_perms_by_name;
+GO
+
+GRANT ALL ON [ t.perms by name ] TO user_perms_by_name;
+GO
+
+GRANT ALL ON v_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON table_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON proc_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT CURRENT_USER;
+GO
+
+
+
+-- =============== Tables ===============
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'INSERT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'DELETE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'REFERENCES');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+SELECT CURRENT_USER
+GO
+
+REVOKE SELECT ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+-- tsql
+REVOKE ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT REFERENCES ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY');
+GO
+
+SELECT HAS_PERMS_BY_NAME('"db_perms_by_name".[dbo]."t_perms_by_name"','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+
+
+-- =============== Views ===============
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'INSERT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'DELETE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'REFERENCES');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE SELECT ON OBJECT::v_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+-- tsql
+REVOKE ALL ON OBJECT::v_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT REFERENCES ON OBJECT::v_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT ALL ON OBJECT::v_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT');
+GO
+
+
+
+-- =============== Columns ===============
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'INSERT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'DELETE', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'REFERENCES', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'EXECUTE', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+-- tsql
+REVOKE SELECT ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GRANT SELECT (col2) ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col2', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE', 'col1', 'COLUMN');
+GO
+
+-- tsql
+REVOKE ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY', '"col1"', 'COLUMN');
+GO
+
+-- tsql
+GRANT REFERENCES (col1) ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ANY', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name]."dbo".[t_perms_by_name]','OBJECT', 'ANY', '"col1"', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('"db_perms_by_name".[dbo]."t_perms_by_name"','OBJECT', 'ANY', '"col1"', 'COLUMN');
+GO
+
+-- tsql
+GRANT ALL ON OBJECT::db_perms_by_name.dbo.t_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+
+
+-- =============== Scalar-valued functions ===============
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'INSERT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'DELETE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'REFERENCES');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE EXECUTE ON OBJECT::scalar_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE ALL ON OBJECT::scalar_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT EXECUTE ON OBJECT::scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT ALL ON OBJECT::scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('scalar_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+
+
+-- =============== Table-valued functions ===============
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'INSERT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'DELETE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'REFERENCES');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE EXECUTE ON OBJECT::table_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE ALL ON OBJECT::table_function_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT EXECUTE ON OBJECT::table_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT ALL ON OBJECT::table_function_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('table_function_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+
+
+-- =============== Procedures ===============
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'INSERT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'DELETE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'REFERENCES');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE EXECUTE ON OBJECT::proc_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+-- tsql
+REVOKE ALL ON OBJECT::proc_perms_by_name FROM user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT EXECUTE ON OBJECT::proc_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'ANY');
+GO
+
+-- tsql
+GRANT ALL ON OBJECT::proc_perms_by_name TO user_perms_by_name;
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('proc_perms_by_name','OBJECT', 'EXECUTE');
+GO
+
+
+
+-- =============== Database permissions ================
+
+SELECT HAS_PERMS_BY_NAME(db_name(),'DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME(db_name(),'DATABASE', 'CREATE SCHEMA');
+GO
+
+-- tsql
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CONNECT REPLICATION');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+
+USE msdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+
+USE tempdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('msdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('tempdb','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existent_db','DATABASE', 'CREATE SCHEMA');
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master','DATABASE', 'CREATE SCHEMA');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE TABLE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name','DATABASE', 'CREATE SCHEMA');
+GO
+
+
+
+-- =============== Server permissions ================
+
+-- tsql
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, 'DATABASE', 'VIEW SERVER STATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name', NULL, 'VIEW SERVER STATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name', 'SERVER', 'VIEW SERVER STATE');
+GO
+
+-- Unsupported permission for server
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER ANY ENDPOINT');
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, 'SERVER', 'VIEW SERVER STATE');
+GO
+
+USE tempdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+
+USE msdb;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+
+-- tsql user=user_perms_by_name password=test
+USE master;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+
+USE db_perms_by_name;
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE');
+GO
+
+
+
+-- =============== Object name splitting ================
+
+-- invalid table spec (five part name or more)
+SELECT HAS_PERMS_BY_NAME('invalid.server.db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('server.db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].[dbo].[t_perms_by_name]','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].[dbo].[t_perms_by_name]','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master.dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[dbo].[t_perms_by_name]','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[dbo].[t_perms_by_name]','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('dbo.t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('dbo.t_perms_by_name','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('s_perms_by_name.t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[t_perms_by_name]','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[t_perms_by_name]','OBJECT', 'UPDATE');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.dbo.t_perms_by_name','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].[dbo].[t_perms_by_name]','OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo.[t_perms_by_name]','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.[dbo].[t_perms_by_name]','OBJECT', 'UPDATE', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.[dbo.t_perms_by_name','OBJECT', 'SELECT', '[col1]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo.[t_perms_by_name]','OBJECT', 'SELECT', 'col1]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo.[t_perms_by_name]','OBJECT', 'SELECT', '[col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name]','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('"db_perms_by_name".dbo."t_perms_by_name"','OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name"','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('"t_perms_by_name','OBJECT', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[db_perms_by_name].dbo."t_perms_by_name"', 'OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('db_perms_by_name.."t_perms_by_name"', 'OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('master..t_perms_by_name', 'OBJECT', 'SELECT', '"col1"', 'COLUMN');
+GO
+
+
+
+-- =============== Special handling ================
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'non_existing_sub_securable_class');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'non_existing_column', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'non_existing_permission');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','non_existing_securable_class', 'SELECT');
+GO
+
+SELECT HAS_PERMS_BY_NAME('non_existing_table','OBJECT', 'UPDATE');
+GO
+
+-- test permission type that only exists in SQL Server
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'ALTER');
+GO
+
+-- test permission type that only exists in Postgres
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'TRUNCATE');
+GO
+
+-- test unsupported securable class
+SELECT HAS_PERMS_BY_NAME(db_name(), 'SEARCH PROPERTY LIST', 'CONTROL');
+GO
+
+-- test invalid sub-securable_class
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', 'TABLE');
+GO
+
+-- test invalid securable class for sub-securable_class
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','DATABASE', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col1', NULL);
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', NULL, 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', NULL, 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name', NULL, 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, 'OBJECT', 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'SELECT', 'col1', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('dbo.t_perms_by_name     ','OBJECT    ', 'SELECT   ', 'col2   ', 'COLUMN ');
+GO
+
+SELECT HAS_PERMS_BY_NAME('dBo.t_PeRmS_bY_nAmE','oBjEcT', 'sElEcT', 'CoL2', 'cOlUmN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('  t_perms_by_name','OBJECT', 'SELECT', 'col2', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name',' OBJECT', 'SELECT', 'col2', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', ' SELECT', 'col2', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', ' col2', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col2', ' COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[.t perms.by.name.]', 'OBJECT', 'SELECT')
+GO
+
+SELECT HAS_PERMS_BY_NAME('".t perms.by.name."', 'OBJECT', 'SELECT')
+GO
+
+SELECT HAS_PERMS_BY_NAME('[ t.perms by name ]', 'OBJECT', 'SELECT')
+GO
+
+SELECT HAS_PERMS_BY_NAME('" t.perms by name "', 'OBJECT', 'SELECT')
+GO
+
+SELECT HAS_PERMS_BY_NAME('[.t perms.by.name.]', 'OBJECT', 'SELECT', '".column perms.by.name."', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('".t perms.by.name."', 'OBJECT', 'SELECT', '[.column perms.by.name.]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[.t perms.by.name.]', 'OBJECT', 'ANY', '".column perms.by.name."', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('".t perms.by.name."', 'OBJECT', 'ANY', '[.column perms.by.name.]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[ t.perms by name ]', 'OBJECT', 'SELECT', '" column perms.by.name "', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('" t.perms by name "', 'OBJECT', 'SELECT', '[ column perms.by.name ]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[ t.perms by name ]', 'OBJECT', 'ANY', '" column perms.by.name "', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('" t.perms by name "', 'OBJECT', 'ANY', '[ column perms.by.name ]', 'COLUMN');
+GO
+
+SELECT HAS_PERMS_BY_NAME('[ non.existent.db ].".non existent.schema.".[non .. existent table]', 'OBJECT', 'SELECT', '[. non. existent.column]', 'COLUMN');
+GO
+
+USE master;
+GO
+
+
+
+-- =============== Cleanup ===============
+
+-- tsql
+USE db_perms_by_name;
+GO
+
+DROP PROCEDURE proc_perms_by_name;
+GO
+
+DROP FUNCTION table_function_perms_by_name;
+GO
+
+DROP FUNCTION scalar_function_perms_by_name;
+GO
+
+DROP VIEW IF EXISTS v_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS t_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS s_perms_by_name.t_perms_by_name;
+GO
+
+DROP SCHEMA s_perms_by_name
+GO
+
+DROP TABLE IF EXISTS [.t perms.by.name.];
+GO
+
+DROP TABLE IF EXISTS [ t.perms by name ];
+GO
+
+USE master;
+GO
+
+DROP DATABASE db_perms_by_name;
+GO
+
+DROP LOGIN user_perms_by_name;
+GO
+
+DROP TABLE IF EXISTS t_perms_by_name;
+GO


### PR DESCRIPTION
Support HAS_PERMS_BY_NAME for the following:
- Object types: Tables, Views, Columns, Scalar/Table Functions,
	Procedures, Servers, Databases
- Permissions: SELECT, UPDATE, INSERT, DELETE, REFERENCES, EXECUTE, ANY,
	VIEW SERVER STATE, CREATE TABLE, CREATE SCHEMA

Other object types and permissions will return NULL

Task: BABEL-2323
Signed-off-by: Aaron Congo <aaronc@bitquilltech.com>

### Description

 - Implement HAS_PERMS_BY_NAME to support SSMS functionality
 
### Issues Resolved

- N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).