### PR TITLE
Add sys.data_spaces

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1926,3 +1926,14 @@ SELECT
   ,CAST(0 as sys.BIGINT) as secondary_lag_seconds
 WHERE FALSE;
 GRANT SELECT ON sys.dm_hadr_database_replica_states TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.data_spaces
+AS
+SELECT 
+  CAST('PRIMARY' as SYSNAME) AS name,
+  CAST(1 as INT) AS data_space_id,
+  CAST('FG' as CHAR(2)) AS type,
+  CAST('ROWS_FILEGROUP' as NVARCHAR(60)) AS type_desc,
+  CAST(1 as sys.BIT) AS is_default,
+  CAST(0 as sys.BIT) AS is_system;
+GRANT SELECT ON sys.data_spaces TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -2481,5 +2481,16 @@ SELECT CAST(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'::pg_catalog.text AS sys.DATETIM
 $BODY$
 LANGUAGE SQL PARALLEL SAFE;
 
+CREATE OR REPLACE VIEW sys.data_spaces
+AS
+SELECT 
+  CAST('PRIMARY' as SYSNAME) AS name,
+  CAST(1 as INT) AS data_space_id,
+  CAST('FG' as CHAR(2)) AS type,
+  CAST('ROWS_FILEGROUP' as NVARCHAR(60)) AS type_desc,
+  CAST(1 as sys.BIT) AS is_default,
+  CAST(0 as sys.BIT) AS is_system;
+GRANT SELECT ON sys.data_spaces TO PUBLIC;
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/sys-data_spaces.out
+++ b/test/JDBC/expected/sys-data_spaces.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.data_spaces;
+GO
+~~START~~
+varchar#!#int#!#char#!#nvarchar#!#bit#!#bit
+PRIMARY#!#1#!#FG#!#ROWS_FILEGROUP#!#1#!#0
+~~END~~

--- a/test/JDBC/expected/sys-data_spaces.out
+++ b/test/JDBC/expected/sys-data_spaces.out
@@ -4,3 +4,4 @@ GO
 varchar#!#int#!#char#!#nvarchar#!#bit#!#bit
 PRIMARY#!#1#!#FG#!#ROWS_FILEGROUP#!#1#!#0
 ~~END~~
+

--- a/test/JDBC/input/views/sys-data_spaces.sql
+++ b/test/JDBC/input/views/sys-data_spaces.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.data_spaces;
+GO


### PR DESCRIPTION
### Description
Previously Babelfish did not support sys.data_spaces view. These changes add the stub implementation of the sys.data_spaces view with a single hardcoded entry.
 
Task: BABELFISH-345

Signed-off-by: Sertay Sener seners@amazon.com

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.