### PR TITLE
An error when executing select func leads to internal error "InstrStartNode called twice in a row"

### DIFF
--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1104,6 +1104,9 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 	SimpleEcontextStackEntry *volatile topEntry = simple_econtext_stack;
 	bool support_tsql_trans = pltsql_support_tsql_transactions();
 	uint32 before_tran_count = NestedTranCount;
+	bool ro_func = (estate->func->fn_prokind == PROKIND_FUNCTION) &&
+		(estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER) &&
+		(strcmp(estate->func->fn_signature, "inline_code_block") != 0);
 
 	PG_TRY();
 	{
@@ -1132,8 +1135,12 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		 * We do not start savepoint for batch commands as
 		 * error handling must be taken care of at statement
 		 * level
+		 * For RO functions start savepoint even when transaction
+		 * is not active to retain top level portals. A transaction
+		 * rollback will cleanup portal data which can lead to
+		 * problems when control returns back to portal level
 		 */
-		if ((!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive()))
+		if (!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && (IsTransactionBlockActive() || ro_func))
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);
@@ -1158,8 +1165,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			elog(DEBUG5, "TSQL TXN Release internal savepoint");
 			ReleaseCurrentSubTransaction();
 			MemoryContextSwitchTo(cur_ctxt);
-			if (!support_tsql_trans)
-				CurrentResourceOwner = oldowner;
+			CurrentResourceOwner = oldowner;
 		}
 
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
@@ -1236,6 +1242,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			/* Rollback internal savepoint if it is current savepoint */
 			RollbackAndReleaseCurrentSubTransaction();
 			MemoryContextSwitchTo(cur_ctxt);
+			CurrentResourceOwner = oldowner;
 		}
 		else if (!IsTransactionBlockActive())
 		{
@@ -1282,16 +1289,6 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		}
 
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
-
-		/*
-		 * In case of error, cleanup all snapshots.
-		 * It is expected that next command will establish
-		 * required new snapshot
-		 */
-		while (ActiveSnapshotSet())
-			PopActiveSnapshot();
-		if (pltsql_snapshot_portal != NULL)
-			pltsql_snapshot_portal->portalSnapshot = NULL;
 
 		handle_error(estate, stmt, edata, topEntry, terminate_batch);
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9479,6 +9479,9 @@ pltsql_xact_cb(XactEvent event, void *arg)
 		simple_econtext_stack = NULL;
 		shared_simple_eval_estate = NULL;
 	}
+	/* Reset portal snapshot in case of commit/rollback */
+	if (pltsql_snapshot_portal != NULL)
+		pltsql_snapshot_portal->portalSnapshot = NULL;
 	AbortCurTransaction = false;
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3410,6 +3410,7 @@ static void terminate_batch(bool send_error, bool compile_error)
 				 */
 				while (ActiveSnapshotSet())
 					PopActiveSnapshot();
+				pltsql_snapshot_portal->portalSnapshot = NULL;
 			}
 			MarkPortalDone(pltsql_snapshot_portal);
 			PortalDrop(pltsql_snapshot_portal, false);

--- a/test/JDBC/expected/BABEL-3101.out
+++ b/test/JDBC/expected/BABEL-3101.out
@@ -1,0 +1,133 @@
+CREATE FUNCTION  f_3101()
+RETURNS NVARCHAR(255)
+AS
+begin
+	DECLARE @n NVARCHAR(255)
+	SELECT @n = QUOTENAME(name) FROM sys.tables
+	RETURN @n
+end
+GO
+
+select f_3101()
+GO
+~~START~~
+nvarchar
+<NULL>
+~~ERROR (Code: 206)~~
+
+~~ERROR (Message: The function quotename is found but cannot be used. Possibly due to datatype mismatch and implicit casting is not allowed.)~~
+
+
+
+
+
+
+
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+			INSERT INTO @returnList SELECT @name
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+		INSERT INTO @returnList SELECT @stringToSplit
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+~~START~~
+nvarchar
+this
+is
+split
+~~END~~
+
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+~~START~~
+tinyint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function date_part(unknown, text) does not exist)~~
+
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+~~START~~
+int
+0
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+
+DROP FUNCTION f_3101
+GO
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/input/BABEL-3101.sql
+++ b/test/JDBC/input/BABEL-3101.sql
@@ -1,0 +1,106 @@
+CREATE FUNCTION  f_3101()
+RETURNS NVARCHAR(255)
+AS
+begin
+	DECLARE @n NVARCHAR(255)
+	SELECT @n = QUOTENAME(name) FROM sys.tables
+	RETURN @n
+end
+GO
+
+select f_3101()
+GO
+
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+
+			INSERT INTO @returnList SELECT @name
+
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+
+		INSERT INTO @returnList SELECT @stringToSplit
+
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+
+DROP FUNCTION f_3101
+GO
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO


### PR DESCRIPTION


A select function call will run function inside a SELECT portal.
If the function throws an error, TSQL error handling will rollback
the internal PG transaction to support undo behavior. The rollback
will cleanup all active portals assuming PG semantic for transactions.

As portal is still active at higher level, this can result in
unpredictable behavior including above error and server crash.

We solve this issue by always running a TSQL function inside an internal
savepoint. We rely on the fact that TSQL functions cannot have side
effects like data write, transaction etc. In case of an error, rollback
to savepoint takes care of statement undo without effecting portals
active at higher level.

Task : BABEL-3101
Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).