### PR TITLE
Add sys.filetables, sys.registered_search_property_lists and update sys.identity_columns.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -687,52 +687,54 @@ WHERE has_schema_privilege(sch.schema_id, 'USAGE')
 AND c.contype = 'f';
 GRANT SELECT ON sys.foreign_keys TO PUBLIC;
 
-create or replace view sys.identity_columns AS
-select out_object_id::bigint as object_id
-  , out_name::name as name
-  , out_column_id::smallint as column_id
-  , out_system_type_id::oid as system_type_id
-  , out_user_type_id::oid as user_type_id
-  , out_max_length as max_length
-  , out_precision::integer as precision
-  , out_scale::integer as scale
-  , out_collation_name::name as collation_name
-  , out_is_nullable::integer as is_nullable
-  , out_is_ansi_padded::integer as is_ansi_padded
-  , out_is_rowguidcol::integer as is_rowguidcol
-  , out_is_identity::integer as is_identity
-  , out_is_computed::integer as is_computed
-  , out_is_filestream::integer as is_filestream
-  , out_is_replicated::integer as is_replicated
-  , out_is_non_sql_subscribed::integer as is_non_sql_subscribed
-  , out_is_merge_published::integer as is_merge_published
-  , out_is_dts_replicated::integer as is_dts_replicated
-  , out_is_xml_document::integer as is_xml_document
-  , out_xml_collection_id::integer as xml_collection_id
-  , out_default_object_id::oid as default_object_id
-  , out_rule_object_id::oid as rule_object_id
-  , out_is_sparse::integer as is_sparse
-  , out_is_column_set::integer as is_column_set
-  , out_generated_always_type::integer as generated_always_type
-  , out_generated_always_type_desc::character varying(60) as generated_always_type_desc
-  , out_encryption_type::integer as encryption_type
-  , out_encryption_type_desc::character varying(64)  as encryption_type_desc
-  , out_encryption_algorithm_name::character varying as encryption_algorithm_name
-  , out_column_encryption_key_id::integer as column_encryption_key_id
-  , out_column_encryption_key_database_name::character varying as column_encryption_key_database_name
-  , out_is_hidden::integer as is_hidden
-  , out_is_masked::integer as is_masked
-  , sys.ident_seed(OBJECT_NAME(sc.out_object_id))::bigint as seed_value
-  , sys.ident_incr(OBJECT_NAME(sc.out_object_id))::bigint as increment_value
-  , sys.babelfish_get_sequence_value(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname)) as last_value
-from sys.columns_internal() sc
+CREATE OR replace view sys.identity_columns AS
+SELECT 
+  CAST(out_object_id AS INT) AS object_id
+  , CAST(out_name AS SYSNAME) AS name
+  , CAST(out_column_id AS INT) AS column_id
+  , CAST(out_system_type_id AS TINYINT) AS system_type_id
+  , CAST(out_user_type_id AS INT) AS user_type_id
+  , CAST(out_max_length AS SMALLINT) AS max_length
+  , CAST(out_precision AS TINYINT) AS precision
+  , CAST(out_scale AS TINYINT) AS scale
+  , CAST(out_collation_name AS SYSNAME) AS collation_name
+  , CAST(out_is_nullable AS sys.BIT) AS is_nullable
+  , CAST(out_is_ansi_padded AS sys.BIT) AS is_ansi_padded
+  , CAST(out_is_rowguidcol AS sys.BIT) AS is_rowguidcol
+  , CAST(out_is_identity AS sys.BIT) AS is_identity
+  , CAST(out_is_computed AS sys.BIT) AS is_computed
+  , CAST(out_is_filestream AS sys.BIT) AS is_filestream
+  , CAST(out_is_replicated AS sys.BIT) AS is_replicated
+  , CAST(out_is_non_sql_subscribed AS sys.BIT) AS is_non_sql_subscribed
+  , CAST(out_is_merge_published AS sys.BIT) AS is_merge_published
+  , CAST(out_is_dts_replicated AS sys.BIT) AS is_dts_replicated
+  , CAST(out_is_xml_document AS sys.BIT) AS is_xml_document
+  , CAST(out_xml_collection_id AS INT) AS xml_collection_id
+  , CAST(out_default_object_id AS INT) AS default_object_id
+  , CAST(out_rule_object_id AS INT) AS rule_object_id
+  , CAST(out_is_sparse AS sys.BIT) AS is_sparse
+  , CAST(out_is_column_set AS sys.BIT) AS is_column_set
+  , CAST(out_generated_always_type AS TINYINT) AS generated_always_type
+  , CAST(out_generated_always_type_desc AS NVARCHAR(60)) AS generated_always_type_desc
+  , CAST(out_encryption_type AS INT) AS encryption_type
+  , CAST(out_encryption_type_desc AS NVARCHAR(60)) AS encryption_type_desc
+  , CAST(out_encryption_algorithm_name AS SYSNAME) AS encryption_algorithm_name
+  , CAST(out_column_encryption_key_id AS INT) column_encryption_key_id
+  , CAST(out_column_encryption_key_database_name AS SYSNAME) AS column_encryption_key_database_name
+  , CAST(out_is_hidden AS sys.BIT) AS is_hidden
+  , CAST(out_is_masked AS sys.BIT) AS is_masked
+  , CAST(sys.ident_seed(OBJECT_NAME(sc.out_object_id)) AS SQL_VARIANT) AS seed_value
+  , CAST(sys.ident_incr(OBJECT_NAME(sc.out_object_id)) AS SQL_VARIANT) AS increment_value
+  , CAST(sys.babelfish_get_sequence_value(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname)) AS SQL_VARIANT) AS last_value
+  , CAST(0 as sys.BIT) as is_not_for_replication
+FROM sys.columns_internal() sc
 INNER JOIN pg_attribute a ON sc.out_name = a.attname AND sc.out_column_id = a.attnum
-inner join pg_class c on c.oid = a.attrelid
-inner join sys.pg_namespace_ext ext on ext.oid = c.relnamespace
-where not a.attisdropped
-and sc.out_is_identity::integer = 1
-and pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname)  is not null
-and has_sequence_privilege(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname), 'USAGE,SELECT,UPDATE');
+INNER JOIN pg_class c ON c.oid = a.attrelid
+INNER JOIN sys.pg_namespace_ext ext ON ext.oid = c.relnamespace
+WHERE NOT a.attisdropped
+AND sc.out_is_identity::INTEGER = 1
+AND pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname) IS NOT NULL
+AND has_sequence_privilege(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname), 'USAGE,SELECT,UPDATE');
 GRANT SELECT ON sys.identity_columns TO PUBLIC;
 
 create or replace view sys.indexes as
@@ -2151,3 +2153,25 @@ SELECT
   CAST('' as NVARCHAR(60)) AS non_transacted_access_desc
 WHERE FALSE;
 GRANT SELECT ON sys.database_filestream_options TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.filetables
+AS
+SELECT 
+   CAST(0 AS INT) AS object_id,
+   CAST(0 AS sys.BIT) AS is_enabled,
+   CAST('' AS VARCHAR(255)) AS directory_name,
+   CAST(0 AS INT) AS filename_collation_id,
+   CAST('' AS VARCHAR) AS filename_collation_name
+   WHERE FALSE;
+GRANT SELECT ON sys.filetables TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.registered_search_property_lists
+AS
+SELECT 
+   CAST(0 AS INT) AS property_list_id,
+   CAST('' AS SYSNAME) AS name,
+   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS create_date,
+   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS modify_date,
+   CAST(0 AS INT) AS principal_id
+WHERE FALSE;
+GRANT SELECT ON sys.registered_search_property_lists TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2170,8 +2170,8 @@ AS
 SELECT 
    CAST(0 AS INT) AS property_list_id,
    CAST('' AS SYSNAME) AS name,
-   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS create_date,
-   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS modify_date,
+   CAST(NULL AS DATETIME) AS create_date,
+   CAST(NULL AS DATETIME) AS modify_date,
    CAST(0 AS INT) AS principal_id
 WHERE FALSE;
 GRANT SELECT ON sys.registered_search_property_lists TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -580,8 +580,8 @@ AS
 SELECT 
    CAST(0 AS INT) AS property_list_id,
    CAST('' AS SYSNAME) AS name,
-   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS create_date,
-   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS modify_date,
+   CAST(NULL AS DATETIME) AS create_date,
+   CAST(NULL AS DATETIME) AS modify_date,
    CAST(0 AS INT) AS principal_id
 WHERE FALSE;
 GRANT SELECT ON sys.registered_search_property_lists TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -564,6 +564,82 @@ $$
 	END
 $$;
 
+CREATE OR REPLACE VIEW sys.filetables
+AS
+SELECT 
+   CAST(0 AS INT) AS object_id,
+   CAST(0 AS sys.BIT) AS is_enabled,
+   CAST('' AS VARCHAR(255)) AS directory_name,
+   CAST(0 AS INT) AS filename_collation_id,
+   CAST('' AS VARCHAR) AS filename_collation_name
+   WHERE FALSE;
+GRANT SELECT ON sys.filetables TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.registered_search_property_lists
+AS
+SELECT 
+   CAST(0 AS INT) AS property_list_id,
+   CAST('' AS SYSNAME) AS name,
+   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS create_date,
+   CAST('2022-02-22 22:22:22.222' AS DATETIME) AS modify_date,
+   CAST(0 AS INT) AS principal_id
+WHERE FALSE;
+GRANT SELECT ON sys.registered_search_property_lists TO PUBLIC;
+
+ALTER VIEW sys.identity_columns RENAME TO identity_columns_deprecated;
+
+CREATE OR replace view sys.identity_columns AS
+SELECT 
+  CAST(out_object_id AS INT) AS object_id
+  , CAST(out_name AS SYSNAME) AS name
+  , CAST(out_column_id AS INT) AS column_id
+  , CAST(out_system_type_id AS TINYINT) AS system_type_id
+  , CAST(out_user_type_id AS INT) AS user_type_id
+  , CAST(out_max_length AS SMALLINT) AS max_length
+  , CAST(out_precision AS TINYINT) AS precision
+  , CAST(out_scale AS TINYINT) AS scale
+  , CAST(out_collation_name AS SYSNAME) AS collation_name
+  , CAST(out_is_nullable AS sys.BIT) AS is_nullable
+  , CAST(out_is_ansi_padded AS sys.BIT) AS is_ansi_padded
+  , CAST(out_is_rowguidcol AS sys.BIT) AS is_rowguidcol
+  , CAST(out_is_identity AS sys.BIT) AS is_identity
+  , CAST(out_is_computed AS sys.BIT) AS is_computed
+  , CAST(out_is_filestream AS sys.BIT) AS is_filestream
+  , CAST(out_is_replicated AS sys.BIT) AS is_replicated
+  , CAST(out_is_non_sql_subscribed AS sys.BIT) AS is_non_sql_subscribed
+  , CAST(out_is_merge_published AS sys.BIT) AS is_merge_published
+  , CAST(out_is_dts_replicated AS sys.BIT) AS is_dts_replicated
+  , CAST(out_is_xml_document AS sys.BIT) AS is_xml_document
+  , CAST(out_xml_collection_id AS INT) AS xml_collection_id
+  , CAST(out_default_object_id AS INT) AS default_object_id
+  , CAST(out_rule_object_id AS INT) AS rule_object_id
+  , CAST(out_is_sparse AS sys.BIT) AS is_sparse
+  , CAST(out_is_column_set AS sys.BIT) AS is_column_set
+  , CAST(out_generated_always_type AS TINYINT) AS generated_always_type
+  , CAST(out_generated_always_type_desc AS NVARCHAR(60)) AS generated_always_type_desc
+  , CAST(out_encryption_type AS INT) AS encryption_type
+  , CAST(out_encryption_type_desc AS NVARCHAR(60)) AS encryption_type_desc
+  , CAST(out_encryption_algorithm_name AS SYSNAME) AS encryption_algorithm_name
+  , CAST(out_column_encryption_key_id AS INT) column_encryption_key_id
+  , CAST(out_column_encryption_key_database_name AS SYSNAME) AS column_encryption_key_database_name
+  , CAST(out_is_hidden AS sys.BIT) AS is_hidden
+  , CAST(out_is_masked AS sys.BIT) AS is_masked
+  , CAST(sys.ident_seed(OBJECT_NAME(sc.out_object_id)) AS SQL_VARIANT) AS seed_value
+  , CAST(sys.ident_incr(OBJECT_NAME(sc.out_object_id)) AS SQL_VARIANT) AS increment_value
+  , CAST(sys.babelfish_get_sequence_value(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname)) AS SQL_VARIANT) AS last_value
+  , CAST(0 as sys.BIT) as is_not_for_replication
+FROM sys.columns_internal() sc
+INNER JOIN pg_attribute a ON sc.out_name = a.attname AND sc.out_column_id = a.attnum
+INNER JOIN pg_class c ON c.oid = a.attrelid
+INNER JOIN sys.pg_namespace_ext ext ON ext.oid = c.relnamespace
+WHERE NOT a.attisdropped
+AND sc.out_is_identity::INTEGER = 1
+AND pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname) IS NOT NULL
+AND has_sequence_privilege(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname), 'USAGE,SELECT,UPDATE');
+GRANT SELECT ON sys.identity_columns TO PUBLIC;
+
+CALL sys.babelfish_drop_deprecated_view('sys', 'identity_columns_deprecated');
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);

--- a/test/JDBC/expected/sys-filetables.out
+++ b/test/JDBC/expected/sys-filetables.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.filetables;
+GO
+~~START~~
+int#!#bit#!#varchar#!#int#!#varchar
+~~END~~
+

--- a/test/JDBC/expected/sys-registered_search_property_lists.out
+++ b/test/JDBC/expected/sys-registered_search_property_lists.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.registered_search_property_lists;
+GO
+~~START~~
+int#!#varchar#!#datetime#!#datetime#!#int
+~~END~~
+

--- a/test/JDBC/input/views/sys-filetables.sql
+++ b/test/JDBC/input/views/sys-filetables.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.filetables;
+GO

--- a/test/JDBC/input/views/sys-registered_search_property_lists.sql
+++ b/test/JDBC/input/views/sys-registered_search_property_lists.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.registered_search_property_lists;
+GO

--- a/test/JDBC/sql_expected/sys-identity_columns.out
+++ b/test/JDBC/sql_expected/sys-identity_columns.out
@@ -7,7 +7,7 @@ go
 SELECT seed_value, increment_value, last_value FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns');
 go
 ~~START~~
-bigint#!#bigint#!#bigint
+sql_variant#!#sql_variant#!#sql_variant
 1#!#1#!#1
 ~~END~~
 


### PR DESCRIPTION
### Description

This PR adds the stub implementations for sys.filetables, sys.registered_search_property_lists and updates sys.identity_columns. It also adds and updates the appropriate unit tests.

Task: BABELFISH-462, BABELFISH-470, BABELFISH-468.

Signed-off-by: Sertay Sener <seners@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.