### PR TITLE
Allow 'LOAD' for identifier without delimiter

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -4525,6 +4525,7 @@ keyword
     | LISTENER_IP
     | LISTENER_PORT
     | LISTENER_URL
+    | LOAD // works like a unreserved keyword, differently from the document
     | LOB_COMPACTION
     | LOCAL
     | LOCAL_SERVICE_NAME

--- a/test/JDBC/expected/BABEL-3160.out
+++ b/test/JDBC/expected/BABEL-3160.out
@@ -1,0 +1,18 @@
+use master;
+go
+
+CREATE TABLE load(load int);
+go
+INSERT INTO load values (1);
+go
+~~ROW COUNT: 1~~
+
+SELECT load FROM load;
+go
+~~START~~
+int
+1
+~~END~~
+
+DROP TABLE load;
+go

--- a/test/JDBC/input/BABEL-3160.sql
+++ b/test/JDBC/input/BABEL-3160.sql
@@ -1,0 +1,11 @@
+use master;
+go
+
+CREATE TABLE load(load int);
+go
+INSERT INTO load values (1);
+go
+SELECT load FROM load;
+go
+DROP TABLE load;
+go


### PR DESCRIPTION
### Description

Allow 'LOAD' for identifier without delimiter

Other than official document saying LOAD is a reserved keyword,
'LOAD' is allowed to be used for table/column name without delimiter.
 
### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/137


### Check List
- [v] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).