### PR TITLE
Update the constraint_column_id field of the sys.foreign_key_columns.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -629,20 +629,18 @@ select out_object_id::oid as object_id
 from sys.columns_internal();
 GRANT SELECT ON sys.columns TO PUBLIC;
 
-create or replace view sys.foreign_key_columns as
-select distinct
-  c.oid as constraint_object_id
-  , c.confkey as constraint_column_id
-  , c.conrelid as parent_object_id
-  , a_con.attnum as parent_column_id
-  , c.confrelid as referenced_object_id
-  , a_conf.attnum as referenced_column_id
-from pg_constraint c
-inner join pg_attribute a_con on a_con.attrelid = c.conrelid and a_con.attnum = any(c.conkey)
-inner join pg_attribute a_conf on a_conf.attrelid = c.confrelid and a_conf.attnum = any(c.confkey)
-where c.contype = 'f'
-and (c.connamespace in (select schema_id from sys.schemas))
-and has_schema_privilege(c.connamespace, 'USAGE');
+CREATE OR replace view sys.foreign_key_columns as
+SELECT DISTINCT
+  CAST(c.oid AS INT) AS constraint_object_id
+  ,CAST((generate_series(1,ARRAY_LENGTH(c.conkey,1))) AS INT) AS constraint_column_id
+  ,CAST(c.conrelid AS INT) AS parent_object_id
+  ,CAST((UNNEST (c.conkey)) AS INT) AS parent_column_id
+  ,CAST(c.confrelid AS INT) AS referenced_object_id
+  ,CAST((UNNEST(c.confkey)) AS INT) AS referenced_column_id
+FROM pg_constraint c
+WHERE c.contype = 'f'
+AND (c.connamespace IN (SELECT schema_id FROM sys.schemas))
+AND has_schema_privilege(c.connamespace, 'USAGE');
 GRANT SELECT ON sys.foreign_key_columns TO PUBLIC;
 
 create or replace view sys.foreign_keys as

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -2496,7 +2496,7 @@ AND (c.connamespace IN (SELECT schema_id FROM sys.schemas))
 AND has_schema_privilege(c.connamespace, 'USAGE');
 GRANT SELECT ON sys.foreign_key_columns TO PUBLIC;
 
-SELECT sys.drop_view('sys', 'foreign_key_columns_deprecated');
+CALL sys.babelfish_drop_deprecated_view('sys', 'foreign_key_columns_deprecated');
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/sys-foreign_key_columns.out
+++ b/test/JDBC/expected/sys-foreign_key_columns.out
@@ -1,13 +1,13 @@
 CREATE DATABASE db1;
 GO
 
-USE db1
+USE db1;
 GO
 
-create table fk_1 (a int, primary key (a))
+create table fk_1 (a int, primary key (a));
 GO
 
-create table fk_2 (a int, b int, primary key (a), foreign key (b) references fk_1(a))
+create table fk_2 (a int, b int, primary key (a), foreign key (b) references fk_1(a));
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_2');
@@ -26,7 +26,7 @@ int
 ~~END~~
 
 
-USE master
+USE master;
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_2');
@@ -45,10 +45,10 @@ int
 ~~END~~
 
 
-create table fk_3 (a int, primary key (a))
+create table fk_3 (a int, primary key (a));
 GO
 
-create table fk_4 (a int, b int, primary key (a), foreign key (b) references fk_3(a))
+create table fk_4 (a int, b int, primary key (a), foreign key (b) references fk_3(a));
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_4');
@@ -67,7 +67,7 @@ int
 ~~END~~
 
 
-USE db1
+USE db1;
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_4');
@@ -92,7 +92,7 @@ GO
 drop table fk_1;
 GO
 
-USE master
+USE master;
 GO
 
 drop table fk_4;
@@ -101,5 +101,136 @@ GO
 drop table fk_3;
 GO
 
-DROP DATABASE db1
+USE db1;
+GO
+
+CREATE TABLE pk_t1 (
+    PID_1 INT NOT NULL,
+    PID_2 INT NOT NULL,
+    PRIMARY KEY (PID_1, PID_2)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+CREATE TABLE pk_t2 (
+    PID_3 INT NOT NULL,
+    PID_4 INT NOT NULL,
+    PRIMARY KEY (PID_3, PID_4)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+CREATE TABLE fk_t1 (
+    PID_1 INT,
+    PID_2 INT,
+    FOREIGN KEY (PID_1, PID_2) REFERENCES pk_t1(PID_1, PID_2)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+CREATE TABLE fk_t2 (
+    PID_3 INT,
+    PID_4 INT,
+    FOREIGN KEY (PID_3, PID_4) REFERENCES pk_t2(PID_3, PID_4)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+CREATE TABLE pk_t3 (
+    PID_5 INT NOT NULL,
+    PID_6 INT NOT NULL,
+    PRIMARY KEY (PID_5, PID_6)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+CREATE TABLE fk_t3 (
+    PID_3 INT NOT NULL,
+    PID_4 INT NOT NULL,
+    PID_5 INT NOT NULL,
+    PID_6 INT NOT NULL,
+    FOREIGN KEY (PID_3, PID_4) REFERENCES pk_t2(PID_3, PID_4),
+    FOREIGN KEY (PID_5, PID_6) REFERENCES pk_t3(PID_5, PID_6)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+
+SELECT constraint_column_id, parent_column_id, referenced_column_id FROM sys.foreign_key_columns ORDER BY constraint_column_id, parent_column_id, referenced_column_id;
+DROP TABLE fk_t3;
+GO
+~~START~~
+int#!#int#!#int
+1#!#1#!#1
+1#!#1#!#1
+1#!#1#!#1
+1#!#3#!#1
+2#!#2#!#2
+2#!#2#!#2
+2#!#2#!#2
+2#!#4#!#2
+~~END~~
+
+
+DROP TABLE fk_t2;
+GO
+
+DROP TABLE fk_t1;
+GO
+
+DROP TABLE pk_t3;
+GO
+
+DROP TABLE pk_t2;
+GO
+
+DROP TABLE pk_t1;
+GO
+
+USE master;
+GO
+
+DROP DATABASE db1;
 GO

--- a/test/JDBC/input/views/sys-foreign_key_columns.sql
+++ b/test/JDBC/input/views/sys-foreign_key_columns.sql
@@ -1,22 +1,13 @@
 CREATE DATABASE db1;
 GO
 
-USE db1
+USE db1;
 GO
 
-create table fk_1 (a int, primary key (a))
+create table fk_1 (a int, primary key (a));
 GO
 
-create table fk_2 (a int, b int, primary key (a), foreign key (b) references fk_1(a))
-GO
-
-select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_2');
-GO
-
-select count(*) from sys.foreign_keys where parent_object_id = object_id('fk_2');
-GO
-
-USE master
+create table fk_2 (a int, b int, primary key (a), foreign key (b) references fk_1(a));
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_2');
@@ -25,10 +16,19 @@ GO
 select count(*) from sys.foreign_keys where parent_object_id = object_id('fk_2');
 GO
 
-create table fk_3 (a int, primary key (a))
+USE master;
 GO
 
-create table fk_4 (a int, b int, primary key (a), foreign key (b) references fk_3(a))
+select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_2');
+GO
+
+select count(*) from sys.foreign_keys where parent_object_id = object_id('fk_2');
+GO
+
+create table fk_3 (a int, primary key (a));
+GO
+
+create table fk_4 (a int, b int, primary key (a), foreign key (b) references fk_3(a));
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_4');
@@ -37,7 +37,7 @@ GO
 select count(*) from sys.foreign_keys where parent_object_id = object_id('fk_4');
 GO
 
-USE db1
+USE db1;
 GO
 
 select count(*) from sys.foreign_key_columns where parent_object_id = object_id('fk_4');
@@ -52,7 +52,7 @@ GO
 drop table fk_1;
 GO
 
-USE master
+USE master;
 GO
 
 drop table fk_4;
@@ -61,5 +61,94 @@ GO
 drop table fk_3;
 GO
 
-DROP DATABASE db1
+USE db1;
+GO
+
+CREATE TABLE pk_t1 (
+    PID_1 INT NOT NULL,
+    PID_2 INT NOT NULL,
+    PRIMARY KEY (PID_1, PID_2)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+
+CREATE TABLE pk_t2 (
+    PID_3 INT NOT NULL,
+    PID_4 INT NOT NULL,
+    PRIMARY KEY (PID_3, PID_4)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+
+CREATE TABLE fk_t1 (
+    PID_1 INT,
+    PID_2 INT,
+    FOREIGN KEY (PID_1, PID_2) REFERENCES pk_t1(PID_1, PID_2)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+
+CREATE TABLE fk_t2 (
+    PID_3 INT,
+    PID_4 INT,
+    FOREIGN KEY (PID_3, PID_4) REFERENCES pk_t2(PID_3, PID_4)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+
+CREATE TABLE pk_t3 (
+    PID_5 INT NOT NULL,
+    PID_6 INT NOT NULL,
+    PRIMARY KEY (PID_5, PID_6)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+
+CREATE TABLE fk_t3 (
+    PID_3 INT NOT NULL,
+    PID_4 INT NOT NULL,
+    PID_5 INT NOT NULL,
+    PID_6 INT NOT NULL,
+    FOREIGN KEY (PID_3, PID_4) REFERENCES pk_t2(PID_3, PID_4),
+    FOREIGN KEY (PID_5, PID_6) REFERENCES pk_t3(PID_5, PID_6)
+);
+GO
+
+SELECT COUNT(*) FROM sys.foreign_key_columns;
+GO
+
+SELECT constraint_column_id, parent_column_id, referenced_column_id FROM sys.foreign_key_columns ORDER BY constraint_column_id, parent_column_id, referenced_column_id;
+
+DROP TABLE fk_t3;
+GO
+
+DROP TABLE fk_t2;
+GO
+
+DROP TABLE fk_t1;
+GO
+
+DROP TABLE pk_t3;
+GO
+
+DROP TABLE pk_t2;
+GO
+
+DROP TABLE pk_t1;
+GO
+
+USE master;
+GO
+
+DROP DATABASE db1;
 GO


### PR DESCRIPTION
### Description
This PR adds the appropriate type casts to each field of sys.foreign_key_columns and corrects the constraint_column_id field. Additionally, it simplifies the logic for parent_column_id and referenced_column_id.
 
Task: BABELFISH-417

Signed-off-by: Sertay Sener seners@amazon.com


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.