### PR TITLE
Handle transaction issues with table variables an functions

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -4525,6 +4525,7 @@ keyword
     | LISTENER_IP
     | LISTENER_PORT
     | LISTENER_URL
+    | LOAD // works like a unreserved keyword, differently from the document
     | LOB_COMPACTION
     | LOCAL
     | LOCAL_SERVICE_NAME

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1050,7 +1050,8 @@ void handle_error(PLtsql_execstate *estate,
 					PLtsql_stmt *stmt,
 					ErrorData *edata, 
 					SimpleEcontextStackEntry *volatile topEntry, 
-					bool *terminate_batch)
+					bool *terminate_batch,
+					bool ro_func)
 {
 	/* Determine if we want to override the transactional behaviour. */
 	uint8_t override_flag = override_txn_behaviour(stmt);
@@ -1070,9 +1071,9 @@ void handle_error(PLtsql_execstate *estate,
 		pltsql_create_econtext(estate);
 
 	/* In case of errors which terminate execution, let outer layer handle it */
-	if (last_error_mapping_failed || abort_execution(estate, edata, terminate_batch, override_flag))
+	if (last_error_mapping_failed || abort_execution(estate, edata, terminate_batch, override_flag) || ro_func)
 	{
-		elog(DEBUG1, "TSQL TXN Stop execution error mapping failed : %d current batch status %d", last_error_mapping_failed, *terminate_batch);
+		elog(DEBUG1, "TSQL TXN Stop execution error mapping failed : %d current batch status : %d read only function : %d", last_error_mapping_failed, *terminate_batch, ro_func);
 		FreeErrorData(edata);
 		PG_RE_THROW();
 	}
@@ -1104,6 +1105,9 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 	SimpleEcontextStackEntry *volatile topEntry = simple_econtext_stack;
 	bool support_tsql_trans = pltsql_support_tsql_transactions();
 	uint32 before_tran_count = NestedTranCount;
+	bool ro_func = (estate->func->fn_prokind == PROKIND_FUNCTION) &&
+		(estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER) &&
+		(strcmp(estate->func->fn_signature, "inline_code_block") != 0);
 
 	PG_TRY();
 	{
@@ -1132,8 +1136,12 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		 * We do not start savepoint for batch commands as
 		 * error handling must be taken care of at statement
 		 * level
+		 * For RO functions start savepoint even when transaction
+		 * is not active to retain top level portals. A transaction
+		 * rollback will cleanup portal data which can lead to
+		 * problems when control returns back to portal level
 		 */
-		if ((!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive()))
+		if (!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && (IsTransactionBlockActive() || ro_func))
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);
@@ -1158,8 +1166,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			elog(DEBUG5, "TSQL TXN Release internal savepoint");
 			ReleaseCurrentSubTransaction();
 			MemoryContextSwitchTo(cur_ctxt);
-			if (!support_tsql_trans)
-				CurrentResourceOwner = oldowner;
+			CurrentResourceOwner = oldowner;
 		}
 
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
@@ -1236,6 +1243,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			/* Rollback internal savepoint if it is current savepoint */
 			RollbackAndReleaseCurrentSubTransaction();
 			MemoryContextSwitchTo(cur_ctxt);
+			CurrentResourceOwner = oldowner;
 		}
 		else if (!IsTransactionBlockActive())
 		{
@@ -1283,17 +1291,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
 
-		/*
-		 * In case of error, cleanup all snapshots.
-		 * It is expected that next command will establish
-		 * required new snapshot
-		 */
-		while (ActiveSnapshotSet())
-			PopActiveSnapshot();
-		if (pltsql_snapshot_portal != NULL)
-			pltsql_snapshot_portal->portalSnapshot = NULL;
-
-		handle_error(estate, stmt, edata, topEntry, terminate_batch);
+		handle_error(estate, stmt, edata, topEntry, terminate_batch, ro_func);
 
 		rc = PLTSQL_RC_OK;
 	}

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9479,6 +9479,9 @@ pltsql_xact_cb(XactEvent event, void *arg)
 		simple_econtext_stack = NULL;
 		shared_simple_eval_estate = NULL;
 	}
+	/* Reset portal snapshot in case of commit/rollback */
+	if (pltsql_snapshot_portal != NULL)
+		pltsql_snapshot_portal->portalSnapshot = NULL;
 	AbortCurTransaction = false;
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3476,8 +3476,15 @@ _PG_fini(void)
 static void terminate_batch(bool send_error, bool compile_error)
 {
 	bool error_mapping_failed = false;
+	int rc;
 
 	elog(DEBUG2, "TSQL TXN finish current batch, error : %d compilation error : %d", send_error, compile_error);
+
+	/*
+	 * Disconnect from SPI manager
+	 */
+	if ((rc = SPI_finish()) != SPI_OK_FINISH)
+		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	if (send_error)
 	{
@@ -3706,12 +3713,6 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	ENRDropTempTables(currentQueryEnv);
 	remove_queryEnv();
 	pltsql_revert_guc(save_nestlevel);
-
-	/*
-	 * Disconnect from SPI manager
-	 */
-	if ((rc = SPI_finish()) != SPI_OK_FINISH)
-		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	terminate_batch(false /* send_error */, false /* compile_error */);
 
@@ -3952,12 +3953,6 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 		FreeExecutorState(simple_eval_estate);
 		pltsql_free_function_memory(func);
 	}
-	/*
-	 * Disconnect from SPI manager
-	 */
-	if ((rc = SPI_finish()) != SPI_OK_FINISH)
-		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
-
 	sql_dialect = saved_dialect;
 	
 	terminate_batch(false /* send_error */, false /* compile_error */);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3511,6 +3511,7 @@ static void terminate_batch(bool send_error, bool compile_error)
 				 */
 				while (ActiveSnapshotSet())
 					PopActiveSnapshot();
+				pltsql_snapshot_portal->portalSnapshot = NULL;
 			}
 			MarkPortalDone(pltsql_snapshot_portal);
 			PortalDrop(pltsql_snapshot_portal, false);

--- a/contrib/babelfishpg_tsql/src/prepare.c
+++ b/contrib/babelfishpg_tsql/src/prepare.c
@@ -50,6 +50,7 @@ prepare_stmt_execsql(PLtsql_execstate *estate, PLtsql_function *func, PLtsql_stm
 
 	exec_prepare_plan(estate, expr, CURSOR_OPT_PARALLEL_OK, keepplan);
 	stmt->mod_stmt = false;
+	stmt->mod_stmt_tablevar = false;
 	foreach(l, SPI_plan_get_plan_sources(expr->plan))
 	{
 		CachedPlanSource *plansource = (CachedPlanSource *) lfirst(l);

--- a/test/JDBC/expected/BABEL-213.out
+++ b/test/JDBC/expected/BABEL-213.out
@@ -169,6 +169,11 @@ GO
 
 ~~ERROR (Message: division by zero)~~
 
+~~START~~
+int
+<NULL>
+~~END~~
+
 
 -- assignment to different type
 -- char(200)->int (error should be thrwon)

--- a/test/JDBC/expected/BABEL-3101.out
+++ b/test/JDBC/expected/BABEL-3101.out
@@ -1,0 +1,130 @@
+CREATE FUNCTION  f_3101()
+RETURNS NVARCHAR(255)
+AS
+begin
+	DECLARE @n NVARCHAR(255)
+	SELECT @n = QUOTENAME(name) FROM sys.tables
+	RETURN @n
+end
+GO
+
+select f_3101()
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+
+
+
+
+
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+			INSERT INTO @returnList SELECT @name
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+		INSERT INTO @returnList SELECT @stringToSplit
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+~~START~~
+nvarchar
+this
+is
+split
+~~END~~
+
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+~~START~~
+tinyint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function date_part(unknown, text) does not exist)~~
+
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+~~START~~
+int
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+
+DROP FUNCTION f_3101
+GO
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/expected/BABEL-3101.out
+++ b/test/JDBC/expected/BABEL-3101.out
@@ -1,21 +1,3 @@
-CREATE FUNCTION  f_3101()
-RETURNS NVARCHAR(255)
-AS
-begin
-	DECLARE @n NVARCHAR(255)
-	SELECT @n = QUOTENAME(name) FROM sys.tables
-	RETURN @n
-end
-GO
-
-select f_3101()
-GO
-~~START~~
-nvarchar
-<NULL>
-~~END~~
-
-
 
 
 
@@ -114,9 +96,6 @@ int
 
 ~~ERROR (Message: division by zero)~~
 
-
-DROP FUNCTION f_3101
-GO
 
 DROP FUNCTION my_splitstring_3101
 GO

--- a/test/JDBC/expected/BABEL-3108.out
+++ b/test/JDBC/expected/BABEL-3108.out
@@ -1,0 +1,37 @@
+CREATE TABLE t3108(c1 nvarchar(50));
+GO
+
+CREATE FUNCTION f3108_i ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max) Declare @TscList AS Table(tc nvarchar(10)) insert into @TscList SELECT Distinct c1 From t3108 with (nolock)
+	select  @tcs = COALESCE(@tcs + ', ', '') + tc from @TscList order by tc
+	RETURN isnull(@tcs,'')
+END
+GO
+
+CREATE FUNCTION f3108_o ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max);
+	SELECT @tcs = f3108_i(@val)
+	RETURN Case WHEN @tcs='|' then '' else isnull(@tcs,   '') end
+END
+GO
+
+declare @val nvarchar(50) = ' ' SELECT f3108_o(@val) as tc
+GO
+~~START~~
+nvarchar
+
+~~END~~
+
+
+DROP FUNCTION f3108_o
+GO
+
+DROP FUNCTION f3108_i
+GO
+
+DROP TABLE t3108
+GO

--- a/test/JDBC/expected/BABEL-3160.out
+++ b/test/JDBC/expected/BABEL-3160.out
@@ -1,0 +1,18 @@
+use master;
+go
+
+CREATE TABLE load(load int);
+go
+INSERT INTO load values (1);
+go
+~~ROW COUNT: 1~~
+
+SELECT load FROM load;
+go
+~~START~~
+int
+1
+~~END~~
+
+DROP TABLE load;
+go

--- a/test/JDBC/expected/BABEL-PROCID.out
+++ b/test/JDBC/expected/BABEL-PROCID.out
@@ -266,6 +266,8 @@ varchar
 Running trigger trg_err_check
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 -- Test insert through a procedure
 CREATE PROCEDURE table_insert
@@ -284,6 +286,8 @@ GO
 varchar
 Running trigger trg_err_check
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 varchar

--- a/test/JDBC/input/BABEL-3101.sql
+++ b/test/JDBC/input/BABEL-3101.sql
@@ -1,16 +1,3 @@
-CREATE FUNCTION  f_3101()
-RETURNS NVARCHAR(255)
-AS
-begin
-	DECLARE @n NVARCHAR(255)
-	SELECT @n = QUOTENAME(name) FROM sys.tables
-	RETURN @n
-end
-GO
-
-select f_3101()
-GO
-
 CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
 RETURNS
 @returnList TABLE ([Value] [nvarchar] (50))
@@ -89,9 +76,6 @@ END
 GO
 
 select table_3101_0()
-GO
-
-DROP FUNCTION f_3101
 GO
 
 DROP FUNCTION my_splitstring_3101

--- a/test/JDBC/input/BABEL-3101.sql
+++ b/test/JDBC/input/BABEL-3101.sql
@@ -1,0 +1,106 @@
+CREATE FUNCTION  f_3101()
+RETURNS NVARCHAR(255)
+AS
+begin
+	DECLARE @n NVARCHAR(255)
+	SELECT @n = QUOTENAME(name) FROM sys.tables
+	RETURN @n
+end
+GO
+
+select f_3101()
+GO
+
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+
+			INSERT INTO @returnList SELECT @name
+
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+
+		INSERT INTO @returnList SELECT @stringToSplit
+
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+
+DROP FUNCTION f_3101
+GO
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/input/BABEL-3108.sql
+++ b/test/JDBC/input/BABEL-3108.sql
@@ -1,0 +1,32 @@
+CREATE TABLE t3108(c1 nvarchar(50));
+GO
+
+CREATE FUNCTION f3108_i ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max) Declare @TscList AS Table(tc nvarchar(10)) insert into @TscList SELECT Distinct c1 From t3108 with (nolock)
+	select  @tcs = COALESCE(@tcs + ', ', '') + tc from @TscList order by tc
+	RETURN isnull(@tcs,'')
+END
+GO
+
+CREATE FUNCTION f3108_o ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max);
+	SELECT @tcs = f3108_i(@val)
+	RETURN Case WHEN @tcs='|' then '' else isnull(@tcs,   '') end
+END
+GO
+
+declare @val nvarchar(50) = ' ' SELECT f3108_o(@val) as tc
+GO
+
+DROP FUNCTION f3108_o
+GO
+
+DROP FUNCTION f3108_i
+GO
+
+DROP TABLE t3108
+GO

--- a/test/JDBC/input/BABEL-3160.sql
+++ b/test/JDBC/input/BABEL-3160.sql
@@ -1,0 +1,11 @@
+use master;
+go
+
+CREATE TABLE load(load int);
+go
+INSERT INTO load values (1);
+go
+SELECT load FROM load;
+go
+DROP TABLE load;
+go


### PR DESCRIPTION
These changes fix two issues.
We do not start internal transaction when doing DML on table variables.
We run all statements inside a function using internal savepoint so that an error can be handled without impacting current transaction. This is important as functions run inside SELECT portals which do not handle transaction event like rollback properly.

Task: BABEL-3101, BABEL-3108
Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).