### PR TITLE
Fix the JDBC timeout error in release mode

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1145,13 +1145,12 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	volatile LocalTransactionId before_lxid;
 	LocalTransactionId after_lxid;
 	SimpleEcontextStackEntry *topEntry;
-      	char *old_db_name = NULL;
+      	char *old_db_name = get_cur_db_name();
       	char *cur_db_name = NULL;
 	LOCAL_FCINFO(fcinfo,1);
 
 	PG_TRY();
 	{
-                old_db_name = get_cur_db_name();
                 /*
 		* First we evaluate the string expression. Its result is the
 		* querystring we have to execute.


### PR DESCRIPTION
We were assigning a non-volatile variable "old_db_name" inside TRY earlier. Now we have moved assignment out of TRY block. 
In release mode, it was leading to segmentation fault in the case of runtime error earlier.

Task: BABEL-3077
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

