### PR TITLE
Remove debug flags while building engine in Github Action

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -8,7 +8,7 @@ runs:
         cd ..
         git clone --branch BABEL_2_X_DEV__PG_14_2 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
         cd postgresql_modified_for_babelfish
-        ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+        ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --with-libxml --with-uuid=ossp --with-icu
         make -j 4 2>error.txt
         make install
         make check


### PR DESCRIPTION
### Description

While running the Github actions, we are building the modified postgres
engine in debug mode. This commit removes those debug flags so that
engine is built in release mode.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).