### PR TITLE
Instead of trigger behaves incorrectly when called recursively

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1707,6 +1707,7 @@ extern bool pltsql_cursor_close_on_commit;
 extern bool pltsql_disable_batch_auto_commit;
 extern bool pltsql_disable_internal_savepoint;
 extern bool pltsql_disable_txn_in_triggers;
+extern bool pltsql_recursive_triggers;
 
 extern int text_size;
 extern int pltsql_rowcount;

--- a/test/JDBC/expected/BABEL-405.out
+++ b/test/JDBC/expected/BABEL-405.out
@@ -39,6 +39,8 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 select * from t_405_insert2;
 go
@@ -59,6 +61,8 @@ go
 insert into t_405_insert2 values(2);
 select * from t_405_insert2;
 go
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 ~~END~~
@@ -122,6 +126,8 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 select * from t_405_delete2;
 go
@@ -143,6 +149,8 @@ go
 delete from t_405_delete2;
 select * from t_405_delete2;
 go
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 2
@@ -159,6 +167,8 @@ go
 varchar
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 int
@@ -214,6 +224,8 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
   
 select * from t_405_update2;
 go
@@ -235,6 +247,8 @@ go
 update t_405_update2 set x = 3 where 1 = 1;
 select * from t_405_update2;
 go
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -295,6 +309,8 @@ int
 1
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 
 drop trigger tr1;

--- a/test/JDBC/expected/TestInsteadofTriggers.out
+++ b/test/JDBC/expected/TestInsteadofTriggers.out
@@ -58,6 +58,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -67,6 +71,8 @@ int
 int#!#varchar
 2#!#second
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 
 begin tran;
@@ -85,6 +91,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -94,6 +104,8 @@ int
 int#!#varchar
 3#!#third
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 commit;
 go
@@ -112,6 +124,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 begin tran
 go
@@ -128,6 +144,10 @@ int
 int
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback;
 go
@@ -148,6 +168,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -157,6 +181,8 @@ int
 int#!#varchar
 6#!#six
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback;
 go
@@ -186,6 +212,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -195,6 +225,8 @@ int
 int#!#varchar
 2#!#second
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 
 begin tran;
@@ -213,6 +245,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -222,6 +258,8 @@ int
 int#!#varchar
 3#!#third
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback;
 go
@@ -308,6 +346,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -334,6 +376,10 @@ int
 int
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 int
@@ -368,6 +414,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -394,6 +444,10 @@ int
 int
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 int
@@ -431,6 +485,10 @@ int
 int
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 int
@@ -474,6 +532,10 @@ int
 int
 1
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 ~~START~~
 int
@@ -543,6 +605,10 @@ int
 1
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 ~~START~~
 int
 1
@@ -552,6 +618,8 @@ int
 int#!#varchar
 3#!#third
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 
 drop table tmp__1 
@@ -567,9 +635,9 @@ go
 
 insert into triggerErrorTab values(1);
 go
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 515)~~
 
-~~ERROR (Message: relation "invalidtab" does not exist)~~
+~~ERROR (Message: null value in column "c1" of relation "triggererrortab" violates not-null constraint)~~
 
 
 
@@ -650,6 +718,8 @@ go
 
 insert into triggerTab1 values(1, 'value3');
 go
+~~ROW COUNT: 1~~
+
 
 
 drop procedure triggerProc1;
@@ -708,6 +778,12 @@ varchar
 nest level 3
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 begin tran
 go
@@ -717,6 +793,12 @@ go
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go
@@ -759,6 +841,10 @@ varchar
 nest level 3
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 begin tran
 go
@@ -768,6 +854,10 @@ go
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go
@@ -780,6 +870,12 @@ go
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go
@@ -828,6 +924,8 @@ varchar
 nest level 3
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 begin tran
 go
@@ -837,6 +935,8 @@ go
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go
@@ -849,6 +949,12 @@ go
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go
@@ -939,6 +1045,12 @@ varchar
 nest level 3
 ~~END~~
 
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 if (@@trancount > 0) rollback tran;
 go
 
@@ -960,6 +1072,12 @@ nest level 2
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go
@@ -1020,6 +1138,12 @@ nest level 2
 varchar
 nest level 3
 ~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
 
 if (@@trancount > 0) rollback tran;
 go

--- a/test/JDBC/input/BABEL-3115.sql
+++ b/test/JDBC/input/BABEL-3115.sql
@@ -1,0 +1,31 @@
+CREATE TABLE t
+(
+c1 int IDENTITY(1,1) PRIMARY KEY,
+c2 varchar(20) UNIQUE not null
+);
+GO
+
+INSERT INTO t(c2) VALUES ('Joe'), ('Steve');
+GO
+
+SELECT * FROM t
+go
+
+CREATE TRIGGER TR_t ON t INSTEAD OF INSERT
+AS
+DECLARE @c1 int, @c2 varchar(20);
+SELECT @c1 = c1, @c2 = c2 FROM inserted;
+INSERT INTO t (c2) VALUES(@c2 + '2') --BUG: This INSERT disappears
+GO
+
+INSERT INTO t(c2) VALUES ('Joe')
+GO
+
+SELECT * FROM t
+GO
+
+drop trigger TR_t
+GO
+
+drop table t
+GO

--- a/test/JDBC/input/BABEL-3116.sql
+++ b/test/JDBC/input/BABEL-3116.sql
@@ -1,0 +1,37 @@
+CREATE TABLE t1 (
+    id int IDENTITY(1,1) NOT NULL,
+    c1 int DEFAULT 0,
+    c2 int DEFAULT 0,
+    c3 int DEFAULT 0
+);
+GO
+
+INSERT INTO t1 (c1, c2, c3)
+VALUES (1, 1, 1);
+GO
+
+SELECT * FROM t1;
+GO
+
+CREATE TRIGGER trg_t1
+ON t1
+INSTEAD OF UPDATE
+AS
+UPDATE t1
+SET c3 = c3 + 1
+WHERE id IN (SELECT DISTINCT id FROM inserted);
+GO
+
+UPDATE t1
+SET c1 = c1 + 1 --Trigger should cause c3 to be 2
+WHERE id = 1;
+GO
+
+SELECT * FROM t1;
+GO
+
+drop trigger trg_t1
+GO
+
+drop table t1
+GO

--- a/test/JDBC/input/BABEL-3118.sql
+++ b/test/JDBC/input/BABEL-3118.sql
@@ -1,0 +1,31 @@
+CREATE TABLE t
+(
+c1 int IDENTITY(1,1) PRIMARY KEY,
+c2 varchar(20),
+);
+GO
+
+INSERT INTO t(c2) VALUES ('Joe'), ('Steve');
+GO
+
+SELECT * FROM t
+GO
+
+CREATE TRIGGER tr_txz ON t
+INSTEAD OF DELETE
+AS
+DELETE FROM t WHERE c2 IN(SELECT c2 FROM deleted)
+SELECT '@@ROWCOUNT from the DELETE trigger, the value should be 1', @@ROWCOUNT
+GO
+
+DELETE FROM t WHERE c2 = 'Steve'
+GO
+
+SELECT  * FROM t
+GO
+
+drop trigger tr_txz;
+GO
+
+drop table t
+GO

--- a/test/JDBC/sql_expected/BABEL-2787.out
+++ b/test/JDBC/sql_expected/BABEL-2787.out
@@ -14,6 +14,8 @@ int
 3
 ~~END~~
 
+~~ROW COUNT: 3~~
+
 
 select count(*) from employeeData;
 GO
@@ -51,6 +53,8 @@ GO
 int
 4
 ~~END~~
+
+~~ROW COUNT: 4~~
 
 
 select * from employeeData;
@@ -96,6 +100,8 @@ int#!#varchar
 8#!#a
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 update employeeData set Emp_First_name = 'kkk' where Emp_First_name = 'a'
 GO
@@ -108,6 +114,8 @@ int#!#varchar
 int#!#varchar
 8#!#a
 ~~END~~
+
+~~ROW COUNT: 1~~
 
 
 update employeeData set Emp_First_name = 'ddd'
@@ -127,6 +135,8 @@ int#!#varchar
 10#!#c
 11#!#d
 ~~END~~
+
+~~ROW COUNT: 4~~
 
 
 drop trigger updEmployeeData

--- a/test/JDBC/sql_expected/BABEL-2944.out
+++ b/test/JDBC/sql_expected/BABEL-2944.out
@@ -51,6 +51,8 @@ int
 0
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 drop trigger updEmployeeData;
 GO

--- a/test/JDBC/sql_expected/BABEL-3115.out
+++ b/test/JDBC/sql_expected/BABEL-3115.out
@@ -1,0 +1,50 @@
+CREATE TABLE t
+(
+c1 int IDENTITY(1,1) PRIMARY KEY,
+c2 varchar(20) UNIQUE not null
+);
+GO
+
+INSERT INTO t(c2) VALUES ('Joe'), ('Steve');
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM t
+go
+~~START~~
+int#!#varchar
+1#!#Joe
+2#!#Steve
+~~END~~
+
+
+CREATE TRIGGER TR_t ON t INSTEAD OF INSERT
+AS
+DECLARE @c1 int, @c2 varchar(20);
+SELECT @c1 = c1, @c2 = c2 FROM inserted;
+INSERT INTO t (c2) VALUES(@c2 + '2') --BUG: This INSERT disappears
+GO
+
+INSERT INTO t(c2) VALUES ('Joe')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM t
+GO
+~~START~~
+int#!#varchar
+1#!#Joe
+2#!#Steve
+4#!#Joe2
+~~END~~
+
+
+drop trigger TR_t
+GO
+
+drop table t
+GO

--- a/test/JDBC/sql_expected/BABEL-3116.out
+++ b/test/JDBC/sql_expected/BABEL-3116.out
@@ -1,0 +1,53 @@
+CREATE TABLE t1 (
+    id int IDENTITY(1,1) NOT NULL,
+    c1 int DEFAULT 0,
+    c2 int DEFAULT 0,
+    c3 int DEFAULT 0
+);
+GO
+
+INSERT INTO t1 (c1, c2, c3)
+VALUES (1, 1, 1);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM t1;
+GO
+~~START~~
+int#!#int#!#int#!#int
+1#!#1#!#1#!#1
+~~END~~
+
+
+CREATE TRIGGER trg_t1
+ON t1
+INSTEAD OF UPDATE
+AS
+UPDATE t1
+SET c3 = c3 + 1
+WHERE id IN (SELECT DISTINCT id FROM inserted);
+GO
+
+UPDATE t1
+SET c1 = c1 + 1 --Trigger should cause c3 to be 2
+WHERE id = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM t1;
+GO
+~~START~~
+int#!#int#!#int#!#int
+1#!#1#!#1#!#2
+~~END~~
+
+
+drop trigger trg_t1
+GO
+
+drop table t1
+GO

--- a/test/JDBC/sql_expected/BABEL-3118.out
+++ b/test/JDBC/sql_expected/BABEL-3118.out
@@ -1,0 +1,53 @@
+CREATE TABLE t
+(
+c1 int IDENTITY(1,1) PRIMARY KEY,
+c2 varchar(20),
+);
+GO
+
+INSERT INTO t(c2) VALUES ('Joe'), ('Steve');
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM t
+GO
+~~START~~
+int#!#varchar
+1#!#Joe
+2#!#Steve
+~~END~~
+
+
+CREATE TRIGGER tr_txz ON t
+INSTEAD OF DELETE
+AS
+DELETE FROM t WHERE c2 IN(SELECT c2 FROM deleted)
+SELECT '@@ROWCOUNT from the DELETE trigger, the value should be 1', @@ROWCOUNT
+GO
+
+DELETE FROM t WHERE c2 = 'Steve'
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+@@ROWCOUNT from the DELETE trigger, the value should be 1#!#1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT  * FROM t
+GO
+~~START~~
+int#!#varchar
+1#!#Joe
+~~END~~
+
+
+drop trigger tr_txz;
+GO
+
+drop table t
+GO

--- a/test/JDBC/sql_expected/BABEL-3119.out
+++ b/test/JDBC/sql_expected/BABEL-3119.out
@@ -10,6 +10,8 @@ GO
 
 INSERT INTO t(c1) VALUES(1) 
 GO
+~~ROW COUNT: 1~~
+
 
 CREATE TABLE t2(c1 int)
 GO


### PR DESCRIPTION
Add a check when executing INSTEAD OF triggers to see if the trigger has already fired for a given row.

Without this check, an INSTEAD OF trigger that issues it's own DML against the same table would have it's DML also fire the trigger, creating undesired recursion. For example, if an INSTEAD OF trigger on table A did it's own INSERT into table A (instead of the original insert), that new INSERT would fire the INSTEAD OF trigger a second time, resulting in no insert actually taking place.

### Details
recursively calling the instead of trigger may lose the last DML data for the triggered table

Instead of trigger behaves incorrectly in recursive call. It happens when there is recursive call inside an instead of trigger like below:
When DML triggers instead of trigger A_trigger and A_trigger will:
- condition i : it'll execute a DML statement and trigger A_trigger again
- condition ii : it'll execute a DML statement and trigger another B_trigger and inside B_trigger, it meets the condition i or condition ii

The right behaviour is that second call of A_trigger should not be triggered and the second DML should execute as normal DML do. It should not execute like a DML with instead of trigger.

Task: BABEL-3115 & BABEL-3116 & BABEL-3118
Signed-off-by: Zhibai Song <szh@amazon.com>

### Description

Row inserted by an INSTEAD-OF INSERT trigger is missing in the example below: 

```
-- repro in Babelfish:
1>
2> CREATE TABLE t
3> (
4> c1 int IDENTITY(1,1) PRIMARY KEY,
5> c2 varchar(20) UNIQUE,
6> );
7>
8> INSERT INTO t(c2)
9> VALUES ('Joe'), ('Steve');
10>
11>
12> SELECT * FROM t
13> GO
c1          c2
----------- --------------------
          1 Joe
          2 Steve
1>
2> CREATE TRIGGER TR_t ON t
3> INSTEAD OF INSERT
4> AS
5>  DECLARE @c1 int, @c2 varchar(20)
6> SELECT @c1 = c1, @c2 = c2 FROM inserted
7> INSERT INTO t (c2) VALUES(@c2 + '2') --BUG: This INSERT disappears
8> GO
1>
2> INSERT INTO t(c2) VALUES ('Joe')
3> GO
1>
2> --There should be 3 rows, but there are only 2 rows. The INSERT from the trigger is lost.
3> SELECT * FROM t
4> GO
c1          c2
----------- --------------------
          1 Joe
          2 Steve
```
Explanation: 
- Insert inside instead of trigger causes a recursive trigger execution
- A recursive trigger execution is capped at nesting level of one and should be a no-op.
- We skip both DML and trigger execution but we should execute the original DML as trigger is a no-op.

The same problem will happen for Delete/Update as well.

### Issues Resolved

The fix identifies a recursive instead of trigger and do the DML execution without instead of trigger
 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).