### PR TITLE
[DO NOT MERGE without reverting test hacks] Add missing TOP (NULL) commit

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2731,11 +2731,11 @@ tsql_top_clause:
 						A_Const* n = (A_Const *)$3;
 						if(n->val.type == T_Integer && n->val.val.ival == 100)
 						{
-								$$ = makeNullAConst(@1);
+								$$ = NULL;
 						}
 						else if(n->val.type == T_Float && atof(n->val.val.str) == 100.0)
 						{
-								$$ = makeNullAConst(@1);
+								$$ = NULL;
 						}
 						else
 						{
@@ -2760,11 +2760,11 @@ tsql_top_clause:
 					A_Const* n = (A_Const *)$2;
 					if(n->val.type == T_Integer && n->val.val.ival == 100)
 					{
-							$$ = makeNullAConst(@1);
+							$$ = NULL;
 					}
 					else if(n->val.type == T_Float && atof(n->val.val.str) == 100.0)
 					{
-							$$ = makeNullAConst(@1);
+							$$ = NULL;
 					}
 					else
 					{

--- a/test/JDBC/expected/BABEL-1161.out
+++ b/test/JDBC/expected/BABEL-1161.out
@@ -121,17 +121,14 @@ int
 
 
 -- empty scalar subquery
--- note: we have a bug here: BABEL-1181
--- please update the comment and expected output once the bug is fixed.
+-- SELECT TOP (NULL) should throw error
 select top (select a from babel_1161_t31 where a2 = 'c') * from babel_1161_t32 order by b;
 GO
 ~~START~~
 int
-1
-2
-3
-4
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
 
 
 -- not a single row

--- a/test/JDBC/expected/BABEL-1181.out
+++ b/test/JDBC/expected/BABEL-1181.out
@@ -1,0 +1,146 @@
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- top (2) should only return 2 rows
+select top (2) * from t1;
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+-- top (NULL) should throw error
+select top (NULL) * from t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+create table t2 (a int, b int);
+insert into t2 values (1, NULL);
+go
+~~ROW COUNT: 1~~
+
+-- top (1) should only return 1 row
+select top (select a from t2) * from t1;
+go
+~~START~~
+int
+1
+~~END~~
+
+-- top (NULL) should throw error
+select top (select b from t2) * from t1;
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+declare @a int;
+set @a = 1;
+-- top (1) should only return 1 row
+select top (@a) * from t1;
+go
+~~START~~
+int
+1
+~~END~~
+
+declare @a int;
+set @a = NULL;
+-- top (NULL) should throw error
+select top (@a) * from t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- test CTE
+create table t3 (a int, b int);
+insert into t3 values (1, NULL);
+insert into t3 values (100, 1);
+insert into t3 values (200, 2);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- test TOP as part of query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select a from t3 as cte)
+select top (1) * from cte;
+go
+~~START~~
+int
+1
+~~END~~
+
+-- top (NULL) should throw error
+with cte (cte_a) as (select a from t3 as cte)
+select top (NULL) * from cte;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- test TOP as part of CTE
+-- top (2) should only return 2 rows
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select * from cte;
+go
+~~START~~
+int
+1
+100
+~~END~~
+
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(NULL) a from t3 as cte)
+select * from cte;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- test TOP as part of both CTE and query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(1) * from cte;
+go
+~~START~~
+int
+1
+~~END~~
+
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(NULL) * from cte;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- cleanup
+drop table t1;
+drop table t2;
+drop table t3;
+go

--- a/test/JDBC/input/BABEL-1161.sql
+++ b/test/JDBC/input/BABEL-1161.sql
@@ -97,8 +97,7 @@ select top (select a from babel_1161_t31 where a2 = 'b') * from babel_1161_t32 o
 GO
 
 -- empty scalar subquery
--- note: we have a bug here: BABEL-1181
--- please update the comment and expected output once the bug is fixed.
+-- SELECT TOP (NULL) should throw error
 select top (select a from babel_1161_t31 where a2 = 'c') * from babel_1161_t32 order by b;
 GO
 

--- a/test/JDBC/input/BABEL-1181.sql
+++ b/test/JDBC/input/BABEL-1181.sql
@@ -1,0 +1,74 @@
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+go
+-- top (2) should only return 2 rows
+select top (2) * from t1;
+go
+-- top (NULL) should throw error
+select top (NULL) * from t1;
+go
+
+create table t2 (a int, b int);
+insert into t2 values (1, NULL);
+go
+-- top (1) should only return 1 row
+select top (select a from t2) * from t1;
+go
+-- top (NULL) should throw error
+select top (select b from t2) * from t1;
+go
+
+declare @a int;
+set @a = 1;
+-- top (1) should only return 1 row
+select top (@a) * from t1;
+go
+declare @a int;
+set @a = NULL;
+-- top (NULL) should throw error
+select top (@a) * from t1;
+go
+
+-- test CTE
+create table t3 (a int, b int);
+insert into t3 values (1, NULL);
+insert into t3 values (100, 1);
+insert into t3 values (200, 2);
+go
+-- test TOP as part of query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select a from t3 as cte)
+select top (1) * from cte;
+go
+-- top (NULL) should throw error
+with cte (cte_a) as (select a from t3 as cte)
+select top (NULL) * from cte;
+go
+
+-- test TOP as part of CTE
+-- top (2) should only return 2 rows
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select * from cte;
+go
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(NULL) a from t3 as cte)
+select * from cte;
+go
+
+-- test TOP as part of both CTE and query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(1) * from cte;
+go
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(NULL) * from cte;
+go
+
+-- cleanup
+drop table t1;
+drop table t2;
+drop table t3;
+go


### PR DESCRIPTION
### Description
Make SELECT TOP (NULL) throw error instead of returning all rows (#96)

Previously, SELECT TOP (NULL) returned all rows. This commit makes it throw an error instead by adding a NULL-check in the execution of LIMIT node, and also in the planner because the planner by default skips building a LIMIT node

Note: this was originally released as part of Aurora Babelfish 1.1 and was inadvertently missed as part of the move to GitHub.

Task: BABEL-1181
Author: Zitao Quan <qztao@amazon.com>
Signed-off-by: Sharu Goel <goelshar@amazon.com>

Co-authored-by: Sharu Goel <30777678+thephantomthief@users.noreply.github.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
