### PR TITLE
Added support in version upgrade test framework to upload generated output of failing tests

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -99,9 +99,26 @@ jobs:
           timestamp=`ls -Art | tail -n 1`
           cd $timestamp
           mkdir -p ~/upgrade
-          mv $timestamp.diff ~/upgrade/output-diff.diff
-          mv "$timestamp"_runSummary.log ~/upgrade/run-summary.log
-  
+          cp $timestamp.diff ~/upgrade/output-diff.diff
+          cp "$timestamp"_runSummary.log ~/upgrade/run-summary.log
+          mkdir -p ~/failed-testscript-outputs
+          # copy output files of failed test scripts
+          BASE_VERSION=${{ steps.read-base-and-final-version.outputs.base-version }}
+          BASE_VERSION=${BASE_VERSION/./_}
+          FINAL_VERSION=${{ steps.read-base-and-final-version.outputs.final-version }}
+          FINAL_VERSION=${FINAL_VERSION/./_}
+          
+          for f in $(grep "[A-Za-z_\-]*:[ ]*Failed" $timestamp"_runSummary.log" | cut -d ":" -f 1); 
+          do 
+            if [[ -f ../../output/$f".out" ]]; then
+              cp ../../output/$f".out" ~/failed-testscript-outputs/$f".out"
+            elif [[ -f ../../output/$BASE_VERSION"__preparation__"$f".out" ]]; then
+              cp ../../output/$BASE_VERSION"__preparation__"$f".out" ~/failed-testscript-outputs/$BASE_VERSION"__preparation__"$f".out"
+            else
+              cp ../../output/$FINAL_VERSION"__verfication_cleanup__"$BASE_VERSION"__"$f".out" ~/failed-testscript-outputs/$FINAL_VERSION"__verfication_cleanup__"$BASE_VERSION"__"$f".out"
+            fi
+          done
+
       - name: Upload Logs
         if: always() && steps.test-file-rename.outcome == 'success'
         uses: actions/upload-artifact@v2
@@ -111,4 +128,5 @@ jobs:
             ~/upgrade/*.log
             ~/upgrade/*.diff
             ~/postgres*/data/logfile
+            ~/failed-testscript-outputs
             


### PR DESCRIPTION
### Description

Added support in version upgrade test framework to upload generated output of failing tests.

Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).