### PR TITLE
Outer join terminates connection with error "Internal error at ReadAndHandleColumnData"

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2979,7 +2979,7 @@ SetAttributesForColmetada(TdsColumnMetaData *col)
 	if (HeapTupleIsValid(tp))
 	{
 		att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-		col->attNotNull = att_tup->attnotnull;
+
 		if (att_tup->attgenerated != '\0')
 			col->attgenerated = true;
 

--- a/test/JDBC/expected/BABEL-3141.out
+++ b/test/JDBC/expected/BABEL-3141.out
@@ -1,0 +1,32 @@
+CREATE TABLE t1(
+	id INT,
+	comment NVARCHAR(20)
+) 
+GO
+
+CREATE TABLE t2(
+	id INT,
+	t1_id INT,
+	PRIMARY KEY(id ASC)
+) 
+GO
+
+INSERT t1 VALUES (1, 'test')	
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM t1 a LEFT JOIN t2 b ON b.t1_id = a.id 
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int
+1#!#test#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE t1
+GO
+
+DROP TABLE t2
+GO

--- a/test/JDBC/input/BABEL-3141.sql
+++ b/test/JDBC/input/BABEL-3141.sql
@@ -1,0 +1,25 @@
+CREATE TABLE t1(
+	id INT,
+	comment NVARCHAR(20)
+) 
+GO
+
+CREATE TABLE t2(
+	id INT,
+	t1_id INT,
+	PRIMARY KEY(id ASC)
+) 
+GO
+
+INSERT t1 VALUES (1, 'test')	
+GO
+
+SELECT * FROM t1 a LEFT JOIN t2 b ON b.t1_id = a.id 
+GO
+
+-- Cleanup
+DROP TABLE t1
+GO
+
+DROP TABLE t2
+GO


### PR DESCRIPTION
### Description

Even though a base column is NOT NULL, it can be NULL when projected
from outer part of outer-join. Current logic to send the TDS column
metadata relies on nullability information in catalog because of which
it can happen that TDS extension sends a NULL value for a column it
thinks is NOT nullable. This will result in the extension sending
garbage values as part of response causing clients to terminate
connection.

This commit removes the logic of fetching nullability information from
catalog and instead just treats all columns as NOT nullable. Going
forward, we will need some other method to retrieve the nullability
information correctly.

Task: BABEL-3141
Signed-off-by: Sharu Goel <goelshar@amazon.com>
 
### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/115
BABEL-3141


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).