### PR TITLE
Fixed the expected output file of TestAuth(Pyodbc)

### DIFF
--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run JDBC Tests
         id: jdbc
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: |
           cd test/JDBC/
           mvn test

--- a/test/python/expected/pyodbc/TestAuth.out
+++ b/test/python/expected/pyodbc/TestAuth.out
@@ -1,26 +1,26 @@
 #database name, username and password should not exceed 128 characters
 py_auth#!#database|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 3701)~~
-~~ERROR (Message: [42S02] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (3701) (SQLDriverConnect))~~
+~~ERROR (Message: [42S02] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (3701) (SQLDriverConnect))~~
 
 py_auth#!#database|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
 
 py_auth#!#user|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
+~~ERROR (Message: [42000] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
 
 py_auth#!#user|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
 
 #not sure why any password is accepted during authentication through cloud desktop
 #This test should throw error but from cloud desktop a connection is successfully established
 #py_auth#!#password|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 py_auth#!#password|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
 
 py_auth#!#others|-|packetSize=0
 ~~SUCCESS~~
@@ -30,5 +30,5 @@ py_auth#!#others|-|packetSize=4096
 ~~SUCCESS~~
 py_auth#!#database|-|test1 SELECT 1
 ~~ERROR (Code: 3701)~~
-~~ERROR (Message: [42S02] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (3701) (SQLDriverConnect))~~
+~~ERROR (Message: [42S02] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (3701) (SQLDriverConnect))~~
 


### PR DESCRIPTION
This change is due to recent release of pyodbc.
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).