### PR TITLE
Fix minor-version-upgrade github action

### DIFF
--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -98,9 +98,6 @@ jobs:
           cd contrib && make && sudo make install
 
       - uses: actions/checkout@v2
-        with:
-          repository: babelfish-for-postgresql/babelfish_extensions
-          ref: ${{env.EXTENSION_VER_TO}}
 
       - name: Set env variables and build extensions using ${{env.EXTENSION_VER_TO}}
         id: build-extensions-newer


### PR DESCRIPTION
While building the new extensions binary, we were checking out the
EXTENSION_VER_TO. Because of that, the changes introduced in the PR were
not visible. Fixed the same.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).