### PR TITLE
mitigate the upgrade issue to 1.2.0 due to DROP OPERATOR.

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.1.0--1.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.1.0--1.2.0.sql
@@ -310,30 +310,33 @@ AS $$
   SELECT sys.int2fixeddecimaldiv($1, $2)::sys.MONEY;
 $$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 
+-- DROP OPERATOR can't work if other DB objects already refer to the operator.
+-- We keep the operator as it is for minor version upgrade.
+-- It will be fixed in major version upgrade by pg_dump and pg_restore.
 
-DROP OPERATOR IF EXISTS sys./ (INT8, FIXEDDECIMAL);
+--DROP OPERATOR IF EXISTS sys./ (INT8, FIXEDDECIMAL);
 
-CREATE OPERATOR sys./ (
-    LEFTARG    = INT8,
-    RIGHTARG   = FIXEDDECIMAL,
-    PROCEDURE  = int8fixeddecimaldiv_money
-);
+--CREATE OPERATOR sys./ (
+--    LEFTARG    = INT8,
+--    RIGHTARG   = FIXEDDECIMAL,
+--    PROCEDURE  = int8fixeddecimaldiv_money
+--);
 
-DROP OPERATOR IF EXISTS sys./ (INT4, FIXEDDECIMAL);
+--DROP OPERATOR IF EXISTS sys./ (INT4, FIXEDDECIMAL);
 
-CREATE OPERATOR sys./ (
-    LEFTARG    = INT4,
-    RIGHTARG   = FIXEDDECIMAL,
-    PROCEDURE  = int4fixeddecimaldiv_money
-);
+--CREATE OPERATOR sys./ (
+--    LEFTARG    = INT4,
+--    RIGHTARG   = FIXEDDECIMAL,
+--    PROCEDURE  = int4fixeddecimaldiv_money
+--);
 
-DROP OPERATOR IF EXISTS sys./ (INT2, FIXEDDECIMAL);
+--DROP OPERATOR IF EXISTS sys./ (INT2, FIXEDDECIMAL);
 
-CREATE OPERATOR sys./ (
-    LEFTARG    = INT2,
-    RIGHTARG   = FIXEDDECIMAL,
-    PROCEDURE  = int2fixeddecimaldiv_money
-);
+--CREATE OPERATOR sys./ (
+--    LEFTARG    = INT2,
+--    RIGHTARG   = FIXEDDECIMAL,
+--    PROCEDURE  = int2fixeddecimaldiv_money
+--);
 
 CREATE FUNCTION sys.fixeddecimalum(sys.SMALLMONEY)
 RETURNS sys.SMALLMONEY
@@ -871,13 +874,17 @@ $$
 $$
 LANGUAGE SQL VOLATILE;
 
-DROP OPERATOR IF EXISTS sys.+(text, text);
+-- DROP OPERATOR can't work if other DB objects already refer to the operator.
+-- We keep the operator as it is for minor version upgrade.
+-- It will be fixed in major version upgrade by pg_dump and pg_restore.
 
-CREATE OPERATOR sys.+ (
-    LEFTARG = text,
-    RIGHTARG = text,
-    FUNCTION = sys.babelfish_concat_wrapper_outer
-);
+--DROP OPERATOR IF EXISTS sys.+(text, text);
+
+--CREATE OPERATOR sys.+ (
+--    LEFTARG = text,
+--    RIGHTARG = text,
+--    FUNCTION = sys.babelfish_concat_wrapper_outer
+--);
 
 CREATE OR REPLACE FUNCTION sys.babelfish_concat_wrapper(leftarg sys.varchar, rightarg sys.varchar) RETURNS sys.varchar(8000) AS
 $$


### PR DESCRIPTION
### Description

If the operator is already referenced by other database objects such as
a SQL view, drop operator will throw an error and upgrade will fail.

To mitigate the issue, we remove DROP operator from minor version
upgrade script. This issue will be resolved during major version upgrade
by modified version of pg_dump/pg_restore.

Task:Babel-3112
Signed-off-by: Sangil Song <sonsangi@amazon.com>

### Issues Resolved

[List any issues this PR will resolve]
https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/91

### Check List
- [v] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).