### PR TITLE
Add support for join hint conversions

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4825,11 +4825,7 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 	{
 		if (enable_hint_mapping && !wctx->sample_clause())
 		{
-			std::string table_name;
-			if (ctx->full_object_name())
-				table_name = stripQuoteFromId(ctx->full_object_name()->object_name);
-			else if (ctx->local_id())
-				table_name = ::getFullText(ctx->local_id());
+			std::string table_name = extractTableName(nullptr, ctx);
 			extractTableHints(wctx, table_name);
 		}
 		removeCtxStringFromQuery(expr, wctx, baseCtx);
@@ -4838,11 +4834,7 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 	for (auto actx : ctx->as_table_alias())
 	{
 		std::string alias_name = ::getFullText(actx->table_alias()->id());
-		std::string table_name;
-		if (ctx->full_object_name())
-			table_name = stripQuoteFromId(ctx->full_object_name()->object_name);
-		else if (ctx->local_id())
-			table_name = ::getFullText(ctx->local_id());
+		std::string table_name = extractTableName(nullptr, ctx);
 		if (!table_name.empty())
 		{
 			alias_mapping[alias_name] = table_name;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -101,8 +101,10 @@ void removeTokenStringFromQuery(PLtsql_expr* expr, TerminalNode* tokenNode, Pars
 void removeCtxStringFromQuery(PLtsql_expr* expr, ParserRuleContext *ctx, ParserRuleContext *baseCtx);
 void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx);
 void extractTableHints(TSqlParser::With_table_hintsContext *tctx, std::string table_name);
-std::string extractTableName(TSqlParser::Ddl_objectContext *ctx);
+std::string extractTableName(TSqlParser::Ddl_objectContext *ctx, TSqlParser::Table_source_itemContext *tctx);
 void extractTableHint(TSqlParser::Table_hintContext *table_hint, std::string table_name);
+void extractJoinHint(TSqlParser::Join_hintContext *join_hint, std::string table_name1, std::string table_name2);
+void extractJoinHintFromOption(TSqlParser::OptionContext *option);
 std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> index_valuesCtx, char *table_name);
 
 static void *makeBatch(TSqlParser::Tsql_fileContext *ctx, tsqlBuilder &builder);
@@ -3150,6 +3152,10 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 				}
 			}
 		}
+		else if (option->JOIN())
+			extractJoinHintFromOption(option);
+		else if (option->FORCE() && option->ORDER())
+			query_hints.push_back("Set(join_collapse_limit 1)");
 	}
 }
 
@@ -3162,13 +3168,23 @@ void extractTableHints(TSqlParser::With_table_hintsContext *tctx, std::string ta
 	}
 }
 
-std::string extractTableName(TSqlParser::Ddl_objectContext *ctx)
+std::string extractTableName(TSqlParser::Ddl_objectContext *dctx, TSqlParser::Table_source_itemContext *tctx)
 {
 	std::string table_name;
-	if (ctx->full_object_name())
-		table_name = stripQuoteFromId(ctx->full_object_name()->object_name);
-	else if (ctx->local_id())
-		table_name = ::getFullText(ctx->local_id());
+	if (dctx == nullptr)
+	{
+		if (tctx->full_object_name())
+			table_name = stripQuoteFromId(tctx->full_object_name()->object_name);
+		else if (tctx->local_id())
+			table_name = ::getFullText(tctx->local_id());
+	}
+	else
+	{
+		if (dctx->full_object_name())
+			table_name = stripQuoteFromId(dctx->full_object_name()->object_name);
+		else if (dctx->local_id())
+			table_name = ::getFullText(dctx->local_id());
+	}
 	return table_name;
 }
 
@@ -3179,6 +3195,40 @@ void extractTableHint(TSqlParser::Table_hintContext *table_hint, std::string tab
 		std::string index_values = extractIndexValues(table_hint->index_value(), const_cast <char *>(table_name.c_str()));
 		if (!index_values.empty())
 			query_hints.push_back("IndexScan(" + table_name + " " + index_values + ")");
+	}
+}
+
+void extractJoinHint(TSqlParser::Join_hintContext *join_hint, std::string table_name1, std::string table_name2)
+{
+	if (join_hint->LOOP())
+	{
+		query_hints.push_back("NestLoop(" + table_name1 + " " + table_name2 + ")");
+	}
+	else if (join_hint->HASH())
+	{
+		query_hints.push_back("HashJoin(" + table_name1 + " " + table_name2 + ")");
+	}
+	else if(join_hint->MERGE())
+	{
+		query_hints.push_back("MergeJoin(" + table_name1 + " " + table_name2 + ")");
+	}
+}
+
+void extractJoinHintFromOption(TSqlParser::OptionContext *option) {
+	if (option->LOOP())
+	{
+		query_hints.push_back("Set(enable_hashjoin off)");
+		query_hints.push_back("Set(enable_mergejoin off)");
+	}
+	else if (option->HASH())
+	{
+		query_hints.push_back("Set(enable_mergejoin off)");
+		query_hints.push_back("Set(enable_nestloop off)");
+	}
+	else if(option->MERGE())
+	{
+		query_hints.push_back("Set(enable_hashjoin off)");
+		query_hints.push_back("Set(enable_nestloop off)");
 	}
 }
 
@@ -4781,7 +4831,17 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 		removeCtxStringFromQuery(expr, wctx, baseCtx);
 	}
 	if (ctx->join_hint())
+	{
+		std::string table_name1;
+		if (ctx->table_source_item()[0]->JOIN())
+			table_name1 = extractTableName(nullptr, ctx->table_source_item()[0]->table_source_item()[0]);
+		else
+			table_name1 = extractTableName(nullptr, ctx->table_source_item()[0]);
+		std::string table_name2 = extractTableName(nullptr, ctx->table_source_item()[1]);
+		if (!table_name1.empty() && !table_name2.empty())
+			extractJoinHint(ctx->join_hint(), table_name1, table_name2);
 		removeCtxStringFromQuery(expr, ctx->join_hint(), baseCtx);
+	}
 }
 
 void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext *ctx, PLtsql_stmt_execsql *stmt)
@@ -4793,7 +4853,7 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 		{
 			if (!ictx->with_table_hints()->sample_clause() && ictx->ddl_object())
 			{
-				std::string table_name = extractTableName(ictx->ddl_object());
+				std::string table_name = extractTableName(ictx->ddl_object(), nullptr);
 				extractTableHints(ictx->with_table_hints(), table_name);
 			}
 			removeCtxStringFromQuery(stmt->sqlstmt, ictx->with_table_hints(), ctx);
@@ -4814,7 +4874,7 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 		{
 			if (!uctx->with_table_hints()->sample_clause() && uctx->ddl_object())
 			{
-				std::string table_name = extractTableName(uctx->ddl_object());
+				std::string table_name = extractTableName(uctx->ddl_object(), nullptr);
 				extractTableHints(uctx->with_table_hints(), table_name);
 			}
 			removeCtxStringFromQuery(stmt->sqlstmt, uctx->with_table_hints(), ctx);
@@ -4828,6 +4888,11 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 	else if (ctx->delete_statement())
 	{
 		auto dctx = ctx->delete_statement();
+		if (dctx->table_sources())
+		{
+			for (auto tctx : dctx->table_sources()->table_source_item()) // from-clause (to remove hints)
+				post_process_table_source(tctx, stmt->sqlstmt, ctx);
+		}
 		if (dctx->delete_statement_from()->table_alias() && dctx->delete_statement_from()->table_alias()->with_table_hints())
 		{
 			if (!dctx->delete_statement_from()->table_alias()->with_table_hints()->sample_clause()) 
@@ -4841,7 +4906,7 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 		{
 			if (!dctx->with_table_hints()->sample_clause() && dctx->delete_statement_from()->ddl_object()) 
 			{
-				std::string table_name = extractTableName(dctx->delete_statement_from()->ddl_object());
+				std::string table_name = extractTableName(dctx->delete_statement_from()->ddl_object(), nullptr);
 				extractTableHints(dctx->with_table_hints(), table_name);
 			}
 			removeCtxStringFromQuery(stmt->sqlstmt, dctx->with_table_hints(), ctx);

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -34,8 +34,8 @@ go
 /*
  * Run a SELECT query without any hints to ensure that un-hinted queries still work.
  * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
- * than the index scan that we're hinting in the query below. This verifies that the next test is actually valid.
- * If the planner was going to choose a sequential scan anyway, the next test wouldn't actually prove that hints were working.
+ * than the index scan that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ * If the planner was going to choose a index scan anyway, the next test wouldn't actually prove that hints were working.
  */
 select * from babel_3292_t1 where b1 = 1
 go

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -568,14 +568,6 @@ go
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
 go
 
-select set_config('babelfishpg_tsql.explain_costs', 'off', false)
-go
-~~START~~
-text
-off
-~~END~~
-
-
 set babelfish_showplan_all on
 go
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -42,8 +42,8 @@ go
 /*
  * Run a SELECT query without any hints to ensure that un-hinted queries still work.
  * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
- * than the index scan that we're hinting in the query below. This verifies that the next test is actually valid.
- * If the planner was going to choose a sequential scan anyway, the next test wouldn't actually prove that hints were working.
+ * than the index scan that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ * If the planner was going to choose a index scan anyway, the next test wouldn't actually prove that hints were working.
  */
 select * from babel_3292_t1 where b1 = 1
 go

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -1,0 +1,340 @@
+drop table if exists babel_3293_t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+create table babel_3293_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_t1_b1 on babel_3293_t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query joining two tables without any join hints to ensure that un-hinted queries still work.
+ * This also ensures that when the SELECT query is not hinted it produces a different plan(hash join)
+ * than the other join plans that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+/*
+ * Give the hints in the queries to follow a specified join plan.
+ * The query plan should now use the specified join plan instead of hash join it uses in the un-hinted test above.
+ */
+select * from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from babel_3293_t1                                     join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+-- Join hints through option clause
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_mergejoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                   
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_mergejoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+-- Queries with both table hints and join hints
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) NestLoop(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1                                     inner      join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) right outer merge join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) MergeJoin(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1                                     right outer       join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+              Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join, table hint(babel_3293_t1, index(index_babel_3293_t1_b1)), table hint(babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_mergejoin off) IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                      
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3293_t1
+go
+
+drop table babel_3293_t2
+go
+
+
+-- Test all queries by specifying a database and schema name
+use tempdb
+go
+
+drop table if exists babel_3293_schema.t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+drop schema if exists babel_3293_schema
+go
+
+create schema babel_3293_schema
+go
+
+create table babel_3293_schema.t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_schema_t1_b1 on babel_3293_schema.t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+select * from tempdb.babel_3293_schema.t1 inner merge join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(t1 babel_3293_t2) */ select * from tempdb.babel_3293_schema.t1 inner       join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: t1.a1
+        ->  Bitmap Heap Scan on t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1                                            join babel_3293_t2                                 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Hash Join
+  Hash Cond: (t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
+        Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join, table hint(tempdb.babel_3293_schema.t1, index(index_babel_3293_schema_t1_b1)), table hint(tempdb.dbo.babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
+Merge Join
+  Merge Cond: (t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: t1.a1
+        ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
+              Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3293_schema.t1 
+go
+
+drop table babel_3293_t2
+go
+
+drop schema babel_3293_schema
+go

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -285,17 +285,16 @@ Merge Join
 ~~END~~
 
 
-select * from babel_3293_t1 t1, babel_3293_t2 t2 inner hash join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+select * from babel_3293_t1 t1, babel_3293_t2 t2 inner hash join babel_3293_t3 t3 on t2.a2 = t3.a3
 go
 ~~START~~
 text
-Query Text: /*+ HashJoin(t1 t2 t3) Leading(t1 t2 t3)*/ select * from babel_3293_t1 t1, babel_3293_t2 t2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+Query Text: /*+ HashJoin(t1 t2 t3) Leading(t1 t2 t3)*/ select * from babel_3293_t1 t1, babel_3293_t2 t2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3
 Hash Join
   Hash Cond: (t2.a2 = t3.a3)
-  ->  Hash Join
-        Hash Cond: (t1.a1 = t2.a2)
+  ->  Nested Loop
         ->  Seq Scan on babel_3293_t1 t1
-        ->  Hash
+        ->  Materialize
               ->  Seq Scan on babel_3293_t2 t2
   ->  Hash
         ->  Seq Scan on babel_3293_t3 t3
@@ -437,6 +436,90 @@ Nested Loop
   ->  Materialize
         ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
               Index Cond: (b2 = 1)
+~~END~~
+
+
+-- Join hints on nested subqueries are not supported
+select * from (select distinct a1 as a1 from babel_3293_t1) s1 inner merge join babel_3293_t2 on s1.a1 = babel_3293_t2.a2
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) */ select * from (select distinct a1 as a1 from babel_3293_t1) s1 inner       join babel_3293_t2 on s1.a1 = babel_3293_t2.a2
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  HashAggregate
+        Group Key: babel_3293_t1.a1
+        ->  Seq Scan on babel_3293_t1
+  ->  Hash
+        ->  Seq Scan on babel_3293_t2
+~~END~~
+
+
+select * from (select babel_3293_t1.* from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s1 inner join (select babel_3293_t1.* from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s2 on s1.a1 = s2.a1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) HashJoin(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2)*/ select * from (select babel_3293_t1.* from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s1 inner join (select babel_3293_t1.* from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s2 on s1.a1 = s2.a1
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2_1.a2)
+  ->  Hash Join
+        Hash Cond: (babel_3293_t1.a1 = babel_3293_t1_1.a1)
+        ->  Hash Join
+              Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+              ->  Seq Scan on babel_3293_t1
+              ->  Hash
+                    ->  Seq Scan on babel_3293_t2
+        ->  Hash
+              ->  Seq Scan on babel_3293_t1 babel_3293_t1_1
+  ->  Hash
+        ->  Seq Scan on babel_3293_t2 babel_3293_t2_1
+~~END~~
+
+
+-- Test FORCE ORDER hints
+/**
+ * Run a SELECT query with multiple joins such that the join order indicated by the query syntax is not preserved during query optimization.
+ * This ensures that when the FORCE ORDER query hint is given in the test below, the join order is preserved.
+ * If the join order was to be preserved even without the hint, the next test would not prove that the FORCE ORDER hint is working.
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3
+go
+~~START~~
+text
+Query Text: select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
+        ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        ->  Sort
+              Sort Key: babel_3293_t3.b3
+              ->  Seq Scan on babel_3293_t3
+  ->  Hash
+        ->  Seq Scan on babel_3293_t2
+~~END~~
+
+
+/*
+ * Run the above SELECT query and give the FORCE ORDER query hint to make sure that the join order is preserved
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3 option(force order)
+go
+~~START~~
+text
+Query Text: /*+ Set(join_collapse_limit 1) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3                    
+Merge Join
+  Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
+  ->  Sort
+        Sort Key: babel_3293_t1.b1
+        ->  Hash Join
+              Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+              ->  Seq Scan on babel_3293_t1
+              ->  Hash
+                    ->  Seq Scan on babel_3293_t2
+  ->  Sort
+        Sort Key: babel_3293_t3.b3
+        ->  Seq Scan on babel_3293_t3
 ~~END~~
 
 
@@ -589,53 +672,6 @@ Delete on babel_3293_t1
 ~~END~~
 
 
--- Test FORCE ORDER hints
-/**
- * Run a SELECT query with multiple joins such that the join order indicated by the query syntax is not preserved during query optimization.
- * This ensures that when the FORCE ORDER query hint is given in the test below, the join order is preserved.
- * If the join order was to be preserved even without the hint, the next test would not prove that the FORCE ORDER hint is working.
- */
-select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3
-go
-~~START~~
-text
-Query Text: select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3
-Hash Join
-  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
-  ->  Merge Join
-        Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
-        ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
-        ->  Sort
-              Sort Key: babel_3293_t3.b3
-              ->  Seq Scan on babel_3293_t3
-  ->  Hash
-        ->  Seq Scan on babel_3293_t2
-~~END~~
-
-
-/*
- * Run the above SELECT query and give the FORCE ORDER query hint to make sure that the join order is preserved
- */
-select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3 option(force order)
-go
-~~START~~
-text
-Query Text: /*+ Set(join_collapse_limit 1) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3                    
-Merge Join
-  Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
-  ->  Sort
-        Sort Key: babel_3293_t1.b1
-        ->  Hash Join
-              Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
-              ->  Seq Scan on babel_3293_t1
-              ->  Hash
-                    ->  Seq Scan on babel_3293_t2
-  ->  Sort
-        Sort Key: babel_3293_t3.b3
-        ->  Seq Scan on babel_3293_t3
-~~END~~
-
-
 set babelfish_showplan_all off
 go
 
@@ -755,6 +791,23 @@ Merge Join
               ->  Seq Scan on t1
               ->  Hash
                     ->  Seq Scan on babel_3293_t2
+  ->  Sort
+        Sort Key: babel_3293_t3.b3
+        ->  Seq Scan on babel_3293_t3
+~~END~~
+
+
+select * from tempdb.babel_3293_schema.t1 inner loop join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 left outer merge join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3
+go
+~~START~~
+text
+Query Text: /*+ NestLoop(t1 babel_3293_t2) MergeJoin(t1 babel_3293_t2 babel_3293_t3) Leading(t1 babel_3293_t2 babel_3293_t3)*/ select * from tempdb.babel_3293_schema.t1 inner      join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 left outer       join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3
+Merge Left Join
+  Merge Cond: (t1.b1 = babel_3293_t3.b3)
+  ->  Nested Loop
+        ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
+        ->  Index Scan using babel_3293_t2_pkey on babel_3293_t2
+              Index Cond: (a2 = t1.a1)
   ->  Sort
         Sort Key: babel_3293_t3.b3
         ->  Seq Scan on babel_3293_t3

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -255,6 +255,53 @@ Nested Loop
 ~~END~~
 
 
+select * from babel_3293_t1, babel_3293_t2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1, babel_3293_t2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
+Merge Join
+  Merge Cond: (babel_3293_t2.a2 = babel_3293_t3.a3)
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Index Scan using babel_3293_t1_pkey on babel_3293_t1
+        ->  Index Scan using babel_3293_t2_pkey on babel_3293_t2
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
+~~END~~
+
+
+select * from babel_3293_t1 t1, babel_3293_t2 t2 inner merge join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(t1 t2 t3) Leading(t1 t2 t3)*/ select * from babel_3293_t1 t1, babel_3293_t2 t2 inner       join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+Merge Join
+  Merge Cond: (t2.a2 = t3.a3)
+  ->  Merge Join
+        Merge Cond: (t1.a1 = t2.a2)
+        ->  Index Scan using babel_3293_t1_pkey on babel_3293_t1 t1
+        ->  Index Scan using babel_3293_t2_pkey on babel_3293_t2 t2
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3 t3
+~~END~~
+
+
+select * from babel_3293_t1 t1, babel_3293_t2 t2 inner hash join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+go
+~~START~~
+text
+Query Text: /*+ HashJoin(t1 t2 t3) Leading(t1 t2 t3)*/ select * from babel_3293_t1 t1, babel_3293_t2 t2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+Hash Join
+  Hash Cond: (t2.a2 = t3.a3)
+  ->  Hash Join
+        Hash Cond: (t1.a1 = t2.a2)
+        ->  Seq Scan on babel_3293_t1 t1
+        ->  Hash
+              ->  Seq Scan on babel_3293_t2 t2
+  ->  Hash
+        ->  Seq Scan on babel_3293_t3 t3
+~~END~~
+
+
 -- Join hints through option clause
 select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
 go

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -181,16 +181,43 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t3) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Hash Join
+              Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+              ->  Bitmap Heap Scan on babel_3293_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+              ->  Hash
+                    ->  Bitmap Heap Scan on babel_3293_t2
+                          Recheck Cond: (b2 = 1)
+                          ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                Index Cond: (b2 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t3.a3
+        ->  Seq Scan on babel_3293_t3
+              Filter: (b3 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
-  ->  Hash Join
-        Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Nested Loop
+        Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
         ->  Bitmap Heap Scan on babel_3293_t1
               Recheck Cond: (b1 = 1)
               ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
                     Index Cond: (b1 = 1)
-        ->  Hash
+        ->  Materialize
               ->  Bitmap Heap Scan on babel_3293_t2
                     Recheck Cond: (b2 = 1)
                     ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
@@ -201,20 +228,23 @@ Nested Loop
 ~~END~~
 
 
-select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 go
 ~~START~~
 text
-Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) NestLoop(babel_3293_t1 babel_3293_t3) */ select * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
-  ->  Nested Loop
-        Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
-        ->  Bitmap Heap Scan on babel_3293_t1
-              Recheck Cond: (b1 = 1)
-              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
-                    Index Cond: (b1 = 1)
-        ->  Materialize
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Sort
+              Sort Key: babel_3293_t1.a1
+              ->  Bitmap Heap Scan on babel_3293_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+        ->  Sort
+              Sort Key: babel_3293_t2.a2
               ->  Bitmap Heap Scan on babel_3293_t2
                     Recheck Cond: (b2 = 1)
                     ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
@@ -512,6 +542,53 @@ Delete on babel_3293_t1
 ~~END~~
 
 
+-- Test FORCE ORDER hints
+/**
+ * Run a SELECT query with multiple joins such that the join order indicated by the query syntax is not preserved during query optimization.
+ * This ensures that when the FORCE ORDER query hint is given in the test below, the join order is preserved.
+ * If the join order was to be preserved even without the hint, the next test would not prove that the FORCE ORDER hint is working.
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3
+go
+~~START~~
+text
+Query Text: select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
+        ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        ->  Sort
+              Sort Key: babel_3293_t3.b3
+              ->  Seq Scan on babel_3293_t3
+  ->  Hash
+        ->  Seq Scan on babel_3293_t2
+~~END~~
+
+
+/*
+ * Run the above SELECT query and give the FORCE ORDER query hint to make sure that the join order is preserved
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3 option(force order)
+go
+~~START~~
+text
+Query Text: /*+ Set(join_collapse_limit 1) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3                    
+Merge Join
+  Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
+  ->  Sort
+        Sort Key: babel_3293_t1.b1
+        ->  Hash Join
+              Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+              ->  Seq Scan on babel_3293_t1
+              ->  Hash
+                    ->  Seq Scan on babel_3293_t2
+  ->  Sort
+        Sort Key: babel_3293_t3.b3
+        ->  Seq Scan on babel_3293_t3
+~~END~~
+
+
 set babelfish_showplan_all off
 go
 
@@ -535,6 +612,9 @@ go
 drop table if exists babel_3293_t2
 go
 
+drop table if exists babel_3293_t3
+go
+
 drop schema if exists babel_3293_schema
 go
 
@@ -553,13 +633,8 @@ go
 create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
 go
 
-select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+create table babel_3293_t3(a3 int PRIMARY KEY, b3 int)
 go
-~~START~~
-text
-off
-~~END~~
-
 
 set babelfish_showplan_all on
 go
@@ -586,11 +661,11 @@ Merge Join
 ~~END~~
 
 
-select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_b1)) join tempdb.dbo.babel_3293_t2 (index(index_babel_3293_t2_b2)) on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1                                            join babel_3293_t2                                 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: /*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1                                            join tempdb.dbo.babel_3293_t2                                 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Hash Join
   Hash Cond: (t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
@@ -601,11 +676,11 @@ Hash Join
 ~~END~~
 
 
-select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join, table hint(tempdb.babel_3293_schema.t1, index(index_babel_3293_schema_t1_b1)), table hint(tempdb.dbo.babel_3293_t2, index(index_babel_3293_t2_b2)))
+select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join, table hint(tempdb.babel_3293_schema.t1, index(index_babel_3293_schema_t1_b1)), table hint(tempdb.dbo.babel_3293_t2, index(index_babel_3293_t2_b2)))
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
 Merge Join
   Merge Cond: (t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -616,6 +691,26 @@ Merge Join
         Sort Key: babel_3293_t2.a2
         ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
               Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3 option(force order)
+go
+~~START~~
+text
+Query Text: /*+ Set(join_collapse_limit 1) */ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3                    
+Merge Join
+  Merge Cond: (t1.b1 = babel_3293_t3.b3)
+  ->  Sort
+        Sort Key: t1.b1
+        ->  Hash Join
+              Hash Cond: (t1.a1 = babel_3293_t2.a2)
+              ->  Seq Scan on t1
+              ->  Hash
+                    ->  Seq Scan on babel_3293_t2
+  ->  Sort
+        Sort Key: babel_3293_t3.b3
+        ->  Seq Scan on babel_3293_t3
 ~~END~~
 
 
@@ -635,6 +730,9 @@ drop table babel_3293_schema.t1
 go
 
 drop table babel_3293_t2
+go
+
+drop table babel_3293_t3
 go
 
 drop schema babel_3293_schema

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -1,0 +1,641 @@
+drop table if exists babel_3293_t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+drop table if exists babel_3293_t3
+go
+
+create table babel_3293_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_t1_b1 on babel_3293_t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+create table babel_3293_t3(a3 int PRIMARY KEY, b3 int)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query joining two tables without any join hints to ensure that un-hinted queries still work.
+ * This also ensures that when the SELECT query is not hinted it produces a different plan(hash join)
+ * than the other join plans that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+/*
+ * Give the hints in the queries to follow a specified join plan.
+ * The query plan should now use the specified join plan instead of hash join it uses in the un-hinted test above.
+ */
+select * from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from babel_3293_t1                                     join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+-- Queries with multiple joins
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Hash Join
+        Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+        ->  Hash
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
+        Index Cond: (a3 = babel_3293_t2.a2)
+        Filter: (b3 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Sort
+              Sort Key: babel_3293_t1.a1
+              ->  Bitmap Heap Scan on babel_3293_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+        ->  Sort
+              Sort Key: babel_3293_t2.a2
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
+        Index Cond: (a3 = babel_3293_t2.a2)
+        Filter: (b3 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t3) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Hash Join
+        Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+        ->  Hash
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
+        Index Cond: (a3 = babel_3293_t2.a2)
+        Filter: (b3 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) NestLoop(babel_3293_t1 babel_3293_t3) */ select * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Nested Loop
+        Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+        ->  Materialize
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
+        Index Cond: (a3 = babel_3293_t2.a2)
+        Filter: (b3 = 1)
+~~END~~
+
+
+-- Join hints through option clause
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_mergejoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                   
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_mergejoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                   
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Sort
+              Sort Key: babel_3293_t1.a1
+              ->  Bitmap Heap Scan on babel_3293_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+        ->  Sort
+              Sort Key: babel_3293_t2.a2
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t3.a3
+        ->  Seq Scan on babel_3293_t3
+              Filter: (b3 = 1)
+~~END~~
+
+
+-- Queries with both table hints and join hints
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) NestLoop(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1                                     inner      join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) right outer merge join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) MergeJoin(babel_3293_t1 babel_3293_t2) */ select * from babel_3293_t1                                     right outer       join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+              Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join, table hint(babel_3293_t1, index(index_babel_3293_t1_b1)), table hint(babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_mergejoin off) IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                      
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+-- UPDATE and DELETE queries with join hints needs to be revisited later. pg_hint_plan is currently not following the given join hints 
+-- Test UPDATE queries with and without hints
+update babel_3293_t1 set a1 = 1 from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: update babel_3293_t1 set a1 = 1 from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Update on babel_3293_t1
+  ->  Nested Loop
+        ->  HashAggregate
+              Group Key: babel_3293_t1_1.ctid
+              ->  Hash Join
+                    Hash Cond: (babel_3293_t1_1.a1 = babel_3293_t2.a2)
+                    ->  Bitmap Heap Scan on babel_3293_t1 babel_3293_t1_1
+                          Recheck Cond: (b1 = 1)
+                          ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                                Index Cond: (b1 = 1)
+                    ->  Hash
+                          ->  Bitmap Heap Scan on babel_3293_t2
+                                Recheck Cond: (b2 = 1)
+                                ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                      Index Cond: (b2 = 1)
+        ->  Tid Scan on babel_3293_t1
+              TID Cond: (ctid = babel_3293_t1_1.ctid)
+~~END~~
+
+
+update babel_3293_t1 set a1 = 1 from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) */ update babel_3293_t1 set a1 = 1 from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Update on babel_3293_t1
+  ->  Nested Loop
+        ->  HashAggregate
+              Group Key: babel_3293_t1_1.ctid
+              ->  Hash Join
+                    Hash Cond: (babel_3293_t1_1.a1 = babel_3293_t2.a2)
+                    ->  Bitmap Heap Scan on babel_3293_t1 babel_3293_t1_1
+                          Recheck Cond: (b1 = 1)
+                          ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                                Index Cond: (b1 = 1)
+                    ->  Hash
+                          ->  Bitmap Heap Scan on babel_3293_t2
+                                Recheck Cond: (b2 = 1)
+                                ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                      Index Cond: (b2 = 1)
+        ->  Tid Scan on babel_3293_t1
+              TID Cond: (ctid = babel_3293_t1_1.ctid)
+~~END~~
+
+
+update babel_3293_t1 set a1 = 1 from babel_3293_t1 with(index(index_babel_3293_t1_b1)) full outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) MergeJoin(babel_3293_t1 babel_3293_t2) */ update babel_3293_t1 set a1 = 1 from babel_3293_t1                                     full outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Update on babel_3293_t1
+  ->  Nested Loop
+        ->  HashAggregate
+              Group Key: babel_3293_t1_1.ctid
+              ->  Hash Join
+                    Hash Cond: (babel_3293_t1_1.a1 = babel_3293_t2.a2)
+                    ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1 babel_3293_t1_1
+                          Index Cond: (b1 = 1)
+                    ->  Hash
+                          ->  Bitmap Heap Scan on babel_3293_t2
+                                Recheck Cond: (b2 = 1)
+                                ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                      Index Cond: (b2 = 1)
+        ->  Tid Scan on babel_3293_t1
+              TID Cond: (ctid = babel_3293_t1_1.ctid)
+~~END~~
+
+
+-- Test DELETE queries with and without hints
+delete babel_3293_t1 from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: delete babel_3293_t1 from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Delete on babel_3293_t1
+  ->  Nested Loop
+        ->  HashAggregate
+              Group Key: babel_3293_t1_1.ctid
+              ->  Hash Join
+                    Hash Cond: (babel_3293_t1_1.a1 = babel_3293_t2.a2)
+                    ->  Bitmap Heap Scan on babel_3293_t1 babel_3293_t1_1
+                          Recheck Cond: (b1 = 1)
+                          ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                                Index Cond: (b1 = 1)
+                    ->  Hash
+                          ->  Bitmap Heap Scan on babel_3293_t2
+                                Recheck Cond: (b2 = 1)
+                                ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                      Index Cond: (b2 = 1)
+        ->  Tid Scan on babel_3293_t1
+              TID Cond: (ctid = babel_3293_t1_1.ctid)
+~~END~~
+
+
+delete babel_3293_t1 from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3293_t1 babel_3293_t2) */ delete babel_3293_t1 from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Delete on babel_3293_t1
+  ->  Nested Loop
+        ->  HashAggregate
+              Group Key: babel_3293_t1_1.ctid
+              ->  Hash Join
+                    Hash Cond: (babel_3293_t1_1.a1 = babel_3293_t2.a2)
+                    ->  Bitmap Heap Scan on babel_3293_t1 babel_3293_t1_1
+                          Recheck Cond: (b1 = 1)
+                          ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                                Index Cond: (b1 = 1)
+                    ->  Hash
+                          ->  Bitmap Heap Scan on babel_3293_t2
+                                Recheck Cond: (b2 = 1)
+                                ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                      Index Cond: (b2 = 1)
+        ->  Tid Scan on babel_3293_t1
+              TID Cond: (ctid = babel_3293_t1_1.ctid)
+~~END~~
+
+
+delete babel_3293_t1 from babel_3293_t1 with(index(index_babel_3293_t1_b1)) left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) MergeJoin(babel_3293_t1 babel_3293_t2) */ delete babel_3293_t1 from babel_3293_t1                                     left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Delete on babel_3293_t1
+  ->  Nested Loop
+        ->  HashAggregate
+              Group Key: babel_3293_t1_1.ctid
+              ->  Hash Join
+                    Hash Cond: (babel_3293_t1_1.a1 = babel_3293_t2.a2)
+                    ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1 babel_3293_t1_1
+                          Index Cond: (b1 = 1)
+                    ->  Hash
+                          ->  Bitmap Heap Scan on babel_3293_t2
+                                Recheck Cond: (b2 = 1)
+                                ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                      Index Cond: (b2 = 1)
+        ->  Tid Scan on babel_3293_t1
+              TID Cond: (ctid = babel_3293_t1_1.ctid)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3293_t1
+go
+
+drop table babel_3293_t2
+go
+
+drop table babel_3293_t3
+go
+
+-- Test all queries by specifying a database and schema name
+use tempdb
+go
+
+drop table if exists babel_3293_schema.t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+drop schema if exists babel_3293_schema
+go
+
+create schema babel_3293_schema
+go
+
+create table babel_3293_schema.t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_schema_t1_b1 on babel_3293_schema.t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+select * from tempdb.babel_3293_schema.t1 inner merge join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(t1 babel_3293_t2) */ select * from tempdb.babel_3293_schema.t1 inner       join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: t1.a1
+        ->  Bitmap Heap Scan on t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1                                            join babel_3293_t2                                 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Hash Join
+  Hash Cond: (t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
+        Index Cond: (b1 = 1)
+  ->  Hash
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join, table hint(tempdb.babel_3293_schema.t1, index(index_babel_3293_schema_t1_b1)), table hint(tempdb.dbo.babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
+Merge Join
+  Merge Cond: (t1.a1 = babel_3293_t2.a2)
+  ->  Sort
+        Sort Key: t1.a1
+        ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
+              Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t2.a2
+        ->  Index Scan using index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e on babel_3293_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+drop table babel_3293_schema.t1 
+go
+
+drop table babel_3293_t2
+go
+
+drop schema babel_3293_schema
+go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -32,8 +32,8 @@ go
 /*
  * Run a SELECT query without any hints to ensure that un-hinted queries still work.
  * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
- * than the index scan that we're hinting in the query below. This verifies that the next test is actually valid.
- * If the planner was going to choose a sequential scan anyway, the next test wouldn't actually prove that hints were working.
+ * than the index scan that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ * If the planner was going to choose a index scan anyway, the next test wouldn't actually prove that hints were working.
  */
 select * from babel_3292_t1 where b1 = 1
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -29,8 +29,8 @@ go
 /*
  * Run a SELECT query without any hints to ensure that un-hinted queries still work.
  * This also ensures that when the SELECT query is not hinted it produces a different plan(bitmap heap scan and bitmap index scan)
- * than the index scan that we're hinting in the query below. This verifies that the next test is actually valid.
- * If the planner was going to choose a sequential scan anyway, the next test wouldn't actually prove that hints were working.
+ * than the index scan that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ * If the planner was going to choose a index scan anyway, the next test wouldn't actually prove that hints were working.
  */
 select * from babel_3292_t1 where b1 = 1
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -201,9 +201,6 @@ go
 create index index_babel_3292_t2_b2 on babel_3292_t2(b2)
 go
 
-select set_config('babelfishpg_tsql.explain_costs', 'off', false)
-go
-
 set babelfish_showplan_all on
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3293.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3293.sql
@@ -1,0 +1,182 @@
+drop table if exists babel_3293_t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+drop table if exists babel_3293_t3
+go
+
+create table babel_3293_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_t1_b1 on babel_3293_t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+create table babel_3293_t3(a3 int PRIMARY KEY, b3 int)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query joining two tables without any join hints to ensure that un-hinted queries still work.
+ * This also ensures that when the SELECT query is not hinted it produces a different plan(hash join)
+ * than the other join plans that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+/*
+ * Give the hints in the queries to follow a specified join plan.
+ * The query plan should now use the specified join plan instead of hash join it uses in the un-hinted test above.
+ */
+select * from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+
+-- Queries with multiple joins
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+
+select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+
+-- Join hints through option clause
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join)
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join)
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+
+-- Queries with both table hints and join hints
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) right outer merge join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join, table hint(babel_3293_t1, index(index_babel_3293_t1_b1)), table hint(babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+
+-- UPDATE and DELETE queries with join hints needs to be revisited later. pg_hint_plan is currently not following the given join hints 
+-- Test UPDATE queries with and without hints
+update babel_3293_t1 set a1 = 1 from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+update babel_3293_t1 set a1 = 1 from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+update babel_3293_t1 set a1 = 1 from babel_3293_t1 with(index(index_babel_3293_t1_b1)) full outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+-- Test DELETE queries with and without hints
+delete babel_3293_t1 from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+delete babel_3293_t1 from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+delete babel_3293_t1 from babel_3293_t1 with(index(index_babel_3293_t1_b1)) left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3293_t1
+go
+
+drop table babel_3293_t2
+go
+
+drop table babel_3293_t3
+go
+
+-- Test all queries by specifying a database and schema name
+use tempdb
+go
+
+drop table if exists babel_3293_schema.t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+drop schema if exists babel_3293_schema
+go
+
+create schema babel_3293_schema
+go
+
+create table babel_3293_schema.t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_schema_t1_b1 on babel_3293_schema.t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+set babelfish_showplan_all on
+go
+
+select * from tempdb.babel_3293_schema.t1 inner merge join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+
+select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join, table hint(tempdb.babel_3293_schema.t1, index(index_babel_3293_schema_t1_b1)), table hint(tempdb.dbo.babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false)
+go
+
+drop table babel_3293_schema.t1 
+go
+
+drop table babel_3293_t2
+go
+
+drop schema babel_3293_schema
+go

--- a/test/JDBC/pg_hint_plan/BABEL-3293.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3293.sql
@@ -1,0 +1,131 @@
+drop table if exists babel_3293_t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+create table babel_3293_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_t1_b1 on babel_3293_t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+set babelfish_showplan_all on
+go
+
+/*
+ * Run a SELECT query joining two tables without any join hints to ensure that un-hinted queries still work.
+ * This also ensures that when the SELECT query is not hinted it produces a different plan(hash join)
+ * than the other join plans that we're hinting in the queries below. This verifies that the next set of tests are actually valid.
+ */
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+/*
+ * Give the hints in the queries to follow a specified join plan.
+ * The query plan should now use the specified join plan instead of hash join it uses in the un-hinted test above.
+ */
+select * from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+
+-- Join hints through option clause
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join)
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join)
+go
+
+-- Queries with both table hints and join hints
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) right outer merge join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(loop join, table hint(babel_3293_t1, index(index_babel_3293_t1_b1)), table hint(babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3293_t1
+go
+
+drop table babel_3293_t2
+go
+
+
+-- Test all queries by specifying a database and schema name
+use tempdb
+go
+
+drop table if exists babel_3293_schema.t1
+go
+
+drop table if exists babel_3293_t2
+go
+
+drop schema if exists babel_3293_schema
+go
+
+create schema babel_3293_schema
+go
+
+create table babel_3293_schema.t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3293_schema_t1_b1 on babel_3293_schema.t1(b1)
+go
+
+create table babel_3293_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3293_t2_b2 on babel_3293_t2(b2)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+set babelfish_showplan_all on
+go
+
+select * from tempdb.babel_3293_schema.t1 inner merge join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
+select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
+go
+
+select * from tempdb.babel_3293_schema.t1 join babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(merge join, table hint(tempdb.babel_3293_schema.t1, index(index_babel_3293_schema_t1_b1)), table hint(tempdb.dbo.babel_3293_t2, index(index_babel_3293_t2_b2)))
+go
+
+set babelfish_showplan_all off
+go
+
+-- cleanup
+drop table babel_3293_schema.t1 
+go
+
+drop table babel_3293_t2
+go
+
+drop schema babel_3293_schema
+go

--- a/test/JDBC/pg_hint_plan/BABEL-3293.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3293.sql
@@ -68,6 +68,15 @@ go
 select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 go
 
+select * from babel_3293_t1, babel_3293_t2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
+go
+
+select * from babel_3293_t1 t1, babel_3293_t2 t2 inner merge join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+go
+
+select * from babel_3293_t1 t1, babel_3293_t2 t2 inner hash join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+go
+
 -- Join hints through option clause
 select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
 go


### PR DESCRIPTION
### Description

Currently Babelfish does not support join hints. To add support for query hints, we are using the third-part library pg_hint_plan. This pull request has the following changes:

`Add support for T-SQL join hints (MERGE | HASH | LOOP JOIN) conversion`
`Add a test to verify the hinted queries work as expected`

 
### Issues Resolved

Task: BABEL-3293


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).