### PR TITLE
Throw error if typmod is -1 for non-FuncExpr in TdsGetGenericTypmod

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -1255,9 +1255,9 @@ int TdsGetGenericTypmod(Node *expr)
 				func = (FuncExpr *) expr;
 
 				/*
-				* Look up the return type typmod from a persistent
-				* store using function oid.
-				*/
+				 * Look up the return type typmod from a persistent
+				 * store using function oid.
+				 */
 				func_oid = func->funcid;
 				Assert(func_oid != InvalidOid);
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -1250,8 +1250,6 @@ int TdsGetGenericTypmod(Node *expr)
 				FuncExpr *func;
 				Oid     func_oid = InvalidOid;
 
-				if (!expr)
-					return rettypmod;
 				func = (FuncExpr *) expr;
 
 				/*

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -1238,24 +1238,46 @@ SendColInfoToken(int natts, bool sendRowStat)
 static
 int TdsGetGenericTypmod(Node *expr)
 {
-	FuncExpr *func;
-	Oid     func_oid = InvalidOid;
 	int rettypmod = -1;
 
 	if (!expr)
 		return rettypmod;
-	func = (FuncExpr *) expr;
 
-	/*
-	 * Look up the return type typmod from a persistent
-	 * store using function oid.
-	 */
-	func_oid = func->funcid;
-	Assert(func_oid != InvalidOid);
+	switch(nodeTag(expr))
+	{
+		case T_FuncExpr:
+			{
+				FuncExpr *func;
+				Oid     func_oid = InvalidOid;
 
-	if (func->funcresulttype != VOIDOID)
-		rettypmod = pltsql_plugin_handler_ptr->pltsql_get_generic_typmod(func_oid,
-				func->args == NIL ? 0 : func->args->length, func->funcresulttype);
+				if (!expr)
+					return rettypmod;
+				func = (FuncExpr *) expr;
+
+				/*
+				* Look up the return type typmod from a persistent
+				* store using function oid.
+				*/
+				func_oid = func->funcid;
+				Assert(func_oid != InvalidOid);
+
+				if (func->funcresulttype != VOIDOID)
+					rettypmod = pltsql_plugin_handler_ptr->pltsql_get_generic_typmod(func_oid,
+							func->args == NIL ? 0 : func->args->length, func->funcresulttype);
+			}
+			break;
+		default:
+			/*
+			 * TODO: expectation is that apart from Func type expressions, we never get
+			 * typmod = -1 when we reach TDS extension for CHAR/NCHAR datatypes. We
+			 * should figure out a determinstic typmod for all other expression types
+			 * inside the engine or babelfishpg_tsql extension.
+			 */
+			ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
+					errmsg("The string size for the given CHAR/NCHAR data is not defined. "
+							"Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n)")));
+			break;
+	}
 
 	return rettypmod;
 }

--- a/test/JDBC/expected/BABEL-2998.out
+++ b/test/JDBC/expected/BABEL-2998.out
@@ -1,0 +1,99 @@
+-- tsql
+-- typmod associated with NULL will be -1 so this will throw an error
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION 
+SELECT NULL AS Col1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The string size for the given CHAR/NCHAR data is not defined. Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n))~~
+
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION ALL
+SELECT NULL AS Col1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The string size for the given CHAR/NCHAR data is not defined. Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n))~~
+
+
+-- taking suggestion from above error, added explicit CAST and CONVERT
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION 
+SELECT CAST(NULL AS CHAR(10)) AS Col1
+GO
+~~START~~
+char
+1         
+<NULL>
+~~END~~
+
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION ALL
+SELECT CONVERT(CHAR(10), NULL) AS Col1
+GO
+~~START~~
+char
+1         
+<NULL>
+~~END~~
+
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION ALL
+SELECT CAST(NULL AS CHAR(10)) AS Col1
+GO
+~~START~~
+char
+1         
+<NULL>
+~~END~~
+
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION 
+SELECT CONVERT(CHAR(10), NULL) AS Col1
+GO
+~~START~~
+char
+1         
+<NULL>
+~~END~~
+
+
+-- psql
+-- create a function from PG endpoint and try calling it from T-SQL endpoint
+CREATE FUNCTION sys.func_2998() RETURNS CHAR(20) LANGUAGE SQL RETURN 'abc';
+GO
+
+-- tsql
+-- throws error
+SELECT func_2998()
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The string size for the given CHAR/NCHAR data is not defined. Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n))~~
+
+
+-- taking suggestion from above error, added explicit CAST and CONVERT
+SELECT CAST(func_2998() AS CHAR(20))
+GO
+~~START~~
+char
+abc                 
+~~END~~
+
+
+SELECT CONVERT(CHAR(20), func_2998())
+GO
+~~START~~
+char
+abc                 
+~~END~~
+
+
+-- psql
+DROP FUNCTION sys.func_2998()
+GO

--- a/test/JDBC/expected/BABEL-2998.out
+++ b/test/JDBC/expected/BABEL-2998.out
@@ -65,7 +65,7 @@ char
 
 -- psql
 -- create a function from PG endpoint and try calling it from T-SQL endpoint
-CREATE FUNCTION sys.func_2998() RETURNS CHAR(20) LANGUAGE SQL RETURN 'abc';
+CREATE FUNCTION sys.func_2998() RETURNS CHAR(20) LANGUAGE SQL AS 'SELECT ''abc''';
 GO
 
 -- tsql

--- a/test/JDBC/input/BABEL-2998.mix
+++ b/test/JDBC/input/BABEL-2998.mix
@@ -1,0 +1,53 @@
+-- tsql
+-- typmod associated with NULL will be -1 so this will throw an error
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION 
+SELECT NULL AS Col1
+GO
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION ALL
+SELECT NULL AS Col1
+GO
+
+-- taking suggestion from above error, added explicit CAST and CONVERT
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION 
+SELECT CAST(NULL AS CHAR(10)) AS Col1
+GO
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION ALL
+SELECT CONVERT(CHAR(10), NULL) AS Col1
+GO
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION ALL
+SELECT CAST(NULL AS CHAR(10)) AS Col1
+GO
+
+SELECT CAST('1' AS CHAR(10)) AS Col1
+UNION 
+SELECT CONVERT(CHAR(10), NULL) AS Col1
+GO
+
+-- psql
+-- create a function from PG endpoint and try calling it from T-SQL endpoint
+CREATE FUNCTION sys.func_2998() RETURNS CHAR(20) LANGUAGE SQL RETURN 'abc';
+GO
+
+-- tsql
+-- throws error
+SELECT func_2998()
+GO
+
+-- taking suggestion from above error, added explicit CAST and CONVERT
+SELECT CAST(func_2998() AS CHAR(20))
+GO
+
+SELECT CONVERT(CHAR(20), func_2998())
+GO
+
+-- psql
+DROP FUNCTION sys.func_2998()
+GO

--- a/test/JDBC/input/BABEL-2998.mix
+++ b/test/JDBC/input/BABEL-2998.mix
@@ -33,7 +33,7 @@ GO
 
 -- psql
 -- create a function from PG endpoint and try calling it from T-SQL endpoint
-CREATE FUNCTION sys.func_2998() RETURNS CHAR(20) LANGUAGE SQL RETURN 'abc';
+CREATE FUNCTION sys.func_2998() RETURNS CHAR(20) LANGUAGE SQL AS 'SELECT ''abc''';
 GO
 
 -- tsql


### PR DESCRIPTION
### Description

Previously, TdsGetGenericTypmod assumed that it will always get an
FuncExpr as an argument. However, TdsGetGenericTypmod is called whenever
an Expr typmod is -1 for CHAR/NCHAR data type. Thus, if an Expr was not
of FuncExpr type, it was incorrectly casting it to FuncExpr causing the
backend to crash.

In this commit, we added a default case in TdsGetGenericTypmod for all
non FuncExpr type Expr to throw an error suggesting user to use an
explicit CAST or CONVERT to provide Babelfish a deterministic string
size for CHAR/NCHAR data type. Ideally, we should figure out the correct
typmod for these data types in the engine or babelfishpg_tsql extension
itself.

Task: BABEL-2998/3348
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).