### PR TITLE
Add helper script to run minor version upgrade in local env

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -154,7 +154,7 @@ elif [ "$1" == "pg_upgrade" ]; then
     ../postgres/bin/pg_upgrade -U $USER \
         -b $SOURCE_WS/postgres/bin -B $TARGET_WS/postgres/bin \
         -d $SOURCE_WS/postgres/data -D $TARGET_WS/postgres/data \
-        -p 5432 -P 5433 -j 4 --link --verbose
+        -p 5432 -P 5433 -j 4 --link --verbose --retain
     echo ""
 
     ./delete_old_cluster.sh


### PR DESCRIPTION
### Description

This commit can help developers to run minor version upgrade tests more
easily in their local environment.

Suppose that we have the following directory structure:
```
$HOME
  |- pg14.2
    |- postgresql_modified_for_babelfish
    |- babelfish_extension
  |- pg14.latest
    |- postgresql_modified_for_babelfish
    |- postgres
    |- babelfish_extension
```
Then, minor version upgrade test can be reproduced by executing the
following two commands in the target (pg14.latest) directory:
```
./dev-tools.sh minor_version_upgrade ~/pg14.2
./dev-tools.sh test input
```
Signed-off-by: Jungkook Lee <jungkook@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).