### PR TITLE
Handle transaction error handling issues for table variables and functions

### DIFF
--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1050,7 +1050,8 @@ void handle_error(PLtsql_execstate *estate,
 					PLtsql_stmt *stmt,
 					ErrorData *edata, 
 					SimpleEcontextStackEntry *volatile topEntry, 
-					bool *terminate_batch)
+					bool *terminate_batch,
+					bool ro_func)
 {
 	/* Determine if we want to override the transactional behaviour. */
 	uint8_t override_flag = override_txn_behaviour(stmt);
@@ -1070,9 +1071,9 @@ void handle_error(PLtsql_execstate *estate,
 		pltsql_create_econtext(estate);
 
 	/* In case of errors which terminate execution, let outer layer handle it */
-	if (last_error_mapping_failed || abort_execution(estate, edata, terminate_batch, override_flag))
+	if (last_error_mapping_failed || abort_execution(estate, edata, terminate_batch, override_flag) || ro_func)
 	{
-		elog(DEBUG1, "TSQL TXN Stop execution error mapping failed : %d current batch status %d", last_error_mapping_failed, *terminate_batch);
+		elog(DEBUG1, "TSQL TXN Stop execution error mapping failed : %d current batch status : %d read only function : %d", last_error_mapping_failed, *terminate_batch, ro_func);
 		FreeErrorData(edata);
 		PG_RE_THROW();
 	}
@@ -1104,6 +1105,9 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 	SimpleEcontextStackEntry *volatile topEntry = simple_econtext_stack;
 	bool support_tsql_trans = pltsql_support_tsql_transactions();
 	uint32 before_tran_count = NestedTranCount;
+	bool ro_func = (estate->func->fn_prokind == PROKIND_FUNCTION) &&
+		(estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER) &&
+		(strcmp(estate->func->fn_signature, "inline_code_block") != 0);
 
 	PG_TRY();
 	{
@@ -1132,8 +1136,12 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		 * We do not start savepoint for batch commands as
 		 * error handling must be taken care of at statement
 		 * level
+		 * For RO functions start savepoint even when transaction
+		 * is not active to retain top level portals. A transaction
+		 * rollback will cleanup portal data which can lead to
+		 * problems when control returns back to portal level
 		 */
-		if ((!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive()))
+		if (!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && (IsTransactionBlockActive() || ro_func))
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);
@@ -1158,8 +1166,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			elog(DEBUG5, "TSQL TXN Release internal savepoint");
 			ReleaseCurrentSubTransaction();
 			MemoryContextSwitchTo(cur_ctxt);
-			if (!support_tsql_trans)
-				CurrentResourceOwner = oldowner;
+			CurrentResourceOwner = oldowner;
 		}
 
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
@@ -1236,6 +1243,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			/* Rollback internal savepoint if it is current savepoint */
 			RollbackAndReleaseCurrentSubTransaction();
 			MemoryContextSwitchTo(cur_ctxt);
+			CurrentResourceOwner = oldowner;
 		}
 		else if (!IsTransactionBlockActive())
 		{
@@ -1283,17 +1291,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
 
-		/*
-		 * In case of error, cleanup all snapshots.
-		 * It is expected that next command will establish
-		 * required new snapshot
-		 */
-		while (ActiveSnapshotSet())
-			PopActiveSnapshot();
-		if (pltsql_snapshot_portal != NULL)
-			pltsql_snapshot_portal->portalSnapshot = NULL;
-
-		handle_error(estate, stmt, edata, topEntry, terminate_batch);
+		handle_error(estate, stmt, edata, topEntry, terminate_batch, ro_func);
 
 		rc = PLTSQL_RC_OK;
 	}

--- a/contrib/babelfishpg_tsql/src/prepare.c
+++ b/contrib/babelfishpg_tsql/src/prepare.c
@@ -50,6 +50,7 @@ prepare_stmt_execsql(PLtsql_execstate *estate, PLtsql_function *func, PLtsql_stm
 
 	exec_prepare_plan(estate, expr, CURSOR_OPT_PARALLEL_OK, keepplan);
 	stmt->mod_stmt = false;
+	stmt->mod_stmt_tablevar = false;
 	foreach(l, SPI_plan_get_plan_sources(expr->plan))
 	{
 		CachedPlanSource *plansource = (CachedPlanSource *) lfirst(l);

--- a/test/JDBC/expected/BABEL-213.out
+++ b/test/JDBC/expected/BABEL-213.out
@@ -169,6 +169,11 @@ GO
 
 ~~ERROR (Message: division by zero)~~
 
+~~START~~
+int
+<NULL>
+~~END~~
+
 
 -- assignment to different type
 -- char(200)->int (error should be thrwon)

--- a/test/JDBC/expected/BABEL-3101.out
+++ b/test/JDBC/expected/BABEL-3101.out
@@ -1,0 +1,109 @@
+
+
+
+
+
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+			INSERT INTO @returnList SELECT @name
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+		INSERT INTO @returnList SELECT @stringToSplit
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+~~START~~
+nvarchar
+this
+is
+split
+~~END~~
+
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+~~START~~
+tinyint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function date_part(unknown, text) does not exist)~~
+
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+~~START~~
+int
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/expected/BABEL-3108.out
+++ b/test/JDBC/expected/BABEL-3108.out
@@ -1,0 +1,37 @@
+CREATE TABLE t3108(c1 nvarchar(50));
+GO
+
+CREATE FUNCTION f3108_i ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max) Declare @TscList AS Table(tc nvarchar(10)) insert into @TscList SELECT Distinct c1 From t3108 with (nolock)
+	select  @tcs = COALESCE(@tcs + ', ', '') + tc from @TscList order by tc
+	RETURN isnull(@tcs,'')
+END
+GO
+
+CREATE FUNCTION f3108_o ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max);
+	SELECT @tcs = f3108_i(@val)
+	RETURN Case WHEN @tcs='|' then '' else isnull(@tcs,   '') end
+END
+GO
+
+declare @val nvarchar(50) = ' ' SELECT f3108_o(@val) as tc
+GO
+~~START~~
+nvarchar
+
+~~END~~
+
+
+DROP FUNCTION f3108_o
+GO
+
+DROP FUNCTION f3108_i
+GO
+
+DROP TABLE t3108
+GO

--- a/test/JDBC/expected/BABEL-PROCID.out
+++ b/test/JDBC/expected/BABEL-PROCID.out
@@ -266,6 +266,8 @@ varchar
 Running trigger trg_err_check
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 -- Test insert through a procedure
 CREATE PROCEDURE table_insert
@@ -284,6 +286,8 @@ GO
 varchar
 Running trigger trg_err_check
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 varchar

--- a/test/JDBC/input/BABEL-3101.sql
+++ b/test/JDBC/input/BABEL-3101.sql
@@ -1,0 +1,90 @@
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+
+			INSERT INTO @returnList SELECT @name
+
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+
+		INSERT INTO @returnList SELECT @stringToSplit
+
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/input/BABEL-3108.sql
+++ b/test/JDBC/input/BABEL-3108.sql
@@ -1,0 +1,32 @@
+CREATE TABLE t3108(c1 nvarchar(50));
+GO
+
+CREATE FUNCTION f3108_i ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max) Declare @TscList AS Table(tc nvarchar(10)) insert into @TscList SELECT Distinct c1 From t3108 with (nolock)
+	select  @tcs = COALESCE(@tcs + ', ', '') + tc from @TscList order by tc
+	RETURN isnull(@tcs,'')
+END
+GO
+
+CREATE FUNCTION f3108_o ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max);
+	SELECT @tcs = f3108_i(@val)
+	RETURN Case WHEN @tcs='|' then '' else isnull(@tcs,   '') end
+END
+GO
+
+declare @val nvarchar(50) = ' ' SELECT f3108_o(@val) as tc
+GO
+
+DROP FUNCTION f3108_o
+GO
+
+DROP FUNCTION f3108_i
+GO
+
+DROP TABLE t3108
+GO


### PR DESCRIPTION
Avoid starting new transaction for insert into table variables

There are two issue which lead to the problem.
A select on a function internally creates a portal to hold the results.
The portal has its own resource owner which is used for all the
snapshots created during function execution. A transaction event inside
the function will reset resource owner to top transaction. Ideally, we
should reset back to portal resource owner at the earliest. This is not
happening right now as we do not want to do reset for cases where
transaction/savepoint was started before portal creation. We need to
distinguish between these two cases.
We start internal transactions for DDLs/DMLs but not for queries. We
were starting transactions for insert into table variables which we
should not. This internal transaction was resetting the resource owner
from portal to top transaction.
This change fixes the second problem. The first problem will be fixed as
a followup later.

---------

An error when executing select func leads to internal error "InstrStartNode called twice in a row"

A select function call will run function inside a SELECT portal.
If the function throws an error, TSQL error handling will rollback
the internal PG transaction to support undo behavior. The rollback
will cleanup all active portals assuming PG semantic for transactions.

As portal is still active at higher level, this can result in
unpredictable behavior including above error and server crash.

We solve this issue by always running a TSQL function inside an internal
savepoint. We rely on the fact that TSQL functions cannot have side
effects like data write, transaction etc. In case of an error, rollback
to savepoint takes care of statement undo without effecting portals
active at higher level.

--------

Handle missing SPI finish call for error cases

Every TSQL execution batch/proc/func call will create
a SPI connection and later close it using SPI finish.
However, SPI finish was missed for error cases and
can lead to in-correct SPI call stack for nested calls.
As a result, current call handler can call finish on
a leaked SPI connection of its children. This can cause
many issues including memory corruption.
As a fix, make sure that a call handler always does SPI
finish including error cases.
Also, did one small fix to make a copy of procedure name
info when unwinding a call stack. Otherwise, procedure name allocation
is no longer valid.

Task:Babel-3101,3108,3195
Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).