### PR TITLE
Fixed build-modified-postgres composite action to use correct branch name and repository owner based on push or pull_request

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -3,7 +3,7 @@ inputs:
   engine_branch:
     description: 'Engine Branch'
     required: no
-    default: $GITHUB_REF_NAME
+    default: 'latest'
   install_dir:
     description: 'Engine install directory'
     required: no
@@ -16,11 +16,30 @@ runs:
       run: |
         cd ..
         rm -rf postgresql_modified_for_babelfish
-        $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$GITHUB_REPOSITORY_OWNER" "${{inputs.engine_branch}}"
+        
+        if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
+          if [[ ${{inputs.engine_branch}} == "latest" ]]; then
+            ENGINE_BRANCH=$GITHUB_HEAD_REF
+          else
+            ENGINE_BRANCH=${{inputs.engine_branch}}
+          fi            
+          REPOSITORY_OWNER=$HEAD_OWNER
+        else
+          if [[ ${{inputs.engine_branch}} == "latest" ]]; then
+            ENGINE_BRANCH=$GITHUB_REF_NAME
+          else
+            ENGINE_BRANCH=${{inputs.engine_branch}}
+          fi
+          REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER
+        fi
+
+        $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
         cd postgresql_modified_for_babelfish
         ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         make -j 4 2>error.txt
         make install
         make check
         cd contrib && make && sudo make install
+      env:
+        HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
       shell: bash

--- a/.github/template/version-branch-template.yml
+++ b/.github/template/version-branch-template.yml
@@ -14,5 +14,5 @@
   engine_branch: BABEL_2_1_STABLE__PG_14_3
   extension_branch: BABEL_2_1_STABLE
 '14.latest':
-  engine_branch: ${{ github.ref_name }}
+  engine_branch: latest
   extension_branch: latest


### PR DESCRIPTION
### Description

This commit updates the build-modified-postgres composite action such that, it will correctly figure out repository owner name and engine branch name for pull request.
 
### Issues Resolved

Currently, In build-modified-postgres composite action, GITHUB_REPOSITORY_OWNER environment variable is used to get repository owner, but for a PR raised in public repository, GITHUB_REPOSITORY_OWNER will store the value of the public repository's organization name instead of source repository owner name (through which the PR raised).
Also for engine_branch input parameter the default value is GITHUB_REF_NAME which when PR raised will store value : refs/pull/<pr_number>/merge , instead of PR branch name

Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).