### PR TITLE
Unable to transfer data to a table with Identity Columns using IEW

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -126,6 +126,7 @@ static void FillTabNameWithoutNumParts(StringInfo buf, uint8 numParts, TdsRelati
 static void SetTdsEstateErrorData(void);
 static void ResetTdsEstateErrorData(void);
 static bool get_attnotnull(Oid relid, AttrNumber attnum);
+static char get_attidentity(Oid relid, AttrNumber attnum);
 
 static inline void
 SendPendingDone(bool more)
@@ -1364,6 +1365,14 @@ PrepareRowDescription(TupleDesc typeinfo, List *targetlist, int16 *formats,
 		}
 
 		col->attNotNull = get_attnotnull(col->relOid, col->attrNum);
+		{
+			char attidentity = get_attidentity(col->relOid, col->attrNum);
+			if (attidentity != '\0')
+				col->attidentity = true;
+			else
+				col->attidentity = false;
+		}
+
 		switch (finfo->sendFuncId)
 		{
 			/*
@@ -2937,4 +2946,32 @@ get_attnotnull(Oid relid, AttrNumber attnum)
 	}
 	/* Assume att is nullable if no valid heap tuple is found */
 	return false;
+}
+
+/*
+ * get_attidentity
+ *		Given the relation id and the attribute number,
+ *		return the "attidentity" field from the attribute relation.
+ */
+static char
+get_attidentity(Oid relid, AttrNumber attnum)
+{
+	HeapTuple	  tp;
+	Form_pg_attribute att_tup;
+
+	tp = SearchSysCache2(ATTNUM, 
+			ObjectIdGetDatum(relid),
+			Int16GetDatum(attnum));
+
+	if (HeapTupleIsValid(tp))
+	{
+		char result;
+		att_tup = (Form_pg_attribute) GETSTRUCT(tp);
+		result = att_tup->attidentity;
+		ReleaseSysCache(tp);
+
+		return result;
+	}
+	/* return '\0' if no valid heap tuple is found */
+	return '\0';
 }

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -675,19 +675,21 @@ SetColMetadataForFixedType(TdsColumnMetaData *col, uint8_t tdsType, uint8_t maxS
 	/*
 	 * If column is Not NULL constrained then we don't want to send
 	 * maxSize except for uniqueidentifier and xml.
-       * TODO: We should send TDS_COL_METADATA_NOT_NULL_FLAGS
-       * This needs to be done for identity contraints
+	 * This needs to be done for identity contraints as well.
 	 */
 	if (col->attNotNull && tdsType != TDS_TYPE_UNIQUEIDENTIFIER && tdsType != TDS_TYPE_XML)
-      {
+	{
 		col->metaLen = sizeof(col->metaEntry.type1) - 1;
-	        col->metaEntry.type1.flags = TDS_COL_METADATA_NOT_NULL_FLAGS;
-      }
-      else
-      {
+		if (col->attidentity)
+			col->metaEntry.type1.flags = TDS_COLMETA_IDENTITY;
+		else
+			col->metaEntry.type1.flags = TDS_COL_METADATA_NOT_NULL_FLAGS;
+	}
+	else
+	{
 		col->metaLen = sizeof(col->metaEntry.type1);
-              col->metaEntry.type1.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
-      }
+		col->metaEntry.type1.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
+	}
 	col->metaEntry.type1.tdsTypeId = tdsType;
 	col->metaEntry.type1.maxSize = maxSize;
 }

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -181,6 +181,7 @@ typedef struct TdsColumnMetaData
 	AttrNumber				attrNum;	/* attribute number in the relation */
 	TdsRelationMetaDataInfo	relinfo;
 	bool 					attNotNull; 	/* true if the column has not null constraint */
+	bool 					attidentity;	/* true if it is an identity column */
 } TdsColumnMetaData;
 
 /* Partial Length Prefixed-bytes */

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -2501,6 +2501,13 @@ int exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *stm
 		bulk_load_table_name = pstrdup(stmt->table_name);
 	}
 
+	/* if columns to be inserted into are explicitly mentioned then update the table name with them */
+	if (stmt->column_refs)
+	{
+		char *temp = bulk_load_table_name;
+		bulk_load_table_name = psprintf("%s (%s)", temp, stmt->column_refs);
+		pfree(temp);
+	}
 	MemoryContextSwitchTo(oldContext);
 
 	if (!OidIsValid(rel_oid))

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -915,6 +915,7 @@ typedef struct PLtsql_stmt_insert_bulk
     char  *table_name;
     char  *schema_name;
     char  *db_name;
+    char  *column_refs;
 } PLtsql_stmt_insert_bulk;
 
 /*


### PR DESCRIPTION
This commit is intended to fix the issue faced whiled importing Identity Columns' data into Babelfish.

It required 2 fixes:
1. Metadata being sent from The TDS protocol was not identity specific for an Identity Column. To do so, we have created a function in get_attidentity which returns true if it is an Identity Column, using this we chose to send Identity specific flags.
2. Save the column names sent with INSERT BULK query in order to insert into only these columns during BULK LOAD Processing

Task: BABEL-3097
Signed-off-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).