### PR TITLE
Support for empty input string handling in datetime, smalldatetime, datetime2, datetimeoffset datatypes

### DIFF
--- a/contrib/babelfishpg_common/src/datetime.c
+++ b/contrib/babelfishpg_common/src/datetime.c
@@ -64,6 +64,15 @@ datetime_in_str(char *str)
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
 
+	/*
+	 * Set input to default '1900-01-01 00:00:00.000' if empty string encountered
+	 */
+	if (*str == '\0')
+	{
+		result = initializeToDefaultDatetime();
+		PG_RETURN_TIMESTAMP(result);
+	}
+
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
@@ -598,3 +607,22 @@ datetime_mi_float8(PG_FUNCTION_ARGS)
 	CheckDatetimeRange(result);
 	PG_RETURN_TIMESTAMP(result);
 }
+
+/*
+ * Set input to default '1900-01-01 00:00:00' if empty string encountered
+ */
+Timestamp
+initializeToDefaultDatetime(void)
+{
+	Timestamp result;
+	struct pg_tm tt, *tm = &tt;
+
+	tm->tm_year = 1900;
+	tm->tm_mon = 1;
+	tm->tm_mday = 1;
+	tm->tm_hour = tm->tm_min = tm->tm_sec = 0;
+
+	tm2timestamp(tm, 0, NULL, &result);
+
+	return result;
+} 

--- a/contrib/babelfishpg_common/src/datetime.h
+++ b/contrib/babelfishpg_common/src/datetime.h
@@ -25,6 +25,8 @@
 /* upper bond: 9999-12-31 23:59:29.999 */
 #define END_DATETIME	INT64CONST(252455615999999000)
 
+extern Timestamp initializeToDefaultDatetime(void);
+
 /* Range-check a datetime */
 #define IS_VALID_DATETIME(t)  (MIN_DATETIME <= (t) && (t) < END_DATETIME)
 

--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -17,7 +17,7 @@
 
 #include "miscadmin.h"
 #include "datetime2.h"
-
+#include "datetime.h"
 
 PG_FUNCTION_INFO_V1(datetime2_in);
 PG_FUNCTION_INFO_V1(datetime2_out);
@@ -55,6 +55,15 @@ datetime2_in_str(char *str, int32 typmod)
 	char	   *field[MAXDATEFIELDS];
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
+
+	/* Set input to default '1900-01-01 00:00:00.* if empty string encountered */
+	if (*str == '\0')
+	{
+		result = initializeToDefaultDatetime();
+		AdjustDatetime2ForTypmod(&result, typmod);
+
+		PG_RETURN_TIMESTAMP(result);
+	}
 
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);

--- a/contrib/babelfishpg_common/src/smalldatetime.c
+++ b/contrib/babelfishpg_common/src/smalldatetime.c
@@ -15,6 +15,7 @@
 #include "utils/timestamp.h"
 
 #include "miscadmin.h"
+#include "datetime.h"
 
 PG_FUNCTION_INFO_V1(smalldatetime_in);
 PG_FUNCTION_INFO_V1(smalldatetime_recv);
@@ -63,6 +64,15 @@ smalldatetime_in_str(char *str)
 	char	   *field[MAXDATEFIELDS];
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
+
+	/* Set input to default '1900-01-01 00:00:00' if empty string encountered */
+	if (*str == '\0')
+	{
+		result = initializeToDefaultDatetime();
+		AdjustTimestampForSmallDatetime(&result);
+
+		PG_RETURN_TIMESTAMP(result);
+	}
 
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);

--- a/test/JDBC/expected/emptydatetime.out
+++ b/test/JDBC/expected/emptydatetime.out
@@ -1,0 +1,97 @@
+
+-- [BABEL-3306] Support for empty input string handling in datetime, smalldatetime, datetime2, datetimeoffset datatypes
+create table #srtestnull_t1 (a varchar(2), dt smalldatetime null);
+go
+insert into #srtestnull_t1 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t1;
+go
+~~START~~
+varchar#!#smalldatetime
+A#!#1900-01-01 00:00:00.0
+~~END~~
+
+drop table #srtestnull_t1;
+go
+
+create table #srtestnull_t2 (a varchar(2), dt datetime null);
+go
+insert into #srtestnull_t2 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t2;
+go
+~~START~~
+varchar#!#datetime
+A#!#1900-01-01 00:00:00.0
+~~END~~
+
+drop table #srtestnull_t2;
+go
+
+create table #srtestnull_t3 (a varchar(2), dt datetime2(4) null);
+go
+insert into #srtestnull_t3 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t3;
+go
+~~START~~
+varchar#!#datetime2
+A#!#1900-01-01 00:00:00.0000
+~~END~~
+
+drop table #srtestnull_t3;
+go
+
+create table #srtestnull_t4 (a varchar(2), dt datetimeoffset(6) null);
+go
+insert into #srtestnull_t4 values ('A', '');
+go
+~~ROW COUNT: 1~~
+
+select * from #srtestnull_t4;
+go
+~~START~~
+varchar#!#datetimeoffset
+A#!#1900-01-01 00:00:00.000000 +00:00
+~~END~~
+
+drop table #srtestnull_t4;
+go
+
+select cast('' as datetime);
+go
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+
+
+select cast('' as smalldatetime);
+go
+~~START~~
+smalldatetime
+1900-01-01 00:00:00.0
+~~END~~
+
+
+select cast('' as datetime2(4));
+go
+~~START~~
+datetime2
+1900-01-01 00:00:00.0000
+~~END~~
+
+
+select cast('' as datetimeoffset(6));
+go
+~~START~~
+datetimeoffset
+1900-01-01 00:00:00.000000 +00:00
+~~END~~
+

--- a/test/JDBC/input/emptydatetime.sql
+++ b/test/JDBC/input/emptydatetime.sql
@@ -1,0 +1,49 @@
+-- [BABEL-3306] Support for empty input string handling in datetime, smalldatetime, datetime2, datetimeoffset datatypes
+
+create table #srtestnull_t1 (a varchar(2), dt smalldatetime null);
+go
+insert into #srtestnull_t1 values ('A', '');
+go
+select * from #srtestnull_t1;
+go
+drop table #srtestnull_t1;
+go
+
+create table #srtestnull_t2 (a varchar(2), dt datetime null);
+go
+insert into #srtestnull_t2 values ('A', '');
+go
+select * from #srtestnull_t2;
+go
+drop table #srtestnull_t2;
+go
+
+create table #srtestnull_t3 (a varchar(2), dt datetime2(4) null);
+go
+insert into #srtestnull_t3 values ('A', '');
+go
+select * from #srtestnull_t3;
+go
+drop table #srtestnull_t3;
+go
+
+create table #srtestnull_t4 (a varchar(2), dt datetimeoffset(6) null);
+go
+insert into #srtestnull_t4 values ('A', '');
+go
+select * from #srtestnull_t4;
+go
+drop table #srtestnull_t4;
+go
+
+select cast('' as datetime);
+go
+
+select cast('' as smalldatetime);
+go
+
+select cast('' as datetime2(4));
+go
+
+select cast('' as datetimeoffset(6));
+go


### PR DESCRIPTION
### Description
Empty input string for datetime column was throwing invalid input syntax error in Babelfish.
The fix will store and return default datetime value '1900-01-01 *' whenever empty input string is encountered.

Task: BABEL-3306
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).