### PR TITLE
Correct the datatype of columns in server/database_principals

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -191,15 +191,15 @@ AS SELECT
 CAST(Base.rolname AS sys.SYSNAME) AS name,
 CAST(Base.oid As INT) AS principal_id,
 CAST(CAST(Base.oid as INT) as sys.varbinary(85)) AS sid,
-Ext.type,
+CAST(Ext.type AS CHAR(1)) as type,
 CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_LOGIN' ELSE NULL END AS NVARCHAR(60)) AS type_desc,
-Ext.is_disabled,
-Ext.create_date,
-Ext.modify_date,
-Ext.default_database_name,
-Ext.default_language_name,
-Ext.credential_id,
-Ext.owning_principal_id,
+CAST(Ext.is_disabled AS INT) AS is_disabled,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(Ext.default_database_name AS SYS.SYSNAME) AS default_database_name,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(Ext.credential_id AS INT) AS credential_id,
+CAST(Ext.owning_principal_id AS INT) AS owning_principal_id,
 CAST(Ext.is_fixed_role AS sys.BIT) AS is_fixed_role
 FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname;
 
@@ -230,22 +230,22 @@ GRANT SELECT ON sys.babelfish_authid_user_ext TO PUBLIC;
 
 -- DATABASE_PRINCIPALS
 CREATE VIEW sys.database_principals AS SELECT
-Ext.orig_username AS name,
+CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
 CAST(Base.OID AS INT) AS principal_id,
-Ext.type,
+CAST(Ext.type AS CHAR(1)) as type,
 CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_USER'
 WHEN Ext.type = 'R' THEN 'DATABASE_ROLE'
 ELSE NULL END AS SYS.NVARCHAR(60)) AS type_desc,
-Ext.default_schema_name,
-Ext.create_date,
-Ext.modify_date,
-Ext.owning_principal_id,
+CAST(Ext.default_schema_name AS SYS.SYSNAME) AS default_schema_name,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(Ext.owning_principal_id AS INT) AS owning_principal_id,
 CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
 CAST(Ext.is_fixed_role AS SYS.BIT) AS is_fixed_role,
-Ext.authentication_type,
-Ext.authentication_type_desc,
-Ext.default_language_name,
-Ext.default_language_lcid,
+CAST(Ext.authentication_type AS INT) AS authentication_type,
+CAST(Ext.authentication_type_desc AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(Ext.default_language_lcid AS INT) AS default_language_lcid,
 CAST(Ext.allow_encrypted_value_modifications AS SYS.BIT) AS allow_encrypted_value_modifications
 FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
 ON Base.rolname = Ext.rolname

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1350,7 +1350,7 @@ WHERE Ext.database_name = DB_NAME();
 GRANT SELECT ON sys.database_principals TO PUBLIC;
 
 -- Drop the deprecated view if there isn't any dependent object
-SELECT sys.babelfish_drop_deprecated_view('sys', 'database_principals_deprecated');
+CALL sys.babelfish_drop_deprecated_view('sys', 'database_principals_deprecated');
 
 ALTER VIEW sys.server_principals RENAME TO server_principals_deprecated;
 -- sys.server_principals is used only in is_srvrolemember() function.
@@ -1376,7 +1376,7 @@ FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_login_ext AS E
 GRANT SELECT ON sys.server_principals TO PUBLIC;
 
 -- Drop the deprecated view if there isn't any dependent object
-SELECT sys.babelfish_drop_deprecated_view('sys', 'server_principals_deprecated');
+CALL sys.babelfish_drop_deprecated_view('sys', 'server_principals_deprecated');
 
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1320,6 +1320,64 @@ END;
 $$
 LANGUAGE plpgsql;
 
+ALTER VIEW sys.database_principals RENAME TO database_principals_deprecated;
+-- sys.database_principals don't have any dependent objects
+-- DATABASE_PRINCIPALS
+CREATE VIEW sys.database_principals AS SELECT
+CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
+CAST(Base.OID AS INT) AS principal_id,
+CAST(Ext.type AS CHAR(1)) as type,
+CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_USER'
+WHEN Ext.type = 'R' THEN 'DATABASE_ROLE'
+ELSE NULL END AS SYS.NVARCHAR(60)) AS type_desc,
+CAST(Ext.default_schema_name AS SYS.SYSNAME) AS default_schema_name,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(Ext.owning_principal_id AS INT) AS owning_principal_id,
+CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(Ext.is_fixed_role AS SYS.BIT) AS is_fixed_role,
+CAST(Ext.authentication_type AS INT) AS authentication_type,
+CAST(Ext.authentication_type_desc AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(Ext.default_language_lcid AS INT) AS default_language_lcid,
+CAST(Ext.allow_encrypted_value_modifications AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
+ON Base.rolname = Ext.rolname
+LEFT OUTER JOIN pg_catalog.pg_roles Base2
+ON Ext.login_name = Base2.rolname
+WHERE Ext.database_name = DB_NAME();
+
+GRANT SELECT ON sys.database_principals TO PUBLIC;
+
+-- Drop the deprecated view if there isn't any dependent object
+SELECT sys.babelfish_drop_deprecated_view('sys', 'database_principals_deprecated');
+
+ALTER VIEW sys.server_principals RENAME TO server_principals_deprecated;
+-- sys.server_principals is used only in is_srvrolemember() function.
+-- Nothing needs to be done for function as body doesn't get changed dynamically.
+-- SERVER_PRINCIPALS
+CREATE VIEW sys.server_principals
+AS SELECT
+CAST(Base.rolname AS sys.SYSNAME) AS name,
+CAST(Base.oid As INT) AS principal_id,
+CAST(CAST(Base.oid as INT) as sys.varbinary(85)) AS sid,
+CAST(Ext.type AS CHAR(1)) as type,
+CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_LOGIN' ELSE NULL END AS NVARCHAR(60)) AS type_desc,
+CAST(Ext.is_disabled AS INT) AS is_disabled,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(Ext.default_database_name AS SYS.SYSNAME) AS default_database_name,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(Ext.credential_id AS INT) AS credential_id,
+CAST(Ext.owning_principal_id AS INT) AS owning_principal_id,
+CAST(Ext.is_fixed_role AS sys.BIT) AS is_fixed_role
+FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname;
+
+GRANT SELECT ON sys.server_principals TO PUBLIC;
+
+-- Drop the deprecated view if there isn't any dependent object
+SELECT sys.babelfish_drop_deprecated_view('sys', 'server_principals_deprecated');
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);

--- a/test/JDBC/expected/BABEL-1442.out
+++ b/test/JDBC/expected/BABEL-1442.out
@@ -218,7 +218,7 @@ GO
 SELECT default_database_name FROM sys.server_principals WHERE name = 'r1';
 GO
 ~~START~~
-nvarchar
+varchar
 master
 ~~END~~
 
@@ -253,7 +253,7 @@ GO
 SELECT default_database_name FROM sys.server_principals WHERE name = 'r6';
 GO
 ~~START~~
-nvarchar
+varchar
 master
 ~~END~~
 
@@ -309,7 +309,7 @@ GO
 SELECT default_database_name FROM sys.server_principals WHERE name = 'r1';
 GO
 ~~START~~
-nvarchar
+varchar
 tempdb
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-3009.out
+++ b/test/JDBC/expected/BABEL-3009.out
@@ -1,0 +1,45 @@
+SELECT ac.name,tp.name as type_name FROM sys.all_columns ac
+LEFT JOIN sys.types tp ON tp.system_type_id = ac.system_type_id
+WHERE ac.object_id = object_id('sys.server_principals') ORDER BY ac.name;
+GO
+~~START~~
+varchar#!#text
+create_date#!#datetime
+credential_id#!#int
+default_database_name#!#sysname
+default_language_name#!#sysname
+is_disabled#!#int
+is_fixed_role#!#bit
+modify_date#!#datetime
+name#!#sysname
+owning_principal_id#!#int
+principal_id#!#int
+sid#!#varbinary
+type#!#<NULL>
+type_desc#!#nvarchar
+~~END~~
+
+
+SELECT ac.name,tp.name as type_name FROM sys.all_columns ac
+LEFT JOIN sys.types tp ON tp.system_type_id = ac.system_type_id
+WHERE ac.object_id = object_id('sys.database_principals') ORDER BY ac.name;
+GO
+~~START~~
+varchar#!#text
+allow_encrypted_value_modifications#!#bit
+authentication_type#!#int
+authentication_type_desc#!#nvarchar
+create_date#!#datetime
+default_language_lcid#!#int
+default_language_name#!#sysname
+default_schema_name#!#sysname
+is_fixed_role#!#bit
+modify_date#!#datetime
+name#!#sysname
+owning_principal_id#!#int
+principal_id#!#int
+sid#!#varbinary
+type#!#<NULL>
+type_desc#!#nvarchar
+~~END~~
+

--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -689,7 +689,7 @@ FROM sys.database_principals
 ORDER BY default_schema_name DESC, name;
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 dbo#!#dbo
 db_owner#!#
 guest#!#
@@ -718,7 +718,7 @@ FROM sys.database_principals
 ORDER BY default_schema_name DESC, name;
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 dbo#!#dbo
 db_owner#!#
 ~~END~~

--- a/test/JDBC/expected/BABEL-ROLE.out
+++ b/test/JDBC/expected/BABEL-ROLE.out
@@ -22,7 +22,7 @@ WHERE type = 'R'
 ORDER BY name
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#nvarchar
 ~~END~~
 
 
@@ -45,7 +45,7 @@ FROM sys.database_principals
 WHERE name = 'test1'
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#nvarchar
 test1#!#DATABASE_ROLE
 ~~END~~
 
@@ -152,7 +152,7 @@ master_test2#!#S#!#test2#!#master
 EXEC babel_db_principal
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#nvarchar
 test1#!#DATABASE_ROLE
 test2#!#DATABASE_ROLE
 ~~END~~
@@ -239,7 +239,7 @@ master_test2#!#S#!#test2#!#master
 EXEC babel_db_principal
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#nvarchar
 test1#!#DATABASE_ROLE
 test2#!#DATABASE_ROLE
 test3#!#SQL_USER
@@ -250,7 +250,7 @@ test4#!#SQL_USER
 EXEC babel_role_members
 GO
 ~~START~~
-nvarchar#!#char#!#nvarchar#!#char
+varchar#!#char#!#varchar#!#char
 test1#!#R#!#test2#!#R
 test1#!#R#!#test3#!#S
 test2#!#R#!#test4#!#S
@@ -277,7 +277,7 @@ master_test2#!#S#!#test2#!#master
 EXEC babel_db_principal
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#nvarchar
 test1_new#!#DATABASE_ROLE
 test2#!#DATABASE_ROLE
 test3#!#SQL_USER
@@ -288,7 +288,7 @@ test4#!#SQL_USER
 EXEC babel_role_members
 GO
 ~~START~~
-nvarchar#!#char#!#nvarchar#!#char
+varchar#!#char#!#varchar#!#char
 test1_new#!#R#!#test2#!#R
 test1_new#!#R#!#test3#!#S
 test2#!#R#!#test4#!#S
@@ -321,7 +321,7 @@ master_test2#!#S#!#test2#!#master
 EXEC babel_db_principal
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#nvarchar
 test1_new#!#DATABASE_ROLE
 test2#!#DATABASE_ROLE
 test3#!#SQL_USER
@@ -332,7 +332,7 @@ test4#!#SQL_USER
 EXEC babel_role_members
 GO
 ~~START~~
-nvarchar#!#char#!#nvarchar#!#char
+varchar#!#char#!#varchar#!#char
 test1_new#!#R#!#test2#!#R
 test1_new#!#R#!#test3#!#S
 test2#!#R#!#test4#!#S

--- a/test/JDBC/expected/BABEL-USER.out
+++ b/test/JDBC/expected/BABEL-USER.out
@@ -47,7 +47,7 @@ FROM sys.database_principals
 ORDER BY default_schema_name DESC, name;
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 dbo#!#dbo
 db_owner#!#
 guest#!#
@@ -86,7 +86,7 @@ FROM sys.database_principals
 WHERE name = 'test1';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 test1#!#dbo
 ~~END~~
 
@@ -125,7 +125,7 @@ FROM sys.database_principals
 WHERE name = 'test2';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 test2#!#dbo
 ~~END~~
 
@@ -152,7 +152,7 @@ FROM sys.database_principals
 WHERE name = 'test3';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 test3#!#sch3
 ~~END~~
 
@@ -186,7 +186,7 @@ FROM sys.database_principals
 WHERE name = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA#!#dbo
 ~~END~~
 
@@ -210,7 +210,7 @@ FROM sys.database_principals
 WHERE name = 'test1';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 test1#!#sch3
 ~~END~~
 
@@ -233,7 +233,7 @@ FROM sys.database_principals
 WHERE name = 'test1';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 test1#!#dbo
 ~~END~~
 
@@ -256,7 +256,7 @@ FROM sys.database_principals
 WHERE name = 'new_test1';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 new_test1#!#dbo
 ~~END~~
 
@@ -300,7 +300,7 @@ FROM sys.database_principals
 WHERE name = 'test1';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 ~~END~~
 
 
@@ -312,7 +312,7 @@ FROM sys.database_principals
 WHERE name = 'test2';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 ~~END~~
 
 
@@ -324,7 +324,7 @@ FROM sys.database_principals
 WHERE name = 'test3';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 ~~END~~
 
 
@@ -336,7 +336,7 @@ FROM sys.database_principals
 WHERE name = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 GO
 ~~START~~
-nvarchar#!#nvarchar
+varchar#!#varchar
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-3009.sql
+++ b/test/JDBC/input/BABEL-3009.sql
@@ -1,0 +1,9 @@
+SELECT ac.name,tp.name as type_name FROM sys.all_columns ac
+LEFT JOIN sys.types tp ON tp.system_type_id = ac.system_type_id
+WHERE ac.object_id = object_id('sys.server_principals') ORDER BY ac.name;
+GO
+
+SELECT ac.name,tp.name as type_name FROM sys.all_columns ac
+LEFT JOIN sys.types tp ON tp.system_type_id = ac.system_type_id
+WHERE ac.object_id = object_id('sys.database_principals') ORDER BY ac.name;
+GO

--- a/test/JDBC/sql_expected/sys-server_principals.out
+++ b/test/JDBC/sql_expected/sys-server_principals.out
@@ -11,7 +11,7 @@ FROM sys.server_principals
 WHERE name =  'jdbc_user';
 GO
 ~~START~~
-varchar#!#char#!#nvarchar#!#nvarchar#!#nvarchar
+varchar#!#char#!#nvarchar#!#varchar#!#varchar
 jdbc_user#!#S#!#SQL_LOGIN#!#master#!#English
 ~~END~~
 
@@ -24,7 +24,7 @@ FROM sys.server_principals
 WHERE name in ('jdbc_user', 'serv_principal_test');
 GO
 ~~START~~
-varchar#!#char#!#nvarchar#!#nvarchar#!#nvarchar
+varchar#!#char#!#nvarchar#!#varchar#!#varchar
 jdbc_user#!#S#!#SQL_LOGIN#!#master#!#English
 serv_principal_test#!#S#!#SQL_LOGIN#!#master#!#English
 ~~END~~
@@ -38,7 +38,7 @@ FROM sys.server_principals
 WHERE name in ('jdbc_user', 'serv_principal_test');
 GO
 ~~START~~
-varchar#!#char#!#nvarchar#!#nvarchar#!#nvarchar
+varchar#!#char#!#nvarchar#!#varchar#!#varchar
 jdbc_user#!#S#!#SQL_LOGIN#!#master#!#English
 ~~END~~
 


### PR DESCRIPTION
### Description

Previously, server/database_principals view's definition was having
wrong datatypes for example create_date and modify_date column's datatype as
timestamptz which was incorrect.

This commit corrects the datatypes of columns by explicitly casting them
to correct type in server_principals and database_principals views. For
upgrade part, it renames the views by adding the suffix '_deprecated' like
server_principals_deprecated and recreate it with correct datatypes in upgrade
script. Drop the deprecated view if there is not any dependent object
using sys.babelfish_drop_deprecated_view helper function.

Task: BABEL-3009,2713
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>
 
### Issues Resolved

Task: BABEL-3009,2713


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).