### PR TITLE
Minor fixes for minor version upgrade action

### DIFF
--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -43,50 +43,17 @@ jobs:
           ref: ${{env.EXTENSION_VER_FROM}}
 
       - name: Set env variables and build extensions using ${{env.EXTENSION_VER_FROM}}
+        id: build-extensions-older
         if: always() && steps.compile-antlr.outcome == 'success'
-        run: |
-          export PG_CONFIG=~/postgres/bin/pg_config
-          export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
-          export cmake=$(which cmake)
-          cd contrib/babelfishpg_money
-          make && make install
-          cd ../babelfishpg_common
-          make && make install
-          cd ../babelfishpg_tds
-          make && make install
-          echo Now building bbf_tsql
-          cd ../babelfishpg_tsql
-          make && make install
+        uses: ./.github/composite-actions/build-extensions
 
       - name: Install extensions
-        run: |
-          cd ~
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
-          sudo apt-get install mssql-tools unixodbc-dev
-          export PATH=/opt/mssql-tools/bin:$PATH
-          ~/postgres/bin/initdb -D ~/postgres/data/
-          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile start
-          cd postgres/data
-          sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
-          sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
-          ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
-          sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
-          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile restart
-          sudo ~/postgres/bin/psql -d postgres -U runner -c "CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;"
-          sudo ~/postgres/bin/psql -d postgres -U runner -c "DROP DATABASE IF EXISTS jdbc_testdb;"
-          sudo ~/postgres/bin/psql -d postgres -U runner -c "CREATE DATABASE jdbc_testdb OWNER jdbc_user;"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "set allow_system_table_mods = on;"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "CREATE EXTENSION "babelfishpg_tds" CASCADE;"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "GRANT ALL ON SCHEMA sys to jdbc_user;"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "ALTER USER jdbc_user CREATEDB;"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "CALL sys.initialize_babelfish('jdbc_user');"
-          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
-          sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
+        id: install-extensions-older
+        if: always() && steps.build-extensions-older.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
 
       - name: Build and run tests for Postgres engine using ${{env.ENGINE_VER_TO}}
+        if: always() && steps.install-extensions-older.outcome == 'success'
         run: |
           cd ../postgresql_modified_for_babelfish
           git checkout ${{env.ENGINE_VER_TO}}
@@ -135,19 +102,19 @@ jobs:
           cd test/JDBC/Info
           timestamp=`ls -Art | tail -n 1`
           cd $timestamp
-          mv $timestamp.diff ../output-diff.diff
-          mv "$timestamp"_runSummary.log ../run-summary.log
+          mv $timestamp.diff ../upgrade-output-diff.diff
+          mv "$timestamp"_runSummary.log ../upgrade-run-summary.log
 
       - name: Upload Run Summary 
         if: always() && steps.test-file-rename == 'success'
         uses: actions/upload-artifact@v2
         with:
-          name: run-summary.log
-          path: test/JDBC/Info/run-summary.log
+          name: upgrade-run-summary.log
+          path: test/JDBC/Info/upgrade-run-summary.log
 
       - name: Upload Output Diff
         if: always() && steps.jdbc.outcome == 'failure'
         uses: actions/upload-artifact@v2
         with:
-          name: output-diff.diff
-          path: test/JDBC/Info/output-diff.diff
+          name: upgrade-output-diff.diff
+          path: test/JDBC/Info/upgrade-output-diff.diff


### PR DESCRIPTION
### Description

This commit makes the following fixes in the Minor Version Upgrade
Tests Github action:
  1. Use composite actions for building and installing older version
     of extensions.
  2. Create separate output diff and summary log files.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).