### PR TITLE
Support Cross-Database SELECT and DML Querying

### DIFF
--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -940,13 +940,7 @@ get_physical_schema_name(char *db_name, const char *schema_name)
 	 */
 	truncate_tsql_identifier(name);
 
-	/* JIRA-1793: Workaround: temperarily disable cross db reference */
-	if (strcmp(db_name, get_cur_db_name()) != 0)
-		ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("Cross DB query is not supported")));
-
-	else if (SINGLE_DB == get_migration_mode())
+	if (SINGLE_DB == get_migration_mode())
 	{
 		if ((strlen(db_name) == 6 && (strncmp(db_name, "master", 6) == 0)) ||
 			(strlen(db_name) == 6 && (strncmp(db_name, "tempdb", 6) == 0)) ||

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1013,6 +1013,7 @@ typedef struct PLtsql_stmt_execsql
 	bool		need_to_push_result; /* push result to client */
 	bool		is_tsql_select_assign_stmt; /* T-SQL SELECT-assign (i.e. SELECT @a=1) */
 	bool 		insert_exec; 	/* INSERT-EXEC stmt? */
+	bool		is_cross_db;	/* cross database reference */
 } PLtsql_stmt_execsql;
 
 /*

--- a/test/JDBC/BABEL-2455.sql
+++ b/test/JDBC/BABEL-2455.sql
@@ -46,10 +46,6 @@ go
 drop table master..t2455;
 go
 
--- error due to cross db access
-create table yourdb..t2455(a int);
-go
-
 create table .s2455.t2455(a int);
 insert into .s2455.t2455 values (1);
 go

--- a/test/JDBC/expected/BABEL-1712.out
+++ b/test/JDBC/expected/BABEL-1712.out
@@ -36,12 +36,6 @@ GO
 
 ~~ERROR (Message: relation "t1" does not exist)~~
 
-SELECT * FROM db1.dbo.t1;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Cross DB query is not supported)~~
-
 SELECT * FROM dbo.t1; -- error expected, querying master.dbo.t1
 GO
 ~~ERROR (Code: 33557097)~~

--- a/test/JDBC/expected/BABEL-2455.out
+++ b/test/JDBC/expected/BABEL-2455.out
@@ -142,14 +142,6 @@ ok
 drop table master..t2455;
 go
 
--- error due to cross db access
-create table yourdb..t2455(a int);
-go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Cross DB query is not supported)~~
-
-
 create table .s2455.t2455(a int);
 insert into .s2455.t2455 values (1);
 go

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -134,14 +134,6 @@ GO
 ~~ERROR (Message: permission denied for procedure master_p1)~~
 
 
-UPDATE dbo.db1_t1
-SET dbo.db1_t1.a = dbo.db1_t1.a + 1
-FROM master.dbo.master_t1 AS x
-WHERE dbo.db1_t1.a = x.a;
-GO
-~~ROW COUNT: 4~~
-
-
 SELECT current_user;
 GO
 ~~START~~
@@ -178,17 +170,6 @@ int#!#int
 
 USE MASTER;
 GO
-
-SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
-GO
-~~START~~
-int
-11
-11
-11
-31
-~~END~~
-
 
 --tsql
 USE MASTER;
@@ -259,17 +240,6 @@ GO
 -- tsql user=johndoe password=12345678
 USE MASTER;
 GO
-
-SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
-GO
-~~START~~
-int
-11
-11
-11
-31
-~~END~~
-
 
 USE db1;
 GO

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -1,0 +1,396 @@
+-- tsql
+USE MASTER;
+GO
+
+CREATE TABLE dbo.master_t1 (id int identity, a int);
+GO
+
+CREATE PROCEDURE dbo.master_p1
+AS
+SELECT a FROM dbo.master_t1;
+GO
+
+CREATE DATABASE db1;
+GO
+
+USE db1;
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+INSERT INTO master.dbo.master_t1 VALUES (10);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+~~START~~
+int#!#int
+1#!#10
+~~END~~
+
+
+SELECT * FROM master..master_t1 ORDER BY id;
+GO
+~~START~~
+int#!#int
+1#!#10
+~~END~~
+
+
+UPDATE master.dbo.master_t1
+SET a = 11
+WHERE id = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+~~START~~
+int#!#int
+1#!#11
+~~END~~
+
+
+DELETE FROM master.dbo.master_t1
+WHERE id = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+CREATE PROCEDURE p1
+AS
+INSERT INTO master.dbo.master_t1 VALUES (10);
+GO
+
+EXEC p1;
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p1;
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p1;
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dbo.db1_t1 (a int);
+GO
+
+INSERT INTO dbo.db1_t1 (a)
+SELECT (a) FROM master.dbo.master_t1;
+GO
+~~ROW COUNT: 3~~
+
+
+INSERT INTO dbo.db1_t1 (a)
+OUTPUT inserted.a INTO master.dbo.master_t1 (a)
+VALUES (30);
+GO
+~~ROW COUNT: 1~~
+
+
+-- Expect an error
+INSERT INTO dbo.db1_t1 (a)
+EXECUTE master.dbo.master_p1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-database references are not implemented: master.dbo.master_p1)~~
+
+
+-- Expect an error
+EXECUTE master.dbo.master_p1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure master_p1)~~
+
+
+UPDATE dbo.db1_t1
+SET dbo.db1_t1.a = dbo.db1_t1.a + 1
+FROM master.dbo.master_t1 AS x
+WHERE dbo.db1_t1.a = x.a;
+GO
+~~ROW COUNT: 4~~
+
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+CREATE TABLE dbo.db1_t2 (a int);
+GO
+
+INSERT INTO dbo.db1_t2 VALUES (20);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO master.dbo.master_t1 (a)
+SELECT (a) FROM db1_t2;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+~~START~~
+int#!#int
+2#!#10
+3#!#10
+4#!#10
+5#!#30
+6#!#20
+~~END~~
+
+
+USE MASTER;
+GO
+
+SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
+GO
+~~START~~
+int
+11
+11
+11
+31
+~~END~~
+
+
+--tsql
+USE MASTER;
+GO
+
+CREATE LOGIN johndoe WITH PASSWORD = '12345678';
+GO
+
+CREATE USER master_janedoe FOR LOGIN johndoe;
+GO
+
+USE db1;
+GO
+
+CREATE USER db1_janedoe FOR LOGIN johndoe;
+GO
+
+-- tsql    user=johndoe    password=12345678
+USE MASTER;
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+master_janedoe
+~~END~~
+
+
+SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table db1_t1)~~
+
+
+USE db1;
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+db1_janedoe
+~~END~~
+
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table master_t1)~~
+
+
+-- tsql
+USE MASTER;
+GO
+
+GRANT SELECT ON dbo.master_t1 TO master_janedoe;
+GO
+
+USE db1;
+GO
+
+GRANT SELECT ON dbo.db1_t1 TO db1_janedoe;
+GO
+
+-- tsql user=johndoe password=12345678
+USE MASTER;
+GO
+
+SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
+GO
+~~START~~
+int
+11
+11
+11
+31
+~~END~~
+
+
+USE db1;
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+~~START~~
+int#!#int
+2#!#10
+3#!#10
+4#!#10
+5#!#30
+6#!#20
+~~END~~
+
+
+USE master;
+GO
+
+-- tsql
+USE MASTER;
+GO
+
+DROP DATABASE db1;
+GO
+
+DROP TABLE dbo.master_t1;
+GO
+
+DROP PROC dbo.master_p1;
+GO
+
+DROP USER master_janedoe;
+GO
+
+DROP LOGIN johndoe;
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+CREATE DATABASE db1;
+GO
+
+CREATE DATABASE db2;
+GO
+
+USE db1;
+GO
+
+CREATE TABLE dbo.db1_t1 (id int identity, a int);
+GO
+
+USE db2;
+GO
+
+INSERT INTO db1.dbo.db1_t1 (a) VALUES (10);
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE PROCEDURE p1
+AS
+INSERT INTO db1.dbo.db1_t1 VALUES (1);
+GO
+
+EXEC p1;
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p1;
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dbo.db2_t1 (b int);
+GO
+
+INSERT INTO dbo.db2_t1 (b)
+SELECT a FROM db1.dbo.db1_t1
+WHERE id = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dbo.db2_t1 ORDER BY b;
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+DROP DATABASE db1;
+GO
+
+DROP DATABASE db2;
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+

--- a/test/JDBC/input/BABEL-1712.sql
+++ b/test/JDBC/input/BABEL-1712.sql
@@ -20,8 +20,6 @@ USE master;
 GO
 SELECT * FROM t1; -- doesn't exist expected, querying master.dbo.t1
 GO
-SELECT * FROM db1.dbo.t1;
-GO
 SELECT * FROM dbo.t1; -- error expected, querying master.dbo.t1
 GO
 -- search path

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -81,12 +81,6 @@ GO
 EXECUTE master.dbo.master_p1;
 GO
 
-UPDATE dbo.db1_t1
-SET dbo.db1_t1.a = dbo.db1_t1.a + 1
-FROM master.dbo.master_t1 AS x
-WHERE dbo.db1_t1.a = x.a;
-GO
-
 SELECT current_user;
 GO
 
@@ -104,9 +98,6 @@ SELECT * FROM master.dbo.master_t1 ORDER BY id;
 GO
 
 USE MASTER;
-GO
-
-SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
 GO
 
 --tsql
@@ -159,9 +150,6 @@ GO
 
 -- tsql user=johndoe password=12345678
 USE MASTER;
-GO
-
-SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
 GO
 
 USE db1;

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -1,0 +1,257 @@
+-- tsql
+USE MASTER;
+GO
+
+CREATE TABLE dbo.master_t1 (id int identity, a int);
+GO
+
+CREATE PROCEDURE dbo.master_p1
+AS
+SELECT a FROM dbo.master_t1;
+GO
+
+CREATE DATABASE db1;
+GO
+
+USE db1;
+GO
+
+SELECT current_user;
+GO
+
+INSERT INTO master.dbo.master_t1 VALUES (10);
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+
+SELECT * FROM master..master_t1 ORDER BY id;
+GO
+
+UPDATE master.dbo.master_t1
+SET a = 11
+WHERE id = 1;
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+
+DELETE FROM master.dbo.master_t1
+WHERE id = 1;
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+
+SELECT current_user;
+GO
+
+CREATE PROCEDURE p1
+AS
+INSERT INTO master.dbo.master_t1 VALUES (10);
+GO
+
+EXEC p1;
+GO
+
+EXEC p1;
+GO
+
+EXEC p1;
+GO
+
+CREATE TABLE dbo.db1_t1 (a int);
+GO
+
+INSERT INTO dbo.db1_t1 (a)
+SELECT (a) FROM master.dbo.master_t1;
+GO
+
+INSERT INTO dbo.db1_t1 (a)
+OUTPUT inserted.a INTO master.dbo.master_t1 (a)
+VALUES (30);
+GO
+
+-- Expect an error
+INSERT INTO dbo.db1_t1 (a)
+EXECUTE master.dbo.master_p1;
+GO
+
+-- Expect an error
+EXECUTE master.dbo.master_p1;
+GO
+
+UPDATE dbo.db1_t1
+SET dbo.db1_t1.a = dbo.db1_t1.a + 1
+FROM master.dbo.master_t1 AS x
+WHERE dbo.db1_t1.a = x.a;
+GO
+
+SELECT current_user;
+GO
+
+CREATE TABLE dbo.db1_t2 (a int);
+GO
+
+INSERT INTO dbo.db1_t2 VALUES (20);
+GO
+
+INSERT INTO master.dbo.master_t1 (a)
+SELECT (a) FROM db1_t2;
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+
+USE MASTER;
+GO
+
+SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
+GO
+
+--tsql
+USE MASTER;
+GO
+
+CREATE LOGIN johndoe WITH PASSWORD = '12345678';
+GO
+
+CREATE USER master_janedoe FOR LOGIN johndoe;
+GO
+
+USE db1;
+GO
+
+CREATE USER db1_janedoe FOR LOGIN johndoe;
+GO
+
+-- tsql    user=johndoe    password=12345678
+USE MASTER;
+GO
+
+SELECT current_user;
+GO
+
+SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
+GO
+
+USE db1;
+GO
+
+SELECT current_user;
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+
+-- tsql
+USE MASTER;
+GO
+
+GRANT SELECT ON dbo.master_t1 TO master_janedoe;
+GO
+
+USE db1;
+GO
+
+GRANT SELECT ON dbo.db1_t1 TO db1_janedoe;
+GO
+
+-- tsql user=johndoe password=12345678
+USE MASTER;
+GO
+
+SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
+GO
+
+USE db1;
+GO
+
+SELECT * FROM master.dbo.master_t1 ORDER BY id;
+GO
+
+USE master;
+GO
+
+-- tsql
+USE MASTER;
+GO
+
+DROP DATABASE db1;
+GO
+
+DROP TABLE dbo.master_t1;
+GO
+
+DROP PROC dbo.master_p1;
+GO
+
+DROP USER master_janedoe;
+GO
+
+DROP LOGIN johndoe;
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();
+GO
+
+-- tsql
+USE master;
+GO
+
+CREATE DATABASE db1;
+GO
+
+CREATE DATABASE db2;
+GO
+
+USE db1;
+GO
+
+CREATE TABLE dbo.db1_t1 (id int identity, a int);
+GO
+
+USE db2;
+GO
+
+INSERT INTO db1.dbo.db1_t1 (a) VALUES (10);
+GO
+
+CREATE PROCEDURE p1
+AS
+INSERT INTO db1.dbo.db1_t1 VALUES (1);
+GO
+
+EXEC p1;
+GO
+
+EXEC p1;
+GO
+
+CREATE TABLE dbo.db2_t1 (b int);
+GO
+
+INSERT INTO dbo.db2_t1 (b)
+SELECT a FROM db1.dbo.db1_t1
+WHERE id = 1;
+GO
+
+SELECT * FROM dbo.db2_t1 ORDER BY b;
+GO
+
+-- tsql
+USE master;
+GO
+
+DROP DATABASE db1;
+GO
+
+DROP DATABASE db2;
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+SELECT pg_reload_conf();
+GO


### PR DESCRIPTION
Support SELECT, INSERT, UPDATE, DELETE statements for accessing and
manipulating cross-database tables and views. This commit uses ANTLR to
confirm if the query is cross-database. It also checks if the query is only
a DML query or used to return a result set. It will then set a flag in the
statement's execution object and check that flag during the executor stage.
If true, the current user will be temporarily set to the Login to enable
permissions for the statement execution. Otherwise, permission checks will
prevent the cross-database statement from executing.

Task: BABEL-3134
Signed-off-by: Tony Lin <tonyvlin@amazon.com>