### PR TITLE
sysadmin should be a row in sys.server_principals

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -108,7 +108,10 @@ create_bbf_authid_login_ext(CreateRoleStmt *stmt)
 
 	new_record_login_ext[LOGIN_EXT_ROLNAME] = CStringGetDatum(stmt->role);
 	new_record_login_ext[LOGIN_EXT_IS_DISABLED] = Int32GetDatum(0);
-	new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("S");
+	if (strcmp(stmt->role, "sysadmin") == 0)
+		new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("R");
+	else
+		new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("S");
 	new_record_login_ext[LOGIN_EXT_CREDENTIAL_ID] = Int32GetDatum(-1); /* placeholder */
 	new_record_login_ext[LOGIN_EXT_OWNING_PRINCIPAL_ID] = Int32GetDatum(-1); /* placeholder */
 	new_record_login_ext[LOGIN_EXT_IS_FIXED_ROLE] = Int32GetDatum(0);

--- a/test/JDBC/expected/BABEL-2403.out
+++ b/test/JDBC/expected/BABEL-2403.out
@@ -55,6 +55,8 @@ name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext mus
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_login_ext must also exist in pg_authid"}
 text#!#sys#!#name#!#{"Rule": "<default_database_name> in babelfish_authid_login_ext must also exist in babelfish_sysdatabases"}
+name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_login_ext must also exist in pg_authid"}
+text#!#sys#!#name#!#{"Rule": "<default_database_name> in babelfish_authid_login_ext must also exist in babelfish_sysdatabases"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_user_ext must also exist in pg_authid"}
 text#!#sys#!#name#!#{"Rule": "<database_name> in babelfish_authid_user_ext must also exist in babelfish_sysdatabases"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_user_ext must also exist in pg_authid"}
@@ -140,6 +142,8 @@ name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
+name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_login_ext must also exist in pg_authid"}
+text#!#sys#!#name#!#{"Rule": "<default_database_name> in babelfish_authid_login_ext must also exist in babelfish_sysdatabases"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_login_ext must also exist in pg_authid"}
 text#!#sys#!#name#!#{"Rule": "<default_database_name> in babelfish_authid_login_ext must also exist in babelfish_sysdatabases"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_user_ext must also exist in pg_authid"}

--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -224,7 +224,7 @@ SELECT COUNT(*) FROM sys.babelfish_authid_login_ext;
 go
 ~~START~~
 int
-1
+2
 ~~END~~
 
 
@@ -235,7 +235,7 @@ SELECT COUNT(*) FROM sys.babelfish_authid_login_ext;
 go
 ~~START~~
 int
-2
+3
 ~~END~~
 
 
@@ -247,7 +247,7 @@ SELECT COUNT(*) FROM sys.babelfish_authid_login_ext;
 go
 ~~START~~
 int
-3
+4
 ~~END~~
 
 
@@ -315,7 +315,7 @@ SELECT COUNT(*) FROM sys.babelfish_authid_login_ext;
 go
 ~~START~~
 int
-2
+3
 ~~END~~
 
 
@@ -326,7 +326,7 @@ SELECT COUNT(*) FROM sys.babelfish_authid_login_ext;
 go
 ~~START~~
 int
-1
+2
 ~~END~~
 
 

--- a/test/JDBC/input/views/sys-server_principals.sql
+++ b/test/JDBC/input/views/sys-server_principals.sql
@@ -1,9 +1,14 @@
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.server_principals');
 GO
 
-SELECT name, type, type_desc, default_database_name, default_language_name
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id
 FROM sys.server_principals 
 WHERE name =  'jdbc_user';
+GO
+
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id
+FROM sys.server_principals 
+WHERE name =  'sysadmin';
 GO
 
 CREATE LOGIN serv_principal_test WITH PASSWORD = 'test';
@@ -11,7 +16,7 @@ GO
 
 SELECT name, type, type_desc, default_database_name, default_language_name
 FROM sys.server_principals 
-WHERE name in ('jdbc_user', 'serv_principal_test');
+WHERE name in ('jdbc_user', 'serv_principal_test') order by name;
 GO
 
 DROP LOGIN serv_principal_test;

--- a/test/JDBC/sql_expected/sys-server_principals.out
+++ b/test/JDBC/sql_expected/sys-server_principals.out
@@ -6,13 +6,23 @@ int
 ~~END~~
 
 
-SELECT name, type, type_desc, default_database_name, default_language_name
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id
 FROM sys.server_principals 
 WHERE name =  'jdbc_user';
 GO
 ~~START~~
-varchar#!#char#!#nvarchar#!#varchar#!#varchar
-jdbc_user#!#S#!#SQL_LOGIN#!#master#!#English
+varchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int#!#int
+jdbc_user#!#S#!#SQL_LOGIN#!#master#!#English#!#-1#!#-1
+~~END~~
+
+
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id
+FROM sys.server_principals 
+WHERE name =  'sysadmin';
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int#!#int
+sysadmin#!#R#!#SERVER_ROLE#!#<NULL>#!#English#!#<NULL>#!#1
 ~~END~~
 
 
@@ -21,7 +31,7 @@ GO
 
 SELECT name, type, type_desc, default_database_name, default_language_name
 FROM sys.server_principals 
-WHERE name in ('jdbc_user', 'serv_principal_test');
+WHERE name in ('jdbc_user', 'serv_principal_test') order by name;
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#varchar#!#varchar


### PR DESCRIPTION
In SQL Server, sysadmin is a server-level role,
and it is the only server-level role which we currently implement in Babelfish.
Therefore, the role should be present in the emulated catalog
sys.server_principals, but no such rows is currently in this catalog.

Task: BABEL-2472
Signed-off-by: Shalini Lohia <lshalini@amazon.com>
