### PR TITLE
Add support to run prepare and verify scripts in normal JDBC test run

### DIFF
--- a/test/JDBC/src/main/java/com/sqlsamples/Config.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/Config.java
@@ -26,6 +26,7 @@ public class Config {
     static boolean outputErrorCode = Boolean.parseBoolean(properties.getProperty("outputErrorCode"));
     static String scheduleFileName = properties.getProperty("scheduleFile");
     static String testFileRoot = properties.getProperty("testFileRoot");
+    static boolean isUpgradeTestMode =  Boolean.parseBoolean(properties.getProperty("isUpgradeTestMode"));
 
     static String connectionString = constructConnectionString();
 

--- a/test/JDBC/src/main/resources/config.txt
+++ b/test/JDBC/src/main/resources/config.txt
@@ -38,3 +38,6 @@ scheduleFile = ./jdbc_schedule
 
 # Where to find the input, output, expected, etc.
 testFileRoot = ./
+
+# WHETHER TEST RUN MODE IS UPGRADE TEST RUN
+isUpgradeTestMode = false

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -64,12 +64,12 @@ public class TestQueryFile {
     // helper function to fetch the prefix of a prepare,
     // verify or cleanup test file name
     public static String getFileNamePrefix (String fileName) {
-        if (fileName.contains("-prepare")) {
-            return fileName.split("-prepare")[0];
-        } else if (fileName.contains("-verify")) {
-            return fileName.split("-verify")[0];
-        } else if (fileName.contains("-cleanup")) {
-            return fileName.split("-cleanup")[0];
+        if (fileName.contains("-vu-prepare")) {
+            return fileName.split("-vu-prepare")[0];
+        } else if (fileName.contains("-vu-verify")) {
+            return fileName.split("-vu-verify")[0];
+        } else if (fileName.contains("-vu-cleanup")) {
+            return fileName.split("-vu-cleanup")[0];
         } else {
             return fileName;
         }
@@ -79,11 +79,11 @@ public class TestQueryFile {
     // verify or a cleanup file. Numbers are allocated based on
     // what ordering we want the files to be in
     public static int getFileOrderUtil (String fileName) {
-        if (fileName.contains("-prepare")) {
+        if (fileName.contains("-vu-prepare")) {
             return 0;
-        } else if (fileName.contains("-verify")) {
+        } else if (fileName.contains("-vu-verify")) {
             return 1;
-        } else if (fileName.contains("-cleanup")) {
+        } else if (fileName.contains("-vu-cleanup")) {
             return 2;
         } else {
             return 3;


### PR DESCRIPTION
### Description

We have added support to test Major and Minor version upgrade on an
already populated database. Currently, we are using these prepare and
verify test scripts for testing version upgrade only.

This commit adds support in the JDBC test framework to run the prepare
and verify test scripts as part of standard JDBC test run (i.e. test run
not aimed for upgrade testing). We will run the prepare and verify
scripts in pairs together in case of standard JDBC test run.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).