### PR TITLE
Add sys.filegroups, sys.stats, sys.master_files.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2353,7 +2353,7 @@ SELECT
    CAST(0 as sys.BIT) AS user_created,
    CAST(0 as sys.BIT) AS no_recompute,
    CAST(0 as sys.BIT) AS has_filter,
-   CAST('' as sys.NVARCHAR) AS filter_definition,
+   CAST('' as sys.NVARCHAR(4000)) AS filter_definition,
    CAST(0 as sys.BIT) AS is_temporary,
    CAST(0 as sys.BIT) AS is_incremental,
    CAST(0 as sys.BIT) AS has_persisted_sample,

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2290,3 +2290,74 @@ SELECT
 WHERE FALSE;
 GRANT SELECT ON sys.registered_search_property_lists TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.filegroups
+AS
+SELECT 
+   ds.name,
+   ds.data_space_id,
+   ds.type,
+   ds.type_desc,
+   ds.is_default,
+   ds.is_system,
+   CAST(NULL as UNIQUEIDENTIFIER) AS filegroup_guid,
+   CAST(0 as INT) AS log_filegroup_id,
+   CAST(0 as sys.BIT) AS is_read_only,
+   CAST(0 as sys.BIT) AS is_autogrow_all_files
+FROM sys.data_spaces ds WHERE type = 'FG';
+GRANT SELECT ON sys.filegroups TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.master_files
+AS
+SELECT
+    CAST(0 as INT) AS database_id,
+    CAST(0 as INT) AS file_id,
+    CAST(NULL as UNIQUEIDENTIFIER) AS file_guid,
+    CAST(0 as sys.TINYINT) AS type,
+    CAST('' as NVARCHAR(60)) AS type_desc,
+    CAST(0 as INT) AS data_space_id,
+    CAST('' as SYSNAME) AS name,
+    CAST('' as NVARCHAR(260)) AS physical_name,
+    CAST(0 as sys.TINYINT) AS state,
+    CAST('' as NVARCHAR(60)) AS state_desc,
+    CAST(0 as INT) AS size,
+    CAST(0 as INT) AS max_size,
+    CAST(0 as INT) AS growth,
+    CAST(0 as sys.BIT) AS is_media_read_only,
+    CAST(0 as sys.BIT) AS is_read_only,
+    CAST(0 as sys.BIT) AS is_sparse,
+    CAST(0 as sys.BIT) AS is_percent_growth,
+    CAST(0 as sys.BIT) AS is_name_reserved,
+    CAST(0 as NUMERIC(25,0)) AS create_lsn,
+    CAST(0 as NUMERIC(25,0)) AS drop_lsn,
+    CAST(0 as NUMERIC(25,0)) AS read_only_lsn,
+    CAST(0 as NUMERIC(25,0)) AS read_write_lsn,
+    CAST(0 as NUMERIC(25,0)) AS differential_base_lsn,
+    CAST(NULL as UNIQUEIDENTIFIER) AS differential_base_guid,
+    CAST(NULL as DATETIME) AS differential_base_time,
+    CAST(0 as NUMERIC(25,0)) AS redo_start_lsn,
+    CAST(NULL as UNIQUEIDENTIFIER) AS redo_start_fork_guid,
+    CAST(0 as NUMERIC(25,0)) AS redo_target_lsn,
+    CAST(NULL as UNIQUEIDENTIFIER) AS redo_target_fork_guid,
+    CAST(0 as NUMERIC(25,0)) AS backup_lsn,
+    CAST(0 as INT) AS credential_id
+WHERE FALSE;
+GRANT SELECT ON sys.master_files TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.stats
+AS
+SELECT 
+   CAST(0 as INT) AS object_id,
+   CAST('' as SYSNAME) AS name,
+   CAST(0 as INT) AS stats_id,
+   CAST(0 as sys.BIT) AS auto_created,
+   CAST(0 as sys.BIT) AS user_created,
+   CAST(0 as sys.BIT) AS no_recompute,
+   CAST(0 as sys.BIT) AS has_filter,
+   CAST('' as sys.NVARCHAR) AS filter_definition,
+   CAST(0 as sys.BIT) AS is_temporary,
+   CAST(0 as sys.BIT) AS is_incremental,
+   CAST(0 as sys.BIT) AS has_persisted_sample,
+   CAST(0 as INT) AS stats_generation_method,
+   CAST('' as VARCHAR(255)) AS stats_generation_method_desc
+WHERE FALSE;
+GRANT SELECT ON sys.stats TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -784,6 +784,78 @@ GRANT SELECT ON sys.identity_columns TO PUBLIC;
 
 CALL sys.babelfish_drop_deprecated_view('sys', 'identity_columns_deprecated');
 
+CREATE OR REPLACE VIEW sys.filegroups
+AS
+SELECT 
+   ds.name,
+   ds.data_space_id,
+   ds.type,
+   ds.type_desc,
+   ds.is_default,
+   ds.is_system,
+   CAST(NULL as UNIQUEIDENTIFIER) AS filegroup_guid,
+   CAST(0 as INT) AS log_filegroup_id,
+   CAST(0 as sys.BIT) AS is_read_only,
+   CAST(0 as sys.BIT) AS is_autogrow_all_files
+FROM sys.data_spaces ds WHERE type = 'FG';
+GRANT SELECT ON sys.filegroups TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.master_files
+AS
+SELECT
+    CAST(0 as INT) AS database_id,
+    CAST(0 as INT) AS file_id,
+    CAST(NULL as UNIQUEIDENTIFIER) AS file_guid,
+    CAST(0 as sys.TINYINT) AS type,
+    CAST('' as NVARCHAR(60)) AS type_desc,
+    CAST(0 as INT) AS data_space_id,
+    CAST('' as SYSNAME) AS name,
+    CAST('' as NVARCHAR(260)) AS physical_name,
+    CAST(0 as sys.TINYINT) AS state,
+    CAST('' as NVARCHAR(60)) AS state_desc,
+    CAST(0 as INT) AS size,
+    CAST(0 as INT) AS max_size,
+    CAST(0 as INT) AS growth,
+    CAST(0 as sys.BIT) AS is_media_read_only,
+    CAST(0 as sys.BIT) AS is_read_only,
+    CAST(0 as sys.BIT) AS is_sparse,
+    CAST(0 as sys.BIT) AS is_percent_growth,
+    CAST(0 as sys.BIT) AS is_name_reserved,
+    CAST(0 as NUMERIC(25,0)) AS create_lsn,
+    CAST(0 as NUMERIC(25,0)) AS drop_lsn,
+    CAST(0 as NUMERIC(25,0)) AS read_only_lsn,
+    CAST(0 as NUMERIC(25,0)) AS read_write_lsn,
+    CAST(0 as NUMERIC(25,0)) AS differential_base_lsn,
+    CAST(NULL as UNIQUEIDENTIFIER) AS differential_base_guid,
+    CAST(NULL as DATETIME) AS differential_base_time,
+    CAST(0 as NUMERIC(25,0)) AS redo_start_lsn,
+    CAST(NULL as UNIQUEIDENTIFIER) AS redo_start_fork_guid,
+    CAST(0 as NUMERIC(25,0)) AS redo_target_lsn,
+    CAST(NULL as UNIQUEIDENTIFIER) AS redo_target_fork_guid,
+    CAST(0 as NUMERIC(25,0)) AS backup_lsn,
+    CAST(0 as INT) AS credential_id
+WHERE FALSE;
+GRANT SELECT ON sys.master_files TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.stats
+AS
+SELECT 
+   CAST(0 as INT) AS object_id,
+   CAST('' as SYSNAME) AS name,
+   CAST(0 as INT) AS stats_id,
+   CAST(0 as sys.BIT) AS auto_created,
+   CAST(0 as sys.BIT) AS user_created,
+   CAST(0 as sys.BIT) AS no_recompute,
+   CAST(0 as sys.BIT) AS has_filter,
+   CAST('' as sys.NVARCHAR) AS filter_definition,
+   CAST(0 as sys.BIT) AS is_temporary,
+   CAST(0 as sys.BIT) AS is_incremental,
+   CAST(0 as sys.BIT) AS has_persisted_sample,
+   CAST(0 as INT) AS stats_generation_method,
+   CAST('' as VARCHAR(255)) AS stats_generation_method_desc
+WHERE FALSE;
+GRANT SELECT ON sys.stats TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -847,7 +847,7 @@ SELECT
    CAST(0 as sys.BIT) AS user_created,
    CAST(0 as sys.BIT) AS no_recompute,
    CAST(0 as sys.BIT) AS has_filter,
-   CAST('' as sys.NVARCHAR) AS filter_definition,
+   CAST('' as sys.NVARCHAR(4000)) AS filter_definition,
    CAST(0 as sys.BIT) AS is_temporary,
    CAST(0 as sys.BIT) AS is_incremental,
    CAST(0 as sys.BIT) AS has_persisted_sample,

--- a/test/JDBC/expected/sys-filegroups.out
+++ b/test/JDBC/expected/sys-filegroups.out
@@ -1,0 +1,7 @@
+SELECT * FROM sys.filegroups;
+GO
+~~START~~
+varchar#!#int#!#char#!#nvarchar#!#bit#!#bit#!#uniqueidentifier#!#int#!#bit#!#bit
+PRIMARY#!#1#!#FG#!#ROWS_FILEGROUP#!#1#!#0#!#<NULL>#!#0#!#0#!#0
+~~END~~
+

--- a/test/JDBC/expected/sys-master_files.out
+++ b/test/JDBC/expected/sys-master_files.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.master_files;
+GO
+~~START~~
+int#!#int#!#uniqueidentifier#!#tinyint#!#nvarchar#!#int#!#varchar#!#nvarchar#!#tinyint#!#nvarchar#!#int#!#int#!#int#!#bit#!#bit#!#bit#!#bit#!#bit#!#numeric#!#numeric#!#numeric#!#numeric#!#numeric#!#uniqueidentifier#!#datetime#!#numeric#!#uniqueidentifier#!#numeric#!#uniqueidentifier#!#numeric#!#int
+~~END~~
+

--- a/test/JDBC/expected/sys-stats.out
+++ b/test/JDBC/expected/sys-stats.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.stats;
+GO
+~~START~~
+int#!#varchar#!#int#!#bit#!#bit#!#bit#!#bit#!#nvarchar#!#bit#!#bit#!#bit#!#int#!#varchar
+~~END~~
+

--- a/test/JDBC/input/views/sys-filegroups.sql
+++ b/test/JDBC/input/views/sys-filegroups.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.filegroups;
+GO

--- a/test/JDBC/input/views/sys-master_files.sql
+++ b/test/JDBC/input/views/sys-master_files.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.master_files;
+GO

--- a/test/JDBC/input/views/sys-stats.sql
+++ b/test/JDBC/input/views/sys-stats.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.stats;
+GO


### PR DESCRIPTION
### Description

This PR adds the stub implementations for sys.filegroups, sys.stats, sys.master_files views along with the unit tests.

Task: BABELFISH-463, BABELFISH-464, BABELFISH-469.

Signed-off-by: Sertay Sener <seners@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.