### PR TITLE
Specify antlr4-python3-runtime package version in isolation test workflow

### DIFF
--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -49,7 +49,7 @@ jobs:
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           cd ~/work/babelfish_extensions/babelfish_extensions/test/python
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
-          pip3 install pyodbc pymssql pytest pytest-xdist antlr4-python3-runtime
+          pip3 install pyodbc pymssql pytest pytest-xdist antlr4-python3-runtime==4.9.3
       
       - name: Generate .spec file parser
         run: |


### PR DESCRIPTION
Previously, the Isolation test workflow was failing because it was
implicitly  installing the latest version 4.10 of the antlr4-python3-runtime
package, which was not compatible with antlr 4.9.3.

This commits fixes this by specifying the version in the isolation
test workflow configuration.

Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).