### PR TITLE
Add support for converting index hints having table aliases

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4803,7 +4803,6 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 				extractTableHints(actx->table_alias()->with_table_hints(), alias_name);
 			removeCtxStringFromQuery(expr, actx->table_alias()->with_table_hints(), baseCtx);
 		}
-		
 	}
 	
 	if (ctx->join_hint())

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -103,7 +103,7 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx);
 void extractTableHints(TSqlParser::With_table_hintsContext *tctx, std::string table_name);
 std::string extractTableName(TSqlParser::Ddl_objectContext *ctx);
 void extractTableHint(TSqlParser::Table_hintContext *table_hint, std::string table_name);
-std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> index_valuesCtx, char *table_name);
+std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> index_valuesCtx, std::string table_name);
 
 static void *makeBatch(TSqlParser::Tsql_fileContext *ctx, tsqlBuilder &builder);
 //static void *makeBatch(TSqlParser::Block_statementContext *ctx, tsqlBuilder &builder);
@@ -201,6 +201,7 @@ static void clear_rewritten_query_fragment();
 // add information of rewritten_query_fragment information to mutator
 static void add_rewritten_query_fragment_to_mutator(PLtsql_expr_query_mutator *mutator);
 
+static std::unordered_map<std::string, std::string> alias_mapping;
 static std::vector<std::string> query_hints;
 static void add_query_hints(PLtsql_expr* expr);
 static void clear_query_hints();
@@ -573,6 +574,7 @@ static void
 clear_query_hints()
 {
 	query_hints.clear();
+	alias_mapping.clear();
 }
 
 /*
@@ -3176,14 +3178,16 @@ void extractTableHint(TSqlParser::Table_hintContext *table_hint, std::string tab
 {
 	if (table_hint->INDEX())
 	{
-		std::string index_values = extractIndexValues(table_hint->index_value(), const_cast <char *>(table_name.c_str()));
+		std::string index_values = extractIndexValues(table_hint->index_value(), table_name);
 		if (!index_values.empty())
 			query_hints.push_back("IndexScan(" + table_name + " " + index_values + ")");
 	}
 }
 
-std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> index_valuesCtx, char *table_name)
+std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> index_valuesCtx, std::string table_name)
 {
+	if(alias_mapping.find(table_name) != alias_mapping.end())
+		table_name = alias_mapping[table_name];
 	std::string index_values;
 	for (auto ictx: index_valuesCtx)
 	{
@@ -3191,7 +3195,7 @@ std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> ind
 		{
 			if (index_values.size())
 				index_values += " ";
-			char * index_value = construct_unique_index_name(const_cast <char *>(::getFullText(ictx->id()).c_str()), table_name);
+			char * index_value = construct_unique_index_name(const_cast <char *>(::getFullText(ictx->id()).c_str()), const_cast <char *>(table_name.c_str()));
 			index_values += std::string(index_value);
 		}
 	}
@@ -4780,6 +4784,28 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 		}
 		removeCtxStringFromQuery(expr, wctx, baseCtx);
 	}
+
+	for (auto actx : ctx->as_table_alias())
+	{
+		std::string alias_name = ::getFullText(actx->table_alias()->id());
+		std::string table_name;
+		if (ctx->full_object_name())
+			table_name = stripQuoteFromId(ctx->full_object_name()->object_name);
+		else if (ctx->local_id())
+			table_name = ::getFullText(ctx->local_id());
+		if (!table_name.empty())
+		{
+			alias_mapping[alias_name] = table_name;
+		}
+		if (actx->table_alias()->with_table_hints())
+		{
+			if (enable_hint_mapping && !actx->table_alias()->with_table_hints()->sample_clause())
+				extractTableHints(actx->table_alias()->with_table_hints(), alias_name);
+			removeCtxStringFromQuery(expr, actx->table_alias()->with_table_hints(), baseCtx);
+		}
+		
+	}
+	
 	if (ctx->join_hint())
 		removeCtxStringFromQuery(expr, ctx->join_hint(), baseCtx);
 }

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -101,22 +101,22 @@ Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
 ~~END~~
 
 
-select * from babel_3292_t1 t with(index=index_babel_3292_t1_b1) where b1 = 1
+select * from babel_3292_t1 t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 t                                    where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t
+Query Text: /*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 t1                                    where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
   Index Cond: (b1 = 1)
 ~~END~~
 
 
-select * from babel_3292_t1 as t with(index=index_babel_3292_t1_b1) where b1 = 1
+select * from babel_3292_t1 as t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 as t                                    where b1 = 1
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t
+Query Text: /*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 as t1                                    where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -131,12 +131,12 @@ Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
 ~~END~~
 
 
-select * from babel_3292_t1 t where b1=1 option(table hint(t, index(index_babel_3292_t1_b1)))
+select * from babel_3292_t1 t1 where b1=1 option(table hint(t1, index(index_babel_3292_t1_b1)))
 go
 ~~START~~
 text
-Query Text: /*+ IndexScan(t index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 t where b1=1                                                     
-Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t
+Query Text: /*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 t1 where b1=1                                                      
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
   Index Cond: (b1 = 1)
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -101,12 +101,42 @@ Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
 ~~END~~
 
 
+select * from babel_3292_t1 t with(index=index_babel_3292_t1_b1) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 t                                    where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 as t with(index=index_babel_3292_t1_b1) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 as t                                    where b1 = 1
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t
+  Index Cond: (b1 = 1)
+~~END~~
+
+
 select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
 go
 ~~START~~
 text
 Query Text: /*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 where b1=1                                                                 
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 t where b1=1 option(table hint(t, index(index_babel_3292_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ select * from babel_3292_t1 t where b1=1                                                     
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t
   Index Cond: (b1 = 1)
 ~~END~~
 
@@ -206,6 +236,34 @@ Nested Loop
         Index Cond: (b1 = 1)
   ->  Materialize
         ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 t2 with(index=index_babel_3292_t2_b2) where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1 t1                                   , babel_3292_t2 t2                                    where b1 = 1 and b2 = 1
+Nested Loop
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from babel_3292_t1 t1, babel_3292_t2 t2 where b1 = 1 and b2 = 1 option(table hint(t1, index(index_babel_3292_t1_b1)), table hint(t2, index(index_babel_3292_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from babel_3292_t1 t1, babel_3292_t2 t2 where b1 = 1 and b2 = 1                                                                                                     
+Nested Loop
+  ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
               Index Cond: (b2 = 1)
 ~~END~~
 
@@ -531,11 +589,31 @@ Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297
 ~~END~~
 
 
+select * from tempdb.babel_3292_schema.t1 t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from tempdb.babel_3292_schema.t1 t1                                        where b1 = 1
+Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
 select * from tempdb.babel_3292_schema.t1 where b1=1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
 go
 ~~START~~
 text
 Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from tempdb.babel_3292_schema.t1 where b1=1                                                                                      
+Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3292_schema.t1 t1 where b1=1 option(table hint(t1, index(index_babel_3292_schema_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ select * from tempdb.babel_3292_schema.t1 t1 where b1=1                                                             
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -577,6 +655,20 @@ Nested Loop
 ~~END~~
 
 
+select * from tempdb.babel_3292_schema.t1 t1 with(index(index_babel_3292_schema_t1_b1)), tempdb.dbo.babel_3292_t2 t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1 t1                                           , tempdb.dbo.babel_3292_t2 t2                                     where b1 = 1 and b2 = 1
+Nested Loop
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
 select * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
 go
 ~~START~~
@@ -587,6 +679,20 @@ Nested Loop
         Index Cond: (b1 = 1)
   ->  Materialize
         ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3292_schema.t1 t1, tempdb.dbo.babel_3292_t2 t2 where b1 = 1 and b2 = 1 option(table hint(t1, index(index_babel_3292_schema_t1_b1)), table hint(t2, index(index_babel_3292_t2_b2)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1 t1, tempdb.dbo.babel_3292_t2 t2 where b1 = 1 and b2 = 1                                                                                                            
+Nested Loop
+  ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+        Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
               Index Cond: (b2 = 1)
 ~~END~~
 
@@ -672,6 +778,21 @@ HashAggregate
 ~~END~~
 
 
+select * from tempdb.babel_3292_schema.t1 t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 with(index=index_babel_3292_t2_b2) where b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1 t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2                                    where b2 = 1
+HashAggregate
+  Group Key: t1.a1, t1.b1, t1.c1
+  ->  Append
+        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
 select * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
 go
 ~~START~~
@@ -683,6 +804,21 @@ HashAggregate
         ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
               Index Cond: (b1 = 1)
         ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+              Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1 option(table hint(t1, index(index_babel_3292_schema_t1_b1)), table hint(t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ select * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1                                                                                                            
+HashAggregate
+  Group Key: t1.a1, t1.b1, t1.c1
+  ->  Append
+        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+              Index Cond: (b1 = 1)
+        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
               Index Cond: (b2 = 1)
 ~~END~~
 

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -54,7 +54,16 @@ go
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
+select * from babel_3292_t1 t with(index=index_babel_3292_t1_b1) where b1 = 1
+go
+
+select * from babel_3292_t1 as t with(index=index_babel_3292_t1_b1) where b1 = 1
+go
+
 select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+
+select * from babel_3292_t1 t where b1=1 option(table hint(t, index(index_babel_3292_t1_b1)))
 go
 
 -- Test with multiple index hints
@@ -78,6 +87,12 @@ select * from babel_3292_t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 wi
 go
 
 select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)), table hint(babel_3292_t2, index(index_babel_3292_t2_b2)))
+go
+
+select * from babel_3292_t1 t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 t2 with(index=index_babel_3292_t2_b2) where b1 = 1 and b2 = 1
+go
+
+select * from babel_3292_t1 t1, babel_3292_t2 t2 where b1 = 1 and b2 = 1 option(table hint(t1, index(index_babel_3292_t1_b1)), table hint(t2, index(index_babel_3292_t2_b2)))
 go
 
 -- Test INSERT queries with and without hints
@@ -195,7 +210,13 @@ go
 select * from tempdb.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
 go
 
+select * from tempdb.babel_3292_schema.t1 t1 (index(index_babel_3292_schema_t1_b1)) where b1 = 1
+go
+
 select * from tempdb.babel_3292_schema.t1 where b1=1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)))
+go
+
+select * from tempdb.babel_3292_schema.t1 t1 where b1=1 option(table hint(t1, index(index_babel_3292_schema_t1_b1)))
 go
 
 select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1), index(index_babel_3292_schema_t1_c1)) where b1 = 1 and c1 = 1
@@ -207,7 +228,13 @@ go
 select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)), tempdb.dbo.babel_3292_t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
 go
 
+select * from tempdb.babel_3292_schema.t1 t1 with(index(index_babel_3292_schema_t1_b1)), tempdb.dbo.babel_3292_t2 t2 with(index(index_babel_3292_t2_b2)) where b1 = 1 and b2 = 1
+go
+
 select * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2)))
+go
+
+select * from tempdb.babel_3292_schema.t1 t1, tempdb.dbo.babel_3292_t2 t2 where b1 = 1 and b2 = 1 option(table hint(t1, index(index_babel_3292_schema_t1_b1)), table hint(t2, index(index_babel_3292_t2_b2)))
 go
 
 insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) where b1 = 1
@@ -231,7 +258,13 @@ go
 select * from tempdb.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 with(index=index_babel_3292_t2_b2) where b2 = 1
 go
 
+select * from tempdb.babel_3292_schema.t1 t1 with(index=index_babel_3292_schema_t1_b1) where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 with(index=index_babel_3292_t2_b2) where b2 = 1
+go
+
 select * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1 option(table hint(tempdb.babel_3292_schema.t1, index(index_babel_3292_schema_t1_b1)), table hint(tempdb.dbo.babel_3292_t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
+go
+
+select * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1 option(table hint(t1, index(index_babel_3292_schema_t1_b1)), table hint(t2, index(index_babel_3292_t2_b2))) -- Both queries have a hint
 go
 
 set babelfish_showplan_all off

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -54,16 +54,16 @@ go
 select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
-select * from babel_3292_t1 t with(index=index_babel_3292_t1_b1) where b1 = 1
+select * from babel_3292_t1 t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
-select * from babel_3292_t1 as t with(index=index_babel_3292_t1_b1) where b1 = 1
+select * from babel_3292_t1 as t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 
 select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
 go
 
-select * from babel_3292_t1 t where b1=1 option(table hint(t, index(index_babel_3292_t1_b1)))
+select * from babel_3292_t1 t1 where b1=1 option(table hint(t1, index(index_babel_3292_t1_b1)))
 go
 
 -- Test with multiple index hints


### PR DESCRIPTION
### Description

Currently Babelfish does not support index hints in queries having table aliases. This pull request has changes to add support for it.
 
### Issues Resolved

Task: BABEL-3352


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).