### PR TITLE
remove DROP FUNCTION/PROCEDURE from upgrade script from 1.1.0 to 1.2.0.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.1.0--1.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.1.0--1.2.0.sql
@@ -3257,8 +3257,8 @@ end;
 $$
 LANGUAGE plpgsql;
 
--- Need to DROP first because input types are changed during upgrade
-DROP FUNCTION sys.sp_describe_undeclared_parameters_internal;
+-- Need to rename and recreate the object due to previous incorrect definition.
+ALTER FUNCTION sys.sp_describe_undeclared_parameters_internal RENAME TO sp_describe_undeclared_parameters_internal_deprecated_1_2;
 -- BABEL-1797: initial support of sp_describe_undeclared_parameters
 -- sys.sp_describe_undeclared_parameters_internal: internal function
 -- For the result rows, can we create a template table for it?
@@ -3296,8 +3296,9 @@ AS 'babelfishpg_tsql', 'sp_describe_undeclared_parameters_internal'
 LANGUAGE C;
 GRANT ALL on FUNCTION sys.sp_describe_undeclared_parameters_internal TO PUBLIC;
 
--- Need to DROP first because input types are changed during upgrade
-DROP PROCEDURE sys.sp_describe_undeclared_parameters;
+-- Need to rename and recreate the object due to previous incorrect definition.
+ALTER PROCEDURE sys.sp_describe_undeclared_parameters RENAME TO sp_describe_undeclared_parameters_deprecated_1_2;
+
 CREATE OR REPLACE PROCEDURE sys.sp_describe_undeclared_parameters (
  "@tsql" sys.nvarchar(4000),
     "@params" sys.nvarchar(4000) = NULL)
@@ -3433,15 +3434,15 @@ $$
 LANGUAGE 'pltsql';
 GRANT EXECUTE ON PROCEDURE sys.sp_fkeys TO PUBLIC;
 
--- Need to drop previous incorrect definition.
-DROP FUNCTION sys.checksum;
+-- Need to rename and recreate the object due to previous incorrect definition.
+ALTER FUNCTION sys.checksum RENAME TO checksum_deprecated_1_2;
 CREATE OR REPLACE FUNCTION sys.checksum(VARIADIC arr TEXT[])
 RETURNS INTEGER
 AS 'babelfishpg_tsql', 'checksum'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
--- Need to drop previous incorrect definition.
-DROP FUNCTION sys.babelfish_inconsistent_metadata;
+-- Need to rename and recreate the object due to previous incorrect definition.
+ALTER FUNCTION sys.babelfish_inconsistent_metadata RENAME TO babelfish_inconsistent_metadata_deprecated_1_2;
 CREATE OR REPLACE FUNCTION sys.babelfish_inconsistent_metadata(return_consistency boolean default false)
 RETURNS table (
 	object_type varchar(32),


### PR DESCRIPTION
### Description

If the user has a SQL view depending on to-be-dropped objects, upgrade will
fail. Instead of DROP, we will rename the existing objects and re-create
it with the correct definition.

Task: BABEL-3242
Signed-off-by: Sangil Song <sonsangi@amazon.com>

### Check List
- [v] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).