### PR TITLE
Remove check for SSL_OP_NO_TICKET from TDS library

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds-secure-openssl.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds-secure-openssl.c
@@ -227,9 +227,7 @@ Tds_be_tls_init(bool isServerStart)
 	}
 
 	/* disallow SSL session tickets */
-#ifdef SSL_OP_NO_TICKET			/* added in OpenSSL 0.9.8f */
 	SSL_CTX_set_options(context, SSL_OP_NO_TICKET);
-#endif
 
 	/* disallow SSL session caching, too */
 	SSL_CTX_set_session_cache_mode(context, SSL_SESS_CACHE_OFF);


### PR DESCRIPTION
This commit removes the check for SSL_OP_NO_TICKET flag because the
support for Openssl version 0.9.8 was removed since the release of PG
13 and the flag was introduced in 0.9.8 itself.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).