### PR TITLE
Disable triggers for Insert Bulk.

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3,6 +3,7 @@
 
 #include "funcapi.h"
 
+#include "access/table.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_language.h"
 #include "commands/proclang.h"
@@ -104,6 +105,7 @@ static Node *get_underlying_node_from_implicit_casting(Node *n, NodeTag underlyi
 int pltsql_proc_return_code;
 
 char *bulk_load_table_name = NULL;
+Oid bulk_load_table_oid = InvalidOid;
 
 PLtsql_execstate *get_current_tsql_estate()
 {
@@ -2527,7 +2529,6 @@ int exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *stm
 {
 	char *bulk_load_schema_name = NULL;
 	MemoryContext	oldContext;
-	Oid rel_oid = InvalidOid;
 	Oid schema_oid = InvalidOid;
 
 	if (!stmt->db_name || stmt->db_name[0] == '\0')
@@ -2550,13 +2551,13 @@ int exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *stm
 	/* save the table name for the next Bulk load Request */
 	if (bulk_load_schema_name)
 	{
-		rel_oid = get_relname_relid(stmt->table_name, schema_oid);
+		bulk_load_table_oid = get_relname_relid(stmt->table_name, schema_oid);
 		bulk_load_table_name = psprintf("\"%s\".\"%s\"", bulk_load_schema_name, stmt->table_name);
 		pfree(bulk_load_schema_name);
 	}
 	else
 	{
-		rel_oid = RelnameGetRelid(stmt->table_name);
+		bulk_load_table_oid = RelnameGetRelid(stmt->table_name);
 		bulk_load_table_name = pstrdup(stmt->table_name);
 	}
 
@@ -2569,7 +2570,7 @@ int exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *stm
 	}
 	MemoryContextSwitchTo(oldContext);
 
-	if (!OidIsValid(rel_oid))
+	if (!OidIsValid(bulk_load_table_oid))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_TABLE),
 						errmsg("relation \"%s\" does not exist",
@@ -2582,33 +2583,42 @@ int
 execute_bulk_load_insert(int ncol, int nrow, Oid *argtypes,
 				Datum *Values, const char *Nulls)
 {
+	Relation rel;
 	int rc;
 	int retValue = -1;
 	StringInfo src = makeStringInfo();
 	StringInfo bindParams = makeStringInfo();
 	int count = 1;
-
-	elog(DEBUG2, "Insert Bulk operation on destination table: %s", bulk_load_table_name);
-	appendStringInfo(src, "Insert into %s values ", bulk_load_table_name);
-	for (int i = 0; i < nrow; i++)
-	{
-		for (int j = 0; j < ncol; j++)
-			appendStringInfo(bindParams, ",$%d", count++);
-
-		bindParams->data[0] = ' ';
-		appendStringInfo(src, "(%s),", bindParams->data);
-		resetStringInfo(bindParams);
-	}
-	src->data[src->len - 1] = ' '; /* Taking care of the last ',' */
-
-	set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
-						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-
-	PushActiveSnapshot(GetTransactionSnapshot());
+	Snapshot snap;
 
 	PG_TRY();
 	{
+		elog(DEBUG2, "Insert Bulk operation on destination table: %s", bulk_load_table_name);
+		appendStringInfo(src, "Insert into %s values ", bulk_load_table_name);
+
+		/* Disable triggers on the table. */
+		rel = table_open(bulk_load_table_oid, AccessShareLock);
+		EnableDisableTrigger(rel, NULL, TRIGGER_DISABLED, false, AccessShareLock);
+		relation_close(rel, AccessShareLock);
+
+		for (int i = 0; i < nrow; i++)
+		{
+			for (int j = 0; j < ncol; j++)
+				appendStringInfo(bindParams, ",$%d", count++);
+
+			bindParams->data[0] = ' ';
+			appendStringInfo(src, "(%s),", bindParams->data);
+			resetStringInfo(bindParams);
+		}
+		src->data[src->len - 1] = ' '; /* Taking care of the last ',' */
+
+		set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
+							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+
+		snap = GetTransactionSnapshot();
+		PushActiveSnapshot(snap);
+
 		if ((rc = SPI_connect()) < 0)
 			elog(ERROR, "SPI_connect() failed with return code %d", rc);
 
@@ -2623,14 +2633,20 @@ execute_bulk_load_insert(int ncol, int nrow, Oid *argtypes,
 		PopActiveSnapshot();
 
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-									(superuser() ? PGC_SUSET :  PGC_USERSET),
-										PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+
+		/* Re-Enable triggers on the table after insertion. */
+		rel = table_open(bulk_load_table_oid, AccessShareLock);
+		EnableDisableTrigger(rel, NULL, TRIGGER_FIRES_ON_ORIGIN, false, AccessShareLock);
+		relation_close(rel, AccessShareLock);
 	}
 	PG_CATCH();
 	{
 		MemoryContext oldcontext;
 		SPI_finish();
-		PopActiveSnapshot();
+		if (ActiveSnapshotSet() && GetActiveSnapshot() == snap)
+			PopActiveSnapshot();
 		oldcontext = CurrentMemoryContext;
 
 		/*
@@ -2647,8 +2663,13 @@ execute_bulk_load_insert(int ncol, int nrow, Oid *argtypes,
 		MemoryContextSwitchTo(oldcontext);
 
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-									(superuser() ? PGC_SUSET : PGC_USERSET),
-										PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+
+		/* Re-Enable triggers on the table incase of an error. */
+		rel = table_open(bulk_load_table_oid, AccessShareLock);
+		EnableDisableTrigger(rel, NULL, TRIGGER_FIRES_ON_ORIGIN, false, AccessShareLock);
+		relation_close(rel, AccessShareLock);
 
 		PG_RE_THROW();
 	}
@@ -2674,6 +2695,7 @@ execute_bulk_load_insert(int ncol, int nrow, Oid *argtypes,
 		pfree(src);
 	}
 	bulk_load_table_name = NULL;
+	bulk_load_table_oid = InvalidOid;
 	return retValue;
 }
 

--- a/test/dotnet/ExpectedOutput/insertBulk.out
+++ b/test/dotnet/ExpectedOutput/insertBulk.out
@@ -365,3 +365,31 @@ hello#!#jello
 662
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Create table sourceTable(a int identity, b int)
+#Q#Create table destinationTable(a int identity, b int)
+#Q#insert into sourceTable values (1)
+#Q#insert into sourceTable values (2)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table t_rcv (a int)
+#Q#create table t_rcv2 (b int)
+#Q#create trigger tri on t_rcv for insert as begin insert t_rcv2 select a*-1 from inserted end
+#Q#insert t_rcv values (123)
+#Q#select * from t_rcv
+#D#int
+123
+123
+-123
+#Q#select * from t_rcv2
+#D#int
+-123
+#Q#drop table t_rcv
+#Q#drop table t_rcv2

--- a/test/dotnet/input/InsertBulk/insertBulk.txt
+++ b/test/dotnet/input/InsertBulk/insertBulk.txt
@@ -284,3 +284,26 @@ Select * from sourceTable
 Select * from destinationTable
 drop table sourceTable
 drop table destinationTable
+
+# identity
+Create table sourceTable(a int identity, b int)
+Create table destinationTable(a int identity, b int)
+insert into sourceTable values (1)
+insert into sourceTable values (2)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+# trigger
+create table t_rcv (a int)
+create table t_rcv2 (b int)
+create trigger tri on t_rcv for insert as begin insert t_rcv2 select a*-1 from inserted end
+insert t_rcv values (123)
+insertbulk#!#t_rcv#!#t_rcv
+insertbulk#!#t_rcv2#!#t_rcv
+select * from t_rcv
+select * from t_rcv2
+drop table t_rcv
+drop table t_rcv2


### PR DESCRIPTION
### Description

If no additional option is provided, Insert Bulk disables all triggers on target table before insertion. With this commit we disable triggers for the target table just before insertion and then re-enable them once done.

Task: BABEL-3203
Authored-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))
Signed-off-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com)) 

### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).