### PR TITLE
Clear structures if a conflicting join hint error is thrown 

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -578,9 +578,8 @@ add_query_hints(PLtsql_expr *expr)
 	// If a query has both join hint and query hint which is a join hint, it should have all the join hints as the query hints as well
 	if (isJoinHintInOptionClause && ((join_hints_info[LOOP_JOIN_HINT] && !join_hints_info[LOOP_QUERY_HINT]) || (join_hints_info[HASH_JOIN_HINT] && !join_hints_info[HASH_QUERY_HINT]) || (join_hints_info[MERGE_JOIN_HINT] && !join_hints_info[MERGE_QUERY_HINT])))
 	{
-		isJoinHintInOptionClause = false;
-		for (size_t i=0; i<JOIN_HINTS_INFO_VECTOR_SIZE; i++)
-			join_hints_info[i] = false;
+		clear_query_hints();
+		clear_tables_info();
 		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Conflicting JOIN optimizer hints specified", getLineAndPos(ctx));
 	}
 	std::string hint =  "/*+ ";
@@ -1435,7 +1434,7 @@ public:
 		add_rewritten_query_fragment_to_mutator(statementMutator.get());
 
 		/* Add query hints */
-		if (query_hints.size())
+		if (query_hints.size() && enable_hint_mapping)
 		{
 			add_query_hints(statementMutator.get()->expr);
 			clear_query_hints();
@@ -3204,6 +3203,16 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 				query_hints.push_back("Set(max_parallel_workers_per_gather " + value + ")");
 		}
 	}
+
+	if (isJoinHintInOptionClause)
+	{
+		if (!join_hints_info[LOOP_QUERY_HINT])
+			query_hints.push_back("Set(enable_nestloop off)");
+		if (!join_hints_info[HASH_QUERY_HINT])
+			query_hints.push_back("Set(enable_hashjoin off)");
+		if (!join_hints_info[MERGE_QUERY_HINT])
+			query_hints.push_back("Set(enable_mergejoin off)");
+	}
 }
 
 void extractTableHints(TSqlParser::With_table_hintsContext *tctx, std::string table_name)
@@ -3267,23 +3276,11 @@ void extractJoinHint(TSqlParser::Join_hintContext *join_hint, std::string table_
 void extractJoinHintFromOption(TSqlParser::OptionContext *option) {
 	isJoinHintInOptionClause = true;
 	if (option->LOOP())
-	{
 		join_hints_info[LOOP_QUERY_HINT] = true;
-		query_hints.push_back("Set(enable_hashjoin off)");
-		query_hints.push_back("Set(enable_mergejoin off)");
-	}
 	else if (option->HASH())
-	{
 		join_hints_info[HASH_QUERY_HINT] = true;
-		query_hints.push_back("Set(enable_mergejoin off)");
-		query_hints.push_back("Set(enable_nestloop off)");
-	}
 	else if (option->MERGE())
-	{
 		join_hints_info[MERGE_QUERY_HINT] = true;
-		query_hints.push_back("Set(enable_hashjoin off)");
-		query_hints.push_back("Set(enable_nestloop off)");
-	}
 }
 
 std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> index_valuesCtx, std::string table_name)
@@ -4949,7 +4946,7 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 
 	for (auto wctx : ctx->with_table_hints())
 	{
-		if (enable_hint_mapping && !wctx->sample_clause())
+		if (!wctx->sample_clause())
 			extractTableHints(wctx, table_name);
 		removeCtxStringFromQuery(expr, wctx, baseCtx);
 	}
@@ -4964,7 +4961,7 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 		}
 		if (actx->table_alias()->with_table_hints())
 		{
-			if (enable_hint_mapping && !actx->table_alias()->with_table_hints()->sample_clause())
+			if (!actx->table_alias()->with_table_hints()->sample_clause())
 				extractTableHints(actx->table_alias()->with_table_hints(), alias_name);
 			removeCtxStringFromQuery(expr, actx->table_alias()->with_table_hints(), baseCtx);
 		}
@@ -4982,7 +4979,7 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 
 	if (ctx->join_hint())
 	{
-		if (num_of_tables > 1)
+		if (enable_hint_mapping && num_of_tables > 1)
 		{
 			leading_hint = "Leading(" + table_names + ")";
 			extractJoinHint(ctx->join_hint(), table_names);

--- a/test/JDBC/expected/BABEL-3291.out
+++ b/test/JDBC/expected/BABEL-3291.out
@@ -49,5 +49,13 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
 drop table babel_3291_t1
 go

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -819,6 +819,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
 select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
 go
 ~~START~~

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -91,6 +91,28 @@ Merge Join
 ~~END~~
 
 
+select * from babel_3293_t1 t1 inner merge join babel_3293_t2 t2 on t1.a1 = t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(t1 t2) Leading(t1 t2)*/ select * from babel_3293_t1 t1 inner       join babel_3293_t2 t2 on t1.a1 = t2.a2 where b1 = 1 and b2 = 1
+Merge Join
+  Merge Cond: (t1.a1 = t2.a2)
+  ->  Sort
+        Sort Key: t1.a1
+        ->  Bitmap Heap Scan on babel_3293_t1 t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                    Index Cond: (b1 = 1)
+  ->  Sort
+        Sort Key: t2.a2
+        ->  Bitmap Heap Scan on babel_3293_t2 t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
 select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 go
 ~~START~~
@@ -269,6 +291,33 @@ Nested Loop
 ~~END~~
 
 
+select * from babel_3293_t1 t1 left outer merge join babel_3293_t2 t2 on t1.a1 = t2.a2 inner loop join babel_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(t1 t2) NestLoop(t1 t2 t3) Leading(t1 t2 t3)*/ select * from babel_3293_t1 t1 left outer       join babel_3293_t2 t2 on t1.a1 = t2.a2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Nested Loop
+  Join Filter: (t1.a1 = t3.a3)
+  ->  Merge Join
+        Merge Cond: (t1.a1 = t2.a2)
+        ->  Sort
+              Sort Key: t1.a1
+              ->  Bitmap Heap Scan on babel_3293_t1 t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+        ->  Sort
+              Sort Key: t2.a2
+              ->  Bitmap Heap Scan on babel_3293_t2 t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3 t3
+        Index Cond: (a3 = t2.a2)
+        Filter: (b3 = 1)
+~~END~~
+
+
 select * from babel_3293_t1, babel_3293_t2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
 go
 ~~START~~
@@ -320,7 +369,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_mergejoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Query Text: /*+ Set(enable_nestloop off) Set(enable_mergejoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Bitmap Heap Scan on babel_3293_t1
@@ -339,7 +388,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                   
+Query Text: /*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                   
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -380,7 +429,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                   
+Query Text: /*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                   
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
   ->  Merge Join
@@ -416,7 +465,7 @@ select * from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = 
 go
 ~~START~~
 text
-Query Text: /*+ HashJoin(babel_3293_t1 babel_3293_t2) Set(enable_hashjoin off) Set(enable_nestloop off) HashJoin(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2) Set(enable_mergejoin off) Set(enable_nestloop off) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2)*/ select * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                  
+Query Text: /*+ HashJoin(babel_3293_t1 babel_3293_t2) Set(enable_nestloop off) Set(enable_mergejoin off) Leading(babel_3293_t1 babel_3293_t2)*/ select * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                  
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Seq Scan on babel_3293_t1
@@ -429,11 +478,11 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) Set(enable_hashjoin off) Set(enable_mergejoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                              
-Nested Loop
-  ->  Seq Scan on babel_3293_t1
+Query Text: /*+ Set(enable_hashjoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                              
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Index Scan using babel_3293_t1_pkey on babel_3293_t1
   ->  Index Scan using babel_3293_t2_pkey on babel_3293_t2
-        Index Cond: (a2 = babel_3293_t1.a1)
 ~~END~~
 
 
@@ -455,22 +504,26 @@ select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = 
 go
 ~~START~~
 text
-Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) Set(enable_hashjoin off) Set(enable_nestloop off) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2) MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3) Set(enable_hashjoin off) Set(enable_nestloop off) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2) MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3) Set(enable_hashjoin off) Set(enable_nestloop off) Set(enable_hashjoin off) Set(enable_mergejoin off) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3 babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                              
-Nested Loop
-  ->  Nested Loop
-        Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
-        ->  Bitmap Heap Scan on babel_3293_t1
-              Recheck Cond: (b1 = 1)
-              ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
-                    Index Cond: (b1 = 1)
-        ->  Materialize
-              ->  Bitmap Heap Scan on babel_3293_t2
-                    Recheck Cond: (b2 = 1)
-                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
-                          Index Cond: (b2 = 1)
-  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3
-        Index Cond: (a3 = babel_3293_t1.a1)
-        Filter: (b3 = 1)
+Query Text: /*+ NestLoop(babel_3293_t1 babel_3293_t2) MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) Set(enable_hashjoin off) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ select * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                              
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Sort
+        Sort Key: babel_3293_t1.a1
+        ->  Nested Loop
+              Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+              ->  Bitmap Heap Scan on babel_3293_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+              ->  Materialize
+                    ->  Bitmap Heap Scan on babel_3293_t2
+                          Recheck Cond: (b2 = 1)
+                          ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                                Index Cond: (b2 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t3.a3
+        ->  Seq Scan on babel_3293_t3
+              Filter: (b3 = 1)
 ~~END~~
 
 
@@ -512,7 +565,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_hashjoin off) Set(enable_mergejoin off) IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                      
+Query Text: /*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) Set(enable_hashjoin off) Set(enable_mergejoin off) */ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                      
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
@@ -847,7 +900,7 @@ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempd
 go
 ~~START~~
 text
-Query Text: /*+ Set(enable_hashjoin off) Set(enable_nestloop off) IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
+Query Text: /*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) Set(enable_nestloop off) Set(enable_hashjoin off) */ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
 Merge Join
   Merge Cond: (t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -902,6 +955,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
 select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false)
 go
 ~~START~~

--- a/test/JDBC/expected/BABEL-3294.out
+++ b/test/JDBC/expected/BABEL-3294.out
@@ -115,6 +115,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
 select set_config('force_parallel_mode', '0', false)
 go
 ~~START~~

--- a/test/JDBC/expected/BABEL-3295.out
+++ b/test/JDBC/expected/BABEL-3295.out
@@ -1,10 +1,16 @@
 drop table if exists babel_3295_t1
 go
 
+drop table if exists babel_3295_t2
+go
+
 create table babel_3295_t1(a1 int PRIMARY KEY, b1 int)
 go
 
 create index index_babel_3295_t1_b1 on babel_3295_t1(b1)
+go
+
+create table babel_3295_t2(a2 int PRIMARY KEY, b2 int)
 go
 
 select set_config('babelfishpg_tsql.explain_costs', 'off', false)
@@ -19,8 +25,8 @@ set babelfish_showplan_all on
 go
 
 /*
- * Run a SELECT query and give the hint to follow a index scan
- * The hint should not be applied as the GUC for hint mapping has not ben enabled
+ * Run multiple queries and give different hints
+ * The hints should not be applied as the GUC for hint mapping has not ben enabled
  */
 select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
 go
@@ -31,6 +37,44 @@ Bitmap Heap Scan on babel_3295_t1
   Recheck Cond: (b1 = 1)
   ->  Bitmap Index Scan on index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7
         Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3295_t1 where b1 = 1 option(table hint(babel_3295_t1, index(index_babel_3295_t1_b1)))
+go
+~~START~~
+text
+Query Text: select * from babel_3295_t1 where b1 = 1                                                                 
+Bitmap Heap Scan on babel_3295_t1
+  Recheck Cond: (b1 = 1)
+  ->  Bitmap Index Scan on index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7
+        Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3295_t1 inner merge join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+go
+~~START~~
+text
+Query Text: select * from babel_3295_t1 inner       join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+Hash Join
+  Hash Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
+  ->  Seq Scan on babel_3295_t1
+  ->  Hash
+        ->  Seq Scan on babel_3295_t2
+~~END~~
+
+
+select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2 option(merge join)
+go
+~~START~~
+text
+Query Text: select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2                   
+Hash Join
+  Hash Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
+  ->  Seq Scan on babel_3295_t1
+  ->  Hash
+        ->  Seq Scan on babel_3295_t2
 ~~END~~
 
 
@@ -49,8 +93,8 @@ set babelfish_showplan_all on
 go
 
 /*
- * Run a SELECT query and give the hint to follow a index scan
- * The hint should now be applied as the GUC for hint mapping has ben enabled
+ * Run the queries again
+ * The hints should now be applied as the GUC for hint mapping has ben enabled
  */
 select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
 go
@@ -62,10 +106,52 @@ Index Scan using index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7
 ~~END~~
 
 
+select * from babel_3295_t1 where b1 = 1 option(table hint(babel_3295_t1, index(index_babel_3295_t1_b1)))
+go
+~~START~~
+text
+Query Text: /*+ IndexScan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ select * from babel_3295_t1 where b1 = 1                                                                 
+Index Scan using index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7 on babel_3295_t1
+  Index Cond: (b1 = 1)
+~~END~~
+
+
+select * from babel_3295_t1 inner merge join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+go
+~~START~~
+text
+Query Text: /*+ MergeJoin(babel_3295_t1 babel_3295_t2) Leading(babel_3295_t1 babel_3295_t2)*/ select * from babel_3295_t1 inner       join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+Merge Join
+  Merge Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
+  ->  Index Scan using babel_3295_t1_pkey on babel_3295_t1
+  ->  Index Scan using babel_3295_t2_pkey on babel_3295_t2
+~~END~~
+
+
+select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2 option(merge join)
+go
+~~START~~
+text
+Query Text: /*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2                   
+Merge Join
+  Merge Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
+  ->  Index Scan using babel_3295_t1_pkey on babel_3295_t1
+  ->  Index Scan using babel_3295_t2_pkey on babel_3295_t2
+~~END~~
+
+
 set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
 select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
 go
 ~~START~~
@@ -75,4 +161,7 @@ off
 
 
 drop table babel_3295_t1
+go
+
+drop table babel_3295_t2
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3291.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3291.sql
@@ -30,5 +30,8 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+
 drop table babel_3291_t1
 go

--- a/test/JDBC/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3292.sql
@@ -268,6 +268,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+
 select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3293.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3293.sql
@@ -46,6 +46,9 @@ go
 select * from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 go
 
+select * from babel_3293_t1 t1 inner merge join babel_3293_t2 t2 on t1.a1 = t2.a2 where b1 = 1 and b2 = 1
+go
+
 select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 go
 
@@ -69,6 +72,9 @@ select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.
 go
 
 select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner loop join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+
+select * from babel_3293_t1 t1 left outer merge join babel_3293_t2 t2 on t1.a1 = t2.a2 inner loop join babel_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 go
 
 select * from babel_3293_t1, babel_3293_t2 inner merge join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
@@ -234,6 +240,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+
 select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false)
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3294.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3294.sql
@@ -45,6 +45,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+
 select set_config('force_parallel_mode', '0', false)
 go
 

--- a/test/JDBC/pg_hint_plan/BABEL-3295.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3295.sql
@@ -1,10 +1,16 @@
 drop table if exists babel_3295_t1
 go
 
+drop table if exists babel_3295_t2
+go
+
 create table babel_3295_t1(a1 int PRIMARY KEY, b1 int)
 go
 
 create index index_babel_3295_t1_b1 on babel_3295_t1(b1)
+go
+
+create table babel_3295_t2(a2 int PRIMARY KEY, b2 int)
 go
 
 select set_config('babelfishpg_tsql.explain_costs', 'off', false)
@@ -14,10 +20,19 @@ set babelfish_showplan_all on
 go
 
 /*
- * Run a SELECT query and give the hint to follow a index scan
- * The hint should not be applied as the GUC for hint mapping has not ben enabled
+ * Run multiple queries and give different hints
+ * The hints should not be applied as the GUC for hint mapping has not ben enabled
  */
 select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
+go
+
+select * from babel_3295_t1 where b1 = 1 option(table hint(babel_3295_t1, index(index_babel_3295_t1_b1)))
+go
+
+select * from babel_3295_t1 inner merge join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+go
+
+select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2 option(merge join)
 go
 
 set babelfish_showplan_all off
@@ -30,18 +45,33 @@ set babelfish_showplan_all on
 go
 
 /*
- * Run a SELECT query and give the hint to follow a index scan
- * The hint should now be applied as the GUC for hint mapping has ben enabled
+ * Run the queries again
+ * The hints should now be applied as the GUC for hint mapping has ben enabled
  */
 select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
+go
+
+select * from babel_3295_t1 where b1 = 1 option(table hint(babel_3295_t1, index(index_babel_3295_t1_b1)))
+go
+
+select * from babel_3295_t1 inner merge join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+go
+
+select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2 option(merge join)
 go
 
 set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+
 select set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false);
 go
 
 drop table babel_3295_t1
+go
+
+drop table babel_3295_t2
 go


### PR DESCRIPTION
### Description
This PR has the following changes:

1.  Clear structures if a conflicting join hint error is thrown
2. Fix mapping  of join hints passed as a query hint 
3. Add more test cases for validating hint mapping GUC
4. Add more test cases to validate join hint on tables having aliases


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).