### PR TITLE
Add error to sp_describe_undeclared_parameters stored procedure for unsupported use case

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -642,6 +642,11 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 		/* Parse the list of parameters, and determine which and how many are undeclared. */
 		select_stmt = (SelectStmt *)insert_stmt->selectStmt;
 		values_list = select_stmt->valuesLists;
+		if (list_length(values_list) > 1) {
+			ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("Unsupported use case in sp_describe_undeclared_parameters")));
+		}
 		foreach(lc, values_list)
 		{
 			List *sublist = lfirst(lc);

--- a/test/JDBC/expected/sp_describe_undeclared_parameters.out
+++ b/test/JDBC/expected/sp_describe_undeclared_parameters.out
@@ -31,6 +31,24 @@ int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#
 ~~ERROR (Message: Unsupported use case in sp_describe_undeclared_parameters)~~
 
 
+EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (@P1), (@P2)'
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unsupported use case in sp_describe_undeclared_parameters)~~
+
+
+EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (@P1), (@P2), (@P3)'
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unsupported use case in sp_describe_undeclared_parameters)~~
+
+
 -- Done testing simple error scenario
 -- Set-up
 CREATE SCHEMA error_mapping;

--- a/test/JDBC/input/ErrorMapping/sp_describe_undeclared_parameters.sql
+++ b/test/JDBC/input/ErrorMapping/sp_describe_undeclared_parameters.sql
@@ -12,6 +12,12 @@ GO
 
 EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (1)';
 GO
+
+EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (@P1), (@P2)'
+GO
+
+EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (@P1), (@P2), (@P3)'
+GO
 -- Done testing simple error scenario
 
 -- Set-up

--- a/test/JDBC/sql_expected/sp_describe_undeclared_parameters.out
+++ b/test/JDBC/sql_expected/sp_describe_undeclared_parameters.out
@@ -25,6 +25,25 @@ int#!#nvarchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#nvarchar#
 ~~END~~
 
 
+EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (@P1), (@P2)'
+GO
+~~START~~
+int#!#nvarchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#nvarchar#!#int#!#int
+1#!#@P1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@P2#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+~~END~~
+
+
+EXEC sp_describe_undeclared_parameters @tsql = N'INSERT INTO simpletable VALUES (@P1), (@P2), (@P3)'
+GO
+~~START~~
+int#!#nvarchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#nvarchar#!#int#!#int
+1#!#@P1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@P2#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+3#!#@P3#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+~~END~~
+
+
 -- Done testing simple error scenario
 -- Set-up
 CREATE SCHEMA error_mapping;


### PR DESCRIPTION
### Description

This PR adds a new error message "Unsupported use case..." (error code 0A000) to the stored
procedure sp_describe_undeclared_parameters to avoid a possible segfault that could cause Babelfish to become unresponsive.

This error will occur if sp_describe_undeclared_parameters is called with more than one list of VALUES for an INSERT statement, e.g. sp_describe_undeclared_parameters @tsql = N'INSERT INTO mytable VALUES (@P1, @P2, @P3), (@P4, @P5, @P6)'.

Additionally, update the tests for sp_describe_undeclared_parameters to test this new unsupported use case error.

Task: BABELFISH-367

Signed-off-by: rossd-bitquill <dutkiert@amazon.com>
 
### Issues Resolved

sp_describe_undeclared_parameters previouly behaved unexpectedly when
provided with multiple VALUES lists for an INSERT statement.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).