### PR TITLE
Fix sys.all_columns with correct column types

### DIFF
--- a/test/JDBC/expected/BABEL-1756.out
+++ b/test/JDBC/expected/BABEL-1756.out
@@ -4,7 +4,7 @@ GO
 SELECT colid, name, collation_100 FROM sys.spt_tablecollations_view WHERE object_id = sys.object_id('foo') ORDER BY colid
 GO
 ~~START~~
-smallint#!#varchar#!#nvarchar
+int#!#varchar#!#nvarchar
 1#!#test_collation#!#default
 ~~END~~
 
@@ -12,7 +12,7 @@ smallint#!#varchar#!#nvarchar
 exec sp_tablecollations_100 'foo'
 GO
 ~~START~~
-smallint#!#varchar#!#binary#!#nvarchar
+int#!#varchar#!#binary#!#nvarchar
 1#!#test_collation#!#<NULL>#!#default
 ~~END~~
 
@@ -20,7 +20,7 @@ smallint#!#varchar#!#binary#!#nvarchar
 exec ..sp_tablecollations_100 'foo'
 GO
 ~~START~~
-smallint#!#varchar#!#binary#!#nvarchar
+int#!#varchar#!#binary#!#nvarchar
 1#!#test_collation#!#<NULL>#!#default
 ~~END~~
 

--- a/test/JDBC/input/views/sys-all_columns.sql
+++ b/test/JDBC/input/views/sys-all_columns.sql
@@ -34,4 +34,5 @@ ORDER BY name
 GO
 
 DROP TABLE IF EXISTS sys_all_columns_table
+DROP TABLE IF EXISTS columns_scale_precision_length_test
 GO

--- a/test/JDBC/input/views/sys-all_columns.sql
+++ b/test/JDBC/input/views/sys-all_columns.sql
@@ -17,5 +17,21 @@ GO
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.all_columns');
 GO
 
+CREATE TABLE columns_scale_precision_length_test (
+intcol int,
+char128col varchar(128),
+bitcol bit,
+datecol date,
+moneycol money,
+datetimecol datetime,
+)
+GO
+
+SELECT name, column_id, max_length, precision, scale, collation_name, is_nullable, is_ansi_padded, is_rowguidcol, is_identity, is_computed, is_filestream, is_replicated, is_non_sql_subscribed, is_merge_published, is_dts_replicated, is_xml_document, xml_collection_id, default_object_id, rule_object_id, is_sparse, is_column_set, generated_always_type, generated_always_type_desc
+FROM sys.all_columns
+WHERE name='intcol' OR name='char128col' OR name='bitcol' OR name='datecol' OR name='moneycol' OR name='datetimecol'
+ORDER BY name
+GO
+
 DROP TABLE IF EXISTS sys_all_columns_table
 GO

--- a/test/JDBC/sql_expected/sys-all_columns.out
+++ b/test/JDBC/sql_expected/sys-all_columns.out
@@ -56,4 +56,5 @@ moneycol#!#5#!#8#!#19#!#4#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!
 
 
 DROP TABLE IF EXISTS sys_all_columns_table
+DROP TABLE IF EXISTS columns_scale_precision_length_test
 GO

--- a/test/JDBC/sql_expected/sys-all_columns.out
+++ b/test/JDBC/sql_expected/sys-all_columns.out
@@ -14,7 +14,7 @@ WHERE name in ('sac_int_col', 'sac_text_col_not_null', 'sac_date_col')
 ORDER BY name
 GO
 ~~START~~
-varchar#!#int#!#smallint
+varchar#!#bit#!#int
 sac_date_col#!#1#!#3
 sac_int_col#!#0#!#1
 sac_text_col_not_null#!#0#!#2

--- a/test/JDBC/sql_expected/sys-all_columns.out
+++ b/test/JDBC/sql_expected/sys-all_columns.out
@@ -25,7 +25,33 @@ SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.all_column
 GO
 ~~START~~
 int
-34
+27
+~~END~~
+
+
+CREATE TABLE columns_scale_precision_length_test (
+intcol int,
+char128col varchar(128),
+bitcol bit,
+datecol date,
+moneycol money,
+datetimecol datetime,
+)
+GO
+
+SELECT name, column_id, max_length, precision, scale, collation_name, is_nullable, is_ansi_padded, is_rowguidcol, is_identity, is_computed, is_filestream, is_replicated, is_non_sql_subscribed, is_merge_published, is_dts_replicated, is_xml_document, xml_collection_id, default_object_id, rule_object_id, is_sparse, is_column_set, generated_always_type, generated_always_type_desc
+FROM sys.all_columns
+WHERE name='intcol' OR name='char128col' OR name='bitcol' OR name='datecol' OR name='moneycol' OR name='datetimecol'
+ORDER BY name
+GO
+~~START~~
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#bit#!#bit#!#tinyint#!#nvarchar
+bitcol#!#3#!#1#!#1#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
+char128col#!#2#!#128#!#0#!#0#!#bbf_unicode_cp1_ci_as#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
+datecol#!#4#!#3#!#10#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
+datetimecol#!#6#!#8#!#23#!#3#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
+intcol#!#1#!#4#!#10#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
+moneycol#!#5#!#8#!#19#!#4#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
 ~~END~~
 
 


### PR DESCRIPTION
### Description

The previous implementation of sys.all_columns did not match documented
column types for many columns.  This change fixes those discrepancies.
Note: the only exception is the system_type_id which is currently
implemented in Babelfish as type int, so casting to tinyint will cause
an error.

Also, this PR implements the scale, max_length, and precision columns with
actual values using existing helper functions, where before a default was used.

This change also adds tests for the static columns of sys.all_columns and updates tests for BABEL-1756 to reflect the new return type of int.

Task: BABELFISH-402
Signed-off-by: Ross [C] Dutkiewicz <dutkiert@amazon.com>
 
### Issues Resolved

None

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).