### PR TITLE
NUMERIC overflow causes TDS error for aggregate function…

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -645,11 +645,29 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			/* select max(a) from t; max(a) is an Aggref */
 			Aggref *aggref = (Aggref *) expr;
 			TargetEntry *te;
+			const char *aggFuncName;
+			int32 typmod;
+			uint8_t precision, scale;
 
 			Assert(aggref->args != NIL);
 
 			te = (TargetEntry *) linitial(aggref->args);
-			return resolve_numeric_typmod_from_exp((Node *) te->expr);
+			typmod = resolve_numeric_typmod_from_exp((Node *) te->expr);
+			aggFuncName = get_func_name(aggref->aggfnoid);
+
+			scale = (typmod - VARHDRSZ) & 0xffff;
+			precision = ((typmod - VARHDRSZ) >> 16) & 0xffff;
+
+			/*
+			 * [BABEL-3074] NUMERIC overflow causes TDS error for aggregate
+			 * function sum(); resultant precision should be individual precision + 1
+			 */
+			if (aggFuncName && strlen(aggFuncName) == 3 &&
+					(strncmp(aggFuncName, "sum", 3) == 0))
+				precision++;
+
+			pfree(aggFuncName);
+			return ((precision << 16) | scale) + VARHDRSZ;
 		}
 		case T_PlaceHolderVar:
 		{

--- a/test/JDBC/expected/BABEL-785.out
+++ b/test/JDBC/expected/BABEL-785.out
@@ -183,7 +183,7 @@ select (100 / SUM((((size) * 8.00) / 1024))) from testTbl as T;
 go
 ~~START~~
 numeric
-0.0073942620526
+0.00739426205264
 ~~END~~
 
 

--- a/test/JDBC/expected/TestDecimal.out
+++ b/test/JDBC/expected/TestDecimal.out
@@ -544,3 +544,31 @@ numeric
 
 
 DROP TABLE decimal_table;
+
+# BABEL-3074
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount decimal(6, 2));
+INSERT INTO overflow_test VALUES (1, 5000.00);
+~~ROW COUNT: 1~~
+
+INSERT INTO overflow_test VALUES (2, 6000.00);
+~~ROW COUNT: 1~~
+
+SELECT count(*), sum(amount) FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#11000.00
+~~END~~
+
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#11100.00
+~~END~~
+
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
+~~START~~
+numeric
+1.16363636363636360
+~~END~~
+
+DROP TABLE overflow_test;

--- a/test/JDBC/expected/TestDecimal.out
+++ b/test/JDBC/expected/TestDecimal.out
@@ -553,9 +553,6 @@ INSERT INTO overflow_test VALUES (1, 5000.00);
 INSERT INTO overflow_test VALUES (2, 6000.00);
 ~~ROW COUNT: 1~~
 
-INSERT INTO overflow_test VALUES (2, 6000.00);
-~~ROW COUNT: 1~~
- 
 SELECT count(*), sum(amount) FROM overflow_test;
 ~~START~~
 int#!#numeric

--- a/test/JDBC/expected/TestDecimal.out
+++ b/test/JDBC/expected/TestDecimal.out
@@ -553,6 +553,9 @@ INSERT INTO overflow_test VALUES (1, 5000.00);
 INSERT INTO overflow_test VALUES (2, 6000.00);
 ~~ROW COUNT: 1~~
 
+INSERT INTO overflow_test VALUES (2, 6000.00);
+~~ROW COUNT: 1~~
+ 
 SELECT count(*), sum(amount) FROM overflow_test;
 ~~START~~
 int#!#numeric

--- a/test/JDBC/expected/TestNumeric.out
+++ b/test/JDBC/expected/TestNumeric.out
@@ -732,3 +732,31 @@ numeric#!#numeric
 
 
 drop table babel_2048_t1;
+
+# BABEL-3074
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount numeric(6, 2));
+INSERT INTO overflow_test VALUES (1, 5000.00);
+~~ROW COUNT: 1~~
+
+INSERT INTO overflow_test VALUES (2, 6000.00);
+~~ROW COUNT: 1~~
+
+SELECT count(*), sum(amount) FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#11000.00
+~~END~~
+
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#11100.00
+~~END~~
+
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
+~~START~~
+numeric
+1.16363636363636360
+~~END~~
+
+DROP TABLE overflow_test;

--- a/test/JDBC/expected/TestNumeric.out
+++ b/test/JDBC/expected/TestNumeric.out
@@ -741,9 +741,6 @@ INSERT INTO overflow_test VALUES (1, 5000.00);
 INSERT INTO overflow_test VALUES (2, 6000.00);
 ~~ROW COUNT: 1~~
 
-INSERT INTO overflow_test VALUES (2, 6000.00);
-~~ROW COUNT: 1~~
-
 SELECT count(*), sum(amount) FROM overflow_test;
 ~~START~~
 int#!#numeric

--- a/test/JDBC/expected/TestNumeric.out
+++ b/test/JDBC/expected/TestNumeric.out
@@ -741,6 +741,9 @@ INSERT INTO overflow_test VALUES (1, 5000.00);
 INSERT INTO overflow_test VALUES (2, 6000.00);
 ~~ROW COUNT: 1~~
 
+INSERT INTO overflow_test VALUES (2, 6000.00);
+~~ROW COUNT: 1~~
+
 SELECT count(*), sum(amount) FROM overflow_test;
 ~~START~~
 int#!#numeric

--- a/test/JDBC/input/datatypes/TestDecimal.txt
+++ b/test/JDBC/input/datatypes/TestDecimal.txt
@@ -178,3 +178,12 @@ insert into decimal_table values(0.00000000000000000000000000);
 SELECT * FROM decimal_table;
 
 DROP TABLE decimal_table;
+
+# BABEL-3074
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount decimal(6, 2));
+INSERT INTO overflow_test VALUES (1, 5000.00);
+INSERT INTO overflow_test VALUES (2, 6000.00);
+SELECT count(*), sum(amount) FROM overflow_test;
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
+DROP TABLE overflow_test;

--- a/test/JDBC/input/datatypes/TestNumeric.txt
+++ b/test/JDBC/input/datatypes/TestNumeric.txt
@@ -226,3 +226,12 @@ select case when a <= 1 then b - a when a > 1 then c - a end from babel_2048_t1;
 select Max(c-b), Min(c-b) from babel_2048_t1;
 
 drop table babel_2048_t1;
+
+# BABEL-3074
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount numeric(6, 2));
+INSERT INTO overflow_test VALUES (1, 5000.00);
+INSERT INTO overflow_test VALUES (2, 6000.00);
+SELECT count(*), sum(amount) FROM overflow_test;
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
+DROP TABLE overflow_test;


### PR DESCRIPTION
Description:
Without this fix, expected resultant precision for aggregate function SUM()
was always same as individual precision which caused numeric overflow
error when #digits in sum became 1 more than precision of individual
operand.

Task: BABEL-3074
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).