### PR TITLE
Nullable DATETIME column does not store NULL

### DIFF
--- a/contrib/babelfishpg_common/sql/datetime.sql
+++ b/contrib/babelfishpg_common/sql/datetime.sql
@@ -43,7 +43,6 @@ CREATE TYPE sys.DATETIME (
 	CATEGORY       = 'D',
 	PREFERRED      = false,
 	COLLATABLE     = false,
-    DEFAULT        = '1900-01-01 00:00:00',
     PASSEDBYVALUE
 );
 

--- a/contrib/babelfishpg_common/sql/datetime2.sql
+++ b/contrib/babelfishpg_common/sql/datetime2.sql
@@ -43,7 +43,6 @@ CREATE TYPE sys.DATETIME2 (
 	CATEGORY       = 'D',
 	PREFERRED      = false,
 	COLLATABLE     = false,
-    DEFAULT        = '1900-01-01 00:00:00',
     PASSEDBYVALUE
 );
 

--- a/contrib/babelfishpg_common/sql/datetimeoffset.sql
+++ b/contrib/babelfishpg_common/sql/datetimeoffset.sql
@@ -41,8 +41,7 @@ CREATE TYPE sys.DATETIMEOFFSET (
 	ALIGNMENT      = 'double',
 	STORAGE        = 'plain',
 	CATEGORY       = 'D',
-	PREFERRED      = false,
-    DEFAULT        = '1900-01-01 00:00+0'
+	PREFERRED      = false
 );
 
 CREATE FUNCTION sys.datetimeoffseteq(sys.DATETIMEOFFSET, sys.DATETIMEOFFSET)

--- a/contrib/babelfishpg_common/sql/smalldatetime.sql
+++ b/contrib/babelfishpg_common/sql/smalldatetime.sql
@@ -43,7 +43,6 @@ CREATE TYPE sys.SMALLDATETIME (
 	CATEGORY       = 'D',
 	PREFERRED      = false,
 	COLLATABLE     = false,
-    DEFAULT        = '1900-01-01 00:00',
     PASSEDBYVALUE
 );
 

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.1.0--2.2.0.sql
@@ -107,5 +107,17 @@ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 CREATE CAST (FIXEDDECIMAL AS sys.DATETIME)
 WITH FUNCTION sys.money2datetime (FIXEDDECIMAL) AS IMPLICIT;
 
+-- Problem: Nullable DATETIME column does not store NULL
+-- Solution: Setting typdefault to NULL for datetime, smalldatetime,
+-- datetime2, datetimeoffset datatypes in pg_type table
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'smalldatetime' AND typname IN (SELECT name FROM sys.types);
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'datetime' AND typname IN (SELECT name FROM sys.types);
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'datetime2' AND typname IN (SELECT name FROM sys.types);
+
+UPDATE pg_type SET typdefault = null WHERE typname = 'datetimeoffset' AND typname IN (SELECT name FROM sys.types);
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/13_6__preparation__BABEL-2769-vu-prepare.out
+++ b/test/JDBC/expected/13_6__preparation__BABEL-2769-vu-prepare.out
@@ -1,0 +1,43 @@
+CREATE TABLE BABEL_2769_vu_prepare_Smalldatetime (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime2 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetimeoffset (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/14_3__preparation__BABEL-2769-vu-prepare.out
+++ b/test/JDBC/expected/14_3__preparation__BABEL-2769-vu-prepare.out
@@ -1,0 +1,43 @@
+CREATE TABLE BABEL_2769_vu_prepare_Smalldatetime (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime2 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetimeoffset (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/14_latest__verification_cleanup__13_6__BABEL-2769-vu-cleanup.out
+++ b/test/JDBC/expected/14_latest__verification_cleanup__13_6__BABEL-2769-vu-cleanup.out
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_2769_vu_cleanup_Smalldatetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime2;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetimeoffset;
+go

--- a/test/JDBC/expected/14_latest__verification_cleanup__13_6__BABEL-2769-vu-verify.out
+++ b/test/JDBC/expected/14_latest__verification_cleanup__13_6__BABEL-2769-vu-verify.out
@@ -1,0 +1,35 @@
+SELECT * FROM BABEL_2769_vu_verify_Smalldatetime;
+go
+~~START~~
+varchar#!#smalldatetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+~~END~~
+
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime;
+go
+~~START~~
+varchar#!#datetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+~~END~~
+
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime2;
+go
+~~START~~
+varchar#!#datetime2
+First#!#1900-01-01 00:00:00.000
+Second#!#1900-01-01 00:00:00.000
+~~END~~
+
+
+SELECT * FROM BABEL_2769_vu_verify_Datetimeoffset;
+go
+~~START~~
+varchar#!#datetimeoffset
+First#!#1900-01-01 00:00:00.00000 +00:00
+Second#!#1900-01-01 00:00:00.00000 +00:00
+~~END~~
+

--- a/test/JDBC/expected/14_latest__verification_cleanup__14_3__BABEL-2769-vu-cleanup.out
+++ b/test/JDBC/expected/14_latest__verification_cleanup__14_3__BABEL-2769-vu-cleanup.out
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_2769_vu_cleanup_Smalldatetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime2;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetimeoffset;
+go

--- a/test/JDBC/expected/14_latest__verification_cleanup__14_3__BABEL-2769-vu-verify.out
+++ b/test/JDBC/expected/14_latest__verification_cleanup__14_3__BABEL-2769-vu-verify.out
@@ -1,0 +1,35 @@
+SELECT * FROM BABEL_2769_vu_verify_Smalldatetime;
+go
+~~START~~
+varchar#!#smalldatetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+~~END~~
+
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime;
+go
+~~START~~
+varchar#!#datetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+~~END~~
+
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime2;
+go
+~~START~~
+varchar#!#datetime2
+First#!#1900-01-01 00:00:00.000
+Second#!#1900-01-01 00:00:00.000
+~~END~~
+
+
+SELECT * FROM BABEL_2769_vu_verify_Datetimeoffset;
+go
+~~START~~
+varchar#!#datetimeoffset
+First#!#1900-01-01 00:00:00.00000 +00:00
+Second#!#1900-01-01 00:00:00.00000 +00:00
+~~END~~
+

--- a/test/JDBC/expected/ISC-Domains.out
+++ b/test/JDBC/expected/ISC-Domains.out
@@ -66,9 +66,9 @@ master#!#isc_domains#!#binary_t#!#binary#!#8#!#8#!#<NULL>#!#<NULL>#!#<NULL>#!#<N
 master#!#isc_domains#!#bit_t#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#char_t#!#char#!#10#!#10#!#<NULL>#!#<NULL>#!#sql_latin1_general_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#date_t#!#date#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>
-master#!#isc_domains#!#datetime2_t#!#datetime2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#1900-01-01 00:00:00
-master#!#isc_domains#!#datetime_t#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#1900-01-01 00:00:00
-master#!#isc_domains#!#datetimeoffset_t#!#datetimeoffset#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#1900-01-01 00:00+0
+master#!#isc_domains#!#datetime2_t#!#datetime2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#<NULL>
+master#!#isc_domains#!#datetime_t#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#<NULL>
+master#!#isc_domains#!#datetimeoffset_t#!#datetimeoffset#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#<NULL>
 master#!#isc_domains#!#image_t#!#image#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#int_t#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#money_t#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#19#!#10#!#4#!#<NULL>#!#<NULL>
@@ -78,7 +78,7 @@ master#!#isc_domains#!#ntext_t#!#ntext#!#1073741823#!#2147483646#!#<NULL>#!#<NUL
 master#!#isc_domains#!#numeric_t#!#numeric#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#10#!#3#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#nvarchar_t#!#nvarchar#!#8#!#16#!#<NULL>#!#<NULL>#!#sql_latin1_general_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#real_t#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#24#!#2#!#<NULL>#!#<NULL>#!#<NULL>
-master#!#isc_domains#!#smalldatetime_t#!#smalldatetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#1900-01-01 00:00
+master#!#isc_domains#!#smalldatetime_t#!#smalldatetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>
 master#!#isc_domains#!#smallint_t#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#smallmoney_t#!#smallmoney#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#10#!#10#!#4#!#<NULL>#!#<NULL>
 master#!#isc_domains#!#sql_variant_t#!#sql_variant#!#0#!#0#!#<NULL>#!#<NULL>#!#sql_latin1_general_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>

--- a/test/JDBC/expected/babel_datetime.out
+++ b/test/JDBC/expected/babel_datetime.out
@@ -9,7 +9,7 @@ select a from t1 where b = 1
 go
 ~~START~~
 datetime
-1900-01-01 00:00:00.0
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_datetime2.out
+++ b/test/JDBC/expected/babel_datetime2.out
@@ -559,7 +559,7 @@ select a from t1 where b = 1;
 go
 ~~START~~
 datetime2
-1900-01-01 00:00:00.000000
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_datetimeoffset.out
+++ b/test/JDBC/expected/babel_datetimeoffset.out
@@ -105,7 +105,7 @@ select a from t1 where b = 1;
 go
 ~~START~~
 datetimeoffset
-1900-01-01 00:00:00.000000 +00:00
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_smalldatetime.out
+++ b/test/JDBC/expected/babel_smalldatetime.out
@@ -308,7 +308,7 @@ go
 
 ~~START~~
 smalldatetime
-1900-01-01 00:00:00.0
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/nullableDatetime.out
+++ b/test/JDBC/expected/nullableDatetime.out
@@ -1,0 +1,85 @@
+
+-- Nullable DATETIME column does not store NULL
+CREATE TABLE nullableDatetime_Smalldatetime (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO nullableDatetime_Smalldatetime ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO nullableDatetime_Smalldatetime ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM nullableDatetime_Smalldatetime;
+go
+~~START~~
+varchar#!#smalldatetime
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE nullableDatetime_Smalldatetime;
+go
+
+CREATE TABLE nullableDatetime_Datetime (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO nullableDatetime_Datetime ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO nullableDatetime_Datetime ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM nullableDatetime_Datetime;
+go
+~~START~~
+varchar#!#datetime
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE nullableDatetime_Datetime;
+go
+
+CREATE TABLE nullableDatetime_Datetime2 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO nullableDatetime_Datetime2 ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO nullableDatetime_Datetime2 ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM nullableDatetime_Datetime2;
+go
+~~START~~
+varchar#!#datetime2
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE nullableDatetime_Datetime2;
+go
+
+CREATE TABLE nullableDatetime_Datetimeoffset (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO nullableDatetime_Datetimeoffset ( c1 ) VALUES ('First');
+go
+~~ROW COUNT: 1~~
+
+INSERT INTO nullableDatetime_Datetimeoffset ( c1 ) VALUES ('Second');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM nullableDatetime_Datetimeoffset;
+go
+~~START~~
+varchar#!#datetimeoffset
+First#!#<NULL>
+Second#!#<NULL>
+~~END~~
+
+DROP TABLE nullableDatetime_Datetimeoffset;
+go

--- a/test/JDBC/input/nullableDatetime.sql
+++ b/test/JDBC/input/nullableDatetime.sql
@@ -1,0 +1,45 @@
+-- Nullable DATETIME column does not store NULL
+
+CREATE TABLE nullableDatetime_Smalldatetime (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO nullableDatetime_Smalldatetime ( c1 ) VALUES ('First');
+go
+INSERT INTO nullableDatetime_Smalldatetime ( c1 ) VALUES ('Second');
+go
+SELECT * FROM nullableDatetime_Smalldatetime;
+go
+DROP TABLE nullableDatetime_Smalldatetime;
+go
+
+CREATE TABLE nullableDatetime_Datetime (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO nullableDatetime_Datetime ( c1 ) VALUES ('First');
+go
+INSERT INTO nullableDatetime_Datetime ( c1 ) VALUES ('Second');
+go
+SELECT * FROM nullableDatetime_Datetime;
+go
+DROP TABLE nullableDatetime_Datetime;
+go
+
+CREATE TABLE nullableDatetime_Datetime2 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO nullableDatetime_Datetime2 ( c1 ) VALUES ('First');
+go
+INSERT INTO nullableDatetime_Datetime2 ( c1 ) VALUES ('Second');
+go
+SELECT * FROM nullableDatetime_Datetime2;
+go
+DROP TABLE nullableDatetime_Datetime2;
+go
+
+CREATE TABLE nullableDatetime_Datetimeoffset (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO nullableDatetime_Datetimeoffset ( c1 ) VALUES ('First');
+go
+INSERT INTO nullableDatetime_Datetimeoffset ( c1 ) VALUES ('Second');
+go
+SELECT * FROM nullableDatetime_Datetimeoffset;
+go
+DROP TABLE nullableDatetime_Datetimeoffset;
+go

--- a/test/JDBC/upgrade/13_6/preparation/BABEL-2769-vu-prepare.sql
+++ b/test/JDBC/upgrade/13_6/preparation/BABEL-2769-vu-prepare.sql
@@ -1,0 +1,27 @@
+CREATE TABLE BABEL_2769_vu_prepare_Smalldatetime (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime2 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetimeoffset (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Second');
+go

--- a/test/JDBC/upgrade/14_3/preparation/BABEL-2769-vu-prepare.sql
+++ b/test/JDBC/upgrade/14_3/preparation/BABEL-2769-vu-prepare.sql
@@ -1,0 +1,27 @@
+CREATE TABLE BABEL_2769_vu_prepare_Smalldatetime (c1 VARCHAR(32) NOT NULL, c2 SMALLDATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime (c1 VARCHAR(32) NOT NULL, c2 DATETIME NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetime2 (c1 VARCHAR(32) NOT NULL, c2 DATETIME2(3) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Second');
+go
+
+CREATE TABLE BABEL_2769_vu_prepare_Datetimeoffset (c1 VARCHAR(32) NOT NULL, c2 DATETIMEOFFSET(5) NULL);
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('First');
+go
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Second');
+go

--- a/test/JDBC/upgrade/14_latest/verification_cleanup/13_6/BABEL-2769-vu-cleanup.sql
+++ b/test/JDBC/upgrade/14_latest/verification_cleanup/13_6/BABEL-2769-vu-cleanup.sql
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_2769_vu_cleanup_Smalldatetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime2;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetimeoffset;
+go

--- a/test/JDBC/upgrade/14_latest/verification_cleanup/13_6/BABEL-2769-vu-verify.sql
+++ b/test/JDBC/upgrade/14_latest/verification_cleanup/13_6/BABEL-2769-vu-verify.sql
@@ -1,0 +1,11 @@
+SELECT * FROM BABEL_2769_vu_verify_Smalldatetime;
+go
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime;
+go
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime2;
+go
+
+SELECT * FROM BABEL_2769_vu_verify_Datetimeoffset;
+go

--- a/test/JDBC/upgrade/14_latest/verification_cleanup/14_3/BABEL-2769-vu-cleanup.sql
+++ b/test/JDBC/upgrade/14_latest/verification_cleanup/14_3/BABEL-2769-vu-cleanup.sql
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_2769_vu_cleanup_Smalldatetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetime2;
+go
+
+DROP TABLE BABEL_2769_vu_cleanup_Datetimeoffset;
+go

--- a/test/JDBC/upgrade/14_latest/verification_cleanup/14_3/BABEL-2769-vu-verify.sql
+++ b/test/JDBC/upgrade/14_latest/verification_cleanup/14_3/BABEL-2769-vu-verify.sql
@@ -1,0 +1,11 @@
+SELECT * FROM BABEL_2769_vu_verify_Smalldatetime;
+go
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime;
+go
+
+SELECT * FROM BABEL_2769_vu_verify_Datetime2;
+go
+
+SELECT * FROM BABEL_2769_vu_verify_Datetimeoffset;
+go

--- a/test/dotnet/ExpectedOutput/insertBulk.out
+++ b/test/dotnet/ExpectedOutput/insertBulk.out
@@ -307,7 +307,7 @@ hello#!#jello
 #Q#Select * from destinationTable
 #D#datetime#!#datetime
 12/13/2000 12:58:23#!#02/28/1900 23:59:59
-01/01/1900 00:00:00#!#12/31/9999 23:59:59
+#!#12/31/9999 23:59:59
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#Create table sourceTable(a smalldatetime, b smalldatetime not null)
@@ -321,7 +321,7 @@ hello#!#jello
 #Q#Select * from destinationTable
 #D#smalldatetime#!#smalldatetime
 05/08/2007 12:35:00#!#12/13/2000 12:58:00
-01/01/1900 00:00:00#!#02/28/2000 23:46:00
+#!#02/28/2000 23:46:00
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#Create table sourceTable(a Datetime2(6), b Datetime2(6) not null)
@@ -335,7 +335,7 @@ hello#!#jello
 #Q#Select * from destinationTable
 #D#datetime2#!#datetime2
 10/23/2016 12:45:37#!#10/23/2016 12:45:37
-01/01/1900 00:00:00#!#10/23/2016 12:45:37
+#!#10/23/2016 12:45:37
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#Create table sourceTable(a sql_variant, b sql_variant not null)

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -33,9 +33,6 @@ Could not find tests for function sys.openjson_with
 Could not find tests for function sys.parsename
 Could not find tests for function sys.proc_param_helper
 Could not find tests for function sys.role_id
-Could not find tests for function sys.suser_id_internal
-Could not find tests for function sys.suser_name_internal
-Could not find tests for function sys.space
 Could not find tests for function sys.sp_columns_100_internal
 Could not find tests for function sys.sp_columns_managed_internal
 Could not find tests for function sys.sp_datatype_info_helper
@@ -49,7 +46,10 @@ Could not find tests for function sys.sp_special_columns_precision_helper
 Could not find tests for function sys.sp_special_columns_scale_helper
 Could not find tests for function sys.sp_statistics_internal
 Could not find tests for function sys.sp_tables_internal
+Could not find tests for function sys.space
 Could not find tests for function sys.stuff
+Could not find tests for function sys.suser_id_internal
+Could not find tests for function sys.suser_name_internal
 Could not find tests for function sys.sysdatetime
 Could not find tests for function sys.timefromparts
 Could not find tests for function sys.tsql_get_returntypmodvalue
@@ -79,7 +79,6 @@ Could not find tests for procedure sys.sp_columns_managed
 Could not find tests for procedure sys.sp_databases
 Could not find tests for procedure sys.sp_helprole
 Could not find tests for procedure sys.sp_helprolemember
-Could not find tests for procedure sys.sp_helpuser
 Could not find tests for procedure sys.sp_oledb_ro_usrname
 Could not find tests for procedure sys.sp_special_columns_100
 Could not find tests for procedure sys.sp_sproc_columns_100
@@ -164,26 +163,26 @@ Could not find upgrade tests for function sys.fn_mapped_system_error_list
 Could not find upgrade tests for function sys.formatmessage
 Could not find upgrade tests for function sys.get_babel_server_collation_oid
 Could not find upgrade tests for function sys.get_current_full_xact_id
-Could not find upgrade tests for function sys.getdate
 Could not find upgrade tests for function sys.get_host_os
 Could not find upgrade tests for function sys.get_tds_id
+Could not find upgrade tests for function sys.getdate
 Could not find upgrade tests for function sys.getutcdate
 Could not find upgrade tests for function sys.has_dbaccess
-Could not find upgrade tests for function sys.hashbytes
 Could not find upgrade tests for function sys.has_perms_by_name
+Could not find upgrade tests for function sys.hashbytes
 Could not find upgrade tests for function sys.ident_current
 Could not find upgrade tests for function sys.ident_incr
 Could not find upgrade tests for function sys.ident_seed
 Could not find upgrade tests for function sys.is_collated_ci_as
 Could not find upgrade tests for function sys.is_collated_ci_as_internal
-Could not find upgrade tests for function sys.isdate
-Could not find upgrade tests for function sys.isjson
 Could not find upgrade tests for function sys.is_member
-Could not find upgrade tests for function sys.isnull
-Could not find upgrade tests for function sys.isnumeric
 Could not find upgrade tests for function sys.is_rolemember
 Could not find upgrade tests for function sys.is_rolemember_internal
 Could not find upgrade tests for function sys.is_table_type
+Could not find upgrade tests for function sys.isdate
+Could not find upgrade tests for function sys.isjson
+Could not find upgrade tests for function sys.isnull
+Could not find upgrade tests for function sys.isnumeric
 Could not find upgrade tests for function sys.json_query
 Could not find upgrade tests for function sys.json_value
 Could not find upgrade tests for function sys.language
@@ -211,14 +210,12 @@ Could not find upgrade tests for function sys.servername
 Could not find upgrade tests for function sys.servicename
 Could not find upgrade tests for function sys.sid_binary
 Could not find upgrade tests for function sys.sign
-Could not find upgrade tests for function sys.space
 Could not find upgrade tests for function sys.sp_columns_100_internal
 Could not find upgrade tests for function sys.sp_columns_managed_internal
 Could not find upgrade tests for function sys.sp_datatype_info_helper
 Could not find upgrade tests for function sys.sp_describe_first_result_set_internal
 Could not find upgrade tests for function sys.sp_describe_undeclared_parameters_internal
 Could not find upgrade tests for function sys.sp_getapplock_function
-Could not find upgrade tests for function sys.spid
 Could not find upgrade tests for function sys.sp_pkeys_internal
 Could not find upgrade tests for function sys.sp_releaseapplock_function
 Could not find upgrade tests for function sys.sp_special_columns_length_helper
@@ -226,6 +223,7 @@ Could not find upgrade tests for function sys.sp_special_columns_precision_helpe
 Could not find upgrade tests for function sys.sp_special_columns_scale_helper
 Could not find upgrade tests for function sys.sp_statistics_internal
 Could not find upgrade tests for function sys.sp_tables_internal
+Could not find upgrade tests for function sys.space
 Could not find upgrade tests for function sys.square
 Could not find upgrade tests for function sys.string_escape
 Could not find upgrade tests for function sys.string_split
@@ -249,7 +247,6 @@ Could not find upgrade tests for function sys.tsql_type_radix_for_sp_columns_hel
 Could not find upgrade tests for function sys.tsql_type_scale_helper
 Could not find upgrade tests for function sys.unicode
 Could not find upgrade tests for function sys.user_id
-Could not find upgrade tests for function sys.user_name
 Could not find upgrade tests for function sys.version
 Could not find upgrade tests for function sys.year
 Could not find upgrade tests for procedure babel_catalog_initializer
@@ -282,7 +279,6 @@ Could not find upgrade tests for procedure sys.sp_getapplock
 Could not find upgrade tests for procedure sys.sp_helpdb
 Could not find upgrade tests for procedure sys.sp_helprole
 Could not find upgrade tests for procedure sys.sp_helprolemember
-Could not find upgrade tests for procedure sys.sp_helpuser
 Could not find upgrade tests for procedure sys.sp_oledb_ro_usrname
 Could not find upgrade tests for procedure sys.sp_pkeys
 Could not find upgrade tests for procedure sys.sp_prepare
@@ -294,8 +290,8 @@ Could not find upgrade tests for procedure sys.sp_sproc_columns_100
 Could not find upgrade tests for procedure sys.sp_statistics
 Could not find upgrade tests for procedure sys.sp_statistics_100
 Could not find upgrade tests for procedure sys.sp_stored_procedures
-Could not find upgrade tests for procedure sys.sp_tablecollations_100
 Could not find upgrade tests for procedure sys.sp_table_privileges
+Could not find upgrade tests for procedure sys.sp_tablecollations_100
 Could not find upgrade tests for procedure sys.sp_tables
 Could not find upgrade tests for procedure sys.sp_unprepare
 Could not find upgrade tests for procedure sys.sp_updatestats
@@ -330,21 +326,19 @@ Could not find upgrade tests for view sys.change_tracking_databases
 Could not find upgrade tests for view sys.change_tracking_tables
 Could not find upgrade tests for view sys.check_constraints
 Could not find upgrade tests for view sys.computed_columns
+Could not find upgrade tests for view sys.data_spaces
 Could not find upgrade tests for view sys.database_files
 Could not find upgrade tests for view sys.database_filestream_options
 Could not find upgrade tests for view sys.database_recovery_status
 Could not find upgrade tests for view sys.database_role_members
-Could not find upgrade tests for view sys.data_spaces
 Could not find upgrade tests for view sys.default_constraints
-Could not find upgrade tests for view sys.dm_exec_connections
-Could not find upgrade tests for view sys.dm_exec_sessions
 Could not find upgrade tests for view sys.dm_hadr_cluster
 Could not find upgrade tests for view sys.dm_hadr_database_replica_states
 Could not find upgrade tests for view sys.dm_os_host_info
 Could not find upgrade tests for view sys.endpoints
 Could not find upgrade tests for view sys.filegroups
-Could not find upgrade tests for view sys.filetables
 Could not find upgrade tests for view sys.filetable_system_defined_objects
+Could not find upgrade tests for view sys.filetables
 Could not find upgrade tests for view sys.foreign_key_columns
 Could not find upgrade tests for view sys.foreign_keys
 Could not find upgrade tests for view sys.fulltext_catalogs
@@ -365,8 +359,6 @@ Could not find upgrade tests for view sys.registered_search_property_lists
 Could not find upgrade tests for view sys.schemas
 Could not find upgrade tests for view sys.selective_xml_index_paths
 Could not find upgrade tests for view sys.shipped_objects_not_in_sys
-Could not find upgrade tests for view sys.spatial_indexes
-Could not find upgrade tests for view sys.spatial_index_tessellations
 Could not find upgrade tests for view sys.sp_column_privileges_view
 Could not find upgrade tests for view sys.sp_columns_100_view
 Could not find upgrade tests for view sys.sp_databases_view
@@ -378,6 +370,8 @@ Could not find upgrade tests for view sys.sp_statistics_view
 Could not find upgrade tests for view sys.sp_stored_procedures_view
 Could not find upgrade tests for view sys.sp_table_privileges_view
 Could not find upgrade tests for view sys.sp_tables_view
+Could not find upgrade tests for view sys.spatial_index_tessellations
+Could not find upgrade tests for view sys.spatial_indexes
 Could not find upgrade tests for view sys.spt_columns_view_managed
 Could not find upgrade tests for view sys.spt_tablecollations_view
 Could not find upgrade tests for view sys.sql_modules
@@ -389,11 +383,10 @@ Could not find upgrade tests for view sys.sysdatabases
 Could not find upgrade tests for view sys.sysforeignkeys
 Could not find upgrade tests for view sys.sysindexes
 Could not find upgrade tests for view sys.syslanguages
-Could not find upgrade tests for view sys.sysprocesses
 Could not find upgrade tests for view sys.system_objects
 Could not find upgrade tests for view sys.system_sql_modules
-Could not find upgrade tests for view sys.tables
 Could not find upgrade tests for view sys.table_types
+Could not find upgrade tests for view sys.tables
 Could not find upgrade tests for view sys.triggers
 Could not find upgrade tests for view sys.types
 Could not find upgrade tests for view sys.views

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -22,10 +22,10 @@ Unexpected drop found for operator class sys.numeric_fixeddecimal_ops in file ba
 Unexpected drop found for operator class sys.numeric_fixeddecimal_ops in file babelfishpg_common--1.0.0--1.1.0.sql
 Unexpected drop found for operator family sys.fixeddecimal_ops in file babelfishpg_common--1.0.0--1.1.0.sql
 Unexpected drop found for operator family sys.fixeddecimal_ops in file babelfishpg_common--1.0.0--1.1.0.sql
-Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
-Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
-Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys.+ in file babelfishpg_common--1.1.0--1.2.0.sql
+Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
+Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
+Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_function in file babelfishpg_tsql--1.2.1--2.0.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_function in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--2.0.0--2.1.0.sql


### PR DESCRIPTION
### Description

Before Fix:
Nullable datetime column was storing default datetime value '1900-01-01 *' instead of NULL

After Fix:
Nullable datetime column is returning NULL value for all datetime related datatypes. Fix includes dropping default stored value for new tables on these datatypes and setting typdefault to null on upgrade-script for existing tables.

Task: BABEL-2769
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).