### PR TITLE
Update sp_helpuser and change db_owner into role

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2214,52 +2214,95 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE PROCEDURE sys.sp_helpuser("@name_in_db" sys.SYSNAME = NULL) AS
+CREATE OR REPLACE PROCEDURE sys.sp_helpuser("@name_in_db" sys.SYSNAME = NULL) AS
 $$
 BEGIN
+	-- If security account is not specified, return info about all users
 	IF @name_in_db IS NULL
 	BEGIN
-		SELECT CAST(Ext.orig_username AS SYS.SYSNAME) AS 'UserName',
-			   CAST(CASE WHEN Ext.orig_username = 'dbo' THEN 'db_owner' ELSE 'PUBLIC' END AS SYS.SYSNAME) AS 'RoleName',
-			   CAST(Ext.login_name AS SYS.SYSNAME) AS 'LoginName',
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
+			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN 'db_owner' 
+					WHEN Ext2.orig_username IS NULL THEN 'public'
+					ELSE Ext2.orig_username END 
+					AS SYS.SYSNAME) AS 'RoleName',
+			   CAST(Ext1.login_name AS SYS.SYSNAME) AS 'LoginName',
 			   CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',
-			   CAST(Ext.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
-			   CAST(Base.oid AS INT) AS 'UserID',
-			   CAST(CAST(Base.oid AS INT) AS SYS.VARBINARY(85))  AS 'SID'
-			FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
-			ON Base.rolname = Ext.rolname
-			LEFT OUTER JOIN sys.babelfish_authid_login_ext As LogExt
-			ON LogExt.rolname = Ext.orig_username
-			WHERE Ext.database_name = DB_NAME()
+			   CAST(Ext1.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
+			   CAST(Base1.oid AS INT) AS 'UserID',
+			   CAST(CAST(Base1.oid AS INT) AS SYS.VARBINARY(85)) AS 'SID'
+		FROM sys.babelfish_authid_user_ext AS Ext1
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.rolname = Ext1.rolname
+		LEFT OUTER JOIN pg_catalog.pg_auth_members AS Authmbr ON Base1.oid = Authmbr.member
+		LEFT OUTER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.roleid
+		LEFT OUTER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		LEFT OUTER JOIN sys.babelfish_authid_login_ext As LogExt ON LogExt.rolname = Ext1.login_name
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext1.type = 'S'
+		ORDER BY UserName, RoleName;
 	END
+	-- If the security account is the db fixed role - db_owner
     ELSE IF @name_in_db = 'db_owner'
 	BEGIN
-		-- simplification of role case, since no user defined roles exist yet
+		-- TODO: Need to change after we can add/drop members to/from db_owner
 		SELECT CAST('db_owner' AS SYS.SYSNAME) AS 'Role_name',
 			   ROLE_ID('db_owner') AS 'Role_id',
-			   CAST('dbo' AS SYS.SYSNAME) AS Users_in_role,
+			   CAST('dbo' AS SYS.SYSNAME) AS 'Users_in_role',
 			   USER_ID('dbo') AS 'Userid';
 	END
+	-- If the security account is a db role
 	ELSE IF EXISTS (SELECT 1
-					  FROM sys.babelfish_authid_user_ext
-						WHERE (orig_username = @name_in_db
-						      OR lower(orig_username) = lower(@name_in_db))
-						      AND database_name = DB_NAME())
+					FROM sys.babelfish_authid_user_ext
+					WHERE (orig_username = @name_in_db
+					OR lower(orig_username) = lower(@name_in_db))
+					AND database_name = DB_NAME()
+					AND type = 'R')
 	BEGIN
-		SELECT CAST(Ext.orig_username AS SYS.SYSNAME) AS 'UserName',
-			   CAST(CASE WHEN Ext.orig_username = 'dbo' THEN 'db_owner' ELSE 'PUBLIC' END AS SYS.SYSNAME) AS 'RoleName',
-			   CAST(Ext.login_name AS SYS.SYSNAME) AS 'LoginName',
-			   CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',
-			   CAST(Ext.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
-			   CAST(Base.oid AS INT) AS 'UserID',
-			   CAST(CAST(Base.oid AS INT) AS SYS.VARBINARY(85))  AS 'SID'
-			FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
-			ON Base.rolname = Ext.rolname
-			LEFT OUTER JOIN sys.babelfish_authid_login_ext As LogExt
-			ON LogExt.rolname = Ext.orig_username
-			WHERE Ext.database_name = DB_NAME()
-				  AND (orig_username = @name_in_db OR lower(orig_username) = lower(@name_in_db));
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'Role_name',
+			   CAST(Base1.oid AS INT) AS 'Role_id',
+			   CAST(Ext2.orig_username AS SYS.SYSNAME) AS 'Users_in_role',
+			   CAST(Base2.oid AS INT) AS 'Userid'
+		FROM sys.babelfish_authid_user_ext AS Ext2
+		INNER JOIN pg_catalog.pg_roles AS Base2 ON Base2.rolname = Ext2.rolname
+		INNER JOIN pg_catalog.pg_auth_members AS Authmbr ON Base2.oid = Authmbr.member
+		LEFT OUTER JOIN pg_catalog.pg_roles AS Base1 ON Base1.oid = Authmbr.roleid
+		LEFT OUTER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Base1.rolname = Ext1.rolname
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext2.database_name = DB_NAME()
+		AND Ext1.type = 'R'
+		AND Ext2.orig_username != 'db_owner'
+		AND (Ext1.orig_username = @name_in_db OR lower(Ext1.orig_username) = lower(@name_in_db))
+		ORDER BY Role_name, Users_in_role;
 	END
+	-- If the security account is a user
+	ELSE IF EXISTS (SELECT 1
+					FROM sys.babelfish_authid_user_ext
+					WHERE (orig_username = @name_in_db
+					OR lower(orig_username) = lower(@name_in_db))
+					AND database_name = DB_NAME()
+					AND type = 'S')
+	BEGIN
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
+			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN 'db_owner' 
+					WHEN Ext2.orig_username IS NULL THEN 'public' 
+					ELSE Ext2.orig_username END 
+					AS SYS.SYSNAME) AS 'RoleName',
+			   CAST(Ext1.login_name AS SYS.SYSNAME) AS 'LoginName',
+			   CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',
+			   CAST(Ext1.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
+			   CAST(Base1.oid AS INT) AS 'UserID',
+			   CAST(CAST(Base1.oid AS INT) AS SYS.VARBINARY(85)) AS 'SID'
+		FROM sys.babelfish_authid_user_ext AS Ext1
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.rolname = Ext1.rolname
+		LEFT OUTER JOIN pg_catalog.pg_auth_members AS Authmbr ON Base1.oid = Authmbr.member
+		LEFT OUTER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.roleid
+		LEFT OUTER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		LEFT OUTER JOIN sys.babelfish_authid_login_ext As LogExt ON LogExt.rolname = Ext1.login_name
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext1.type = 'S'
+		AND (Ext1.orig_username = @name_in_db OR lower(Ext1.orig_username) = lower(@name_in_db))
+		ORDER BY UserName, RoleName;
+	END
+	-- If the security account is not valid
 	ELSE 
 		RAISERROR ( 'The name supplied (%s) is not a user, role, or aliased login.', 16, 1, @name_in_db);
 END;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -1989,6 +1989,102 @@ $$
 $$
 LANGUAGE SQL STRICT STABLE PARALLEL SAFE;
 
+CREATE OR REPLACE PROCEDURE sys.sp_helpuser("@name_in_db" sys.SYSNAME = NULL) AS
+$$
+BEGIN
+	-- If security account is not specified, return info about all users
+	IF @name_in_db IS NULL
+	BEGIN
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
+			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN 'db_owner'
+					WHEN Ext2.orig_username IS NULL THEN 'public'
+					ELSE Ext2.orig_username END
+					AS SYS.SYSNAME) AS 'RoleName',
+				CAST(Ext1.login_name AS SYS.SYSNAME) AS 'LoginName',
+				CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',
+				CAST(Ext1.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
+				CAST(Base1.oid AS INT) AS 'UserID',
+				CAST(CAST(Base1.oid AS INT) AS SYS.VARBINARY(85)) AS 'SID'
+		FROM sys.babelfish_authid_user_ext AS Ext1
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.rolname = Ext1.rolname
+		LEFT OUTER JOIN pg_catalog.pg_auth_members AS Authmbr ON Base1.oid = Authmbr.member
+		LEFT OUTER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.roleid
+		LEFT OUTER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		LEFT OUTER JOIN sys.babelfish_authid_login_ext As LogExt ON LogExt.rolname = Ext1.login_name
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext1.type = 'S'
+		ORDER BY UserName, RoleName;
+	END
+	-- If the security account is the db fixed role - db_owner
+	ELSE IF @name_in_db = 'db_owner'
+	BEGIN
+		-- TODO: Need to change after we can add/drop members to/from db_owner
+		SELECT CAST('db_owner' AS SYS.SYSNAME) AS 'Role_name',
+			   ROLE_ID('db_owner') AS 'Role_id',
+			   CAST('dbo' AS SYS.SYSNAME) AS 'Users_in_role',
+			   USER_ID('dbo') AS 'Userid';
+	END
+	-- If the security account is a db role
+	ELSE IF EXISTS (SELECT 1
+					FROM sys.babelfish_authid_user_ext
+					WHERE (orig_username = @name_in_db
+					OR lower(orig_username) = lower(@name_in_db))
+					AND database_name = DB_NAME()
+					AND type = 'R')
+	BEGIN
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'Role_name',
+			   CAST(Base1.oid AS INT) AS 'Role_id',
+			   CAST(Ext2.orig_username AS SYS.SYSNAME) AS 'Users_in_role',
+			   CAST(Base2.oid AS INT) AS 'Userid'
+		FROM sys.babelfish_authid_user_ext AS Ext2
+		INNER JOIN pg_catalog.pg_roles AS Base2 ON Base2.rolname = Ext2.rolname
+		INNER JOIN pg_catalog.pg_auth_members AS Authmbr ON Base2.oid = Authmbr.member
+		LEFT OUTER JOIN pg_catalog.pg_roles AS Base1 ON Base1.oid = Authmbr.roleid
+		LEFT OUTER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Base1.rolname = Ext1.rolname
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext2.database_name = DB_NAME()
+		AND Ext1.type = 'R'
+		AND Ext2.orig_username != 'db_owner'
+		AND (Ext1.orig_username = @name_in_db OR lower(Ext1.orig_username) = lower(@name_in_db))
+		ORDER BY Role_name, Users_in_role;
+	END
+	-- If the security account is a user
+	ELSE IF EXISTS (SELECT 1
+					FROM sys.babelfish_authid_user_ext
+					WHERE (orig_username = @name_in_db
+					OR lower(orig_username) = lower(@name_in_db))
+					AND database_name = DB_NAME()
+					AND type = 'S')
+	BEGIN
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
+			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN 'db_owner'
+					WHEN Ext2.orig_username IS NULL THEN 'public'
+					ELSE Ext2.orig_username END
+					AS SYS.SYSNAME) AS 'RoleName',
+				CAST(Ext1.login_name AS SYS.SYSNAME) AS 'LoginName',
+				CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',
+				CAST(Ext1.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
+				CAST(Base1.oid AS INT) AS 'UserID',
+				CAST(CAST(Base1.oid AS INT) AS SYS.VARBINARY(85)) AS 'SID'
+		FROM sys.babelfish_authid_user_ext AS Ext1
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.rolname = Ext1.rolname
+		LEFT OUTER JOIN pg_catalog.pg_auth_members AS Authmbr ON Base1.oid = Authmbr.member
+		LEFT OUTER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.roleid
+		LEFT OUTER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		LEFT OUTER JOIN sys.babelfish_authid_login_ext As LogExt ON LogExt.rolname = Ext1.login_name
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext1.type = 'S'
+		AND (Ext1.orig_username = @name_in_db OR lower(Ext1.orig_username) = lower(@name_in_db))
+		ORDER BY UserName, RoleName;
+	END
+	-- If the security account is not valid
+	ELSE
+		RAISERROR ( 'The name supplied (%s) is not a user, role, or aliased login.', 16, 1, @name_in_db);
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE on PROCEDURE sys.sp_helpuser TO PUBLIC;
+
 CREATE OR REPLACE PROCEDURE sys.sp_helprole("@rolename" sys.SYSNAME = NULL) AS
 $$
 BEGIN

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -455,9 +455,8 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 		set_cur_db(old_dbid, old_dbname);
 		if (dbo_role)
 			add_to_bbf_authid_user_ext(dbo_role, "dbo", dbname, "dbo", NULL, false);
-		/* TODO: change it into role */
 		if (db_owner_role)
-			add_to_bbf_authid_user_ext(db_owner_role, "db_owner", dbname, NULL, NULL, false);
+			add_to_bbf_authid_user_ext(db_owner_role, "db_owner", dbname, NULL, NULL, true);
 		if (guest)
 			add_to_bbf_authid_user_ext(guest, "guest", dbname, NULL, NULL, false);
 	}

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -991,9 +991,8 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 			dbo_list = lappend(dbo_list, rolspec);
 			add_to_bbf_authid_user_ext(dbo_role, "dbo", db_name, "dbo", NULL, false);
 		}
-		/* TODO: change it into role */
 		if (db_owner_role)
-			add_to_bbf_authid_user_ext(db_owner_role, "db_owner", db_name, NULL, NULL, false);
+			add_to_bbf_authid_user_ext(db_owner_role, "db_owner", db_name, NULL, NULL, true);
 		if (guest)
 			add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false);
 

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER.out
@@ -71,6 +71,7 @@ EXEC babel_role_members
 GO
 ~~START~~
 varchar#!#char#!#varchar#!#char
+db_owner#!#R#!#dbo#!#S
 test_role1#!#R#!#test_role2#!#R
 test_role1#!#R#!#test_user1#!#S
 test_role2#!#R#!#test_role3#!#R
@@ -173,20 +174,19 @@ int
 ~~END~~
 
 
--- Should return NULL
--- TODO: admin user should be able to view members of db_owner
+-- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'test_role1')
 GO
 ~~START~~
 int
-<NULL>
+0
 ~~END~~
 
 SELECT IS_ROLEMEMBER('db_owner', 'test_user1')
 GO
 ~~START~~
 int
-<NULL>
+0
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-ROLE.out
+++ b/test/JDBC/expected/BABEL-ROLE.out
@@ -6,30 +6,6 @@ master
 ~~END~~
 
 
-SELECT rolname, type, orig_username, database_name
-FROM sys.babelfish_authid_user_ext
-WHERE type = 'R'
-ORDER BY rolname, orig_username
-GO
-~~START~~
-varchar#!#char#!#nvarchar#!#nvarchar
-master_db_owner#!#R#!#db_owner#!#master
-msdb_db_owner#!#R#!#db_owner#!#msdb
-tempdb_db_owner#!#R#!#db_owner#!#tempdb
-~~END~~
-
-
-SELECT name, type_desc
-FROM sys.database_principals
-WHERE type = 'R'
-ORDER BY name
-GO
-~~START~~
-varchar#!#nvarchar
-db_owner#!#DATABASE_ROLE
-~~END~~
-
-
 -- Test CREATE ROLE
 CREATE ROLE test1
 GO

--- a/test/JDBC/expected/BABEL-ROLE.out
+++ b/test/JDBC/expected/BABEL-ROLE.out
@@ -13,6 +13,9 @@ ORDER BY rolname, orig_username
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
+master_db_owner#!#R#!#db_owner#!#master
+msdb_db_owner#!#R#!#db_owner#!#msdb
+tempdb_db_owner#!#R#!#db_owner#!#tempdb
 ~~END~~
 
 
@@ -23,6 +26,7 @@ ORDER BY name
 GO
 ~~START~~
 varchar#!#nvarchar
+db_owner#!#DATABASE_ROLE
 ~~END~~
 
 
@@ -251,6 +255,7 @@ EXEC babel_role_members
 GO
 ~~START~~
 varchar#!#char#!#varchar#!#char
+db_owner#!#R#!#dbo#!#S
 test1#!#R#!#test2#!#R
 test1#!#R#!#test3#!#S
 test2#!#R#!#test4#!#S
@@ -289,6 +294,7 @@ EXEC babel_role_members
 GO
 ~~START~~
 varchar#!#char#!#varchar#!#char
+db_owner#!#R#!#dbo#!#S
 test1_new#!#R#!#test2#!#R
 test1_new#!#R#!#test3#!#S
 test2#!#R#!#test4#!#S
@@ -333,6 +339,7 @@ EXEC babel_role_members
 GO
 ~~START~~
 varchar#!#char#!#varchar#!#char
+db_owner#!#R#!#dbo#!#S
 test1_new#!#R#!#test2#!#R
 test1_new#!#R#!#test3#!#S
 test2#!#R#!#test4#!#S

--- a/test/JDBC/input/BABEL-ROLE-MEMBER.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER.mix
@@ -98,8 +98,7 @@ GO
 SELECT IS_ROLEMEMBER('test_user1', 'test_user1')
 GO
 
--- Should return NULL
--- TODO: admin user should be able to view members of db_owner
+-- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'test_role1')
 GO
 SELECT IS_ROLEMEMBER('db_owner', 'test_user1')

--- a/test/JDBC/input/BABEL-ROLE.sql
+++ b/test/JDBC/input/BABEL-ROLE.sql
@@ -1,18 +1,6 @@
 SELECT DB_NAME()
 GO
 
-SELECT rolname, type, orig_username, database_name
-FROM sys.babelfish_authid_user_ext
-WHERE type = 'R'
-ORDER BY rolname, orig_username
-GO
-
-SELECT name, type_desc
-FROM sys.database_principals
-WHERE type = 'R'
-ORDER BY name
-GO
-
 -- Test CREATE ROLE
 CREATE ROLE test1
 GO


### PR DESCRIPTION
Previously sp_helpuser only supports db users. This commit adds support
for
1. The "RoleName" column of sp_helpuser output when calling EXEC
   sp_helpuser 'user_name'
2. The sp_helpuser functionality for calling EXEC sp_helpuser
   'role_name'

Another change in this commit is about db_owner.
Previously in Babelfish catalog, the type of db_owner is SQL user. This
commit changes it into database role. This does not impact any of the
underlying implementation.

Task: BABEL-3186/3187
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).