### PR TITLE
EXECUTE('USE dbname') should not change current session's DB context

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1145,10 +1145,14 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	volatile LocalTransactionId before_lxid;
 	LocalTransactionId after_lxid;
 	SimpleEcontextStackEntry *topEntry;
+	char *old_db_name = NULL;
+	char *cur_db_name = NULL;
 	LOCAL_FCINFO(fcinfo,1);
+	estate->is_inside_execute = true;
 
 	PG_TRY();
 	{
+		old_db_name = get_cur_db_name();
 		/*
 		* First we evaluate the string expression. Its result is the
 		* querystring we have to execute.
@@ -1177,6 +1181,10 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 		/* Pass the control the inline handler */
 		pltsql_inline_handler(fcinfo);
 
+		cur_db_name = get_cur_db_name();
+		if(strcmp(cur_db_name, old_db_name) != 0)
+			set_session_properties(old_db_name);
+
 		if (fcinfo->isnull)
 			elog(ERROR, "pltsql_inline_handler failed");
 	}
@@ -1201,6 +1209,7 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 			estate->simple_eval_estate = NULL;
 		pltsql_create_econtext(estate);
 	}
+	estate->is_inside_execute = false;
 	exec_eval_cleanup(estate);
 	return PLTSQL_RC_OK;
 }
@@ -2432,6 +2441,8 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 	char message[128];
 	int16 old_db_id = get_cur_db_id();
 	int16 new_db_id = get_db_id(stmt->db_name);
+	PLExecStateCallStack *top_es_entry;
+	bool suppress_db_change_msg = false;
 
 	if (!DbidIsValid(new_db_id))
 		ereport(ERROR,
@@ -2450,13 +2461,28 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 						stmt->db_name, stmt->db_name)));
 
 	set_session_properties(stmt->db_name);
-	snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
-	/* send env change token to user */
-	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change)
-		((*pltsql_protocol_plugin_ptr)->send_env_change) (1, stmt->db_name, old_db_name);
-	/* send message to user */
-	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_info)
-		((*pltsql_protocol_plugin_ptr)->send_info) (0, 1, 0, message, 0);
+	top_es_entry = exec_state_call_stack->next;
+	while(top_es_entry != NULL)
+	{
+		if(top_es_entry->estate && top_es_entry->estate->is_inside_execute)
+		{
+			suppress_db_change_msg = true;
+			break;
+		}
+		else
+			top_es_entry = top_es_entry->next;
+	}
+
+	if(!suppress_db_change_msg)
+	{
+		snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
+		/* send env change token to user */
+		if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change)
+			((*pltsql_protocol_plugin_ptr)->send_env_change) (1, stmt->db_name, old_db_name);
+		/* send message to user */
+		if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_info)
+			((*pltsql_protocol_plugin_ptr)->send_info) (0, 1, 0, message, 0);
+	}
 	return PLTSQL_RC_OK;
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4250,6 +4250,7 @@ pltsql_estate_setup(PLtsql_execstate *estate,
 	estate->paramLI->parserSetupArg = NULL; /* filled during use */
 	estate->paramLI->numParams = estate->ndatums;
 	estate->use_shared_simple_eval_state = false;
+	estate->is_inside_execute = false;
 
 	/* set up for use of appropriate simple-expression EState and cast hash */
 	if (simple_eval_estate)

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1368,6 +1368,7 @@ typedef struct PLtsql_execstate
 	bool 		insert_exec;
 
 	List 		*explain_infos;
+	bool            is_inside_execute;
 } PLtsql_execstate;
 
 /*

--- a/test/JDBC/expected/usedb_inside_execute.out
+++ b/test/JDBC/expected/usedb_inside_execute.out
@@ -8,7 +8,7 @@ t
 ~~END~~
 
 -- tsql
-
+ 
 --aborts the transaction when database is not found
 use db1;
 go

--- a/test/JDBC/expected/usedb_inside_execute.out
+++ b/test/JDBC/expected/usedb_inside_execute.out
@@ -1,0 +1,154 @@
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+  
+  
+-- tsql
+--aborts the transaction when database is not found
+use db1;
+go
+~~ERROR (Code: 911)~~
+  
+~~ERROR (Message: database "db1" does not exist)~~
+  
+  
+create database db1;
+go
+  
+create database db2;
+go
+  
+create database db3;
+go
+  
+-- should be master
+select db_name();
+go
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+-- should not change the session to db1 after exec
+exec('use db1 select db_name()'); select db_name();
+go
+~~START~~
+nvarchar
+db1
+~~END~~
+  
+~~START~~
+nvarchar
+master
+~~END~~
+  
+  
+-- should change the context to db1
+use db1; select db_name();
+go
+~~START~~
+nvarchar
+db1
+~~END~~
+  
+  
+use master
+go
+  
+-- nested execute; should not change the database context
+execute('USE db2; EXECUTE(''USE db1 SELECT db_name()''); SELECT db_name();'); select db_name();
+go
+~~START~~
+nvarchar
+db1
+~~END~~
+
+~~START~~
+nvarchar
+db2
+~~END~~
+  
+~~START~~
+nvarchar
+master
+~~END~~
+  
+  
+use db2;
+go
+  
+create procedure use_db as begin EXECUTE('USE db3 SELECT db_name()') end
+go
+  
+use master
+go
+  
+-- nested execute with procedure
+EXECUTE('USE db1; EXECUTE(''USE db2; exec use_db; SELECT db_name();''); SELECT db_name();') select db_name();
+go
+~~START~~
+nvarchar
+db3
+~~END~~
+
+~~START~~
+nvarchar
+db2
+~~END~~
+  
+~~START~~
+nvarchar
+db1
+~~END~~
+  
+~~START~~
+nvarchar
+master
+~~END~~
+  
+  
+-- nested execute with runtime error
+EXECUTE('USE db1; EXECUTE(''USE db2 SELECT 1/0''); SELECT db_name();'); select db_name();
+go
+~~ERROR (Code: 8134)~~
+  
+~~ERROR (Message: division by zero)~~
+  
+~~START~~
+nvarchar
+db1
+~~END~~
+  
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+use db2; drop procedure use_db; use master;
+go
+  
+drop database db1;
+go
+  
+drop database db2;
+go
+  
+drop database db3;
+go
+  
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+

--- a/test/JDBC/expected/usedb_inside_execute.out
+++ b/test/JDBC/expected/usedb_inside_execute.out
@@ -6,26 +6,26 @@ GO
 bool
 t
 ~~END~~
-  
-  
+
 -- tsql
+
 --aborts the transaction when database is not found
 use db1;
 go
 ~~ERROR (Code: 911)~~
-  
+
 ~~ERROR (Message: database "db1" does not exist)~~
-  
-  
+
+
 create database db1;
 go
-  
+
 create database db2;
 go
-  
+
 create database db3;
 go
-  
+
 -- should be master
 select db_name();
 go
@@ -42,13 +42,13 @@ go
 nvarchar
 db1
 ~~END~~
-  
+
 ~~START~~
 nvarchar
 master
 ~~END~~
-  
-  
+
+
 -- should change the context to db1
 use db1; select db_name();
 go
@@ -56,11 +56,11 @@ go
 nvarchar
 db1
 ~~END~~
-  
-  
+
+
 use master
 go
-  
+
 -- nested execute; should not change the database context
 execute('USE db2; EXECUTE(''USE db1 SELECT db_name()''); SELECT db_name();'); select db_name();
 go
@@ -73,22 +73,22 @@ db1
 nvarchar
 db2
 ~~END~~
-  
+
 ~~START~~
 nvarchar
 master
 ~~END~~
-  
-  
+
+
 use db2;
 go
-  
+
 create procedure use_db as begin EXECUTE('USE db3 SELECT db_name()') end
 go
-  
+
 use master
 go
-  
+
 -- nested execute with procedure
 EXECUTE('USE db1; EXECUTE(''USE db2; exec use_db; SELECT db_name();''); SELECT db_name();') select db_name();
 go
@@ -101,30 +101,30 @@ db3
 nvarchar
 db2
 ~~END~~
-  
+
 ~~START~~
 nvarchar
 db1
 ~~END~~
-  
+
 ~~START~~
 nvarchar
 master
 ~~END~~
-  
-  
+
+
 -- nested execute with runtime error
 EXECUTE('USE db1; EXECUTE(''USE db2 SELECT 1/0''); SELECT db_name();'); select db_name();
 go
 ~~ERROR (Code: 8134)~~
-  
+
 ~~ERROR (Message: division by zero)~~
-  
+
 ~~START~~
 nvarchar
 db1
 ~~END~~
-  
+
 ~~START~~
 nvarchar
 master
@@ -133,16 +133,16 @@ master
 
 use db2; drop procedure use_db; use master;
 go
-  
+
 drop database db1;
 go
-  
+
 drop database db2;
 go
-  
+
 drop database db3;
 go
-  
+
 -- psql
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
 SELECT pg_reload_conf();

--- a/test/JDBC/input/usedb_inside_execute.mix
+++ b/test/JDBC/input/usedb_inside_execute.mix
@@ -1,0 +1,71 @@
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();
+GO
+  
+-- tsql
+--aborts the transaction when database is not found
+use db1;
+go
+  
+create database db1;
+go
+  
+create database db2;
+go
+  
+create database db3;
+go
+  
+-- should be master
+select db_name();
+go
+  
+-- should not change the session to db1 after exec
+exec('use db1 select db_name()'); select db_name();
+go
+  
+-- should change the context to db1
+use db1; select db_name();
+go
+  
+use master
+go
+
+-- nested execute; should not change the database context
+execute('USE db2; EXECUTE(''USE db1 SELECT db_name()''); SELECT db_name();'); select db_name();
+go
+  
+use db2;
+go
+  
+create procedure use_db as begin EXECUTE('USE db3 SELECT db_name()') end
+go
+  
+use master
+go
+  
+-- nested execute with procedure
+EXECUTE('USE db1; EXECUTE(''USE db2; exec use_db; SELECT db_name();''); SELECT db_name();') select db_name();
+go
+  
+-- nested execute with runtime error
+EXECUTE('USE db1; EXECUTE(''USE db2 SELECT 1/0''); SELECT db_name();'); select db_name();
+go
+  
+use db2; drop procedure use_db; use master;
+go
+  
+drop database db1;
+go
+
+drop database db2;
+go
+  
+drop database db3;
+go
+  
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+SELECT pg_reload_conf();
+GO

--- a/test/JDBC/input/usedb_inside_execute.mix
+++ b/test/JDBC/input/usedb_inside_execute.mix
@@ -2,69 +2,69 @@
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 SELECT pg_reload_conf();
 GO
-  
+ 
 -- tsql
 --aborts the transaction when database is not found
 use db1;
 go
-  
+
 create database db1;
 go
-  
+
 create database db2;
 go
-  
+
 create database db3;
 go
-  
+
 -- should be master
 select db_name();
 go
-  
+
 -- should not change the session to db1 after exec
 exec('use db1 select db_name()'); select db_name();
 go
-  
+
 -- should change the context to db1
 use db1; select db_name();
 go
-  
+
 use master
 go
 
 -- nested execute; should not change the database context
 execute('USE db2; EXECUTE(''USE db1 SELECT db_name()''); SELECT db_name();'); select db_name();
 go
-  
+
 use db2;
 go
-  
+
 create procedure use_db as begin EXECUTE('USE db3 SELECT db_name()') end
 go
-  
+
 use master
 go
-  
+
 -- nested execute with procedure
 EXECUTE('USE db1; EXECUTE(''USE db2; exec use_db; SELECT db_name();''); SELECT db_name();') select db_name();
 go
-  
+
 -- nested execute with runtime error
 EXECUTE('USE db1; EXECUTE(''USE db2 SELECT 1/0''); SELECT db_name();'); select db_name();
 go
-  
+
 use db2; drop procedure use_db; use master;
 go
-  
+
 drop database db1;
 go
 
 drop database db2;
 go
-  
+
 drop database db3;
 go
-  
+
 -- psql
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
 SELECT pg_reload_conf();


### PR DESCRIPTION
Use dbname should change the database context only within the scope of
EXECUTE.

Task: BABEL-3077
Signed-off-by: Shalini Lohia <lshalini@amazon.com>