### PR TITLE
Insufficient shared memory error during MVU while loading babelfishpg_tds library

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -167,6 +167,8 @@ static relname_lookup_hook_type prev_relname_lookup_hook = NULL;
 /* Shmem hook */
 static shmem_startup_hook_type next_shmem_startup_hook = NULL;
 
+static Size tds_memsize(void);
+
 /* Shmem init interfaces */
 static void tds_status_shmem_startup(void);
 static void tds_stats_shmem_shutdown(int code, Datum arg);
@@ -196,6 +198,13 @@ _PG_init(void)
 	tds_instr_plugin_ptr = (TdsInstrPlugin **) find_rendezvous_variable("TdsInstrPlugin");
 
 	pe_init();
+
+	/*
+	 * Request additional shared resources.  (These are no-ops if we're not in
+	 * the postmaster process.)  We'll allocate or attach to the shared
+	 * resources in tds_status_shmem_startup().
+	 */
+	RequestAddinShmemSpace(tds_memsize());
 
 	prev_relname_lookup_hook = relname_lookup_hook;
 	relname_lookup_hook = tvp_lookup;
@@ -233,6 +242,17 @@ static Size
 TdsLanguageBufferSize()
 {
 	return mul_size(LANGDATALEN, NumBackendStatSlots);
+}
+
+static Size
+tds_memsize()
+{
+	Size	size;
+
+	size = TdsStatusArraySize();
+	size = add_size(size, TdsLibraryNameBufferSize());
+	size = add_size(size, TdsLanguageBufferSize());
+	return size;
 }
 
 /*


### PR DESCRIPTION
PG throws error "not enough shared memory" during MVU
when babelfishpg_tds is added in shared_preload_libraries
which is because required shared space was not being
registered before allocating it.

Fixed this by explicitly calling RequestAddinShmemSpace
function with the required shared memory from _pg_init.

Task: BABEL-3302
Authored-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).