### PR TITLE
store value of "babelfishpg_tsql.server_collation_name" GUC in lower case

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -484,7 +484,7 @@ Datum init_server_collation_oid(PG_FUNCTION_ARGS)
 bool
 is_server_collation_CI_AS()
 {
-	get_server_collation_oid_internal();
+	get_server_collation_oid_internal(false);
 	return pltsql_db_collation_is_CI_AS;
 }
 
@@ -870,11 +870,11 @@ collation_list(PG_FUNCTION_ARGS)
 Datum
 get_server_collation_oid(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_OID(get_server_collation_oid_internal());
+	PG_RETURN_OID(get_server_collation_oid_internal(false));
 }
 
 Oid
-get_server_collation_oid_internal(void)
+get_server_collation_oid_internal(bool missingOk)
 {
 	Oid nspoid;
 	const char *collname = pltsql_server_collation_name;
@@ -897,26 +897,29 @@ get_server_collation_oid_internal(void)
 					 ObjectIdGetDatum(nspoid));
 
 	if (!OidIsValid(server_collation_oid))
-	server_collation_oid = GetSysCacheOid3(COLLNAMEENCNSP, Anum_pg_collation_oid,
-					 PointerGetDatum(collname),
-					 Int32GetDatum(COLL_DEFAULT_ENCODING),
-					 ObjectIdGetDatum(nspoid));
+		server_collation_oid = GetSysCacheOid3(COLLNAMEENCNSP, Anum_pg_collation_oid,
+								PointerGetDatum(collname),
+								Int32GetDatum(COLL_DEFAULT_ENCODING),
+								ObjectIdGetDatum(nspoid));
 
 	if (!OidIsValid(server_collation_oid))
 	{
-	ereport(WARNING,
-		(errcode(ERRCODE_INTERNAL_ERROR),
-		 errmsg("Server default collation sys.\"%s\" is not defined, using the cluster default collation",
-			pltsql_server_collation_name)));
-	// server_collation_oid = DEFAULT_COLLATION_OID;
-	pltsql_db_collation_is_CI_AS = false;
-	server_collation_collidx = NOT_FOUND;
-		return DEFAULT_COLLATION_OID;
+		if (!missingOk)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Server default collation sys.\"%s\" is not defined, using the cluster default collation",
+					 pltsql_server_collation_name)));
+		else
+		{
+			pltsql_db_collation_is_CI_AS = false;
+			server_collation_collidx = NOT_FOUND;
+			return DEFAULT_COLLATION_OID;
+		}
 	}
 	else
 	{
-	pltsql_db_collation_is_CI_AS = collation_is_CI_AS(server_collation_oid);
-	server_collation_collidx = get_server_collation_collidx();
+		pltsql_db_collation_is_CI_AS = collation_is_CI_AS(server_collation_oid);
+		server_collation_collidx = get_server_collation_collidx();
 	}
 
 	return server_collation_oid;
@@ -924,7 +927,7 @@ get_server_collation_oid_internal(void)
 
 Oid BABELFISH_CLUSTER_COLLATION_OID()
 {
-	get_server_collation_oid_internal(); /* set and cache server_collation_oid */
+	get_server_collation_oid_internal(false); /* set and cache server_collation_oid */
 
 	if (sql_dialect == SQL_DIALECT_TSQL
 		&& OidIsValid(server_collation_oid))
@@ -1239,7 +1242,7 @@ transform_funcexpr(Node* node)
 				Oid lower_funcid = 870; // lower
 				Oid result_type = 25;   // text
 
-				get_server_collation_oid_internal();
+				get_server_collation_oid_internal(true);
 
 				if (!OidIsValid(server_collation_oid))
 					return node;
@@ -1362,7 +1365,7 @@ transform_likenode(Node* node)
 			Pattern_Prefix_Status pstatus;
 			int		 collidx_of_cs_as;
 
-			get_server_collation_oid_internal();
+			get_server_collation_oid_internal(true);
 
 			if (!OidIsValid(server_collation_oid))
 				return node;

--- a/contrib/babelfishpg_tsql/src/collation.h
+++ b/contrib/babelfishpg_tsql/src/collation.h
@@ -71,7 +71,7 @@ extern int get_server_collation_collidx(void);
 extern int find_any_collation(const char *collation_name);
 extern bool is_server_collation_CI_AS(void);
 extern int find_cs_as_collation(int collidx);
-extern Oid get_server_collation_oid_internal(void);
+extern Oid get_server_collation_oid_internal(bool missingOk);
 extern int find_locale(const char *given_locale);
 extern bool is_valid_server_collation_name(const char *collname);
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -331,11 +331,11 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 
 	/* TODO: Extract options */
 
-	tuple = SearchSysCache1(COLLOID, ObjectIdGetDatum(get_server_collation_oid_internal()));
+	tuple = SearchSysCache1(COLLOID, ObjectIdGetDatum(get_server_collation_oid_internal(false)));
 	if (!HeapTupleIsValid(tuple))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				errmsg("collation with OID %u does not exist", get_server_collation_oid_internal())));
+				errmsg("OID corresponding to collation \"%s\" does not exist", pltsql_server_collation_name)));
 	default_collation = ((Form_pg_collation) GETSTRUCT(tuple))->collname;
 	ReleaseSysCache(tuple);
 

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1,5 +1,6 @@
 #include "postgres.h"
 #include "commands/explain.h"
+#include "parser/scansup.h"  /* downcase_identifier */
 #include "utils/guc.h"
 
 #include "guc.h"
@@ -111,7 +112,18 @@ static const struct config_enum_entry escape_hatch_options[] = {
 
 static bool check_server_collation_name(char **newval, void **extra, GucSource source)
 {
-    return is_valid_server_collation_name(*newval);
+	if (is_valid_server_collation_name(*newval))
+	{
+		/*
+		 * We are storing value in lower case since
+		 * Collation names are stored in lowercase into pg catalog (pg_collation).
+		 */
+		char *dupval = pstrdup(*newval);
+		strcpy(*newval, downcase_identifier(dupval, strlen(dupval), false, false));
+		pfree(dupval);
+		return true;
+	}
+	return false;
 }
 
 static bool check_default_locale (char **newval, void **extra, GucSource source)

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -915,7 +915,7 @@ tsql_coerce_string_literal_hook(ParseCallbackState *pcbstate, Oid targetTypeId,
 						msg = pstrdup("An empty or space-only string cannot be converted into numeric/decimal data type");
 						args = list_make1(makeConst(TEXTOID,
 													-1,
-													get_server_collation_oid_internal(),
+													get_server_collation_oid_internal(false),
 													-1,
 													PointerGetDatum(cstring_to_text(msg)),
 													false,


### PR DESCRIPTION
### Description

store value of "babelfishpg_tsql.server_collation_name" GUC in lower case

Collation names are being stored in lower case into pg catalog (pg_collation). We load this info in sys cache and we
lookup the oid of server_collation_name from this sys cache which was failing if we specify server_collation_name in
camel case.

With this commit, we will store value of "babelfishpg_tsql.server_collation_name" in lower case so that lookup would not
get failed.

Task: BABEL-3236
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).