### PR TITLE
Fix DB crash while creating temporary table inside trigger

### DIFF
--- a/test/JDBC/input/BABEL-3119.sql
+++ b/test/JDBC/input/BABEL-3119.sql
@@ -1,0 +1,37 @@
+CREATE TABLE t(c1 int)
+GO
+
+CREATE TRIGGER trfjk ON t
+instead of INSERT
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t(c1) VALUES(1) 
+GO
+
+CREATE TABLE t2(c1 int)
+GO
+
+CREATE TRIGGER trfjk2 ON t2
+instead of UPDATE
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t2(c1) VALUES(1) 
+GO
+
+drop trigger trfjk
+go
+
+drop trigger trfjk2
+go
+
+drop table t
+GO
+
+drop table t2
+GO

--- a/test/JDBC/sql_expected/BABEL-3119.out
+++ b/test/JDBC/sql_expected/BABEL-3119.out
@@ -1,0 +1,39 @@
+CREATE TABLE t(c1 int)
+GO
+
+CREATE TRIGGER trfjk ON t
+instead of INSERT
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t(c1) VALUES(1) 
+GO
+
+CREATE TABLE t2(c1 int)
+GO
+
+CREATE TRIGGER trfjk2 ON t2
+instead of UPDATE
+AS
+DECLARE @a int
+CREATE TABLE #t2(c1 int) --This one is causing the problem
+GO
+
+INSERT INTO t2(c1) VALUES(1) 
+GO
+~~ROW COUNT: 1~~
+
+
+drop trigger trfjk
+go
+
+drop trigger trfjk2
+go
+
+drop table t
+GO
+
+drop table t2
+GO


### PR DESCRIPTION
Create temporary table inside trigger will cause the PG crash due to TSQL temp table check inside PG runtime. To fix it, we changed the temp table check logic in TSQL inside PG runtime. This commit introduces the test cases for the same.

Task: BABEL-3119
Authored-by: Zhibai Song szh@amazon.com
Signed-off-by: Kuntal Ghosh kuntalgh@amazon.com

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).