### PR TITLE
[BABEL-2769] Nullable DATETIME column does not store NULL; [BABEL-330…

### DIFF
--- a/contrib/babelfishpg_common/sql/datetime.sql
+++ b/contrib/babelfishpg_common/sql/datetime.sql
@@ -43,7 +43,6 @@ CREATE TYPE sys.DATETIME (
 	CATEGORY       = 'D',
 	PREFERRED      = false,
 	COLLATABLE     = false,
-    DEFAULT        = '1900-01-01 00:00:00',
     PASSEDBYVALUE
 );
 

--- a/contrib/babelfishpg_common/sql/datetime2.sql
+++ b/contrib/babelfishpg_common/sql/datetime2.sql
@@ -43,7 +43,6 @@ CREATE TYPE sys.DATETIME2 (
 	CATEGORY       = 'D',
 	PREFERRED      = false,
 	COLLATABLE     = false,
-    DEFAULT        = '1900-01-01 00:00:00',
     PASSEDBYVALUE
 );
 

--- a/contrib/babelfishpg_common/sql/datetimeoffset.sql
+++ b/contrib/babelfishpg_common/sql/datetimeoffset.sql
@@ -41,8 +41,7 @@ CREATE TYPE sys.DATETIMEOFFSET (
 	ALIGNMENT      = 'double',
 	STORAGE        = 'plain',
 	CATEGORY       = 'D',
-	PREFERRED      = false,
-    DEFAULT        = '1900-01-01 00:00+0'
+	PREFERRED      = false
 );
 
 CREATE FUNCTION sys.datetimeoffseteq(sys.DATETIMEOFFSET, sys.DATETIMEOFFSET)

--- a/contrib/babelfishpg_common/sql/smalldatetime.sql
+++ b/contrib/babelfishpg_common/sql/smalldatetime.sql
@@ -43,7 +43,6 @@ CREATE TYPE sys.SMALLDATETIME (
 	CATEGORY       = 'D',
 	PREFERRED      = false,
 	COLLATABLE     = false,
-    DEFAULT        = '1900-01-01 00:00',
     PASSEDBYVALUE
 );
 

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.1.0--2.2.0.sql
@@ -8,5 +8,17 @@ RETURNS sys.DATETIME2
 AS 'babelfishpg_common', 'sqlvariant2datetime2'
 LANGUAGE C VOLATILE STRICT PARALLEL SAFE;
 
+-- [BABEL-2769] Nullable DATETIME column does not store NULL
+-- Solution: Setting typdefault to NULL for datetime, smalldatetime,
+-- datetime2, datetimeoffset datatypes in pg_type table
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'smalldatetime';
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'datetime';
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'datetime2';
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'datetimeoffset';
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_common/src/datetime.c
+++ b/contrib/babelfishpg_common/src/datetime.c
@@ -64,6 +64,13 @@ datetime_in_str(char *str)
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
 
+	/* Set input to default '1900-01-01 00:00:00.000' if empty string encountered */
+	if (*str == '\0')
+	{
+		result = initializeToDefaultDatetime();
+		PG_RETURN_TIMESTAMP(result);
+	}
+
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
@@ -597,4 +604,21 @@ datetime_mi_float8(PG_FUNCTION_ARGS)
 
 	CheckDatetimeRange(result);
 	PG_RETURN_TIMESTAMP(result);
+}
+
+/* Set input to default '1900-01-01 00:00:00' if empty string encountered */
+Timestamp
+initializeToDefaultDatetime(void)
+{
+	Timestamp result;
+	struct pg_tm tt, *tm = &tt;
+
+	tm->tm_year = 1900;
+	tm->tm_mon = 1;
+	tm->tm_mday = 1;
+	tm->tm_hour = tm->tm_min = tm->tm_sec = 0;
+
+	tm2timestamp(tm, 0, NULL, &result);
+
+	return result;
 }

--- a/contrib/babelfishpg_common/src/datetime.h
+++ b/contrib/babelfishpg_common/src/datetime.h
@@ -28,4 +28,6 @@
 /* Range-check a datetime */
 #define IS_VALID_DATETIME(t)  (MIN_DATETIME <= (t) && (t) < END_DATETIME)
 
+extern Timestamp initializeToDefaultDatetime(void);
+
 #endif							/* PLTSQL_DATETIME_H */

--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -17,7 +17,7 @@
 
 #include "miscadmin.h"
 #include "datetime2.h"
-
+#include "datetime.h"
 
 PG_FUNCTION_INFO_V1(datetime2_in);
 PG_FUNCTION_INFO_V1(datetime2_out);
@@ -55,6 +55,15 @@ datetime2_in_str(char *str, int32 typmod)
 	char	   *field[MAXDATEFIELDS];
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
+
+	/* Set input to default '1900-01-01 00:00:00.* if empty string encountered */
+	if (*str == '\0')
+	{
+		result = initializeToDefaultDatetime();
+		AdjustDatetime2ForTypmod(&result, typmod);
+
+		PG_RETURN_TIMESTAMP(result);
+	}
 
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -17,6 +17,7 @@
 #include "fmgr.h"
 #include "miscadmin.h"
 #include "datetimeoffset.h"
+#include "datetime.h"
 
 static void AdjustDatetimeoffsetForTypmod(Timestamp *time, int32 typmod);
 static void CheckDatetimeoffsetRange(const tsql_datetimeoffset* df);
@@ -92,6 +93,17 @@ datetimeoffset_in(PG_FUNCTION_ARGS)
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
 
 	datetimeoffset = (tsql_datetimeoffset *)palloc(DATETIMEOFFSET_LEN);
+
+	/* Set input to default '1900-01-01 00:00:00.* 00:00' if empty string encountered */
+	if (*str == '\0')
+	{
+		tsql_ts = initializeToDefaultDatetime();
+		AdjustDatetimeoffsetForTypmod(&tsql_ts, typmod);
+		datetimeoffset->tsql_ts = (int64)tsql_ts;
+		datetimeoffset->tsql_tz = 0;
+		PG_RETURN_DATETIMEOFFSET(datetimeoffset);
+	}
+
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 

--- a/contrib/babelfishpg_common/src/smalldatetime.c
+++ b/contrib/babelfishpg_common/src/smalldatetime.c
@@ -15,6 +15,7 @@
 #include "utils/timestamp.h"
 
 #include "miscadmin.h"
+#include "datetime.h"
 
 PG_FUNCTION_INFO_V1(smalldatetime_in);
 PG_FUNCTION_INFO_V1(smalldatetime_recv);
@@ -63,6 +64,15 @@ smalldatetime_in_str(char *str)
 	char	   *field[MAXDATEFIELDS];
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
+
+	/* Set input to default '1900-01-01 00:00:00' if empty string encountered */
+	if (*str == '\0')
+	{
+		result = initializeToDefaultDatetime();
+		AdjustTimestampForSmallDatetime(&result);
+
+		PG_RETURN_TIMESTAMP(result);
+	}
 
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);

--- a/test/JDBC/expected/ISC-Domains.out
+++ b/test/JDBC/expected/ISC-Domains.out
@@ -66,9 +66,9 @@ master#!#isc_domains#!#binary_t#!#binary#!#8#!#8#!#<NULL>#!#<NULL>#!#<NULL>#!#<N
 master#!#isc_domains#!#bit_t#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#char_t#!#char#!#10#!#10#!#<NULL>#!#<NULL>#!#sql_latin1_general_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#date_t#!#date#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>
-master#!#isc_domains#!#datetime2_t#!#datetime2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#1900-01-01 00:00:00
-master#!#isc_domains#!#datetime_t#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#1900-01-01 00:00:00
-master#!#isc_domains#!#datetimeoffset_t#!#datetimeoffset#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#1900-01-01 00:00+0
+master#!#isc_domains#!#datetime2_t#!#datetime2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#<NULL>
+master#!#isc_domains#!#datetime_t#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#<NULL>
+master#!#isc_domains#!#datetimeoffset_t#!#datetimeoffset#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#<NULL>
 master#!#isc_domains#!#image_t#!#image#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#int_t#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#money_t#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#19#!#10#!#4#!#<NULL>#!#<NULL>
@@ -78,7 +78,7 @@ master#!#isc_domains#!#ntext_t#!#ntext#!#1073741823#!#2147483646#!#<NULL>#!#<NUL
 master#!#isc_domains#!#numeric_t#!#numeric#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#10#!#3#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#nvarchar_t#!#nvarchar#!#8#!#16#!#<NULL>#!#<NULL>#!#sql_latin1_general_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#real_t#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#24#!#2#!#<NULL>#!#<NULL>#!#<NULL>
-master#!#isc_domains#!#smalldatetime_t#!#smalldatetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#1900-01-01 00:00
+master#!#isc_domains#!#smalldatetime_t#!#smalldatetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>
 master#!#isc_domains#!#smallint_t#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#smallmoney_t#!#smallmoney#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#10#!#10#!#4#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#sql_variant_t#!#sql_variant#!#0#!#0#!#<NULL>#!#<NULL>#!#sql_latin1_general_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>

--- a/test/JDBC/expected/babel_datetime.out
+++ b/test/JDBC/expected/babel_datetime.out
@@ -9,7 +9,7 @@ select a from t1 where b = 1
 go
 ~~START~~
 datetime
-1900-01-01 00:00:00.0
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_datetime2.out
+++ b/test/JDBC/expected/babel_datetime2.out
@@ -559,7 +559,7 @@ select a from t1 where b = 1;
 go
 ~~START~~
 datetime2
-1900-01-01 00:00:00.000000
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_datetimeoffset.out
+++ b/test/JDBC/expected/babel_datetimeoffset.out
@@ -105,7 +105,7 @@ select a from t1 where b = 1;
 go
 ~~START~~
 datetimeoffset
-1900-01-01 00:00:00.000000 +00:00
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_smalldatetime.out
+++ b/test/JDBC/expected/babel_smalldatetime.out
@@ -308,7 +308,7 @@ go
 
 ~~START~~
 smalldatetime
-1900-01-01 00:00:00.0
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/nullableDatetime.out
+++ b/test/JDBC/expected/nullableDatetime.out
@@ -1,0 +1,181 @@
+
+-- [BABEL-2769] Nullable DATETIME column does not store NULL
+CREATE DATABASE db_babel_2769;
+go
+
+USE db_babel_2769;
+go
+
+CREATE TABLE Smalldatetime2769 (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM Smalldatetime2769;
+go
+~~START~~
+varchar#!#smalldatetime
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE Smalldatetime2769;
+go
+
+CREATE TABLE Datetime2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO Datetime2769 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM Datetime2769;
+go
+~~START~~
+varchar#!#datetime
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE Datetime2769;
+go
+
+CREATE TABLE Datetime2_2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM Datetime2_2769;
+go
+~~START~~
+varchar#!#datetime2
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE Datetime2_2769;
+go
+
+CREATE TABLE Datetimeoffset2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM Datetimeoffset2769;
+go
+~~START~~
+varchar#!#datetimeoffset
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE Datetimeoffset2769;
+go
+
+create table #srtestnull_t1 (a varchar(2), dt smalldatetime null);
+go
+insert into #srtestnull_t1 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+insert into #srtestnull_t1 (a) values ('B');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t1;
+go
+~~START~~
+varchar#!#smalldatetime
+A#!#1900-01-01 00:00:00.0
+B#!#<NULL>
+~~END~~
+
+drop table #srtestnull_t1;
+go
+
+create table #srtestnull_t2 (a varchar(2), dt datetime null);
+go
+insert into #srtestnull_t2 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+insert into #srtestnull_t2 (a) values ('B');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t2;
+go
+~~START~~
+varchar#!#datetime
+A#!#1900-01-01 00:00:00.0
+B#!#<NULL>
+~~END~~
+
+drop table #srtestnull_t2;
+go
+
+create table #srtestnull_t3 (a varchar(2), dt datetime2(4) null);
+go
+insert into #srtestnull_t3 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+insert into #srtestnull_t3 (a) values ('B');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t3;
+go
+~~START~~
+varchar#!#datetime2
+A#!#1900-01-01 00:00:00.0000
+B#!#<NULL>
+~~END~~
+
+drop table #srtestnull_t3;
+go
+
+create table #srtestnull_t4 (a varchar(2), dt datetimeoffset(6) null);
+go
+insert into #srtestnull_t4 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+insert into #srtestnull_t4 (a) values ('B');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t4;
+go
+~~START~~
+varchar#!#datetimeoffset
+A#!#1900-01-01 00:00:00.000000 +00:00
+B#!#<NULL>
+~~END~~
+
+drop table #srtestnull_t4;
+go
+
+USE master;
+go
+
+DROP DATABASE db_babel_2769;
+go

--- a/test/JDBC/input/nullableDatetime.sql
+++ b/test/JDBC/input/nullableDatetime.sql
@@ -1,0 +1,101 @@
+-- [BABEL-2769] Nullable DATETIME column does not store NULL
+
+CREATE DATABASE db_babel_2769;
+go
+
+USE db_babel_2769;
+go
+
+CREATE TABLE Smalldatetime2769 (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('Second');
+go
+SELECT * FROM Smalldatetime2769;
+go
+DROP TABLE Smalldatetime2769;
+go
+
+CREATE TABLE Datetime2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('Second');
+go
+SELECT * FROM Datetime2769;
+go
+DROP TABLE Datetime2769;
+go
+
+CREATE TABLE Datetime2_2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('Second');
+go
+SELECT * FROM Datetime2_2769;
+go
+DROP TABLE Datetime2_2769;
+go
+
+CREATE TABLE Datetimeoffset2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('Second');
+go
+SELECT * FROM Datetimeoffset2769;
+go
+DROP TABLE Datetimeoffset2769;
+go
+
+create table #srtestnull_t1 (a varchar(2), dt smalldatetime null);
+go
+insert into #srtestnull_t1 values ('A', '');
+go
+insert into #srtestnull_t1 (a) values ('B');
+go
+select * from #srtestnull_t1;
+go
+drop table #srtestnull_t1;
+go
+
+create table #srtestnull_t2 (a varchar(2), dt datetime null);
+go
+insert into #srtestnull_t2 values ('A', '');
+go
+insert into #srtestnull_t2 (a) values ('B');
+go
+select * from #srtestnull_t2;
+go
+drop table #srtestnull_t2;
+go
+
+create table #srtestnull_t3 (a varchar(2), dt datetime2(4) null);
+go
+insert into #srtestnull_t3 values ('A', '');
+go
+insert into #srtestnull_t3 (a) values ('B');
+go
+select * from #srtestnull_t3;
+go
+drop table #srtestnull_t3;
+go
+
+create table #srtestnull_t4 (a varchar(2), dt datetimeoffset(6) null);
+go
+insert into #srtestnull_t4 values ('A', '');
+go
+insert into #srtestnull_t4 (a) values ('B');
+go
+select * from #srtestnull_t4;
+go
+drop table #srtestnull_t4;
+go
+
+USE master;
+go
+
+DROP DATABASE db_babel_2769;
+go

--- a/test/JDBC/upgrade/preparation/BABEL-2769-prepare.sql
+++ b/test/JDBC/upgrade/preparation/BABEL-2769-prepare.sql
@@ -1,0 +1,61 @@
+CREATE DATABASE db_babel_2769;
+go
+
+USE db_babel_2769;
+go
+
+CREATE TABLE Smalldatetime2769 (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE Datetime2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE Datetime2_2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE Datetimeoffset2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('Second');
+go
+
+create table #srtestnull (a varchar(2), dt smalldatetime null);
+go
+insert into #srtestnull values ('A', '');
+go
+insert into #srtestnull (a) values ('B');
+go
+
+create table #srtestnull (a varchar(2), dt datetime null);
+go
+insert into #srtestnull values ('A', '');
+go
+insert into #srtestnull (a) values ('B');
+go
+
+create table #srtestnull (a varchar(2), dt datetime2(4) null);
+go
+insert into #srtestnull values ('A', '');
+go
+insert into #srtestnull (a) values ('B');
+go
+
+create table #srtestnull (a varchar(2), dt datetimeoffset(6) null);
+go
+insert into #srtestnull values ('A', '');
+go
+insert into #srtestnull (a) values ('B');
+go

--- a/test/JDBC/upgrade/verification/BABEL-2769-prepare.sql
+++ b/test/JDBC/upgrade/verification/BABEL-2769-prepare.sql
@@ -1,0 +1,63 @@
+-- [BABEL-2769] Nullable DATETIME column does not store NULL
+
+CREATE DATABASE db_babel_2769;
+go
+
+USE db_babel_2769;
+go
+
+CREATE TABLE Smalldatetime2769 (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Smalldatetime2769 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE Datetime2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetime2769 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE Datetime2_2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetime2_2769 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE Datetimeoffset2769 (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('First');
+go
+INSERT INTO Datetimeoffset2769 ( c1 ) VALUES ('Second');
+go
+
+create table #srtestnull_t1 (a varchar(2), dt smalldatetime null);
+go
+insert into #srtestnull_t1 values ('A', '');
+go
+insert into #srtestnull_t1 (a) values ('B');
+go
+
+create table #srtestnull_t2 (a varchar(2), dt datetime null);
+go
+insert into #srtestnull_t2 values ('A', '');
+go
+insert into #srtestnull_t2 (a) values ('B');
+go
+
+create table #srtestnull_t3 (a varchar(2), dt datetime2(4) null);
+go
+insert into #srtestnull_t3 values ('A', '');
+go
+insert into #srtestnull_t3 (a) values ('B');
+go
+
+create table #srtestnull_t4 (a varchar(2), dt datetimeoffset(6) null);
+go
+insert into #srtestnull_t4 values ('A', '');
+go
+insert into #srtestnull_t4 (a) values ('B');
+go

--- a/test/JDBC/upgrade/verification/BABEL-2769-verify.sql
+++ b/test/JDBC/upgrade/verification/BABEL-2769-verify.sql
@@ -1,0 +1,50 @@
+-- [BABEL-2769] Nullable DATETIME column does not store NULL
+
+USE db_babel_2769;
+go
+
+SELECT * FROM Smalldatetime2769;
+go
+DROP TABLE Smalldatetime2769;
+go
+
+SELECT * FROM Datetime2769;
+go
+DROP TABLE Datetime2769;
+go
+
+SELECT * FROM Datetime2_2769;
+go
+DROP TABLE Datetime2_2769;
+go
+
+SELECT * FROM Datetimeoffset2769;
+go
+DROP TABLE Datetimeoffset2769;
+go
+
+select * from #srtestnull_t1;
+go
+drop table #srtestnull_t1;
+go
+
+select * from #srtestnull_t2;
+go
+drop table #srtestnull_t2;
+go
+
+select * from #srtestnull_t3;
+go
+drop table #srtestnull_t3;
+go
+
+select * from #srtestnull_t4;
+go
+drop table #srtestnull_t4;
+go
+
+USE master;
+go
+
+DROP DATABASE db_babel_2769;
+go


### PR DESCRIPTION
### Description
[BABEL-2769] Nullable DATETIME column does not store NULL
[BABEL-3306] Support for empty input string handling in datetime, smalldatetime, datetime2, datetimeoffset datatypes

Before Fix:
1. Nullable datetime column was storing default datetime value '1900-01-01 *' instead of NULL
2. Empty input string for datetime column was throwing invalid input syntax error in Babelfish.

After Fix:
1. Nullable datetime column is returning NULL value for all datetime related datatypes. Fix includes
   dropping default stored value for new tables on these datatypes and setting typdefault to null on upgrade-script for existing tables.
2. Storing default datetime value '1900-01-01 *' whenever empty input string encountered.

Task: BABEL-2769, BABEL-3306
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).