### PR TITLE
Fix tds_collation_id and tds_collation_sort_id fields of sp_describe_first_result_set procedure

### DIFF
--- a/contrib/babelfishpg_tsql/src/collationproperty.c
+++ b/contrib/babelfishpg_tsql/src/collationproperty.c
@@ -37,6 +37,14 @@ Datum collationproperty(PG_FUNCTION_ARGS) {
 		PG_RETURN_BYTEA_P(convertIntToSQLVariantByteA(coll.style));
 	    else if (strcasecmp(property, "Version") == 0)
 		PG_RETURN_BYTEA_P(convertIntToSQLVariantByteA(coll.ver));
+	    /*
+	     * Below properties are added for internal usage with sp_describe_first_result_set
+	     * to return correct tds_collation_id and tds_collation_sort_id fields.
+	     */
+	    else if (strcasecmp(property, "CollationId") == 0)
+		PG_RETURN_BYTEA_P(convertIntToSQLVariantByteA((coll.collateflags << 20) | coll.lcid));
+	    else if (strcasecmp(property, "SortId") == 0)
+		PG_RETURN_BYTEA_P(convertIntToSQLVariantByteA(coll.sortid));
 	    else
 		PG_RETURN_NULL();
 	}

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -318,8 +318,8 @@ static char *sp_describe_first_result_set_query(char *viewName)
 			"WHEN t3.\"DATA_TYPE\" = \'decimal\' THEN 17 "
 			"ELSE t4.max_length END as int) "
 		"as tds_length, "
-		"CAST(NULL as int) as tds_collation_id, "
-		"CAST(NULL AS sys.tinyint) AS tds_collation_sort_id "
+		"CAST(COLLATIONPROPERTY(t4.collation_name, 'CollationId') as int) as tds_collation_id, "
+		"CAST(COLLATIONPROPERTY(t4.collation_name, 'SortId') as int) AS tds_collation_sort_id "
 	"FROM information_schema.columns t1, information_schema_tsql.columns t3, "
 	"sys.columns t4, pg_class t5 "
 	"LEFT OUTER JOIN (sys.babelfish_namespace_ext ext JOIN sys.pg_namespace_ext t6 ON t6.nspname = ext.nspname) "
@@ -383,7 +383,7 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 		}
 
 		/* If TSQL Query is NULL string or a non-select query then send no rows. */
-		if (parsedbatch && strncmp(parsedbatch, "select", 6) == 0)
+		if (parsedbatch && strncasecmp(parsedbatch, "select", 6) == 0)
 		{
 			sp_describe_first_result_set_inprogress = true;
 			query = psprintf("CREATE VIEW %s as %s", sp_describe_first_result_set_view_name, parsedbatch);

--- a/test/JDBC/expected/BABEL-3000.out
+++ b/test/JDBC/expected/BABEL-3000.out
@@ -23,7 +23,7 @@ exec sp_describe_first_result_set N'select * from var'
 go
 ~~START~~
 bit#!#int#!#varchar#!#bit#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#varchar#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#smallint#!#smallint#!#smallint#!#int#!#int#!#int#!#tinyint
-0#!#1#!#a#!#1#!#25#!#text#!#-1#!#0#!#0#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#35#!#16#!#<NULL>#!#<NULL>
+0#!#1#!#a#!#1#!#25#!#text#!#-1#!#0#!#0#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#35#!#16#!#13632521#!#52
 0#!#2#!#b#!#1#!#142#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#241#!#8100#!#<NULL>#!#<NULL>
 ~~END~~
 


### PR DESCRIPTION
### Description

Fix tds_collation_id and tds_collation_sort_id fields of sp_describe_first_result_set procedure

BCP in functionality with any collations other than english collation
was failing because of incorrect configuration of tds_collation_id and
tds_collation_sort_id fields of sp_describe_first_result_set procedure
which BCP utility internally uses to determine metadata.

This commit fixes tds_collation_id and tds_collation_sort_id fields by
adding appropriate property support in COLLATIONPROPERTY() which will be
used by sp_describe_first_result_set.

Task: BABEL-3316
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).