### PR TITLE
Add tests for T-SQL procedures and CREATE PROC syntax

### DIFF
--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -96,6 +96,7 @@ REGRESS += test/babel_set_command
 # REGRESS += test/babel_datatype TODO: fix BABEL-2636 "Money datatype doesn't support any currency symbol other than Dollar" before enabling this test
 REGRESS += test/babel_function
 REGRESS += test/babel_table_type
+REGRESS += test/babel_procedures
 
 # We need the previous version to test extension upgrade scripts
 ifdef PREV_EXTVERSION

--- a/contrib/babelfishpg_tsql/expected/test/babel_procedures.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_procedures.out
@@ -1,0 +1,79 @@
+CREATE EXTENSION IF NOT EXISTS "babelfishpg_tsql";
+NOTICE:  extension "babelfishpg_tsql" already exists, skipping
+-- test sp_unprepare
+create table t1 ( a int );
+insert into t1 values (1);
+insert into t1 values (2);
+prepare s_100 (int) as select * from t1 where a = $1;
+execute s_100(1);
+ a 
+---
+ 1
+(1 row)
+
+set babelfishpg_tsql.sql_dialect = "tsql";
+call sp_unprepare(null);
+ERROR:  expect handle as integer
+call sp_unprepare(10);
+call sp_unprepare(100);
+execute s_100(1);
+ERROR:  procedure s_100(integer) does not exist
+LINE 1: execute s_100(1);
+        ^
+HINT:  No procedure matches the given name and argument types. You might need to add explicit type casts.
+\tsql on
+-- Test 'with' in procedure language that shouldn't be recognized as CTE
+create or replace procedure prc1 as begin
+select count(*) from t1 with (tablockx)
+end
+go
+call prc1();
+go
+ count 
+-------
+     2
+(1 row)
+
+create or replace procedure prc2 as begin
+insert into t1 select * from t1 with (tablockx);
+end
+go
+call prc2();
+go
+-- Test C-style comment with a following '@'
+create procedure prc3
+/* comment */
+@p int
+as 
+select 123;
+go
+-- BABEL-831
+CREATE PROCEDURE babel_831_proc
+AS
+BEGIN
+        CREATE TABLE #t(id INT)
+        DECLARE Babel831Cursor CURSOR FOR SELECT id FROM #t
+        OPEN Babel831Cursor
+        CLOSE Babel831Cursor
+END
+GO
+exec babel_831_proc
+GO
+--BABEL-1099
+CREATE TABLE babel_1099_t1 (a int);
+CREATE TABLE babel_1099_t2 (a int);
+CREATE PROCEDURE babel_1099_proc AS
+    TRUNCATE TABLE babel_1099_t1
+    TRUNCATE TABLE babel_1099_t2
+GO
+EXEC babel_1099_proc
+GO
+\tsql off
+drop table t1;
+drop table babel_1099_t1;
+drop table babel_1099_t2;
+drop procedure prc1;
+drop procedure prc2;
+drop procedure prc3;
+drop procedure babel_831_proc;
+drop procedure babel_1099_proc;

--- a/contrib/babelfishpg_tsql/sql/test/babel_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/test/babel_procedures.sql
@@ -1,0 +1,80 @@
+CREATE EXTENSION IF NOT EXISTS "babelfishpg_tsql";
+
+-- test sp_unprepare
+create table t1 ( a int );
+insert into t1 values (1);
+insert into t1 values (2);
+
+prepare s_100 (int) as select * from t1 where a = $1;
+execute s_100(1);
+
+set babelfishpg_tsql.sql_dialect = "tsql";
+
+call sp_unprepare(null);
+call sp_unprepare(10);
+call sp_unprepare(100);
+
+execute s_100(1);
+
+\tsql on
+
+-- Test 'with' in procedure language that shouldn't be recognized as CTE
+create or replace procedure prc1 as begin
+select count(*) from t1 with (tablockx)
+end
+go
+
+call prc1();
+go
+
+create or replace procedure prc2 as begin
+insert into t1 select * from t1 with (tablockx);
+end
+go
+
+call prc2();
+go
+
+-- Test C-style comment with a following '@'
+create procedure prc3
+/* comment */
+@p int
+as 
+select 123;
+go
+
+-- BABEL-831
+CREATE PROCEDURE babel_831_proc
+AS
+BEGIN
+        CREATE TABLE #t(id INT)
+        DECLARE Babel831Cursor CURSOR FOR SELECT id FROM #t
+        OPEN Babel831Cursor
+        CLOSE Babel831Cursor
+END
+GO
+
+exec babel_831_proc
+GO
+
+--BABEL-1099
+CREATE TABLE babel_1099_t1 (a int);
+CREATE TABLE babel_1099_t2 (a int);
+CREATE PROCEDURE babel_1099_proc AS
+    TRUNCATE TABLE babel_1099_t1
+    TRUNCATE TABLE babel_1099_t2
+GO
+
+EXEC babel_1099_proc
+GO
+
+\tsql off
+
+drop table t1;
+drop table babel_1099_t1;
+drop table babel_1099_t2;
+drop procedure prc1;
+drop procedure prc2;
+drop procedure prc3;
+drop procedure babel_831_proc;
+drop procedure babel_1099_proc;

--- a/test/JDBC/expected/babel_1127.out
+++ b/test/JDBC/expected/babel_1127.out
@@ -1,0 +1,21 @@
+-- expected error due to invalid syntax
+CREATE PROCEDURE p1 AS
+CREATE PROC p2
+AS
+SELECT * FROM t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'PROC' at line 3 and character position 7)~~
+
+
+-- expected error due to invalid syntax
+CREATE PROCEDURE p3 AS
+CREATE PROC p4
+AS
+SELECT 1234
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'PROC' at line 3 and character position 7)~~
+

--- a/test/JDBC/input/babel_1127.sql
+++ b/test/JDBC/input/babel_1127.sql
@@ -1,0 +1,13 @@
+-- expected error due to invalid syntax
+CREATE PROCEDURE p1 AS
+CREATE PROC p2
+AS
+SELECT * FROM t1
+GO
+
+-- expected error due to invalid syntax
+CREATE PROCEDURE p3 AS
+CREATE PROC p4
+AS
+SELECT 1234
+GO


### PR DESCRIPTION
### Description

This commit contains the following changes:
1. Added babel_procedures to the babelfishpg_tsql set of installcheck tests.
2. Added test for CREATE PROC syntax in JDBC test framework.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).