### PR TITLE
Add Support for TDS ColumnMetadata flags.

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -28,6 +28,7 @@
 #include "parser/parse_coerce.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
+#include "utils/syscache.h"
 #include "utils/memdebug.h"
 #include "utils/numeric.h"
 #include "utils/portal.h"
@@ -125,8 +126,8 @@ static void FillTabNameWithNumParts(StringInfo buf, uint8 numParts, TdsRelationM
 static void FillTabNameWithoutNumParts(StringInfo buf, uint8 numParts, TdsRelationMetaDataInfo relMetaDataInfo);
 static void SetTdsEstateErrorData(void);
 static void ResetTdsEstateErrorData(void);
-static bool get_attnotnull(Oid relid, AttrNumber attnum);
-static char get_attidentity(Oid relid, AttrNumber attnum);
+static void SetAttributesForColmetada(TdsColumnMetaData *col);
+
 static inline void
 SendPendingDone(bool more)
 {
@@ -1381,14 +1382,7 @@ PrepareRowDescription(TupleDesc typeinfo, List *targetlist, int16 *formats,
 			col->attrNum = 0;
 		}
 
-		col->attNotNull = get_attnotnull(col->relOid, col->attrNum);
-		{
-			char attidentity = get_attidentity(col->relOid, col->attrNum);
-			if (attidentity != '\0')
-				col->attidentity = true;
-			else
-				col->attidentity = false;
-		}
+		SetAttributesForColmetada(col);
 
 		switch (finfo->sendFuncId)
 		{
@@ -2937,53 +2931,32 @@ GetTdsEstateErrorData(int *number, int *severity, int *state)
 }
 
 /*
- * get_attnotnull
- *		Given the relation id and the attribute number,
- *		return the "attnotnull" field from the attribute relation.
  */
-static bool
-get_attnotnull(Oid relid, AttrNumber attnum)
+static void
+SetAttributesForColmetada(TdsColumnMetaData *col)
 {
 	HeapTuple	  tp;
 	Form_pg_attribute att_tup;
 
-	tp = SearchSysCache2(ATTNUM,
-			ObjectIdGetDatum(relid),
-			Int16GetDatum(attnum));
+	tp = SearchSysCache2(ATTNUM, 
+			ObjectIdGetDatum(col->relOid),
+			Int16GetDatum(col->attrNum));
+
+	/* Initialise to false if no valid heap tuple is found. */
+	col->attNotNull = false;
+	col->attidentity = false;
+	col->attgenerated = false;
 
 	if (HeapTupleIsValid(tp))
 	{
-		bool result;
-
 		att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-		result = att_tup->attnotnull;
+		col->attNotNull = att_tup->attnotnull;
+		if (att_tup->attgenerated != '\0')
+			col->attgenerated = true;
+
+		if (att_tup->attidentity != '\0')
+			col->attidentity = true;
+
 		ReleaseSysCache(tp);
-
-		return result;
 	}
-	/* Assume att is nullable if no valid heap tuple is found */
-	return false;
-}
-
-char
-get_attidentity(Oid relid, AttrNumber attnum)
-{
-	HeapTuple	  tp;
-	Form_pg_attribute att_tup;
-
-	tp = SearchSysCache2(ATTNUM,
-			ObjectIdGetDatum(relid),
-			Int16GetDatum(attnum));
-
-	if (HeapTupleIsValid(tp))
-	{
-		char result;
-		att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-		result = att_tup->attidentity;
-		ReleaseSysCache(tp);
-
-		return result;
-	}
-	/* return '\0' if no valid heap tuple is found */
-	return '\0';
 }

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -246,6 +246,9 @@ typedef TDSRequestData *TDSRequest;
 #define TDS_COL_METADATA_DEFAULT_FLAGS  TDS_COLMETA_NULLABLE | \
 					TDS_COLMETA_UPD_UNKNOWN
 #define TDS_COL_METADATA_NOT_NULL_FLAGS TDS_COLMETA_UPD_UNKNOWN
+#define TDS_COL_METADATA_IDENTITY_FLAGS TDS_COLMETA_IDENTITY
+#define TDS_COL_METADATA_COMPUTED_FLAGS TDS_COLMETA_NULLABLE | \
+					TDS_COLMETA_COMPUTED
 
 /* Macro for TVP tokens. */
 #define TVP_ROW_TOKEN				0x01
@@ -681,14 +684,17 @@ SetColMetadataForFixedType(TdsColumnMetaData *col, uint8_t tdsType, uint8_t maxS
 	{
 		col->metaLen = sizeof(col->metaEntry.type1) - 1;
 		if (col->attidentity)
-			col->metaEntry.type1.flags = TDS_COLMETA_IDENTITY;
+			col->metaEntry.type1.flags = TDS_COL_METADATA_IDENTITY_FLAGS;
 		else
 			col->metaEntry.type1.flags = TDS_COL_METADATA_NOT_NULL_FLAGS;
 	}
 	else
 	{
 		col->metaLen = sizeof(col->metaEntry.type1);
-		col->metaEntry.type1.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
+		if (col->attgenerated)
+			col->metaEntry.type1.flags = TDS_COL_METADATA_COMPUTED_FLAGS;
+		else
+			col->metaEntry.type1.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
 	}
 	col->metaEntry.type1.tdsTypeId = tdsType;
 	col->metaEntry.type1.maxSize = maxSize;

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -182,6 +182,7 @@ typedef struct TdsColumnMetaData
 	TdsRelationMetaDataInfo	relinfo;
 	bool 					attNotNull; 	/* true if the column has not null constraint */
 	bool 					attidentity;	/* true if it is an identity column */
+	bool 					attgenerated;	/* true if it is a computed column */
 } TdsColumnMetaData;
 
 /* Partial Length Prefixed-bytes */


### PR DESCRIPTION
Earlier we were sending generic flags for each of the columns.
With this commit we have added support to send computed and identity
flags for their respective columns.

Task: BABEL-217
Signed-off-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))
 
### Issues Resolved
Any application making use of this metadata flag, for example Import-Export Wizard, will start working properly for Identity and Computed Columns.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).