### PR TITLE
sp_ procedures created in master are not accessible from other databases

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -629,10 +629,40 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	volatile int rc;
 	SimpleEcontextStackEntry *topEntry;
 	SPIExecuteOptions options;
+	bool		need_path_reset = false;
 
 	Oid current_user_id = GetUserId();
+	char *cur_dbname = get_cur_db_name();
+
+	/* fetch current search_path */
+	List *path_oids = fetch_search_path(false);
+	char *old_search_path = flatten_search_path(path_oids);
+	char *new_search_path;
+	if (stmt->proc_name == NULL)
+		stmt->proc_name = "";
+
 	if (stmt->is_cross_db)
 		SetCurrentRoleId(GetSessionUserId(), false);
+
+	/*
+	 * TODO: BABEL-2992 The following check can be removed after the
+	 * correct implementation of schema resolution for SQL objects.
+	 */
+	if (strcmp(stmt->proc_name, "sp_describe_first_result_set") != 0)
+	{
+		if (strncmp(stmt->proc_name, "sp_", 3) == 0 && strcmp(cur_dbname, "master") != 0
+			&& (stmt->schema_name == '\0' || strncmp(stmt->schema_name, "dbo", strlen(stmt->schema_name)) == 0))
+			{
+				new_search_path = psprintf("%s, master_dbo", old_search_path);
+
+				/* Add master_dbo to the new search path */
+				(void) set_config_option("search_path", new_search_path,
+								PGC_USERSET, PGC_S_SESSION,
+								GUC_ACTION_SAVE, true, 0, false);
+				SetCurrentRoleId(GetSessionUserId(), false);
+				need_path_reset = true;
+			}
+	}
 
 	/* PG_TRY to ensure we clear the plan link, if needed, on failure */
 	PG_TRY();
@@ -975,6 +1005,14 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	}
 	PG_CATCH();
 	{
+		if (need_path_reset)
+		{
+			(void) set_config_option("search_path", old_search_path,
+						PGC_USERSET, PGC_S_SESSION,
+						GUC_ACTION_SAVE, true, 0, false);
+			SetCurrentRoleId(current_user_id, false);
+		}
+
 		if (stmt->is_cross_db)
 			SetCurrentRoleId(current_user_id, false);
 		/*
@@ -993,6 +1031,15 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 
 	if (stmt->is_cross_db)
 		SetCurrentRoleId(current_user_id, false);
+
+	if (need_path_reset)
+	{
+		(void) set_config_option("search_path", old_search_path,
+							PGC_USERSET, PGC_S_SESSION,
+							GUC_ACTION_SAVE, true, 0, false);
+		SetCurrentRoleId(current_user_id, false);
+	}
+	list_free(path_oids);
 
 	if (expr->plan && !expr->plan->saved)
 	{

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -76,6 +76,8 @@ typedef struct PLtsql_stmt_exec
 	/* indicates whether we're executing a scalar UDF using EXEC keyword */
 	bool		is_scalar_func;
 	bool        	is_cross_db;   /* cross database reference */
+	char            *proc_name;
+	char            *schema_name;
 } PLtsql_stmt_exec;
 
 typedef struct

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1891,6 +1891,7 @@ extern bool TryLockLogicalDatabaseForSession(int16 dbid, LOCKMODE lockmode);
 extern void UnlockLogicalDatabaseForSession(int16 dbid, LOCKMODE lockmode, bool force);
 extern char *bpchar_to_cstring(const BpChar *bpchar);
 extern char *varchar_to_cstring(const VarChar *varchar);
+extern char *flatten_search_path(List *oid_list);
 
 typedef struct
 {

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -808,3 +808,25 @@ varchar_to_cstring(const VarChar *varchar)
 
 	return result;
 }
+
+/*
+ * Convert list of schema OIDs to schema names.
+ */
+
+char *
+flatten_search_path(List *oid_list)
+{
+	StringInfoData pathbuf;
+	ListCell   *lc;
+
+	initStringInfo(&pathbuf);
+
+	foreach(lc, oid_list)
+	{
+		Oid			schema_oid = lfirst_oid(lc);
+		char	   *schema_name = get_namespace_name(schema_oid);
+		appendStringInfo(&pathbuf, " %s,", quote_identifier(schema_name));
+	}
+	pathbuf.data[strlen(pathbuf.data) - 1] = '\0';
+	return pathbuf.data;
+}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4198,6 +4198,8 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 		std::string func_proc_name;
 		TSqlParser::Execute_statement_argContext *func_proc_args = body->execute_statement_arg();
 		bool is_cross_db = false;
+		std::string proc_name;
+		std::string schema_name;
 
 		if (body->func_proc_name_server_database_schema())
 		{
@@ -4208,6 +4210,10 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 				if (!string_matches(db_name.c_str(), get_cur_db_name()))
 				is_cross_db = true;
 			}
+			if (body->func_proc_name_server_database_schema()->schema)
+				schema_name = stripQuoteFromId(body->func_proc_name_server_database_schema()->schema);
+			if (body->func_proc_name_server_database_schema()->procedure)
+				proc_name = stripQuoteFromId(body->func_proc_name_server_database_schema()->procedure);
 		}
 		else 
 		{
@@ -4238,6 +4244,15 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 		if (is_cross_db)
 			result->is_cross_db = true;
 
+		if (!proc_name.empty())
+		{
+			result->proc_name = pstrdup(downcase_truncate_identifier(proc_name.c_str(), proc_name.length(), true));
+		}
+		if (!schema_name.empty())
+		{
+			result->schema_name = pstrdup(downcase_truncate_identifier(schema_name.c_str(), schema_name.length(), true));
+		}
+
 		if (func_proc_args)
 		{
 			std::vector<tsql_exec_param *> params;
@@ -4260,7 +4275,11 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 		}
 
 		std::stringstream ss;
-		ss << "EXEC " << (!rewritten_name.empty() ? rewritten_name : func_proc_name);
+		std::string name = (!rewritten_name.empty() ? rewritten_name : func_proc_name);
+		// Rewrite proc name to sp_* if the schema is "dbo" and proc name starts with "sp_"
+		if (pg_strncasecmp(name.c_str(), "dbo.sp_", 6) == 0)
+			name.erase(name.begin() + 0, name.begin() + 4);
+		ss << "EXEC " << name;
 		if (func_proc_args)
 			ss << " " << ::getFullText(func_proc_args);
 		std::string expr_query = ss.str();

--- a/test/JDBC/expected/sp_proc.out
+++ b/test/JDBC/expected/sp_proc.out
@@ -3,18 +3,18 @@ go
 
 exec sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 exec dbo.sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 create database db1
@@ -25,42 +25,42 @@ go
 
 exec master.dbo.sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 exec sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 exec .sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 exec ..sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 exec dbo.sp_hello
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 create proc call_sp_helllo as exec sp_hello
@@ -68,10 +68,10 @@ go
 
 exec call_sp_helllo
 go
-~START~~
+~~START~~
 int
 1
-~END~~
+~~END~~
 
 
 create proc sp_hello as select 2
@@ -80,26 +80,26 @@ go
 --Executes the sp_hello in db1
 exec sp_hello
 go
-~START~~
+~~START~~
 int
 2
-~END~~
+~~END~~
 
 
 exec dbo.sp_hello
 go
-~START~~
+~~START~~
 int
 2
-~END~~
+~~END~~
 
 
 exec call_sp_helllo
 go
-~START~~
+~~START~~
 int
 2
-~END~~
+~~END~~
 
 
 drop proc sp_hello
@@ -113,16 +113,16 @@ go
 
 exec sp_hello;
 go
-~ERROR (Code: 8134)~~
+~~ERROR (Code: 8134)~~
 
-~ERROR (Message: division by zero)~~
+~~ERROR (Message: division by zero)~~
 
 
 exec @a;
 go
-~ERROR (Code: 33557097)~~
+~~ERROR (Code: 33557097)~~
 
-~ERROR (Message: procedure @a() does not exist)~~
+~~ERROR (Message: procedure @a() does not exist)~~
 
 
 drop proc sp_hello;

--- a/test/JDBC/expected/sp_proc.out
+++ b/test/JDBC/expected/sp_proc.out
@@ -1,0 +1,139 @@
+create proc sp_hello as select 1
+go
+
+exec sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+exec dbo.sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+create database db1
+go
+
+use db1
+go
+
+exec master.dbo.sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+exec sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+exec .sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+exec ..sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+exec dbo.sp_hello
+go
+~START~~
+int
+1
+~END~~
+
+
+create proc call_sp_helllo as exec sp_hello
+go
+
+exec call_sp_helllo
+go
+~START~~
+int
+1
+~END~~
+
+
+create proc sp_hello as select 2
+go
+
+--Executes the sp_hello in db1
+exec sp_hello
+go
+~START~~
+int
+2
+~END~~
+
+
+exec dbo.sp_hello
+go
+~START~~
+int
+2
+~END~~
+
+
+exec call_sp_helllo
+go
+~START~~
+int
+2
+~END~~
+
+
+drop proc sp_hello
+go
+
+drop proc call_sp_helllo
+go
+
+create proc sp_hello as select 1/0;
+go
+
+exec sp_hello;
+go
+~ERROR (Code: 8134)~~
+
+~ERROR (Message: division by zero)~~
+
+
+exec @a;
+go
+~ERROR (Code: 33557097)~~
+
+~ERROR (Message: procedure @a() does not exist)~~
+
+
+drop proc sp_hello;
+go
+
+use master
+go
+
+drop proc sp_hello
+go
+
+drop database db1
+go
+

--- a/test/JDBC/input/sp_proc.sql
+++ b/test/JDBC/input/sp_proc.sql
@@ -1,0 +1,76 @@
+create proc sp_hello as select 1
+go
+
+exec sp_hello
+go
+
+exec dbo.sp_hello
+go
+
+create database db1
+go
+
+use db1
+go
+
+exec master.dbo.sp_hello
+go
+
+exec sp_hello
+go
+
+exec .sp_hello
+go
+
+exec ..sp_hello
+go
+
+exec dbo.sp_hello
+go
+
+create proc call_sp_helllo as exec sp_hello
+go
+
+exec call_sp_helllo
+go
+
+create proc sp_hello as select 2
+go
+
+--Executes the sp_hello in db1
+exec sp_hello
+go
+
+exec dbo.sp_hello
+go
+
+exec call_sp_helllo
+go
+
+drop proc sp_hello
+go
+
+drop proc call_sp_helllo
+go
+
+create proc sp_hello as select 1/0;
+go
+
+exec sp_hello;
+go
+
+exec @a;
+go
+
+drop proc sp_hello;
+go
+
+use master
+go
+
+drop proc sp_hello
+go
+
+drop database db1
+go
+


### PR DESCRIPTION
Implement a function to get schema names. When procedures starting with
"sp_" are created in master database, it should be accessible in all
the other databases. We have set the search_path so that if the procedure
is not found in the current schema, it searches the schema "master_dbo"
for the proc name. Reset the search path after the execution is over.

Task: BABEL-2549
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).