### PR TITLE
Add Support for TDS ColumnMetadata flags.

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -28,6 +28,7 @@
 #include "parser/parse_coerce.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
+#include "utils/syscache.h"
 #include "utils/memdebug.h"
 #include "utils/numeric.h"
 #include "utils/portal.h"
@@ -125,7 +126,7 @@ static void FillTabNameWithNumParts(StringInfo buf, uint8 numParts, TdsRelationM
 static void FillTabNameWithoutNumParts(StringInfo buf, uint8 numParts, TdsRelationMetaDataInfo relMetaDataInfo);
 static void SetTdsEstateErrorData(void);
 static void ResetTdsEstateErrorData(void);
-static bool get_attnotnull(Oid relid, AttrNumber attnum);
+static void SetAttributesForColmetada(TdsColumnMetaData *col);
 
 static inline void
 SendPendingDone(bool more)
@@ -1363,7 +1364,8 @@ PrepareRowDescription(TupleDesc typeinfo, List *targetlist, int16 *formats,
 			col->attrNum = 0;
 		}
 
-		col->attNotNull = get_attnotnull(col->relOid, col->attrNum);
+		SetAttributesForColmetada(col);
+
 		switch (finfo->sendFuncId)
 		{
 			/*
@@ -2911,30 +2913,34 @@ GetTdsEstateErrorData(int *number, int *severity, int *state)
 }
 
 /*
- * get_attnotnull
- *		Given the relation id and the attribute number,
- *		return the "attnotnull" field from the attribute relation.
+ * Using the relation id and the attribute number, set the attributes
+ * required in the TDS Column Metadata from the attributes relation.
  */
-static bool
-get_attnotnull(Oid relid, AttrNumber attnum)
+static void
+SetAttributesForColmetada(TdsColumnMetaData *col)
 {
 	HeapTuple	  tp;
 	Form_pg_attribute att_tup;
 
-	tp = SearchSysCache2(ATTNUM,
-			ObjectIdGetDatum(relid),
-			Int16GetDatum(attnum));
+	tp = SearchSysCache2(ATTNUM, 
+			ObjectIdGetDatum(col->relOid),
+			Int16GetDatum(col->attrNum));
+
+	/* Initialise to false if no valid heap tuple is found. */
+	col->attNotNull = false;
+	col->attidentity = false;
+	col->attgenerated = false;
 
 	if (HeapTupleIsValid(tp))
 	{
-		bool result;
-
 		att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-		result = att_tup->attnotnull;
-		ReleaseSysCache(tp);
+		col->attNotNull = att_tup->attnotnull;
+		if (att_tup->attgenerated != '\0')
+			col->attgenerated = true;
 
-		return result;
+		if (att_tup->attidentity != '\0')
+			col->attidentity = true;
+
+		ReleaseSysCache(tp);
 	}
-	/* Assume att is nullable if no valid heap tuple is found */
-	return false;
 }

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -246,6 +246,9 @@ typedef TDSRequestData *TDSRequest;
 #define TDS_COL_METADATA_DEFAULT_FLAGS  TDS_COLMETA_NULLABLE | \
 					TDS_COLMETA_UPD_UNKNOWN
 #define TDS_COL_METADATA_NOT_NULL_FLAGS TDS_COLMETA_UPD_UNKNOWN
+#define TDS_COL_METADATA_IDENTITY_FLAGS TDS_COLMETA_IDENTITY
+#define TDS_COL_METADATA_COMPUTED_FLAGS TDS_COLMETA_NULLABLE | \
+					TDS_COLMETA_COMPUTED
 
 /* Macro for TVP tokens. */
 #define TVP_ROW_TOKEN				0x01
@@ -675,19 +678,25 @@ SetColMetadataForFixedType(TdsColumnMetaData *col, uint8_t tdsType, uint8_t maxS
 	/*
 	 * If column is Not NULL constrained then we don't want to send
 	 * maxSize except for uniqueidentifier and xml.
-       * TODO: We should send TDS_COL_METADATA_NOT_NULL_FLAGS
-       * This needs to be done for identity contraints
+	 * TODO: We should send TDS_COL_METADATA_NOT_NULL_FLAGS
+	 * This needs to be done for identity contraints
 	 */
 	if (col->attNotNull && tdsType != TDS_TYPE_UNIQUEIDENTIFIER && tdsType != TDS_TYPE_XML)
-      {
+	{
 		col->metaLen = sizeof(col->metaEntry.type1) - 1;
-	        col->metaEntry.type1.flags = TDS_COL_METADATA_NOT_NULL_FLAGS;
-      }
-      else
-      {
+		if (col->attidentity)
+			col->metaEntry.type1.flags = TDS_COL_METADATA_IDENTITY_FLAGS;
+		else
+			col->metaEntry.type1.flags = TDS_COL_METADATA_NOT_NULL_FLAGS;
+	}
+	else
+	{
 		col->metaLen = sizeof(col->metaEntry.type1);
-              col->metaEntry.type1.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
-      }
+		if (col->attgenerated)
+			col->metaEntry.type1.flags = TDS_COL_METADATA_COMPUTED_FLAGS;
+		else
+			col->metaEntry.type1.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
+	}
 	col->metaEntry.type1.tdsTypeId = tdsType;
 	col->metaEntry.type1.maxSize = maxSize;
 }

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -181,6 +181,8 @@ typedef struct TdsColumnMetaData
 	AttrNumber				attrNum;	/* attribute number in the relation */
 	TdsRelationMetaDataInfo	relinfo;
 	bool 					attNotNull; 	/* true if the column has not null constraint */
+	bool 					attidentity;	/* true if it is an identity column */
+	bool 					attgenerated;	/* true if it is a computed column */
 } TdsColumnMetaData;
 
 /* Partial Length Prefixed-bytes */

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2731,11 +2731,11 @@ tsql_top_clause:
 						A_Const* n = (A_Const *)$3;
 						if(n->val.type == T_Integer && n->val.val.ival == 100)
 						{
-								$$ = makeNullAConst(@1);
+								$$ = NULL;
 						}
 						else if(n->val.type == T_Float && atof(n->val.val.str) == 100.0)
 						{
-								$$ = makeNullAConst(@1);
+								$$ = NULL;
 						}
 						else
 						{
@@ -2760,11 +2760,11 @@ tsql_top_clause:
 					A_Const* n = (A_Const *)$2;
 					if(n->val.type == T_Integer && n->val.val.ival == 100)
 					{
-							$$ = makeNullAConst(@1);
+							$$ = NULL;
 					}
 					else if(n->val.type == T_Float && atof(n->val.val.str) == 100.0)
 					{
-							$$ = makeNullAConst(@1);
+							$$ = NULL;
 					}
 					else
 					{

--- a/test/JDBC/expected/BABEL-1161.out
+++ b/test/JDBC/expected/BABEL-1161.out
@@ -121,17 +121,14 @@ int
 
 
 -- empty scalar subquery
--- note: we have a bug here: BABEL-1181
--- please update the comment and expected output once the bug is fixed.
+-- SELECT TOP (NULL) should throw error
 select top (select a from babel_1161_t31 where a2 = 'c') * from babel_1161_t32 order by b;
 GO
 ~~START~~
 int
-1
-2
-3
-4
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
 
 
 -- not a single row

--- a/test/JDBC/expected/BABEL-1181.out
+++ b/test/JDBC/expected/BABEL-1181.out
@@ -1,0 +1,146 @@
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- top (2) should only return 2 rows
+select top (2) * from t1;
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+-- top (NULL) should throw error
+select top (NULL) * from t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+create table t2 (a int, b int);
+insert into t2 values (1, NULL);
+go
+~~ROW COUNT: 1~~
+
+-- top (1) should only return 1 row
+select top (select a from t2) * from t1;
+go
+~~START~~
+int
+1
+~~END~~
+
+-- top (NULL) should throw error
+select top (select b from t2) * from t1;
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+declare @a int;
+set @a = 1;
+-- top (1) should only return 1 row
+select top (@a) * from t1;
+go
+~~START~~
+int
+1
+~~END~~
+
+declare @a int;
+set @a = NULL;
+-- top (NULL) should throw error
+select top (@a) * from t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- test CTE
+create table t3 (a int, b int);
+insert into t3 values (1, NULL);
+insert into t3 values (100, 1);
+insert into t3 values (200, 2);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- test TOP as part of query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select a from t3 as cte)
+select top (1) * from cte;
+go
+~~START~~
+int
+1
+~~END~~
+
+-- top (NULL) should throw error
+with cte (cte_a) as (select a from t3 as cte)
+select top (NULL) * from cte;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- test TOP as part of CTE
+-- top (2) should only return 2 rows
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select * from cte;
+go
+~~START~~
+int
+1
+100
+~~END~~
+
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(NULL) a from t3 as cte)
+select * from cte;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- test TOP as part of both CTE and query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(1) * from cte;
+go
+~~START~~
+int
+1
+~~END~~
+
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(NULL) * from cte;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- cleanup
+drop table t1;
+drop table t2;
+drop table t3;
+go

--- a/test/JDBC/input/BABEL-1161.sql
+++ b/test/JDBC/input/BABEL-1161.sql
@@ -97,8 +97,7 @@ select top (select a from babel_1161_t31 where a2 = 'b') * from babel_1161_t32 o
 GO
 
 -- empty scalar subquery
--- note: we have a bug here: BABEL-1181
--- please update the comment and expected output once the bug is fixed.
+-- SELECT TOP (NULL) should throw error
 select top (select a from babel_1161_t31 where a2 = 'c') * from babel_1161_t32 order by b;
 GO
 

--- a/test/JDBC/input/BABEL-1181.sql
+++ b/test/JDBC/input/BABEL-1181.sql
@@ -1,0 +1,74 @@
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+go
+-- top (2) should only return 2 rows
+select top (2) * from t1;
+go
+-- top (NULL) should throw error
+select top (NULL) * from t1;
+go
+
+create table t2 (a int, b int);
+insert into t2 values (1, NULL);
+go
+-- top (1) should only return 1 row
+select top (select a from t2) * from t1;
+go
+-- top (NULL) should throw error
+select top (select b from t2) * from t1;
+go
+
+declare @a int;
+set @a = 1;
+-- top (1) should only return 1 row
+select top (@a) * from t1;
+go
+declare @a int;
+set @a = NULL;
+-- top (NULL) should throw error
+select top (@a) * from t1;
+go
+
+-- test CTE
+create table t3 (a int, b int);
+insert into t3 values (1, NULL);
+insert into t3 values (100, 1);
+insert into t3 values (200, 2);
+go
+-- test TOP as part of query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select a from t3 as cte)
+select top (1) * from cte;
+go
+-- top (NULL) should throw error
+with cte (cte_a) as (select a from t3 as cte)
+select top (NULL) * from cte;
+go
+
+-- test TOP as part of CTE
+-- top (2) should only return 2 rows
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select * from cte;
+go
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(NULL) a from t3 as cte)
+select * from cte;
+go
+
+-- test TOP as part of both CTE and query
+-- top (1) should only return 1 row
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(1) * from cte;
+go
+-- top (NULL) should throw error
+with cte (cte_a) as (select top(2) a from t3 as cte)
+select top(NULL) * from cte;
+go
+
+-- cleanup
+drop table t1;
+drop table t2;
+drop table t3;
+go


### PR DESCRIPTION
### Description

Earlier we were sending generic flags for each of the columns.
With this commit we have added support to send computed and identity
flags for their respective columns.

Task: BABEL-217
Signed-off-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).