### PR TITLE
Remove deprecated check in Major version upgrade util composite action

### DIFF
--- a/.github/composite-actions/major-version-upgrade-util/action.yml
+++ b/.github/composite-actions/major-version-upgrade-util/action.yml
@@ -65,7 +65,7 @@ runs:
     - uses: actions/checkout@v2
 
     - name: Run JDBC Verify Tests
-      if: always() && steps.change-migration-mode.outcome == 'success' && inputs.is_final_ver == 'true'
+      if: always() && steps.run-pg_upgrade.outcome == 'success' && inputs.is_final_ver == 'true'
       id: jdbc-verify-tests
       run: |
         cd test/JDBC/


### PR DESCRIPTION
### Description
Version upgrade test framework was not running maven tests with verify scripts after upgrade. This happened due to deprecated check for change-migration-mode step which is no longer present in the major version upgrade utility composite action.

This commit will remove check for change-migration-mode step from the major version upgrade utility composite action.

Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).