### PR TITLE
Rewording GH issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -2,35 +2,25 @@ name: Babelfish for PostgreSQL Extensions Bug Report
 description: File a bug report for Babelfish Extensions
 title: "[Bug]: "
 labels: ["bug", "triage"]
-assignees:
-  - amazon-auto
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@example.com
-    validations:
-      required: false
+        Thank you for taking the time to fill out this bug report.
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
+      description: Please provide details about the bug, and the steps needed to recreate the bug.
+      placeholder: Tell us about the bug.
+      value: "Tell us about the bug."
     validations:
       required: true
   - type: dropdown
     id: version
     attributes:
       label: Version
-      description: What version of our software are you running?
+      description: Which version of Babelfish are you running?
       options:
         - BABEL_1_X_DEV (Default)
     validations:
@@ -39,19 +29,18 @@ body:
     id: extension
     attributes:
       label: Extension
-      description: What extension is the problem occurring with?
+      description: Which extension is the problem occurring with?
       options:
         - babelfishpg_tsql (Default)
         - babelfishpg_tds
         - babelfishpg_money
         - babelfishpg_common
-        - fixeddecimal
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: os
     attributes:
-      label: What flavour of Linux are you running into the bug?
+      label: Which flavor of Linux are you using when you see the bug?
       multiple: true
       options:
         - Ubuntu (Default)
@@ -68,7 +57,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq).
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Babelfish for PostgreSQL Website
-    url: https://github.community/
-    about: Please ask and answer questions here.
+    url: https://babelfishpg.org/
+    about: Visit our website for online documentation and news.

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,62 +1,41 @@
-name: Babelfish for PostgreSQL Extensions Feature Request Form
-description: Propose an enhancement for Babelfish for PostgreSQL Extensions
-title: "[Enhancement]: "
-labels: ["enhancement", "untriaged"]
-assignees:
-  - amazon-auto
+name: Babelfish for PostgreSQL Question
+description: Ask a question of the Babelfish maintainers
+title: "[Question]: "
+labels: ["question", "untriaged"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@example.com
-    validations:
-      required: false
+        Thank you for using Babelfish.
   - type: textarea
-    id: what-intends
+    id: what-question
     attributes:
-      label: What this feature/enhancement tries to solve?
-      description: Be explanatory, as detailed as you can.
-      placeholder: Tell us what you have in mind!
-      value: "This is my feature request!"
+      label: What's your question?
+      description: Tell us about your question in detail.
+      placeholder: Provide as much information about your question as possible.
+      value: "Tell us about your question."
     validations:
       required: true
-  - type: textarea
-    id: brief-desc-implementation
-    attributes:
-      label: If want to provide us a more details about how to implement.
-      description: Share with us if you have more details about the implementation.
-    validations:
-      required: false 
   - type: dropdown
     id: version
     attributes:
       label: Version
-      description: What version of our software are you running?
+      description: Which version of Babelfish are you running?
       options:
-        - babelfishpg_tsql (Default)
-        - babelfishpg_tds
-        - babelfishpg_money
-        - babelfishpg_common
-        - fixeddecimal
+        - BABEL_1_X_DEV (Default)
     validations:
-      required: true
+      required: false
   - type: textarea
-    id: docs
+    id: logs
     attributes:
-      label: Relevant documentation
-      description: Please attach relevant documentation.
+      label: Relevant log output or information
+      description: Please copy and paste any relevant log output here. The log output will be automatically formatted into code, so no need for backticks.
       render: shell
   - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq).
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,42 +1,41 @@
 name: Babelfish for PostgreSQL Question
-description: Make a question to maintainers
+description: Ask a question of the Babelfish maintainers
 title: "[Question]: "
 labels: ["question", "untriaged"]
-assignees:
-  - amazon-auto
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for using Babelfish!
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@example.com
-    validations:
-      required: false
+        Thank you for using Babelfish.
   - type: textarea
     id: what-question
     attributes:
-      label: What's the question?
-      description: Tell us about your doubts.
-      placeholder: Do your question as detailed as possible.
-      value: "I have a question!"
+      label: What's your question?
+      description: Tell us about your question in detail.
+      placeholder: Provide as much information about your question as possible.
+      value: "Tell us about your question."
     validations:
       required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: Which version of Babelfish are you running?
+      options:
+        - BABEL_1_X_DEV (Default)
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:
       label: Relevant log output or information
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: Please copy and paste any relevant log output here. The log output will be automatically formatted into code, so no need for backticks.
       render: shell
   - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://aws.github.io/code-of-conduct-faq).
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true


### PR DESCRIPTION
Signed-off-by: 3manuek <3manuek@gmail.com>

### Description

Rewording and improving Github Issue templates. 
 
### Issues Resolved

[54](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/54)

This is a reimplementation of [PR 45](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/45).


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).