### PR TITLE
Fix datatypes of various system views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1,42 +1,42 @@
 /* Tsql system catalog views */
 create or replace view sys.tables as
 select
-  t.relname as name
-  , t.oid as object_id
-  , null::integer as principal_id
-  , sch.schema_id as schema_id
+  CAST(t.relname as sys._ci_sysname) as name
+  , CAST(t.oid as int) as object_id
+  , CAST(NULL as int) as principal_id
+  , CAST(sch.schema_id as int) as schema_id
   , 0 as parent_object_id
-  , 'U'::varchar(2) as type
-  , 'USER_TABLE'::varchar(60) as type_desc
-  , null::timestamp as create_date
-  , null::timestamp as modify_date
-  , 0 as is_ms_shipped
-  , 0 as is_published
-  , 0 as is_schema_published
+  , CAST('U' as CHAR(2)) as type
+  , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
+  , CAST(NULL as sys.datetime) as create_date
+  , CAST(NULL as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
   , case reltoastrelid when 0 then 0 else 1 end as lob_data_space_id
-  , null::integer as filestream_data_space_id
-  , relnatts as max_column_id_used
-  , 0 as lock_on_bulk_load
-  , 1 as uses_ansi_nulls
-  , 0 as is_replicated
-  , 0 as has_replication_filter
-  , 0 as is_merge_published
-  , 0 as is_sync_tran_subscribed
-  , 0 as has_unchecked_assembly_data
+  , CAST(NULL as int) as filestream_data_space_id
+  , CAST(relnatts as int) as max_column_id_used
+  , CAST(0 as sys.bit) as lock_on_bulk_load
+  , CAST(1 as sys.bit) as uses_ansi_nulls
+  , CAST(0 as sys.bit) as is_replicated
+  , CAST(0 as sys.bit) as has_replication_filter
+  , CAST(0 as sys.bit) as is_merge_published
+  , CAST(0 as sys.bit) as is_sync_tran_subscribed
+  , CAST(0 as sys.bit) as has_unchecked_assembly_data
   , 0 as text_in_row_limit
-  , 0 as large_value_types_out_of_row
-  , 0 as is_tracked_by_cdc
-  , 0 as lock_escalation
-  , 'TABLE'::varchar(60) as lock_escalation_desc
-  , 0 as is_filetable
-  , 0 as durability
-  , 'SCHEMA_AND_DATA'::varchar(60) as durability_desc
-  , 0 as is_memory_optimized
-  , case relpersistence when 't' then 2 else 0 end as temporal_type
-  , case relpersistence when 't' then 'SYSTEM_VERSIONED_TEMPORAL_TABLE' else 'NON_TEMPORAL_TABLE' end as temporal_type_desc
-  , null::integer as history_table_id
-  , 0 as is_remote_data_archive_enabled
-  , 0 as is_external
+  , CAST(0 as sys.bit) as large_value_types_out_of_row
+  , CAST(0 as sys.bit) as is_tracked_by_cdc
+  , CAST(0 as sys.tinyint) as lock_escalation
+  , CAST('TABLE' as sys.nvarchar(60)) as lock_escalation_desc
+  , CAST(0 as sys.bit) as is_filetable
+  , CAST(0 as sys.tinyint) as durability
+  , CAST('SCHEMA_AND_DATA' as sys.nvarchar(60)) as durability_desc
+  , CAST(0 as sys.bit) is_memory_optimized
+  , case relpersistence when 't' then CAST(2 as sys.tinyint) else CAST(0 as sys.tinyint) end as temporal_type
+  , case relpersistence when 't' then CAST('SYSTEM_VERSIONED_TEMPORAL_TABLE' as sys.nvarchar(60)) else CAST('NON_TEMPORAL_TABLE' as sys.nvarchar(60)) end as temporal_type_desc
+  , CAST(null as integer) as history_table_id
+  , CAST(0 as sys.bit) as is_remote_data_archive_enabled
+  , CAST(0 as sys.bit) as is_external
 from pg_class t inner join sys.schemas sch on t.relnamespace = sch.schema_id
 where t.relpersistence in ('p', 'u', 't')
 and t.relkind = 'r'
@@ -571,40 +571,40 @@ $$
 language plpgsql;
 
 create or replace view sys.columns AS
-select out_object_id::oid as object_id
-  , out_name::name as name
-  , out_column_id::smallint as column_id
-  , out_system_type_id::oid as system_type_id
-  , out_user_type_id::oid as user_type_id
-  , out_max_length::smallint as max_length
-  , out_precision::integer as precision
-  , out_scale::integer as scale
-  , out_collation_name::name as collation_name
-  , out_is_nullable::integer as is_nullable
-  , out_is_ansi_padded::integer as is_ansi_padded
-  , out_is_rowguidcol::integer as is_rowguidcol
-  , out_is_identity::integer as is_identity
-  , out_is_computed::integer as is_computed
-  , out_is_filestream::integer as is_filestream
-  , out_is_replicated::integer as is_replicated
-  , out_is_non_sql_subscribed::integer as is_non_sql_subscribed
-  , out_is_merge_published::integer as is_merge_published
-  , out_is_dts_replicated::integer as is_dts_replicated
-  , out_is_xml_document::integer as is_xml_document
-  , out_xml_collection_id::integer as xml_collection_id
-  , out_default_object_id::oid as default_object_id
-  , out_rule_object_id::oid as rule_object_id
-  , out_is_sparse::integer as is_sparse
-  , out_is_column_set::integer as is_column_set
-  , out_generated_always_type::integer as generated_always_type
-  , out_generated_always_type_desc::varchar(60) as generated_always_type_desc
-  , out_encryption_type::integer as encryption_type
-  , out_encryption_type_desc::varchar(64) as encryption_type_desc
-  , out_encryption_algorithm_name::varchar as encryption_algorithm_name
-  , out_column_encryption_key_id::integer as column_encryption_key_id
-  , out_column_encryption_key_database_name::varchar as column_encryption_key_database_name
-  , out_is_hidden::integer as is_hidden
-  , out_is_masked::integer as is_masked
+select out_object_id as object_id
+  , out_name as name
+  , out_column_id as column_id
+  , out_system_type_id as system_type_id
+  , out_user_type_id as user_type_id
+  , out_max_length as max_length
+  , out_precision as precision
+  , out_scale as scale
+  , out_collation_name as collation_name
+  , out_is_nullable as is_nullable
+  , out_is_ansi_padded as is_ansi_padded
+  , out_is_rowguidcol as is_rowguidcol
+  , out_is_identity as is_identity
+  , out_is_computed as is_computed
+  , out_is_filestream as is_filestream
+  , out_is_replicated as is_replicated
+  , out_is_non_sql_subscribed as is_non_sql_subscribed
+  , out_is_merge_published as is_merge_published
+  , out_is_dts_replicated as is_dts_replicated
+  , out_is_xml_document as is_xml_document
+  , out_xml_collection_id as xml_collection_id
+  , out_default_object_id as default_object_id
+  , out_rule_object_id as rule_object_id
+  , out_is_sparse as is_sparse
+  , out_is_column_set as is_column_set
+  , out_generated_always_type as generated_always_type
+  , out_generated_always_type_desc as generated_always_type_desc
+  , out_encryption_type as encryption_type
+  , out_encryption_type_desc as encryption_type_desc
+  , out_encryption_algorithm_name as encryption_algorithm_name
+  , out_column_encryption_key_id as column_encryption_key_id
+  , out_column_encryption_key_database_name as column_encryption_key_database_name
+  , out_is_hidden as is_hidden
+  , out_is_masked as is_masked
   , out_graph_type as graph_type
   , out_graph_type_desc as graph_type_desc
 from sys.columns_internal();
@@ -1083,20 +1083,20 @@ GRANT SELECT ON sys.table_types TO PUBLIC;
 create or replace view sys.default_constraints
 AS
 select CAST(('DF_' || tab.name || '_' || d.oid) as sys.sysname) as name
-  , d.oid as object_id
-  , null::int as principal_id
-  , tab.schema_id as schema_id
-  , d.adrelid as parent_object_id
-  , 'D'::char(2) as type
-  , 'DEFAULT_CONSTRAINT'::sys.nvarchar(60) AS type_desc
-  , null::timestamp as create_date
-  , null::timestamp as modified_date
-  , 0::sys.bit as is_ms_shipped
-  , 0::sys.bit as is_published
-  , 0::sys.bit as is_schema_published
-  , d.adnum::int as parent_column_id
-  , pg_get_expr(d.adbin, d.adrelid) as definition
-  , 1::sys.bit as is_system_named
+  , CAST(d.oid as int) as object_id
+  , CAST(null as int) as principal_id
+  , CAST(tab.schema_id as int) as schema_id
+  , CAST(d.adrelid as int) as parent_object_id
+  , CAST('D' as char(2)) as type
+  , CAST('DEFAULT_CONSTRAINT' as sys.nvarchar(60)) AS type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modified_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+  , CAST(d.adnum as int) as  parent_column_id
+  , CAST(pg_get_expr(d.adbin, d.adrelid) as sys.varchar) as definition
+  , CAST(1 as sys.bit) as is_system_named
 from pg_catalog.pg_attrdef as d
 inner join pg_attribute a on a.attrelid = d.adrelid and d.adnum = a.attnum
 inner join sys.tables tab on d.adrelid = tab.object_id
@@ -1133,142 +1133,142 @@ GRANT SELECT ON sys.check_constraints TO PUBLIC;
 
 create or replace view sys.objects as
 select
-      t.name
-    , t.object_id
-    , t.principal_id
-    , t.schema_id
-    , t.parent_object_id
-    , 'U' as type
-    , 'USER_TABLE' as type_desc
-    , t.create_date
-    , t.modify_date
-    , t.is_ms_shipped
-    , t.is_published
-    , t.is_schema_published
+      CAST(t.name as sys.sysname) as name 
+    , CAST(t.object_id as int) as object_id
+    , CAST(t.principal_id as int) as principal_id
+    , CAST(t.schema_id as int) as schema_id
+    , CAST(t.parent_object_id as int) as parent_object_id
+    , CAST('U' as char(2)) as type
+    , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
+    , CAST(t.create_date as sys.datetime) as create_date
+    , CAST(t.modify_date as sys.datetime) as modify_date
+    , CAST(t.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(t.is_published as sys.bit) as is_published
+    , CAST(t.is_schema_published as sys.bit) as is_schema_published
 from  sys.tables t
 union all
 select
-      v.name
-    , v.object_id
-    , v.principal_id
-    , v.schema_id
-    , v.parent_object_id
-    , 'V' as type
-    , 'VIEW' as type_desc
-    , v.create_date
-    , v.modify_date
-    , v.is_ms_shipped
-    , v.is_published
-    , v.is_schema_published
+      CAST(v.name as sys.sysname) as name
+    , CAST(v.object_id as int) as object_id
+    , CAST(v.principal_id as int) as principal_id
+    , CAST(v.schema_id as int) as schema_id
+    , CAST(v.parent_object_id as int) as parent_object_id
+    , CAST('V' as char(2)) as type
+    , CAST('VIEW' as sys.nvarchar(60)) as type_desc
+    , CAST(v.create_date as sys.datetime) as create_date
+    , CAST(v.modify_date as sys.datetime) as modify_date
+    , CAST(v.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(v.is_published as sys.bit) as is_published
+    , CAST(v.is_schema_published as sys.bit) as is_schema_published
 from  sys.views v
 union all
 select
-      f.name
-    , f.object_id
-    , f.principal_id
-    , f.schema_id
-    , f.parent_object_id
-    , 'F' as type
-    , 'FOREIGN_KEY_CONSTRAINT'
-    , f.create_date
-    , f.modify_date
-    , f.is_ms_shipped
-    , f.is_published
-    , f.is_schema_published
+      CAST(f.name as sys.sysname) as name
+    , CAST(f.object_id as int) as object_id
+    , CAST(f.principal_id as int) as principal_id
+    , CAST(f.schema_id as int) as schema_id
+    , CAST(f.parent_object_id as int) as parent_object_id
+    , CAST('F' as char(2)) as type
+    , CAST('FOREIGN_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(f.create_date as sys.datetime) as create_date
+    , CAST(f.modify_date as sys.datetime) as modify_date
+    , CAST(f.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(f.is_published as sys.bit) as is_published
+    , CAST(f.is_schema_published as sys.bit) as is_schema_published
  from sys.foreign_keys f
 union all
 select
-      p.name
-    , p.object_id
-    , p.principal_id
-    , p.schema_id
-    , p.parent_object_id
-    , 'PK' as type
-    , 'PRIMARY_KEY_CONSTRAINT' as type_desc
-    , p.create_date
-    , p.modify_date
-    , p.is_ms_shipped
-    , p.is_published
-    , p.is_schema_published
+      CAST(p.name as sys.sysname) as name
+    , CAST(p.object_id as int) as object_id
+    , CAST(p.principal_id as int) as principal_id
+    , CAST(p.schema_id as int) as schema_id
+    , CAST(p.parent_object_id as int) as parent_object_id
+    , CAST('PK' as char(2)) as type
+    , CAST('PRIMARY_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(p.create_date as sys.datetime) as create_date
+    , CAST(p.modify_date as sys.datetime) as modify_date
+    , CAST(p.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(p.is_published as sys.bit) as is_published
+    , CAST(p.is_schema_published as sys.bit) as is_schema_published
 from sys.key_constraints p
 where p.type = 'PK'
 union all
 select
-      pr.name
-    , pr.object_id
-    , pr.principal_id
-    , pr.schema_id
-    , pr.parent_object_id
-    , pr.type
-    , pr.type_desc
-    , pr.create_date
-    , pr.modify_date
-    , pr.is_ms_shipped
-    , pr.is_published
-    , pr.is_schema_published
+      CAST(pr.name as sys.sysname) as name
+    , CAST(pr.object_id as int) as object_id
+    , CAST(pr.principal_id as int) as principal_id
+    , CAST(pr.schema_id as int) as schema_id
+    , CAST(pr.parent_object_id as int) as parent_object_id
+    , CAST(pr.type as char(2)) as type
+    , CAST(pr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(pr.create_date as sys.datetime) as create_date
+    , CAST(pr.modify_date as sys.datetime) as modify_date
+    , CAST(pr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(pr.is_published as sys.bit) as is_published
+    , CAST(pr.is_schema_published as sys.bit) as is_schema_published
  from sys.procedures pr
 union all
 select
-    def.name::name
-  , def.object_id
-  , def.principal_id
-  , def.schema_id
-  , def.parent_object_id
-  , def.type
-  , def.type_desc
-  , def.create_date
-  , def.modified_date as modify_date
-  , def.is_ms_shipped::int
-  , def.is_published::int
-  , def.is_schema_published::int
+    CAST(def.name as sys.sysname) as name
+  , CAST(def.object_id as int) as object_id
+  , CAST(def.principal_id as int) as principal_id
+  , CAST(def.schema_id as int) as schema_id
+  , CAST(def.parent_object_id as int) as parent_object_id
+  , CAST(def.type as char(2)) as type
+  , CAST(def.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(def.create_date as sys.datetime) as create_date
+  , CAST(def.modified_date as sys.datetime) as modify_date
+  , CAST(def.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(def.is_published as sys.bit) as is_published
+  , CAST(def.is_schema_published as sys.bit) as is_schema_published
   from sys.default_constraints def
 union all
 select
-    chk.name::name
-  , chk.object_id
-  , chk.principal_id
-  , chk.schema_id
-  , chk.parent_object_id
-  , chk.type
-  , chk.type_desc
-  , chk.create_date
-  , chk.modify_date
-  , chk.is_ms_shipped::int
-  , chk.is_published::int
-  , chk.is_schema_published::int
+    CAST(chk.name as sys.sysname) as name
+  , CAST(chk.object_id as int) as object_id
+  , CAST(chk.principal_id as int) as principal_id
+  , CAST(chk.schema_id as int) as schema_id
+  , CAST(chk.parent_object_id as int) as parent_object_id
+  , CAST(chk.type as char(2)) as type
+  , CAST(chk.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(chk.create_date as sys.datetime) as create_date
+  , CAST(chk.modify_date as sys.datetime) as modify_date
+  , CAST(chk.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(chk.is_published as sys.bit) as is_published
+  , CAST(chk.is_schema_published as sys.bit) as is_schema_published
   from sys.check_constraints chk
 union all
 select
-   p.relname as name
-  ,p.oid as object_id
-  , null::integer as principal_id
-  , s.schema_id as schema_id
-  , 0 as parent_object_id
-  , 'SO'::varchar(2) as type
-  , 'SEQUENCE_OBJECT'::varchar(60) as type_desc
-  , null::timestamp as create_date
-  , null::timestamp as modify_date
-  , 0 as is_ms_shipped
-  , 0 as is_published
-  , 0 as is_schema_published
+    CAST(p.relname as sys.sysname) as name
+  , CAST(p.oid as int) as object_id
+  , CAST(null as int) as principal_id
+  , CAST(s.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('SO' as char(2)) as type
+  , CAST('SEQUENCE_OBJECT' as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
 from pg_class p
 inner join sys.schemas s on s.schema_id = p.relnamespace
 and p.relkind = 'S'
 and has_schema_privilege(s.schema_id, 'USAGE')
 union all
 select
-    ('TT_' || tt.name || '_' || tt.type_table_object_id)::name as name
-  , tt.type_table_object_id as object_id
-  , tt.principal_id as principal_id
-  , tt.schema_id as schema_id
-  , 0 as parent_object_id
-  , 'TT'::varchar(2) as type
-  , 'TABLE_TYPE'::varchar(60) as type_desc
-  , null::timestamp as create_date
-  , null::timestamp as modify_date
-  , 1 as is_ms_shipped
-  , 0 as is_published
-  , 0 as is_schema_published
+    CAST(('TT_' || tt.name || '_' || tt.type_table_object_id) as sys.sysname) as name
+  , CAST(tt.type_table_object_id as int) as object_id
+  , CAST(tt.principal_id as int) as principal_id
+  , CAST(tt.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('TT' as char(2)) as type
+  , CAST('TABLE_TYPE' as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(1 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
 from sys.table_types tt;
 GRANT SELECT ON sys.objects TO PUBLIC;
 
@@ -1277,28 +1277,28 @@ select
   s.name
   , s.object_id as id
   , s.type as xtype
-  , s.schema_id as uid
-  , 0 as info
+  , CAST(s.schema_id as smallint) as uid
+  , CAST(0 as smallint) as info
   , 0 as status
   , 0 as base_schema_ver
   , 0 as replinfo
   , s.parent_object_id as parent_obj
   , s.create_date as crdate
-  , 0 as ftcatid
+  , CAST(0 as smallint) as ftcatid
   , 0 as schema_ver
   , 0 as stats_schema_ver
   , s.type
-  , 0 as userstat
-  , 0 as sysstat
-  , 0 as indexdel
-  , s.modify_date as refdate
+  , CAST(0 as smallint) as userstat
+  , CAST(0 as smallint) as sysstat
+  , CAST(0 as smallint) as indexdel
+  , CAST(s.modify_date as sys.datetime) as refdate
   , 0 as version
   , 0 as deltrig
   , 0 as instrig
   , 0 as updtrig
   , 0 as seltrig
   , 0 as category
-  , 0 as cache
+  , CAST(0 as smallint) as cache
 from sys.objects s;
 GRANT SELECT ON sys.sysobjects TO PUBLIC;
 
@@ -1582,31 +1582,6 @@ SELECT 1001 as type,
   NULL::varbinary(6000) binarydefinition ,
   NULL::image definition;
 GRANT SELECT ON sys.syscharsets TO PUBLIC;
-
-create or replace view sys.default_constraints
-AS
-select CAST(('DF_' || tab.name || '_' || d.oid) as sys.sysname) as name
-  , d.oid as object_id
-  , null::int as principal_id
-  , tab.schema_id as schema_id
-  , d.adrelid as parent_object_id
-  , 'D'::char(2) as type
-  , 'DEFAULT_CONSTRAINT'::sys.nvarchar(60) AS type_desc
-  , null::timestamp as create_date
-  , null::timestamp as modified_date
-  , 0::sys.bit as is_ms_shipped
-  , 0::sys.bit as is_published
-  , 0::sys.bit as is_schema_published
-  , d.adnum::int as parent_column_id
-  , pg_get_expr(d.adbin, d.adrelid) as definition
-  , 1::sys.bit as is_system_named
-from pg_catalog.pg_attrdef as d
-inner join pg_attribute a on a.attrelid = d.adrelid and d.adnum = a.attnum
-inner join sys.tables tab on d.adrelid = tab.object_id
-WHERE a.atthasdef = 't' and a.attgenerated = ''
-AND has_schema_privilege(tab.schema_id, 'USAGE')
-AND has_column_privilege(a.attrelid, a.attname, 'SELECT,INSERT,UPDATE,REFERENCES');
-GRANT SELECT ON sys.default_constraints TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.computed_columns
 AS

--- a/test/JDBC/expected/ISC-Table_Constraints.out
+++ b/test/JDBC/expected/ISC-Table_Constraints.out
@@ -123,7 +123,7 @@ tbl_pk_pkey#!#sch1#!#tbl_pk#!#PRIMARY KEY
 ~~END~~
 
 ~~START~~
-varchar#!#varchar#!#varchar#!#text
+varchar#!#varchar#!#varchar#!#nvarchar
 tbl_fk_a_fkey#!#dbo#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_a_fkey#!#sch1#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_pkey#!#dbo#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT

--- a/test/JDBC/expected/sys-syscolumns.out
+++ b/test/JDBC/expected/sys-syscolumns.out
@@ -186,7 +186,7 @@ go
 select name, column_id, precision, scale from sys.columns where object_id=OBJECT_ID('t1') order by name;
 go
 ~~START~~
-varchar#!#smallint#!#int#!#int
+varchar#!#int#!#tinyint#!#tinyint
 a#!#1#!#10#!#0
 b#!#2#!#53#!#0
 c#!#3#!#19#!#0
@@ -205,7 +205,7 @@ go
 select name, column_id, is_identity, is_computed from sys.columns where object_id=OBJECT_ID('t2') order by name;
 go
 ~~START~~
-varchar#!#smallint#!#int#!#int
+varchar#!#int#!#bit#!#bit
 a#!#1#!#0#!#0
 b#!#2#!#1#!#0
 c#!#3#!#0#!#1
@@ -218,7 +218,7 @@ go
 select name, column_id, is_ansi_padded from sys.columns where object_id=OBJECT_ID('t3') order by name;
 go
 ~~START~~
-varchar#!#smallint#!#int
+varchar#!#int#!#bit
 a#!#1#!#1
 b#!#2#!#1
 c#!#3#!#1
@@ -237,7 +237,7 @@ go
 select name, column_id, collation_name from sys.columns where object_id=OBJECT_ID('t4') order by name;
 go
 ~~START~~
-varchar#!#smallint#!#varchar
+varchar#!#int#!#varchar
 c1#!#1#!#bbf_unicode_cp1_ci_ai
 c2#!#2#!#bbf_unicode_cp1_ci_as
 c3#!#3#!#bbf_unicode_cp1_cs_ai
@@ -293,7 +293,7 @@ GO
 select name,max_length,precision,scale from sys.columns where object_id = OBJECT_ID('test_columns') order by name;
 GO
 ~~START~~
-varchar#!#smallint#!#int#!#int
+varchar#!#smallint#!#tinyint#!#tinyint
 c1#!#8#!#19#!#0
 c10#!#8#!#53#!#0
 c11#!#16#!#0#!#0
@@ -344,7 +344,7 @@ CREATE TABLE t1(c1 datetime2(0)
 select name,max_length,precision,scale from sys.columns where object_id = OBJECT_ID('t1') order by name;
 GO
 ~~START~~
-varchar#!#smallint#!#int#!#int
+varchar#!#smallint#!#tinyint#!#tinyint
 c1#!#6#!#19#!#0
 c2#!#8#!#26#!#6
 c3#!#8#!#26#!#0

--- a/test/JDBC/expected/sys-table_types.out
+++ b/test/JDBC/expected/sys-table_types.out
@@ -40,7 +40,7 @@ from sys.objects
 where name like 'TT_tt_type%';
 GO
 ~~START~~
-int#!#int#!#text#!#text#!#datetime#!#datetime#!#int#!#int#!#int
+int#!#int#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit
 <NULL>#!#0#!#TT#!#TABLE_TYPE#!#<NULL>#!#<NULL>#!#1#!#0#!#0
 ~~END~~
 

--- a/test/JDBC/sql_expected/sys-default_constraints.out
+++ b/test/JDBC/sql_expected/sys-default_constraints.out
@@ -10,7 +10,7 @@ GO
 SELECT definition FROM sys.default_constraints where name LIKE '%sys_default_definitions%'
 GO
 ~~START~~
-text
+varchar
 50
 ~~END~~
 


### PR DESCRIPTION


### Description

Previously, sys.tables, sys.columns, sys.objects,
sys.default_constraints, and sys.sysobjects were implemented in
Babelfish with data types that did not match the documentation. This
commit fixes those data types to match the official documentation.

Task: BABEL-2710, BABELFISH-344
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).