### PR TITLE
Disable adding/dropping role members to db_owner

### DIFF
--- a/test/JDBC/expected/BABEL-ROLE.out
+++ b/test/JDBC/expected/BABEL-ROLE.out
@@ -195,6 +195,21 @@ GO
 ~~ERROR (Message: Cannot use the special principal 'db_owner')~~
 
 
+-- Add/drop member to db_owner, should fail before full support
+ALTER ROLE db_owner ADD MEMBER test1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Adding members to db_owner is not currently supported in Babelfish)~~
+
+
+ALTER ROLE db_owner DROP MEMBER test1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Dropping members to db_owner is not currently supported in Babelfish)~~
+
+
 CREATE USER test4
 GO
 

--- a/test/JDBC/input/BABEL-ROLE.sql
+++ b/test/JDBC/input/BABEL-ROLE.sql
@@ -129,6 +129,13 @@ GO
 ALTER ROLE test1 ADD MEMBER db_owner
 GO
 
+-- Add/drop member to db_owner, should fail before full support
+ALTER ROLE db_owner ADD MEMBER test1
+GO
+
+ALTER ROLE db_owner DROP MEMBER test1
+GO
+
 CREATE USER test4
 GO
 


### PR DESCRIPTION
Task: BABEL-3237
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).