### PR TITLE
Implemented sys.triggers

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1125,177 +1125,6 @@ WHERE has_schema_privilege(s.schema_id, 'USAGE')
 AND c.contype = 'c' and c.conrelid != 0;
 GRANT SELECT ON sys.check_constraints TO PUBLIC;
 
-create or replace view sys.objects as
-select
-      CAST(t.name as sys.sysname) as name 
-    , CAST(t.object_id as int) as object_id
-    , CAST(t.principal_id as int) as principal_id
-    , CAST(t.schema_id as int) as schema_id
-    , CAST(t.parent_object_id as int) as parent_object_id
-    , CAST('U' as char(2)) as type
-    , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
-    , CAST(t.create_date as sys.datetime) as create_date
-    , CAST(t.modify_date as sys.datetime) as modify_date
-    , CAST(t.is_ms_shipped as sys.bit) as is_ms_shipped
-    , CAST(t.is_published as sys.bit) as is_published
-    , CAST(t.is_schema_published as sys.bit) as is_schema_published
-from  sys.tables t
-union all
-select
-      CAST(v.name as sys.sysname) as name
-    , CAST(v.object_id as int) as object_id
-    , CAST(v.principal_id as int) as principal_id
-    , CAST(v.schema_id as int) as schema_id
-    , CAST(v.parent_object_id as int) as parent_object_id
-    , CAST('V' as char(2)) as type
-    , CAST('VIEW' as sys.nvarchar(60)) as type_desc
-    , CAST(v.create_date as sys.datetime) as create_date
-    , CAST(v.modify_date as sys.datetime) as modify_date
-    , CAST(v.is_ms_shipped as sys.bit) as is_ms_shipped
-    , CAST(v.is_published as sys.bit) as is_published
-    , CAST(v.is_schema_published as sys.bit) as is_schema_published
-from  sys.views v
-union all
-select
-      CAST(f.name as sys.sysname) as name
-    , CAST(f.object_id as int) as object_id
-    , CAST(f.principal_id as int) as principal_id
-    , CAST(f.schema_id as int) as schema_id
-    , CAST(f.parent_object_id as int) as parent_object_id
-    , CAST('F' as char(2)) as type
-    , CAST('FOREIGN_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
-    , CAST(f.create_date as sys.datetime) as create_date
-    , CAST(f.modify_date as sys.datetime) as modify_date
-    , CAST(f.is_ms_shipped as sys.bit) as is_ms_shipped
-    , CAST(f.is_published as sys.bit) as is_published
-    , CAST(f.is_schema_published as sys.bit) as is_schema_published
- from sys.foreign_keys f
-union all
-select
-      CAST(p.name as sys.sysname) as name
-    , CAST(p.object_id as int) as object_id
-    , CAST(p.principal_id as int) as principal_id
-    , CAST(p.schema_id as int) as schema_id
-    , CAST(p.parent_object_id as int) as parent_object_id
-    , CAST('PK' as char(2)) as type
-    , CAST('PRIMARY_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
-    , CAST(p.create_date as sys.datetime) as create_date
-    , CAST(p.modify_date as sys.datetime) as modify_date
-    , CAST(p.is_ms_shipped as sys.bit) as is_ms_shipped
-    , CAST(p.is_published as sys.bit) as is_published
-    , CAST(p.is_schema_published as sys.bit) as is_schema_published
-from sys.key_constraints p
-where p.type = 'PK'
-union all
-select
-      CAST(pr.name as sys.sysname) as name
-    , CAST(pr.object_id as int) as object_id
-    , CAST(pr.principal_id as int) as principal_id
-    , CAST(pr.schema_id as int) as schema_id
-    , CAST(pr.parent_object_id as int) as parent_object_id
-    , CAST(pr.type as char(2)) as type
-    , CAST(pr.type_desc as sys.nvarchar(60)) as type_desc
-    , CAST(pr.create_date as sys.datetime) as create_date
-    , CAST(pr.modify_date as sys.datetime) as modify_date
-    , CAST(pr.is_ms_shipped as sys.bit) as is_ms_shipped
-    , CAST(pr.is_published as sys.bit) as is_published
-    , CAST(pr.is_schema_published as sys.bit) as is_schema_published
- from sys.procedures pr
-union all
-select
-    CAST(def.name as sys.sysname) as name
-  , CAST(def.object_id as int) as object_id
-  , CAST(def.principal_id as int) as principal_id
-  , CAST(def.schema_id as int) as schema_id
-  , CAST(def.parent_object_id as int) as parent_object_id
-  , CAST(def.type as char(2)) as type
-  , CAST(def.type_desc as sys.nvarchar(60)) as type_desc
-  , CAST(def.create_date as sys.datetime) as create_date
-  , CAST(def.modified_date as sys.datetime) as modify_date
-  , CAST(def.is_ms_shipped as sys.bit) as is_ms_shipped
-  , CAST(def.is_published as sys.bit) as is_published
-  , CAST(def.is_schema_published as sys.bit) as is_schema_published
-  from sys.default_constraints def
-union all
-select
-    CAST(chk.name as sys.sysname) as name
-  , CAST(chk.object_id as int) as object_id
-  , CAST(chk.principal_id as int) as principal_id
-  , CAST(chk.schema_id as int) as schema_id
-  , CAST(chk.parent_object_id as int) as parent_object_id
-  , CAST(chk.type as char(2)) as type
-  , CAST(chk.type_desc as sys.nvarchar(60)) as type_desc
-  , CAST(chk.create_date as sys.datetime) as create_date
-  , CAST(chk.modify_date as sys.datetime) as modify_date
-  , CAST(chk.is_ms_shipped as sys.bit) as is_ms_shipped
-  , CAST(chk.is_published as sys.bit) as is_published
-  , CAST(chk.is_schema_published as sys.bit) as is_schema_published
-  from sys.check_constraints chk
-union all
-select
-    CAST(p.relname as sys.sysname) as name
-  , CAST(p.oid as int) as object_id
-  , CAST(null as int) as principal_id
-  , CAST(s.schema_id as int) as schema_id
-  , CAST(0 as int) as parent_object_id
-  , CAST('SO' as char(2)) as type
-  , CAST('SEQUENCE_OBJECT' as sys.nvarchar(60)) as type_desc
-  , CAST(null as sys.datetime) as create_date
-  , CAST(null as sys.datetime) as modify_date
-  , CAST(0 as sys.bit) as is_ms_shipped
-  , CAST(0 as sys.bit) as is_published
-  , CAST(0 as sys.bit) as is_schema_published
-from pg_class p
-inner join sys.schemas s on s.schema_id = p.relnamespace
-and p.relkind = 'S'
-and has_schema_privilege(s.schema_id, 'USAGE')
-union all
-select
-    CAST(('TT_' || tt.name || '_' || tt.type_table_object_id) as sys.sysname) as name
-  , CAST(tt.type_table_object_id as int) as object_id
-  , CAST(tt.principal_id as int) as principal_id
-  , CAST(tt.schema_id as int) as schema_id
-  , CAST(0 as int) as parent_object_id
-  , CAST('TT' as char(2)) as type
-  , CAST('TABLE_TYPE' as sys.nvarchar(60)) as type_desc
-  , CAST(null as sys.datetime) as create_date
-  , CAST(null as sys.datetime) as modify_date
-  , CAST(1 as sys.bit) as is_ms_shipped
-  , CAST(0 as sys.bit) as is_published
-  , CAST(0 as sys.bit) as is_schema_published
-from sys.table_types tt;
-GRANT SELECT ON sys.objects TO PUBLIC;
-
-create or replace view sys.sysobjects as
-select
-  s.name
-  , s.object_id as id
-  , s.type as xtype
-  , CAST(s.schema_id as smallint) as uid
-  , CAST(0 as smallint) as info
-  , 0 as status
-  , 0 as base_schema_ver
-  , 0 as replinfo
-  , s.parent_object_id as parent_obj
-  , s.create_date as crdate
-  , CAST(0 as smallint) as ftcatid
-  , 0 as schema_ver
-  , 0 as stats_schema_ver
-  , s.type
-  , CAST(0 as smallint) as userstat
-  , CAST(0 as smallint) as sysstat
-  , CAST(0 as smallint) as indexdel
-  , CAST(s.modify_date as sys.datetime) as refdate
-  , 0 as version
-  , 0 as deltrig
-  , 0 as instrig
-  , 0 as updtrig
-  , 0 as seltrig
-  , 0 as category
-  , CAST(0 as smallint) as cache
-from sys.objects s;
-GRANT SELECT ON sys.sysobjects TO PUBLIC;
-
 create or replace view sys.shipped_objects_not_in_sys AS
 -- This portion of view retrieves information on objects that reside in a schema in one specfic database.
 -- For example, 'master_dbo' schema can only exist in the 'master' database.
@@ -1427,7 +1256,10 @@ select
   , p.oid as object_id
   , null::integer as principal_id
   , s.oid as schema_id
-  , 0 as parent_object_id
+  , cast (case when tr.tgrelid is not null 
+  		       then tr.tgrelid 
+  		       else 0 end as int) 
+    as parent_object_id
   , case p.prokind
       when 'p' then 'P'::varchar(2)
       when 'a' then 'AF'::varchar(2)
@@ -1453,6 +1285,7 @@ select
   , 0 as is_schema_published
 from pg_proc p
 inner join pg_namespace s on s.oid = p.pronamespace
+left join pg_trigger tr on tr.tgfoid = p.oid
 where (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
 and has_schema_privilege(s.oid, 'USAGE')
 and has_function_privilege(p.oid, 'EXECUTE')
@@ -1565,6 +1398,225 @@ select
 from sys.all_objects t
 where t.type = 'V';
 GRANT SELECT ON sys.all_views TO PUBLIC;
+
+-- TODO: BABELFISH-506
+CREATE OR REPLACE VIEW sys.triggers
+AS
+SELECT
+  CAST(p.proname as sys.sysname) as name,
+  CAST(p.oid as int) as object_id,
+  CAST(1 as sys.tinyint) as parent_class,
+  CAST('OBJECT_OR_COLUMN' as sys.nvarchar(60)) AS parent_class_desc,
+  CAST(tr.tgrelid as int) AS parent_id,
+  CAST('TR' as sys.bpchar(2)) AS type,
+  CAST('SQL_TRIGGER' as sys.nvarchar(60)) AS type_desc,
+  CAST(NULL as sys.datetime) AS create_date,
+  CAST(NULL as sys.datetime) AS modify_date,
+  CAST(0 as sys.bit) AS is_ms_shipped,
+  CAST(
+      CASE WHEN tr.tgenabled = 'D'
+      THEN 1
+      ELSE 0
+      END
+      AS sys.bit
+  )	AS is_disabled,
+  CAST(0 as sys.bit) AS is_not_for_replication,
+  CAST(get_bit(CAST(CAST(tr.tgtype as int) as bit(7)),0) as sys.bit) AS is_instead_of_trigger
+FROM pg_proc p
+inner join sys.schemas sch on sch.schema_id = p.pronamespace
+left join pg_trigger tr on tr.tgfoid = p.oid
+where has_schema_privilege(sch.schema_id, 'USAGE')
+and has_function_privilege(p.oid, 'EXECUTE')
+and p.prokind = 'f'
+and format_type(p.prorettype, null) = 'trigger';
+GRANT SELECT ON sys.triggers TO PUBLIC;
+
+create or replace view sys.objects as
+select
+      CAST(t.name as sys.sysname) as name 
+    , CAST(t.object_id as int) as object_id
+    , CAST(t.principal_id as int) as principal_id
+    , CAST(t.schema_id as int) as schema_id
+    , CAST(t.parent_object_id as int) as parent_object_id
+    , CAST('U' as char(2)) as type
+    , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
+    , CAST(t.create_date as sys.datetime) as create_date
+    , CAST(t.modify_date as sys.datetime) as modify_date
+    , CAST(t.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(t.is_published as sys.bit) as is_published
+    , CAST(t.is_schema_published as sys.bit) as is_schema_published
+from  sys.tables t
+union all
+select
+      CAST(v.name as sys.sysname) as name
+    , CAST(v.object_id as int) as object_id
+    , CAST(v.principal_id as int) as principal_id
+    , CAST(v.schema_id as int) as schema_id
+    , CAST(v.parent_object_id as int) as parent_object_id
+    , CAST('V' as char(2)) as type
+    , CAST('VIEW' as sys.nvarchar(60)) as type_desc
+    , CAST(v.create_date as sys.datetime) as create_date
+    , CAST(v.modify_date as sys.datetime) as modify_date
+    , CAST(v.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(v.is_published as sys.bit) as is_published
+    , CAST(v.is_schema_published as sys.bit) as is_schema_published
+from  sys.views v
+union all
+select
+      CAST(f.name as sys.sysname) as name
+    , CAST(f.object_id as int) as object_id
+    , CAST(f.principal_id as int) as principal_id
+    , CAST(f.schema_id as int) as schema_id
+    , CAST(f.parent_object_id as int) as parent_object_id
+    , CAST('F' as char(2)) as type
+    , CAST('FOREIGN_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(f.create_date as sys.datetime) as create_date
+    , CAST(f.modify_date as sys.datetime) as modify_date
+    , CAST(f.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(f.is_published as sys.bit) as is_published
+    , CAST(f.is_schema_published as sys.bit) as is_schema_published
+ from sys.foreign_keys f
+union all
+select
+      CAST(p.name as sys.sysname) as name
+    , CAST(p.object_id as int) as object_id
+    , CAST(p.principal_id as int) as principal_id
+    , CAST(p.schema_id as int) as schema_id
+    , CAST(p.parent_object_id as int) as parent_object_id
+    , CAST('PK' as char(2)) as type
+    , CAST('PRIMARY_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(p.create_date as sys.datetime) as create_date
+    , CAST(p.modify_date as sys.datetime) as modify_date
+    , CAST(p.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(p.is_published as sys.bit) as is_published
+    , CAST(p.is_schema_published as sys.bit) as is_schema_published
+from sys.key_constraints p
+where p.type = 'PK'
+union all
+select
+      CAST(pr.name as sys.sysname) as name
+    , CAST(pr.object_id as int) as object_id
+    , CAST(pr.principal_id as int) as principal_id
+    , CAST(pr.schema_id as int) as schema_id
+    , CAST(pr.parent_object_id as int) as parent_object_id
+    , CAST(pr.type as char(2)) as type
+    , CAST(pr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(pr.create_date as sys.datetime) as create_date
+    , CAST(pr.modify_date as sys.datetime) as modify_date
+    , CAST(pr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(pr.is_published as sys.bit) as is_published
+    , CAST(pr.is_schema_published as sys.bit) as is_schema_published
+ from sys.procedures pr
+union all
+select
+      CAST(tr.name as sys.sysname) as name
+    , CAST(tr.object_id as int) as object_id
+    , CAST(NULL as int) as principal_id
+    , CAST(p.pronamespace as int) as schema_id
+    , CAST(tr.parent_id as int) as parent_object_id
+    , CAST(tr.type as char(2)) as type
+    , CAST(tr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(tr.create_date as sys.datetime) as create_date
+    , CAST(tr.modify_date as sys.datetime) as modify_date
+    , CAST(tr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(0 as sys.bit) as is_published
+    , CAST(0 as sys.bit) as is_schema_published
+  from sys.triggers tr
+  inner join pg_proc p on p.oid = tr.object_id
+union all 
+select
+    CAST(def.name as sys.sysname) as name
+  , CAST(def.object_id as int) as object_id
+  , CAST(def.principal_id as int) as principal_id
+  , CAST(def.schema_id as int) as schema_id
+  , CAST(def.parent_object_id as int) as parent_object_id
+  , CAST(def.type as char(2)) as type
+  , CAST(def.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(def.create_date as sys.datetime) as create_date
+  , CAST(def.modified_date as sys.datetime) as modify_date
+  , CAST(def.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(def.is_published as sys.bit) as is_published
+  , CAST(def.is_schema_published as sys.bit) as is_schema_published
+  from sys.default_constraints def
+union all
+select
+    CAST(chk.name as sys.sysname) as name
+  , CAST(chk.object_id as int) as object_id
+  , CAST(chk.principal_id as int) as principal_id
+  , CAST(chk.schema_id as int) as schema_id
+  , CAST(chk.parent_object_id as int) as parent_object_id
+  , CAST(chk.type as char(2)) as type
+  , CAST(chk.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(chk.create_date as sys.datetime) as create_date
+  , CAST(chk.modify_date as sys.datetime) as modify_date
+  , CAST(chk.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(chk.is_published as sys.bit) as is_published
+  , CAST(chk.is_schema_published as sys.bit) as is_schema_published
+  from sys.check_constraints chk
+union all
+select
+    CAST(p.relname as sys.sysname) as name
+  , CAST(p.oid as int) as object_id
+  , CAST(null as int) as principal_id
+  , CAST(s.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('SO' as char(2)) as type
+  , CAST('SEQUENCE_OBJECT' as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+from pg_class p
+inner join sys.schemas s on s.schema_id = p.relnamespace
+and p.relkind = 'S'
+and has_schema_privilege(s.schema_id, 'USAGE')
+union all
+select
+    CAST(('TT_' || tt.name || '_' || tt.type_table_object_id) as sys.sysname) as name
+  , CAST(tt.type_table_object_id as int) as object_id
+  , CAST(tt.principal_id as int) as principal_id
+  , CAST(tt.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('TT' as char(2)) as type
+  , CAST('TABLE_TYPE' as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(1 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+from sys.table_types tt;
+GRANT SELECT ON sys.objects TO PUBLIC;
+
+create or replace view sys.sysobjects as
+select
+  s.name
+  , s.object_id as id
+  , s.type as xtype
+  , CAST(s.schema_id as smallint) as uid
+  , CAST(0 as smallint) as info
+  , 0 as status
+  , 0 as base_schema_ver
+  , 0 as replinfo
+  , s.parent_object_id as parent_obj
+  , s.create_date as crdate
+  , CAST(0 as smallint) as ftcatid
+  , 0 as schema_ver
+  , 0 as stats_schema_ver
+  , s.type
+  , CAST(0 as smallint) as userstat
+  , CAST(0 as smallint) as sysstat
+  , CAST(0 as smallint) as indexdel
+  , CAST(s.modify_date as sys.datetime) as refdate
+  , 0 as version
+  , 0 as deltrig
+  , 0 as instrig
+  , 0 as updtrig
+  , 0 as seltrig
+  , 0 as category
+  , CAST(0 as smallint) as cache
+from sys.objects s;
+GRANT SELECT ON sys.sysobjects TO PUBLIC;
 
 -- TODO: BABEL-3127
 CREATE OR REPLACE VIEW sys.all_sql_modules_internal AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -164,6 +164,37 @@ WHERE has_schema_privilege(sch.schema_id, 'USAGE')
 AND c.contype = 'f';
 GRANT SELECT ON sys.foreign_keys TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.triggers
+AS
+SELECT
+  CAST(p.proname as sys.sysname) as name,
+  CAST(p.oid as int) as object_id,
+  CAST(1 as sys.tinyint) as parent_class,
+  CAST('OBJECT_OR_COLUMN' as sys.nvarchar(60)) AS parent_class_desc,
+  CAST(tr.tgrelid as int) AS parent_id,
+  CAST('TR' as sys.bpchar(2)) AS type,
+  CAST('SQL_TRIGGER' as sys.nvarchar(60)) AS type_desc,
+  CAST(NULL as sys.datetime) AS create_date,
+  CAST(NULL as sys.datetime) AS modify_date,
+  CAST(0 as sys.bit) AS is_ms_shipped,
+  CAST(
+      CASE WHEN tr.tgenabled = 'D'
+      THEN 1
+      ELSE 0
+      END
+      AS sys.bit
+  )	AS is_disabled,
+  CAST(0 as sys.bit) AS is_not_for_replication,
+  CAST(get_bit(CAST(CAST(tr.tgtype as int) as bit(7)),0) as sys.bit) AS is_instead_of_trigger
+FROM pg_proc p
+inner join sys.schemas sch on sch.schema_id = p.pronamespace
+left join pg_trigger tr on tr.tgfoid = p.oid
+where has_schema_privilege(sch.schema_id, 'USAGE')
+and has_function_privilege(p.oid, 'EXECUTE')
+and p.prokind = 'f'
+and format_type(p.prorettype, null) = 'trigger';
+GRANT SELECT ON sys.triggers TO PUBLIC;
+
 ALTER VIEW sys.key_constraints RENAME TO key_constraints_deprecated;
 
 CREATE OR replace view sys.key_constraints AS
@@ -275,6 +306,22 @@ select
     , CAST(pr.is_schema_published as sys.bit) as is_schema_published
  from sys.procedures pr
 union all
+select
+      CAST(tr.name as sys.sysname) as name
+    , CAST(tr.object_id as int) as object_id
+    , CAST(NULL as int) as principal_id
+    , CAST(p.pronamespace as int) as schema_id
+    , CAST(tr.parent_id as int) as parent_object_id
+    , CAST(tr.type as char(2)) as type
+    , CAST(tr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(tr.create_date as sys.datetime) as create_date
+    , CAST(tr.modify_date as sys.datetime) as modify_date
+    , CAST(tr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(0 as sys.bit) as is_published
+    , CAST(0 as sys.bit) as is_schema_published
+  from sys.triggers tr
+  inner join pg_proc p on p.oid = tr.object_id
+union all 
 select
     CAST(def.name as sys.sysname) as name
   , CAST(def.object_id as int) as object_id
@@ -1040,6 +1087,226 @@ SELECT
     , CAST(0 as int) as cells_per_object
 WHERE FALSE;
 GRANT SELECT ON sys.spatial_index_tessellations TO PUBLIC;
+create or replace view sys.all_objects as
+select 
+    cast (name as sys.sysname) 
+  , cast (object_id as integer) 
+  , cast ( principal_id as integer)
+  , cast (schema_id as integer)
+  , cast (parent_object_id as integer)
+  , cast (type as char(2))
+  , cast (type_desc as sys.nvarchar(60))
+  , cast (create_date as sys.datetime)
+  , cast (modify_date as sys.datetime)
+  , cast (case when (schema_id::regnamespace::text = 'sys') then 1
+          when name in (select name from sys.shipped_objects_not_in_sys nis 
+                        where nis.name = name and nis.schemaid = schema_id and nis.type = type) then 1 
+          else 0 end as sys.bit) as is_ms_shipped
+  , cast (is_published as sys.bit)
+  , cast (is_schema_published as sys.bit)
+from
+(
+-- details of user defined and system tables
+select
+    t.relname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'U' as type
+  , 'USER_TABLE' as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class t inner join pg_namespace s on s.oid = t.relnamespace
+where t.relpersistence in ('p', 'u', 't')
+and t.relkind = 'r'
+and (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
+union all
+-- details of user defined and system views
+select
+    t.relname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'V'::varchar(2) as type
+  , 'VIEW'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class t inner join pg_namespace s on s.oid = t.relnamespace
+where t.relkind = 'v'
+and (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and has_table_privilege(quote_ident(s.nspname) ||'.'||quote_ident(t.relname), 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
+union all
+-- details of user defined and system foreign key constraints
+select
+    c.conname as name
+  , c.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , c.conrelid as parent_object_id
+  , 'F' as type
+  , 'FOREIGN_KEY_CONSTRAINT'
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_constraint c
+inner join pg_namespace s on s.oid = c.connamespace
+where (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and c.contype = 'f'
+union all
+-- details of user defined and system primary key constraints
+select
+    c.conname as name
+  , c.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , c.conrelid as parent_object_id
+  , 'PK' as type
+  , 'PRIMARY_KEY_CONSTRAINT' as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_constraint c
+inner join pg_namespace s on s.oid = c.connamespace
+where (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and c.contype = 'p'
+union all
+-- details of user defined and system defined procedures
+select
+    p.proname as name
+  , p.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , cast (case when tr.tgrelid is not null 
+  		       then tr.tgrelid 
+  		       else 0 end as int) 
+    as parent_object_id
+  , case p.prokind
+      when 'p' then 'P'::varchar(2)
+      when 'a' then 'AF'::varchar(2)
+      else
+        case format_type(p.prorettype, null) when 'trigger'
+          then 'TR'::varchar(2)
+          else 'FN'::varchar(2)
+        end
+    end as type
+  , case p.prokind
+      when 'p' then 'SQL_STORED_PROCEDURE'::varchar(60)
+      when 'a' then 'AGGREGATE_FUNCTION'::varchar(60)
+      else
+        case format_type(p.prorettype, null) when 'trigger'
+          then 'SQL_TRIGGER'::varchar(60)
+          else 'SQL_SCALAR_FUNCTION'::varchar(60)
+        end
+    end as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_proc p
+inner join pg_namespace s on s.oid = p.pronamespace
+left join pg_trigger tr on tr.tgfoid = p.oid
+where (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and has_function_privilege(p.oid, 'EXECUTE')
+union all
+-- details of all default constraints
+select
+    ('DF_' || o.relname || '_' || d.oid)::name as name
+  , d.oid as object_id
+  , null::int as principal_id
+  , o.relnamespace as schema_id
+  , d.adrelid as parent_object_id
+  , 'D'::char(2) as type
+  , 'DEFAULT_CONSTRAINT'::sys.nvarchar(60) AS type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_catalog.pg_attrdef d
+inner join pg_attribute a on a.attrelid = d.adrelid and d.adnum = a.attnum
+inner join pg_class o on d.adrelid = o.oid
+inner join pg_namespace s on s.oid = o.relnamespace
+where a.atthasdef = 't' and a.attgenerated = ''
+and (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and has_column_privilege(a.attrelid, a.attname, 'SELECT,INSERT,UPDATE,REFERENCES')
+union all
+-- details of all check constraints
+select
+    c.conname::name
+  , c.oid::integer as object_id
+  , NULL::integer as principal_id 
+  , c.connamespace::integer as schema_id
+  , c.conrelid::integer as parent_object_id
+  , 'C'::char(2) as type
+  , 'CHECK_CONSTRAINT'::sys.nvarchar(60) as type_desc
+  , null::sys.datetime as create_date
+  , null::sys.datetime as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_catalog.pg_constraint as c
+inner join pg_namespace s on s.oid = c.connamespace
+where (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+and c.contype = 'c' and c.conrelid != 0
+union all
+-- details of user defined and system defined sequence objects
+select
+  p.relname as name
+  , p.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'SO'::varchar(2) as type
+  , 'SEQUENCE_OBJECT'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class p
+inner join pg_namespace s on s.oid = p.relnamespace
+where p.relkind = 'S'
+and (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+and has_schema_privilege(s.oid, 'USAGE')
+union all
+-- details of user defined table types
+select
+    ('TT_' || tt.name || '_' || tt.type_table_object_id)::name as name
+  , tt.type_table_object_id as object_id
+  , tt.principal_id as principal_id
+  , tt.schema_id as schema_id
+  , 0 as parent_object_id
+  , 'TT'::varchar(2) as type
+  , 'TABLE_TYPE'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 1 as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from sys.table_types tt
+) ot;
+GRANT SELECT ON sys.all_objects TO PUBLIC;
 
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.

--- a/test/JDBC/expected/sys-triggers.out
+++ b/test/JDBC/expected/sys-triggers.out
@@ -1,0 +1,126 @@
+-- Setup
+CREATE TABLE master_table(a int)
+GO
+
+CREATE TRIGGER master_trig ON master_table AFTER INSERT
+AS
+BEGIN
+SELECT 1
+END
+GO
+
+CREATE DATABASE db1
+GO
+
+USE db1
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+CREATE TABLE t2(b int)
+GO
+
+CREATE TRIGGER trig1 ON t1 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT 1
+END
+GO
+
+CREATE TRIGGER trig2 ON t2 AFTER INSERT
+AS
+BEGIN
+SELECT 1
+END
+GO
+
+-- test instead of insert trigger
+SELECT 
+    name,
+    parent_class,
+    parent_class_desc,
+    type,
+    type_desc,
+    create_date,
+    modify_date,
+    is_ms_shipped,
+    is_disabled,
+    is_not_for_replication,
+    is_instead_of_trigger
+FROM sys.triggers
+WHERE name = 'trig1'
+GO
+~~START~~
+varchar#!#tinyint#!#nvarchar#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#bit
+trig1#!#1#!#OBJECT_OR_COLUMN#!#TR#!#SQL_TRIGGER#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1
+~~END~~
+
+
+-- test after insert trigger
+SELECT 
+    name,
+    parent_class,
+    parent_class_desc,
+    type,
+    type_desc,
+    create_date,
+    modify_date,
+    is_ms_shipped,
+    is_disabled,
+    is_not_for_replication,
+    is_instead_of_trigger
+FROM sys.triggers
+WHERE name = 'trig2'
+GO
+~~START~~
+varchar#!#tinyint#!#nvarchar#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#bit
+trig2#!#1#!#OBJECT_OR_COLUMN#!#TR#!#SQL_TRIGGER#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#0
+~~END~~
+
+
+-- test schema-scoped visibility of view
+SELECT 
+    name,
+    parent_class,
+    parent_class_desc,
+    type,
+    type_desc,
+    create_date,
+    modify_date,
+    is_ms_shipped,
+    is_disabled,
+    is_not_for_replication,
+    is_instead_of_trigger
+FROM sys.triggers
+WHERE name = 'master_trig'
+GO
+~~START~~
+varchar#!#tinyint#!#nvarchar#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#bit
+~~END~~
+
+
+-- Cleanup
+DROP TRIGGER trig1
+GO
+
+DROP TRIGGER trig2
+GO
+
+DROP table t1
+GO
+
+DROP table t2
+GO
+
+USE master
+GO
+
+DROP TRIGGER master_trig
+GO
+
+DROP table master_table
+GO
+
+DROP database db1
+GO

--- a/test/JDBC/input/views/sys-triggers.sql
+++ b/test/JDBC/input/views/sys-triggers.sql
@@ -1,0 +1,112 @@
+-- Setup
+CREATE TABLE master_table(a int)
+GO
+
+CREATE TRIGGER master_trig ON master_table AFTER INSERT
+AS
+BEGIN
+SELECT 1
+END
+GO
+
+CREATE DATABASE db1
+GO
+
+USE db1
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+CREATE TABLE t2(b int)
+GO
+
+CREATE TRIGGER trig1 ON t1 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT 1
+END
+GO
+
+CREATE TRIGGER trig2 ON t2 AFTER INSERT
+AS
+BEGIN
+SELECT 1
+END
+GO
+
+-- test instead of insert trigger
+SELECT 
+    name,
+    parent_class,
+    parent_class_desc,
+    type,
+    type_desc,
+    create_date,
+    modify_date,
+    is_ms_shipped,
+    is_disabled,
+    is_not_for_replication,
+    is_instead_of_trigger
+FROM sys.triggers
+WHERE name = 'trig1'
+GO
+
+-- test after insert trigger
+SELECT 
+    name,
+    parent_class,
+    parent_class_desc,
+    type,
+    type_desc,
+    create_date,
+    modify_date,
+    is_ms_shipped,
+    is_disabled,
+    is_not_for_replication,
+    is_instead_of_trigger
+FROM sys.triggers
+WHERE name = 'trig2'
+GO
+
+-- test schema-scoped visibility of view
+SELECT 
+    name,
+    parent_class,
+    parent_class_desc,
+    type,
+    type_desc,
+    create_date,
+    modify_date,
+    is_ms_shipped,
+    is_disabled,
+    is_not_for_replication,
+    is_instead_of_trigger
+FROM sys.triggers
+WHERE name = 'master_trig'
+GO
+
+-- Cleanup
+DROP TRIGGER trig1
+GO
+
+DROP TRIGGER trig2
+GO
+
+DROP table t1
+GO
+
+DROP table t2
+GO
+
+USE master
+GO
+
+DROP TRIGGER master_trig
+GO
+
+DROP table master_table
+GO
+
+DROP database db1
+GO


### PR DESCRIPTION
### Description

This commit adds the sys.triggers view to Babelfish, which unblocks SSMS Generate Script Wizard functionalities.

NOTE: This currently only supports DML triggers, as DDL triggers are not yet supported.

Task: BABELFISH-479
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).