### PR TITLE
Ignore use of :: in front of function names.

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5028,6 +5028,7 @@ func_proc_name_database_schema
 func_proc_name_server_database_schema
     : (server=id? DOT)? database=id? DOT schema=id? DOT procedure=id
     | (schema=id? DOT)? procedure=id
+    | colon_colon procedure=id
     ;
 
 ddl_object

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1987,6 +1987,13 @@ public:
 
 	TSqlParser::IdContext *proc = ctx->procedure;
 
+	// if the func name contains colon_colon, it must begin with it. see grammar
+    if (ctx->colon_colon())
+    {
+        // Treat ::func() as func()
+        stream.setText(ctx->start->getStartIndex(), "  ");
+    }
+
 	// See the commment in enterFunc_proc_name_schema() for an explanation of this code
 	
 	if (proc->keyword() || proc->colon_colon())

--- a/test/JDBC/expected/BABEL-3299.out
+++ b/test/JDBC/expected/BABEL-3299.out
@@ -1,0 +1,30 @@
+SELECT COUNT(*) FROM ::fn_helpcollations() where [Name] = DATABASEPROPERTYEX(DB_NAME(), 'Collation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM ::isnull(NULL, 0)
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM isnull(NULL, 0)
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM ::
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '<EOF>' at line 2 and character position 0)~~
+

--- a/test/JDBC/expected/BABEL-3299.out
+++ b/test/JDBC/expected/BABEL-3299.out
@@ -28,3 +28,24 @@ GO
 
 ~~ERROR (Message: syntax error near '<EOF>' at line 2 and character position 0)~~
 
+
+CREATE TABLE t3299 (a int);
+GO
+
+/* Should throw a syntax error */
+CREATE TRIGGER t1
+ON t3299
+AFTER UPDATE
+AS
+IF (::UPDATE(a))
+BEGIN
+RAISERROR(0, 0, 0)
+END;
+GO
+~~ERROR (Code: 10727)~~
+
+~~ERROR (Message: syntax error near 'UPDATE' at line 6 and character position 6)~~
+
+
+DROP TABLE t3299;
+GO

--- a/test/JDBC/input/BABEL-3299.sql
+++ b/test/JDBC/input/BABEL-3299.sql
@@ -9,3 +9,20 @@ GO
 
 SELECT * FROM ::
 GO
+
+CREATE TABLE t3299 (a int);
+GO
+
+/* Should throw a syntax error */
+CREATE TRIGGER t1
+ON t3299
+AFTER UPDATE
+AS
+IF (::UPDATE(a))
+BEGIN
+RAISERROR(0, 0, 0)
+END;
+GO
+
+DROP TABLE t3299;
+GO

--- a/test/JDBC/input/BABEL-3299.sql
+++ b/test/JDBC/input/BABEL-3299.sql
@@ -1,0 +1,11 @@
+SELECT COUNT(*) FROM ::fn_helpcollations() where [Name] = DATABASEPROPERTYEX(DB_NAME(), 'Collation')
+GO
+
+SELECT * FROM ::isnull(NULL, 0)
+GO
+
+SELECT * FROM isnull(NULL, 0)
+GO
+
+SELECT * FROM ::
+GO


### PR DESCRIPTION
In T-SQL ::foo() is treated as foo(). We rewrite these statements in the parser
to remove the :: to achieve this functionality.

Task: BABEL-3299
Signed-off-by: Tim Chang <changti@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).