### PR TITLE
Add sys.data_spaces.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1818,3 +1818,14 @@ SELECT  value_in_use AS value,
         END AS status
 FROM sys.babelfish_configurations;
 GRANT SELECT ON sys.sysconfigures TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.data_spaces
+AS
+SELECT 
+  CAST('PRIMARY' as SYSNAME) AS name,
+  CAST(0 as INT) AS data_space_id,
+  CAST('FG' as CHAR(2)) AS type,
+  CAST('ROWS_FILEGROUP' as NVARCHAR(60)) AS type_desc,
+  CAST(1 as sys.BIT) AS is_default,
+  CAST(0 as sys.BIT) AS is_system;
+GRANT SELECT ON sys.data_spaces TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.2.0--1.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.2.0--1.3.0.sql
@@ -914,5 +914,16 @@ AS $$
 $$
 LANGUAGE SQL IMMUTABLE PARALLEL RESTRICTED;
  
+CREATE OR REPLACE VIEW sys.data_spaces
+AS
+SELECT 
+  CAST('PRIMARY' as SYSNAME) AS name,
+  CAST(0 as INT) AS data_space_id,
+  CAST('FG' as CHAR(2)) AS type,
+  CAST('ROWS_FILEGROUP' as NVARCHAR(60)) AS type_desc,
+  CAST(1 as sys.BIT) AS is_default,
+  CAST(0 as sys.BIT) AS is_system;
+GRANT SELECT ON sys.data_spaces TO PUBLIC;
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/sys-data_spaces.out
+++ b/test/JDBC/expected/sys-data_spaces.out
@@ -1,0 +1,7 @@
+SELECT * FROM sys.data_spaces;
+GO
+~~START~~
+varchar#!#int#!#char#!#nvarchar#!#bit#!#bit
+PRIMARY#!#0#!#FG#!#ROWS_FILEGROUP#!#1#!#0
+~~END~~
+

--- a/test/JDBC/input/views/sys-data_spaces.sql
+++ b/test/JDBC/input/views/sys-data_spaces.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.data_spaces;
+GO


### PR DESCRIPTION
### Description

Adds the stub implementation of sys.data_spaces.

Task: BABELFISH-345
Signed-off-by: Sertay Sener <seners@amazon.com>
 
### Issues Resolved
N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).