### PR TITLE
Add support for Index-related T-SQL hint conversion

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1458,6 +1458,7 @@ public:
 			add_rewritten_query_fragment_to_mutator(&mutator);
 			mutator.run();
 		}
+		clear_query_hints();
 		clear_rewritten_query_fragment();
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -3135,6 +3135,12 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 		if (option->TABLE())
 		{
 			std::string table_name = ::getFullText(option->table_name());
+			size_t idx = table_name.find('.');
+			while (idx != std::string::npos)
+			{
+				table_name = table_name.substr(idx + 1);
+				idx = table_name.find('.');
+			}
 			if (!table_name.empty())
 			{
 				for(auto table_hint: option->table_hint())
@@ -3159,7 +3165,7 @@ std::string extractTableName(TSqlParser::Ddl_objectContext *ctx)
 {
 	std::string table_name;
 	if (ctx->full_object_name())
-		table_name = ::getFullText(ctx->full_object_name());
+		table_name = stripQuoteFromId(ctx->full_object_name()->object_name);
 	else if (ctx->local_id())
 		table_name = ::getFullText(ctx->local_id());
 	return table_name;
@@ -4764,7 +4770,7 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 		if (!wctx->sample_clause()) {
 			std::string table_name;
 			if (ctx->full_object_name())
-				table_name = ::getFullText(ctx->full_object_name());
+				table_name = stripQuoteFromId(ctx->full_object_name()->object_name);
 			else if (ctx->local_id())
 				table_name = ::getFullText(ctx->local_id());
 			extractTableHints(wctx, table_name);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1458,7 +1458,6 @@ public:
 			add_rewritten_query_fragment_to_mutator(&mutator);
 			mutator.run();
 		}
-		clear_query_hints();
 		clear_rewritten_query_fragment();
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -3134,13 +3134,7 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 	{
 		if (option->TABLE())
 		{
-			std::string table_name = ::getFullText(option->table_name());
-			size_t idx = table_name.find('.');
-			while (idx != std::string::npos)
-			{
-				table_name = table_name.substr(idx + 1);
-				idx = table_name.find('.');
-			}
+			std::string table_name = ::getFullText(option->table_name()->table);
 			if (!table_name.empty())
 			{
 				for(auto table_hint: option->table_hint())

--- a/test/JDBC/expected/BABEL-3291.out
+++ b/test/JDBC/expected/BABEL-3291.out
@@ -4,6 +4,14 @@ go
 create table babel_3291_t1(a1 int PRIMARY KEY, b1 int)
 go
 
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
 set babelfish_showplan_all on
 go
 
@@ -18,7 +26,7 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3291_t1 where a1 = 1
-Index Scan using babel_3291_t1_pkey on babel_3291_t1  (cost=0.15..8.17 rows=1 width=8)
+Index Scan using babel_3291_t1_pkey on babel_3291_t1
   Index Cond: (a1 = 1)
 ~~END~~
 
@@ -32,7 +40,7 @@ go
 ~~START~~
 text
 Query Text: select /*+SeqScan(babel_3291_t1)*/ * from babel_3291_t1 where a1 = 1
-Seq Scan on babel_3291_t1  (cost=0.00..38.25 rows=1 width=8)
+Seq Scan on babel_3291_t1
   Filter: (a1 = 1)
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -227,6 +227,17 @@ Insert on babel_3292_t2
 ~~END~~
 
 
+insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1                                                                 
+Insert on babel_3292_t2
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
 -- Test UPDATE queries with and without hints
 update babel_3292_t1 set a1 = 1 where b1 = 1
 go
@@ -252,6 +263,17 @@ Update on babel_3292_t1
 ~~END~~
 
 
+update babel_3292_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ update babel_3292_t1 set a1 = 1 where b1 = 1                                                                 
+Update on babel_3292_t1
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
 -- Test DELETE queries with and without hints
 delete from babel_3292_t1 where b1 = 1
 go
@@ -271,6 +293,17 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ delete from babel_3292_t1                                     where b1 = 1
+Delete on babel_3292_t1
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+delete from babel_3292_t1 where b1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ delete from babel_3292_t1 where b1 = 1                                                                 
 Delete on babel_3292_t1
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -314,6 +347,23 @@ HashAggregate
 ~~END~~
 
 
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1))) -- Only one query has a hint
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                 
+HashAggregate
+  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+  ->  Append
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+              Index Cond: (b1 = 1)
+        ->  Bitmap Heap Scan on babel_3292_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Both queries have a hint
 go
 ~~START~~
@@ -326,6 +376,87 @@ HashAggregate
               Index Cond: (b1 = 1)
         ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
               Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)), table hint(babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                                                                           
+HashAggregate
+  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+  ->  Append
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+-- Test CTE queries with and without hints
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+go
+~~START~~
+text
+Query Text: with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+Bitmap Heap Scan on babel_3292_t1
+  Recheck Cond: ((c1 = 1) AND (b1 = 1))
+  ->  BitmapAnd
+        ->  Bitmap Index Scan on index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c
+              Index Cond: (c1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+  Index Cond: (b1 = 1)
+  Filter: (c1 = 1)
+~~END~~
+
+
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1                                                                 
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+  Index Cond: (b1 = 1)
+  Filter: (c1 = 1)
+~~END~~
+
+
+-- Limitation: Hint given on a CTE is not applied
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte with(index=index_babel_3292_t1_c1) where c1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1_cte index_babel_3292_t1_c1babel_32961b5cc4ed008f5c7776c7f58f0abe80b) */ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte                                    where c1 = 1
+Bitmap Heap Scan on babel_3292_t1
+  Recheck Cond: ((c1 = 1) AND (b1 = 1))
+  ->  BitmapAnd
+        ->  Bitmap Index Scan on index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c
+              Index Cond: (c1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+-- Only the hint given on an existing table will be applied
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1) select * from babel_3292_t1_cte with(index=index_babel_3292_t1_c1) where c1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1_cte index_babel_3292_t1_c1babel_32961b5cc4ed008f5c7776c7f58f0abe80b) */ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte                                    where c1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+  Index Cond: (b1 = 1)
+  Filter: (c1 = 1)
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -472,7 +472,7 @@ go
 
 
 -- Test all queries by specifying a database and schema name
-use d
+use tempdb
 go
 
 drop table if exists babel_3292_schema.t1
@@ -513,53 +513,53 @@ off
 set babelfish_showplan_all on
 go
 
-select * from d.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
+select * from tempdb.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from d.babel_3292_schema.t1                                        where b1 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from tempdb.babel_3292_schema.t1                                        where b1 = 1
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1 where b1=1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+select * from tempdb.babel_3292_schema.t1 where b1=1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from d.babel_3292_schema.t1 where b1=1                                                                                 
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from tempdb.babel_3292_schema.t1 where b1=1                                                                                      
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
+select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ select * from d.babel_3292_schema.t1                                                                                  where b1 = 1 and c1 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ select * from tempdb.babel_3292_schema.t1                                                                                  where b1 = 1 and c1 = 1
 Index Scan using index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0 on t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)))
+select * from tempdb.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ select * from d.babel_3292_schema.t1 where b1 = 1 and c1 = 1                                                                                                                       
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ select * from tempdb.babel_3292_schema.t1 where b1 = 1 and c1 = 1                                                                                                                            
 Index Scan using index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0 on t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), d.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), tempdb.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1                                           , d.dbo.babel_3292_t2                                     where b1 = 1 and b2 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1                                           , tempdb.dbo.babel_3292_t2                                     where b1 = 1 and b2 = 1
 Nested Loop
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -569,11 +569,11 @@ Nested Loop
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1, d.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
+select * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1, d.dbo.babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                                                 
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                                                           
 Nested Loop
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -583,77 +583,77 @@ Nested Loop
 ~~END~~
 
 
-insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1                                            where b1 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1                                            where b1 = 1
 Insert on babel_3292_t2
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
 ~~END~~
 
 
-insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 where b1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 where b1 = 1                                                                                 
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 where b1 = 1                                                                                      
 Insert on babel_3292_t2
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
 ~~END~~
 
 
-update d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) set a1 = 1 where b1 = 1
+update tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) set a1 = 1 where b1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ update d.babel_3292_schema.t1                                            set a1 = 1 where b1 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ update tempdb.babel_3292_schema.t1                                            set a1 = 1 where b1 = 1
 Update on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
 ~~END~~
 
 
-update d.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+update tempdb.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ update d.babel_3292_schema.t1 set a1 = 1 where b1 = 1                                                                                 
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ update tempdb.babel_3292_schema.t1 set a1 = 1 where b1 = 1                                                                                      
 Update on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
 ~~END~~
 
 
-delete from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+delete from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ delete from d.babel_3292_schema.t1                                            where b1 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ delete from tempdb.babel_3292_schema.t1                                            where b1 = 1
 Delete on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
 ~~END~~
 
 
-delete from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+delete from tempdb.babel_3292_schema.t1 where b1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ delete from d.babel_3292_schema.t1 where b1 = 1                                                                                 
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ delete from tempdb.babel_3292_schema.t1 where b1 = 1                                                                                      
 Delete on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from d.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
+select * from tempdb.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1                                           where b1 = 1 UNION select * from d.dbo.babel_3292_t2                                    where b2 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2                                    where b2 = 1
 HashAggregate
   Group Key: t1.a1, t1.b1, t1.c1
   ->  Append
@@ -664,11 +664,11 @@ HashAggregate
 ~~END~~
 
 
-select * from d.babel_3292_schema.t1 where b1 = 1 UNION select * from d.dbo.babel_3292_t2 where b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+select * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1 where b1 = 1 UNION select * from d.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                 
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                           
 HashAggregate
   Group Key: t1.a1, t1.b1, t1.c1
   ->  Append

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -19,6 +19,14 @@ go
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
 go
 
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
 set babelfish_showplan_all on
 go
 
@@ -33,9 +41,9 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1 where b1 = 1
-Bitmap Heap Scan on babel_3292_t1  (cost=4.23..14.79 rows=10 width=12)
+Bitmap Heap Scan on babel_3292_t1
   Recheck Cond: (b1 = 1)
-  ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.23 rows=10 width=0)
+  ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
         Index Cond: (b1 = 1)
 ~~END~~
 
@@ -49,7 +57,7 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                 where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -59,7 +67,7 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -69,7 +77,7 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                     where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -79,7 +87,17 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                    where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 where b1=1                                                                 
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -92,12 +110,12 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1 where b1 = 1 and c1 = 1
-Bitmap Heap Scan on babel_3292_t1  (cost=8.71..12.72 rows=1 width=12)
+Bitmap Heap Scan on babel_3292_t1
   Recheck Cond: ((c1 = 1) AND (b1 = 1))
-  ->  BitmapAnd  (cost=8.71..8.71 rows=1 width=0)
-        ->  Bitmap Index Scan on index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c  (cost=0.00..4.23 rows=10 width=0)
+  ->  BitmapAnd
+        ->  Bitmap Index Scan on index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c
               Index Cond: (c1 = 1)
-        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.23 rows=10 width=0)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
               Index Cond: (b1 = 1)
 ~~END~~
 
@@ -107,7 +125,18 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ select * from babel_3292_t1                                                                    where b1 = 1 and c1 = 1
-Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1  (cost=0.15..32.35 rows=1 width=12)
+Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1
+  Index Cond: (c1 = 1)
+  Filter: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 where b1 = 1 and c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ select * from babel_3292_t1 where b1 = 1 and c1 = 1                                                                                                
+Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
 ~~END~~
@@ -121,15 +150,15 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
-Nested Loop  (cost=8.47..31.10 rows=110 width=20)
-  ->  Bitmap Heap Scan on babel_3292_t2  (cost=4.24..14.91 rows=11 width=8)
+Nested Loop
+  ->  Bitmap Heap Scan on babel_3292_t2
         Recheck Cond: (b2 = 1)
-        ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434  (cost=0.00..4.24 rows=11 width=0)
+        ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
               Index Cond: (b2 = 1)
-  ->  Materialize  (cost=4.23..14.84 rows=10 width=12)
-        ->  Bitmap Heap Scan on babel_3292_t1  (cost=4.23..14.79 rows=10 width=12)
+  ->  Materialize
+        ->  Bitmap Heap Scan on babel_3292_t1
               Recheck Cond: (b1 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.23 rows=10 width=0)
+              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
                     Index Cond: (b1 = 1)
 ~~END~~
 
@@ -139,11 +168,11 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                    , babel_3292_t2                                     where b1 = 1 and b2 = 1
-Nested Loop  (cost=0.31..70.07 rows=110 width=20)
-  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
+Nested Loop
+  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
         Index Cond: (b2 = 1)
-  ->  Materialize  (cost=0.15..32.38 rows=10 width=12)
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
               Index Cond: (b1 = 1)
 ~~END~~
 
@@ -153,11 +182,25 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                   , babel_3292_t2                                    where b1 = 1 and b2 = 1
-Nested Loop  (cost=0.31..70.07 rows=110 width=20)
-  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
+Nested Loop
+  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
         Index Cond: (b2 = 1)
-  ->  Materialize  (cost=0.15..32.38 rows=10 width=12)
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)), table hint(babel_3292_t2, index(index_babel_3292_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                           
+Nested Loop
+  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+        Index Cond: (b2 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
               Index Cond: (b1 = 1)
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -1,0 +1,60 @@
+drop table if exists babel_3292_t1
+go
+
+create table babel_3292_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
+go
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query without any hints to ensure that un-hinted queries still work.
+ * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
+ * than the index scan that we're hinting in the query below. This verifies that the next test is actually valid.
+ * If the planner was going to choose a sequential scan anyway, the next test wouldn't actually prove that hints were working.
+ */
+select * from babel_3292_t1 where b1 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3292_t1 where b1 = 1
+Bitmap Heap Scan on babel_3292_t1  (cost=4.24..14.91 rows=11 width=8)
+  Recheck Cond: (b1 = 1)
+  ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.24 rows=11 width=0)
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+/*
+ * Run SELECT queries and give the hint to follow a index scan. 
+ * The query plan should now use a idex scan instead of the bitmap heap and bitmap index scan it uses in the un-hinted test above.
+ */
+select * from babel_3292_t1 (index(index_babel_3292_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                 where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 (index=index_babel_3292_t1_b1) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3292_t1
+go

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -469,3 +469,225 @@ go
 
 drop table babel_3292_t2
 go
+
+
+-- Test all queries by specifying a database and schema name
+use d
+go
+
+drop table if exists babel_3292_schema.t1
+go
+
+drop table if exists babel_3292_t2
+go
+
+drop schema if exists babel_3292_schema
+go
+
+create schema babel_3292_schema
+go
+
+create table babel_3292_schema.t1(a1 int PRIMARY KEY, b1 int, c1 int)
+go
+
+create index index_babel_3292_schema_t1_b1 on babel_3292_schema.t1(b1)
+go
+
+create index index_babel_3292_schema_t1_c1 on babel_3292_schema.t1(c1)
+go
+
+create table babel_3292_t2(a2 int PRIMARY KEY, b2 int, c2 int)
+go
+
+create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+select * from d.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from d.babel_3292_schema.t1                                        where b1 = 1
+Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1 where b1=1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from d.babel_3292_schema.t1 where b1=1                                                                                 
+Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ select * from d.babel_3292_schema.t1                                                                                  where b1 = 1 and c1 = 1
+Index Scan using index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0 on t1
+  Index Cond: (c1 = 1)
+  Filter: (b1 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ select * from d.babel_3292_schema.t1 where b1 = 1 and c1 = 1                                                                                                                       
+Index Scan using index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0 on t1
+  Index Cond: (c1 = 1)
+  Filter: (b1 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), d.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1                                           , d.dbo.babel_3292_t2                                     where b1 = 1 and b2 = 1
+Nested Loop
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1, d.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1, d.dbo.babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                                                 
+Nested Loop
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1                                            where b1 = 1
+Insert on babel_3292_t2
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 where b1 = 1                                                                                 
+Insert on babel_3292_t2
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+update d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) set a1 = 1 where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ update d.babel_3292_schema.t1                                            set a1 = 1 where b1 = 1
+Update on t1
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+update d.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ update d.babel_3292_schema.t1 set a1 = 1 where b1 = 1                                                                                 
+Update on t1
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+delete from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ delete from d.babel_3292_schema.t1                                            where b1 = 1
+Delete on t1
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+delete from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ delete from d.babel_3292_schema.t1 where b1 = 1                                                                                 
+Delete on t1
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from d.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1                                           where b1 = 1 UNION select * from d.dbo.babel_3292_t2                                    where b2 = 1
+HashAggregate
+  Group Key: t1.a1, t1.b1, t1.c1
+  ->  Append
+        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from d.babel_3292_schema.t1 where b1 = 1 UNION select * from d.dbo.babel_3292_t2 where b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from d.babel_3292_schema.t1 where b1 = 1 UNION select * from d.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                 
+HashAggregate
+  Group Key: t1.a1, t1.b1, t1.c1
+  ->  Append
+        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3292_schema.t1 
+go
+
+drop table babel_3292_t2
+go
+
+drop schema babel_3292_schema
+go

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -29,7 +29,7 @@ Bitmap Heap Scan on babel_3292_t1  (cost=4.24..14.91 rows=11 width=8)
 
 
 /*
- * Run SELECT queries and give the hint to follow a index scan. 
+ * Run SELECT queries and give the hint to follow a index scan using different syntaxes.
  * The query plan should now use a idex scan instead of the bitmap heap and bitmap index scan it uses in the un-hinted test above.
  */
 select * from babel_3292_t1 (index(index_babel_3292_t1_b1)) where b1 = 1
@@ -47,6 +47,26 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                     where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                    where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
   Index Cond: (b1 = 1)
 ~~END~~

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -13,7 +13,7 @@ go
 create index index_babel_3292_t1_c1 on babel_3292_t1(c1)
 go
 
-create table babel_3292_t2(a2 int PRIMARY KEY, b2 int)
+create table babel_3292_t2(a2 int PRIMARY KEY, b2 int, c2 int)
 go
 
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
@@ -30,6 +30,7 @@ off
 set babelfish_showplan_all on
 go
 
+-- Test SELECT queries with and without hints
 /*
  * Run a SELECT query without any hints to ensure that un-hinted queries still work.
  * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
@@ -102,9 +103,7 @@ Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
 ~~END~~
 
 
-/*
- * Test with multiple index hints
- */
+-- Test with multiple index hints
 select * from babel_3292_t1 where b1 = 1 and c1 = 1
 go
 ~~START~~
@@ -142,24 +141,22 @@ Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c
 ~~END~~
 
 
-/*
- * Test with multiple tables
- */
+-- Test with multiple tables
 select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
 go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
 Nested Loop
-  ->  Bitmap Heap Scan on babel_3292_t2
-        Recheck Cond: (b2 = 1)
-        ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
-              Index Cond: (b2 = 1)
+  ->  Bitmap Heap Scan on babel_3292_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+              Index Cond: (b1 = 1)
   ->  Materialize
-        ->  Bitmap Heap Scan on babel_3292_t1
-              Recheck Cond: (b1 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
-                    Index Cond: (b1 = 1)
+        ->  Bitmap Heap Scan on babel_3292_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 
@@ -169,11 +166,11 @@ go
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                    , babel_3292_t2                                     where b1 = 1 and b2 = 1
 Nested Loop
-  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-        Index Cond: (b2 = 1)
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
   ->  Materialize
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
 ~~END~~
 
 
@@ -183,11 +180,11 @@ go
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                   , babel_3292_t2                                    where b1 = 1 and b2 = 1
 Nested Loop
-  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-        Index Cond: (b2 = 1)
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
   ->  Materialize
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
 ~~END~~
 
 
@@ -197,11 +194,138 @@ go
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                           
 Nested Loop
-  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-        Index Cond: (b2 = 1)
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
   ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+-- Test INSERT queries with and without hints
+insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1
+go
+~~START~~
+text
+Query Text: insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1
+Insert on babel_3292_t2
+  ->  Bitmap Heap Scan on babel_3292_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+insert into babel_3292_t2 select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ insert into babel_3292_t2 select * from babel_3292_t1                                     where b1 = 1
+Insert on babel_3292_t2
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+-- Test UPDATE queries with and without hints
+update babel_3292_t1 set a1 = 1 where b1 = 1
+go
+~~START~~
+text
+Query Text: update babel_3292_t1 set a1 = 1 where b1 = 1
+Update on babel_3292_t1
+  ->  Bitmap Heap Scan on babel_3292_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+update babel_3292_t1 with(index(index_babel_3292_t1_b1)) set a1 = 1 where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ update babel_3292_t1                                     set a1 = 1 where b1 = 1
+Update on babel_3292_t1
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+-- Test DELETE queries with and without hints
+delete from babel_3292_t1 where b1 = 1
+go
+~~START~~
+text
+Query Text: delete from babel_3292_t1 where b1 = 1
+Delete on babel_3292_t1
+  ->  Bitmap Heap Scan on babel_3292_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+delete from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ delete from babel_3292_t1                                     where b1 = 1
+Delete on babel_3292_t1
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+-- Test UNION queries with and without hints
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 -- None of the queries have a hint
+go
+~~START~~
+text
+Query Text: select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1
+HashAggregate
+  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+  ->  Append
+        ->  Bitmap Heap Scan on babel_3292_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+                    Index Cond: (b1 = 1)
+        ->  Bitmap Heap Scan on babel_3292_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Only one query has a hint
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
+HashAggregate
+  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+  ->  Append
+        ->  Bitmap Heap Scan on babel_3292_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+                    Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Both queries have a hint
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                    where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
+HashAggregate
+  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+  ->  Append
         ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
               Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -1,25 +1,23 @@
 drop table if exists babel_3292_t1
 go
 
-create table babel_3292_t1(a1 int PRIMARY KEY, b1 int)
+drop table if exists babel_3292_t2
+go
+
+create table babel_3292_t1(a1 int PRIMARY KEY, b1 int, c1 int)
 go
 
 create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
 go
 
+create index index_babel_3292_t1_c1 on babel_3292_t1(c1)
+go
+
 create table babel_3292_t2(a2 int PRIMARY KEY, b2 int)
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "babel_3292_t2" already exists)~~
-
 
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434" already exists)~~
-
 
 set babelfish_showplan_all on
 go
@@ -35,9 +33,9 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1 where b1 = 1
-Bitmap Heap Scan on babel_3292_t1  (cost=4.24..14.91 rows=11 width=8)
+Bitmap Heap Scan on babel_3292_t1  (cost=4.23..14.79 rows=10 width=12)
   Recheck Cond: (b1 = 1)
-  ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.24 rows=11 width=0)
+  ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.23 rows=10 width=0)
         Index Cond: (b1 = 1)
 ~~END~~
 
@@ -51,7 +49,7 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                 where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -61,7 +59,7 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -71,7 +69,7 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                     where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -81,30 +79,58 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1                                    where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
   Index Cond: (b1 = 1)
 ~~END~~
 
 
-
 /*
  * Test with multiple index hints
+ */
+select * from babel_3292_t1 where b1 = 1 and c1 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3292_t1 where b1 = 1 and c1 = 1
+Bitmap Heap Scan on babel_3292_t1  (cost=8.71..12.72 rows=1 width=12)
+  Recheck Cond: ((c1 = 1) AND (b1 = 1))
+  ->  BitmapAnd  (cost=8.71..8.71 rows=1 width=0)
+        ->  Bitmap Index Scan on index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c  (cost=0.00..4.23 rows=10 width=0)
+              Index Cond: (c1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.23 rows=10 width=0)
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 with(index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)) where b1 = 1 and c1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ select * from babel_3292_t1                                                                    where b1 = 1 and c1 = 1
+Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1  (cost=0.15..32.35 rows=1 width=12)
+  Index Cond: (c1 = 1)
+  Filter: (b1 = 1)
+~~END~~
+
+
+/*
+ * Test with multiple tables
  */
 select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
 go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
-Nested Loop  (cost=8.48..31.36 rows=121 width=16)
-  ->  Bitmap Heap Scan on babel_3292_t1  (cost=4.24..14.91 rows=11 width=8)
-        Recheck Cond: (b1 = 1)
-        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.24 rows=11 width=0)
-              Index Cond: (b1 = 1)
-  ->  Materialize  (cost=4.24..14.97 rows=11 width=8)
-        ->  Bitmap Heap Scan on babel_3292_t2  (cost=4.24..14.91 rows=11 width=8)
-              Recheck Cond: (b2 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434  (cost=0.00..4.24 rows=11 width=0)
-                    Index Cond: (b2 = 1)
+Nested Loop  (cost=8.47..31.10 rows=110 width=20)
+  ->  Bitmap Heap Scan on babel_3292_t2  (cost=4.24..14.91 rows=11 width=8)
+        Recheck Cond: (b2 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434  (cost=0.00..4.24 rows=11 width=0)
+              Index Cond: (b2 = 1)
+  ->  Materialize  (cost=4.23..14.84 rows=10 width=12)
+        ->  Bitmap Heap Scan on babel_3292_t1  (cost=4.23..14.79 rows=10 width=12)
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.23 rows=10 width=0)
+                    Index Cond: (b1 = 1)
 ~~END~~
 
 
@@ -113,12 +139,12 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                    , babel_3292_t2                                     where b1 = 1 and b2 = 1
-Nested Loop  (cost=0.31..74.23 rows=121 width=16)
-  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
-        Index Cond: (b1 = 1)
-  ->  Materialize  (cost=0.15..36.40 rows=11 width=8)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
-              Index Cond: (b2 = 1)
+Nested Loop  (cost=0.31..70.07 rows=110 width=20)
+  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
+        Index Cond: (b2 = 1)
+  ->  Materialize  (cost=0.15..32.38 rows=10 width=12)
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+              Index Cond: (b1 = 1)
 ~~END~~
 
 
@@ -127,12 +153,12 @@ go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                   , babel_3292_t2                                    where b1 = 1 and b2 = 1
-Nested Loop  (cost=0.31..74.23 rows=121 width=16)
-  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
-        Index Cond: (b1 = 1)
-  ->  Materialize  (cost=0.15..36.40 rows=11 width=8)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
-              Index Cond: (b2 = 1)
+Nested Loop  (cost=0.31..70.07 rows=110 width=20)
+  ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
+        Index Cond: (b2 = 1)
+  ->  Materialize  (cost=0.15..32.38 rows=10 width=12)
+        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..32.33 rows=10 width=12)
+              Index Cond: (b1 = 1)
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -7,6 +7,20 @@ go
 create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
 go
 
+create table babel_3292_t2(a2 int PRIMARY KEY, b2 int)
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "babel_3292_t2" already exists)~~
+
+
+create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434" already exists)~~
+
+
 set babelfish_showplan_all on
 go
 
@@ -72,9 +86,62 @@ Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
 ~~END~~
 
 
+
+/*
+ * Test with multiple index hints
+ */
+select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
+Nested Loop  (cost=8.48..31.36 rows=121 width=16)
+  ->  Bitmap Heap Scan on babel_3292_t1  (cost=4.24..14.91 rows=11 width=8)
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736  (cost=0.00..4.24 rows=11 width=0)
+              Index Cond: (b1 = 1)
+  ->  Materialize  (cost=4.24..14.97 rows=11 width=8)
+        ->  Bitmap Heap Scan on babel_3292_t2  (cost=4.24..14.91 rows=11 width=8)
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434  (cost=0.00..4.24 rows=11 width=0)
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)), babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                    , babel_3292_t2                                     where b1 = 1 and b2 = 1
+Nested Loop  (cost=0.31..74.23 rows=121 width=16)
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+        Index Cond: (b1 = 1)
+  ->  Materialize  (cost=0.15..36.40 rows=11 width=8)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 with(index=index_babel_3292_t2_b2) where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1                                   , babel_3292_t2                                    where b1 = 1 and b2 = 1
+Nested Loop  (cost=0.31..74.23 rows=121 width=16)
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1  (cost=0.15..36.35 rows=11 width=8)
+        Index Cond: (b1 = 1)
+  ->  Materialize  (cost=0.15..36.40 rows=11 width=8)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2  (cost=0.15..36.35 rows=11 width=8)
+              Index Cond: (b2 = 1)
+~~END~~
+
+
 set babelfish_showplan_all off
 go
 
 -- cleanup
 drop table babel_3292_t1
+go
+
+drop table babel_3292_t2
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3291.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3291.sql
@@ -4,6 +4,9 @@ go
 create table babel_3291_t1(a1 int PRIMARY KEY, b1 int)
 go
 
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
 set babelfish_showplan_all on
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -1,0 +1,37 @@
+drop table if exists babel_3292_t1
+go
+
+create table babel_3292_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
+go
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query without any hints to ensure that un-hinted queries still work.
+ * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
+ * than the index scan that we're hinting in the query below. This verifies that the next test is actually valid.
+ * If the planner was going to choose a sequential scan anyway, the next test wouldn't actually prove that hints were working.
+ */
+select * from babel_3292_t1 where b1 = 1
+go
+
+/*
+ * Run SELECT queries and give the hint to follow a index scan. 
+ * The query plan should now use a idex scan instead of the bitmap heap and bitmap index scan it uses in the un-hinted test above.
+ */
+select * from babel_3292_t1 (index(index_babel_3292_t1_b1)) where b1 = 1
+go
+
+select * from babel_3292_t1 (index=index_babel_3292_t1_b1) where b1 = 1
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3292_t1
+go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -84,11 +84,17 @@ go
 insert into babel_3292_t2 select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
 go
 
+insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+
 -- Test UPDATE queries with and without hints
 update babel_3292_t1 set a1 = 1 where b1 = 1
 go
 
 update babel_3292_t1 with(index(index_babel_3292_t1_b1)) set a1 = 1 where b1 = 1
+go
+
+update babel_3292_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
 go
 
 -- Test DELETE queries with and without hints
@@ -98,6 +104,9 @@ go
 delete from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
 go
 
+delete from babel_3292_t1 where b1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+
 -- Test UNION queries with and without hints
 select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 -- None of the queries have a hint
 go
@@ -105,7 +114,31 @@ go
 select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Only one query has a hint
 go
 
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1))) -- Only one query has a hint
+go
+
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Both queries have a hint
+go
+
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)), table hint(babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+go
+
+-- Test CTE queries with and without hints
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+go
+
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+go
+
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+
+-- Limitation: Hint given on a CTE is not applied
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte with(index=index_babel_3292_t1_c1) where c1 = 1
+go
+
+-- Only the hint given on an existing table will be applied
+with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1) select * from babel_3292_t1_cte with(index=index_babel_3292_t1_c1) where c1 = 1
 go
 
 set babelfish_showplan_all off

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -19,6 +19,9 @@ go
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
 go
 
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
 set babelfish_showplan_all on
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -150,3 +150,96 @@ go
 
 drop table babel_3292_t2
 go
+
+
+-- Test all queries by specifying a database and schema name
+use d
+go
+
+drop table if exists babel_3292_schema.t1
+go
+
+drop table if exists babel_3292_t2
+go
+
+drop schema if exists babel_3292_schema
+go
+
+create schema babel_3292_schema
+go
+
+create table babel_3292_schema.t1(a1 int PRIMARY KEY, b1 int, c1 int)
+go
+
+create index index_babel_3292_schema_t1_b1 on babel_3292_schema.t1(b1)
+go
+
+create index index_babel_3292_schema_t1_c1 on babel_3292_schema.t1(c1)
+go
+
+create table babel_3292_t2(a2 int PRIMARY KEY, b2 int, c2 int)
+go
+
+create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+set babelfish_showplan_all on
+go
+
+select * from d.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+
+select * from d.babel_3292_schema.t1 where b1=1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+
+select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
+go
+
+select * from d.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)))
+go
+
+select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), d.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+go
+
+select * from d.babel_3292_schema.t1, d.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
+go
+
+insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+
+insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+
+update d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) set a1 = 1 where b1 = 1
+go
+
+update d.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+
+delete from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+
+delete from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+
+select * from d.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from d.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
+go
+
+select * from d.babel_3292_schema.t1 where b1 = 1 UNION select * from d.dbo.babel_3292_t2 where b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3292_schema.t1 
+go
+
+drop table babel_3292_t2
+go
+
+drop schema babel_3292_schema
+go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -20,13 +20,19 @@ select * from babel_3292_t1 where b1 = 1
 go
 
 /*
- * Run SELECT queries and give the hint to follow a index scan. 
+ * Run SELECT queries and give the hint to follow a index scan using different syntaxes.
  * The query plan should now use a idex scan instead of the bitmap heap and bitmap index scan it uses in the un-hinted test above.
  */
 select * from babel_3292_t1 (index(index_babel_3292_t1_b1)) where b1 = 1
 go
 
 select * from babel_3292_t1 (index=index_babel_3292_t1_b1) where b1 = 1
+go
+
+select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
+go
+
+select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
 set babelfish_showplan_all off

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -7,6 +7,12 @@ go
 create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
 go
 
+create table babel_3292_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
+go
+
 set babelfish_showplan_all on
 go
 
@@ -35,9 +41,25 @@ go
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
+
+/*
+ * Test with multiple index hints
+ */
+select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)), babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+go
+
+select * from babel_3292_t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 with(index=index_babel_3292_t2_b2) where b1 = 1 and b2 = 1
+go
+
 set babelfish_showplan_all off
 go
 
 -- cleanup
 drop table babel_3292_t1
+go
+
+drop table babel_3292_t2
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -13,7 +13,7 @@ go
 create index index_babel_3292_t1_c1 on babel_3292_t1(c1)
 go
 
-create table babel_3292_t2(a2 int PRIMARY KEY, b2 int)
+create table babel_3292_t2(a2 int PRIMARY KEY, b2 int, c2 int)
 go
 
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
@@ -25,6 +25,7 @@ go
 set babelfish_showplan_all on
 go
 
+-- Test SELECT queries with and without hints
 /*
  * Run a SELECT query without any hints to ensure that un-hinted queries still work.
  * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
@@ -53,9 +54,7 @@ go
 select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
 go
 
-/*
- * Test with multiple index hints
- */
+-- Test with multiple index hints
 select * from babel_3292_t1 where b1 = 1 and c1 = 1
 go
 
@@ -65,9 +64,7 @@ go
 select * from babel_3292_t1 where b1 = 1 and c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)))
 go
 
-/*
- * Test with multiple tables
- */
+-- Test with multiple tables
 select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
 go
 
@@ -78,6 +75,37 @@ select * from babel_3292_t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 wi
 go
 
 select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)), table hint(babel_3292_t2, index(index_babel_3292_t2_b2)))
+go
+
+-- Test INSERT queries with and without hints
+insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1
+go
+
+insert into babel_3292_t2 select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
+go
+
+-- Test UPDATE queries with and without hints
+update babel_3292_t1 set a1 = 1 where b1 = 1
+go
+
+update babel_3292_t1 with(index(index_babel_3292_t1_b1)) set a1 = 1 where b1 = 1
+go
+
+-- Test DELETE queries with and without hints
+delete from babel_3292_t1 where b1 = 1
+go
+
+delete from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
+go
+
+-- Test UNION queries with and without hints
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1 -- None of the queries have a hint
+go
+
+select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Only one query has a hint
+go
+
+select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1 UNION select * from babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1 -- Both queries have a hint
 go
 
 set babelfish_showplan_all off

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -1,10 +1,16 @@
 drop table if exists babel_3292_t1
 go
 
-create table babel_3292_t1(a1 int PRIMARY KEY, b1 int)
+drop table if exists babel_3292_t2
+go
+
+create table babel_3292_t1(a1 int PRIMARY KEY, b1 int, c1 int)
 go
 
 create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
+go
+
+create index index_babel_3292_t1_c1 on babel_3292_t1(c1)
 go
 
 create table babel_3292_t2(a2 int PRIMARY KEY, b2 int)
@@ -41,9 +47,17 @@ go
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
-
 /*
  * Test with multiple index hints
+ */
+select * from babel_3292_t1 where b1 = 1 and c1 = 1
+go
+
+select * from babel_3292_t1 with(index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)) where b1 = 1 and c1 = 1
+go
+
+/*
+ * Test with multiple tables
  */
 select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -47,6 +47,9 @@ go
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
+select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+
 /*
  * Test with multiple index hints
  */
@@ -54,6 +57,9 @@ select * from babel_3292_t1 where b1 = 1 and c1 = 1
 go
 
 select * from babel_3292_t1 with(index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)) where b1 = 1 and c1 = 1
+go
+
+select * from babel_3292_t1 where b1 = 1 and c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)))
 go
 
 /*
@@ -66,6 +72,9 @@ select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)), babel_3292_t2 w
 go
 
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 with(index=index_babel_3292_t2_b2) where b1 = 1 and b2 = 1
+go
+
+select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)), table hint(babel_3292_t2, index(index_babel_3292_t2_b2)))
 go
 
 set babelfish_showplan_all off

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -153,7 +153,7 @@ go
 
 
 -- Test all queries by specifying a database and schema name
-use d
+use tempdb
 go
 
 drop table if exists babel_3292_schema.t1
@@ -189,46 +189,46 @@ go
 set babelfish_showplan_all on
 go
 
-select * from d.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
+select * from tempdb.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 
-select * from d.babel_3292_schema.t1 where b1=1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+select * from tempdb.babel_3292_schema.t1 where b1=1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 
-select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
+select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
 go
 
-select * from d.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)))
+select * from tempdb.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)))
 go
 
-select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), d.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), tempdb.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
 go
 
-select * from d.babel_3292_schema.t1, d.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
+select * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
 go
 
-insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 
-insert into d.dbo.babel_3292_t2 select * from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 where b1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 
-update d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) set a1 = 1 where b1 = 1
+update tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) set a1 = 1 where b1 = 1
 go
 
-update d.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+update tempdb.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 
-delete from d.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
+delete from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 
-delete from d.babel_3292_schema.t1 where b1 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+delete from tempdb.babel_3292_schema.t1 where b1 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 
-select * from d.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from d.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
+select * from tempdb.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
 go
 
-select * from d.babel_3292_schema.t1 where b1 = 1 UNION select * from d.dbo.babel_3292_t2 where b2 = 1 option(table hint(d.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(d.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+select * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
 go
 
 set babelfish_showplan_all off


### PR DESCRIPTION
### Description
Description

Currently Babelfish does not support query hints. To add support for query hints, we are using the third-part library pg_hint_plan. This pull request has the following changes:

1. Add support for Index-related T-SQL hint (INDEX(index_name), INDEX=index_name) conversion
2. Add a test to verify the hinted queries work as expected

 
### Issues Resolved

Task: BABEL-3292


### Check List
- [] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).