### PR TITLE
Fixed upgrade script regarding the following msdb policy objects: fn_syspolicy_is_automation_enabled, syspolicy_configuration, and syspolicy_system_health_state

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1304,7 +1304,10 @@ select t.name,t.type, ns.oid as schemaid from
 (
   values 
     ('xp_qv','master_dbo','P'),
-    ('xp_instance_regread','master_dbo','P')  
+    ('xp_instance_regread','master_dbo','P'),
+    ('fn_syspolicy_is_automation_enabled', 'msdb_dbo', 'FN'),
+    ('syspolicy_configuration', 'msdb_dbo', 'V'),
+    ('syspolicy_system_health_state', 'msdb_dbo', 'V')
 ) t(name,schema_name, type)
 inner join pg_catalog.pg_namespace ns on t.schema_name = ns.nspname
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -581,15 +581,16 @@ LANGUAGE SQL;
 
 CREATE OR REPLACE VIEW msdb_dbo.syspolicy_system_health_state
 AS
-    SELECT 
-        CAST(0 as BIGINT) AS health_state_id,
-        CAST(0 as INT) AS policy_id,
-        CAST(NULL AS sys.DATETIME) AS last_run_date,
-        CAST('' AS sys.NVARCHAR(400)) AS target_query_expression_with_id,
-        CAST('' AS sys.NVARCHAR) AS target_query_expression,
-        CAST(1 as sys.BIT) AS result
-    WHERE FALSE;
-GRANT SELECT ON msdb_dbo.syspolicy_system_health_state TO sysadmin;
+SELECT 
+    CAST(0 as BIGINT) AS health_state_id,
+    CAST(0 as INT) AS policy_id,
+    CAST(NULL AS sys.DATETIME) AS last_run_date,
+    CAST('' AS sys.NVARCHAR(400)) AS target_query_expression_with_id,
+    CAST('' AS sys.NVARCHAR) AS target_query_expression,
+    CAST(1 as sys.BIT) AS result
+WHERE FALSE;
+GRANT SELECT ON msdb_dbo.syspolicy_system_health_state TO PUBLIC;
+ALTER VIEW msdb_dbo.syspolicy_system_health_state OWNER TO sysadmin;
 
 CREATE OR REPLACE FUNCTION msdb_dbo.fn_syspolicy_is_automation_enabled()
 RETURNS INTEGER
@@ -598,14 +599,16 @@ $fn_body$
     SELECT 0;
 $fn_body$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+ALTER FUNCTION msdb_dbo.fn_syspolicy_is_automation_enabled() OWNER TO sysadmin;
 
 CREATE OR REPLACE VIEW msdb_dbo.syspolicy_configuration
 AS
-    SELECT
-        CAST(NULL AS sys.SYSNAME) AS name,
-        CAST(NULL AS sys.sql_variant) AS current_value
-    WHERE FALSE; -- Condition will result in view with an empty result set
-GRANT SELECT ON msdb_dbo.syspolicy_configuration TO sysadmin;
+SELECT
+    CAST(NULL AS sys.SYSNAME) AS name,
+    CAST(NULL AS sys.sql_variant) AS current_value
+WHERE FALSE; -- Condition will result in view with an empty result set
+GRANT SELECT ON msdb_dbo.syspolicy_configuration TO PUBLIC;
+ALTER VIEW msdb_dbo.syspolicy_configuration OWNER TO sysadmin;
 
 -- Disassociate msdb objects from the extension
 CALL sys.babelfish_remove_object_from_extension('view', 'msdb_dbo.sysdatabases');

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -610,6 +610,34 @@ WHERE FALSE; -- Condition will result in view with an empty result set
 GRANT SELECT ON msdb_dbo.syspolicy_configuration TO PUBLIC;
 ALTER VIEW msdb_dbo.syspolicy_configuration OWNER TO sysadmin;
 
+create or replace view sys.shipped_objects_not_in_sys AS
+-- This portion of view retrieves information on objects that reside in a schema in one specfic database.
+-- For example, 'master_dbo' schema can only exist in the 'master' database.
+-- Internally stored schema name (nspname) must be provided.
+select t.name,t.type, ns.oid as schemaid from
+(
+  values 
+    ('xp_qv','master_dbo','P'),
+    ('xp_instance_regread','master_dbo','P'),
+    ('fn_syspolicy_is_automation_enabled', 'msdb_dbo', 'FN'),
+    ('syspolicy_configuration', 'msdb_dbo', 'V'),
+    ('syspolicy_system_health_state', 'msdb_dbo', 'V')
+) t(name,schema_name, type)
+inner join pg_catalog.pg_namespace ns on t.schema_name = ns.nspname
+
+union all 
+
+-- This portion of view retrieves information on objects that reside in a schema in any number of databases.
+-- For example, 'dbo' schema can exist in the 'master', 'tempdb', 'msdb', and any user created database.
+select t.name,t.type, ns.oid  as schemaid from
+(
+  values 
+    ('sysdatabases','dbo','V')
+) t (name, schema_name, type)
+inner join sys.babelfish_namespace_ext b on t.schema_name=b.orig_name
+inner join pg_catalog.pg_namespace ns on b.nspname = ns.nspname;
+GRANT SELECT ON sys.shipped_objects_not_in_sys TO PUBLIC;
+
 -- Disassociate msdb objects from the extension
 CALL sys.babelfish_remove_object_from_extension('view', 'msdb_dbo.sysdatabases');
 CALL sys.babelfish_remove_object_from_extension('schema', 'msdb_dbo');


### PR DESCRIPTION
### Description

Previously, several msdb objects were checked in (msdb.dbo.fn_syspolicy_is_automation_enabled(), msdb.dbo.syspolicy_configuration, and msdb.dbo.syspolicy_system_health_state) with an error in the upgrade script which did not assign sysadmin as the owner of these objects. Furthermore, sys.shipped_objects_not_in_sys  needed to be modified in order to include these objects as well. This commit fixes both of those issues.

Tasks: BABELFISH-439, BABELFISH-441, BABELFISH-442
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).