### PR TITLE
Added/modified sys.*_sql_modules system views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -872,26 +872,6 @@ where has_schema_privilege(sch.schema_id, 'USAGE')
 and has_function_privilege(p.oid, 'EXECUTE');
 GRANT SELECT ON sys.procedures TO PUBLIC;
 
-create or replace view sys.sql_modules as
-select
-  p.oid as object_id
-  , pg_get_functiondef(p.oid) as definition
-  , 1 as uses_ansi_nulls
-  , 1 as uses_quoted_identifier
-  , 0 as is_schema_bound
-  , 0 as uses_database_collation
-  , 0 as is_recompiled
-  , case when p.proisstrict then 1 else 0 end as null_on_null_input
-  , null::integer as execute_as_principal_id
-  , 0 as uses_native_compilation
-from pg_proc p
-inner join sys.schemas s on s.schema_id = p.pronamespace
-inner join pg_type t on t.oid = p.prorettype
-left join pg_collation c on c.oid = t.typcollation
-where has_schema_privilege(s.schema_id, 'USAGE')
-and has_function_privilege(p.oid, 'EXECUTE');
-GRANT SELECT ON sys.sql_modules TO PUBLIC;
-
 create or replace view sys.sysforeignkeys as
 select
   c.conname as name
@@ -1565,6 +1545,85 @@ select
 from sys.all_objects t
 where t.type = 'V';
 GRANT SELECT ON sys.all_views TO PUBLIC;
+
+-- TODO: BABEL-3127
+CREATE OR REPLACE VIEW sys.all_sql_modules_internal AS
+SELECT
+  ao.object_id AS object_id
+  , CAST(
+      CASE WHEN ao.type in ('P', 'FN', 'IN', 'TF', 'RF') THEN pg_get_functiondef(ao.object_id)
+      WHEN ao.type = 'V' THEN NULL
+      WHEN ao.type = 'TR' THEN NULL
+      ELSE NULL
+      END
+    AS sys.nvarchar(4000)) AS definition  -- Object definition work in progress, will update definition with BABEL-3127 Jira.
+  , CAST(1 as sys.bit)  AS uses_ansi_nulls
+  , CAST(1 as sys.bit)  AS uses_quoted_identifier
+  , CAST(0 as sys.bit)  AS is_schema_bound
+  , CAST(0 as sys.bit)  AS uses_database_collation
+  , CAST(0 as sys.bit)  AS is_recompiled
+  , CAST(
+      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF') THEN
+        CASE WHEN p.proisstrict THEN 1
+        ELSE 0 
+        END
+      ELSE 0
+      END
+    AS sys.bit) as null_on_null_input
+  , null::integer as execute_as_principal_id
+  , CAST(0 as sys.bit) as uses_native_compilation
+  , CAST(ao.is_ms_shipped as INT) as is_ms_shipped
+FROM sys.all_objects ao
+LEFT JOIN pg_proc p ON ao.object_id = CAST(p.oid AS INT)
+WHERE ao.type in ('P', 'RF', 'V', 'TR', 'FN', 'IF', 'TF', 'R');
+GRANT SELECT ON sys.all_sql_modules_internal TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.all_sql_modules AS
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar(4000))
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1;
+GRANT SELECT ON sys.all_sql_modules TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.system_sql_modules AS
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar(4000))
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+WHERE t1.is_ms_shipped = 1;
+GRANT SELECT ON sys.system_sql_modules TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.sql_modules AS
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar(4000))
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+WHERE t1.is_ms_shipped = 0;
+GRANT SELECT ON sys.sql_modules TO PUBLIC;
 
 CREATE VIEW sys.syscharsets
 AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -2625,6 +2625,91 @@ SELECT
 WHERE FALSE;
 GRANT SELECT ON sys.dm_hadr_database_replica_states TO PUBLIC;
 
+-- TODO: BABEL-3127
+CREATE OR REPLACE VIEW sys.all_sql_modules_internal AS
+SELECT
+  ao.object_id AS object_id
+  , CAST(
+      CASE WHEN ao.type in ('P', 'FN', 'IN', 'TF', 'RF') THEN pg_get_functiondef(ao.object_id)
+      WHEN ao.type = 'V' THEN NULL
+      WHEN ao.type = 'TR' THEN NULL
+      ELSE NULL
+      END
+    AS sys.nvarchar(4000)) AS definition  -- Object definition work in progress, will update definition with BABEL-3127 Jira.
+  , CAST(1 as sys.bit)  AS uses_ansi_nulls
+  , CAST(1 as sys.bit)  AS uses_quoted_identifier
+  , CAST(0 as sys.bit)  AS is_schema_bound
+  , CAST(0 as sys.bit)  AS uses_database_collation
+  , CAST(0 as sys.bit)  AS is_recompiled
+  , CAST(
+      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF') THEN
+        CASE WHEN p.proisstrict THEN 1
+        ELSE 0 
+        END
+      ELSE 0
+      END
+    AS sys.bit) as null_on_null_input
+  , null::integer as execute_as_principal_id
+  , CAST(0 as sys.bit) as uses_native_compilation
+  , CAST(ao.is_ms_shipped as INT) as is_ms_shipped
+FROM sys.all_objects ao
+LEFT JOIN pg_proc p ON ao.object_id = CAST(p.oid AS INT)
+WHERE ao.type in ('P', 'RF', 'V', 'TR', 'FN', 'IF', 'TF', 'R');
+GRANT SELECT ON sys.all_sql_modules_internal TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.all_sql_modules AS
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar(4000))
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1;
+GRANT SELECT ON sys.all_sql_modules TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.system_sql_modules AS
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar(4000))
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+WHERE t1.is_ms_shipped = 1;
+GRANT SELECT ON sys.system_sql_modules TO PUBLIC;
+
+-- sys.sql_modules upgrade (since we are changing datatypes)
+
+ALTER VIEW sys.sql_modules RENAME TO sql_modules_deprecated;
+
+CREATE VIEW sys.sql_modules AS
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar(4000))
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+WHERE t1.is_ms_shipped = 0;
+GRANT SELECT ON sys.sql_modules TO PUBLIC;
+
+call sys.babelfish_drop_deprecated_view('sys', 'sql_modules_deprecated');
+
 ALTER PROCEDURE sys.babel_drop_all_users() RENAME TO babel_drop_all_users_deprecated_2_1;
 
 ALTER VIEW sys.database_principals RENAME TO database_principals_deprecated;

--- a/test/JDBC/expected/sys-all_sql_modules.out
+++ b/test/JDBC/expected/sys-all_sql_modules.out
@@ -1,0 +1,266 @@
+-- Setup
+CREATE DATABASE db1
+GO
+
+CREATE VIEW my_master_view AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE db1
+GO
+
+CREATE TABLE all_sql_modules_table1(a int)
+GO
+
+CREATE TABLE all_sql_modules_table2(a int)
+GO
+
+CREATE TRIGGER all_sql_mod_trig ON all_sql_modules_table2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM all_sql_modules_table1;
+END
+GO
+
+CREATE VIEW all_sql_modules_view AS
+SELECT 1
+GO
+
+CREATE FUNCTION all_sql_modules_function() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC all_sql_modules_proc AS
+SELECT 1
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_function')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE OR REPLACE FUNCTION dbo.all_sql_modules_function()<newline> RETURNS integer<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["-1"], "original_probin": ""}', $function$BEGIN<newline>    RETURN 1;<newline>END$function$<newline>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_view')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'all_sql_mod_trig')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_proc')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE OR REPLACE PROCEDURE dbo.all_sql_modules_proc()<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": [], "original_probin": ""}', $procedure$SELECT 1$procedure$<newline>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test that sys.all_sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('my_master_view')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+-- Test permission for all_sql_modules (query should not have any results)
+CREATE LOGIN all_sql_modules_user WITH PASSWORD='test'
+GO
+
+CREATE USER all_sql_modules_user FOR LOGIN all_sql_modules_user
+GO
+
+USE master
+GO
+
+-- tsql user=all_sql_modules_user password=test
+
+USE db1
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_proc')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+USE master
+GO
+
+-- tsql
+USE db1
+GO
+
+DROP LOGIN all_sql_modules_user
+GO
+
+-- Cleanup
+DROP PROC all_sql_modules_proc
+GO
+
+DROP TRIGGER all_sql_mod_trig
+GO
+
+DROP TABLE all_sql_modules_table1
+GO
+
+DROP TABLE all_sql_modules_table2
+GO
+
+DROP VIEW all_sql_modules_view
+GO
+
+DROP FUNCTION all_sql_modules_function
+GO
+
+USE master
+GO
+
+DROP VIEW my_master_view
+GO
+
+DROP DATABASE db1
+GO

--- a/test/JDBC/expected/sys-sql_modules.out
+++ b/test/JDBC/expected/sys-sql_modules.out
@@ -1,0 +1,209 @@
+-- Setup
+CREATE DATABASE db1
+GO
+
+CREATE VIEW my_master_view AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE db1
+GO
+
+CREATE TABLE sql_modules_table1(a int)
+GO
+
+CREATE TABLE sql_modules_table2(a int)
+GO
+
+CREATE TRIGGER sql_mod_trig ON sql_modules_table2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM sql_modules_table1;
+END
+GO
+
+CREATE VIEW sql_modules_view AS
+SELECT 1
+GO
+
+CREATE FUNCTION sql_modules_function() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC sql_modules_proc AS
+SELECT 1
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_function')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE OR REPLACE FUNCTION dbo.sql_modules_function()<newline> RETURNS integer<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["-1"], "original_probin": ""}', $function$BEGIN<newline>    RETURN 1;<newline>END$function$<newline>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_view')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sql_mod_trig')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_proc')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE OR REPLACE PROCEDURE dbo.sql_modules_proc()<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": [], "original_probin": ""}', $procedure$SELECT 1$procedure$<newline>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test that sys.sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('my_master_view')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+-- Test permission for sql_modules (query should not have any results)
+CREATE LOGIN sql_modules_user WITH PASSWORD='test'
+GO
+
+CREATE USER sql_modules_user FOR LOGIN sql_modules_user
+GO
+
+USE master
+GO
+
+-- tsql user=sql_modules_user password=test
+
+USE db1
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_proc')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+USE master
+GO
+
+-- tsql
+USE db1
+GO
+
+DROP LOGIN sql_modules_user
+GO
+
+-- Cleanup
+DROP PROC sql_modules_proc
+GO
+
+DROP TRIGGER sql_mod_trig
+GO
+
+DROP TABLE sql_modules_table1
+GO
+
+DROP TABLE sql_modules_table2
+GO
+
+DROP VIEW sql_modules_view
+GO
+
+DROP FUNCTION sql_modules_function
+GO
+
+USE master
+GO
+
+DROP VIEW my_master_view
+GO
+
+DROP DATABASE db1
+GO

--- a/test/JDBC/expected/sys-system_sql_modules.out
+++ b/test/JDBC/expected/sys-system_sql_modules.out
@@ -1,0 +1,67 @@
+-- Setup
+CREATE DATABASE db1
+GO
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Cleanup
+USE master
+GO
+
+DROP DATABASE db1
+GO

--- a/test/JDBC/input/views/sys-all_sql_modules.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules.mix
@@ -1,0 +1,223 @@
+-- Setup
+CREATE DATABASE db1
+GO
+
+CREATE VIEW my_master_view AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE db1
+GO
+
+CREATE TABLE all_sql_modules_table1(a int)
+GO
+
+CREATE TABLE all_sql_modules_table2(a int)
+GO
+
+CREATE TRIGGER all_sql_mod_trig ON all_sql_modules_table2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM all_sql_modules_table1;
+END
+GO
+
+CREATE VIEW all_sql_modules_view AS
+SELECT 1
+GO
+
+CREATE FUNCTION all_sql_modules_function() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC all_sql_modules_proc AS
+SELECT 1
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_function')
+GO
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_view')
+GO
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'all_sql_mod_trig')
+GO
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_proc')
+GO
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables')
+GO
+
+-- Test that sys.all_sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('my_master_view')
+GO
+
+-- Test permission for all_sql_modules (query should not have any results)
+CREATE LOGIN all_sql_modules_user WITH PASSWORD='test'
+GO
+
+CREATE USER all_sql_modules_user FOR LOGIN all_sql_modules_user
+GO
+
+USE master
+GO
+
+-- tsql user=all_sql_modules_user password=test
+
+USE db1
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('all_sql_modules_proc')
+GO
+
+USE master
+GO
+
+-- tsql
+USE db1
+GO
+
+DROP LOGIN all_sql_modules_user
+GO
+
+-- Cleanup
+DROP PROC all_sql_modules_proc
+GO
+
+DROP TRIGGER all_sql_mod_trig
+GO
+
+DROP TABLE all_sql_modules_table1
+GO
+
+DROP TABLE all_sql_modules_table2
+GO
+
+DROP VIEW all_sql_modules_view
+GO
+
+DROP FUNCTION all_sql_modules_function
+GO
+
+USE master
+GO
+
+DROP VIEW my_master_view
+GO
+
+DROP DATABASE db1
+GO

--- a/test/JDBC/input/views/sys-sql_modules.mix
+++ b/test/JDBC/input/views/sys-sql_modules.mix
@@ -1,0 +1,181 @@
+-- Setup
+CREATE DATABASE db1
+GO
+
+CREATE VIEW my_master_view AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE db1
+GO
+
+CREATE TABLE sql_modules_table1(a int)
+GO
+
+CREATE TABLE sql_modules_table2(a int)
+GO
+
+CREATE TRIGGER sql_mod_trig ON sql_modules_table2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM sql_modules_table1;
+END
+GO
+
+CREATE VIEW sql_modules_view AS
+SELECT 1
+GO
+
+CREATE FUNCTION sql_modules_function() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC sql_modules_proc AS
+SELECT 1
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_function')
+GO
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_view')
+GO
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sql_mod_trig')
+GO
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_proc')
+GO
+
+-- Test that sys.sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('my_master_view')
+GO
+
+-- Test permission for sql_modules (query should not have any results)
+CREATE LOGIN sql_modules_user WITH PASSWORD='test'
+GO
+
+CREATE USER sql_modules_user FOR LOGIN sql_modules_user
+GO
+
+USE master
+GO
+
+-- tsql user=sql_modules_user password=test
+
+USE db1
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sql_modules_proc')
+GO
+
+USE master
+GO
+
+-- tsql
+USE db1
+GO
+
+DROP LOGIN sql_modules_user
+GO
+
+-- Cleanup
+DROP PROC sql_modules_proc
+GO
+
+DROP TRIGGER sql_mod_trig
+GO
+
+DROP TABLE sql_modules_table1
+GO
+
+DROP TABLE sql_modules_table2
+GO
+
+DROP VIEW sql_modules_view
+GO
+
+DROP FUNCTION sql_modules_function
+GO
+
+USE master
+GO
+
+DROP VIEW my_master_view
+GO
+
+DROP DATABASE db1
+GO

--- a/test/JDBC/input/views/sys-system_sql_modules.sql
+++ b/test/JDBC/input/views/sys-system_sql_modules.sql
@@ -1,0 +1,52 @@
+-- Setup
+CREATE DATABASE db1
+GO
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables')
+GO
+
+-- Cleanup
+USE master
+GO
+
+DROP DATABASE db1
+GO


### PR DESCRIPTION
### Description

Previously, sys.sql_modules would only display functions and procedures; however, sys.sql_modules should also be displaying triggers and views. This commit will change sys.sql_modules so that it displays triggers and views. Furthermore, sys.sql_modules previously had incorrect datatypes for its columns. This change will correct the datatypes so that it matches the official documentation. 

In addition, previously, sys.all_sql_modules and sys.system_sql_modules were not implemented. These changes will add the implementations for these views

Task: BABELFISH-369
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).