### PR TITLE
Added a GUC for enabling the T-SQL hint mapping feature

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -73,6 +73,9 @@ extern bool Transform_null_equals;
 bool babelfish_dump_restore = false;
 bool restore_tsql_tabletype = false;
 
+/* T-SQL Hint Mapping */
+bool enable_hint_mapping = false;
+
 static bool check_server_collation_name(char **newval, void **extra, GucSource source);
 static bool check_default_locale (char **newval, void **extra, GucSource source);
 static bool check_ansi_null_dflt_on (bool *newval, void **extra, GucSource source);
@@ -1000,6 +1003,16 @@ define_custom_variables(void)
 				 gettext_noop("Shows that if a table is creating a T-SQL table type during restore"),
 				 NULL,
 				 &restore_tsql_tabletype,
+				 false,
+				 PGC_USERSET,
+				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+				 NULL, NULL, NULL);
+
+	/* T-SQL Hint Mapping */
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_hint_mapping",
+				 gettext_noop("Enables T-SQL hint mapping"),
+				 NULL,
+				 &enable_hint_mapping,
 				 false,
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -66,6 +66,7 @@ extern "C"
 	extern size_t get_num_column_names_to_be_delimited();
 	extern size_t get_num_pg_reserved_keywords_to_be_delimited();
 	extern char * construct_unique_index_name(char *index_name, char *relation_name);
+	extern bool enable_hint_mapping;
 }
 
 static void toDotRecursive(ParseTree *t, const std::vector<std::string> &ruleNames, const std::string &sourceText);
@@ -556,7 +557,8 @@ static void
 add_query_hints(PLtsql_expr *expr)
 {
 	std::string hint =  "/*+ ";
-	for(auto q_hint: query_hints) {
+	for (auto q_hint: query_hints)
+	{
 		hint += q_hint;
 		hint += " ";
 	}
@@ -1391,7 +1393,8 @@ public:
 		add_rewritten_query_fragment_to_mutator(statementMutator.get());
 
 		/* Add query hints */
-		if (query_hints.size()) {
+		if (query_hints.size())
+		{
 			add_query_hints(statementMutator.get()->expr);
 			clear_query_hints();
 		}
@@ -2162,7 +2165,8 @@ static void process_select_statement(
 	Assert(mutator);
 	PLtsql_expr *expr = mutator->expr;
 	ParserRuleContext* baseCtx = mutator->ctx;
-	for (auto octx : selectCtx->option_clause()) {// query hint
+	for (auto octx : selectCtx->option_clause()) // query hint
+	{
 		extractQueryHintsFromOptionClause(octx);
 		removeCtxStringFromQuery(expr, octx, baseCtx);
 	}
@@ -3130,16 +3134,19 @@ void removeCtxStringFromQuery(PLtsql_expr* expr, ParserRuleContext *ctx, ParserR
 
 void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 {
-	for (auto option: octx->option())
+	if (enable_hint_mapping)
 	{
-		if (option->TABLE())
+		for (auto option: octx->option())
 		{
-			std::string table_name = ::getFullText(option->table_name()->table);
-			if (!table_name.empty())
+			if (option->TABLE())
 			{
-				for(auto table_hint: option->table_hint())
+				std::string table_name = ::getFullText(option->table_name()->table);
+				if (!table_name.empty())
 				{
-					extractTableHint(table_hint, table_name);
+					for (auto table_hint: option->table_hint())
+					{
+						extractTableHint(table_hint, table_name);
+					}
 				}
 			}
 		}
@@ -3148,7 +3155,7 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 
 void extractTableHints(TSqlParser::With_table_hintsContext *tctx, std::string table_name)
 {
-	if (!table_name.empty())
+	if (enable_hint_mapping && !table_name.empty())
 	{
 		for (auto table_hint: tctx->table_hint())
 			extractTableHint(table_hint, table_name);
@@ -4760,8 +4767,10 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 	for (auto cctx : ctx->table_source_item())
 		post_process_table_source(cctx, expr, baseCtx);
 
-	for (auto wctx : ctx->with_table_hints()) {
-		if (!wctx->sample_clause()) {
+	for (auto wctx : ctx->with_table_hints())
+	{
+		if (enable_hint_mapping && !wctx->sample_clause())
+		{
 			std::string table_name;
 			if (ctx->full_object_name())
 				table_name = stripQuoteFromId(ctx->full_object_name()->object_name);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -3134,19 +3134,19 @@ void removeCtxStringFromQuery(PLtsql_expr* expr, ParserRuleContext *ctx, ParserR
 
 void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 {
-	if (enable_hint_mapping)
+	if (!enable_hint_mapping)
+		return; // do nothing
+
+	for (auto option: octx->option())
 	{
-		for (auto option: octx->option())
+		if (option->TABLE())
 		{
-			if (option->TABLE())
+			std::string table_name = ::getFullText(option->table_name()->table);
+			if (!table_name.empty())
 			{
-				std::string table_name = ::getFullText(option->table_name()->table);
-				if (!table_name.empty())
+				for (auto table_hint: option->table_hint())
 				{
-					for (auto table_hint: option->table_hint())
-					{
-						extractTableHint(table_hint, table_name);
-					}
+					extractTableHint(table_hint, table_name);
 				}
 			}
 		}

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -27,6 +27,14 @@ off
 ~~END~~
 
 
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
 set babelfish_showplan_all on
 go
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -691,6 +691,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3292_schema.t1 
 go
 

--- a/test/JDBC/expected/BABEL-3295.out
+++ b/test/JDBC/expected/BABEL-3295.out
@@ -66,5 +66,13 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3295_t1
 go

--- a/test/JDBC/expected/BABEL-3295.out
+++ b/test/JDBC/expected/BABEL-3295.out
@@ -1,0 +1,70 @@
+drop table if exists babel_3295_t1
+go
+
+create table babel_3295_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3295_t1_b1 on babel_3295_t1(b1)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query and give the hint to follow a index scan
+ * The hint should not be applied as the GUC for hint mapping has not ben enabled
+ */
+select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3295_t1                                 where b1 = 1
+Bitmap Heap Scan on babel_3295_t1
+  Recheck Cond: (b1 = 1)
+  ->  Bitmap Index Scan on index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query and give the hint to follow a index scan
+ * The hint should now be applied as the GUC for hint mapping has ben enabled
+ */
+select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ select * from babel_3295_t1                                 where b1 = 1
+Index Scan using index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7 on babel_3295_t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3295_t1
+go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -238,6 +238,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
+go
+
 drop table babel_3292_schema.t1 
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -22,6 +22,9 @@ go
 select set_config('babelfishpg_tsql.explain_costs', 'off', false)
 go
 
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+
 set babelfish_showplan_all on
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3295.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3295.sql
@@ -40,5 +40,8 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
+go
+
 drop table babel_3295_t1
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3295.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3295.sql
@@ -1,0 +1,44 @@
+drop table if exists babel_3295_t1
+go
+
+create table babel_3295_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3295_t1_b1 on babel_3295_t1(b1)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query and give the hint to follow a index scan
+ * The hint should not be applied as the GUC for hint mapping has not ben enabled
+ */
+select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
+go
+
+set babelfish_showplan_all off
+go
+
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query and give the hint to follow a index scan
+ * The hint should now be applied as the GUC for hint mapping has ben enabled
+ */
+select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3295_t1
+go


### PR DESCRIPTION
### Description

This pull request has the change to add a GUC to enable the T-SQL hint mapping feature
 
### Issues Resolved

Task: BABEL-3295


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).