### PR TITLE
Change test time out for JDBC tests

### DIFF
--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run JDBC Tests
         id: jdbc
         if: always() && steps.install-extensions.outcome == 'success'
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: |
           cd test/JDBC/
           mvn test

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run JDBC Tests
         id: jdbc
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: |
           cd test/JDBC/
           mvn test


### PR DESCRIPTION
Changed the time out to 25 mins for both JDBC tests and minor version upgrade test

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).