### PR TITLE
Updated CMake Installation Instructions

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -58,8 +58,12 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     To get and use the latest version of cmake:
 
     ```
-    wget https://github.com/Kitware/CMake/releases/download/v3.20.6/cmake-3.20.6-linux-x86_64.sh
-    sh cmake-3.20.6-linux-x86_64.sh
+    wget https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2.tar.gz
+    tar vfxz cmake-3.23.2.tar.gz
+    cd cmake-3.23.2
+    ./bootstrap 
+    make
+    sudo make install
     ```
 
 


### PR DESCRIPTION
Currently, the CMake installation instructions do not work as intended.
After running the current commands, CMake does not seem to be installed
correctly. When running "cmake --version", this error appears: "zsh:
cmake: command not found". This commit updates the instructions by
installing from the .tar file for a newer version of the software,
3.23.2. Whether additional steps were to be taken for the current
  instructions, this update allows CMake to function immediately after
execution. No additional steps are needed.

TASK:
Signed-off-by: Ozzy Nolen <oscarno@amazon.com>

### Description

This commit allows the "cmake" command to be used immediately after execution. It also updates the current instructions to the latest software version.
 
### Issues Resolved

- CMake command not immediately usable after following current commands.
- An older version of CMake being used.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).