### PR TITLE
Reflect T-SQL isolation level in sys.dm_exec_sessions view

### DIFF
--- a/test/JDBC/expected/BABEL-3209.out
+++ b/test/JDBC/expected/BABEL-3209.out
@@ -25,6 +25,6 @@ repeatable read
 
 ~~START~~
 smallint
-3
+5
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-3214.out
+++ b/test/JDBC/expected/BABEL-3214.out
@@ -1,0 +1,100 @@
+
+
+/*
+ * T-SQL transaction isolation level mapping is as follows for dm_exec_sessions:
+ *
+ * 1 = READ UNCOMMITTED
+ * 2 = READ COMMITTED
+ * 3 = REPEATABLE READ
+ * 4 = SERIALIZABLE
+ * 5 = SNAPSHOT
+ */
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+read uncommitted
+~~END~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+read committed
+~~END~~
+
+~~START~~
+smallint
+2
+~~END~~
+
+
+-- Isolation level not supported so will reflect same value as before
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REPEATABLE READ isolation level is not supported)~~
+
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+read committed
+~~END~~
+
+~~START~~
+smallint
+2
+~~END~~
+
+
+-- Isolation level not supported so will reflect same value as before
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SERIALIZABLE isolation level is not supported)~~
+
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+read committed
+~~END~~
+
+~~START~~
+smallint
+2
+~~END~~
+
+
+-- Isolation level internally mapped to PG repeatable read so
+-- current_setting will show "repeatable read" but
+-- dm_exec_sessions will show code for snapshot isolation
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+~~START~~
+varchar
+repeatable read
+~~END~~
+
+~~START~~
+smallint
+5
+~~END~~
+

--- a/test/JDBC/input/BABEL-3214.sql
+++ b/test/JDBC/input/BABEL-3214.sql
@@ -1,0 +1,42 @@
+/*
+ * T-SQL transaction isolation level mapping is as follows for dm_exec_sessions:
+ *
+ * 1 = READ UNCOMMITTED
+ * 2 = READ COMMITTED
+ * 3 = REPEATABLE READ
+ * 4 = SERIALIZABLE
+ * 5 = SNAPSHOT
+ */
+
+
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+
+-- Isolation level not supported so will reflect same value as before
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+GO
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+
+-- Isolation level not supported so will reflect same value as before
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+GO
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO
+
+-- Isolation level internally mapped to PG repeatable read so
+-- current_setting will show "repeatable read" but
+-- dm_exec_sessions will show code for snapshot isolation
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT;
+SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
+SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
+GO


### PR DESCRIPTION
### Description

We reflect the PG default_transaction_isolation GUC in the
transaction_isolation_level column in sys.dm_exec_sessions. However,
this is not correct and we should be reflecting the T-SQL transaction
isolation level in the view.

This commit adds changes to reflect the T-SQL transaction isolation
level in the view even if internally the PG transaction isolation level
might be different.

Task: BABEL-3214
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Issues Resolved

BABEL-3214

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).