### PR TITLE
Throw an error if conflicting join hints are detected in a query in sync with the T-SQL behavior

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -206,6 +206,8 @@ static void add_rewritten_query_fragment_to_mutator(PLtsql_expr_query_mutator *m
 static std::unordered_map<std::string, std::string> alias_to_table_mapping;
 static std::unordered_map<std::string, std::string> table_to_alias_mapping;
 static std::vector<std::string> query_hints;
+static std::vector<bool> join_hints_info(6, false);
+static bool isJoinHintInOptionClause = false;
 static std::string table_names;
 static int num_of_tables = 0;
 static std::string leading_hint;
@@ -564,6 +566,15 @@ add_rewritten_query_fragment_to_mutator(PLtsql_expr_query_mutator *mutator)
 static void
 add_query_hints(PLtsql_expr *expr)
 {
+	ParserRuleContext* ctx = nullptr;
+	// If a query has both join hint and query hint which is a join hint, it should have all the join hints as the query hints as well
+	if (isJoinHintInOptionClause && ((join_hints_info[0] && !join_hints_info[3]) || (join_hints_info[1] && !join_hints_info[4]) || (join_hints_info[2] && !join_hints_info[5])))
+	{
+		isJoinHintInOptionClause = false;
+		for (int i=0;i<6;i++)
+			join_hints_info[i] = false;
+		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Conflicting JOIN optimizer hints specified", getLineAndPos(ctx));
+	}
 	std::string hint =  "/*+ ";
 	for (auto q_hint: query_hints)
 	{
@@ -584,6 +595,9 @@ clear_query_hints()
 {
 	query_hints.clear();
 	leading_hint.clear();
+	for (int i=0;i<6;i++)
+		join_hints_info[i] = false;
+	isJoinHintInOptionClause = false;
 }
 
 static void
@@ -3227,31 +3241,38 @@ void extractJoinHint(TSqlParser::Join_hintContext *join_hint, std::string table_
 {
 	if (join_hint->LOOP())
 	{
+		join_hints_info[0] = true;
 		query_hints.push_back("NestLoop(" + table_names + ")");
 	}
 	else if (join_hint->HASH())
 	{
+		join_hints_info[1] = true;
 		query_hints.push_back("HashJoin(" + table_names + ")");
 	}
 	else if (join_hint->MERGE())
 	{
+		join_hints_info[2] = true;
 		query_hints.push_back("MergeJoin(" + table_names + ")");
 	}
 }
 
 void extractJoinHintFromOption(TSqlParser::OptionContext *option) {
+	isJoinHintInOptionClause = true;
 	if (option->LOOP())
 	{
+		join_hints_info[3] = true;
 		query_hints.push_back("Set(enable_hashjoin off)");
 		query_hints.push_back("Set(enable_mergejoin off)");
 	}
 	else if (option->HASH())
 	{
+		join_hints_info[4] = true;
 		query_hints.push_back("Set(enable_mergejoin off)");
 		query_hints.push_back("Set(enable_nestloop off)");
 	}
 	else if (option->MERGE())
 	{
+		join_hints_info[5] = true;
 		query_hints.push_back("Set(enable_hashjoin off)");
 		query_hints.push_back("Set(enable_nestloop off)");
 	}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -16,6 +16,14 @@
 #include "../antlr/antlr4cpp_generated_src/TSqlParser/TSqlParserBaseListener.h"
 #include "tsqlIface.hpp"
 
+#define LOOP_JOIN_HINT 0
+#define HASH_JOIN_HINT 1
+#define MERGE_JOIN_HINT 2
+#define LOOP_QUERY_HINT 3
+#define HASH_QUERY_HINT 4
+#define MERGE_QUERY_HINT 5
+#define JOIN_HINTS_INFO_VECTOR_SIZE 6
+
 extern "C" {
 #if 0
 #include "tsqlNodes.h"
@@ -206,7 +214,7 @@ static void add_rewritten_query_fragment_to_mutator(PLtsql_expr_query_mutator *m
 static std::unordered_map<std::string, std::string> alias_to_table_mapping;
 static std::unordered_map<std::string, std::string> table_to_alias_mapping;
 static std::vector<std::string> query_hints;
-static std::vector<bool> join_hints_info(6, false);
+static std::vector<bool> join_hints_info(JOIN_HINTS_INFO_VECTOR_SIZE, false);
 static bool isJoinHintInOptionClause = false;
 static std::string table_names;
 static int num_of_tables = 0;
@@ -568,10 +576,10 @@ add_query_hints(PLtsql_expr *expr)
 {
 	ParserRuleContext* ctx = nullptr;
 	// If a query has both join hint and query hint which is a join hint, it should have all the join hints as the query hints as well
-	if (isJoinHintInOptionClause && ((join_hints_info[0] && !join_hints_info[3]) || (join_hints_info[1] && !join_hints_info[4]) || (join_hints_info[2] && !join_hints_info[5])))
+	if (isJoinHintInOptionClause && ((join_hints_info[LOOP_JOIN_HINT] && !join_hints_info[LOOP_QUERY_HINT]) || (join_hints_info[HASH_JOIN_HINT] && !join_hints_info[HASH_QUERY_HINT]) || (join_hints_info[MERGE_JOIN_HINT] && !join_hints_info[MERGE_QUERY_HINT])))
 	{
 		isJoinHintInOptionClause = false;
-		for (int i=0;i<6;i++)
+		for (size_t i=0; i<JOIN_HINTS_INFO_VECTOR_SIZE; i++)
 			join_hints_info[i] = false;
 		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Conflicting JOIN optimizer hints specified", getLineAndPos(ctx));
 	}
@@ -595,7 +603,7 @@ clear_query_hints()
 {
 	query_hints.clear();
 	leading_hint.clear();
-	for (int i=0;i<6;i++)
+	for (size_t i=0; i<JOIN_HINTS_INFO_VECTOR_SIZE; i++)
 		join_hints_info[i] = false;
 	isJoinHintInOptionClause = false;
 }
@@ -3241,17 +3249,17 @@ void extractJoinHint(TSqlParser::Join_hintContext *join_hint, std::string table_
 {
 	if (join_hint->LOOP())
 	{
-		join_hints_info[0] = true;
+		join_hints_info[LOOP_JOIN_HINT] = true;
 		query_hints.push_back("NestLoop(" + table_names + ")");
 	}
 	else if (join_hint->HASH())
 	{
-		join_hints_info[1] = true;
+		join_hints_info[HASH_JOIN_HINT] = true;
 		query_hints.push_back("HashJoin(" + table_names + ")");
 	}
 	else if (join_hint->MERGE())
 	{
-		join_hints_info[2] = true;
+		join_hints_info[MERGE_JOIN_HINT] = true;
 		query_hints.push_back("MergeJoin(" + table_names + ")");
 	}
 }
@@ -3260,19 +3268,19 @@ void extractJoinHintFromOption(TSqlParser::OptionContext *option) {
 	isJoinHintInOptionClause = true;
 	if (option->LOOP())
 	{
-		join_hints_info[3] = true;
+		join_hints_info[LOOP_QUERY_HINT] = true;
 		query_hints.push_back("Set(enable_hashjoin off)");
 		query_hints.push_back("Set(enable_mergejoin off)");
 	}
 	else if (option->HASH())
 	{
-		join_hints_info[4] = true;
+		join_hints_info[HASH_QUERY_HINT] = true;
 		query_hints.push_back("Set(enable_mergejoin off)");
 		query_hints.push_back("Set(enable_nestloop off)");
 	}
 	else if (option->MERGE())
 	{
-		join_hints_info[5] = true;
+		join_hints_info[MERGE_QUERY_HINT] = true;
 		query_hints.push_back("Set(enable_hashjoin off)");
 		query_hints.push_back("Set(enable_nestloop off)");
 	}

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -404,6 +404,76 @@ Merge Join
 ~~END~~
 
 
+-- Conflicting join hints
+select * from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 option(merge join)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conflicting JOIN optimizer hints specified)~~
+
+
+select * from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 option(hash join)
+go
+~~START~~
+text
+Query Text: /*+ HashJoin(babel_3293_t1 babel_3293_t2) Set(enable_hashjoin off) Set(enable_nestloop off) HashJoin(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2) Set(enable_mergejoin off) Set(enable_nestloop off) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2)*/ select * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                  
+Hash Join
+  Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Seq Scan on babel_3293_t1
+  ->  Hash
+        ->  Seq Scan on babel_3293_t2
+~~END~~
+
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 option(merge join, loop join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) Set(enable_hashjoin off) Set(enable_mergejoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                              
+Nested Loop
+  ->  Seq Scan on babel_3293_t1
+  ->  Index Scan using babel_3293_t2_pkey on babel_3293_t2
+        Index Cond: (a2 = babel_3293_t1.a1)
+~~END~~
+
+
+select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conflicting JOIN optimizer hints specified)~~
+
+
+select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conflicting JOIN optimizer hints specified)~~
+
+
+select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join, loop join)
+go
+~~START~~
+text
+Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) Set(enable_hashjoin off) Set(enable_nestloop off) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2) MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3) Set(enable_hashjoin off) Set(enable_nestloop off) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2) MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3) Set(enable_hashjoin off) Set(enable_nestloop off) Set(enable_hashjoin off) Set(enable_mergejoin off) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                              
+Nested Loop
+  ->  Nested Loop
+        Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Bitmap Heap Scan on babel_3293_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+        ->  Materialize
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
+        Index Cond: (a3 = babel_3293_t1.a1)
+        Filter: (b3 = 1)
+~~END~~
+
+
 -- Queries with both table hints and join hints
 select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3293.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3293.sql
@@ -93,6 +93,25 @@ go
 select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
 go
 
+-- Conflicting join hints
+select * from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 option(merge join)
+go
+
+select * from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 option(hash join)
+go
+
+select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 option(merge join, loop join)
+go
+
+select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+
+select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+
+select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join, loop join)
+go
+
 -- Queries with both table hints and join hints
 select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 go


### PR DESCRIPTION
### Description

It has the the changes to throw an error if a query has conflicting join hints
 
### Issues Resolved

Task: BABEL-3388

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).