### PR TITLE
Add catalog_default collation.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/collation.sql
+++ b/contrib/babelfishpg_tsql/sql/collation.sql
@@ -140,6 +140,8 @@ CREATE COLLATION IF NOT EXISTS sys.Vietnamese_CS_AS (provider = icu, locale = 'v
 CREATE COLLATION sys.Vietnamese_CI_AI (provider = icu, locale = 'vi_VN@colStrength=primary', deterministic = false);
 CREATE COLLATION sys.Vietnamese_CI_AS (provider = icu, locale = 'vi_VN@colStrength=secondary', deterministic = false);
 
+CREATE COLLATION IF NOT EXISTS catalog_default FROM ucs_basic;
+
 -- collation catalog
 create table sys.babelfish_helpcollation(
     Name VARCHAR(128) NOT NULL,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -675,6 +675,8 @@ GRANT SELECT ON sys.identity_columns TO PUBLIC;
 
 CALL sys.babelfish_drop_deprecated_view('sys', 'identity_columns_deprecated');
 
+CREATE COLLATION IF NOT EXISTS catalog_default FROM ucs_basic;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);

--- a/test/JDBC/expected/catalog-default-collation.out
+++ b/test/JDBC/expected/catalog-default-collation.out
@@ -1,0 +1,39 @@
+CREATE TABLE col_test1 (a varchar(128) COLLATE CATALOG_DEFAULT);
+insert into col_test1 values 
+('Hello'), 
+('Holla');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE col_test2 (a nvarchar(128) COLLATE CATALOG_DEFAULT);
+insert into col_test2 values 
+('Bonjour'),
+('Guten Tag');
+GO
+~~ROW COUNT: 2~~
+
+
+select a from col_test1;
+GO
+~~START~~
+varchar
+Hello
+Holla
+~~END~~
+
+
+select a from col_test2;
+GO
+~~START~~
+nvarchar
+Bonjour
+Guten Tag
+~~END~~
+
+
+drop table col_test1;
+GO
+
+drop table col_test2;
+GO

--- a/test/JDBC/input/catalog-default-collation.sql
+++ b/test/JDBC/input/catalog-default-collation.sql
@@ -1,0 +1,23 @@
+CREATE TABLE col_test1 (a varchar(128) COLLATE CATALOG_DEFAULT);
+insert into col_test1 values 
+('Hello'), 
+('Holla');
+GO
+
+CREATE TABLE col_test2 (a nvarchar(128) COLLATE CATALOG_DEFAULT);
+insert into col_test2 values 
+('Bonjour'),
+('Guten Tag');
+GO
+
+select a from col_test1;
+GO
+
+select a from col_test2;
+GO
+
+drop table col_test1;
+GO
+
+drop table col_test2;
+GO


### PR DESCRIPTION
### Description

This PR adds the missing catalog_default collation which is used by
SSMS. It also adds the related unit tests.

Task: BABELFISH-401

Signed-off-by: Sertay Sener <seners@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.