### PR TITLE
Add view sys.database_mirroring.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1818,3 +1818,29 @@ SELECT  value_in_use AS value,
         END AS status
 FROM sys.babelfish_configurations;
 GRANT SELECT ON sys.sysconfigures TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.database_mirroring
+AS
+SELECT database_id,
+      CAST(NULL AS sys.uniqueidentifier) AS mirroring_guid,
+      CAST(NULL AS sys.tinyint) AS mirroring_state,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_state_desc,
+      CAST(NULL AS sys.tinyint) AS mirroring_role,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_role_desc,
+      CAST(NULL AS int) AS mirroring_role_sequence,
+      CAST(NULL AS sys.tinyint) as mirroring_safety_level,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_safety_level_desc,
+      CAST(NULL AS int) as mirroring_safety_sequence,
+      CAST(NULL AS sys.nvarchar(128)) AS mirroring_partner_name,
+      CAST(NULL AS sys.nvarchar(128)) AS mirroring_partner_instance,
+      CAST(NULL AS sys.nvarchar(128)) AS mirroring_witness_name,
+      CAST(NULL AS sys.tinyint) AS mirroring_witness_state,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_witness_state_desc,
+      CAST(NULL AS numeric(25,0)) AS mirroring_failover_lsn,
+      CAST(NULL AS int) AS mirroring_connection_timeout,
+      CAST(NULL AS int) AS mirroring_redo_queue,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_redo_queue_type,
+      CAST(NULL AS numeric(25,0)) AS mirroring_end_of_log_lsn,
+      CAST(NULL AS numeric(25,0)) AS mirroring_replication_lsn
+FROM sys.databases;
+GRANT SELECT ON sys.database_mirroring TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.2.0--1.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.2.0--1.3.0.sql
@@ -913,6 +913,32 @@ AS $$
     SELECT CAST(CAST(sys.suser_id() AS INT) AS SYS.VARBINARY(85));
 $$
 LANGUAGE SQL IMMUTABLE PARALLEL RESTRICTED;
+
+CREATE OR REPLACE VIEW sys.database_mirroring
+AS
+SELECT database_id,
+      CAST(NULL AS sys.uniqueidentifier) AS mirroring_guid,
+      CAST(NULL AS sys.tinyint) AS mirroring_state,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_state_desc,
+      CAST(NULL AS sys.tinyint) AS mirroring_role,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_role_desc,
+      CAST(NULL AS int) AS mirroring_role_sequence,
+      CAST(NULL AS sys.tinyint) as mirroring_safety_level,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_safety_level_desc,
+      CAST(NULL AS int) as mirroring_safety_sequence,
+      CAST(NULL AS sys.nvarchar(128)) AS mirroring_partner_name,
+      CAST(NULL AS sys.nvarchar(128)) AS mirroring_partner_instance,
+      CAST(NULL AS sys.nvarchar(128)) AS mirroring_witness_name,
+      CAST(NULL AS sys.tinyint) AS mirroring_witness_state,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_witness_state_desc,
+      CAST(NULL AS numeric(25,0)) AS mirroring_failover_lsn,
+      CAST(NULL AS int) AS mirroring_connection_timeout,
+      CAST(NULL AS int) AS mirroring_redo_queue,
+      CAST(NULL AS sys.nvarchar(60)) AS mirroring_redo_queue_type,
+      CAST(NULL AS numeric(25,0)) AS mirroring_end_of_log_lsn,
+      CAST(NULL AS numeric(25,0)) AS mirroring_replication_lsn
+FROM sys.databases;
+GRANT SELECT ON sys.database_mirroring TO PUBLIC;
  
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/sys-database-mirroring.out
+++ b/test/JDBC/expected/sys-database-mirroring.out
@@ -1,0 +1,8 @@
+SELECT * FROM sys.database_mirroring;
+GO
+~~START~~
+smallint#!#uniqueidentifier#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#int#!#tinyint#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#tinyint#!#nvarchar#!#numeric#!#int#!#int#!#nvarchar#!#numeric#!#numeric
+1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+

--- a/test/JDBC/input/views/sys-database-mirroring.sql
+++ b/test/JDBC/input/views/sys-database-mirroring.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.database_mirroring;
+GO


### PR DESCRIPTION
### Description

Adds the stub implementation of sys.database_mirroring. This view will include a row per database with NULL in every field.

Task: BABELFISH-328
Signed-off-by: Sertay Sener <seners@amazon.com>
 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).