### PR TITLE
Restore the portal-level snapshot for simple expressions, too

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -7338,6 +7338,14 @@ exec_eval_simple_expr(PLtsql_execstate *estate,
 	 */
 	if (expr->expr_simple_in_use && expr->expr_simple_lxid == curlxid)
 		return false;
+	
+	/* Ensure that there's a portal-level snapshot, in case this simple
+	 * expression is the first thing evaluated after a COMMIT or ROLLBACK.
+	 * We'd have to do this anyway before executing the expression, so we
+	 * might as well do it now to ensure that any possible replanning doesn't
+	 * need to take a new snapshot.
+	 */
+	EnsurePortalSnapshotExists();
 
 	/*
 	 * Revalidate cached plan, so that we will notice if it became stale. (We


### PR DESCRIPTION
We missed the need of this change to cover pltsql's "simple expression" code path.
 If the first thing we execute after a COMMIT/ROLLBACK is one of those,
rather than a full-fledged SPI command, we must explicitly do
EnsurePortalSnapshotExists() to make sure we have an outer snapshot.
Note that it wouldn't be good enough to just push a snapshot for the duration
of the expression execution: what comes back might be toasted, so we'd better have a snapshot protecting it.

Task: BABEL-3196
Signed-off-by: Shalini Lohia <lshalini@amazon.com>
Co-authored-by: Shalini Lohia <lshalini@amazon.com>

