### PR TITLE
Error message correction for login permission

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2332,7 +2332,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 					if (!has_privs_of_role(GetSessionUserId(), get_role_oid("sysadmin", false))) 
 						ereport(ERROR,
 								(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-								errmsg("Current login %s do not have permission to create new login",
+								errmsg("Current login %s does not have permission to create new login",
 									GetUserNameFromId(GetSessionUserId(), true))));
 
 					if (get_role_oid(stmt->role, true) != InvalidOid)

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1327,7 +1327,7 @@ check_alter_server_stmt(GrantRoleStmt *stmt)
 	if (!has_privs_of_role(GetSessionUserId(), sysadmin))
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("Current login %s do not have permission to alter server role",
+				 errmsg("Current login %s does not have permission to alter server role",
 					 GetUserNameFromId(GetSessionUserId(), true))));
 
 	/* could not drop the last member of sysadmin */
@@ -1401,7 +1401,7 @@ check_alter_role_stmt(GrantRoleStmt *stmt)
 	if (!has_privs_of_role(GetSessionUserId(), granted))
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("Current login %s do not have permission to alter role %s", 
+				 errmsg("Current login %s does not have permission to alter role %s", 
 						GetUserNameFromId(GetSessionUserId(), true), granted_name)));
 }
 


### PR DESCRIPTION
Task: BABEL-3233
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).