### PR TITLE
Add sys.xml_schema_collections and sys.dm_hadr_database_replica_states stubs

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1818,3 +1818,57 @@ SELECT  value_in_use AS value,
         END AS status
 FROM sys.babelfish_configurations;
 GRANT SELECT ON sys.sysconfigures TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.xml_schema_collections
+AS
+SELECT
+  CAST(NULL AS INT) as xml_collection_id,
+  CAST(NULL AS INT) as schema_id,
+  CAST(NULL AS INT) as principal_id,
+  CAST('sys' AS sys.sysname) as name,
+  CAST(NULL as sys.datetime) as create_date,
+  CAST(NULL as sys.datetime) as modify_date
+WHERE FALSE;
+GRANT SELECT ON sys.xml_schema_collections TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.dm_hadr_database_replica_states
+AS
+SELECT
+   CAST(0 as INT) database_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as group_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as replica_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as group_database_id
+  ,CAST(0 as sys.BIT) as is_local
+  ,CAST(0 as sys.BIT) as is_primary_replica
+  ,CAST(0 as sys.TINYINT) as synchronization_state
+  ,CAST('' as sys.nvarchar(60)) as synchronization_state_desc
+  ,CAST(0 as sys.BIT) as is_commit_participant
+  ,CAST(0 as sys.TINYINT) as synchronization_health
+  ,CAST('' as sys.nvarchar(60)) as synchronization_health_desc
+  ,CAST(0 as sys.TINYINT) as database_state
+  ,CAST('' as sys.nvarchar(60)) as database_state_desc
+  ,CAST(0 as sys.BIT) as is_suspended
+  ,CAST(0 as sys.TINYINT) as suspend_reason
+  ,CAST('' as sys.nvarchar(60)) as suspend_reason_desc
+  ,CAST(0.0 as numeric(25,0)) as truncation_lsn
+  ,CAST(0.0 as numeric(25,0)) as recovery_lsn
+  ,CAST(0.0 as numeric(25,0)) as last_sent_lsn
+  ,CAST(NULL as sys.DATETIME) as last_sent_time
+  ,CAST(0.0 as numeric(25,0)) as last_received_lsn
+  ,CAST(NULL as sys.DATETIME) as last_received_time
+  ,CAST(0.0 as numeric(25,0)) as last_hardened_lsn
+  ,CAST(NULL as sys.DATETIME) as last_hardened_time
+  ,CAST(0.0 as numeric(25,0)) as last_redone_lsn
+  ,CAST(NULL as sys.DATETIME) as last_redone_time
+  ,CAST(0 as sys.BIGINT) as log_send_queue_size
+  ,CAST(0 as sys.BIGINT) as log_send_rate
+  ,CAST(0 as sys.BIGINT) as redo_queue_size
+  ,CAST(0 as sys.BIGINT) as redo_rate
+  ,CAST(0 as sys.BIGINT) as filestream_send_rate
+  ,CAST(0.0 as numeric(25,0)) as end_of_log_lsn
+  ,CAST(0.0 as numeric(25,0)) as last_commit_lsn
+  ,CAST(NULL as sys.DATETIME) as last_commit_time
+  ,CAST(0 as sys.BIGINT) as low_water_mark_for_ghosts
+  ,CAST(0 as sys.BIGINT) as secondary_lag_seconds
+WHERE FALSE;
+GRANT SELECT ON sys.dm_hadr_database_replica_states TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1125,5 +1125,59 @@ END;
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE VIEW sys.xml_schema_collections
+AS
+SELECT
+  CAST(NULL AS INT) as xml_collection_id,
+  CAST(NULL AS INT) as schema_id,
+  CAST(NULL AS INT) as principal_id,
+  CAST('sys' AS sys.sysname) as name,
+  CAST(NULL as sys.datetime) as create_date,
+  CAST(NULL as sys.datetime) as modify_date
+WHERE FALSE;
+GRANT SELECT ON sys.xml_schema_collections TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.dm_hadr_database_replica_states
+AS
+SELECT
+   CAST(0 as INT) database_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as group_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as replica_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as group_database_id
+  ,CAST(0 as sys.BIT) as is_local
+  ,CAST(0 as sys.BIT) as is_primary_replica
+  ,CAST(0 as sys.TINYINT) as synchronization_state
+  ,CAST('' as sys.nvarchar(60)) as synchronization_state_desc
+  ,CAST(0 as sys.BIT) as is_commit_participant
+  ,CAST(0 as sys.TINYINT) as synchronization_health
+  ,CAST('' as sys.nvarchar(60)) as synchronization_health_desc
+  ,CAST(0 as sys.TINYINT) as database_state
+  ,CAST('' as sys.nvarchar(60)) as database_state_desc
+  ,CAST(0 as sys.BIT) as is_suspended
+  ,CAST(0 as sys.TINYINT) as suspend_reason
+  ,CAST('' as sys.nvarchar(60)) as suspend_reason_desc
+  ,CAST(0.0 as numeric(25,0)) as truncation_lsn
+  ,CAST(0.0 as numeric(25,0)) as recovery_lsn
+  ,CAST(0.0 as numeric(25,0)) as last_sent_lsn
+  ,CAST(NULL as sys.DATETIME) as last_sent_time
+  ,CAST(0.0 as numeric(25,0)) as last_received_lsn
+  ,CAST(NULL as sys.DATETIME) as last_received_time
+  ,CAST(0.0 as numeric(25,0)) as last_hardened_lsn
+  ,CAST(NULL as sys.DATETIME) as last_hardened_time
+  ,CAST(0.0 as numeric(25,0)) as last_redone_lsn
+  ,CAST(NULL as sys.DATETIME) as last_redone_time
+  ,CAST(0 as sys.BIGINT) as log_send_queue_size
+  ,CAST(0 as sys.BIGINT) as log_send_rate
+  ,CAST(0 as sys.BIGINT) as redo_queue_size
+  ,CAST(0 as sys.BIGINT) as redo_rate
+  ,CAST(0 as sys.BIGINT) as filestream_send_rate
+  ,CAST(0.0 as numeric(25,0)) as end_of_log_lsn
+  ,CAST(0.0 as numeric(25,0)) as last_commit_lsn
+  ,CAST(NULL as sys.DATETIME) as last_commit_time
+  ,CAST(0 as sys.BIGINT) as low_water_mark_for_ghosts
+  ,CAST(0 as sys.BIGINT) as secondary_lag_seconds
+WHERE FALSE;
+GRANT SELECT ON sys.dm_hadr_database_replica_states TO PUBLIC;
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1107,5 +1107,59 @@ $$;
 
 CALL sys.babel_create_msdb_if_not_exists();
 
+CREATE OR REPLACE VIEW sys.xml_schema_collections
+AS
+SELECT
+  CAST(NULL AS INT) as xml_collection_id,
+  CAST(NULL AS INT) as schema_id,
+  CAST(NULL AS INT) as principal_id,
+  CAST('sys' AS sys.sysname) as name,
+  CAST(NULL as sys.datetime) as create_date,
+  CAST(NULL as sys.datetime) as modify_date
+WHERE FALSE;
+GRANT SELECT ON sys.xml_schema_collections TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.dm_hadr_database_replica_states
+AS
+SELECT
+   CAST(0 as INT) database_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as group_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as replica_id
+  ,CAST(NULL as sys.UNIQUEIDENTIFIER) as group_database_id
+  ,CAST(0 as sys.BIT) as is_local
+  ,CAST(0 as sys.BIT) as is_primary_replica
+  ,CAST(0 as sys.TINYINT) as synchronization_state
+  ,CAST('' as sys.nvarchar(60)) as synchronization_state_desc
+  ,CAST(0 as sys.BIT) as is_commit_participant
+  ,CAST(0 as sys.TINYINT) as synchronization_health
+  ,CAST('' as sys.nvarchar(60)) as synchronization_health_desc
+  ,CAST(0 as sys.TINYINT) as database_state
+  ,CAST('' as sys.nvarchar(60)) as database_state_desc
+  ,CAST(0 as sys.BIT) as is_suspended
+  ,CAST(0 as sys.TINYINT) as suspend_reason
+  ,CAST('' as sys.nvarchar(60)) as suspend_reason_desc
+  ,CAST(0.0 as numeric(25,0)) as truncation_lsn
+  ,CAST(0.0 as numeric(25,0)) as recovery_lsn
+  ,CAST(0.0 as numeric(25,0)) as last_sent_lsn
+  ,CAST(NULL as sys.DATETIME) as last_sent_time
+  ,CAST(0.0 as numeric(25,0)) as last_received_lsn
+  ,CAST(NULL as sys.DATETIME) as last_received_time
+  ,CAST(0.0 as numeric(25,0)) as last_hardened_lsn
+  ,CAST(NULL as sys.DATETIME) as last_hardened_time
+  ,CAST(0.0 as numeric(25,0)) as last_redone_lsn
+  ,CAST(NULL as sys.DATETIME) as last_redone_time
+  ,CAST(0 as sys.BIGINT) as log_send_queue_size
+  ,CAST(0 as sys.BIGINT) as log_send_rate
+  ,CAST(0 as sys.BIGINT) as redo_queue_size
+  ,CAST(0 as sys.BIGINT) as redo_rate
+  ,CAST(0 as sys.BIGINT) as filestream_send_rate
+  ,CAST(0.0 as numeric(25,0)) as end_of_log_lsn
+  ,CAST(0.0 as numeric(25,0)) as last_commit_lsn
+  ,CAST(NULL as sys.DATETIME) as last_commit_time
+  ,CAST(0 as sys.BIGINT) as low_water_mark_for_ghosts
+  ,CAST(0 as sys.BIGINT) as secondary_lag_seconds
+WHERE FALSE;
+GRANT SELECT ON sys.dm_hadr_database_replica_states TO PUBLIC;
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/sys-dm_hadr_database_replica_states.out
+++ b/test/JDBC/expected/sys-dm_hadr_database_replica_states.out
@@ -1,0 +1,7 @@
+-- Test function stub
+SELECT * FROM sys.dm_hadr_database_replica_states;
+GO
+~~START~~
+int#!#uniqueidentifier#!#uniqueidentifier#!#uniqueidentifier#!#bit#!#bit#!#tinyint#!#nvarchar#!#bit#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#bit#!#tinyint#!#nvarchar#!#numeric#!#numeric#!#numeric#!#datetime#!#numeric#!#datetime#!#numeric#!#datetime#!#numeric#!#datetime#!#bigint#!#bigint#!#bigint#!#bigint#!#bigint#!#numeric#!#numeric#!#datetime#!#bigint#!#bigint
+~~END~~
+

--- a/test/JDBC/expected/sys-xml_schema_collections.out
+++ b/test/JDBC/expected/sys-xml_schema_collections.out
@@ -1,0 +1,7 @@
+-- Test function stub
+SELECT * FROM sys.xml_schema_collections
+GO
+~~START~~
+int#!#int#!#int#!#varchar#!#datetime#!#datetime
+~~END~~
+

--- a/test/JDBC/input/views/sys-dm_hadr_database_replica_states.sql
+++ b/test/JDBC/input/views/sys-dm_hadr_database_replica_states.sql
@@ -1,0 +1,3 @@
+-- Test function stub
+SELECT * FROM sys.dm_hadr_database_replica_states;
+GO

--- a/test/JDBC/input/views/sys-xml_schema_collections.sql
+++ b/test/JDBC/input/views/sys-xml_schema_collections.sql
@@ -1,0 +1,3 @@
+-- Test function stub
+SELECT * FROM sys.xml_schema_collections
+GO


### PR DESCRIPTION
### Description

Previously, sys.dm_hadr_database_replica_states and
sys.xml_schema_collections were not implemented in Babelfish. However, these
two views are needed to unblock SSMS functionalities even if Babelfish does
not currently support the functionalities related to these
two views. This commit implements both of these views as stubs in order
to unblock SSMS functionalities.

TASK: BABELFISH-342, BABELFISH-412
Signed-off-by: Favian (Ian) Samatha [ians@bitquilltech.com](mailto:ians@bitquilltech.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).