### PR TITLE
sys.dm_exec_sessions view shows incorrect transaction isolation level boot value

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -137,14 +137,6 @@ typedef struct LocalTdsStatus
 	TransactionId backend_xmin;
 } LocalTdsStatus;
 
-static const struct config_enum_entry isolation_level_options[] = {
-	{"serializable", XACT_SERIALIZABLE, false},
-	{"repeatable read", XACT_REPEATABLE_READ, false},
-	{"read committed", XACT_READ_COMMITTED, false},
-	{"read uncommitted", XACT_READ_UNCOMMITTED, false},
-	{NULL, 0}
-};
-
 static TdsStatus *TdsStatusArray = NULL;
 static TdsStatus *MyTdsStatusEntry;
 static LocalTdsStatus *localTdsStatusTable = NULL;
@@ -369,8 +361,6 @@ tdsstat_bestart(void)
 	int len;
 	char *library_name = NULL;
 	const char *language = NULL;
-	const char *isolation_level_str = NULL;
-	const struct config_enum_entry *entry;
 
 	/*
 	 * To minimize the time spent modifying the TdsStatus entry, and
@@ -406,17 +396,7 @@ tdsstat_bestart(void)
 	ltdsentry.textsize = atoi(GetConfigOption("babelfishpg_tsql.textsize", true, true));
 	ltdsentry.datefirst = atoi(GetConfigOption("babelfishpg_tsql.datefirst", true, true));
 	ltdsentry.lock_timeout = atoi(GetConfigOption("lock_timeout", true, true));
-
-	isolation_level_str = GetConfigOption("default_transaction_isolation", true, true);
-
-	for (entry = isolation_level_options; entry && entry->name; entry++)
-	{
-		if (strcmp(entry->name, isolation_level_str) == 0)
-		{
-			ltdsentry.transaction_isolation = entry->val;
-			break;
-		}
-	}
+	ltdsentry.transaction_isolation = DefaultXactIsoLevel;
 
 	language = GetConfigOption("babelfishpg_tsql.language", true, true);
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -19,6 +19,7 @@
 #include "funcapi.h"
 
 #include "access/printtup.h"
+#include "access/xact.h"
 #include "src/include/tds_int.h"
 #include "src/include/tds_secure.h"
 #include "src/include/tds_instr.h"
@@ -135,6 +136,14 @@ typedef struct LocalTdsStatus
 	 */
 	TransactionId backend_xmin;
 } LocalTdsStatus;
+
+static const struct config_enum_entry isolation_level_options[] = {
+	{"serializable", XACT_SERIALIZABLE, false},
+	{"repeatable read", XACT_REPEATABLE_READ, false},
+	{"read committed", XACT_READ_COMMITTED, false},
+	{"read uncommitted", XACT_READ_UNCOMMITTED, false},
+	{NULL, 0}
+};
 
 static TdsStatus *TdsStatusArray = NULL;
 static TdsStatus *MyTdsStatusEntry;
@@ -360,6 +369,8 @@ tdsstat_bestart(void)
 	int len;
 	char *library_name = NULL;
 	const char *language = NULL;
+	const char *isolation_level_str = NULL;
+	const struct config_enum_entry *entry;
 
 	/*
 	 * To minimize the time spent modifying the TdsStatus entry, and
@@ -395,7 +406,17 @@ tdsstat_bestart(void)
 	ltdsentry.textsize = atoi(GetConfigOption("babelfishpg_tsql.textsize", true, true));
 	ltdsentry.datefirst = atoi(GetConfigOption("babelfishpg_tsql.datefirst", true, true));
 	ltdsentry.lock_timeout = atoi(GetConfigOption("lock_timeout", true, true));
-	ltdsentry.transaction_isolation = atoi(GetConfigOption("default_transaction_isolation", true, true));
+
+	isolation_level_str = GetConfigOption("default_transaction_isolation", true, true);
+
+	for (entry = isolation_level_options; entry && entry->name; entry++)
+	{
+		if (strcmp(entry->name, isolation_level_str) == 0)
+		{
+			ltdsentry.transaction_isolation = entry->val;
+			break;
+		}
+	}
 
 	language = GetConfigOption("babelfishpg_tsql.language", true, true);
 

--- a/test/JDBC/expected/BABEL-1887.out
+++ b/test/JDBC/expected/BABEL-1887.out
@@ -28,7 +28,7 @@ select ansi_warnings, ansi_padding, ansi_nulls, concat_null_yields_null, transac
 GO
 ~~START~~
 bit#!#bit#!#bit#!#bit#!#smallint
-1#!#1#!#1#!#1#!#1
+1#!#1#!#1#!#1#!#2
 ~~END~~
 
 
@@ -65,8 +65,8 @@ select ansi_warnings, ansi_padding, ansi_nulls, concat_null_yields_null, transac
 GO
 ~~START~~
 bit#!#bit#!#bit#!#bit#!#smallint
-1#!#1#!#1#!#1#!#1
-1#!#1#!#1#!#1#!#1
+1#!#1#!#1#!#1#!#2
+1#!#1#!#1#!#1#!#2
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-3209.out
+++ b/test/JDBC/expected/BABEL-3209.out
@@ -1,0 +1,30 @@
+-- Boot Value for transaction isolation level should be "read committed" i.e. 2
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+read committed
+~~END~~
+
+~~START~~
+smallint
+2
+~~END~~
+
+
+-- Explicitly setting transaction isolation level should be reflected in the view
+SET transaction isolation level snapshot;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+repeatable read
+~~END~~
+
+~~START~~
+smallint
+3
+~~END~~
+

--- a/test/JDBC/input/BABEL-3209.sql
+++ b/test/JDBC/input/BABEL-3209.sql
@@ -1,0 +1,10 @@
+-- Boot Value for transaction isolation level should be "read committed" i.e. 2
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+
+-- Explicitly setting transaction isolation level should be reflected in the view
+SET transaction isolation level snapshot;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO


### PR DESCRIPTION
### Description

Initially, we were storing the boot value of the
"default_transaction_isolation" GUC in shared memory by first fetching
the value using GetConfigOption() and later converting it into suitable
integer using atoi(). In this particular case, GetConfigOption() was
returning a string that cannot directly be converted as an integer by
atoi. As a result atoi() was always returning 0 for the boot GUC value.

This commit uses the DefaultXactIsoLevel to set the boot value in shared
memory.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).