### PR TITLE
Enable several ODBC tests due to implemented system stored procedures

### DIFF
--- a/test/odbc/test_metadata.cpp
+++ b/test/odbc/test_metadata.cpp
@@ -248,7 +248,6 @@ TEST_F(Metadata, DISABLED_SQLForeignKeys_ReferFromOtherTables) {
 }
 
 // Tests if SQLTablePrivileges works properly
-// DISABLED PLEASE SEE  BABELFISH-123
 TEST_F(Metadata, SQLTablePrivileges) {
 
   const int CHARSIZE = 255;
@@ -309,7 +308,6 @@ TEST_F(Metadata, SQLTablePrivileges) {
 }
 
 // Tests if SQLTableColumnPrivileges works properly
-// DISABLED PLEASE SEE BABELFISH-124
 TEST_F(Metadata, SQLTableColumnPrivileges) {
 
   const int CHARSIZE = 255;
@@ -634,7 +632,6 @@ TEST_F(Metadata, DISABLED_SQLProcedureColumns) {
 }
 
 // Tests SQLProcedureColumns for success with primary keys
-// DISABLED: PLEASE SEE BABELFISH-121
 TEST_F(Metadata, SQLSpecialColumns_PrimaryKeys) {
 
   OdbcHandler odbcHandler;

--- a/test/odbc/test_metadata.cpp
+++ b/test/odbc/test_metadata.cpp
@@ -249,7 +249,7 @@ TEST_F(Metadata, DISABLED_SQLForeignKeys_ReferFromOtherTables) {
 
 // Tests if SQLTablePrivileges works properly
 // DISABLED PLEASE SEE  BABELFISH-123
-TEST_F(Metadata, DISABLED_SQLTablePrivileges) {
+TEST_F(Metadata, SQLTablePrivileges) {
 
   const int CHARSIZE = 255;
   
@@ -310,7 +310,7 @@ TEST_F(Metadata, DISABLED_SQLTablePrivileges) {
 
 // Tests if SQLTableColumnPrivileges works properly
 // DISABLED PLEASE SEE BABELFISH-124
-TEST_F(Metadata, DISABLED_SQLTableColumnPrivileges) {
+TEST_F(Metadata, SQLTableColumnPrivileges) {
 
   const int CHARSIZE = 255;
   const string PRIV_COL_TABLE1 = "table_col_priv";
@@ -635,7 +635,7 @@ TEST_F(Metadata, DISABLED_SQLProcedureColumns) {
 
 // Tests SQLProcedureColumns for success with primary keys
 // DISABLED: PLEASE SEE BABELFISH-121
-TEST_F(Metadata, DISABLED_SQLSpecialColumns_PrimaryKeys) {
+TEST_F(Metadata, SQLSpecialColumns_PrimaryKeys) {
 
   OdbcHandler odbcHandler;
   RETCODE rcode;


### PR DESCRIPTION
### Description

Previously, SQLTableColumnPrivileges, SQLTablePrivileges, and
SQLSpecialColumns_PrimaryKeys tests were disabled in the ODBC tests due
to unsupported system stored procedures. These procedures have now been
implemented and the tests have been re-enabled.

Task: BABEL-2914/2915/2925
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).