### PR TITLE
Add github action to test Major version upgrade with Babelfish extensions installed

### DIFF
--- a/.github/composite-actions/build-extensions/action.yml
+++ b/.github/composite-actions/build-extensions/action.yml
@@ -1,10 +1,17 @@
 name: 'Build Extensions'
+
+inputs:
+  install_dir:
+    description: 'Engine install directory'
+    required: no
+    default: postgres
+
 runs:
   using: "composite"
   steps:
     - name: Build Extensions
       run: |
-        export PG_CONFIG=~/postgres/bin/pg_config
+        export PG_CONFIG=~/${{inputs.install_dir}}/bin/pg_config
         export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
         export cmake=$(which cmake)
         cd contrib/babelfishpg_money

--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -1,14 +1,24 @@
 name: 'Build Modified Postgres'
 
+inputs:
+  engine_branch:
+    description: 'Engine Branch'
+    required: no
+    default: 'BABEL_2_X_DEV__PG_14_2'
+  install_dir:
+    description: 'Engine install directory'
+    required: no
+    default: postgres
+
 runs:
   using: "composite"
   steps:
     - name: Checkout, Build, and Install the Modified PostgreSQL Instance and Run Tests
       run: |
         cd ..
-        git clone --branch BABEL_2_X_DEV__PG_14_2 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+        git clone --branch ${{inputs.engine_branch}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
         cd postgresql_modified_for_babelfish
-        ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+        ./configure --prefix=$HOME/${{inputs.install_dir}}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         make -j 4 2>error.txt
         make install
         make check

--- a/.github/composite-actions/compile-antlr/action.yml
+++ b/.github/composite-actions/compile-antlr/action.yml
@@ -1,5 +1,11 @@
 name: 'Compile ANTLR'
 
+inputs:
+  install_dir:
+    description: 'Engine install directory'
+    required: no
+    default: postgres
+
 runs:
   using: "composite"
   steps:  
@@ -18,5 +24,5 @@ runs:
         cmake .. -D ANTLR_JAR_LOCATION="/usr/local/lib/antlr-$ANTLR_VERSION-complete.jar" -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
         make -j 4
         sudo make install
-        cp "/usr/local/lib/libantlr4-runtime.so.$ANTLR_VERSION" ~/postgres/lib/
+        cp "/usr/local/lib/libantlr4-runtime.so.$ANTLR_VERSION" ~/${{inputs.install_dir}}/lib/
       shell: bash

--- a/.github/composite-actions/install-extensions/action.yml
+++ b/.github/composite-actions/install-extensions/action.yml
@@ -1,5 +1,15 @@
 name: 'Install Extensions'
 
+inputs:
+  install_dir:
+    description: 'Engine install directory'
+    required: no
+    default: postgres
+  migration_mode:
+    description: 'Database migration mode'
+    required: no
+    default: "single-db"
+
 runs:
   using: "composite"
   steps:
@@ -7,15 +17,15 @@ runs:
       run: |
         cd ~
         export PATH=/opt/mssql-tools/bin:$PATH
-        ~/postgres/bin/initdb -D ~/postgres/data/
-        ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile start
-        cd postgres/data
+        ~/${{inputs.install_dir}}/bin/initdb -D ~/${{inputs.install_dir}}/data/
+        ~/${{inputs.install_dir}}/bin/pg_ctl -D ~/${{inputs.install_dir}}/data/ -l logfile start
+        cd ${{inputs.install_dir}}/data
         sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
         sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
         ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
         sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
-        ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile restart
+        ~/${{inputs.install_dir}}/bin/pg_ctl -D ~/${{inputs.install_dir}}/data/ -l logfile restart
         cd ~/work/babelfish_extensions/babelfish_extensions/
-        sudo ~/postgres/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/create_extension.sql
+        sudo ~/${{inputs.install_dir}}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -f .github/scripts/create_extension.sql
         sqlcmd -S localhost -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
       shell: bash

--- a/.github/scripts/create_extension.sql
+++ b/.github/scripts/create_extension.sql
@@ -7,5 +7,6 @@ CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE;
 GRANT ALL ON SCHEMA sys to :user;
 ALTER USER :user CREATEDB;
 ALTER SYSTEM SET babelfishpg_tsql.database_name = :db;
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = :migration_mode;
 SELECT pg_reload_conf();
 CALL SYS.INITIALIZE_BABELFISH(:'user');

--- a/.github/scripts/post_upgrade.sql
+++ b/.github/scripts/post_upgrade.sql
@@ -1,0 +1,12 @@
+CREATE CAST (pg_catalog.BOOL as sys.BPCHAR)
+WITH FUNCTION pg_catalog.text(pg_catalog.BOOL) AS ASSIGNMENT;
+
+CREATE CAST (pg_catalog.BOOL as sys.VARCHAR)
+WITH FUNCTION pg_catalog.text(pg_catalog.BOOL) AS ASSIGNMENT;
+
+ALTER EXTENSION babelfishpg_common ADD CAST (boolean as sys.bpchar);
+ALTER EXTENSION babelfishpg_common ADD CAST (boolean as sys.varchar);
+
+ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();

--- a/.github/scripts/pre_upgrade.sql
+++ b/.github/scripts/pre_upgrade.sql
@@ -1,0 +1,4 @@
+ALTER EXTENSION babelfishpg_common DROP CAST (boolean as sys.bpchar);
+ALTER EXTENSION babelfishpg_common DROP CAST (boolean as sys.varchar);
+DROP CAST (boolean as sys.bpchar);
+DROP CAST (boolean as sys.varchar);

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -109,13 +109,11 @@ jobs:
         run: |
           cd ~
           ~/${{env.NEW_INSTALL_DIR}}/bin/initdb -D ~/${{env.NEW_INSTALL_DIR}}/data
-          ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data -l logfile14 start
           cd ~/${{env.NEW_INSTALL_DIR}}/data
           sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
           sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
           ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
           sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
-          ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data stop
         shell: bash
 
       - name: Run pg_upgrade
@@ -149,7 +147,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: upgrade-logs
-          path: |
-            ~/upgrade/
-            !~/upgrade/*.custom
+          path: ~/upgrade/*.log
       

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -108,7 +108,7 @@ jobs:
         if: always() && steps.build-extensions-new.outcome == 'success'
         run: |
           echo 'Running pre upgrade script!'
-          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d postgres -U runner -f .github/scripts/pre_upgrade.sql
+          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d jdbc_testdb -U jdbc_user -f .github/scripts/pre_upgrade.sql
           echo 'Starting pg_upgrade'
           cd ~
           mkdir upgrade
@@ -118,13 +118,13 @@ jobs:
           echo $PATH
           export LD_LIBRARY_PATH="$HOME/${{env.NEW_INSTALL_DIR}}/lib:$HOME/${{env.OLD_INSTALL_DIR}}/lib:$LD_LIBRARY_PATH"
           echo $LD_LIBRARY_PATH
-          sudo ~/${{env.NEW_INSTALL_DIR}}/bin/pg_upgrade -U runner -b ~/${{env.OLD_INSTALL_DIR}}/bin -B ~/${{env.NEW_INSTALL_DIR}}/bin \
+          ~/${{env.NEW_INSTALL_DIR}}/bin/pg_upgrade -U runner -b ~/${{env.OLD_INSTALL_DIR}}/bin -B ~/${{env.NEW_INSTALL_DIR}}/bin \
           -d ~/${{env.OLD_INSTALL_DIR}}/data -D ~/${{env.NEW_INSTALL_DIR}}/data -p 5432 -P 5433 -j 4 --links --verbose
           echo 'pg_upgrade completed!'
           cd ~/work/babelfish_extensions/babelfish_extensions/
           echo 'Running post upgrade script!'
           ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data -l ~/${{env.NEW_INSTALL_DIR}}/data/logfile14 start
-          sudo ~/${{env.NEW_INSTALL_DIR}}/bin/psql -d postgres -U runner -f .github/scripts/post_upgrade.sql
+          sudo ~/${{env.NEW_INSTALL_DIR}}/bin/psql -d jdbc_testdb -U jdbc_user -f .github/scripts/post_upgrade.sql
           export PATH=/opt/mssql-tools/bin:$PATH
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
         shell: bash

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -82,10 +82,16 @@ jobs:
       - name: Build Modified Postgres using ${{env.ENGINE_VER_TO}}
         id: build-modified-postgres-new
         if: always() && steps.install-extensions-old.outcome == 'success'
-        uses: ./.github/composite-actions/build-modified-postgres
-        with:
-          engine_branch: ${{env.ENGINE_VER_TO}}
-          install_dir: ${{env.NEW_INSTALL_DIR}}
+        run: |
+          cd ../postgresql_modified_for_babelfish
+          git checkout ${{env.ENGINE_VER_TO}}
+          ./configure --prefix=$HOME/${{env.NEW_INSTALL_DIR}} --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          make clean
+          make -j 4 2>error.txt
+          make install
+          make check
+          cd contrib && make && sudo make install
+        shell: bash
 
       - name: Copy ANTLR
         run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -72,14 +72,14 @@ jobs:
 
       - name: Build Extensions using ${{env.EXTENSION_VER_TO}}
         id: build-extensions-new
-        if: always() && steps.build-modified-postgres-new.outcome = 'success'
+        if: always() && steps.build-modified-postgres-new.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions
         with:
           install_dir: ${{env.NEW_INSTALL_DIR}}
 
       - name: Run pg_upgrade
         id: run-pg_upgrade
-        if: always() && steps.build-extensions-new.outcome = 'success'
+        if: always() && steps.build-extensions-new.outcome == 'success'
         run: |
           echo 'Running pre upgrade script!'
           sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d postgres -U runner -f .github/scripts/pre_upgrade.sql

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -62,13 +62,14 @@ jobs:
         run: |
           cd ~
           export PATH=/opt/mssql-tools/bin:$PATH
-          ~/${{env.OLD_INSTALL_DIR}}/bin/initdb -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 start
+          ~/${{env.OLD_INSTALL_DIR}}/bin/initdb -D ~/${{env.OLD_INSTALL_DIR}}/data
+          ~/${{env.OLD_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 start
           cd ${{env.OLD_INSTALL_DIR}}/data
           sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
           sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
           ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
           sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
-          ~/${{env.OLD_INSTALL_DIR}}/bin/initdb -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 restart
+          ~/${{env.OLD_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 restart
           cd ~/work/babelfish_extensions/babelfish_extensions/
           sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/create_extension.sql
           sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -103,9 +103,22 @@ jobs:
         with:
           install_dir: ${{env.NEW_INSTALL_DIR}}
 
+      - name: Setup new data directory
+        id: setup-new-datadir
+        if: always() && steps.build-extensions-new.outcome == 'success'
+        run: |
+          cd ~
+          ~/${{env.NEW_INSTALL_DIR}}/bin/initdb -D ~/${{env.NEW_INSTALL_DIR}}/data
+          cd ~/${{env.NEW_INSTALL_DIR}}/data
+          sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
+          sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
+          ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
+          sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+        shell: bash
+
       - name: Run pg_upgrade
         id: run-pg_upgrade
-        if: always() && steps.build-extensions-new.outcome == 'success'
+        if: always() && steps.setup-new-datadir.outcome == 'success'
         run: |
           echo 'Running pre upgrade script!'
           sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d jdbc_testdb -U jdbc_user -f .github/scripts/pre_upgrade.sql
@@ -119,7 +132,7 @@ jobs:
           export LD_LIBRARY_PATH="$HOME/${{env.NEW_INSTALL_DIR}}/lib:$HOME/${{env.OLD_INSTALL_DIR}}/lib:$LD_LIBRARY_PATH"
           echo $LD_LIBRARY_PATH
           ~/${{env.NEW_INSTALL_DIR}}/bin/pg_upgrade -U runner -b ~/${{env.OLD_INSTALL_DIR}}/bin -B ~/${{env.NEW_INSTALL_DIR}}/bin \
-          -d ~/${{env.OLD_INSTALL_DIR}}/data -D ~/${{env.NEW_INSTALL_DIR}}/data -p 5432 -P 5433 -j 4 --links --verbose
+          -d ~/${{env.OLD_INSTALL_DIR}}/data -D ~/${{env.NEW_INSTALL_DIR}}/data -p 5432 -P 5433 -j 4 --link --verbose
           echo 'pg_upgrade completed!'
           cd ~/work/babelfish_extensions/babelfish_extensions/
           echo 'Running post upgrade script!'

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -109,11 +109,13 @@ jobs:
         run: |
           cd ~
           ~/${{env.NEW_INSTALL_DIR}}/bin/initdb -D ~/${{env.NEW_INSTALL_DIR}}/data
+          ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data -l logfile14 start
           cd ~/${{env.NEW_INSTALL_DIR}}/data
           sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
           sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
           ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
           sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+          ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data stop
         shell: bash
 
       - name: Run pg_upgrade
@@ -147,5 +149,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: upgrade-logs
-          path: ~/upgrade/*.log
+          path: |
+            ~/upgrade/
+            !~/upgrade/*.custom
       

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -1,0 +1,109 @@
+name: Major Version Upgrade Tests
+on: [push, pull_request]
+
+jobs:
+  run-babelfish-mvu-tests:
+    env:
+      OLD_INSTALL_DIR: postgres13
+      NEW_INSTALL_DIR: postgres14
+      ENGINE_VER_FROM: BABEL_1_X_DEV__PG_13_6
+      EXTENSION_VER_FROM: BABEL_1_X_DEV
+      ENGINE_VER_TO: BABEL_2_X_DEV__PG_14_2
+      EXTENSION_VER_TO: BABEL_2_X_DEV
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        uses: ./.github/composite-actions/install-dependencies
+
+      - name: Build Modified Postgres using ${{env.ENGINE_VER_FROM}}
+        id: build-modified-postgres-old
+        if: always() && steps.install-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_VER_FROM}}
+          install_dir: ${{env.OLD_INSTALL_DIR}}
+      
+      - name: Compile ANTLR
+        id: compile-antlr
+        if: always() && steps.build-modified-postgres-old.outcome == 'success'
+        uses: ./.github/composite-actions/compile-antlr
+        with:
+          install_dir: ${{env.OLD_INSTALL_DIR}}
+
+      - uses: actions/checkout@v2
+        with:
+          repository: babelfish-for-postgresql/babelfish_extensions
+          ref: ${{env.EXTENSION_VER_FROM}}
+      
+      - name: Build Extensions using ${{env.EXTENSION_VER_FROM}}
+        id: build-extensions-old
+        if: always() && steps.compile-antlr.outcome == 'success'
+        uses: ./.github/composite-actions/build-extensions
+        with:
+          install_dir: ${{env.OLD_INSTALL_DIR}}
+      
+      - name: Install Extensions using ${{env.EXTENSION_VER_FROM}}
+        id: install-extensions-old
+        if: always() && steps.build-extensions-old.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
+        with:
+          install_dir: ${{env.OLD_INSTALL_DIR}}
+          migration_mode: "multi-db"
+
+      - name: Build Modified Postgres using ${{env.ENGINE_VER_TO}}
+        id: build-modified-postgres-new
+        if: always() && steps.install-extensions-old.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_VER_TO}}
+          install_dir: ${{env.NEW_INSTALL_DIR}}
+
+      - uses: actions/checkout@v2
+        with:
+          repository: babelfish-for-postgresql/babelfish_extensions
+          ref: ${{env.EXTENSION_VER_TO}}
+
+      - run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/
+
+      - name: Build Extensions using ${{env.EXTENSION_VER_TO}}
+        id: build-extensions-new
+        if: always() && steps.build-modified-postgres-new.outcome = 'success'
+        uses: ./.github/composite-actions/build-extensions
+        with:
+          install_dir: ${{env.NEW_INSTALL_DIR}}
+
+      - name: Run pg_upgrade
+        id: run-pg_upgrade
+        if: always() && steps.build-extensions-new.outcome = 'success'
+        run: |
+          echo 'Running pre upgrade script!'
+          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d postgres -U runner -f .github/scripts/pre_upgrade.sql
+          echo 'Starting pg_upgrade'
+          cd ~
+          mkdir upgrade
+          cd upgrade
+          ~/${{env.OLD_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.OLD_INSTALL_DIR}}/data stop
+          export PATH="$HOME/${{env.NEW_INSTALL_DIR}}/bin:$HOME/${{env.OLD_INSTALL_DIR}}/bin:$PATH"
+          echo $PATH
+          export LD_LIBRARY_PATH="$HOME/${{env.NEW_INSTALL_DIR}}/lib:$HOME/${{env.OLD_INSTALL_DIR}}/lib:$LD_LIBRARY_PATH"
+          echo $LD_LIBRARY_PATH
+          sudo ~/${{env.NEW_INSTALL_DIR}}/bin/pg_upgrade -U runner -b ~/${{env.OLD_INSTALL_DIR}}/bin -B ~/${{env.NEW_INSTALL_DIR}}/bin \
+          -d ~/${{env.OLD_INSTALL_DIR}}/data -D ~/${{env.NEW_INSTALL_DIR}}/data -p 5432 -P 5433 -j 4 --links --verbose
+          echo 'pg_upgrade completed!'
+          cd ~/work/babelfish_extensions/babelfish_extensions/
+          echo 'Running post upgrade script!'
+          ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data -l ~/${{env.NEW_INSTALL_DIR}}/data/logfile14 start
+          sudo ~/${{env.NEW_INSTALL_DIR}}/bin/psql -d postgres -U runner -f .github/scripts/post_upgrade.sql
+      
+      - name: Upload upgrade Log
+        if: always() && steps.run-pg_upgrade.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: upgrade-logs
+          path: ~/upgrade/*.log
+      

--- a/.github/workflows/mvu-tests.yml
+++ b/.github/workflows/mvu-tests.yml
@@ -43,17 +43,40 @@ jobs:
       - name: Build Extensions using ${{env.EXTENSION_VER_FROM}}
         id: build-extensions-old
         if: always() && steps.compile-antlr.outcome == 'success'
-        uses: ./.github/composite-actions/build-extensions
-        with:
-          install_dir: ${{env.OLD_INSTALL_DIR}}
+        run: |
+          export PG_CONFIG=~/${{env.OLD_INSTALL_DIR}}/bin/pg_config
+          export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
+          export cmake=$(which cmake)
+          cd contrib/babelfishpg_money
+          make && make install
+          cd ../babelfishpg_common
+          make && make install
+          cd ../babelfishpg_tds
+          make && make install
+          cd ../babelfishpg_tsql
+          make && make install
       
       - name: Install Extensions using ${{env.EXTENSION_VER_FROM}}
         id: install-extensions-old
         if: always() && steps.build-extensions-old.outcome == 'success'
-        uses: ./.github/composite-actions/install-extensions
-        with:
-          install_dir: ${{env.OLD_INSTALL_DIR}}
-          migration_mode: "multi-db"
+        run: |
+          cd ~
+          export PATH=/opt/mssql-tools/bin:$PATH
+          ~/${{env.OLD_INSTALL_DIR}}/bin/initdb -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 start
+          cd ${{env.OLD_INSTALL_DIR}}/data
+          sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
+          sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
+          ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
+          sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+          ~/${{env.OLD_INSTALL_DIR}}/bin/initdb -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 restart
+          cd ~/work/babelfish_extensions/babelfish_extensions/
+          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/create_extension.sql
+          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
+          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
+          sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
+        shell: bash
+
+      - uses: actions/checkout@v2
 
       - name: Build Modified Postgres using ${{env.ENGINE_VER_TO}}
         id: build-modified-postgres-new
@@ -63,12 +86,8 @@ jobs:
           engine_branch: ${{env.ENGINE_VER_TO}}
           install_dir: ${{env.NEW_INSTALL_DIR}}
 
-      - uses: actions/checkout@v2
-        with:
-          repository: babelfish-for-postgresql/babelfish_extensions
-          ref: ${{env.EXTENSION_VER_TO}}
-
-      - run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/
+      - name: Copy ANTLR
+        run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/
 
       - name: Build Extensions using ${{env.EXTENSION_VER_TO}}
         id: build-extensions-new
@@ -99,6 +118,9 @@ jobs:
           echo 'Running post upgrade script!'
           ~/${{env.NEW_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.NEW_INSTALL_DIR}}/data -l ~/${{env.NEW_INSTALL_DIR}}/data/logfile14 start
           sudo ~/${{env.NEW_INSTALL_DIR}}/bin/psql -d postgres -U runner -f .github/scripts/post_upgrade.sql
+          export PATH=/opt/mssql-tools/bin:$PATH
+          sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
+        shell: bash
       
       - name: Upload upgrade Log
         if: always() && steps.run-pg_upgrade.outcome == 'failure'


### PR DESCRIPTION
This commit adds github action to test major version upgrade with
Babelfish. The action does the following:
1. Builds postgres engine v13.6 and installs it at `~/postgres13`.
2. Builds and installs the babelfish extensions corresponding to
BABEL_1_X_DEV at `~/postgres13`.
3. Initializes the babelfish database.
4. Builds postgres engine v14.2 and installs it at `~/postgres14`.
5. Builds and installs the babelfish extensions corresponding to
BABEL_2_X_DEV at `~/postgres14`.
6. Runs pre_upgrade script.
7. Runs pg_upgrade.
8. Runs post_upgrade script.
9. Uploads upgrade artifacts if pg_upgrade fails.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).