### PR TITLE
Implemented various OBJECTPROPERTY properties

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -2627,10 +2627,116 @@ end
 $body$
 LANGUAGE plpgsql STABLE PARALLEL SAFE STRICT;
 
-CREATE OR REPLACE FUNCTION OBJECTPROPERTY(IN object_id INT, IN property sys.varchar)
-RETURNS INT AS
-$$
+CREATE OR REPLACE FUNCTION objectproperty(
+    id INT,
+    property SYS.VARCHAR
+    )
+RETURNS INT
+AS $$
 BEGIN
+
+    IF NOT EXISTS(SELECT ao.object_id FROM sys.all_objects ao WHERE object_id = id)
+    THEN
+        RETURN NULL;
+    END IF;
+
+    property := RTRIM(LOWER(COALESCE(property, '')));
+
+    IF property = 'ownerid' -- OwnerId
+    THEN
+        RETURN (
+                SELECT CAST(COALESCE(t1.principal_id, pn.nspowner) AS INT)
+                FROM sys.all_objects t1
+                INNER JOIN pg_catalog.pg_namespace pn ON pn.oid = t1.schema_id
+                WHERE t1.object_id = id);
+
+    ELSEIF property = 'isdefaultcnst' -- IsDefaultCnst
+    THEN
+        RETURN (SELECT count(distinct dc.object_id) FROM sys.default_constraints dc WHERE dc.object_id = id);
+
+    ELSEIF property = 'execisquotedidenton' -- ExecIsQuotedIdentOn
+    THEN
+        RETURN (SELECT CAST(sm.uses_quoted_identifier as int) FROM sys.all_sql_modules sm WHERE sm.object_id = id);
+
+    ELSEIF property = 'tablefulltextpopulatestatus' -- TableFullTextPopulateStatus
+    THEN
+        IF NOT EXISTS (SELECT object_id FROM sys.tables t WHERE t.object_id = id) THEN
+            RETURN NULL;
+        END IF;
+        RETURN 0;
+
+    ELSEIF property = 'tablehasvardecimalstorageformat' -- TableHasVarDecimalStorageFormat
+    THEN
+        IF NOT EXISTS (SELECT object_id FROM sys.tables t WHERE t.object_id = id) THEN
+            RETURN NULL;
+        END IF;
+        RETURN 0;
+
+    ELSEIF property = 'ismsshipped' -- IsMSShipped
+    THEN
+        RETURN (SELECT CAST(ao.is_ms_shipped AS int) FROM sys.all_objects ao WHERE ao.object_id = id);
+
+    ELSEIF property = 'isschemabound' -- IsSchemaBound
+    THEN
+        RETURN (SELECT CAST(sm.is_schema_bound AS int) FROM sys.all_sql_modules sm WHERE sm.object_id = id);
+
+    ELSEIF property = 'execisansinullson' -- ExecIsAnsiNullsOn
+    THEN
+        RETURN (SELECT CAST(sm.uses_ansi_nulls AS int) FROM sys.all_sql_modules sm WHERE sm.object_id = id);
+
+    ELSEIF property = 'isdeterministic' -- IsDeterministic
+    THEN
+        RETURN 0;
+    
+    ELSEIF property = 'isprocedure' -- IsProcedure
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'P');
+
+    ELSEIF property = 'istable' -- IsTable
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('IT', 'TT', 'U', 'S'));
+
+    ELSEIF property = 'isview' -- IsView
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'V');
+    
+    ELSEIF property = 'isusertable' -- IsUserTable
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'U' and is_ms_shipped = 0);
+    
+    ELSEIF property = 'istablefunction' -- IsTableFunction
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('IF', 'TF', 'FT'));
+    
+    ELSEIF property = 'isinlinefunction' -- IsInlineFunction
+    THEN
+        RETURN 0;
+    
+    ELSEIF property = 'isscalarfunction' -- IsScalarFunction
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('FN', 'FS'));
+
+    ELSEIF property = 'isprimarykey' -- IsPrimaryKey
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'PK');
+    
+    ELSEIF property = 'isindexed' -- IsIndexed
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.indexes WHERE object_id = id and index_id > 0);
+
+    ELSEIF property = 'isdefault' -- IsDefault
+    THEN
+        RETURN 0;
+
+    ELSEIF property = 'isrule' -- IsRule
+    THEN
+        RETURN 0;
+    
+    ELSEIF property = 'istrigger' -- IsTrigger
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('TA', 'TR'));
+    END IF;
+
     RETURN NULL;
 END;
 $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -29,6 +29,31 @@ end
 $$
 LANGUAGE plpgsql;
 
+-- Drops a function if it does not have any dependent objects.
+-- Is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
+-- Please have this be one of the first statements executed in this upgrade script. 
+CREATE OR REPLACE PROCEDURE babelfish_drop_deprecated_function(schema_name varchar, func_name varchar) AS
+$$
+DECLARE
+    error_msg text;
+    query1 text;
+    query2 text;
+BEGIN
+    query1 := format('alter extension babelfishpg_tsql drop function %s.%s', schema_name, func_name);
+    query2 := format('drop function %s.%s', schema_name, func_name);
+    execute query1;
+    execute query2;
+EXCEPTION
+    when object_not_in_prerequisite_state then --if 'alter extension' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+    when dependent_objects_still_exist then --if 'drop function' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+end
+$$
+LANGUAGE plpgsql;
+
 -- Removes a member object from the extension. The object is not dropped, only disassociated from the extension.
 -- It is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
 CREATE OR REPLACE PROCEDURE babelfish_remove_object_from_extension(obj_type varchar, qualified_obj_name varchar) AS
@@ -282,6 +307,125 @@ GRANT SELECT ON sys.objects TO PUBLIC;
 
 CALL sys.babelfish_drop_deprecated_view('sys', 'foreign_keys_deprecated');
 
+ALTER FUNCTION OBJECTPROPERTY(INT, SYS.VARCHAR) RENAME TO objectproperty_deprecated_2_1_0;
+
+CREATE OR REPLACE FUNCTION objectproperty(
+    id INT,
+    property SYS.VARCHAR
+    )
+RETURNS INT
+AS $$
+BEGIN
+
+    IF NOT EXISTS(SELECT ao.object_id FROM sys.all_objects ao WHERE object_id = id)
+    THEN
+        RETURN NULL;
+    END IF;
+
+    property := RTRIM(LOWER(COALESCE(property, '')));
+
+    IF property = 'ownerid' -- OwnerId
+    THEN
+        RETURN (
+                SELECT CAST(COALESCE(t1.principal_id, pn.nspowner) AS INT)
+                FROM sys.all_objects t1
+                INNER JOIN pg_catalog.pg_namespace pn ON pn.oid = t1.schema_id
+                WHERE t1.object_id = id);
+
+    ELSEIF property = 'isdefaultcnst' -- IsDefaultCnst
+    THEN
+        RETURN (SELECT count(distinct dc.object_id) FROM sys.default_constraints dc WHERE dc.object_id = id);
+
+    ELSEIF property = 'execisquotedidenton' -- ExecIsQuotedIdentOn
+    THEN
+        RETURN (SELECT CAST(sm.uses_quoted_identifier as int) FROM sys.all_sql_modules sm WHERE sm.object_id = id);
+
+    ELSEIF property = 'tablefulltextpopulatestatus' -- TableFullTextPopulateStatus
+    THEN
+        IF NOT EXISTS (SELECT object_id FROM sys.tables t WHERE t.object_id = id) THEN
+            RETURN NULL;
+        END IF;
+        RETURN 0;
+
+    ELSEIF property = 'tablehasvardecimalstorageformat' -- TableHasVarDecimalStorageFormat
+    THEN
+        IF NOT EXISTS (SELECT object_id FROM sys.tables t WHERE t.object_id = id) THEN
+            RETURN NULL;
+        END IF;
+        RETURN 0;
+
+    ELSEIF property = 'ismsshipped' -- IsMSShipped
+    THEN
+        RETURN (SELECT CAST(ao.is_ms_shipped AS int) FROM sys.all_objects ao WHERE ao.object_id = id);
+
+    ELSEIF property = 'isschemabound' -- IsSchemaBound
+    THEN
+        RETURN (SELECT CAST(sm.is_schema_bound AS int) FROM sys.all_sql_modules sm WHERE sm.object_id = id);
+
+    ELSEIF property = 'execisansinullson' -- ExecIsAnsiNullsOn
+    THEN
+        RETURN (SELECT CAST(sm.uses_ansi_nulls AS int) FROM sys.all_sql_modules sm WHERE sm.object_id = id);
+
+    ELSEIF property = 'isdeterministic' -- IsDeterministic
+    THEN
+        RETURN 0;
+    
+    ELSEIF property = 'isprocedure' -- IsProcedure
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'P');
+
+    ELSEIF property = 'istable' -- IsTable
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('IT', 'TT', 'U', 'S'));
+
+    ELSEIF property = 'isview' -- IsView
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'V');
+    
+    ELSEIF property = 'isusertable' -- IsUserTable
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'U' and is_ms_shipped = 0);
+    
+    ELSEIF property = 'istablefunction' -- IsTableFunction
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('IF', 'TF', 'FT'));
+    
+    ELSEIF property = 'isinlinefunction' -- IsInlineFunction
+    THEN
+        RETURN 0;
+    
+    ELSEIF property = 'isscalarfunction' -- IsScalarFunction
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('FN', 'FS'));
+
+    ELSEIF property = 'isprimarykey' -- IsPrimaryKey
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type = 'PK');
+    
+    ELSEIF property = 'isindexed' -- IsIndexed
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.indexes WHERE object_id = id and index_id > 0);
+
+    ELSEIF property = 'isdefault' -- IsDefault
+    THEN
+        RETURN 0;
+
+    ELSEIF property = 'isrule' -- IsRule
+    THEN
+        RETURN 0;
+    
+    ELSEIF property = 'istrigger' -- IsTrigger
+    THEN
+        RETURN (SELECT count(distinct object_id) from sys.all_objects WHERE object_id = id and type in ('TA', 'TR'));
+    END IF;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CALL sys.babelfish_drop_deprecated_function('sys', 'objectproperty_deprecated_2_1_0');
+
 CREATE OR REPLACE FUNCTION sys.DBTS()
 RETURNS sys.ROWVERSION AS
 $$
@@ -371,6 +515,7 @@ CALL sys.babelfish_remove_object_from_extension('procedure', 'master_dbo.xp_inst
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);
 DROP PROCEDURE sys.babelfish_remove_object_from_extension(varchar, varchar);
+DROP PROCEDURE sys.babelfish_drop_deprecated_function(varchar, varchar);
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/objectproperty.out
+++ b/test/JDBC/expected/objectproperty.out
@@ -1,8 +1,1080 @@
--- Test OBJECTPROPERTY Stub
-SELECT OBJECTPROPERTY(0, '')
+-- Global setup for tests
+CREATE DATABASE db1
+GO
+USE db1
+GO
+
+
+-- =============== OwnerId ===============
+-- Setup
+CREATE SCHEMA ownerid_schema
+GO
+
+CREATE TABLE ownerid_schema.ownerid_table(a int) 
+GO
+
+-- Check for correct case
+SELECT CASE
+    WHEN OBJECTPROPERTY(OBJECT_ID('ownerid_schema.ownerid_table'), 'OwnerId')  = (SELECT principal_id 
+            FROM sys.database_principals
+            WHERE name = CURRENT_USER)
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+SUCCESS
+~~END~~
+
+
+-- Check for system object. Should return 10 since that's the owner ID. 
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'OwnerId')
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+-- Invalid property ID (should return NULL)
+SELECT OBJECTPROPERTY(0, 'OwnerId')
 GO
 ~~START~~
 int
 <NULL>
 ~~END~~
 
+
+-- Check for mix-cased property
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'oWnEriD')
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+-- Check for trailing white spaces
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'OwnerId     ')
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+-- Check for trailing white spaces and mixed case
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'oWnEriD     ')
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+-- Cleanup
+DROP TABLE ownerid_schema.ownerid_table
+GO
+
+DROP SCHEMA ownerid_schema
+GO
+
+-- =============== IsDefaultCnst ===============
+-- Setup
+CREATE TABLE isdefaultcnst_table(a int DEFAULT 10)
+GO
+
+CREATE TABLE isdefaultcnst_table2(a int DEFAULT 10, b int DEFAULT 20)
+GO
+
+-- Check for correct cases (should return 1)
+SELECT OBJECTPROPERTY(ct.object_id, 'isdefaultcnst') 
+from sys.default_constraints ct
+where parent_object_id = OBJECT_ID('isdefaultcnst_table')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT OBJECTPROPERTY(ct.object_id, 'isdefaultcnst') 
+from sys.default_constraints ct
+where parent_object_id = OBJECT_ID('isdefaultcnst_table2')
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+-- Check for object_id that exists, but not an index (should return 0)
+SELECT OBJECTPROPERTY(OBJECT_ID('isdefaultcnst_table'), 'IsDefaultCnst')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Check for invalid object_id (should return NULL)
+SELECT OBJECTPROPERTY(0, 'IsDefaultCnst')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE isdefaultcnst_table
+GO
+
+
+
+-- =============== ExecIsQuotedIdentOn ===============
+-- Does not function properly due to sys.sql_modules not recording the correct settings
+-- Setup
+SET QUOTED_IDENTIFIER OFF
+GO
+
+CREATE PROC execisquotedident_proc_off
+AS
+RETURN 1
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE PROC execisquotedident_proc_on
+AS
+RETURN 1
+GO
+
+CREATE TABLE execisquotedident_table(a int)
+GO
+
+-- Currently does not work due to hardcoded value in sys.sql_modules (should be 0)
+SELECT OBJECTPROPERTY(OBJECT_ID('execisquotedident_proc_off'), 'ExecIsQuotedIdentOn') 
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT OBJECTPROPERTY(OBJECT_ID('execisquotedident_proc_on'), 'ExecIsQuotedIdentOn')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Check for object_id that exists, but not a proc, view, function, or sproc (should return NULL)
+SELECT OBJECTPROPERTY(OBJECT_ID('execisquotedident_table'), 'ExecIsQuotedIdentOn')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Check for invalid object_id (should return NULL)
+SELECT OBJECTPROPERTY(0, 'ExecIsQuotedIdentOn')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP PROC execisquotedident_proc_on
+GO
+DROP PROC execisquotedident_proc_off
+GO
+DROP TABLE execisquotedident_table
+GO
+
+
+-- =============== IsMSShipped ===============
+-- Setup
+CREATE TABLE is_ms_shipped_table(a int)
+GO
+
+-- Test for object that exists but isn't ms_shipped
+SELECT OBJECTPROPERTY(OBJECT_ID('is_ms_shipped_table'), 'IsMSShipped')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for object that is ms_shipped
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.sp_tables'), 'IsMSShipped')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsMSShipped')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE is_ms_shipped_table
+GO
+
+
+-- =============== TableFullTextPopulateStatus ===============
+-- Setup
+CREATE TABLE tablefulltextpopulatestatus_table(a int)
+GO
+
+CREATE PROC tablefulltextpopulatestatus_proc
+AS
+RETURN 1
+GO
+
+-- Test with table object
+SELECT OBJECTPROPERTY(OBJECT_ID('tablefulltextpopulatestatus_table'), 'TableFullTextPopulateStatus')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test with non-table object
+SELECT OBJECTPROPERTY(OBJECT_ID('tablefulltextpopulatestatus_proc'), 'TableFullTextPopulateStatus')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'TableFullTextPopulateStatus')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE tablefulltextpopulatestatus_table
+GO
+
+DROP PROC tablefulltextpopulatestatus_proc
+GO
+
+
+-- =============== TableHasVarDecimalStorageFormat ===============
+-- Setup
+CREATE TABLE TableHasVarDecimalStorageFormat_table(a int)
+GO
+
+CREATE proc TableHasVarDecimalStorageFormat_proc
+AS
+RETURN 1
+GO
+
+-- Test with table object
+SELECT OBJECTPROPERTY(OBJECT_ID('TableHasVarDecimalStorageFormat_table'), 'TableHasVarDecimalStorageFormat')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test with non-table object
+SELECT OBJECTPROPERTY(OBJECT_ID('TableHasVarDecimalStorageFormat_proc'), 'TableHasVarDecimalStorageFormat')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'TableHasVarDecimalStorageFormat')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE TableHasVarDecimalStorageFormat_table
+GO
+
+DROP PROC TableHasVarDecimalStorageFormat_proc
+GO
+
+
+-- =============== IsSchemaBound ===============
+-- Currently does not work due to hardcoded value in sys.sql_modules
+-- Setup
+CREATE FUNCTION IsSchemaBound_function_false()
+RETURNS int
+BEGIN
+    return 1
+END
+GO
+
+CREATE FUNCTION IsSchemaBound_function_true()
+RETURNS int
+WITH SCHEMABINDING
+BEGIN
+    return 1
+END
+GO
+
+CREATE TABLE IsSchemaBound_table(a int)
+GO
+
+-- Test when object is not schema bound 
+SELECT OBJECTPROPERTY(OBJECT_ID('IsSchemaBound_function_false'), 'IsSchemaBound')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test when object is schema bound (Currently does not work due to hardcoded value in sys.sql_modules, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsSchemaBound_function_true'), 'IsSchemaBound')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test with object that doesn't have schema bound settings
+SELECT OBJECTPROPERTY(OBJECT_ID('IsSchemaBound_table'), 'IsSchemaBound')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'IsSchemaBound')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsSchemaBound_table
+GO
+
+DROP FUNCTION IsSchemaBound_function_false
+GO
+
+DROP FUNCTION IsSchemaBound_function_true
+GO
+
+
+-- =============== ExecIsAnsiNullsOn ===============
+-- Currently does not work due to hardcoded value in sys.sql_modules
+-- Setup
+SET ANSI_NULLS OFF
+GO
+
+CREATE PROC ansi_nulls_off_proc
+AS
+SELECT CASE WHEN NULL = NULL then 1 else 0 end
+GO
+
+SET ANSI_NULLS ON
+GO
+
+CREATE PROC ansi_nulls_on_proc
+AS
+SELECT CASE WHEN NULL = NULL then 1 else 0 end
+GO
+
+CREATE TABLE ansi_nulls_on_table(a int)
+GO
+
+
+-- Tests when object is created with ansi nulls off and ansi nulls on
+-- Currently does not work due to hardcoded value in sys.sql_modules (should return 0)
+SELECT OBJECTPROPERTY(OBJECT_ID('ansi_nulls_off_proc'), 'ExecIsAnsiNullsOn')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT OBJECTPROPERTY(OBJECT_ID('ansi_nulls_on_proc'), 'ExecIsAnsiNullsOn')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'ExecIsAnsiNullsOn')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Check for object_id that exists, but not a proc, view, function, or sproc (should return NULL)
+SELECT OBJECTPROPERTY(OBJECT_ID('ansi_nulls_on_table'), 'ExecIsAnsiNullsOn')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Check for invalid object_id (should return NULL)
+SELECT OBJECTPROPERTY(0, 'ExecIsAnsiNullsOn')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP PROC ansi_nulls_off_proc
+GO
+
+DROP PROC ansi_nulls_on_proc
+GO
+
+DROP TABLE ansi_nulls_on_table
+GO
+
+
+-- =============== IsDeterministic ===============
+-- Currently does not work since INFORMATION_SCHEMA.ROUTINES does not evaluate if a function is deterministic
+-- Setup
+CREATE FUNCTION IsDeterministic_function_yes()
+RETURNS int
+WITH SCHEMABINDING
+BEGIN
+    return 1;
+END
+GO
+
+CREATE FUNCTION IsDeterministic_function_no()
+RETURNS sys.datetime
+WITH SCHEMABINDING
+BEGIN
+    return GETDATE();
+END
+GO
+
+CREATE TABLE IsDeterministic_table(a int)
+GO
+
+-- Tests for a deterministic function (Currently does not work, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDeterministic_function_yes'), 'IsDeterministic')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Tests for a non-deterministic function
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDeterministic_function_yes'), 'IsDeterministic')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Tests for an object that is not a function
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDeterministic_table'), 'IsDeterministic')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Tests for a non-valid object
+SELECT OBJECTPROPERTY(0, 'IsDeterministic')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+
+-- Cleanup
+DROP FUNCTION IsDeterministic_function_no
+GO
+
+DROP FUNCTION IsDeterministic_function_yes
+GO
+
+DROP TABLE IsDeterministic_table
+GO
+
+-- =============== IsProcedure ===============
+-- Setup
+CREATE PROC IsProcedure_proc AS
+SELECT 1
+GO
+
+CREATE TABLE IsProcedure_table(a int)
+GO
+
+-- Test for success
+SELECT OBJECTPROPERTY(OBJECT_ID('IsProcedure_proc'), 'IsProcedure')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for failure 
+SELECT OBJECTPROPERTY(OBJECT_ID('IsProcedure_table'), 'IsProcedure')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsProcedure')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP PROC IsProcedure_proc
+GO
+
+DROP TABLE IsProcedure_table
+GO
+
+-- =============== IsTable ===============
+-- Setup
+CREATE TABLE IsTable_table(a int)
+GO
+
+CREATE PROC IsTable_proc AS
+SELECT 1
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTable_table'), 'IsTable')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTable_proc'), 'IsTable')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsTable')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsTable_table
+GO
+
+DROP PROC IsTable_proc
+GO
+
+-- =============== IsView ===============
+-- Setup
+CREATE VIEW IsView_view AS
+SELECT 1
+GO
+
+CREATE TABLE IsView_table(a int)
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsView_view'), 'IsView')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsView_table'), 'IsView')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsView')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP VIEW IsView_view
+GO
+
+DROP TABLE IsView_table
+GO
+-- =============== IsUserTable ===============
+-- Setup
+CREATE TABLE IsUserTable_table(a int)
+GO
+
+CREATE VIEW IsUserTable_view AS
+SELECT 1
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsUserTable_table'), 'IsUserTable')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsUserTable_view'), 'IsUserTable')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsUserTable')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsUserTable_table
+GO
+
+DROP VIEW IsUserTable_view
+GO
+
+
+-- =============== IsTableFunction ===============
+-- NOTE: Currently will return 0 since sys.all_objects does not identify objects of type TF (BABELFISH-483)
+-- Setup
+CREATE FUNCTION IsTableFunction_tablefunction()
+RETURNS @t TABLE (
+    c1 int,
+    c2 int
+)
+AS
+BEGIN
+    INSERT INTO @t
+    SELECT 1 as c1, 2 as c2;
+    RETURN;
+END
+GO
+
+CREATE FUNCTION IsTableFunction_inlinetablefunction()
+RETURNS TABLE
+AS
+RETURN
+(
+  SELECT 1 AS c1, 2 AS c2
+)
+GO
+
+CREATE FUNCTION IsTableFunction_function()
+RETURNS INT
+AS
+BEGIN
+RETURN 1
+END
+GO
+
+-- Test for valid table function (currently incorrect from note above, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTableFunction_tablefunction'), 'IsTableFunction')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for valid inline table function (currently incorrect from note above, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTableFunction_inlinetablefunction'), 'IsTableFunction')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTableFunction_function'), 'IsTableFunction')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsTableFunction')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP FUNCTION IsTableFunction_tablefunction
+GO
+
+DROP FUNCTION IsTableFunction_function
+GO
+
+
+-- =============== IsInlineFunction ===============
+-- NOTE: Currently will return 0 since BBF cannot currently identify if a function is inline or not
+-- Setup
+CREATE FUNCTION IsInlineFunction_tablefunction()
+RETURNS INT
+AS
+BEGIN
+    RETURN 1
+END
+GO
+
+CREATE FUNCTION IsInlineFunction_function()
+RETURNS INT
+AS
+BEGIN
+RETURN 1
+END
+GO
+
+-- Test for correct case (currently incorrect from note above, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsInlineFunction_tablefunction'), 'IsInlineFunction')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsInlineFunction_function'), 'IsInlineFunction')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsInlineFunction')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP FUNCTION IsInlineFunction_tablefunction
+GO
+
+DROP FUNCTION IsInlineFunction_function
+GO
+
+-- =============== IsScalarFunction ===============
+-- Setup
+CREATE FUNCTION IsScalarFunction_function()
+RETURNS INT
+AS
+BEGIN
+    RETURN 1
+END
+GO
+
+CREATE TABLE IsScalarFunction_table(a int)
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsScalarFunction_function'), 'IsScalarFunction')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsScalarFunction_table'), 'IsScalarFunction')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsScalarFunction')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP FUNCTION IsScalarFunction_function
+GO
+
+DROP TABLE IsScalarFunction_table
+GO
+
+-- =============== IsPrimaryKey ===============
+-- Setup
+CREATE TABLE IsPrimaryKey_table(a int, CONSTRAINT pk_isprimarykey PRIMARY KEY(a))
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY((SELECT TOP(1) object_id FROM sys.all_objects where name like 'pk_isprimarykey%' ), 'IsPrimaryKey')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsPrimaryKey_table'), 'IsPrimaryKey')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsPrimaryKey')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsPrimaryKey_table
+GO
+
+-- =============== IsIndexed ===============
+-- Setup
+CREATE TABLE IsIndexed_table(a int, CONSTRAINT PK_isprimarykey PRIMARY KEY(a))
+GO
+
+CREATE TABLE IsIndexed_nonindexed_table(a int)
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsIndexed_table'), 'IsIndexed')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsIndexed_nonindexed_table'), 'IsIndexed')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsIndexed')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsIndexed_nonindexed_table
+GO
+
+DROP TABLE IsIndexed_table
+GO
+
+
+-- =============== IsDefault ===============
+-- NOTE: Defaults are currently not supported so will return 0
+-- Setup
+CREATE TABLE IsDefault_table(a int)
+GO
+
+-- Test for valid object
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDefault_table'), 'IsDefault')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsDefault')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsDefault_table
+GO
+
+
+-- =============== IsRule ===============
+-- NOTE: Rules are currently not supported so will return 0
+-- Setup
+CREATE TABLE IsRule_table(a int)
+GO
+
+-- Test for valid object
+SELECT OBJECTPROPERTY(OBJECT_ID('IsRule_table'), 'IsRule')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsRule')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsRule_table
+GO
+
+
+-- =============== IsTrigger ===============
+-- Setup
+CREATE TABLE IsTrigger_table(a int)
+GO
+
+CREATE TRIGGER IsTrigger_trigger ON IsTrigger_table INSTEAD OF INSERT
+AS
+BEGIN
+    SELECT * FROM IsTrigger_table
+END
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTrigger_trigger', 'TR'), 'IsTrigger')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTrigger_table', 'TR'), 'IsTrigger')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsTrigger')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Cleanup
+DROP TABLE IsTrigger_table
+GO
+
+-- Global cleanup for tests
+USE master
+GO
+DROP DATABASE db1
+GO

--- a/test/JDBC/input/functions/objectproperty.sql
+++ b/test/JDBC/input/functions/objectproperty.sql
@@ -1,3 +1,724 @@
--- Test OBJECTPROPERTY Stub
-SELECT OBJECTPROPERTY(0, '')
+-- Global setup for tests
+CREATE DATABASE db1
+GO
+USE db1
+GO
+
+-- =============== OwnerId ===============
+
+-- Setup
+CREATE SCHEMA ownerid_schema
+GO
+
+CREATE TABLE ownerid_schema.ownerid_table(a int) 
+GO
+
+-- Check for correct case
+SELECT CASE
+    WHEN OBJECTPROPERTY(OBJECT_ID('ownerid_schema.ownerid_table'), 'OwnerId')  = (SELECT principal_id 
+            FROM sys.database_principals
+            WHERE name = CURRENT_USER)
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+-- Check for system object. Should return 10 since that's the owner ID. 
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'OwnerId')
+GO
+
+-- Invalid property ID (should return NULL)
+SELECT OBJECTPROPERTY(0, 'OwnerId')
+GO
+
+-- Check for mix-cased property
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'oWnEriD')
+GO
+
+-- Check for trailing white spaces
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'OwnerId     ')
+GO
+
+-- Check for trailing white spaces and mixed case
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.objects'), 'oWnEriD     ')
+GO
+
+-- Cleanup
+DROP TABLE ownerid_schema.ownerid_table
+GO
+
+DROP SCHEMA ownerid_schema
+GO
+-- =============== IsDefaultCnst ===============
+
+-- Setup
+CREATE TABLE isdefaultcnst_table(a int DEFAULT 10)
+GO
+
+CREATE TABLE isdefaultcnst_table2(a int DEFAULT 10, b int DEFAULT 20)
+GO
+
+-- Check for correct cases (should return 1)
+SELECT OBJECTPROPERTY(ct.object_id, 'isdefaultcnst') 
+from sys.default_constraints ct
+where parent_object_id = OBJECT_ID('isdefaultcnst_table')
+GO
+
+SELECT OBJECTPROPERTY(ct.object_id, 'isdefaultcnst') 
+from sys.default_constraints ct
+where parent_object_id = OBJECT_ID('isdefaultcnst_table2')
+GO
+
+-- Check for object_id that exists, but not an index (should return 0)
+SELECT OBJECTPROPERTY(OBJECT_ID('isdefaultcnst_table'), 'IsDefaultCnst')
+GO
+
+-- Check for invalid object_id (should return NULL)
+SELECT OBJECTPROPERTY(0, 'IsDefaultCnst')
+GO
+
+-- Cleanup
+DROP TABLE isdefaultcnst_table
+GO
+
+-- =============== ExecIsQuotedIdentOn ===============
+
+-- Does not function properly due to sys.sql_modules not recording the correct settings
+
+-- Setup
+SET QUOTED_IDENTIFIER OFF
+GO
+
+CREATE PROC execisquotedident_proc_off
+AS
+RETURN 1
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE PROC execisquotedident_proc_on
+AS
+RETURN 1
+GO
+
+CREATE TABLE execisquotedident_table(a int)
+GO
+
+-- Currently does not work due to hardcoded value in sys.sql_modules (should be 0)
+SELECT OBJECTPROPERTY(OBJECT_ID('execisquotedident_proc_off'), 'ExecIsQuotedIdentOn') 
+GO
+
+SELECT OBJECTPROPERTY(OBJECT_ID('execisquotedident_proc_on'), 'ExecIsQuotedIdentOn')
+GO
+
+-- Check for object_id that exists, but not a proc, view, function, or sproc (should return NULL)
+SELECT OBJECTPROPERTY(OBJECT_ID('execisquotedident_table'), 'ExecIsQuotedIdentOn')
+GO
+
+-- Check for invalid object_id (should return NULL)
+SELECT OBJECTPROPERTY(0, 'ExecIsQuotedIdentOn')
+GO
+
+-- Cleanup
+DROP PROC execisquotedident_proc_on
+GO
+DROP PROC execisquotedident_proc_off
+GO
+DROP TABLE execisquotedident_table
+GO
+
+-- =============== IsMSShipped ===============
+
+-- Setup
+CREATE TABLE is_ms_shipped_table(a int)
+GO
+
+-- Test for object that exists but isn't ms_shipped
+SELECT OBJECTPROPERTY(OBJECT_ID('is_ms_shipped_table'), 'IsMSShipped')
+GO
+
+-- Test for object that is ms_shipped
+SELECT OBJECTPROPERTY(OBJECT_ID('sys.sp_tables'), 'IsMSShipped')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsMSShipped')
+GO
+
+-- Cleanup
+DROP TABLE is_ms_shipped_table
+GO
+
+-- =============== TableFullTextPopulateStatus ===============
+
+-- Setup
+CREATE TABLE tablefulltextpopulatestatus_table(a int)
+GO
+
+CREATE PROC tablefulltextpopulatestatus_proc
+AS
+RETURN 1
+GO
+
+-- Test with table object
+SELECT OBJECTPROPERTY(OBJECT_ID('tablefulltextpopulatestatus_table'), 'TableFullTextPopulateStatus')
+GO
+
+-- Test with non-table object
+SELECT OBJECTPROPERTY(OBJECT_ID('tablefulltextpopulatestatus_proc'), 'TableFullTextPopulateStatus')
+GO
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'TableFullTextPopulateStatus')
+GO
+
+-- Cleanup
+DROP TABLE tablefulltextpopulatestatus_table
+GO
+
+DROP PROC tablefulltextpopulatestatus_proc
+GO
+
+-- =============== TableHasVarDecimalStorageFormat ===============
+
+-- Setup
+CREATE TABLE TableHasVarDecimalStorageFormat_table(a int)
+GO
+
+CREATE proc TableHasVarDecimalStorageFormat_proc
+AS
+RETURN 1
+GO
+
+-- Test with table object
+SELECT OBJECTPROPERTY(OBJECT_ID('TableHasVarDecimalStorageFormat_table'), 'TableHasVarDecimalStorageFormat')
+GO
+
+-- Test with non-table object
+SELECT OBJECTPROPERTY(OBJECT_ID('TableHasVarDecimalStorageFormat_proc'), 'TableHasVarDecimalStorageFormat')
+GO
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'TableHasVarDecimalStorageFormat')
+GO
+
+-- Cleanup
+DROP TABLE TableHasVarDecimalStorageFormat_table
+GO
+
+DROP PROC TableHasVarDecimalStorageFormat_proc
+GO
+
+-- =============== IsSchemaBound ===============
+
+-- Currently does not work due to hardcoded value in sys.sql_modules
+-- Setup
+CREATE FUNCTION IsSchemaBound_function_false()
+RETURNS int
+BEGIN
+    return 1
+END
+GO
+
+CREATE FUNCTION IsSchemaBound_function_true()
+RETURNS int
+WITH SCHEMABINDING
+BEGIN
+    return 1
+END
+GO
+
+CREATE TABLE IsSchemaBound_table(a int)
+GO
+
+-- Test when object is not schema bound 
+SELECT OBJECTPROPERTY(OBJECT_ID('IsSchemaBound_function_false'), 'IsSchemaBound')
+GO
+
+-- Test when object is schema bound (Currently does not work due to hardcoded value in sys.sql_modules, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsSchemaBound_function_true'), 'IsSchemaBound')
+GO
+
+-- Test with object that doesn't have schema bound settings
+SELECT OBJECTPROPERTY(OBJECT_ID('IsSchemaBound_table'), 'IsSchemaBound')
+GO
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'IsSchemaBound')
+GO
+
+-- Cleanup
+DROP TABLE IsSchemaBound_table
+GO
+
+DROP FUNCTION IsSchemaBound_function_false
+GO
+
+DROP FUNCTION IsSchemaBound_function_true
+GO
+
+-- =============== ExecIsAnsiNullsOn ===============
+
+-- Currently does not work due to hardcoded value in sys.sql_modules
+-- Setup
+SET ANSI_NULLS OFF
+GO
+
+CREATE PROC ansi_nulls_off_proc
+AS
+SELECT CASE WHEN NULL = NULL then 1 else 0 end
+GO
+
+SET ANSI_NULLS ON
+GO
+
+CREATE PROC ansi_nulls_on_proc
+AS
+SELECT CASE WHEN NULL = NULL then 1 else 0 end
+GO
+
+CREATE TABLE ansi_nulls_on_table(a int)
+GO
+
+-- Tests when object is created with ansi nulls off and ansi nulls on
+
+-- Currently does not work due to hardcoded value in sys.sql_modules (should return 0)
+SELECT OBJECTPROPERTY(OBJECT_ID('ansi_nulls_off_proc'), 'ExecIsAnsiNullsOn')
+GO
+
+SELECT OBJECTPROPERTY(OBJECT_ID('ansi_nulls_on_proc'), 'ExecIsAnsiNullsOn')
+GO
+
+-- Test with invalid object id
+SELECT OBJECTPROPERTY(0, 'ExecIsAnsiNullsOn')
+GO
+
+-- Check for object_id that exists, but not a proc, view, function, or sproc (should return NULL)
+SELECT OBJECTPROPERTY(OBJECT_ID('ansi_nulls_on_table'), 'ExecIsAnsiNullsOn')
+GO
+
+-- Check for invalid object_id (should return NULL)
+SELECT OBJECTPROPERTY(0, 'ExecIsAnsiNullsOn')
+GO
+
+-- Cleanup
+DROP PROC ansi_nulls_off_proc
+GO
+
+DROP PROC ansi_nulls_on_proc
+GO
+
+DROP TABLE ansi_nulls_on_table
+GO
+
+-- =============== IsDeterministic ===============
+
+-- Currently does not work since INFORMATION_SCHEMA.ROUTINES does not evaluate if a function is deterministic
+-- Setup
+CREATE FUNCTION IsDeterministic_function_yes()
+RETURNS int
+WITH SCHEMABINDING
+BEGIN
+    return 1;
+END
+GO
+
+CREATE FUNCTION IsDeterministic_function_no()
+RETURNS sys.datetime
+WITH SCHEMABINDING
+BEGIN
+    return GETDATE();
+END
+GO
+
+CREATE TABLE IsDeterministic_table(a int)
+GO
+
+-- Tests for a deterministic function (Currently does not work, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDeterministic_function_yes'), 'IsDeterministic')
+GO
+
+-- Tests for a non-deterministic function
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDeterministic_function_yes'), 'IsDeterministic')
+GO
+
+-- Tests for an object that is not a function
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDeterministic_table'), 'IsDeterministic')
+GO
+
+-- Tests for a non-valid object
+SELECT OBJECTPROPERTY(0, 'IsDeterministic')
+GO
+
+-- Cleanup
+
+DROP FUNCTION IsDeterministic_function_no
+GO
+
+DROP FUNCTION IsDeterministic_function_yes
+GO
+
+DROP TABLE IsDeterministic_table
+GO
+
+-- =============== IsProcedure ===============
+-- Setup
+CREATE PROC IsProcedure_proc AS
+SELECT 1
+GO
+
+CREATE TABLE IsProcedure_table(a int)
+GO
+
+-- Test for success
+SELECT OBJECTPROPERTY(OBJECT_ID('IsProcedure_proc'), 'IsProcedure')
+GO
+
+-- Test for failure 
+SELECT OBJECTPROPERTY(OBJECT_ID('IsProcedure_table'), 'IsProcedure')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsProcedure')
+GO
+
+-- Cleanup
+DROP PROC IsProcedure_proc
+GO
+
+DROP TABLE IsProcedure_table
+GO
+
+-- =============== IsTable ===============
+-- Setup
+CREATE TABLE IsTable_table(a int)
+GO
+
+CREATE PROC IsTable_proc AS
+SELECT 1
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTable_table'), 'IsTable')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTable_proc'), 'IsTable')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsTable')
+GO
+
+-- Cleanup
+DROP TABLE IsTable_table
+GO
+
+DROP PROC IsTable_proc
+GO
+
+-- =============== IsView ===============
+-- Setup
+CREATE VIEW IsView_view AS
+SELECT 1
+GO
+
+CREATE TABLE IsView_table(a int)
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsView_view'), 'IsView')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsView_table'), 'IsView')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsView')
+GO
+
+-- Cleanup
+DROP VIEW IsView_view
+GO
+
+DROP TABLE IsView_table
+GO
+-- =============== IsUserTable ===============
+-- Setup
+CREATE TABLE IsUserTable_table(a int)
+GO
+
+CREATE VIEW IsUserTable_view AS
+SELECT 1
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsUserTable_table'), 'IsUserTable')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsUserTable_view'), 'IsUserTable')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsUserTable')
+GO
+
+-- Cleanup
+DROP TABLE IsUserTable_table
+GO
+
+DROP VIEW IsUserTable_view
+GO
+
+-- =============== IsTableFunction ===============
+-- NOTE: Currently will return 0 since sys.all_objects does not identify objects of type TF (BABELFISH-483)
+
+-- Setup
+CREATE FUNCTION IsTableFunction_tablefunction()
+RETURNS @t TABLE (
+    c1 int,
+    c2 int
+)
+AS
+BEGIN
+    INSERT INTO @t
+    SELECT 1 as c1, 2 as c2;
+    RETURN;
+END
+GO
+
+CREATE FUNCTION IsTableFunction_inlinetablefunction()
+RETURNS TABLE
+AS
+RETURN
+(
+  SELECT 1 AS c1, 2 AS c2
+)
+GO
+
+CREATE FUNCTION IsTableFunction_function()
+RETURNS INT
+AS
+BEGIN
+RETURN 1
+END
+GO
+
+-- Test for valid table function (currently incorrect from note above, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTableFunction_tablefunction'), 'IsTableFunction')
+GO
+
+-- Test for valid inline table function (currently incorrect from note above, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTableFunction_inlinetablefunction'), 'IsTableFunction')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTableFunction_function'), 'IsTableFunction')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsTableFunction')
+GO
+
+-- Cleanup
+DROP FUNCTION IsTableFunction_tablefunction
+GO
+
+DROP FUNCTION IsTableFunction_function
+GO
+
+-- =============== IsInlineFunction ===============
+-- NOTE: Currently will return 0 since BBF cannot currently identify if a function is inline or not
+
+-- Setup
+CREATE FUNCTION IsInlineFunction_tablefunction()
+RETURNS INT
+AS
+BEGIN
+    RETURN 1
+END
+GO
+
+CREATE FUNCTION IsInlineFunction_function()
+RETURNS INT
+AS
+BEGIN
+RETURN 1
+END
+GO
+
+-- Test for correct case (currently incorrect from note above, should return 1)
+SELECT OBJECTPROPERTY(OBJECT_ID('IsInlineFunction_tablefunction'), 'IsInlineFunction')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsInlineFunction_function'), 'IsInlineFunction')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsInlineFunction')
+GO
+
+-- Cleanup
+DROP FUNCTION IsInlineFunction_tablefunction
+GO
+
+DROP FUNCTION IsInlineFunction_function
+GO
+-- =============== IsScalarFunction ===============
+
+-- Setup
+CREATE FUNCTION IsScalarFunction_function()
+RETURNS INT
+AS
+BEGIN
+    RETURN 1
+END
+GO
+
+CREATE TABLE IsScalarFunction_table(a int)
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsScalarFunction_function'), 'IsScalarFunction')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsScalarFunction_table'), 'IsScalarFunction')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsScalarFunction')
+GO
+
+-- Cleanup
+DROP FUNCTION IsScalarFunction_function
+GO
+
+DROP TABLE IsScalarFunction_table
+GO
+
+-- =============== IsPrimaryKey ===============
+-- Setup
+CREATE TABLE IsPrimaryKey_table(a int, CONSTRAINT pk_isprimarykey PRIMARY KEY(a))
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY((SELECT TOP(1) object_id FROM sys.all_objects where name like 'pk_isprimarykey%' ), 'IsPrimaryKey')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsPrimaryKey_table'), 'IsPrimaryKey')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsPrimaryKey')
+GO
+
+-- Cleanup
+DROP TABLE IsPrimaryKey_table
+GO
+
+-- =============== IsIndexed ===============
+-- Setup
+CREATE TABLE IsIndexed_table(a int, CONSTRAINT PK_isprimarykey PRIMARY KEY(a))
+GO
+
+CREATE TABLE IsIndexed_nonindexed_table(a int)
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsIndexed_table'), 'IsIndexed')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsIndexed_nonindexed_table'), 'IsIndexed')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsIndexed')
+GO
+
+-- Cleanup
+DROP TABLE IsIndexed_nonindexed_table
+GO
+
+DROP TABLE IsIndexed_table
+GO
+
+-- =============== IsDefault ===============
+-- NOTE: Defaults are currently not supported so will return 0
+
+-- Setup
+CREATE TABLE IsDefault_table(a int)
+GO
+
+-- Test for valid object
+SELECT OBJECTPROPERTY(OBJECT_ID('IsDefault_table'), 'IsDefault')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsDefault')
+GO
+
+-- Cleanup
+DROP TABLE IsDefault_table
+GO
+
+-- =============== IsRule ===============
+-- NOTE: Rules are currently not supported so will return 0
+
+-- Setup
+CREATE TABLE IsRule_table(a int)
+GO
+
+-- Test for valid object
+SELECT OBJECTPROPERTY(OBJECT_ID('IsRule_table'), 'IsRule')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsRule')
+GO
+
+-- Cleanup
+DROP TABLE IsRule_table
+GO
+
+-- =============== IsTrigger ===============
+
+-- Setup
+CREATE TABLE IsTrigger_table(a int)
+GO
+
+CREATE TRIGGER IsTrigger_trigger ON IsTrigger_table INSTEAD OF INSERT
+AS
+BEGIN
+    SELECT * FROM IsTrigger_table
+END
+GO
+
+-- Test for correct case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTrigger_trigger', 'TR'), 'IsTrigger')
+GO
+
+-- Test for incorrect case
+SELECT OBJECTPROPERTY(OBJECT_ID('IsTrigger_table', 'TR'), 'IsTrigger')
+GO
+
+-- Test for invalid object
+SELECT OBJECTPROPERTY(0, 'IsTrigger')
+GO
+
+-- Cleanup
+DROP TABLE IsTrigger_table
+GO
+
+-- Global cleanup for tests
+USE master
+GO
+DROP DATABASE db1
 GO


### PR DESCRIPTION
### Description

Previously, OBJECTPROPERTY in BBF was implemented as a stub and did not support any property. This commit adds support for OBJECTPROPERTY and the following properties: OwnerId, ExecQuotedIdentOn, IsDefaultCnst, TableFullTextPopulateStatus, TableHasVarDecimalStorageFormat, IsMSShipped, IsSchemaBound, ExecIsAnsiNullsOn, IsDeterministic, IsRule, IsDefault, and IsTrigger

TASK: BABELFISH-416
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).