### PR TITLE
Support Cross-DB Stored Procedure Call

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -630,6 +630,10 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	SimpleEcontextStackEntry *topEntry;
 	SPIExecuteOptions options;
 
+	Oid current_user_id = GetUserId();
+	if (stmt->is_cross_db)
+		SetCurrentRoleId(GetSessionUserId(), false);
+
 	/* PG_TRY to ensure we clear the plan link, if needed, on failure */
 	PG_TRY();
 	{
@@ -971,6 +975,8 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	}
 	PG_CATCH();
 	{
+		if (stmt->is_cross_db)
+			SetCurrentRoleId(current_user_id, false);
 		/*
 		 * If we aren't saving the plan, unset the pointer.  Note that it
 		 * could have been unset already, in case of a recursive call.
@@ -984,6 +990,9 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	if (stmt->is_cross_db)
+		SetCurrentRoleId(current_user_id, false);
 
 	if (expr->plan && !expr->plan->saved)
 	{

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -75,6 +75,7 @@ typedef struct PLtsql_stmt_exec
 
 	/* indicates whether we're executing a scalar UDF using EXEC keyword */
 	bool		is_scalar_func;
+	bool        	is_cross_db;   /* cross database reference */
 } PLtsql_stmt_exec;
 
 typedef struct

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4113,10 +4113,17 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 	{
 		std::string func_proc_name;
 		TSqlParser::Execute_statement_argContext *func_proc_args = body->execute_statement_arg();
+		bool is_cross_db = false;
 
 		if (body->func_proc_name_server_database_schema())
 		{
 			func_proc_name = ::getFullText(body->func_proc_name_server_database_schema());
+			if (body->func_proc_name_server_database_schema()->database)
+			{
+				std::string db_name = stripQuoteFromId(body->func_proc_name_server_database_schema()->database);
+				if (!string_matches(db_name.c_str(), get_cur_db_name()))
+				is_cross_db = true;
+			}
 		}
 		else 
 		{
@@ -4143,6 +4150,9 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 		result->return_code_dno = return_code_dno;
 		result->paramno = 0;
 		result->params = NIL;
+		// record whether stmt is cross-db
+		if (is_cross_db)
+			result->is_cross_db = true;
 
 		if (func_proc_args)
 		{

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -10,6 +10,16 @@ AS
 SELECT a FROM dbo.master_t1;
 GO
 
+CREATE PROCEDURE dbo.master_p2
+AS
+SELECT 1;
+GO
+
+CREATE PROCEDURE dbo.master_p3
+AS
+SELECT 1/0;
+GO
+
 CREATE DATABASE db1;
 GO
 
@@ -42,6 +52,38 @@ GO
 ~~START~~
 int#!#int
 1#!#10
+~~END~~
+
+
+-- Expects error due to incorrect schema resolution in BBF
+EXEC master.dbo.master_p1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.master_t1" does not exist)~~
+
+
+EXEC master.dbo.master_p2
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- runtime error
+EXEC master.dbo.master_p3
+GO
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+
+EXEC master..master_p2
+GO
+~~START~~
+int
+1
 ~~END~~
 
 
@@ -131,7 +173,7 @@ EXECUTE master.dbo.master_p1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for procedure master_p1)~~
+~~ERROR (Message: relation "dbo.master_t1" does not exist)~~
 
 
 SELECT current_user;
@@ -209,6 +251,13 @@ GO
 USE db1;
 GO
 
+EXEC master.dbo.master_p2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure master_p2)~~
+
+
 SELECT current_user;
 GO
 ~~START~~
@@ -231,6 +280,9 @@ GO
 GRANT SELECT ON dbo.master_t1 TO master_janedoe;
 GO
 
+GRANT EXECUTE ON dbo.master_p2 TO master_janedoe;
+GO
+
 USE db1;
 GO
 
@@ -243,6 +295,14 @@ GO
 
 USE db1;
 GO
+
+EXEC master.dbo.master_p2
+GO
+~~START~~
+int
+1
+~~END~~
+
 
 SELECT * FROM master.dbo.master_t1 ORDER BY id;
 GO
@@ -272,6 +332,12 @@ GO
 DROP PROC dbo.master_p1;
 GO
 
+DROP PROC dbo.master_p2;
+GO
+
+DROP PROC dbo.master_p3;
+GO
+
 DROP USER master_janedoe;
 GO
 
@@ -299,6 +365,12 @@ CREATE DATABASE db2;
 GO
 
 USE db1;
+GO
+
+CREATE PROCEDURE p1
+AS
+EXEC('USE db1');
+SELECT 10;
 GO
 
 CREATE TABLE dbo.db1_t1 (id int identity, a int);
@@ -344,6 +416,17 @@ int
 10
 ~~END~~
 
+
+EXEC db1.dbo.p1;
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+DROP PROCEDURE p1
+GO
 
 -- tsql
 USE master;

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -10,6 +10,16 @@ AS
 SELECT a FROM dbo.master_t1;
 GO
 
+CREATE PROCEDURE dbo.master_p2
+AS
+SELECT 1;
+GO
+
+CREATE PROCEDURE dbo.master_p3
+AS
+SELECT 1/0;
+GO
+
 CREATE DATABASE db1;
 GO
 
@@ -26,6 +36,20 @@ SELECT * FROM master.dbo.master_t1 ORDER BY id;
 GO
 
 SELECT * FROM master..master_t1 ORDER BY id;
+GO
+
+-- Expects error due to incorrect schema resolution in BBF
+EXEC master.dbo.master_p1
+GO
+
+EXEC master.dbo.master_p2
+GO
+
+-- runtime error
+EXEC master.dbo.master_p3
+GO
+
+EXEC master..master_p2
 GO
 
 UPDATE master.dbo.master_t1
@@ -129,6 +153,9 @@ GO
 USE db1;
 GO
 
+EXEC master.dbo.master_p2
+GO
+
 SELECT current_user;
 GO
 
@@ -142,6 +169,9 @@ GO
 GRANT SELECT ON dbo.master_t1 TO master_janedoe;
 GO
 
+GRANT EXECUTE ON dbo.master_p2 TO master_janedoe;
+GO
+
 USE db1;
 GO
 
@@ -153,6 +183,9 @@ USE MASTER;
 GO
 
 USE db1;
+GO
+
+EXEC master.dbo.master_p2
 GO
 
 SELECT * FROM master.dbo.master_t1 ORDER BY id;
@@ -172,6 +205,12 @@ DROP TABLE dbo.master_t1;
 GO
 
 DROP PROC dbo.master_p1;
+GO
+
+DROP PROC dbo.master_p2;
+GO
+
+DROP PROC dbo.master_p3;
 GO
 
 DROP USER master_janedoe;
@@ -196,6 +235,12 @@ CREATE DATABASE db2;
 GO
 
 USE db1;
+GO
+
+CREATE PROCEDURE p1
+AS
+EXEC('USE db1');
+SELECT 10;
 GO
 
 CREATE TABLE dbo.db1_t1 (id int identity, a int);
@@ -227,6 +272,12 @@ WHERE id = 1;
 GO
 
 SELECT * FROM dbo.db2_t1 ORDER BY b;
+GO
+
+EXEC db1.dbo.p1;
+GO
+
+DROP PROCEDURE p1
 GO
 
 -- tsql


### PR DESCRIPTION
This commit uses ANTLR to confirm if the query is cross-database.
It will then set a flag in the statement's execution object and
check that flag during the executor stage. If true, the current user
will be temporarily set to the Login to enable permissions for the
statement execution. Otherwise, permission checks will prevent the
cross-database statement from executing.

Task: BABEL-3275
Signed-off-by: Shalini Lohia <lshalini@amazon.com>