### PR TITLE
EXECUTE('USE dbname') should not change current session's DB context

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1145,11 +1145,14 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	volatile LocalTransactionId before_lxid;
 	LocalTransactionId after_lxid;
 	SimpleEcontextStackEntry *topEntry;
+      char *old_db_name = NULL;
+      char *cur_db_name = NULL;
 	LOCAL_FCINFO(fcinfo,1);
 
 	PG_TRY();
 	{
-		/*
+              old_db_name = get_cur_db_name();
+              /*
 		* First we evaluate the string expression. Its result is the
 		* querystring we have to execute.
 		*/
@@ -1176,12 +1179,18 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 
 		/* Pass the control the inline handler */
 		pltsql_inline_handler(fcinfo);
+              cur_db_name = get_cur_db_name();
 
+              if(strcmp(cur_db_name, old_db_name) != 0)
+                      set_session_properties(old_db_name);
 		if (fcinfo->isnull)
 			elog(ERROR, "pltsql_inline_handler failed");
 	}
 	PG_CATCH();
 	{
+              cur_db_name = get_cur_db_name();
+              if(strcmp(cur_db_name, old_db_name) != 0)
+                      set_session_properties(old_db_name);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -2432,6 +2441,7 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 	char message[128];
 	int16 old_db_id = get_cur_db_id();
 	int16 new_db_id = get_db_id(stmt->db_name);
+      PLExecStateCallStack *top_es_entry;
 
 	if (!DbidIsValid(new_db_id))
 		ereport(ERROR,
@@ -2450,7 +2460,21 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 						stmt->db_name, stmt->db_name)));
 
 	set_session_properties(stmt->db_name);
-	snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
+      top_es_entry = exec_state_call_stack->next;
+      while(top_es_entry != NULL)
+      {
+              /*traverse through the estate stack. If the occurrence of
+               * execute() is found in the stack, suppress the database context
+               * message and avoid sending env token and message to user.
+               */
+              if(top_es_entry->estate && top_es_entry->estate->err_stmt &&
+                     (top_es_entry->estate->err_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH))
+                     return PLTSQL_RC_OK;
+              else
+                     top_es_entry = top_es_entry->next;
+      }
+
+      snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
 	/* send env change token to user */
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change)
 		((*pltsql_protocol_plugin_ptr)->send_env_change) (1, stmt->db_name, old_db_name);

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1145,14 +1145,14 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	volatile LocalTransactionId before_lxid;
 	LocalTransactionId after_lxid;
 	SimpleEcontextStackEntry *topEntry;
-      char *old_db_name = NULL;
-      char *cur_db_name = NULL;
+      	char *old_db_name = NULL;
+      	char *cur_db_name = NULL;
 	LOCAL_FCINFO(fcinfo,1);
 
 	PG_TRY();
 	{
-              old_db_name = get_cur_db_name();
-              /*
+                old_db_name = get_cur_db_name();
+                /*
 		* First we evaluate the string expression. Its result is the
 		* querystring we have to execute.
 		*/
@@ -1179,18 +1179,18 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 
 		/* Pass the control the inline handler */
 		pltsql_inline_handler(fcinfo);
-              cur_db_name = get_cur_db_name();
+                cur_db_name = get_cur_db_name();
 
-              if(strcmp(cur_db_name, old_db_name) != 0)
-                      set_session_properties(old_db_name);
+                if(strcmp(cur_db_name, old_db_name) != 0)
+                        set_session_properties(old_db_name);
 		if (fcinfo->isnull)
 			elog(ERROR, "pltsql_inline_handler failed");
 	}
 	PG_CATCH();
 	{
-              cur_db_name = get_cur_db_name();
-              if(strcmp(cur_db_name, old_db_name) != 0)
-                      set_session_properties(old_db_name);
+                cur_db_name = get_cur_db_name();
+                if(strcmp(cur_db_name, old_db_name) != 0)
+                        set_session_properties(old_db_name);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -2441,7 +2441,7 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 	char message[128];
 	int16 old_db_id = get_cur_db_id();
 	int16 new_db_id = get_db_id(stmt->db_name);
-      PLExecStateCallStack *top_es_entry;
+        PLExecStateCallStack *top_es_entry;
 
 	if (!DbidIsValid(new_db_id))
 		ereport(ERROR,
@@ -2460,21 +2460,21 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 						stmt->db_name, stmt->db_name)));
 
 	set_session_properties(stmt->db_name);
-      top_es_entry = exec_state_call_stack->next;
-      while(top_es_entry != NULL)
-      {
-              /*traverse through the estate stack. If the occurrence of
-               * execute() is found in the stack, suppress the database context
-               * message and avoid sending env token and message to user.
-               */
-              if(top_es_entry->estate && top_es_entry->estate->err_stmt &&
-                     (top_es_entry->estate->err_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH))
-                     return PLTSQL_RC_OK;
-              else
-                     top_es_entry = top_es_entry->next;
-      }
+        top_es_entry = exec_state_call_stack->next;
+        while(top_es_entry != NULL)
+        {
+                /*traverse through the estate stack. If the occurrence of
+                * execute() is found in the stack, suppress the database context
+                * message and avoid sending env token and message to user.
+                */
+                if(top_es_entry->estate && top_es_entry->estate->err_stmt &&
+                       (top_es_entry->estate->err_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH))
+                       return PLTSQL_RC_OK;
+                else
+                       top_es_entry = top_es_entry->next;
+        }
 
-      snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
+        snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
 	/* send env change token to user */
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change)
 		((*pltsql_protocol_plugin_ptr)->send_env_change) (1, stmt->db_name, old_db_name);

--- a/test/JDBC/expected/usedb_inside_execute.out
+++ b/test/JDBC/expected/usedb_inside_execute.out
@@ -1,0 +1,174 @@
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+--aborts the transaction when database is not found
+use db1;
+go
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "db1" does not exist)~~
+
+
+create database db1;
+go
+
+create database db2;
+go
+
+create database db3;
+go
+
+-- should be master
+select db_name();
+go
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+-- should not change the session to db1 after exec
+exec('use db1 select db_name()'); select db_name();
+go
+~~START~~
+nvarchar
+db1
+~~END~~
+
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+-- should change the context to db1
+use db1; select db_name();
+go
+~~START~~
+nvarchar
+db1
+~~END~~
+
+
+use db2; create table t1(a int); use master;
+go
+
+-- handle the catch scenario, the error should abort the batch and
+-- database would be reset to master 
+EXECUTE('USE db1; EXECUTE(''USE db2 create table t1(a int)''); SELECT db_name();'); select db_name()
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "t1" already exists)~~
+
+
+select db_name()
+go
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+use db2; drop table t1; use master;
+go
+
+-- nested execute; should not change the database context
+execute('USE db2; EXECUTE(''USE db1 SELECT db_name()''); SELECT db_name();'); select db_name();
+go
+~~START~~
+nvarchar
+db1
+~~END~~
+
+~~START~~
+nvarchar
+db2
+~~END~~
+
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+use db2;
+go
+
+create procedure use_db as begin EXECUTE('USE db3 SELECT db_name()') end
+go
+
+use master
+go
+
+-- nested execute with procedure
+EXECUTE('USE db1; EXECUTE(''USE db2; exec use_db; SELECT db_name();''); SELECT db_name();') select db_name();
+go
+~~START~~
+nvarchar
+db3
+~~END~~
+
+~~START~~
+nvarchar
+db2
+~~END~~
+
+~~START~~
+nvarchar
+db1
+~~END~~
+
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+-- nested execute with runtime error
+EXECUTE('USE db1; EXECUTE(''USE db2 SELECT 1/0''); SELECT db_name();'); select db_name();
+go
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+~~START~~
+nvarchar
+db1
+~~END~~
+
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+use db2; drop procedure use_db; use master;
+go
+
+drop database db1;
+go
+
+drop database db2;
+go
+
+drop database db3;
+go
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+

--- a/test/JDBC/input/usedb_inside_execute.mix
+++ b/test/JDBC/input/usedb_inside_execute.mix
@@ -1,0 +1,82 @@
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+SELECT pg_reload_conf();
+GO
+
+-- tsql
+--aborts the transaction when database is not found
+use db1;
+go
+
+create database db1;
+go
+
+create database db2;
+go
+
+create database db3;
+go
+
+-- should be master
+select db_name();
+go
+
+-- should not change the session to db1 after exec
+exec('use db1 select db_name()'); select db_name();
+go
+
+-- should change the context to db1
+use db1; select db_name();
+go
+
+use db2; create table t1(a int); use master;
+go
+
+-- handle the catch scenario, the error should abort the batch and
+-- database would be reset to master 
+EXECUTE('USE db1; EXECUTE(''USE db2 create table t1(a int)''); SELECT db_name();'); select db_name()
+go
+
+select db_name()
+go
+
+use db2; drop table t1; use master;
+go
+
+-- nested execute; should not change the database context
+execute('USE db2; EXECUTE(''USE db1 SELECT db_name()''); SELECT db_name();'); select db_name();
+go
+
+use db2;
+go
+
+create procedure use_db as begin EXECUTE('USE db3 SELECT db_name()') end
+go
+
+use master
+go
+
+-- nested execute with procedure
+EXECUTE('USE db1; EXECUTE(''USE db2; exec use_db; SELECT db_name();''); SELECT db_name();') select db_name();
+go
+
+-- nested execute with runtime error
+EXECUTE('USE db1; EXECUTE(''USE db2 SELECT 1/0''); SELECT db_name();'); select db_name();
+go
+
+use db2; drop procedure use_db; use master;
+go
+
+drop database db1;
+go
+
+drop database db2;
+go
+
+drop database db3;
+go
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+SELECT pg_reload_conf();
+GO


### PR DESCRIPTION
Use dbname should change the database context only within the scope of
EXECUTE.

Task: BABEL-3077
Signed-off-by: Shalini Lohia <lshalini@amazon.com>