### PR TITLE
Handle transaction error handling issues for table variables and functions

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -457,7 +457,7 @@ static void pltsql_update_identity_insert_sequence(PLtsql_expr *expr);
 static void pltsql_clean_table_variables(PLtsql_execstate *estate, PLtsql_function *func);
 
 static void pltsql_init_exec_error_data(PLtsqlErrorData *error_data);
-static void pltsql_copy_exec_error_data(PLtsqlErrorData *src, PLtsqlErrorData *dst);
+static void pltsql_copy_exec_error_data(PLtsqlErrorData *src, PLtsqlErrorData *dst, MemoryContext dstCxt);
 PLtsql_estate_err *pltsql_clone_estate_err(PLtsql_estate_err *err);
 
 extern void pltsql_init_anonymous_cursors(PLtsql_execstate *estate);
@@ -4595,15 +4595,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	bool		enable_txn_in_triggers = !pltsql_disable_txn_in_triggers;
     StringInfoData query;
 
-	/*
-	 * if ANTLR is enabled, PLtsql_stmt_push_result will be replaced with PLtsql_stmt_execsql
-	 * with flag need_to_push_result ON. To txn behavior makes consistent regardless of ANTLR,
-	 * adjust enable_txn_in_triggers as same as exec_stmt_push_result.
-	 * same for tsql_select_assign_stmt (select @a=1). with ANTLR=off, it is handled in PLtsql_stmt_query_set.
-	 */
-	if (stmt->need_to_push_result || stmt->is_tsql_select_assign_stmt)
-		enable_txn_in_triggers = false;
-
 	/* Handle naked SELECT stmt differently for INSERT ... EXECUTE */
 	if (stmt->need_to_push_result && estate->insert_exec)
 		return exec_stmt_insert_execute_select(estate, expr);
@@ -4700,6 +4691,15 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		else
 			estate->impl_txn_type = PLTSQL_IMPL_TRAN_ON;
 	}
+
+	/*
+	 * if ANTLR is enabled, PLtsql_stmt_push_result will be replaced with PLtsql_stmt_execsql
+	 * with flag need_to_push_result ON. To txn behavior makes consistent regardless of ANTLR,
+	 * adjust enable_txn_in_triggers as same as exec_stmt_push_result.
+	 * same for tsql_select_assign_stmt (select @a=1). with ANTLR=off, it is handled in PLtsql_stmt_query_set.
+	 */
+	if (stmt->need_to_push_result || stmt->is_tsql_select_assign_stmt || stmt->mod_stmt_tablevar)
+		enable_txn_in_triggers = false;
 
 	if (enable_txn_in_triggers)
 	{
@@ -9394,7 +9394,8 @@ pltsql_estate_cleanup(void)
 	top_es_entry = exec_state_call_stack->next;
 	if (top_es_entry != NULL)
 		pltsql_copy_exec_error_data(&(exec_state_call_stack->error_data),
-									&(top_es_entry->error_data));
+									&(top_es_entry->error_data),
+									top_es_entry->estate->stmt_mcontext_parent);
 	pfree(exec_state_call_stack);
 	exec_state_call_stack = top_es_entry;
 }
@@ -9447,6 +9448,9 @@ pltsql_xact_cb(XactEvent event, void *arg)
 		simple_econtext_stack = NULL;
 		shared_simple_eval_estate = NULL;
 	}
+	/* Reset portal snapshot in case of commit/rollback */
+	if (pltsql_snapshot_portal != NULL)
+		pltsql_snapshot_portal->portalSnapshot = NULL;
 	AbortCurTransaction = false;
 }
 
@@ -9901,12 +9905,18 @@ pltsql_init_exec_error_data(PLtsqlErrorData *error_data)
 }
 
 static void
-pltsql_copy_exec_error_data(PLtsqlErrorData *src, PLtsqlErrorData *dst)
+pltsql_copy_exec_error_data(PLtsqlErrorData *src, PLtsqlErrorData *dst, MemoryContext dstCtx)
 {
 	dst->xact_abort_on = src->xact_abort_on;
 	dst->rethrow_error = src->rethrow_error;
 	dst->trigger_error = src->trigger_error;
-	dst->error_procedure = src->error_procedure;
+	dst->error_procedure = NULL;
+	if (src->error_procedure != NULL)
+	{
+		MemoryContext oldContext = MemoryContextSwitchTo(dstCtx);
+		dst->error_procedure = pstrdup(src->error_procedure);
+		MemoryContextSwitchTo(oldContext);
+	}
 	dst->error_estate = src->error_estate;
 	dst->error_number = src->error_number;
 	dst->error_severity = src->error_severity;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3318,8 +3318,15 @@ _PG_fini(void)
 static void terminate_batch(bool send_error, bool compile_error)
 {
 	bool error_mapping_failed = false;
+	int rc;
 
 	elog(DEBUG2, "TSQL TXN finish current batch, error : %d compilation error : %d", send_error, compile_error);
+
+	/*
+	 * Disconnect from SPI manager
+	 */
+	if ((rc = SPI_finish()) != SPI_OK_FINISH)
+		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	if (send_error)
 	{
@@ -3353,6 +3360,7 @@ static void terminate_batch(bool send_error, bool compile_error)
 				 */
 				while (ActiveSnapshotSet())
 					PopActiveSnapshot();
+				pltsql_snapshot_portal->portalSnapshot = NULL;
 			}
 			MarkPortalDone(pltsql_snapshot_portal);
 			PortalDrop(pltsql_snapshot_portal, false);
@@ -3547,12 +3555,6 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	ENRDropTempTables(currentQueryEnv);
 	remove_queryEnv();
 	pltsql_revert_guc(save_nestlevel);
-
-	/*
-	 * Disconnect from SPI manager
-	 */
-	if ((rc = SPI_finish()) != SPI_OK_FINISH)
-		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	terminate_batch(false /* send_error */, false /* compile_error */);
 
@@ -3793,12 +3795,6 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 		FreeExecutorState(simple_eval_estate);
 		pltsql_free_function_memory(func);
 	}
-	/*
-	 * Disconnect from SPI manager
-	 */
-	if ((rc = SPI_finish()) != SPI_OK_FINISH)
-		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
-
 	sql_dialect = saved_dialect;
 	
 	terminate_batch(false /* send_error */, false /* compile_error */);

--- a/contrib/babelfishpg_tsql/src/prepare.c
+++ b/contrib/babelfishpg_tsql/src/prepare.c
@@ -50,6 +50,7 @@ prepare_stmt_execsql(PLtsql_execstate *estate, PLtsql_function *func, PLtsql_stm
 
 	exec_prepare_plan(estate, expr, CURSOR_OPT_PARALLEL_OK, keepplan);
 	stmt->mod_stmt = false;
+	stmt->mod_stmt_tablevar = false;
 	foreach(l, SPI_plan_get_plan_sources(expr->plan))
 	{
 		CachedPlanSource *plansource = (CachedPlanSource *) lfirst(l);

--- a/test/JDBC/expected/BABEL-213.out
+++ b/test/JDBC/expected/BABEL-213.out
@@ -169,6 +169,11 @@ GO
 
 ~~ERROR (Message: division by zero)~~
 
+~~START~~
+int
+<NULL>
+~~END~~
+
 
 -- assignment to different type
 -- char(200)->int (error should be thrwon)

--- a/test/JDBC/expected/BABEL-3101.out
+++ b/test/JDBC/expected/BABEL-3101.out
@@ -1,0 +1,109 @@
+
+
+
+
+
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+			INSERT INTO @returnList SELECT @name
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+		INSERT INTO @returnList SELECT @stringToSplit
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+~~START~~
+nvarchar
+this
+is
+split
+~~END~~
+
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+~~START~~
+tinyint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function date_part(unknown, text) does not exist)~~
+
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+~~START~~
+int
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/expected/BABEL-3108.out
+++ b/test/JDBC/expected/BABEL-3108.out
@@ -1,0 +1,37 @@
+CREATE TABLE t3108(c1 nvarchar(50));
+GO
+
+CREATE FUNCTION f3108_i ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max) Declare @TscList AS Table(tc nvarchar(10)) insert into @TscList SELECT Distinct c1 From t3108 with (nolock)
+	select  @tcs = COALESCE(@tcs + ', ', '') + tc from @TscList order by tc
+	RETURN isnull(@tcs,'')
+END
+GO
+
+CREATE FUNCTION f3108_o ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max);
+	SELECT @tcs = f3108_i(@val)
+	RETURN Case WHEN @tcs='|' then '' else isnull(@tcs,   '') end
+END
+GO
+
+declare @val nvarchar(50) = ' ' SELECT f3108_o(@val) as tc
+GO
+~~START~~
+nvarchar
+
+~~END~~
+
+
+DROP FUNCTION f3108_o
+GO
+
+DROP FUNCTION f3108_i
+GO
+
+DROP TABLE t3108
+GO

--- a/test/JDBC/expected/BABEL-PROCID.out
+++ b/test/JDBC/expected/BABEL-PROCID.out
@@ -266,6 +266,8 @@ varchar
 Running trigger trg_err_check
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 -- Test insert through a procedure
 CREATE PROCEDURE table_insert
@@ -284,6 +286,8 @@ GO
 varchar
 Running trigger trg_err_check
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 varchar

--- a/test/JDBC/input/BABEL-3101.sql
+++ b/test/JDBC/input/BABEL-3101.sql
@@ -1,0 +1,90 @@
+CREATE FUNCTION my_splitstring_3101 ( @stringToSplit VARCHAR(MAX) )
+RETURNS
+@returnList TABLE ([Value] [nvarchar] (50))
+AS
+BEGIN
+	DECLARE @name NVARCHAR(255)
+	DECLARE @pos INT
+
+	WHILE CHARINDEX(',', @stringToSplit) > 0
+		BEGIN
+			SELECT @pos  = CHARINDEX(',', @stringToSplit)
+			SELECT @name = SUBSTRING(@stringToSplit, 1, @pos-1)
+
+			INSERT INTO @returnList SELECT @name
+
+			SELECT @stringToSplit = SUBSTRING(@stringToSplit, @pos+1, LEN(@stringToSplit)-@pos)
+		END
+
+		INSERT INTO @returnList SELECT @stringToSplit
+
+		RETURN
+END
+GO
+
+select * from my_splitstring_3101('this,is,split')
+GO
+
+CREATE FUNCTION ISOweek_3101 (@date datetime)
+RETURNS tinyint
+AS
+BEGIN
+	DECLARE @ISOweek tinyint
+	SET @ISOweek= DATEPART(wk,@date)+1-DATEPART(wk,CAST(DATEPART(yy,@date) as CHAR(4))+'0104')
+	--Special cases: Jan 1-3 may belong to the previous year
+	IF (@ISOweek=0)
+		SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@date)-1 AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@date) AS CHAR(2)))+1
+	--Special case: Dec 29-31 may belong to the next year
+	IF ((DATEPART(mm,@date)=12) AND ((DATEPART(dd,@date)-DATEPART(dw,@date))>= 28))
+		SET @ISOweek=1
+	RETURN(@ISOweek)
+END
+GO
+
+SELECT ISOWeek_3101(GETDATE())
+GO
+
+CREATE FUNCTION table_3101_2()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	SET @return = 0
+	SET @return = 1/0
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_1()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_2()
+	RETURN @return
+END
+GO
+
+CREATE FUNCTION table_3101_0()
+RETURNS INT
+AS
+BEGIN
+	DECLARE @return INT
+	set @return = table_3101_1()
+	RETURN @return
+END
+GO
+
+select table_3101_0()
+GO
+
+DROP FUNCTION my_splitstring_3101
+GO
+
+DROP FUNCTION ISOWeek_3101
+GO
+
+DROP FUNCTION table_3101_0
+DROP FUNCTION table_3101_1
+DROP FUNCTION table_3101_2
+GO

--- a/test/JDBC/input/BABEL-3108.sql
+++ b/test/JDBC/input/BABEL-3108.sql
@@ -1,0 +1,32 @@
+CREATE TABLE t3108(c1 nvarchar(50));
+GO
+
+CREATE FUNCTION f3108_i ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max) Declare @TscList AS Table(tc nvarchar(10)) insert into @TscList SELECT Distinct c1 From t3108 with (nolock)
+	select  @tcs = COALESCE(@tcs + ', ', '') + tc from @TscList order by tc
+	RETURN isnull(@tcs,'')
+END
+GO
+
+CREATE FUNCTION f3108_o ( @val nvarchar(50) )
+RETURNS nvarchar(max) AS
+BEGIN
+	DECLARE @tcs nvarchar(max);
+	SELECT @tcs = f3108_i(@val)
+	RETURN Case WHEN @tcs='|' then '' else isnull(@tcs,   '') end
+END
+GO
+
+declare @val nvarchar(50) = ' ' SELECT f3108_o(@val) as tc
+GO
+
+DROP FUNCTION f3108_o
+GO
+
+DROP FUNCTION f3108_i
+GO
+
+DROP TABLE t3108
+GO


### PR DESCRIPTION

Avoid starting new transaction for insert into table variables

There are two issue which lead to the problem.
A select on a function internally creates a portal to hold the results.
The portal has its own resource owner which is used for all the
snapshots created during function execution. A transaction event inside
the function will reset resource owner to top transaction. Ideally, we
should reset back to portal resource owner at the earliest. This is not
happening right now as we do not want to do reset for cases where
transaction/savepoint was started before portal creation. We need to
distinguish between these two cases.
We start internal transactions for DDLs/DMLs but not for queries. We
were starting transactions for insert into table variables which we
should not. This internal transaction was resetting the resource owner
from portal to top transaction.

This change fixes the second problem. The first problem will be fixed as
a followup later.

An error when executing select func leads to internal error "InstrStartNode called twice in a row"

A select function call will run function inside a SELECT portal.
If the function throws an error, TSQL error handling will rollback
the internal PG transaction to support undo behavior. The rollback
will cleanup all active portals assuming PG semantic for transactions.

As portal is still active at higher level, this can result in
unpredictable behavior including above error and server crash.

We solve this issue by always running a TSQL function inside an internal
savepoint. We rely on the fact that TSQL functions cannot have side
effects like data write, transaction etc. In case of an error, rollback
to savepoint takes care of statement undo without effecting portals
active at higher level.

Handle missing SPI finish call for error cases

Every TSQL execution batch/proc/func call will create
a SPI connection and later close it using SPI finish.
However, SPI finish was missed for error cases and
can lead to in-correct SPI call stack for nested calls.
As a result, current call handler can call finish on
a leaked SPI connection of its children. This can cause
many issues including memory corruption.
As a fix, make sure that a call handler always does SPI
finish including error cases.
Also, did one small fix to make a copy of procedure name
info when unwinding a call stack. Otherwise, procedure name allocation
is no longer valid.

Task:Babel-3101,3108
Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).