### PR TITLE
Removing 'sysadmin' role from authid_login_ext here

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -719,7 +719,7 @@ Datum drop_all_logins(PG_FUNCTION_ARGS)
 		 * Remove SA from authid_login_ext now but do not add it to the list
 		 * because we don't want to remove the corresponding PG role.
 		 */
-		if (role_is_sa(get_role_oid(rolname, false)))
+		if (role_is_sa(get_role_oid(rolname, false)) || (strcmp(rolname, "sysadmin") == 0))
 			CatalogTupleDelete(bbf_authid_login_ext_rel, &tuple->t_self);
 		else
 			rolname_list = lcons(rolname, rolname_list);


### PR DESCRIPTION
Removing 'sysadmin' role from babelfish_authid_login_ext while removing the babelfish.

Task: BABEL-2472
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

