### PR TITLE
fixed the problem : create tmp table inside trigger will cause the db crash 

### DIFF
--- a/test/JDBC/input/BABEL-3119.sql
+++ b/test/JDBC/input/BABEL-3119.sql
@@ -1,0 +1,37 @@
+CREATE TABLE t(c1 int)
+GO
+
+CREATE TRIGGER trfjk ON t
+instead of INSERT
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t(c1) VALUES(1) 
+GO
+
+CREATE TABLE t2(c1 int)
+GO
+
+CREATE TRIGGER trfjk2 ON t2
+instead of UPDATE
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t2(c1) VALUES(1) 
+GO
+
+drop trigger trfjk
+go
+
+drop trigger trfjk2
+go
+
+drop table t
+GO
+
+drop table t2
+GO

--- a/test/JDBC/sql_expected/BABEL-3119.out
+++ b/test/JDBC/sql_expected/BABEL-3119.out
@@ -1,0 +1,39 @@
+CREATE TABLE t(c1 int)
+GO
+
+CREATE TRIGGER trfjk ON t
+instead of INSERT
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t(c1) VALUES(1) 
+GO
+
+CREATE TABLE t2(c1 int)
+GO
+
+CREATE TRIGGER trfjk2 ON t2
+instead of UPDATE
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t2(c1) VALUES(1) 
+GO
+~~ROW COUNT: 1~~
+
+
+drop trigger trfjk
+go
+
+drop trigger trfjk2
+go
+
+drop table t
+GO
+
+drop table t2
+GO


### PR DESCRIPTION
fixed the problem : create tmp table inside trigger will cause the db crash  (#281)

create tmp table inside trigger will cause the PG crash due to TSQL tmp table check inside PG runtime
To fix it, we changed the tmp table check logic in TSQL inside PG runtime

Task: BABEL-3119
Signed-off-by: Zhibai Song <szh@amazon.com>

Co-authored-by: Zhibai Song <szh@amazon.com>

### Description

he following sequence crashes the BABEL server:

````
1> CREATE TABLE t(c1 int)
2> GO

1> CREATE TRIGGER trfjk ON t
2> INSTEAD OF INSERT
3> AS
4> DECLARE @a int
5> CREATE TABLE #t(c1 int) --This one is causing the problem
6> GO

1> INSERT INTO t(c1) VALUES(1) 
2> go
TCP Provider: An existing connection was forcibly closed by the remote host.
Communication link failure
```` 

### Issues Resolved

the specific sql won't crash server
[List any issues this PR will resolve]
 
### Check List

- Task : BABEL-3119
- Signed-off-by: Zhibai Song szh@amazon.com 

[List any issues this PR will resolve]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
