### PR TITLE
FIX: Creating a tmp table inside a trigger will cause the database to crash

### DIFF
--- a/test/JDBC/input/BABEL-3119.sql
+++ b/test/JDBC/input/BABEL-3119.sql
@@ -1,0 +1,37 @@
+CREATE TABLE t(c1 int)
+GO
+
+CREATE TRIGGER trfjk ON t
+instead of INSERT
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t(c1) VALUES(1) 
+GO
+
+CREATE TABLE t2(c1 int)
+GO
+
+CREATE TRIGGER trfjk2 ON t2
+instead of UPDATE
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t2(c1) VALUES(1) 
+GO
+
+drop trigger trfjk
+go
+
+drop trigger trfjk2
+go
+
+drop table t
+GO
+
+drop table t2
+GO

--- a/test/JDBC/sql_expected/BABEL-3119.out
+++ b/test/JDBC/sql_expected/BABEL-3119.out
@@ -1,0 +1,39 @@
+CREATE TABLE t(c1 int)
+GO
+
+CREATE TRIGGER trfjk ON t
+instead of INSERT
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t(c1) VALUES(1) 
+GO
+
+CREATE TABLE t2(c1 int)
+GO
+
+CREATE TRIGGER trfjk2 ON t2
+instead of UPDATE
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t2(c1) VALUES(1) 
+GO
+~~ROW COUNT: 1~~
+
+
+drop trigger trfjk
+go
+
+drop trigger trfjk2
+go
+
+drop table t
+GO
+
+drop table t2
+GO


### PR DESCRIPTION
### Description

The following sequence crashes the Babelfish server:

````
1> CREATE TABLE t(c1 int)
2> GO

1> CREATE TRIGGER trfjk ON t
2> INSTEAD OF INSERT
3> AS
4> DECLARE @a int
5> CREATE TABLE #t(c1 int) --This one is causing the problem
6> GO

1> INSERT INTO t(c1) VALUES(1) 
2> go
TCP Provider: An existing connection was forcibly closed by the remote host.
Communication link failure
```` 

### Issues Resolved

The specified SQL no longer crashes the server.
[List any issues this PR will resolve]
 
### Check List

- Task : BABEL-3119
- Signed-off-by: Zhibai Song szh@amazon.com 
