### PR TITLE
mitigate the upgrade issue to 1.2.0 due to DROP OPERATOR

### DIFF
--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -14,6 +14,7 @@ jobs:
       EXTENSION_VER_FROM: BABEL_1_0_0
       ENGINE_VER_TO: BABEL_1_X_DEV__PG_13_6
       EXTENSION_VER_TO: BABEL_1_X_DEV
+      scheduleFile: ./jdbc_upgrade_schedule
 
     name: Build and test
     runs-on: ubuntu-latest

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.1.0--1.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.1.0--1.2.0.sql
@@ -310,30 +310,33 @@ AS $$
   SELECT sys.int2fixeddecimaldiv($1, $2)::sys.MONEY;
 $$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 
+-- DROP OPERATOR can't work if other DB objects already refer to the operator.
+-- We keep the operator as it is for minor version upgrade.
+-- It will be fixed in major version upgrade by pg_dump and pg_restore.
 
-DROP OPERATOR IF EXISTS sys./ (INT8, FIXEDDECIMAL);
+--DROP OPERATOR IF EXISTS sys./ (INT8, FIXEDDECIMAL);
 
-CREATE OPERATOR sys./ (
-    LEFTARG    = INT8,
-    RIGHTARG   = FIXEDDECIMAL,
-    PROCEDURE  = int8fixeddecimaldiv_money
-);
+--CREATE OPERATOR sys./ (
+--    LEFTARG    = INT8,
+--    RIGHTARG   = FIXEDDECIMAL,
+--    PROCEDURE  = int8fixeddecimaldiv_money
+--);
 
-DROP OPERATOR IF EXISTS sys./ (INT4, FIXEDDECIMAL);
+--DROP OPERATOR IF EXISTS sys./ (INT4, FIXEDDECIMAL);
 
-CREATE OPERATOR sys./ (
-    LEFTARG    = INT4,
-    RIGHTARG   = FIXEDDECIMAL,
-    PROCEDURE  = int4fixeddecimaldiv_money
-);
+--CREATE OPERATOR sys./ (
+--    LEFTARG    = INT4,
+--    RIGHTARG   = FIXEDDECIMAL,
+--    PROCEDURE  = int4fixeddecimaldiv_money
+--);
 
-DROP OPERATOR IF EXISTS sys./ (INT2, FIXEDDECIMAL);
+--DROP OPERATOR IF EXISTS sys./ (INT2, FIXEDDECIMAL);
 
-CREATE OPERATOR sys./ (
-    LEFTARG    = INT2,
-    RIGHTARG   = FIXEDDECIMAL,
-    PROCEDURE  = int2fixeddecimaldiv_money
-);
+--CREATE OPERATOR sys./ (
+--    LEFTARG    = INT2,
+--    RIGHTARG   = FIXEDDECIMAL,
+--    PROCEDURE  = int2fixeddecimaldiv_money
+--);
 
 CREATE FUNCTION sys.fixeddecimalum(sys.SMALLMONEY)
 RETURNS sys.SMALLMONEY
@@ -871,13 +874,17 @@ $$
 $$
 LANGUAGE SQL VOLATILE;
 
-DROP OPERATOR IF EXISTS sys.+(text, text);
+-- DROP OPERATOR can't work if other DB objects already refer to the operator.
+-- We keep the operator as it is for minor version upgrade.
+-- It will be fixed in major version upgrade by pg_dump and pg_restore.
 
-CREATE OPERATOR sys.+ (
-    LEFTARG = text,
-    RIGHTARG = text,
-    FUNCTION = sys.babelfish_concat_wrapper_outer
-);
+--DROP OPERATOR IF EXISTS sys.+(text, text);
+
+--CREATE OPERATOR sys.+ (
+--    LEFTARG = text,
+--    RIGHTARG = text,
+--    FUNCTION = sys.babelfish_concat_wrapper_outer
+--);
 
 CREATE OR REPLACE FUNCTION sys.babelfish_concat_wrapper(leftarg sys.varchar, rightarg sys.varchar) RETURNS sys.varchar(8000) AS
 $$

--- a/test/JDBC/expected/BABEL-2303_upgrade.out
+++ b/test/JDBC/expected/BABEL-2303_upgrade.out
@@ -1,0 +1,84 @@
+-- Test multiplication between int types and money types
+DECLARE @tinyint tinyint = 5
+DECLARE @smallint smallint = 5
+DECLARE @int bigint = 5
+DECLARE @smallmoney smallmoney = 2
+DECLARE @money money = 2
+SELECT
+ @tinyint * @smallmoney AS should_be_10
+,@tinyint * @money AS should_be_10
+,@smallint * @smallmoney AS should_be_10
+,@smallint * @money AS should_be_10
+,@int * @smallmoney AS should_be_10
+,@int * @money AS should_be_10
+,@smallmoney * @tinyint AS should_be_10
+,@money * @tinyint AS should_be_10
+,@smallmoney * @smallint AS should_be_10
+,@money * @smallint AS should_be_10
+,@smallmoney * @int AS should_be_10
+,@money * @int AS should_be_10
+GO
+~~START~~
+smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money
+10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000
+~~END~~
+
+
+CREATE TABLE t1
+(
+ id int PRIMARY KEY IDENTITY
+,c_tinyint tinyint
+,c_smallint smallint
+,c_smallmoney smallmoney
+,c_money money
+,c_tinyint_m_smallmoney AS c_tinyint * c_smallmoney
+,c_tinyint_m_money AS c_tinyint * c_money
+,c_smallint_m_smallmoney AS c_smallint * c_smallmoney
+,c_smallint_m_money AS c_smallint * c_money
+,c_smallmoney_m_tinyint AS c_smallmoney * c_tinyint
+,c_money_m_tinyint AS c_money * c_tinyint
+,c_smallmoney_m_smallint AS c_smallmoney * c_smallint
+,c_money_m_smallint AS c_money * c_smallint
+)
+GO
+INSERT INTO t1(c_tinyint, c_smallint, c_smallmoney, c_money) VALUES(5,5,2,2)
+GO
+~~ROW COUNT: 1~~
+
+SELECT c_tinyint_m_smallmoney, c_tinyint_m_money, c_smallint_m_smallmoney, c_smallint_m_money, c_smallmoney_m_tinyint, c_money_m_tinyint, c_smallmoney_m_smallint, c_money_m_smallint FROM t1
+GO
+~~START~~
+smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money
+10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000#!#10.0000
+~~END~~
+
+
+-- Test division between int types and money types
+DECLARE @tinyint tinyint = 5
+DECLARE @smallint smallint = 5
+DECLARE @int bigint = 5
+DECLARE @smallmoney smallmoney = 2
+DECLARE @money money = 2
+SELECT
+ @tinyint / @smallmoney AS ts
+,@tinyint / @money AS tm
+,@smallint / @smallmoney AS ss
+,@smallint / @money AS sm
+,@int / @smallmoney AS ids
+,@int / @money AS im
+,@smallmoney / @tinyint AS st
+,@money / @tinyint AS mt
+,@smallmoney / @smallint AS ss
+,@money / @smallint AS ms
+,@smallmoney / @int AS si
+,@money / @int AS mi
+GO
+~~START~~
+smallmoney#!#float#!#smallmoney#!#float#!#smallmoney#!#float#!#smallmoney#!#money#!#smallmoney#!#money#!#smallmoney#!#money
+2.5000#!#2.5#!#2.5000#!#2.5#!#2.5000#!#2.5#!#0.4000#!#0.4000#!#0.4000#!#0.4000#!#0.4000#!#0.4000
+~~END~~
+
+
+-- clean up
+DROP TABLe t1;
+GO

--- a/test/JDBC/expected/BABEL-2687_upgrade.out
+++ b/test/JDBC/expected/BABEL-2687_upgrade.out
@@ -1,0 +1,867 @@
+use master;
+GO
+
+-- real+bigint -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real*bigint -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney+bigint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) + CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney/bigint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) / CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real*decimal(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(54535.5656 AS decimal(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney-int -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) - CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real/decimal(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(54535.5656 AS decimal(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real-decimal(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(54535.5656 AS decimal(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real/int -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real*int -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real+int -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney*int -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) * CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney+int -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) + CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney+int -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) / CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallint/money -> money
+select cast(pg_typeof(CAST(100 AS smallint) / CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+double precision
+~~END~~
+
+-- int/money -> money
+select cast(pg_typeof(CAST(1000 AS int) / CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+double precision
+~~END~~
+
+-- real+money -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real-money -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real/money -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real/numeric(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(54535.5656 AS numeric(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real-numeric(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(54535.5656 AS numeric(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real*numeric(12,4) --> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(54535.5656 AS numeric(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallint+real -> real
+select cast(pg_typeof(CAST(100 AS smallint) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- decimal(12,4)-real -> real
+select cast(pg_typeof(CAST(54535.5656 AS decimal(12,4)) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney-real -> real
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- numeric(12,4)-real -> real
+select cast(pg_typeof(CAST(54535.5656 AS numeric(12,4)) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- int+real -> real
+select cast(pg_typeof(CAST(1000 AS int) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- bigint-real -> real
+select cast(pg_typeof(CAST(5000 AS bigint) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- tinyint+real -> real
+select cast(pg_typeof(CAST(10 AS tinyint) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- tinyint-real -> real
+select cast(pg_typeof(CAST(10 AS tinyint) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- money+real -> real
+select cast(pg_typeof(CAST(420.2313 AS money) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- money*real -> real
+select cast(pg_typeof(CAST(420.2313 AS money) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- decimal(12,4)+real -> real
+select cast(pg_typeof(CAST(54535.5656 AS decimal(12,4)) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- decimal(12,4)*real -> real
+select cast(pg_typeof(CAST(54535.5656 AS decimal(12,4)) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney/real -> real
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney*real -> real
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- bigint/real -> real
+select cast(pg_typeof(CAST(5000 AS bigint) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- numeric(12,4)*real -> real
+select cast(pg_typeof(CAST(54535.5656 AS numeric(12,4)) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- numeric(12,4)/real -> real
+select cast(pg_typeof(CAST(54535.5656 AS numeric(12,4)) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- int/real -> real
+select cast(pg_typeof(CAST(1000 AS int) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney+real -> real
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- bigint*real -> real
+select cast(pg_typeof(CAST(5000 AS bigint) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- tinyint/real -> real
+select cast(pg_typeof(CAST(10 AS tinyint) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallint*real -> real
+select cast(pg_typeof(CAST(100 AS smallint) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real/smallint -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real*smallint -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real+smallint -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney+smallint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) + CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real-smallint -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney-smallint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) - CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- tinyint*smallmoney -> smallmoney
+select cast(pg_typeof(CAST(10 AS tinyint) * CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- bigint*smallmoney -> smallmoney
+select cast(pg_typeof(CAST(5000 AS bigint) * CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- bigint-smallmoney -> smallmoney
+select cast(pg_typeof(CAST(5000 AS bigint) - CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- bigint+smallmoney -> smallmoney
+select cast(pg_typeof(CAST(5000 AS bigint) + CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real+smallmoney -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real*smallmoney -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real/smallmoney -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- int/smallmoney -> smallmoney
+select cast(pg_typeof(CAST(1000 AS int) / CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- int-smallmoney -> smallmoney
+select cast(pg_typeof(CAST(1000 AS int) - CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- int+smallmoney -> smallmoney
+select cast(pg_typeof(CAST(1000 AS int) + CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- tinyint+smallmoney -> smallmoney
+select cast(pg_typeof(CAST(10 AS tinyint) + CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallint/smallmoney -> smallmoney
+select cast(pg_typeof(CAST(100 AS smallint) / CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallint*smallmoney -> smallmoney
+select cast(pg_typeof(CAST(100 AS smallint) * CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallint-smallmoney -> smallmoney
+select cast(pg_typeof(CAST(100 AS smallint) - CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- tinyint/smallmoney -> smallmoney
+select cast(pg_typeof(CAST(10 AS tinyint) / CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney+smallmoney -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) + CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney-smallmoney -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) - CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney*smallmoney -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) * CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney/smallmoney -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) / CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real-bigint -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real/bigint -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney-bigint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) - CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney*bigint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) * CAST(5000 AS bigint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real*tinyint -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real-tinyint -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney*tinyint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) * CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney-tinyint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) - CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney+tinyint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) + CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real+tinyint -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- tinyint+tinyint -> tinyint
+select cast(pg_typeof(CAST(10 AS tinyint) + CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+tinyint
+~~END~~
+
+-- tinyint-tinyint -> tinyint
+select cast(pg_typeof(CAST(10 AS tinyint) - CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+tinyint
+~~END~~
+
+-- tinyint*tinyint -> tinyint
+select cast(pg_typeof(CAST(10 AS tinyint) * CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+tinyint
+~~END~~
+
+-- tinyint/tinyint -> tinyint
+select cast(pg_typeof(CAST(10 AS tinyint) / CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+tinyint
+~~END~~
+
+-- real+decimal(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(54535.5656 AS decimal(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real-int -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(1000 AS int)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- tinyint/money -> money
+select cast(pg_typeof(CAST(10 AS tinyint) / CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+double precision
+~~END~~
+
+-- bigint/money -> money
+select cast(pg_typeof(CAST(5000 AS bigint) / CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+double precision
+~~END~~
+
+-- real*money -> real
+select cast(pg_typeof(CAST(324.463 AS real) * CAST(420.2313 AS money)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- real+numeric(12,4) -> real
+select cast(pg_typeof(CAST(324.463 AS real) + CAST(54535.5656 AS numeric(12,4))) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- money-real -> real
+select cast(pg_typeof(CAST(420.2313 AS money) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- money/real -> real
+select cast(pg_typeof(CAST(420.2313 AS money) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- decimal(12,4)/real -> real
+select cast(pg_typeof(CAST(54535.5656 AS decimal(12,4)) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- numeric(12,4)+real -> real
+select cast(pg_typeof(CAST(54535.5656 AS numeric(12,4)) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- int*real -> real
+select cast(pg_typeof(CAST(1000 AS int) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- int-real -> real
+select cast(pg_typeof(CAST(1000 AS int) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- bigint+real -> real
+select cast(pg_typeof(CAST(5000 AS bigint) + CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- tinyint*real -> real
+select cast(pg_typeof(CAST(10 AS tinyint) * CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallint/real -> real
+select cast(pg_typeof(CAST(100 AS smallint) / CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallint-real -> real
+select cast(pg_typeof(CAST(100 AS smallint) - CAST(324.463 AS real)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- smallmoney/smallint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) / CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney*smallint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) * CAST(100 AS smallint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- bigint/smallmoney -> smallmoney
+select cast(pg_typeof(CAST(5000 AS bigint) / CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real-smallmoney -> real
+select cast(pg_typeof(CAST(324.463 AS real) - CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+
+-- int*smallmoney -> smallmoney
+select cast(pg_typeof(CAST(1000 AS int) * CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallint+smallmoney -> smallmoney
+select cast(pg_typeof(CAST(100 AS smallint) + CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- tinyint-smallmoney -> smallmoney
+select cast(pg_typeof(CAST(10 AS tinyint) - CAST(42.1256 AS smallmoney)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- smallmoney/tinyint -> smallmoney
+select cast(pg_typeof(CAST(42.1256 AS smallmoney) / CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+smallmoney
+~~END~~
+
+-- real/tinyint -> real
+select cast(pg_typeof(CAST(324.463 AS real) / CAST(10 AS tinyint)) as varchar(100)) rettype;
+GO
+~~START~~
+varchar
+real
+~~END~~
+

--- a/test/JDBC/expected/BABEL-2983_upgrade.out
+++ b/test/JDBC/expected/BABEL-2983_upgrade.out
@@ -1,0 +1,308 @@
+use master;
+go
+
+create table t2983(v varchar(10), nv nvarchar(10), c char(10), nc nchar(10), t text, nt ntext);
+go
+insert into t2983 values ('abc', 'def', 'ghi', 'jkl', 'mno', 'pqr');
+go
+~~ROW COUNT: 1~~
+
+
+select v + v from t2983;
+go
+~~START~~
+varchar
+abcabc
+~~END~~
+
+select cast(pg_typeof(v + v) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+"varchar"
+~~END~~
+
+
+select nv + nv from t2983;
+go
+~~START~~
+nvarchar
+defdef
+~~END~~
+
+select cast(pg_typeof(nv + nv) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select c + c from t2983;
+go
+~~START~~
+varchar
+ghi       ghi       
+~~END~~
+
+select cast(pg_typeof(c + c) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+"varchar"
+~~END~~
+
+
+select nc + nc from t2983;
+go
+~~START~~
+nvarchar
+jkl       jkl       
+~~END~~
+
+select cast(pg_typeof(nc + nc) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select t + t from t2983;
+go
+~~START~~
+text
+mnomno
+~~END~~
+
+select cast(pg_typeof(t + t) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+text
+~~END~~
+
+
+select nt + nt from t2983;
+go
+~~START~~
+text
+pqrpqr
+~~END~~
+
+select cast(pg_typeof(nt + nt) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+text
+~~END~~
+
+
+-- string literal
+select '123' + '456' from t2983;
+go
+~~START~~
+varchar
+123456
+~~END~~
+
+select cast(pg_typeof('123' + '456') as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+"varchar"
+~~END~~
+
+
+select '123' + v from t2983;
+go
+~~START~~
+varchar
+123abc
+~~END~~
+
+select cast(pg_typeof('123' + v) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+"varchar"
+~~END~~
+
+
+select v + '123' from t2983;
+go
+~~START~~
+varchar
+abc123
+~~END~~
+
+select cast(pg_typeof(v + '123') as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+"varchar"
+~~END~~
+
+
+select '123' + nv from t2983;
+go
+~~START~~
+nvarchar
+123def
+~~END~~
+
+select cast(pg_typeof('123' + nv) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select nv + '123' from t2983;
+go
+~~START~~
+nvarchar
+def123
+~~END~~
+
+select cast(pg_typeof(nv + '123') as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+-- mixup with nvarchar
+select v + nv from t2983;
+go
+~~START~~
+nvarchar
+abcdef
+~~END~~
+
+select cast(pg_typeof(v + nv) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select nv + v from t2983;
+go
+~~START~~
+nvarchar
+defabc
+~~END~~
+
+select cast(pg_typeof(nv + v) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select c + nv from t2983;
+go
+~~START~~
+nvarchar
+ghi       def
+~~END~~
+
+select cast(pg_typeof(c + nv) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select nv + c from t2983;
+go
+~~START~~
+nvarchar
+defghi       
+~~END~~
+
+select cast(pg_typeof(nv + c) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select nc + nv from t2983;
+go
+~~START~~
+nvarchar
+jkl       def
+~~END~~
+
+select cast(pg_typeof(nc + nv) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select nv + nc from t2983;
+go
+~~START~~
+nvarchar
+defjkl       
+~~END~~
+
+select cast(pg_typeof(nv + nc) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select nc + v from t2983;
+go
+~~START~~
+nvarchar
+jkl       abc
+~~END~~
+
+select cast(pg_typeof(nc + v) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+select v + nc from t2983;
+go
+~~START~~
+nvarchar
+abcjkl       
+~~END~~
+
+select cast(pg_typeof(v + nc) as varchar(20)) from t2983;
+go
+~~START~~
+varchar
+nvarchar
+~~END~~
+
+
+drop table t2983;
+go
+
+declare @v varchar(20) = '01-Aug'
+select datediff(dd, @v + '-2021', '2022-01-01')
+go
+~~START~~
+int
+153
+~~END~~
+

--- a/test/JDBC/expected/babel_money_upgrade.out
+++ b/test/JDBC/expected/babel_money_upgrade.out
@@ -1,0 +1,544 @@
+SELECT set_config('extra_float_digits', '0', 'false')
+go
+~~START~~
+text
+0
+~~END~~
+
+
+-- test money operators return type money
+create table t1(a money, b smallmoney);
+insert into t1 values (1.1234, 2.1234);
+insert into t1 values (2.5678, 3.5678);
+insert into t1 values (4.9012, 5.9012);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from t1 order by a;
+go
+~~START~~
+money#!#smallmoney
+1.1234#!#2.1234
+2.5678#!#3.5678
+4.9012#!#5.9012
+~~END~~
+
+
+-- test implicit casting for money
+create table t2(a money, b smallmoney);
+insert into t2 values (CAST( '1.1234' AS CHAR(10)), CAST( '2.1234' AS CHAR(10)));
+insert into t2 values (CAST( '$2.56789' AS VARCHAR), CAST( '$3.56789' AS VARCHAR));
+insert into t2 values (CAST( '¥4.91' AS TEXT), CAST( '¥5.91' AS TEXT));
+insert into t2 values (CAST( '0006.' AS TEXT), CAST( '0000' AS TEXT));
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from t2 order by a;
+go
+~~START~~
+money#!#smallmoney
+1.1234#!#2.1234
+2.5679#!#3.5679
+4.9100#!#5.9100
+6.0000#!#0.0000
+~~END~~
+
+
+select sum(a), sum(b) from t1;
+go
+~~START~~
+money#!#money
+8.5924#!#11.5924
+~~END~~
+
+
+select cast(pg_typeof(sum(a)) AS VARCHAR(10)), cast(pg_typeof(sum(b)) AS VARCHAR(10)) from t1;
+go
+~~START~~
+varchar#!#varchar
+money#!#money
+~~END~~
+
+
+select avg(a), avg(b) from t1;
+go
+~~START~~
+money#!#money
+2.8641#!#3.8641
+~~END~~
+
+
+select cast(pg_typeof(avg(a)) AS VARCHAR(10)), cast(pg_typeof(avg(b)) AS VARCHAR(10)) from t1;
+go
+~~START~~
+varchar#!#varchar
+money#!#money
+~~END~~
+
+
+select a+b from t1 order by a;
+go
+~~START~~
+money
+3.2468
+6.1356
+10.8024
+~~END~~
+
+
+select cast(pg_typeof(a+b) AS VARCHAR(10)) from t1 order by a;
+go
+~~START~~
+varchar
+money
+money
+money
+~~END~~
+
+
+select b-a from t1 order by a;
+go
+~~START~~
+money
+1.0000
+1.0000
+1.0000
+~~END~~
+
+
+select cast(pg_typeof(b-a) AS VARCHAR(10)) from t1 order by a;
+go
+~~START~~
+varchar
+money
+money
+money
+~~END~~
+
+
+select a*b from t1 order by a;
+go
+~~START~~
+money
+2.3854
+9.1613
+28.9229
+~~END~~
+
+
+select cast(pg_typeof(a*b) AS VARCHAR(10)) from t1 order by a;
+go
+~~START~~
+varchar
+money
+money
+money
+~~END~~
+
+
+select a/b from t1 order by a;
+go
+~~START~~
+money
+0.5290
+0.7197
+0.8305
+~~END~~
+
+
+select cast(pg_typeof(a/b) AS VARCHAR(10)) from t1 order by a;
+go
+~~START~~
+varchar
+money
+money
+money
+~~END~~
+
+
+
+drop table t1, t2;
+-- BABEL-598 Money type as procedure parameter should work without explicit cast
+create table employees(pers_id int, fname nvarchar(20), lname nvarchar(30), sal money);
+go
+
+create procedure p_employee_select
+as
+begin
+	select * from employees
+end;
+go
+
+create procedure p_employee_insert
+@pers_id int, @fname nvarchar(20), @lname nvarchar(30), @sal money
+as
+begin
+	insert into employees values (@pers_id, @fname, @lname, @sal)
+end;
+go
+
+-- test const 123.1234 and 200 are valid MONEY inputs for the procedure without explicit cast
+execute p_employee_insert @pers_id=1, @fname='John', @lname='Johnson', @sal=123.1234;
+execute p_employee_insert @pers_id=1, @fname='Adam', @lname='Smith', @sal=200;
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+execute p_employee_select;
+go
+~~START~~
+int#!#nvarchar#!#nvarchar#!#money
+1#!#John#!#Johnson#!#123.1234
+1#!#Adam#!#Smith#!#200.0000
+~~END~~
+
+
+drop procedure p_employee_select;
+drop procedure p_employee_insert;
+drop table employees;
+go
+
+-- BABEL-920
+-- Test operations(e.g. +,-,*,/) between fixeddecimal(money/smallmoney) and int8(bigint)
+select CAST(2.56 as bigint) + CAST(3.60 as money);
+go
+~~START~~
+money
+5.6000
+~~END~~
+
+select CAST(3.60 as money) + CAST(2.56 as bigint);
+go
+~~START~~
+money
+5.6000
+~~END~~
+
+select CAST(2.56 as bigint) - CAST(3.60 as money);
+go
+~~START~~
+money
+-1.6000
+~~END~~
+
+select CAST(3.60 as money) - CAST(2.56 as bigint);
+go
+~~START~~
+money
+1.6000
+~~END~~
+
+select CAST(2.56 as bigint) * CAST(3.60 as money);
+go
+~~START~~
+money
+7.2000
+~~END~~
+
+select CAST(3.60 as money) * CAST(2.56 as bigint);
+go
+~~START~~
+money
+7.2000
+~~END~~
+
+select CAST(2.56 as bigint) / CAST(3.60 as money);
+go
+~~START~~
+float
+0.5555555555555556
+~~END~~
+
+select CAST(3.60 as money) / CAST(2.56 as bigint);
+go
+~~START~~
+money
+1.8000
+~~END~~
+
+
+select CAST(2.56 as bigint) + CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+5.6000
+~~END~~
+
+select CAST(3.60 as smallmoney) + CAST(2.56 as bigint);
+go
+~~START~~
+smallmoney
+5.6000
+~~END~~
+
+select CAST(2.56 as bigint) - CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+-1.6000
+~~END~~
+
+select CAST(3.60 as smallmoney) - CAST(2.56 as bigint);
+go
+~~START~~
+smallmoney
+1.6000
+~~END~~
+
+select CAST(2.56 as bigint) * CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+7.2000
+~~END~~
+
+select CAST(3.60 as smallmoney) * CAST(2.56 as bigint);
+go
+~~START~~
+smallmoney
+7.2000
+~~END~~
+
+-- select CAST(2.56 as bigint) / CAST(3.60 as smallmoney); -> see BABEL-977
+-- go
+select CAST(3.60 as smallmoney) / CAST(2.56 as bigint);
+go
+~~START~~
+smallmoney
+1.8000
+~~END~~
+
+
+-- Test operations(e.g. +,-,*,/) between fixeddecimal(money/smallmoney) and int4(int)
+select CAST(2.56 as int) + CAST(3.60 as money);
+go
+~~START~~
+money
+5.6000
+~~END~~
+
+select CAST(3.60 as money) + CAST(2.56 as int);
+go
+~~START~~
+money
+5.6000
+~~END~~
+
+select CAST(2.56 as int) - CAST(3.60 as money);
+go
+~~START~~
+money
+-1.6000
+~~END~~
+
+select CAST(3.60 as money) - CAST(2.56 as int);
+go
+~~START~~
+money
+1.6000
+~~END~~
+
+select CAST(2.56 as int) * CAST(3.60 as money);
+go
+~~START~~
+money
+7.2000
+~~END~~
+
+select CAST(3.60 as money) * CAST(2.56 as int);
+go
+~~START~~
+money
+7.2000
+~~END~~
+
+select CAST(2.56 as int) / CAST(3.60 as money);
+go
+~~START~~
+float
+0.5555555555555556
+~~END~~
+
+select CAST(3.60 as money) / CAST(2.56 as int);
+go
+~~START~~
+money
+1.8000
+~~END~~
+
+
+select CAST(2.56 as int) + CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+5.6000
+~~END~~
+
+select CAST(3.60 as smallmoney) + CAST(2.56 as int);
+go
+~~START~~
+smallmoney
+5.6000
+~~END~~
+
+select CAST(2.56 as int) - CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+-1.6000
+~~END~~
+
+select CAST(3.60 as smallmoney) - CAST(2.56 as int);
+go
+~~START~~
+smallmoney
+1.6000
+~~END~~
+
+select CAST(2.56 as int) * CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+7.2000
+~~END~~
+
+select CAST(3.60 as smallmoney) * CAST(2.56 as int);
+go
+~~START~~
+smallmoney
+7.2000
+~~END~~
+
+-- select CAST(2.56 as int) / CAST(3.60 as smallmoney); -> see BABEL-977
+-- go
+select CAST(3.60 as smallmoney) / CAST(2.56 as int);
+go
+~~START~~
+smallmoney
+1.8000
+~~END~~
+
+
+-- Test operations(e.g. +,-,*,/) between fixeddecimal(money/smallmoney) and int2(smallint)
+select CAST(2.56 as smallint) + CAST(3.60 as money);
+go
+~~START~~
+money
+5.6000
+~~END~~
+
+select CAST(3.60 as money) + CAST(2.56 as smallint);
+go
+~~START~~
+money
+5.6000
+~~END~~
+
+select CAST(2.56 as smallint) - CAST(3.60 as money);
+go
+~~START~~
+money
+-1.6000
+~~END~~
+
+select CAST(3.60 as money) - CAST(2.56 as smallint);
+go
+~~START~~
+money
+1.6000
+~~END~~
+
+select CAST(2.56 as smallint) * CAST(3.60 as money);
+go
+~~START~~
+money
+7.2000
+~~END~~
+
+select CAST(3.60 as money) * CAST(2.56 as smallint);
+go
+~~START~~
+money
+7.2000
+~~END~~
+
+select CAST(2.56 as smallint) / CAST(3.60 as money);
+go
+~~START~~
+float
+0.5555555555555556
+~~END~~
+
+select CAST(3.60 as money) / CAST(2.56 as smallint);
+go
+~~START~~
+money
+1.8000
+~~END~~
+
+
+select CAST(2.56 as smallint) + CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+5.6000
+~~END~~
+
+select CAST(3.60 as smallmoney) + CAST(2.56 as smallint);
+go
+~~START~~
+smallmoney
+5.6000
+~~END~~
+
+select CAST(2.56 as smallint) - CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+-1.6000
+~~END~~
+
+select CAST(3.60 as smallmoney) - CAST(2.56 as smallint);
+go
+~~START~~
+smallmoney
+1.6000
+~~END~~
+
+select CAST(2.56 as smallint) * CAST(3.60 as smallmoney);
+go
+~~START~~
+smallmoney
+7.2000
+~~END~~
+
+select CAST(3.60 as smallmoney) * CAST(2.56 as smallint);
+go
+~~START~~
+smallmoney
+7.2000
+~~END~~
+
+-- select CAST(2.56 as smallint) / CAST(3.60 as smallmoney); -> see BABEL-977
+-- go
+select CAST(3.60 as smallmoney) / CAST(2.56 as smallint);
+go
+~~START~~
+smallmoney
+1.8000
+~~END~~
+

--- a/test/JDBC/input/BABEL-2303_upgrade.txt
+++ b/test/JDBC/input/BABEL-2303_upgrade.txt
@@ -1,0 +1,1 @@
+include#!#input/BABEL-2303.sql

--- a/test/JDBC/input/BABEL-2687_upgrade.txt
+++ b/test/JDBC/input/BABEL-2687_upgrade.txt
@@ -1,0 +1,1 @@
+include#!#input/BABEL-2687.sql

--- a/test/JDBC/input/BABEL-2983_upgrade.txt
+++ b/test/JDBC/input/BABEL-2983_upgrade.txt
@@ -1,0 +1,1 @@
+include#!#input/BABEL-2983.sql

--- a/test/JDBC/input/babel_money_upgrade.txt
+++ b/test/JDBC/input/babel_money_upgrade.txt
@@ -1,0 +1,1 @@
+include#!#input/babel_money.sql

--- a/test/JDBC/jdbc_upgrade_schedule
+++ b/test/JDBC/jdbc_upgrade_schedule
@@ -10,19 +10,6 @@
 
 all
 
-# We have rds_superuser privelege when connecting to a instance in
-# mammoth. So tests doing an ALTER SYSTEM don't need to run
-ignore#!#BABEL-1454
-ignore#!#BABEL-SYS-DATABASES
-ignore#!#BABEL-LOGIN-USER-EXT
-ignore#!#BABEL-2403
-ignore#!#BABEL-2578
-ignore#!#BABEL-2975
-
-# max_connections is 5000 and not 100 in mammoth/elephant instances so
-# we are ignoring it in application smoke test run
-ignore#!#sys-max_connections
-
 #TDS fault injection framework is meant for internal testing only. So, ignore tds_faultinjection tests in stable branch
 ignore#!#tds_faultinjection
 

--- a/test/JDBC/jdbc_upgrade_schedule
+++ b/test/JDBC/jdbc_upgrade_schedule
@@ -1,4 +1,4 @@
-# Schedule File for JDBC Test Framework for local run
+# Schedule File for JDBC Test Framework for local run via Upgarde workflow
 # 1. Lines starting with '#' will be treated as comments
 # 2. To run a postgres command:	cmd#!#postgresql#!#<enter postgres command>
 # 3. To run a T-SQL command: cmd#!#sqlserver#!#<enter T-SQL command>
@@ -10,6 +10,19 @@
 
 all
 
+# We have rds_superuser privelege when connecting to a instance in
+# mammoth. So tests doing an ALTER SYSTEM don't need to run
+ignore#!#BABEL-1454
+ignore#!#BABEL-SYS-DATABASES
+ignore#!#BABEL-LOGIN-USER-EXT
+ignore#!#BABEL-2403
+ignore#!#BABEL-2578
+ignore#!#BABEL-2975
+
+# max_connections is 5000 and not 100 in mammoth/elephant instances so
+# we are ignoring it in application smoke test run
+ignore#!#sys-max_connections
+
 #TDS fault injection framework is meant for internal testing only. So, ignore tds_faultinjection tests in stable branch
 ignore#!#tds_faultinjection
 
@@ -17,8 +30,8 @@ ignore#!#tds_faultinjection
 ignore#!#insertbulk
 ignore#!#BABEL-SQLvariant
 
-# Ignore Upgrade related tests
-ignore#!#BABEL-2983_upgrade
-ignore#!#BABEL-2687_upgrade
-ignore#!#BABEL-2303_upgrade
-ignore#!#babel_money_upgrade
+# Only run the corresponding upgrade tests for the below input files
+ignore#!#BABEL-2983
+ignore#!#BABEL-2687
+ignore#!#BABEL-2303
+ignore#!#babel_money


### PR DESCRIPTION
### Description

- mitigate the upgrade issue to 1.2.0 due to DROP OPERATOR.
   - If the operator is already referenced by other database objects 
      such as a SQL view, drop operator will throw an error and
      upgrade will fail.
   - To mitigate the issue, we remove DROP operator from minor 
      version upgrade script. This issue will be resolved during major version upgrade by modified version of pg_dump/pg_restore.

- Set scheduleFile env variable in Upgarde WF

- Cleanup jdbc_upgrade_schedule

- Add new schedule file and separate .out files for Upgrade Workflow
   - Added a new schedule file "jdbc_upgrade_schedule" for the upgrade tests.
     Since we have some tests that will have different expected output with and 
     without upgrade, created a new set of input files
    (.txt) that reuse the .sql input files and added a new set of expected
    output files for upgrade (suffix: "_upgrade.out").
 
Task: BABEL-3112
Signed-off-by: Sangil Song <sonsangi@amazon.com>
Co-authored-by: Sharu Goel <goelshar@amazon.com>

### Issues Resolved
https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/91


### Check List
- [v] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).