### PR TITLE
remove use_antlr GUC from the code

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -15,7 +15,6 @@
 static int migration_mode = SINGLE_DB;
 bool   enable_ownership_structure = false;
 
-bool pltsql_use_antlr = true;
 bool pltsql_dump_antlr_query_graph = false;
 bool pltsql_enable_antlr_detailed_log = false;
 bool pltsql_allow_antlr_to_unsupported_grammar_for_testing = false;
@@ -531,15 +530,6 @@ define_custom_variables(void)
 				 NULL, NULL, NULL);
 
 	/* ANTLR parser */
-	DefineCustomBoolVariable("babelfishpg_tsql.use_antlr",
-				 gettext_noop("Selects new ANTLR parser for pl/tsql functions, procedures, trigger, and batches."),
-				 NULL,
-				 &pltsql_use_antlr,
-				 true,
-				 PGC_SUSET,
-				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-				 NULL, NULL, NULL);
-
 	DefineCustomBoolVariable("babelfishpg_tsql.dump_antlr_query_graph",
 				 gettext_noop("dump query graph parsed by ANTLR parser to local disk"),
 				 NULL,

--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -893,7 +893,6 @@ do_compile(FunctionCallInfo fcinfo,
 	/*
 	 * Now parse the function's text
 	 */
-	if (pltsql_use_antlr)
 	{
 		ANTLR_result result = antlr_parser_cpp(proc_source);
 
@@ -906,10 +905,6 @@ do_compile(FunctionCallInfo fcinfo,
 			report_antlr_error(result);
 			parse_rc = 1; /* invalid input */
 		}
-	}
-	else
-	{
-		parse_rc = pltsql_yyparse();
 	}
 
 	if (parse_rc != 0)
@@ -931,11 +926,8 @@ do_compile(FunctionCallInfo fcinfo,
 		 * where BLOCK is a wrapper for the statements.
 		 * For MSTVF parsing we don't want the wrapper.
 		 */
-		if (pltsql_use_antlr)
-		{
-			Assert(list_length(pltsql_parse_result->body) >= 2);
-			function->action = (PLtsql_stmt_block *) lsecond(pltsql_parse_result->body);
-		}
+		Assert(list_length(pltsql_parse_result->body) >= 2);
+		function->action = (PLtsql_stmt_block *) lsecond(pltsql_parse_result->body);
 		add_decl_table(function, tbl_dno, tbl_typ);
 	}
 
@@ -1280,7 +1272,6 @@ pltsql_compile_inline(char *proc_source, InlineCodeBlockArgs *args)
 	/*
 	 * Now parse the function's text
 	 */
-	if (pltsql_use_antlr)
 	{
 		ANTLR_result result = antlr_parser_cpp(proc_source);
 
@@ -1293,10 +1284,6 @@ pltsql_compile_inline(char *proc_source, InlineCodeBlockArgs *args)
 			report_antlr_error(result);
 			parse_rc = 1; /* invalid input */
 		}
-	}
-	else
-	{
-		parse_rc = pltsql_yyparse();
 	}
 
 	if (parse_rc != 0)

--- a/contrib/babelfishpg_tsql/src/pl_scanner.c
+++ b/contrib/babelfishpg_tsql/src/pl_scanner.c
@@ -778,9 +778,7 @@ location_lineno_init(void)
 int
 pltsql_latest_lineno(void)
 {
-	if (pltsql_use_antlr)
-		return CurrentLineNumber;
-	return cur_line_num;
+	return CurrentLineNumber;
 }
 
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1656,8 +1656,6 @@ extern char *pltsql_default_locale;
 
 extern int  pltsql_variable_conflict;
 
-extern bool pltsql_use_antlr;
-
 /* extra compile-time checks */
 #define PLTSQL_XCHECK_NONE			0
 #define PLTSQL_XCHECK_SHADOWVAR	1


### PR DESCRIPTION
- 'use_antlr' is enabeld by default and we cannot turn it off because
old pl_gram.y parser has not been maintained for long time.
- remove the 'use_antlr' from the code totally. We don't have any plan to
provide an option to turn off ANTLR parser.

Task: BABEL-3152
Signed-off-by: Sangil Song <sonsangi@amazon.com>

### Check List
- [v] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).