### PR TITLE
Add support for SYSTEM_USER

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -54,6 +54,13 @@ $BODY$
 $BODY$
 LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION sys.system_user()
+RETURNS sys.nvarchar(128) AS
+$BODY$
+	SELECT SESSION_USER;
+$BODY$
+LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION sys.babelfish_get_identity_param(IN tablename TEXT, IN optionname TEXT)
 RETURNS INT8
 AS 'babelfishpg_tsql', 'get_identity_param'

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -334,6 +334,13 @@ AS $$
 $$ 
 LANGUAGE SQL IMMUTABLE PARALLEL RESTRICTED;
 
+CREATE OR REPLACE FUNCTION sys.system_user()
+RETURNS sys.nvarchar(128) AS
+$BODY$
+	SELECT SESSION_USER;
+$BODY$
+LANGUAGE SQL;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1565,6 +1565,15 @@ public:
 			}
 		}
 
+		if (ctx->built_in_functions())
+		{
+			auto bctx = ctx->built_in_functions();
+
+			/* Re-write system_user to sys.system_user(). */
+			if (bctx->bif_no_brackets && bctx->SYSTEM_USER())
+				rewritten_query_fragment.emplace(std::make_pair(bctx->bif_no_brackets->getStartIndex(), std::make_pair(::getFullText(bctx->SYSTEM_USER()), "sys.system_user()")));
+		}
+
 		/* analyze scalar function call */
 		if (ctx->func_proc_name_server_database_schema())
 		{

--- a/test/JDBC/expected/SYSTEM_USER.out
+++ b/test/JDBC/expected/SYSTEM_USER.out
@@ -1,0 +1,37 @@
+-- tsql
+SELECT session_user, system_user, current_user, db_name();
+GO
+~~START~~
+varchar#!#nvarchar#!#varchar#!#nvarchar
+jdbc_user#!#jdbc_user#!#dbo#!#master
+~~END~~
+
+
+CREATE LOGIN r1 WITH PASSWORD = '123';
+GO
+
+CREATE LOGIN r2 WITH PASSWORD = '123';
+GO
+
+-- tsql user=r1 password=123
+SELECT session_user, system_user, current_user, db_name();
+GO
+~~START~~
+varchar#!#nvarchar#!#varchar#!#nvarchar
+r1#!#r1#!#guest#!#master
+~~END~~
+
+
+-- tsql user=r2 password=123
+SELECT session_user, system_user, current_user, db_name();
+GO
+~~START~~
+varchar#!#nvarchar#!#varchar#!#nvarchar
+r2#!#r2#!#guest#!#master
+~~END~~
+
+
+-- tsql
+DROP LOGIN r1;
+DROP LOGIN r2;
+GO

--- a/test/JDBC/input/SYSTEM_USER.mix
+++ b/test/JDBC/input/SYSTEM_USER.mix
@@ -1,0 +1,22 @@
+-- tsql
+SELECT session_user, system_user, current_user, db_name();
+GO
+
+CREATE LOGIN r1 WITH PASSWORD = '123';
+GO
+
+CREATE LOGIN r2 WITH PASSWORD = '123';
+GO
+
+-- tsql user=r1 password=123
+SELECT session_user, system_user, current_user, db_name();
+GO
+
+-- tsql user=r2 password=123
+SELECT session_user, system_user, current_user, db_name();
+GO
+
+-- tsql
+DROP LOGIN r1;
+DROP LOGIN r2;
+GO


### PR DESCRIPTION
### Description

This commit adds support for SYSTEM_USER in Babelfish. To add this support, we intercept SYSTEM_USER keyword in the ANTLR parser and re-write it to SYS.SYSTEM_USER() function.
Added test-cases to JDBC.

Authored-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))
Signed-off-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).