### PR TITLE
Support for OPENJSON in Babelfish

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1982,7 +1982,7 @@ AS
 $BODY$
 SELECT  key,
         CASE json_typeof(value) WHEN 'null'     THEN NULL
-                                ELSE            value
+                                ELSE            TRIM (BOTH '"' FROM value::TEXT)
         END,
         CASE json_typeof(value) WHEN 'null'     THEN 0
                                 WHEN 'string'   THEN 1
@@ -2006,7 +2006,7 @@ AS
 $BODY$
 SELECT  (row_number() over ())-1,
         CASE json_typeof(value) WHEN 'null'     THEN NULL
-                                ELSE            value
+                                ELSE            TRIM (BOTH '"' FROM value::TEXT)
         END,
         CASE json_typeof(value) WHEN 'null'     THEN 0
                                 WHEN 'string'   THEN 1

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1971,6 +1971,79 @@ CREATE OR REPLACE FUNCTION sys.json_query(json_string text, path text default '$
 RETURNS sys.NVARCHAR
 AS 'babelfishpg_tsql', 'tsql_json_query' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION sys.openjson_object(json_string text)
+RETURNS TABLE
+(
+    key sys.NVARCHAR(4000),
+    value sys.NVARCHAR,
+    type INTEGER
+)
+AS
+$BODY$
+SELECT  key,
+        CASE json_typeof(value) WHEN 'null'     THEN NULL
+                                ELSE            value
+        END,
+        CASE json_typeof(value) WHEN 'null'     THEN 0
+                                WHEN 'string'   THEN 1
+                                WHEN 'number'   THEN 2
+                                WHEN 'boolean'  THEN 3
+                                WHEN 'array'    THEN 4
+                                WHEN 'object'   THEN 5
+        END
+    FROM json_each(json_string::JSON)
+$BODY$
+LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sys.openjson_array(json_string text)
+RETURNS TABLE
+(
+    key sys.NVARCHAR(4000),
+    value sys.NVARCHAR,
+    type INTEGER
+)
+AS
+$BODY$
+SELECT  (row_number() over ())-1,
+        CASE json_typeof(value) WHEN 'null'     THEN NULL
+                                ELSE            value
+        END,
+        CASE json_typeof(value) WHEN 'null'     THEN 0
+                                WHEN 'string'   THEN 1
+                                WHEN 'number'   THEN 2
+                                WHEN 'boolean'  THEN 3
+                                WHEN 'array'    THEN 4
+                                WHEN 'object'   THEN 5
+        END
+    FROM json_array_elements(json_string::JSON) AS value
+$BODY$
+LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sys.openjson_simple(json_string text, path text default '$')
+RETURNS TABLE
+(
+    key sys.NVARCHAR(4000),
+    value sys.NVARCHAR,
+    type INTEGER
+)
+AS
+$BODY$
+DECLARE
+    sub_json text := sys.json_query(json_string, path);
+BEGIN
+    IF json_typeof(sub_json::JSON) = 'array' THEN
+        RETURN QUERY SELECT * FROM sys.openjson_array(sub_json);
+    ELSE
+        RETURN QUERY SELECT * FROM sys.openjson_object(sub_json);
+    END IF;
+END;
+$BODY$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sys.openjson_with(json_string text, path text, VARIADIC column_paths text[])
+RETURNS SETOF RECORD
+AS 'babelfishpg_tsql', 'tsql_openjson_with' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION sys.sp_datatype_info_helper(
     IN odbcVer smallint,
     IN is_100 bool,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1401,7 +1401,7 @@ AS
 $BODY$
 SELECT  key, 
         CASE json_typeof(value) WHEN 'null'     THEN NULL
-                                ELSE            value
+                                ELSE            TRIM (BOTH '"' FROM value::TEXT)
         END,
         CASE json_typeof(value) WHEN 'null'     THEN 0
                                 WHEN 'string'   THEN 1
@@ -1425,7 +1425,7 @@ AS
 $BODY$
 SELECT  (row_number() over ())-1, 
         CASE json_typeof(value) WHEN 'null'     THEN NULL
-                                ELSE            value
+                                ELSE            TRIM (BOTH '"' FROM value::TEXT)
         END,
         CASE json_typeof(value) WHEN 'null'     THEN 0
                                 WHEN 'string'   THEN 1

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1389,5 +1389,79 @@ CALL sys.babelfish_drop_deprecated_view('sys', 'server_principals_deprecated');
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);
 
+-- OPENJSON functions
+CREATE OR REPLACE FUNCTION sys.openjson_object(json_string text)
+RETURNS TABLE 
+(
+    key sys.NVARCHAR(4000),
+    value sys.NVARCHAR,
+    type INTEGER
+)
+AS 
+$BODY$
+SELECT  key, 
+        CASE json_typeof(value) WHEN 'null'     THEN NULL
+                                ELSE            value
+        END,
+        CASE json_typeof(value) WHEN 'null'     THEN 0
+                                WHEN 'string'   THEN 1
+                                WHEN 'number'   THEN 2
+                                WHEN 'boolean'  THEN 3
+                                WHEN 'array'    THEN 4
+                                WHEN 'object'   THEN 5
+        END
+    FROM json_each(json_string::JSON)
+$BODY$
+LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sys.openjson_array(json_string text)
+RETURNS TABLE 
+(
+    key sys.NVARCHAR(4000),
+    value sys.NVARCHAR,
+    type INTEGER
+)
+AS 
+$BODY$
+SELECT  (row_number() over ())-1, 
+        CASE json_typeof(value) WHEN 'null'     THEN NULL
+                                ELSE            value
+        END,
+        CASE json_typeof(value) WHEN 'null'     THEN 0
+                                WHEN 'string'   THEN 1
+                                WHEN 'number'   THEN 2
+                                WHEN 'boolean'  THEN 3
+                                WHEN 'array'    THEN 4
+                                WHEN 'object'   THEN 5
+        END
+    FROM json_array_elements(json_string::JSON) AS value
+$BODY$
+LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sys.openjson_simple(json_string text, path text default '$')
+RETURNS TABLE 
+(
+    key sys.NVARCHAR(4000),
+    value sys.NVARCHAR,
+    type INTEGER
+)
+AS
+$BODY$
+DECLARE
+    sub_json text := sys.json_query(json_string, path);
+BEGIN
+    IF json_typeof(sub_json::JSON) = 'array' THEN
+        RETURN QUERY SELECT * FROM sys.openjson_array(sub_json);
+    ELSE
+        RETURN QUERY SELECT * FROM sys.openjson_object(sub_json);
+    END IF;
+END;
+$BODY$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sys.openjson_with(json_string text, path text, VARIADIC column_paths text[])
+RETURNS SETOF RECORD
+AS 'babelfishpg_tsql', 'tsql_openjson_with' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+ 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <strstream>
@@ -735,6 +736,134 @@ public:
 													 std::make_pair(::getFullText(exec), "EXECUTE")));
 			}
 		}
+	}
+
+	void exitOpen_json(TSqlParser::Open_jsonContext *ctx) override
+	{
+		if (!ctx->WITH())
+		{
+			/* Map to openjson_simple() */
+			rewritten_query_fragment.emplace(std::make_pair(ctx->getStart()->getStartIndex(),
+											 std::make_pair(ctx->getStart()->getText(), "OPENJSON_SIMPLE")));
+		}
+		else
+		{
+			std::string expr,
+						col_str,
+						col_name,
+						col_type,
+						col_path,
+						col_info,
+						token,
+						with_clause;
+			std::vector<std::string> 	col_defs;
+			/* Map to openjson_with */
+			rewritten_query_fragment.emplace(std::make_pair(ctx->getStart()->getStartIndex(),
+											 std::make_pair(ctx->getStart()->getText(), "OPENJSON_WITH")));
+			/* build the rest of the statement after the JSON or PATH expressions. This is to conform to the parameters expected
+			 * by OPENJSON_WITH(json_expr, json_path, [column_definition_list]). For example, this expression:
+			 *
+			 * select * from openjson(@json, '$.obj') WITH
+			 * 		(
+			 *			a varchar(20),
+			 *			b_col varchar(20) '$.b',
+			 *			o nvarchar(max) '$' AS JSON
+			 *		)
+			 *
+			 * would be rewritten as:
+			 *
+			 * select * from openjson_with(@json, '$.obj', '$.a varchar(20)', '$.b varchar(20)', '$ nvarchar AS JSON') AS
+			 *		f(
+			 *			a varchar(20),
+			 *			b_col varchar(20),
+			 *			o nvarchar
+			 *		)
+			 */
+			if (!ctx->COMMA()) /* check for PATH parameter */
+				expr = ",'$'";
+			/* extract column definitions */
+			for (TSqlParser::Json_column_declarationContext *column : ctx->json_declaration()->json_column_declaration())
+			{
+				col_str = ::getFullText(column);
+				/* split col_str by whitespace */
+				std::istringstream buffer(col_str);
+				std::vector<std::string> col_tokens{std::istream_iterator<std::string>(buffer),
+									std::istream_iterator<std::string>()};
+				col_name = "";
+				col_type = "";
+				col_path = "";
+				for (uint i = 0; i < col_tokens.size(); i++)
+				{
+					token = col_tokens[i];
+					if (col_name == "")
+					{
+						col_name = token;
+						/* handle space-separated column names */
+						if (col_name.size() > 0 && col_name.front() == '[')
+						{
+							while (col_name.back() != ']' && i < col_tokens.size() - 1)
+							{
+								col_name += " " + col_tokens[++i];
+							}
+						}
+						if (col_name.size() > 0 && col_name.front() == '"')
+						{
+							while (col_name.back() != '"' && i < col_tokens.size() - 1)
+							{
+								col_name += " " + col_tokens[++i];
+							}
+						}
+					}
+					else if (col_type == "")
+						col_type = token;
+					else if (col_path == "")
+					{
+						/* check if path param was skipped */
+						if (pg_strcasecmp(token.c_str(), "as") == 0)
+							break;
+						col_path = token;
+						/* check for lax/strict and add the rest of the path parameter */
+						if (col_path.compare("'lax") == 0 || col_path.compare("'strict") == 0)
+						{
+							col_path += " " + col_tokens[++i];
+						}
+					}
+				}
+				/* PG cannot handle varchar(max) or nvarchar(max) so just remove the (max) part */
+				if (col_type.length() > 5 && pg_strcasecmp(col_type.substr(col_type.length() - 5).c_str(), "(max)") == 0)
+					col_type.erase(col_type.length() - 5);
+				/* if path is not defined, use col_name as default path */
+				if (col_path == "")
+					col_path = "'$." + col_name + "'";
+				/* Add path and type to main expr and save column definition in list */
+				col_path.pop_back();
+				col_info = col_path + " " + col_type + (column->AS() && column->JSON() ? " AS JSON" : "") + "'";
+				expr += "," + col_info;
+				col_defs.push_back(col_name + " " + col_type);
+			}
+			expr += ") AS f(";
+			/* add AS clause with column definitions */
+			for (auto & col_def : col_defs)
+			{
+				expr += col_def + std::string(",");
+			}
+			if (expr.back() == ',')
+				expr.pop_back();
+			expr += std::string(")");
+			/* replace end of OPENJSON statement with new column definition arguments */
+			rewritten_query_fragment.emplace(std::make_pair(ctx->RR_BRACKET(0)->getSymbol()->getStartIndex(),
+											 std::make_pair(ctx->RR_BRACKET(0)->getText(), expr)));
+			/* remove with clause */
+			rewritten_query_fragment.emplace(std::make_pair(ctx->WITH()->getSymbol()->getStartIndex(),
+											 std::make_pair(::getFullText(ctx->WITH()), "")));
+			rewritten_query_fragment.emplace(std::make_pair(ctx->LR_BRACKET(1)->getSymbol()->getStartIndex(),
+											 std::make_pair(ctx->LR_BRACKET(1)->getText(), "")));
+			rewritten_query_fragment.emplace(std::make_pair((ctx->json_declaration()->getStart()->getStartIndex()),
+											 std::make_pair(::getFullText(ctx->json_declaration()), "")));
+			rewritten_query_fragment.emplace(std::make_pair(ctx->RR_BRACKET().back()->getSymbol()->getStartIndex(),
+											 std::make_pair(ctx->RR_BRACKET().back()->getText(), "")));
+		}
+
 	}
 };
 

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -175,7 +175,12 @@ protected:
 		// functions and expression
 		antlrcpp::Any visitFunction_call(TSqlParser::Function_callContext *ctx) override;
 		antlrcpp::Any visitAggregate_windowed_function(TSqlParser::Aggregate_windowed_functionContext *ctx) override;
-		antlrcpp::Any visitRowset_function(TSqlParser::Rowset_functionContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_ROWSET_FUNCTION, "rowset function", getLineAndPos(ctx)); return visitChildren(ctx); }
+		antlrcpp::Any visitRowset_function(TSqlParser::Rowset_functionContext *ctx) override {
+			if (!ctx->open_json()) {
+				handle(INSTR_UNSUPPORTED_TSQL_ROWSET_FUNCTION, "rowset function", getLineAndPos(ctx));
+			}
+			return visitChildren(ctx);
+		}
 		antlrcpp::Any visitTrigger_column_updated(TSqlParser::Trigger_column_updatedContext *ctx) override; // UPDATE() in trigger
 		antlrcpp::Any visitFreetext_function(TSqlParser::Freetext_functionContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_FREETEXT, "FREETEXT", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitOdbc_scalar_function(TSqlParser::Odbc_scalar_functionContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_ODBC_SCALAR_FUNCTION, "ODBC scalar functions", getLineAndPos(ctx)); return visitChildren(ctx); }

--- a/test/JDBC/expected/BABEL-OPENJSON.out
+++ b/test/JDBC/expected/BABEL-OPENJSON.out
@@ -7,7 +7,7 @@ go
 ~~START~~
 nvarchar#!#nvarchar#!#int
 a#!#<NULL>#!#0
-b#!#"a"#!#1
+b#!#a#!#1
 c#!#1#!#2
 d#!#true#!#3
 e#!#[1, 2]#!#4
@@ -31,7 +31,7 @@ nvarchar#!#nvarchar#!#int
 Null_value#!#<NULL>#!#0
 Array_value#!#["a", "r", "r", "a", "y"]#!#4
 Object_value#!#{"obj": "ect"}#!#5
-String_value#!#"John"#!#1
+String_value#!#John#!#1
 BooleanTrue_value#!#true#!#3
 BooleanFalse_value#!#false#!#3
 DoublePrecisionFloatingPoint_value#!#45#!#2
@@ -42,11 +42,11 @@ SELECT [key], value FROM OPENJSON(N'{"path":{"to":{"sub-object":["en-GB", "en-UK
 go
 ~~START~~
 nvarchar#!#nvarchar
-0#!#"en-GB"
-1#!#"en-UK"
-2#!#"de-AT"
-3#!#"es-AR"
-4#!#"sr-Cyrl"
+0#!#en-GB
+1#!#en-UK
+2#!#de-AT
+3#!#es-AR
+4#!#sr-Cyrl
 ~~END~~
 
 -- check that value is an object
@@ -78,7 +78,7 @@ select * from openjson(N'{"nonascii":"ちょまど@初詣おみくじ凶\n - des
 go
 ~~START~~
 nvarchar#!#nvarchar#!#int
-nonascii#!#"ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n"#!#1
+nonascii#!#ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-OPENJSON.out
+++ b/test/JDBC/expected/BABEL-OPENJSON.out
@@ -1,0 +1,304 @@
+
+
+-- OPENJSON()
+-- OPENJSON without WITH clause
+select * from OPENJSON(N'{"a":null,"b":"a","c":1,"d":true,"e":[1,2],"f":{"name":"John"}}');
+go
+~~START~~
+nvarchar#!#nvarchar#!#int
+a#!#<NULL>#!#0
+b#!#"a"#!#1
+c#!#1#!#2
+d#!#true#!#3
+e#!#[1, 2]#!#4
+f#!#{"name": "John"}#!#5
+~~END~~
+
+DECLARE @jsonvar NVARCHAR(2048) = N'{
+   "String_value": "John",
+   "DoublePrecisionFloatingPoint_value": 45,
+   "DoublePrecisionFloatingPoint_value": 2.3456,
+   "BooleanTrue_value": true,
+   "BooleanFalse_value": false,
+   "Null_value": null,
+   "Array_value": ["a","r","r","a","y"],
+   "Object_value": {"obj":"ect"}
+}';
+SELECT * FROM OpenJson(@jsonvar);
+go
+~~START~~
+nvarchar#!#nvarchar#!#int
+Null_value#!#<NULL>#!#0
+Array_value#!#["a", "r", "r", "a", "y"]#!#4
+Object_value#!#{"obj": "ect"}#!#5
+String_value#!#"John"#!#1
+BooleanTrue_value#!#true#!#3
+BooleanFalse_value#!#false#!#3
+DoublePrecisionFloatingPoint_value#!#45#!#2
+DoublePrecisionFloatingPoint_value#!#2.3456#!#2
+~~END~~
+
+SELECT [key], value FROM OPENJSON(N'{"path":{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}','$.path.to."sub-object"');
+go
+~~START~~
+nvarchar#!#nvarchar
+0#!#"en-GB"
+1#!#"en-UK"
+2#!#"de-AT"
+3#!#"es-AR"
+4#!#"sr-Cyrl"
+~~END~~
+
+-- check that value is an object
+select * from openjson(N'{"a":1}', 'strict $.a')
+GO
+~~START~~
+nvarchar#!#nvarchar#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Object or array cannot be found in the specified JSON path.)~~
+
+-- check lax/strict path
+select * from openjson(N'{"obj":{"a":1}}', 'lax $.a')
+go
+~~START~~
+nvarchar#!#nvarchar#!#int
+~~END~~
+
+select * from openjson(N'{"obj":{"a":1}}', 'strict $.a')
+go
+~~START~~
+nvarchar#!#nvarchar#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "a")~~
+
+-- check non-ascii characters
+select * from openjson(N'{"nonascii":"ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n"}')
+go
+~~START~~
+nvarchar#!#nvarchar#!#int
+nonascii#!#"ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n"#!#1
+~~END~~
+
+
+-- OPENJSON with WITH clause
+DECLARE @json NVARCHAR(MAX) = N'{"obj":{"a":1}}'
+DECLARE @path NVARCHAR(MAX) = N'$.obj'
+SELECT * FROM OPENJSON(@json, @path) with (a nvarchar(20))
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+-- invalid json input
+SELECT * FROM OPENJSON(N'{"a"') with (a nvarchar(20))
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type json)~~
+
+-- test cases with invalid path params
+select * from openjson(N'{"a":1}', 'strict $.a') with (a nvarchar(20))
+go
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Value referenced by JSON path is not an array or object and cannot be opened with OPENJSON.)~~
+
+select * from openjson(N'{"a":1}', '$.a') with (a nvarchar(20))
+go
+~~START~~
+nvarchar
+~~END~~
+
+-- test array with WITH clause
+select * from openjson(N'[1,2,3,4,null]') WITH (a_col varchar(20) '$');
+GO
+~~START~~
+varchar
+1
+2
+3
+4
+<NULL>
+~~END~~
+
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},{"a":2}]';
+SELECT * FROM OPENJSON(@json) with (name nvarchar(max) '$.a');
+GO
+~~START~~
+nvarchar
+1
+2
+~~END~~
+
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},{"a":2}]';
+SELECT * FROM OPENJSON(@json, '$[0]') with (name nvarchar(max) '$.a');
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+-- test case where with clause is split into multiple lines
+select * from openjson(N'{"a":1}') with (
+  a integer
+);
+GO
+~~START~~
+int
+1
+~~END~~
+
+-- test output truncation
+select * from openjson(N'{"a":"long string"}') with (a nvarchar(5));
+GO
+~~START~~
+nvarchar
+long 
+~~END~~
+
+select * from openjson(N'{"a":123456}') with (a nvarchar(5));
+GO
+~~START~~
+nvarchar
+12345
+~~END~~
+
+select * from openjson(N'{"a":null}') with (a nvarchar(2)); -- should return NULL
+go
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+-- AS JSON
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},[1,2],"a"]';
+SELECT * FROM OPENJSON(@json, '$') with (name nvarchar(max) '$' AS JSON);
+GO
+~~START~~
+nvarchar
+{"a": 1}
+[1, 2]
+<NULL>
+~~END~~
+
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},[1,2],"a"]';
+SELECT * FROM OPENJSON(@json) with (name nvarchar(max) '$');
+GO
+~~START~~
+nvarchar
+<NULL>
+<NULL>
+a
+~~END~~
+
+-- Test invalid column type with AS JSON
+SELECT * FROM OPENJSON(N'{"a":1}') WITH (obj nvarchar(20) '$' AS JSON);
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: AS JSON in WITH clause can only be specified for column of type nvarchar(max))~~
+
+-- TODO fix case with no length specification
+SELECT * from OPENJSON(N'{"a":1}') with (obj nvarchar '$' AS JSON);
+GO
+~~START~~
+nvarchar
+{"a": 1}
+~~END~~
+
+-- check lax/strict path
+DECLARE @json NVARCHAR(MAX) = N'{"obj":{"a":1}}'
+DECLARE @path NVARCHAR(MAX) = N'$.obj'
+SELECT * FROM OPENJSON(@json, @path) with (a nvarchar(20), b nvarchar(20) 'lax $.b')
+GO
+~~START~~
+nvarchar#!#nvarchar
+1#!#<NULL>
+~~END~~
+
+DECLARE @json NVARCHAR(MAX) = N'{"obj":{"a":1}}'
+DECLARE @path NVARCHAR(MAX) = N'$.obj'
+SELECT * FROM OPENJSON(@json, @path) with (a nvarchar(20), b nvarchar(20) 'strict $.b')
+GO
+~~START~~
+nvarchar#!#nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "b")~~
+
+-- check non-ascii characters
+select * from openjson(N'{"nonascii":"ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n"}') with 
+(
+  nonascii nvarchar(max)
+)
+go
+~~START~~
+nvarchar
+ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n
+~~END~~
+
+-- check 2-byte characters
+select * from openjson(N'{"a":"հձղճմ"}') with (a nvarchar(3));
+go
+~~START~~
+nvarchar
+հձղ
+~~END~~
+
+-- test gaps in data
+DECLARE @json NVARCHAR(MAX) = N'[{"b":1},{"a":2},{"a":3,"b":3},{}]'
+SELECT * FROM OPENJSON(@json) WITH (a int, b int, o nvarchar(max) '$' AS JSON)
+GO
+~~START~~
+int#!#int#!#nvarchar
+<NULL>#!#1#!#{"b": 1}
+2#!#<NULL>#!#{"a": 2}
+3#!#3#!#{"a": 3, "b": 3}
+<NULL>#!#<NULL>#!#{}
+~~END~~
+
+
+
+-- comprehensive testing
+DECLARE @json NVARCHAR(4000) = N'{ 
+    "pets" : {
+            "cats" : [
+            { "id" : 1, "name" : "Fluffy", "sex" : "Female" },
+            { "id" : 2, "name" : "Long Tail", "sex" : "Female" },
+            { "id" : 3, "name" : "Scratch", "sex" : "Male" }
+        ],
+            "dogs" : [
+            { "name" : "Fetch", "sex" : "Male" },
+            { "name" : "Fluffy", "sex" : "Male" },
+            { "name" : "Wag", "sex" : "Female" }
+        ]
+    }
+}';
+SELECT * FROM OPENJSON(@json, '$.pets.cats')
+WITH  (
+        [Cat Id]    int             '$.id',  
+        "Cat Name"  varchar(60)     '$.name', 
+        [Sex]       varchar(6)      '$.sex', 
+        [Cats]      nvarchar(max)   '$' AS JSON   
+    );
+GO
+~~START~~
+int#!#varchar#!#varchar#!#nvarchar
+1#!#Fluffy#!#Female#!#{"id": 1, "sex": "Female", "name": "Fluffy"}
+2#!#Long Tail#!#Female#!#{"id": 2, "sex": "Female", "name": "Long Tail"}
+3#!#Scratch#!#Male#!#{"id": 3, "sex": "Male", "name": "Scratch"}
+~~END~~
+

--- a/test/JDBC/input/BABEL-OPENJSON.sql
+++ b/test/JDBC/input/BABEL-OPENJSON.sql
@@ -1,0 +1,130 @@
+
+
+-- OPENJSON()
+-- OPENJSON without WITH clause
+select * from OPENJSON(N'{"a":null,"b":"a","c":1,"d":true,"e":[1,2],"f":{"name":"John"}}');
+go
+DECLARE @jsonvar NVARCHAR(2048) = N'{
+   "String_value": "John",
+   "DoublePrecisionFloatingPoint_value": 45,
+   "DoublePrecisionFloatingPoint_value": 2.3456,
+   "BooleanTrue_value": true,
+   "BooleanFalse_value": false,
+   "Null_value": null,
+   "Array_value": ["a","r","r","a","y"],
+   "Object_value": {"obj":"ect"}
+}';
+SELECT * FROM OpenJson(@jsonvar);
+go
+SELECT [key], value FROM OPENJSON(N'{"path":{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}','$.path.to."sub-object"');
+go
+-- check that value is an object
+select * from openjson(N'{"a":1}', 'strict $.a')
+GO
+-- check lax/strict path
+select * from openjson(N'{"obj":{"a":1}}', 'lax $.a')
+go
+select * from openjson(N'{"obj":{"a":1}}', 'strict $.a')
+go
+-- check non-ascii characters
+select * from openjson(N'{"nonascii":"ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n"}')
+go
+
+-- OPENJSON with WITH clause
+DECLARE @json NVARCHAR(MAX) = N'{"obj":{"a":1}}'
+DECLARE @path NVARCHAR(MAX) = N'$.obj'
+SELECT * FROM OPENJSON(@json, @path) with (a nvarchar(20))
+GO
+-- invalid json input
+SELECT * FROM OPENJSON(N'{"a"') with (a nvarchar(20))
+GO
+-- test cases with invalid path params
+select * from openjson(N'{"a":1}', 'strict $.a') with (a nvarchar(20))
+go
+select * from openjson(N'{"a":1}', '$.a') with (a nvarchar(20))
+go
+-- test array with WITH clause
+select * from openjson(N'[1,2,3,4,null]') WITH (a_col varchar(20) '$');
+GO
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},{"a":2}]';
+SELECT * FROM OPENJSON(@json) with (name nvarchar(max) '$.a');
+GO
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},{"a":2}]';
+SELECT * FROM OPENJSON(@json, '$[0]') with (name nvarchar(max) '$.a');
+GO
+-- test case where with clause is split into multiple lines
+select * from openjson(N'{"a":1}') with (
+  a integer
+);
+GO
+-- test output truncation
+select * from openjson(N'{"a":"long string"}') with (a nvarchar(5));
+GO
+select * from openjson(N'{"a":123456}') with (a nvarchar(5));
+GO
+select * from openjson(N'{"a":null}') with (a nvarchar(2)); -- should return NULL
+go
+-- AS JSON
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},[1,2],"a"]';
+SELECT * FROM OPENJSON(@json, '$') with (name nvarchar(max) '$' AS JSON);
+GO
+DECLARE @json NVARCHAR(MAX);
+SET @json=N'[{"a":1},[1,2],"a"]';
+SELECT * FROM OPENJSON(@json) with (name nvarchar(max) '$');
+GO
+-- Test invalid column type with AS JSON
+SELECT * FROM OPENJSON(N'{"a":1}') WITH (obj nvarchar(20) '$' AS JSON);
+GO
+-- TODO fix case with no length specification
+SELECT * from OPENJSON(N'{"a":1}') with (obj nvarchar '$' AS JSON);
+GO
+-- check lax/strict path
+DECLARE @json NVARCHAR(MAX) = N'{"obj":{"a":1}}'
+DECLARE @path NVARCHAR(MAX) = N'$.obj'
+SELECT * FROM OPENJSON(@json, @path) with (a nvarchar(20), b nvarchar(20) 'lax $.b')
+GO
+DECLARE @json NVARCHAR(MAX) = N'{"obj":{"a":1}}'
+DECLARE @path NVARCHAR(MAX) = N'$.obj'
+SELECT * FROM OPENJSON(@json, @path) with (a nvarchar(20), b nvarchar(20) 'strict $.b')
+GO
+-- check non-ascii characters
+select * from openjson(N'{"nonascii":"ちょまど@初詣おみくじ凶\n - description: ( *ﾟ▽ﾟ* っ)З腐女子！絵描き！| H26新卒文系SE (入社して4ヶ月目の8月にSIer(適応障害になった)を辞職し開発者に転職) | H26秋応用情報合格！| 自作bot (in PHP) chomado_bot | プログラミングガチ初心者\n"}') with 
+(
+  nonascii nvarchar(max)
+)
+go
+-- check 2-byte characters
+select * from openjson(N'{"a":"հձղճմ"}') with (a nvarchar(3));
+go
+-- test gaps in data
+DECLARE @json NVARCHAR(MAX) = N'[{"b":1},{"a":2},{"a":3,"b":3},{}]'
+SELECT * FROM OPENJSON(@json) WITH (a int, b int, o nvarchar(max) '$' AS JSON)
+GO
+
+-- comprehensive testing
+DECLARE @json NVARCHAR(4000) = N'{ 
+    "pets" : {
+            "cats" : [
+            { "id" : 1, "name" : "Fluffy", "sex" : "Female" },
+            { "id" : 2, "name" : "Long Tail", "sex" : "Female" },
+            { "id" : 3, "name" : "Scratch", "sex" : "Male" }
+        ],
+            "dogs" : [
+            { "name" : "Fetch", "sex" : "Male" },
+            { "name" : "Fluffy", "sex" : "Male" },
+            { "name" : "Wag", "sex" : "Female" }
+        ]
+    }
+}';
+
+SELECT * FROM OPENJSON(@json, '$.pets.cats')
+WITH  (
+        [Cat Id]    int             '$.id',  
+        "Cat Name"  varchar(60)     '$.name', 
+        [Sex]       varchar(6)      '$.sex', 
+        [Cats]      nvarchar(max)   '$' AS JSON   
+    );
+GO


### PR DESCRIPTION
This commit implements support for two versions of OPENJSON.

OPENJSON_SIMPLE() - implemented using wrapper functions in
					sys_functions.sql
OPENJSON_WITH() - implemented using C function tsql_openjson_with()
					which uses helper functions added in the engine code
					to retrieve the necessary return values

This commit also modifies the ANTLR parser to rewrite the OPENJSON query
as necessary. In the future, this may be refactored to directly be
supported in the TSQL grammar file instead of relying on ANTLR to rewrite the query.

Task : BABEL-938
Signed-off-by: Jason Teng <jasonten@amazon.com>

### Description

OPENJSON support in Babelfish (along with commit 4640d527645ae7f9a5c514ef2d9ec9ed65ff9557)
 
### Issues Resolved

JIRA issue BABEL-938


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).