### PR TITLE
sp_columns and sp_columns_100 return wrong values for SS_DATA_TYPE for IDENTITY columns

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -518,7 +518,17 @@ BEGIN
 			out_char_octet_length as CHAR_OCTET_LENGTH,
 			out_ordinal_position as ORDINAL_POSITION,
 			out_is_nullable as IS_NULLABLE,
-			out_ss_data_type as SS_DATA_TYPE
+			(
+			CASE
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -6 THEN 48 -- Tinyint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 5 THEN 52 -- Smallint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 4 THEN 56 -- Int Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -5 THEN 63 -- Bigint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 3 THEN 55 -- Decimal Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 2 THEN 63 -- Numeric Identity
+				ELSE out_ss_data_type
+			END
+			) as SS_DATA_TYPE
 	from sys.sp_columns_100_internal(sys.babelfish_truncate_identifier(@table_name),
 		sys.babelfish_truncate_identifier(@table_owner),
 		sys.babelfish_truncate_identifier(@table_qualifier),
@@ -566,7 +576,17 @@ BEGIN
 			out_ss_xml_schemacollection_catalog_name as SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
 			out_ss_xml_schemacollection_schema_name as SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
 			out_ss_xml_schemacollection_name as SS_XML_SCHEMACOLLECTION_NAME,
-			out_ss_data_type as SS_DATA_TYPE
+			(
+			CASE
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -6 THEN 48 -- Tinyint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 5 THEN 52 -- Smallint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 4 THEN 56 -- Int Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -5 THEN 63 -- Bigint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 3 THEN 55 -- Decimal Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 2 THEN 63 -- Numeric Identity
+				ELSE out_ss_data_type
+			END
+			) as SS_DATA_TYPE
 	from sys.sp_columns_100_internal(sys.babelfish_truncate_identifier(@table_name),
 		sys.babelfish_truncate_identifier(@table_owner),
 		sys.babelfish_truncate_identifier(@table_qualifier),

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -3930,6 +3930,64 @@ end;
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE PROCEDURE sys.sp_columns_100 (
+	"@table_name" sys.nvarchar(384),
+	"@table_owner" sys.nvarchar(384) = '',
+	"@table_qualifier" sys.nvarchar(384) = '',
+	"@column_name" sys.nvarchar(384) = '',
+	"@namescope" int = 0,
+	"@odbcver" int = 2,
+	"@fusepattern" smallint = 1)
+AS $$
+BEGIN
+	select out_table_qualifier as TABLE_QUALIFIER,
+			out_table_owner as TABLE_OWNER,
+			out_table_name as TABLE_NAME,
+			out_column_name as COLUMN_NAME,
+			out_data_type as DATA_TYPE,
+			out_type_name as TYPE_NAME,
+			out_precision as PRECISION,
+			out_length as LENGTH,
+			out_scale as SCALE,
+			out_radix as RADIX,
+			out_nullable as NULLABLE,
+			out_remarks as REMARKS,
+			out_column_def as COLUMN_DEF,
+			out_sql_data_type as SQL_DATA_TYPE,
+			out_sql_datetime_sub as SQL_DATETIME_SUB,
+			out_char_octet_length as CHAR_OCTET_LENGTH,
+			out_ordinal_position as ORDINAL_POSITION,
+			out_is_nullable as IS_NULLABLE,
+			out_ss_is_sparse as SS_IS_SPARSE,
+			out_ss_is_column_set as SS_IS_COLUMN_SET,
+			out_ss_is_computed as SS_IS_COMPUTED,
+			out_ss_is_identity as SS_IS_IDENTITY,
+			out_ss_udt_catalog_name as SS_UDT_CATALOG_NAME,
+			out_ss_udt_schema_name as SS_UDT_SCHEMA_NAME,
+			out_ss_udt_assembly_type_name as SS_UDT_ASSEMBLY_TYPE_NAME,
+			out_ss_xml_schemacollection_catalog_name as SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
+			out_ss_xml_schemacollection_schema_name as SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
+			out_ss_xml_schemacollection_name as SS_XML_SCHEMACOLLECTION_NAME,
+			(
+			CASE
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -6 THEN 48 -- Tinyint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 5 THEN 52 -- Smallint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 4 THEN 56 -- Int Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -5 THEN 63 -- Bigint Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 3 THEN 55 -- Decimal Identity
+				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 2 THEN 63 -- Numeric Identity
+				ELSE out_ss_data_type
+			END
+			) as SS_DATA_TYPE
+	from sys.sp_columns_100_internal(sys.babelfish_truncate_identifier(@table_name),
+		sys.babelfish_truncate_identifier(@table_owner),
+		sys.babelfish_truncate_identifier(@table_qualifier),
+		sys.babelfish_truncate_identifier(@column_name), @NameScope, @ODBCVer, @fusepattern);
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT ALL on PROCEDURE sys.sp_columns_100 TO PUBLIC;
+
 CREATE OR REPLACE PROCEDURE sys.sp_columns (
 	"@table_name" sys.nvarchar(384),
     "@table_owner" sys.nvarchar(384) = '', 
@@ -3958,7 +4016,17 @@ BEGIN
 			out_char_octet_length as CHAR_OCTET_LENGTH,
 			out_ordinal_position as ORDINAL_POSITION,
 			out_is_nullable as IS_NULLABLE,
-			out_ss_data_type as SS_DATA_TYPE
+ 			(
+	 			CASE
+	 				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -6 THEN 48 -- Tinyint Identity
+	 				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 5 THEN 52 -- Smallint Identity
+	 				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 4 THEN 56 -- Int Identity
+	 				WHEN out_ss_is_identity = 1 AND out_sql_data_type = -5 THEN 63 -- Bigint Identity
+	 				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 3 THEN 55 -- Decimal Identity
+	 				WHEN out_ss_is_identity = 1 AND out_sql_data_type = 2 THEN 63 -- Numeric Identity
+	 				ELSE out_ss_data_type
+	 			END
+	 			) as SS_DATA_TYPE
 	from sys.sp_columns_100_internal(sys.babelfish_truncate_identifier(@table_name),
 		sys.babelfish_truncate_identifier(@table_owner),
 		sys.babelfish_truncate_identifier(@table_qualifier),

--- a/test/JDBC/expected/BABEL-SPCOLUMNS.out
+++ b/test/JDBC/expected/BABEL-SPCOLUMNS.out
@@ -19,7 +19,7 @@ GO
 EXEC sp_columns @table_name = 't_time'
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 mydb1#!#dbo#!#t_time#!#a#!#-154#!#time#!#15#!#12#!#6#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-154#!#0#!#<NULL>#!#1#!#YES#!#0
 ~~END~~
 
@@ -29,7 +29,7 @@ GO
 exec sp_columns @table_name = 't_text'
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 mydb1#!#dbo#!#t_text#!#a#!#-1#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#2147483647#!#1#!#YES#!#35
 ~~END~~
 
@@ -39,7 +39,7 @@ GO
 exec sp_columns @table_name = 't_int'
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 mydb1#!#dbo#!#t_int#!#a#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#38
 ~~END~~
 
@@ -49,7 +49,7 @@ GO
 exec sp_columns @table_name = 't_money'
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#110
 ~~END~~
 
@@ -58,14 +58,14 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns @table_name = 't_int', @table_owner = 'dbo', @table_qualifier = 'mydb1', @column_name = 'a'
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 mydb1#!#dbo#!#t_int#!#a#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#38
 ~~END~~
 
 EXEC sp_columns 't_int', 'dbo', 'mydb1', 'a'
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 mydb1#!#dbo#!#t_int#!#a#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#38
 ~~END~~
 
@@ -74,7 +74,7 @@ mydb1#!#dbo#!#t_int#!#a#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#
 EXEC sp_columns_100 '%_money', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#110
 ~~END~~
 
@@ -83,7 +83,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 '%_money', 'dbo', NULL, NULL, 0, 2, 0
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: structure of query does not match function result type)~~
@@ -93,7 +93,7 @@ varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallin
 EXEC sp_columns_100 '%[_]money', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#110
 ~~END~~
 
@@ -101,7 +101,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 '%[_]MONEY', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#110
 ~~END~~
 
@@ -109,7 +109,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 't_[a-z][a-z][a-z][a-z][a-z]', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#110
 ~~END~~
 
@@ -117,7 +117,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 't_[a-z][a-z][a-z][a-z][a-z]', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#110
 ~~END~~
 
@@ -125,7 +125,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 'T_[A-Z][A-Z][A-Z][A-Z][A-Z]', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#110
 ~~END~~
 
@@ -133,7 +133,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 't_[a-z][a-z][a-z][a-z][^a-z]', 'dbo', NULL, NULL, 0, 2, 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 

--- a/test/JDBC/expected/sp_columns_100.out
+++ b/test/JDBC/expected/sp_columns_100.out
@@ -15,7 +15,7 @@ go
 EXEC [sys].sp_columns_100 'var', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#var#!#a#!#1#!#char#!#10#!#10#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#10#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#var#!#b#!#-8#!#nchar#!#9#!#18#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#18#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#var#!#c#!#-9#!#nvarchar#!#8#!#16#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#16#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
@@ -32,7 +32,7 @@ master#!#dbo#!#var#!#j#!#-152#!#xml#!#0#!#0#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NU
 EXEC [sys].sp_columns_100 'dates', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#dates#!#a#!#91#!#date#!#10#!#6#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#9#!#1#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 master#!#dbo#!#dates#!#b#!#-154#!#time#!#14#!#12#!#5#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-154#!#0#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 master#!#dbo#!#dates#!#c#!#93#!#datetime#!#23#!#16#!#3#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#9#!#3#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#111
@@ -45,7 +45,7 @@ master#!#dbo#!#dates#!#f#!#-150#!#sql_variant#!#0#!#8000#!#<NULL>#!#10#!#1#!#<NU
 EXEC [sys].sp_columns_100 'nums', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#nums#!#a#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 master#!#dbo#!#nums#!#b#!#5#!#smallint#!#5#!#2#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 master#!#dbo#!#nums#!#c#!#-6#!#tinyint#!#3#!#1#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#-6#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
@@ -72,7 +72,7 @@ go
 EXEC [sys].sp_columns_100 'tbl_rv', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#tbl_rv#!#id#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 master#!#dbo#!#tbl_rv#!#rv#!#-2#!#timestamp#!#8#!#8#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#(get_current_full_xact_id())::rowversion#!#-2#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#45
 ~~END~~
@@ -81,7 +81,7 @@ master#!#dbo#!#tbl_rv#!#rv#!#-2#!#timestamp#!#8#!#8#!#<NULL>#!#<NULL>#!#1#!#<NUL
 EXEC [sys].sp_columns_100 'tbl_tm', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#tbl_tm#!#id#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 master#!#dbo#!#tbl_tm#!#tm#!#-2#!#timestamp#!#8#!#8#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#(get_current_full_xact_id())::"timestamp"#!#-2#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#45
 ~~END~~
@@ -97,7 +97,7 @@ go
 EXEC [sys].sp_columns_100 'maxx', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#maxx#!#a#!#12#!#varchar#!#0#!#0#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#0#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#maxx#!#b#!#-9#!#nvarchar#!#0#!#0#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#0#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#maxx#!#c#!#-3#!#varbinary#!#0#!#0#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#0#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#37
@@ -138,7 +138,7 @@ go
 EXEC [sys].sp_columns_100 'vart', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#vart#!#a#!#1#!#char_t#!#10#!#10#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#10#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#vart#!#b#!#1#!#nchar_t#!#9#!#9#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#9#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#vart#!#c#!#-9#!#nvarchar_t#!#8#!#16#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#16#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
@@ -161,7 +161,7 @@ go
 EXEC [sys].sp_columns_100 'vart', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 
@@ -171,7 +171,7 @@ go
 EXEC [sys].sp_columns_100 'vart', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 
@@ -193,12 +193,147 @@ GO
 EXEC [sys].sp_columns_100 'tidentityintbigwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#tidentityintbigwithareallylongteba669a8099c8b172adc8a937e6cf71d#!#data_type_test#!#1#!#char#!#50#!#50#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#50#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
 master#!#dbo#!#tidentityintbigwithareallylongteba669a8099c8b172adc8a937e6cf71d#!#test_scenario#!#1#!#char#!#60#!#60#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#60#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
-master#!#dbo#!#tidentityintbigwithareallylongteba669a8099c8b172adc8a937e6cf71d#!#value_test#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#3#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#108
+master#!#dbo#!#tidentityintbigwithareallylongteba669a8099c8b172adc8a937e6cf71d#!#value_test#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#3#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#63
 master#!#dbo#!#tidentityintbigwithareallylongteba669a8099c8b172adc8a937e6cf71d#!#inserted_dt#!#93#!#datetime#!#23#!#16#!#3#!#<NULL>#!#1#!#<NULL>#!#getdate()#!#9#!#3#!#<NULL>#!#4#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#111
 master#!#dbo#!#tidentityintbigwithareallylongteba669a8099c8b172adc8a937e6cf71d#!#user_login#!#1#!#char#!#255#!#255#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#user_name_sysname()#!#1#!#<NULL>#!#255#!#5#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
+~~END~~
+
+
+-- test with identity columns
+create table tiny_int_identity ( i_col tinyint identity(1,1), tinyint_col tinyint );
+go
+create table small_int_identity ( i_col smallint identity(1,1), smallint_col smallint );
+go
+create table int_identity ( i_col int identity(1,1), int_col int );
+go
+create table big_int_identity ( i_col bigint identity(1,1), bigint_col bigint );
+go
+create table decimal_int_identity ( i_col decimal(5,0) identity(1,1), dec5int_col decimal(5,0) );
+go
+create table numeric_int_identity ( i_col numeric(5,0) identity(1,1), num5int_col numeric(5,0) );
+go
+create table numeric13_int_identity ( i_col numeric(13,0) identity(1,1), num13int_col numeric(13,0) );
+go
+
+exec [sys].sp_columns_100 N'tiny_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#tiny_int_identity#!#i_col#!#5#!#smallint#!#5#!#2#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#52
+master#!#dbo#!#tiny_int_identity#!#tinyint_col#!#-6#!#tinyint#!#3#!#1#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#-6#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+~~END~~
+
+exec [sys].sp_columns N'tiny_int_identity',N'dbo',NULL,NULL,@ODBCVer=3;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#tiny_int_identity#!#i_col#!#5#!#smallint#!#5#!#2#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#1#!#NO#!#52
+master#!#dbo#!#tiny_int_identity#!#tinyint_col#!#-6#!#tinyint#!#3#!#1#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#-6#!#<NULL>#!#<NULL>#!#2#!#YES#!#38
+~~END~~
+
+
+exec [sys].sp_columns_100 N'small_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#small_int_identity#!#i_col#!#5#!#smallint#!#5#!#2#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#52
+master#!#dbo#!#small_int_identity#!#smallint_col#!#5#!#smallint#!#5#!#2#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+~~END~~
+
+exec [sys].sp_columns N'small_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#small_int_identity#!#i_col#!#5#!#smallint#!#5#!#2#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#1#!#NO#!#52
+master#!#dbo#!#small_int_identity#!#smallint_col#!#5#!#smallint#!#5#!#2#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#2#!#YES#!#38
+~~END~~
+
+
+exec [sys].sp_columns_100 N'int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#int_identity#!#i_col#!#4#!#int#!#10#!#4#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#56
+master#!#dbo#!#int_identity#!#int_col#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+~~END~~
+
+exec [sys].sp_columns N'int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#int_identity#!#i_col#!#4#!#int#!#10#!#4#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#NO#!#56
+master#!#dbo#!#int_identity#!#int_col#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#2#!#YES#!#38
+~~END~~
+
+
+exec [sys].sp_columns_100 N'big_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#big_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#63
+master#!#dbo#!#big_int_identity#!#bigint_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#108
+~~END~~
+
+exec [sys].sp_columns N'big_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#big_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#63
+master#!#dbo#!#big_int_identity#!#bigint_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#2#!#YES#!#108
+~~END~~
+
+
+exec [sys].sp_columns_100 N'decimal_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#decimal_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#63
+master#!#dbo#!#decimal_int_identity#!#dec5int_col#!#3#!#decimal#!#5#!#7#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#106
+~~END~~
+
+exec [sys].sp_columns N'decimal_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#decimal_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#63
+master#!#dbo#!#decimal_int_identity#!#dec5int_col#!#3#!#decimal#!#5#!#7#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#2#!#YES#!#106
+~~END~~
+
+
+exec [sys].sp_columns_100 N'numeric_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#numeric_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#63
+master#!#dbo#!#numeric_int_identity#!#num5int_col#!#2#!#numeric#!#5#!#7#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#2#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#108
+~~END~~
+
+exec [sys].sp_columns N'numeric_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#numeric_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#63
+master#!#dbo#!#numeric_int_identity#!#num5int_col#!#2#!#numeric#!#5#!#7#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#2#!#<NULL>#!#<NULL>#!#2#!#YES#!#108
+~~END~~
+
+
+exec [sys].sp_columns_100 N'numeric13_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
+master#!#dbo#!#numeric13_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#63
+master#!#dbo#!#numeric13_int_identity#!#num13int_col#!#2#!#numeric#!#13#!#15#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#2#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#108
+~~END~~
+
+exec [sys].sp_columns N'numeric13_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
+master#!#dbo#!#numeric13_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#63
+master#!#dbo#!#numeric13_int_identity#!#num13int_col#!#2#!#numeric#!#13#!#15#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#2#!#<NULL>#!#<NULL>#!#2#!#YES#!#108
 ~~END~~
 
 
@@ -209,6 +344,13 @@ drop table nums;
 drop table vart;
 drop table maxx;
 drop table tidentityintbigwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63;
+drop table tiny_int_identity;
+drop table small_int_identity;
+drop table int_identity;
+drop table big_int_identity;
+drop table decimal_int_identity;
+drop table numeric_int_identity;
+drop table numeric13_int_identity;
 drop type char_t;
 drop type nchar_t;
 drop type varchar_t;

--- a/test/JDBC/input/sp_columns_100.sql
+++ b/test/JDBC/input/sp_columns_100.sql
@@ -115,6 +115,57 @@ GO
 EXEC [sys].sp_columns_100 'tidentityintbigwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63', 'dbo', NULL, NULL, @ODBCVer = 3, @fUsePattern = 1
 GO
 
+-- test with identity columns
+create table tiny_int_identity ( i_col tinyint identity(1,1), tinyint_col tinyint );
+go
+create table small_int_identity ( i_col smallint identity(1,1), smallint_col smallint );
+go
+create table int_identity ( i_col int identity(1,1), int_col int );
+go
+create table big_int_identity ( i_col bigint identity(1,1), bigint_col bigint );
+go
+create table decimal_int_identity ( i_col decimal(5,0) identity(1,1), dec5int_col decimal(5,0) );
+go
+create table numeric_int_identity ( i_col numeric(5,0) identity(1,1), num5int_col numeric(5,0) );
+go
+create table numeric13_int_identity ( i_col numeric(13,0) identity(1,1), num13int_col numeric(13,0) );
+go
+
+exec [sys].sp_columns_100 N'tiny_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'tiny_int_identity',N'dbo',NULL,NULL,@ODBCVer=3;
+go
+
+exec [sys].sp_columns_100 N'small_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'small_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+
+exec [sys].sp_columns_100 N'int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+
+exec [sys].sp_columns_100 N'big_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'big_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+
+exec [sys].sp_columns_100 N'decimal_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'decimal_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+
+exec [sys].sp_columns_100 N'numeric_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'numeric_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+
+exec [sys].sp_columns_100 N'numeric13_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+exec [sys].sp_columns N'numeric13_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
+go
+
 -- Cleanup
 drop table var;
 drop table dates;
@@ -122,6 +173,13 @@ drop table nums;
 drop table vart;
 drop table maxx;
 drop table tidentityintbigwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63;
+drop table tiny_int_identity;
+drop table small_int_identity;
+drop table int_identity;
+drop table big_int_identity;
+drop table decimal_int_identity;
+drop table numeric_int_identity;
+drop table numeric13_int_identity;
 drop type char_t;
 drop type nchar_t;
 drop type varchar_t;

--- a/test/JDBC/sql_expected/BABEL-EXTENDEDPROPERTY.out
+++ b/test/JDBC/sql_expected/BABEL-EXTENDEDPROPERTY.out
@@ -21,7 +21,7 @@ varchar#!#varchar#!#varchar#!#sql_variant
 exec [sys].sp_columns_100 N't23',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
 go
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#tinyint
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 


### PR DESCRIPTION
### Description

This commit adjusts sp_columns and sp_columns_100 to return the correct value for SS_DATA_TYPE when there is an IDENTITY column in the table. Currently, the value is hardcoded and does not match the expected value for the procedure.
 
Task: BABEL-3167
Author: Tony Lin <tonyvlin@amazon.com>
Signed-off-by: Jungkook Lee <jungkook@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).