### PR TITLE
Enable transactions tests in ODBC tests

### DIFF
--- a/test/odbc/test_transactions.cpp
+++ b/test/odbc/test_transactions.cpp
@@ -16,8 +16,7 @@ class Transactions : public testing::Test {
 };
 
 // Complete a transaction and assert that the values were correctly inserted
-// DISABLED: Please see BABELFISH-113 
-TEST_F(Transactions, DISABLED_SQLEndTran_Commit) {
+TEST_F(Transactions, SQLEndTran_Commit) {
   OdbcHandler odbcHandler;
   RETCODE rcode;
   string query{};
@@ -59,11 +58,14 @@ TEST_F(Transactions, DISABLED_SQLEndTran_Commit) {
   rcode = SQLGetData(odbcHandler.GetStatementHandle(), col_num, SQL_C_ULONG, &buf, 0, nullptr);
   ASSERT_EQ(rcode, SQL_SUCCESS) << odbcHandler.GetErrorMessage(SQL_HANDLE_STMT, rcode);
   ASSERT_EQ(buf, 2);
+  
+  // Transaction needs to commit before disconnect due to Postgres locking behaviour
+  rcode = SQLEndTran(SQL_HANDLE_DBC, odbcHandler.GetConnectionHandle(), SQL_COMMIT);
+  ASSERT_EQ(rcode, SQL_SUCCESS) << odbcHandler.GetErrorMessage(SQL_HANDLE_DBC, rcode);
 }
 
 // Rollbacks back the transaction and assert that nothing was created
-// DISABLED: Please see BABELFISH-113 
-TEST_F(Transactions, DISABLED_SQLEndTran_Rollback) {
+TEST_F(Transactions, SQLEndTran_Rollback) {
   OdbcHandler odbcHandler;
   RETCODE rcode;
   
@@ -89,11 +91,14 @@ TEST_F(Transactions, DISABLED_SQLEndTran_Rollback) {
 
   rcode = SQLFetch(odbcHandler.GetStatementHandle());
   ASSERT_EQ(rcode, SQL_NO_DATA);
+
+  // Transaction needs to commit before disconnect due to Postgres locking behaviour
+  rcode = SQLEndTran(SQL_HANDLE_DBC, odbcHandler.GetConnectionHandle(), SQL_COMMIT);
+  ASSERT_EQ(rcode, SQL_SUCCESS) << odbcHandler.GetErrorMessage(SQL_HANDLE_DBC, rcode);
 }
 
 // Attempt to disconnect during a transaction
-// DISABLED: Please see BABELFISH-113 
-TEST_F(Transactions, DISABLED_SQL_DisconnectAttemptDuringTransaction) {
+TEST_F(Transactions, SQL_DisconnectAttemptDuringTransaction) {
   OdbcHandler odbcHandler;
   RETCODE rcode;
   string sql_state;
@@ -126,4 +131,8 @@ TEST_F(Transactions, DISABLED_SQL_DisconnectAttemptDuringTransaction) {
 
   rcode = SQLFetch(odbcHandler.GetStatementHandle());
   ASSERT_EQ(rcode, SQL_NO_DATA);
+
+  // Transaction needs to commit before disconnect due to Postgres locking behaviour
+  rcode = SQLEndTran(SQL_HANDLE_DBC, odbcHandler.GetConnectionHandle(), SQL_COMMIT);
+  ASSERT_EQ(rcode, SQL_SUCCESS) << odbcHandler.GetErrorMessage(SQL_HANDLE_DBC, rcode);
 }


### PR DESCRIPTION
### Description
Previously, all the tests in test_transactions.cpp were disabled because
it caused the tests to hang. The reason why these tests were hanging is
due to PostgreSQL's locking behaviour. This commit fixes these hanging tests
by commiting a transaction before the end of the test.

Task: Babelfish-113
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).