### PR TITLE
Support TSQLs Information_schema_tsql.constraint_column_usage view

### DIFF
--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Run JDBC Tests
         id: jdbc
-        timeout-minutes: 15
+        timeout-minutes: 25
         if: always() && steps.run-pg_upgrade.outcome == 'success'
         run: |
           cd test/JDBC/

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run JDBC Tests
         id: jdbc
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: |
           cd test/JDBC/
           mvn test

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -436,4 +436,62 @@ CREATE VIEW information_schema_tsql.check_constraints AS
 
 GRANT SELECT ON information_schema_tsql.check_constraints TO PUBLIC;
 
+/*
+ * CONSTARINT_COLUMN_USAGE
+ */
+
+CREATE OR REPLACE VIEW information_schema_tsql.CONSTRAINT_COLUMN_USAGE AS
+SELECT    CAST(tblcat AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+          CAST(tblschema AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+          CAST(tblname AS sys.nvarchar(128)) AS "TABLE_NAME" ,
+          CAST(colname AS sys.nvarchar(128)) AS "COLUMN_NAME",
+          CAST(cstrcat AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+          CAST(cstrschema AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+          CAST(cstrname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME"
+
+FROM (
+        /* check constraints */
+   SELECT DISTINCT extr.orig_name, r.relname, r.relowner, a.attname, extc.orig_name, c.conname, nr.dbname, nc.dbname
+     FROM sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+          sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
+          pg_attribute a,
+          pg_constraint c,
+          pg_class r, pg_depend d
+
+     WHERE nr.oid = r.relnamespace
+          AND r.oid = a.attrelid
+          AND d.refclassid = 'pg_catalog.pg_class'::regclass
+          AND d.refobjid = r.oid
+          AND d.refobjsubid = a.attnum
+          AND d.classid = 'pg_catalog.pg_constraint'::regclass
+          AND d.objid = c.oid
+          AND c.connamespace = nc.oid
+          AND c.contype = 'c'
+          AND r.relkind IN ('r', 'p')
+          AND NOT a.attisdropped
+
+       UNION ALL
+
+        /* unique/primary key/foreign key constraints */
+   SELECT extr.orig_name, r.relname, r.relowner, a.attname, extc.orig_name, c.conname, nr.dbname, nc.dbname
+     FROM sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+          sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
+          pg_attribute a,
+          pg_constraint c,
+          pg_class r
+     WHERE nr.oid = r.relnamespace
+          AND r.oid = a.attrelid
+          AND nc.oid = c.connamespace
+          AND r.oid = c.conrelid
+          AND a.attnum = ANY (c.conkey)
+          AND NOT a.attisdropped
+          AND c.contype IN ('p', 'u', 'f')
+          AND r.relkind IN ('r', 'p')
+
+      ) AS x (tblschema, tblname, tblowner, colname, cstrschema, cstrname, tblcat, cstrcat)
+
+WHERE pg_has_role(x.tblowner, 'USAGE');
+
+GRANT SELECT ON information_schema_tsql.CONSTRAINT_COLUMN_USAGE TO PUBLIC;
+
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -859,6 +859,60 @@ SELECT
 FROM sys.indexes WHERE FALSE;
 GRANT SELECT ON sys.spatial_indexes TO PUBLIC;
 
+CREATE OR REPLACE VIEW information_schema_tsql.CONSTRAINT_COLUMN_USAGE AS
+SELECT    CAST(tblcat AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+          CAST(tblschema AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+          CAST(tblname AS sys.nvarchar(128)) AS "TABLE_NAME" ,
+          CAST(colname AS sys.nvarchar(128)) AS "COLUMN_NAME",
+          CAST(cstrcat AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+          CAST(cstrschema AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+          CAST(cstrname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME"
+
+FROM (
+        /* check constraints */
+   SELECT DISTINCT extr.orig_name, r.relname, r.relowner, a.attname, extc.orig_name, c.conname, nr.dbname, nc.dbname
+     FROM sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+          sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
+          pg_attribute a,
+          pg_constraint c,
+          pg_class r, pg_depend d
+
+     WHERE nr.oid = r.relnamespace
+          AND r.oid = a.attrelid
+          AND d.refclassid = 'pg_catalog.pg_class'::regclass
+          AND d.refobjid = r.oid
+          AND d.refobjsubid = a.attnum
+          AND d.classid = 'pg_catalog.pg_constraint'::regclass
+          AND d.objid = c.oid
+          AND c.connamespace = nc.oid
+          AND c.contype = 'c'
+          AND r.relkind IN ('r', 'p')
+          AND NOT a.attisdropped
+
+       UNION ALL
+
+        /* unique/primary key/foreign key constraints */
+   SELECT extr.orig_name, r.relname, r.relowner, a.attname, extc.orig_name, c.conname, nr.dbname, nc.dbname
+     FROM sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+          sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
+          pg_attribute a,
+          pg_constraint c,
+          pg_class r
+     WHERE nr.oid = r.relnamespace
+          AND r.oid = a.attrelid
+          AND nc.oid = c.connamespace
+          AND r.oid = c.conrelid
+          AND a.attnum = ANY (c.conkey)
+          AND NOT a.attisdropped
+          AND c.contype IN ('p', 'u', 'f')
+          AND r.relkind IN ('r', 'p')
+
+      ) AS x (tblschema, tblname, tblowner, colname, cstrschema, cstrname, tblcat, cstrcat)
+
+WHERE pg_has_role(x.tblowner, 'USAGE');
+
+GRANT SELECT ON information_schema_tsql.CONSTRAINT_COLUMN_USAGE TO PUBLIC;
+
 CREATE OR REPLACE VIEW sys.filetables
 AS
 SELECT 

--- a/test/JDBC/expected/constraint_column_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-prepare.out
@@ -1,51 +1,23 @@
 create database db1;
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Database 'db1' already exists. Choose a different database name.)~~
-
 
 Use db1;
 go
 
 create table tbl1(a int, b int, primary key(a));
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "tbl1" already exists)~~
-
 
 create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "tbl2" already exists)~~
-
 
 create schema sc1;
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: schema "sc1" already exists)~~
-
 
 create table tbl3 (a int, b int, primary key (a,b));
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "tbl3" already exists)~~
-
 
 create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "tbl4" already exists)~~
-
 
 create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: relation "tbl5" already exists)~~
-

--- a/test/JDBC/expected/constraint_column_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-prepare.out
@@ -1,23 +1,23 @@
-create database db1;
+create database db_constraint_column_usage;
 go
 
-Use db1;
+Use db_constraint_column_usage;
 go
 
-create table tbl1(a int, b int, primary key(a));
+create table tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
 go
 
 create schema sc1;
 go
 
-create table tbl3 (a int, b int, primary key (a,b));
+create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
 go

--- a/test/JDBC/expected/constraint_column_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-prepare.out
@@ -1,23 +1,23 @@
-create database db_constraint_column_usage;
+create database db_constraint_column_usage_vu_prepare;
 go
 
-Use db_constraint_column_usage;
+Use db_constraint_column_usage_vu_prepare;
 go
 
-create table constraint_column_usage_tbl1(arg1 int, arg2 int, primary key(arg1));
+create table constraint_column_usage_vu_prepare_tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table constraint_column_usage_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_tbl1(arg1));
+create table constraint_column_usage_vu_prepare_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_vu_prepare_tbl1(arg1));
 go
 
-create schema constraint_column_usage_sc1;
+create schema constraint_column_usage_vu_prepare_sc1;
 go
 
-create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_vu_prepare_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
+create table constraint_column_usage_vu_prepare_sc1.constraint_column_usage_vu_prepare_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
+create table constraint_column_usage_vu_prepare_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_vu_prepare_tbl3(arg5,arg6));
 go

--- a/test/JDBC/expected/constraint_column_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-prepare.out
@@ -4,20 +4,20 @@ go
 Use db_constraint_column_usage;
 go
 
-create table tbl1(arg1 int, arg2 int, primary key(arg1));
+create table constraint_column_usage_tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
+create table constraint_column_usage_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_tbl1(arg1));
 go
 
-create schema sc1;
+create schema constraint_column_usage_sc1;
 go
 
-create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
+create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
+create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
 go

--- a/test/JDBC/expected/constraint_column_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-prepare.out
@@ -1,0 +1,51 @@
+create database db1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Database 'db1' already exists. Choose a different database name.)~~
+
+
+Use db1;
+go
+
+create table tbl1(a int, b int, primary key(a));
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "tbl1" already exists)~~
+
+
+create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "tbl2" already exists)~~
+
+
+create schema sc1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "sc1" already exists)~~
+
+
+create table tbl3 (a int, b int, primary key (a,b));
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "tbl3" already exists)~~
+
+
+create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "tbl4" already exists)~~
+
+
+create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "tbl5" already exists)~~
+

--- a/test/JDBC/expected/constraint_column_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-verify.out
@@ -5,15 +5,15 @@ SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LI
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-db_constraint_column_usage#!#dbo#!#tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#tbl1_pkey
-db_constraint_column_usage#!#dbo#!#tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
-db_constraint_column_usage#!#dbo#!#tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
-db_constraint_column_usage#!#dbo#!#tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#tbl2_pkey
-db_constraint_column_usage#!#dbo#!#tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#tbl2_arg4_fkey
-db_constraint_column_usage#!#dbo#!#tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
-db_constraint_column_usage#!#dbo#!#tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
-db_constraint_column_usage#!#sc1#!#tbl4#!#arg7#!#db_constraint_column_usage#!#sc1#!#tbl4_check
-db_constraint_column_usage#!#sc1#!#tbl4#!#arg8#!#db_constraint_column_usage#!#sc1#!#tbl4_check
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl1_pkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_pkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_arg4_fkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
+db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg7#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
+db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg8#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
 ~~END~~
 
 
@@ -30,17 +30,17 @@ nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 use db_constraint_column_usage;
 go
 
-drop table tbl2;
+drop table constraint_column_usage_tbl2;
 go
-drop table tbl1;
+drop table constraint_column_usage_tbl1;
 go
-drop table tbl5;
+drop table constraint_column_usage_tbl5;
 go
-drop table tbl3;
+drop table constraint_column_usage_tbl3;
 go
-drop table sc1.tbl4;
+drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
 go
-drop schema sc1;
+drop schema constraint_column_usage_sc1;
 go
 
 use master

--- a/test/JDBC/expected/constraint_column_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-verify.out
@@ -1,19 +1,19 @@
-Use db_constraint_column_usage;
+Use db_constraint_column_usage_vu_prepare;
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl1_pkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_pkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_arg4_fkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
-db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg7#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
-db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg8#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl1#!#arg1#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl1_pkey
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl5#!#arg10#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl5_arg10_arg11_fkey
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl5#!#arg11#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl5_arg10_arg11_fkey
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl2#!#arg3#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl2_pkey
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl2#!#arg4#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl2_arg4_fkey
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl3#!#arg5#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl3_pkey
+db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl3#!#arg6#!#db_constraint_column_usage_vu_prepare#!#dbo#!#constraint_column_usage_vu_prepare_tbl3_pkey
+db_constraint_column_usage_vu_prepare#!#constraint_column_usage_vu_prepare_sc1#!#constraint_column_usage_vu_prepare_tbl4#!#arg7#!#db_constraint_column_usage_vu_prepare#!#constraint_column_usage_vu_prepare_sc1#!#constraint_column_usage_vu_prepare_tbl4_check
+db_constraint_column_usage_vu_prepare#!#constraint_column_usage_vu_prepare_sc1#!#constraint_column_usage_vu_prepare_tbl4#!#arg8#!#db_constraint_column_usage_vu_prepare#!#constraint_column_usage_vu_prepare_sc1#!#constraint_column_usage_vu_prepare_tbl4_check
 ~~END~~
 
 
@@ -27,24 +27,24 @@ nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-use db_constraint_column_usage;
+use db_constraint_column_usage_vu_prepare;
 go
 
-drop table constraint_column_usage_tbl2;
+drop table constraint_column_usage_vu_prepare_tbl2;
 go
-drop table constraint_column_usage_tbl1;
+drop table constraint_column_usage_vu_prepare_tbl1;
 go
-drop table constraint_column_usage_tbl5;
+drop table constraint_column_usage_vu_prepare_tbl5;
 go
-drop table constraint_column_usage_tbl3;
+drop table constraint_column_usage_vu_prepare_tbl3;
 go
-drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
+drop table constraint_column_usage_vu_prepare_sc1.constraint_column_usage_vu_prepare_tbl4;
 go
-drop schema constraint_column_usage_sc1;
+drop schema constraint_column_usage_vu_prepare_sc1;
 go
 
 use master
 go
 
-drop database db_constraint_column_usage;
+drop database db_constraint_column_usage_vu_prepare;
 go

--- a/test/JDBC/expected/constraint_column_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-verify.out
@@ -1,33 +1,33 @@
-Use db1;
+Use db_constraint_column_usage;
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-db1#!#dbo#!#tbl1#!#a#!#db1#!#dbo#!#tbl1_pkey
-db1#!#dbo#!#tbl2#!#b#!#db1#!#dbo#!#tbl2_b_fkey
-db1#!#dbo#!#tbl2#!#a#!#db1#!#dbo#!#tbl2_pkey
-db1#!#dbo#!#tbl3#!#a#!#db1#!#dbo#!#tbl3_pkey
-db1#!#dbo#!#tbl3#!#b#!#db1#!#dbo#!#tbl3_pkey
-db1#!#sc1#!#tbl4#!#a#!#db1#!#sc1#!#tbl4_check
-db1#!#sc1#!#tbl4#!#b#!#db1#!#sc1#!#tbl4_check
-db1#!#dbo#!#tbl5#!#b#!#db1#!#dbo#!#tbl5_b_c_fkey
-db1#!#dbo#!#tbl5#!#c#!#db1#!#dbo#!#tbl5_b_c_fkey
+db_constraint_column_usage#!#dbo#!#tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#tbl1_pkey
+db_constraint_column_usage#!#dbo#!#tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#tbl2_pkey
+db_constraint_column_usage#!#dbo#!#tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#tbl2_arg4_fkey
+db_constraint_column_usage#!#dbo#!#tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
+db_constraint_column_usage#!#dbo#!#tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
+db_constraint_column_usage#!#sc1#!#tbl4#!#arg7#!#db_constraint_column_usage#!#sc1#!#tbl4_check
+db_constraint_column_usage#!#sc1#!#tbl4#!#arg8#!#db_constraint_column_usage#!#sc1#!#tbl4_check
 ~~END~~
 
 
 Use master;
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-use db1;
+use db_constraint_column_usage;
 go
 
 drop table tbl2;
@@ -46,5 +46,5 @@ go
 use master
 go
 
-drop database db1;
+drop database db_constraint_column_usage;
 go

--- a/test/JDBC/expected/constraint_column_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_column_usage-vu-verify.out
@@ -1,0 +1,50 @@
+Use db1;
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+db1#!#dbo#!#tbl1#!#a#!#db1#!#dbo#!#tbl1_pkey
+db1#!#dbo#!#tbl2#!#b#!#db1#!#dbo#!#tbl2_b_fkey
+db1#!#dbo#!#tbl2#!#a#!#db1#!#dbo#!#tbl2_pkey
+db1#!#dbo#!#tbl3#!#a#!#db1#!#dbo#!#tbl3_pkey
+db1#!#dbo#!#tbl3#!#b#!#db1#!#dbo#!#tbl3_pkey
+db1#!#sc1#!#tbl4#!#a#!#db1#!#sc1#!#tbl4_check
+db1#!#sc1#!#tbl4#!#b#!#db1#!#sc1#!#tbl4_check
+db1#!#dbo#!#tbl5#!#b#!#db1#!#dbo#!#tbl5_b_c_fkey
+db1#!#dbo#!#tbl5#!#c#!#db1#!#dbo#!#tbl5_b_c_fkey
+~~END~~
+
+
+Use master;
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+~~END~~
+
+
+use db1;
+go
+
+drop table tbl2;
+go
+drop table tbl1;
+go
+drop table tbl5;
+go
+drop table tbl3;
+go
+drop table sc1.tbl4;
+go
+drop schema sc1;
+go
+
+use master
+go
+
+drop database db1;
+go

--- a/test/JDBC/expected/constraint_column_usage.out
+++ b/test/JDBC/expected/constraint_column_usage.out
@@ -13,13 +13,13 @@ go
 create schema constraint_column_usage_sc1;
 go
 
-create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_sc1.constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
 create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
+create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_sc1.constraint_column_usage_tbl3(arg5,arg6));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
@@ -31,8 +31,8 @@ db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg10#!#db_con
 db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
 db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_pkey
 db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_arg4_fkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
-db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
+db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl3#!#arg5#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl3_pkey
+db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl3#!#arg6#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl3_pkey
 db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg7#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
 db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg8#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
 ~~END~~
@@ -71,7 +71,7 @@ drop table constraint_column_usage_tbl1;
 go
 drop table constraint_column_usage_tbl5;
 go
-drop table constraint_column_usage_tbl3;
+drop table constraint_column_usage_sc1.constraint_column_usage_tbl3;
 go
 drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
 go

--- a/test/JDBC/expected/constraint_column_usage.out
+++ b/test/JDBC/expected/constraint_column_usage.out
@@ -4,37 +4,37 @@ go
 Use db_constraint_column_usage;
 go
 
-create table tbl1(arg1 int, arg2 int, primary key(arg1));
+create table constraint_column_usage_tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
+create table constraint_column_usage_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_tbl1(arg1));
 go
 
-create schema sc1;
+create schema constraint_column_usage_sc1;
 go
 
-create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
+create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
+create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-db_constraint_column_usage#!#dbo#!#tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#tbl1_pkey
-db_constraint_column_usage#!#dbo#!#tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
-db_constraint_column_usage#!#dbo#!#tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
-db_constraint_column_usage#!#dbo#!#tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#tbl2_pkey
-db_constraint_column_usage#!#dbo#!#tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#tbl2_arg4_fkey
-db_constraint_column_usage#!#dbo#!#tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
-db_constraint_column_usage#!#dbo#!#tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
-db_constraint_column_usage#!#sc1#!#tbl4#!#arg7#!#db_constraint_column_usage#!#sc1#!#tbl4_check
-db_constraint_column_usage#!#sc1#!#tbl4#!#arg8#!#db_constraint_column_usage#!#sc1#!#tbl4_check
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl1_pkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_pkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl2_arg4_fkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
+db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#constraint_column_usage_tbl3_pkey
+db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg7#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
+db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4#!#arg8#!#db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usage_tbl4_check
 ~~END~~
 
 
@@ -48,34 +48,34 @@ nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-create table tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
+create table constraint_column_usage_tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-master#!#dbo#!#tbl6#!#arg13#!#master#!#dbo#!#tbl6_arg13_key
+master#!#dbo#!#constraint_column_usage_tbl6#!#arg13#!#master#!#dbo#!#constraint_column_usage_tbl6_arg13_key
 ~~END~~
 
 
-drop table tbl6;
+drop table constraint_column_usage_tbl6;
 go
 
 use db_constraint_column_usage;
 go
 
-drop table tbl2;
+drop table constraint_column_usage_tbl2;
 go
-drop table tbl1;
+drop table constraint_column_usage_tbl1;
 go
-drop table tbl5;
+drop table constraint_column_usage_tbl5;
 go
-drop table tbl3;
+drop table constraint_column_usage_tbl3;
 go
-drop table sc1.tbl4;
+drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
 go
-drop schema sc1;
+drop schema constraint_column_usage_sc1;
 go
 
 use master

--- a/test/JDBC/expected/constraint_column_usage.out
+++ b/test/JDBC/expected/constraint_column_usage.out
@@ -1,66 +1,85 @@
-create database db1;
+create database db_constraint_column_usage;
 go
 
-Use db1;
+Use db_constraint_column_usage;
 go
 
-create table tbl1(a int, b int, primary key(a));
+create table tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
 go
 
 create schema sc1;
 go
 
-create table tbl3 (a int, b int, primary key (a,b));
+create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-db1#!#dbo#!#tbl1#!#a#!#db1#!#dbo#!#tbl1_pkey
-db1#!#dbo#!#tbl2#!#b#!#db1#!#dbo#!#tbl2_b_fkey
-db1#!#dbo#!#tbl2#!#a#!#db1#!#dbo#!#tbl2_pkey
-db1#!#dbo#!#tbl3#!#a#!#db1#!#dbo#!#tbl3_pkey
-db1#!#dbo#!#tbl3#!#b#!#db1#!#dbo#!#tbl3_pkey
-db1#!#sc1#!#tbl4#!#a#!#db1#!#sc1#!#tbl4_check
-db1#!#sc1#!#tbl4#!#b#!#db1#!#sc1#!#tbl4_check
-db1#!#dbo#!#tbl5#!#b#!#db1#!#dbo#!#tbl5_b_c_fkey
-db1#!#dbo#!#tbl5#!#c#!#db1#!#dbo#!#tbl5_b_c_fkey
+db_constraint_column_usage#!#dbo#!#tbl1#!#arg1#!#db_constraint_column_usage#!#dbo#!#tbl1_pkey
+db_constraint_column_usage#!#dbo#!#tbl5#!#arg10#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#tbl5#!#arg11#!#db_constraint_column_usage#!#dbo#!#tbl5_arg10_arg11_fkey
+db_constraint_column_usage#!#dbo#!#tbl2#!#arg3#!#db_constraint_column_usage#!#dbo#!#tbl2_pkey
+db_constraint_column_usage#!#dbo#!#tbl2#!#arg4#!#db_constraint_column_usage#!#dbo#!#tbl2_arg4_fkey
+db_constraint_column_usage#!#dbo#!#tbl3#!#arg5#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
+db_constraint_column_usage#!#dbo#!#tbl3#!#arg6#!#db_constraint_column_usage#!#dbo#!#tbl3_pkey
+db_constraint_column_usage#!#sc1#!#tbl4#!#arg7#!#db_constraint_column_usage#!#sc1#!#tbl4_check
+db_constraint_column_usage#!#sc1#!#tbl4#!#arg8#!#db_constraint_column_usage#!#sc1#!#tbl4_check
 ~~END~~
 
 
 Use master;
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-create table tbl6 (a int, b int, UNIQUE(b));
+create table tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-master#!#dbo#!#tbl6#!#b#!#master#!#dbo#!#tbl6_b_key
+master#!#dbo#!#tbl6#!#arg13#!#master#!#dbo#!#tbl6_arg13_key
 ~~END~~
 
 
 drop table tbl6;
 go
 
-use db1;
+use db_constraint_column_usage;
+go
+
+drop table tbl2;
+go
+drop table tbl1;
+go
+drop table tbl5;
+go
+drop table tbl3;
+go
+drop table sc1.tbl4;
+go
+drop schema sc1;
+go
+
+use master
+go
+
+drop database db_constraint_column_usage;
 go

--- a/test/JDBC/expected/constraint_column_usage.out
+++ b/test/JDBC/expected/constraint_column_usage.out
@@ -1,0 +1,66 @@
+create database db1;
+go
+
+Use db1;
+go
+
+create table tbl1(a int, b int, primary key(a));
+go
+
+create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+go
+
+create schema sc1;
+go
+
+create table tbl3 (a int, b int, primary key (a,b));
+go
+
+create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+go
+
+create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+db1#!#dbo#!#tbl1#!#a#!#db1#!#dbo#!#tbl1_pkey
+db1#!#dbo#!#tbl2#!#b#!#db1#!#dbo#!#tbl2_b_fkey
+db1#!#dbo#!#tbl2#!#a#!#db1#!#dbo#!#tbl2_pkey
+db1#!#dbo#!#tbl3#!#a#!#db1#!#dbo#!#tbl3_pkey
+db1#!#dbo#!#tbl3#!#b#!#db1#!#dbo#!#tbl3_pkey
+db1#!#sc1#!#tbl4#!#a#!#db1#!#sc1#!#tbl4_check
+db1#!#sc1#!#tbl4#!#b#!#db1#!#sc1#!#tbl4_check
+db1#!#dbo#!#tbl5#!#b#!#db1#!#dbo#!#tbl5_b_c_fkey
+db1#!#dbo#!#tbl5#!#c#!#db1#!#dbo#!#tbl5_b_c_fkey
+~~END~~
+
+
+Use master;
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+~~END~~
+
+
+create table tbl6 (a int, b int, UNIQUE(b));
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+master#!#dbo#!#tbl6#!#b#!#master#!#dbo#!#tbl6_b_key
+~~END~~
+
+
+drop table tbl6;
+go
+
+use db1;
+go

--- a/test/JDBC/input/constraint_column_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-prepare.sql
@@ -1,23 +1,23 @@
-create database db1;
+create database db_constraint_column_usage;
 go
 
-Use db1;
+Use db_constraint_column_usage;
 go
 
-create table tbl1(a int, b int, primary key(a));
+create table tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
 go
 
 create schema sc1;
 go
 
-create table tbl3 (a int, b int, primary key (a,b));
+create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
 go

--- a/test/JDBC/input/constraint_column_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-prepare.sql
@@ -1,23 +1,23 @@
-create database db_constraint_column_usage;
+create database db_constraint_column_usage_vu_prepare;
 go
 
-Use db_constraint_column_usage;
+Use db_constraint_column_usage_vu_prepare;
 go
 
-create table constraint_column_usage_tbl1(arg1 int, arg2 int, primary key(arg1));
+create table constraint_column_usage_vu_prepare_tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table constraint_column_usage_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_tbl1(arg1));
+create table constraint_column_usage_vu_prepare_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_vu_prepare_tbl1(arg1));
 go
 
-create schema constraint_column_usage_sc1;
+create schema constraint_column_usage_vu_prepare_sc1;
 go
 
-create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_vu_prepare_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
+create table constraint_column_usage_vu_prepare_sc1.constraint_column_usage_vu_prepare_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
+create table constraint_column_usage_vu_prepare_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_vu_prepare_tbl3(arg5,arg6));
 go

--- a/test/JDBC/input/constraint_column_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-prepare.sql
@@ -4,20 +4,20 @@ go
 Use db_constraint_column_usage;
 go
 
-create table tbl1(arg1 int, arg2 int, primary key(arg1));
+create table constraint_column_usage_tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
+create table constraint_column_usage_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_tbl1(arg1));
 go
 
-create schema sc1;
+create schema constraint_column_usage_sc1;
 go
 
-create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
+create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
+create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
 go

--- a/test/JDBC/input/constraint_column_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-prepare.sql
@@ -1,0 +1,23 @@
+create database db1;
+go
+
+Use db1;
+go
+
+create table tbl1(a int, b int, primary key(a));
+go
+
+create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+go
+
+create schema sc1;
+go
+
+create table tbl3 (a int, b int, primary key (a,b));
+go
+
+create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+go
+
+create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+go

--- a/test/JDBC/input/constraint_column_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-verify.sql
@@ -1,4 +1,4 @@
-Use db_constraint_column_usage;
+Use db_constraint_column_usage_vu_prepare;
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
@@ -10,24 +10,24 @@ go
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
-use db_constraint_column_usage;
+use db_constraint_column_usage_vu_prepare;
 go
 
-drop table constraint_column_usage_tbl2;
+drop table constraint_column_usage_vu_prepare_tbl2;
 go
-drop table constraint_column_usage_tbl1;
+drop table constraint_column_usage_vu_prepare_tbl1;
 go
-drop table constraint_column_usage_tbl5;
+drop table constraint_column_usage_vu_prepare_tbl5;
 go
-drop table constraint_column_usage_tbl3;
+drop table constraint_column_usage_vu_prepare_tbl3;
 go
-drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
+drop table constraint_column_usage_vu_prepare_sc1.constraint_column_usage_vu_prepare_tbl4;
 go
-drop schema constraint_column_usage_sc1;
+drop schema constraint_column_usage_vu_prepare_sc1;
 go
 
 use master
 go
 
-drop database db_constraint_column_usage;
+drop database db_constraint_column_usage_vu_prepare;
 go

--- a/test/JDBC/input/constraint_column_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-verify.sql
@@ -13,17 +13,17 @@ go
 use db_constraint_column_usage;
 go
 
-drop table tbl2;
+drop table constraint_column_usage_tbl2;
 go
-drop table tbl1;
+drop table constraint_column_usage_tbl1;
 go
-drop table tbl5;
+drop table constraint_column_usage_tbl5;
 go
-drop table tbl3;
+drop table constraint_column_usage_tbl3;
 go
-drop table sc1.tbl4;
+drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
 go
-drop schema sc1;
+drop schema constraint_column_usage_sc1;
 go
 
 use master

--- a/test/JDBC/input/constraint_column_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-verify.sql
@@ -1,0 +1,33 @@
+Use db1;
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+
+Use master;
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+
+use db1;
+go
+
+drop table tbl2;
+go
+drop table tbl1;
+go
+drop table tbl5;
+go
+drop table tbl3;
+go
+drop table sc1.tbl4;
+go
+drop schema sc1;
+go
+
+use master
+go
+
+drop database db1;
+go

--- a/test/JDBC/input/constraint_column_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_column_usage-vu-verify.sql
@@ -1,16 +1,16 @@
-Use db1;
+Use db_constraint_column_usage;
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
 Use master;
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
-use db1;
+use db_constraint_column_usage;
 go
 
 drop table tbl2;
@@ -29,5 +29,5 @@ go
 use master
 go
 
-drop database db1;
+drop database db_constraint_column_usage;
 go

--- a/test/JDBC/input/constraint_column_usage.sql
+++ b/test/JDBC/input/constraint_column_usage.sql
@@ -13,13 +13,13 @@ go
 create schema constraint_column_usage_sc1;
 go
 
-create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_sc1.constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
 create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
+create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_sc1.constraint_column_usage_tbl3(arg5,arg6));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
@@ -49,7 +49,7 @@ drop table constraint_column_usage_tbl1;
 go
 drop table constraint_column_usage_tbl5;
 go
-drop table constraint_column_usage_tbl3;
+drop table constraint_column_usage_sc1.constraint_column_usage_tbl3;
 go
 drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
 go

--- a/test/JDBC/input/constraint_column_usage.sql
+++ b/test/JDBC/input/constraint_column_usage.sql
@@ -1,0 +1,44 @@
+create database db1;
+go
+
+Use db1;
+go
+
+create table tbl1(a int, b int, primary key(a));
+go
+
+create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+go
+
+create schema sc1;
+go
+
+create table tbl3 (a int, b int, primary key (a,b));
+go
+
+create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+go
+
+create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+
+Use master;
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+
+create table tbl6 (a int, b int, UNIQUE(b));
+go
+
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+go
+
+drop table tbl6;
+go
+
+use db1;
+go

--- a/test/JDBC/input/constraint_column_usage.sql
+++ b/test/JDBC/input/constraint_column_usage.sql
@@ -1,44 +1,63 @@
-create database db1;
+create database db_constraint_column_usage;
 go
 
-Use db1;
+Use db_constraint_column_usage;
 go
 
-create table tbl1(a int, b int, primary key(a));
+create table tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(a int, b int, primary key(a), foreign key(b) references tbl1(a));
+create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
 go
 
 create schema sc1;
 go
 
-create table tbl3 (a int, b int, primary key (a,b));
+create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (a int, b int, check ( a > 0  and b < 0));
+create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (a int, b int, c int, foreign key(b,c) references tbl3(a,b));
+create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
 Use master;
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
-create table tbl6 (a int, b int, UNIQUE(b));
+create table tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
 go
 
-SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY CONSTRAINT_NAME;
+SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
 drop table tbl6;
 go
 
-use db1;
+use db_constraint_column_usage;
+go
+
+drop table tbl2;
+go
+drop table tbl1;
+go
+drop table tbl5;
+go
+drop table tbl3;
+go
+drop table sc1.tbl4;
+go
+drop schema sc1;
+go
+
+use master
+go
+
+drop database db_constraint_column_usage;
 go

--- a/test/JDBC/input/constraint_column_usage.sql
+++ b/test/JDBC/input/constraint_column_usage.sql
@@ -4,22 +4,22 @@ go
 Use db_constraint_column_usage;
 go
 
-create table tbl1(arg1 int, arg2 int, primary key(arg1));
+create table constraint_column_usage_tbl1(arg1 int, arg2 int, primary key(arg1));
 go
 
-create table tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references tbl1(arg1));
+create table constraint_column_usage_tbl2(arg3 int, arg4 int, primary key(arg3), foreign key(arg4) references constraint_column_usage_tbl1(arg1));
 go
 
-create schema sc1;
+create schema constraint_column_usage_sc1;
 go
 
-create table tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
+create table constraint_column_usage_tbl3 (arg5 int, arg6 int, primary key (arg5,arg6));
 go
 
-create table sc1.tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
+create table constraint_column_usage_sc1.constraint_column_usage_tbl4 (arg7 int, arg8 int, check ( arg7 > 0  and arg8 < 0));
 go
 
-create table tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references tbl3(arg5,arg6));
+create table constraint_column_usage_tbl5 (arg9 int, arg10 int, arg11 int, foreign key(arg10,arg11) references constraint_column_usage_tbl3(arg5,arg6));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
@@ -31,29 +31,29 @@ go
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
-create table tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
+create table constraint_column_usage_tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
-drop table tbl6;
+drop table constraint_column_usage_tbl6;
 go
 
 use db_constraint_column_usage;
 go
 
-drop table tbl2;
+drop table constraint_column_usage_tbl2;
 go
-drop table tbl1;
+drop table constraint_column_usage_tbl1;
 go
-drop table tbl5;
+drop table constraint_column_usage_tbl5;
 go
-drop table tbl3;
+drop table constraint_column_usage_tbl3;
 go
-drop table sc1.tbl4;
+drop table constraint_column_usage_sc1.constraint_column_usage_tbl4;
 go
-drop schema sc1;
+drop schema constraint_column_usage_sc1;
 go
 
 use master

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -42,4 +42,3 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
-constraint_column_usage

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -42,3 +42,4 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
+constraint_column_usage

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -49,4 +49,3 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
-constraint_column_usage

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -49,3 +49,4 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
+constraint_column_usage

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -50,5 +50,3 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
-constraint_column_usage
-

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -50,3 +50,4 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
+constraint_column_usage

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -51,3 +51,4 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
+constraint_column_usage

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -51,5 +51,3 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
-constraint_column_usage
-

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -50,3 +50,4 @@ sys-schema-name
 sys-suser_sid
 sys-suser_sname
 sys-trigger_nestlevel
+constraint_column_usage

--- a/test/JDBC/upgrade/14_latest/schedule
+++ b/test/JDBC/upgrade/14_latest/schedule
@@ -37,3 +37,4 @@ BABEL-3221
 BABEL-3249
 BABEL-3204
 BABEL-3234
+constraint_column_usage


### PR DESCRIPTION
We have supported TSQLs Information_schema_tsql.constraint_column_usage view.

Task: BABEL-3399
Signed-off-by: Anju Bharti <abanju@amazon.com>

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).