### PR TITLE
Fix bug in OUTPUT clause where no values are returned

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -1251,7 +1251,8 @@ get_transformed_output_list(List *tsql_output_clause)
 			{
 				ResTarget *target = makeNode(ResTarget);
 				ColumnRef  *cref = (ColumnRef *) node;
- 
+				local_variable = false;
+				
 				if(!strcmp(strVal(linitial(cref->fields)), "deleted") && list_length(cref->fields) >= 2)
 				{
 					if (IsA((Node*) llast(cref->fields), String))
@@ -1287,7 +1288,6 @@ get_transformed_output_list(List *tsql_output_clause)
 				}
 				else
 				{
-					local_variable = false;
 					if(!strncmp(strVal(linitial(cref->fields)), "@", 1) && estate)
 					{
 						for (i = 0; i < estate->ndatums; i++)

--- a/test/JDBC/expected/BABEL-588.out
+++ b/test/JDBC/expected/BABEL-588.out
@@ -1916,3 +1916,107 @@ go
 drop table t1;
 go
 
+
+-- Test OUTPUT INTO with a table with NULL column --
+CREATE TABLE [dbo].[t1]
+(
+    [Id] [int] NOT NULL IDENTITY(1, 1),
+    [Name] [varchar] (100)  NOT NULL,
+    [Desc] [varchar] (32)  NULL,
+) 
+go
+
+
+
+DECLARE @t2 TABLE (Id INT, Name VARCHAR(50))
+INSERT INTO dbo.t1 (Name)
+OUTPUT Inserted.Id, Inserted.Name INTO @t2
+VALUES ('abc')
+SELECT * FROM @t2
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+
+SELECT * FROM dbo.t1
+go
+~~START~~
+int#!#varchar#!#varchar
+1#!#abc#!#<NULL>
+~~END~~
+
+
+-- Cleanup --
+drop table t1
+go
+
+
+
+
+
+
+
+
+-- Test that a local variable at the beginning of OUTPUT INTO list works properly -- 
+CREATE TABLE t1 (
+      id                 integer       NOT NULL,
+      fname              varchar(128)  NOT NULL,
+      lname              varchar(128)      NULL,
+      age                integer       NOT NULL,
+      preferredname      AS (fname),
+      CONSTRAINT pk_t1 PRIMARY KEY (
+         id,
+         lname
+        )
+);
+CREATE TABLE #t2 (
+      operation          varchar(128),
+      gender             varchar(1),
+      id                 integer       NOT NULL,
+      fname              varchar(128)  NOT NULL,
+      lname              varchar(128)      NULL,
+      age                integer       NOT NULL,
+      preferredname      varchar(128)
+);
+INSERT INTO t1 VALUES (
+    1,
+    'john',
+    'doe',
+    28
+);
+DECLARE @str_operation VARCHAR(8);
+SET @str_operation    = 'DELETE';
+DECLARE @str_gender VARCHAR(1);
+SET @str_gender  = 'M';
+DELETE t1
+OUTPUT @str_operation, @str_gender, deleted.id, deleted.fname, deleted.lname, 
+        deleted.age, deleted.preferredname
+INTO #t2
+WHERE 1=1;
+SELECT * FROM t1;
+SELECT * FROM #t2;
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#varchar#!#int#!#varchar
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#int#!#varchar#!#varchar#!#int#!#varchar
+DELETE#!#M#!#1#!#john#!#doe#!#28#!#john
+~~END~~
+
+
+-- Cleanup
+DROP TABLE t1;
+go
+
+DROP TABLE #t2;
+go

--- a/test/JDBC/input/BABEL-588.sql
+++ b/test/JDBC/input/BABEL-588.sql
@@ -1124,3 +1124,82 @@ go
 drop table t1;
 go
 
+-- Test OUTPUT INTO with a table with NULL column --
+
+CREATE TABLE [dbo].[t1]
+(
+    [Id] [int] NOT NULL IDENTITY(1, 1),
+    [Name] [varchar] (100)  NOT NULL,
+    [Desc] [varchar] (32)  NULL,
+) 
+go
+
+DECLARE @t2 TABLE (Id INT, Name VARCHAR(50))
+
+INSERT INTO dbo.t1 (Name)
+OUTPUT Inserted.Id, Inserted.Name INTO @t2
+VALUES ('abc')
+
+SELECT * FROM @t2
+go
+
+SELECT * FROM dbo.t1
+go
+
+-- Cleanup --
+drop table t1
+go
+
+-- Test that a local variable at the beginning of OUTPUT INTO list works properly -- 
+CREATE TABLE t1 (
+      id                 integer       NOT NULL,
+      fname              varchar(128)  NOT NULL,
+      lname              varchar(128)      NULL,
+      age                integer       NOT NULL,
+      preferredname      AS (fname),
+      CONSTRAINT pk_t1 PRIMARY KEY (
+         id,
+         lname
+        )
+);
+
+CREATE TABLE #t2 (
+      operation          varchar(128),
+      gender             varchar(1),
+      id                 integer       NOT NULL,
+      fname              varchar(128)  NOT NULL,
+      lname              varchar(128)      NULL,
+      age                integer       NOT NULL,
+      preferredname      varchar(128)
+);
+
+
+INSERT INTO t1 VALUES (
+    1,
+    'john',
+    'doe',
+    28
+);
+
+DECLARE @str_operation VARCHAR(8);
+SET @str_operation    = 'DELETE';
+
+DECLARE @str_gender VARCHAR(1);
+SET @str_gender  = 'M';
+
+DELETE t1
+OUTPUT @str_operation, @str_gender, deleted.id, deleted.fname, deleted.lname, 
+        deleted.age, deleted.preferredname
+INTO #t2
+WHERE 1=1;
+
+SELECT * FROM t1;
+SELECT * FROM #t2;
+go
+
+-- Cleanup
+DROP TABLE t1;
+go
+
+DROP TABLE #t2;
+go


### PR DESCRIPTION
Fix bug in OUTPUT clause where no values are returned

Fix issue of NULL returning list when local variable is at the beginning of OUTPUT INTO list

Task: BABEL-2786
Signed-off-by: Avantika Dasgupta <davantik@amazon.com>