### PR TITLE
Add sys.fulltext_catalogs, sys.fulltext_stoplists and sys.fulltext_indexes views.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2368,12 +2368,12 @@ SELECT
    CAST(0 as INT) AS fulltext_catalog_id,
    CAST('' as SYSNAME) AS name,
    CAST('' as NVARCHAR(260)) AS path,
-   CAST(0 as BIT) AS is_default,
-   CAST(0 as BIT) AS is_accent_sensitivity_on,
+   CAST(0 as sys.BIT) AS is_default,
+   CAST(0 as sys.BIT) AS is_accent_sensitivity_on,
    CAST(0 as INT) AS data_space_id,
    CAST(0 as INT) AS file_id,
    CAST(0 as INT) AS principal_id,
-   CAST(2 as BIT) AS is_importing
+   CAST(2 as sys.BIT) AS is_importing
 WHERE FALSE;
 GRANT SELECT ON sys.fulltext_catalogs TO PUBLIC;
 
@@ -2394,10 +2394,10 @@ SELECT
    CAST(0 as INT) AS object_id,
    CAST(0 as INT) AS unique_index_id,
    CAST(0 as INT) AS fulltext_catalog_id,
-   CAST(0 as BIT) AS is_enabled,
+   CAST(0 as sys.BIT) AS is_enabled,
    CAST('O' as CHAR(1)) AS change_tracking_state,
    CAST('' as NVARCHAR(60)) AS change_tracking_state_desc,
-   CAST(0 as BIT) AS has_crawl_completed,
+   CAST(0 as sys.BIT) AS has_crawl_completed,
    CAST('' as CHAR(1)) AS crawl_type,
    CAST('' as NVARCHAR(60)) AS crawl_type_desc,
    CAST(NULL as DATETIME) AS crawl_start_date,

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2361,3 +2361,50 @@ SELECT
    CAST('' as VARCHAR(255)) AS stats_generation_method_desc
 WHERE FALSE;
 GRANT SELECT ON sys.stats TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.fulltext_catalogs
+AS
+SELECT 
+   CAST(0 as INT) AS fulltext_catalog_id,
+   CAST('' as SYSNAME) AS name,
+   CAST('' as NVARCHAR(260)) AS path,
+   CAST(0 as BIT) AS is_default,
+   CAST(0 as BIT) AS is_accent_sensitivity_on,
+   CAST(0 as INT) AS data_space_id,
+   CAST(0 as INT) AS file_id,
+   CAST(0 as INT) AS principal_id,
+   CAST(2 as BIT) AS is_importing
+WHERE FALSE;
+GRANT SELECT ON sys.fulltext_catalogs TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.fulltext_stoplists
+AS
+SELECT 
+   CAST(0 as INT) AS stoplist_id,
+   CAST('' as SYSNAME) AS name,
+   CAST(NULL as DATETIME) AS create_date,
+   CAST(NULL as DATETIME) AS modify_date,
+   CAST(0 as INT) AS Principal_id
+WHERE FALSE;
+GRANT SELECT ON sys.fulltext_stoplists TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.fulltext_indexes
+AS
+SELECT 
+   CAST(0 as INT) AS object_id,
+   CAST(0 as INT) AS unique_index_id,
+   CAST(0 as INT) AS fulltext_catalog_id,
+   CAST(0 as BIT) AS is_enabled,
+   CAST('O' as CHAR(1)) AS change_tracking_state,
+   CAST('' as NVARCHAR(60)) AS change_tracking_state_desc,
+   CAST(0 as BIT) AS has_crawl_completed,
+   CAST('' as CHAR(1)) AS crawl_type,
+   CAST('' as NVARCHAR(60)) AS crawl_type_desc,
+   CAST(NULL as DATETIME) AS crawl_start_date,
+   CAST(NULL as DATETIME) AS crawl_end_date,
+   CAST(NULL as BINARY(8)) AS incremental_timestamp,
+   CAST(0 as INT) AS stoplist_id,
+   CAST(0 as INT) AS data_space_id,
+   CAST(0 as INT) AS property_list_id
+WHERE FALSE;
+GRANT SELECT ON sys.fulltext_indexes TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -856,6 +856,53 @@ SELECT
 WHERE FALSE;
 GRANT SELECT ON sys.stats TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.fulltext_catalogs
+AS
+SELECT 
+   CAST(0 as INT) AS fulltext_catalog_id,
+   CAST('' as SYSNAME) AS name,
+   CAST('' as NVARCHAR(260)) AS path,
+   CAST(0 as BIT) AS is_default,
+   CAST(0 as BIT) AS is_accent_sensitivity_on,
+   CAST(0 as INT) AS data_space_id,
+   CAST(0 as INT) AS file_id,
+   CAST(0 as INT) AS principal_id,
+   CAST(2 as BIT) AS is_importing
+WHERE FALSE;
+GRANT SELECT ON sys.fulltext_catalogs TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.fulltext_stoplists
+AS
+SELECT 
+   CAST(0 as INT) AS stoplist_id,
+   CAST('' as SYSNAME) AS name,
+   CAST(NULL as DATETIME) AS create_date,
+   CAST(NULL as DATETIME) AS modify_date,
+   CAST(0 as INT) AS Principal_id
+WHERE FALSE;
+GRANT SELECT ON sys.fulltext_stoplists TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.fulltext_indexes
+AS
+SELECT 
+   CAST(0 as INT) AS object_id,
+   CAST(0 as INT) AS unique_index_id,
+   CAST(0 as INT) AS fulltext_catalog_id,
+   CAST(0 as BIT) AS is_enabled,
+   CAST('O' as CHAR(1)) AS change_tracking_state,
+   CAST('' as NVARCHAR(60)) AS change_tracking_state_desc,
+   CAST(0 as BIT) AS has_crawl_completed,
+   CAST('' as CHAR(1)) AS crawl_type,
+   CAST('' as NVARCHAR(60)) AS crawl_type_desc,
+   CAST(NULL as DATETIME) AS crawl_start_date,
+   CAST(NULL as DATETIME) AS crawl_end_date,
+   CAST(NULL as BINARY(8)) AS incremental_timestamp,
+   CAST(0 as INT) AS stoplist_id,
+   CAST(0 as INT) AS data_space_id,
+   CAST(0 as INT) AS property_list_id
+WHERE FALSE;
+GRANT SELECT ON sys.fulltext_indexes TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -862,12 +862,12 @@ SELECT
    CAST(0 as INT) AS fulltext_catalog_id,
    CAST('' as SYSNAME) AS name,
    CAST('' as NVARCHAR(260)) AS path,
-   CAST(0 as BIT) AS is_default,
-   CAST(0 as BIT) AS is_accent_sensitivity_on,
+   CAST(0 as sys.BIT) AS is_default,
+   CAST(0 as sys.BIT) AS is_accent_sensitivity_on,
    CAST(0 as INT) AS data_space_id,
    CAST(0 as INT) AS file_id,
    CAST(0 as INT) AS principal_id,
-   CAST(2 as BIT) AS is_importing
+   CAST(2 as sys.BIT) AS is_importing
 WHERE FALSE;
 GRANT SELECT ON sys.fulltext_catalogs TO PUBLIC;
 
@@ -888,10 +888,10 @@ SELECT
    CAST(0 as INT) AS object_id,
    CAST(0 as INT) AS unique_index_id,
    CAST(0 as INT) AS fulltext_catalog_id,
-   CAST(0 as BIT) AS is_enabled,
+   CAST(0 as sys.BIT) AS is_enabled,
    CAST('O' as CHAR(1)) AS change_tracking_state,
    CAST('' as NVARCHAR(60)) AS change_tracking_state_desc,
-   CAST(0 as BIT) AS has_crawl_completed,
+   CAST(0 as sys.BIT) AS has_crawl_completed,
    CAST('' as CHAR(1)) AS crawl_type,
    CAST('' as NVARCHAR(60)) AS crawl_type_desc,
    CAST(NULL as DATETIME) AS crawl_start_date,

--- a/test/JDBC/expected/sys-fulltext_catalogs.out
+++ b/test/JDBC/expected/sys-fulltext_catalogs.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.fulltext_catalogs;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data type bit is not supported yet)~~
+

--- a/test/JDBC/expected/sys-fulltext_catalogs.out
+++ b/test/JDBC/expected/sys-fulltext_catalogs.out
@@ -1,6 +1,6 @@
 SELECT * FROM sys.fulltext_catalogs;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: data type bit is not supported yet)~~
+~~START~~
+int#!#varchar#!#nvarchar#!#bit#!#bit#!#int#!#int#!#int#!#bit
+~~END~~
 

--- a/test/JDBC/expected/sys-fulltext_indexes.out
+++ b/test/JDBC/expected/sys-fulltext_indexes.out
@@ -1,6 +1,6 @@
 SELECT * FROM sys.fulltext_indexes;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: data type bit is not supported yet)~~
+~~START~~
+int#!#int#!#int#!#bit#!#char#!#nvarchar#!#bit#!#char#!#nvarchar#!#datetime#!#datetime#!#binary#!#int#!#int#!#int
+~~END~~
 

--- a/test/JDBC/expected/sys-fulltext_indexes.out
+++ b/test/JDBC/expected/sys-fulltext_indexes.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.fulltext_indexes;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data type bit is not supported yet)~~
+

--- a/test/JDBC/expected/sys-fulltext_stoplists.out
+++ b/test/JDBC/expected/sys-fulltext_stoplists.out
@@ -1,0 +1,6 @@
+SELECT * FROM sys.fulltext_stoplists;
+GO
+~~START~~
+int#!#varchar#!#datetime#!#datetime#!#int
+~~END~~
+

--- a/test/JDBC/input/views/sys-fulltext_catalogs.sql
+++ b/test/JDBC/input/views/sys-fulltext_catalogs.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.fulltext_catalogs;
+GO

--- a/test/JDBC/input/views/sys-fulltext_indexes.sql
+++ b/test/JDBC/input/views/sys-fulltext_indexes.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.fulltext_indexes;
+GO

--- a/test/JDBC/input/views/sys-fulltext_stoplists.sql
+++ b/test/JDBC/input/views/sys-fulltext_stoplists.sql
@@ -1,0 +1,2 @@
+SELECT * FROM sys.fulltext_stoplists;
+GO


### PR DESCRIPTION
### Description

This PR adds the stub implementations for sys.fulltext_catalogs, sys.fulltext_stoplists and sys.fulltext_indexes views along with the unit tests.

Tasks: BABELFISH-489, BABELFISH-490, BABELFISH-487.

Signed-off-by: Sertay Sener <seners@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.