### PR TITLE
Escape hatch for SET SHOWPLAN_ALL and SET STATISTICS PROFILE

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1092,6 +1092,7 @@ int escape_hatch_session_settings = EH_IGNORE;
 int escape_hatch_unique_constraint = EH_STRICT;
 int escape_hatch_ignore_dup_key = EH_STRICT;
 int escape_hatch_rowversion = EH_STRICT;
+int escape_hatch_showplan_all = EH_STRICT;
 
 void
 define_escape_hatch_variables(void)
@@ -1403,6 +1404,17 @@ define_escape_hatch_variables(void)
 							  gettext_noop("escape hatch for TIMESTAMP/ROWVERSION columns"),
 							  NULL,
 							  &escape_hatch_rowversion,
+							  EH_STRICT,
+							  escape_hatch_options,
+							  PGC_USERSET,
+							  GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							  NULL, NULL, NULL);
+
+	/* SHOWPLAN_ALL */
+	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_showplan_all",
+							  gettext_noop("escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE"),
+							  NULL,
+							  &escape_hatch_showplan_all,
 							  EH_STRICT,
 							  escape_hatch_options,
 							  PGC_USERSET,

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -37,6 +37,8 @@ extern "C" {
 #include "catalog/pg_proc.h"
 #include "parser/scansup.h"
 
+#include "guc.h"
+
 #endif
 
 #ifdef LOG // maybe already defined in elog.h, which is conflicted with grammar token LOG
@@ -75,6 +77,8 @@ extern "C"
 	extern size_t get_num_pg_reserved_keywords_to_be_delimited();
 	extern char * construct_unique_index_name(char *index_name, char *relation_name);
 	extern bool enable_hint_mapping;
+
+	extern int escape_hatch_showplan_all;
 }
 
 static void toDotRecursive(ParseTree *t, const std::vector<std::string> &ruleNames, const std::string &sourceText);
@@ -4058,7 +4062,7 @@ makeSetStatement(TSqlParser::Set_statementContext *ctx, tsqlBuilder &builder)
 		else if (set_special_ctx->set_on_off_option().size() == 1)
 		{
 			auto option = set_special_ctx->set_on_off_option().front();
-			if (option->BABELFISH_SHOWPLAN_ALL())
+			if (option->BABELFISH_SHOWPLAN_ALL() || (option->SHOWPLAN_ALL() && escape_hatch_showplan_all == EH_IGNORE))
 				return makeSetExplainModeStatement(ctx, true);
 			return makeSQL(ctx);
 		}
@@ -4076,7 +4080,14 @@ makeSetStatement(TSqlParser::Set_statementContext *ctx, tsqlBuilder &builder)
 		else if (set_special_ctx->OFFSETS())
 			return nullptr;
 		else if (set_special_ctx->STATISTICS())
+		{
+			for (auto kw : set_special_ctx->set_statistics_keyword())
+			{
+				if (kw->PROFILE() && escape_hatch_showplan_all == EH_IGNORE)
+					return makeSetExplainModeStatement(ctx, false);
+			}
 			return nullptr;
+		}
 		else if (set_special_ctx->BABELFISH_STATISTICS() && set_special_ctx->PROFILE())
 			return makeSetExplainModeStatement(ctx, false);
 		else

--- a/test/JDBC/expected/BABEL-3248.out
+++ b/test/JDBC/expected/BABEL-3248.out
@@ -1,0 +1,84 @@
+select set_config('babelfishpg_tsql.explain_costs', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+select current_setting('babelfishpg_tsql.escape_hatch_showplan_all');
+go
+~~START~~
+text
+strict
+~~END~~
+
+
+-- SHOWPLAN_ALL and STATISTICS PROFILE should be ignored
+set showplan_all on;
+go
+select 1;
+go
+~~START~~
+int
+1
+~~END~~
+
+set showplan_all off;
+go
+set statistics profile on;
+go
+select 1;
+go
+~~START~~
+int
+1
+~~END~~
+
+set statistics profile off;
+go
+
+-- SHOWPLAN_ALL and STATISTICS PROFILE should return BBF query plans
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_showplan_all', 'ignore';
+go
+
+set showplan_all on;
+go
+select 1;
+go
+~~START~~
+text
+Query Text: select 1
+Result
+~~END~~
+
+set showplan_all off;
+go
+set statistics profile on;
+go
+select 1;
+go
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+Query Text: select 1
+Result (actual rows=1 loops=1)
+~~END~~
+
+set statistics profile off;
+go
+
+-- clean up
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_showplan_all', 'strict';
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'on', false);
+go
+~~START~~
+text
+on
+~~END~~
+

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -1990,6 +1990,7 @@ babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch fo
 babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
 babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
 babelfishpg_tsql.escape_hatch_session_settings#!#strict#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
 babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
@@ -2044,6 +2045,7 @@ babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch fo
 babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
 babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
 babelfishpg_tsql.escape_hatch_session_settings#!#strict#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
 babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
@@ -2079,6 +2081,7 @@ babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch fo
 babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
 babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
 babelfishpg_tsql.escape_hatch_session_settings#!#strict#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
 babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints

--- a/test/JDBC/input/BABEL-3248.sql
+++ b/test/JDBC/input/BABEL-3248.sql
@@ -1,0 +1,42 @@
+select set_config('babelfishpg_tsql.explain_costs', 'off', false);
+go
+select current_setting('babelfishpg_tsql.escape_hatch_showplan_all');
+go
+
+-- SHOWPLAN_ALL and STATISTICS PROFILE should be ignored
+set showplan_all on;
+go
+select 1;
+go
+set showplan_all off;
+go
+set statistics profile on;
+go
+select 1;
+go
+set statistics profile off;
+go
+
+-- SHOWPLAN_ALL and STATISTICS PROFILE should return BBF query plans
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_showplan_all', 'ignore';
+go
+
+set showplan_all on;
+go
+select 1;
+go
+set showplan_all off;
+go
+set statistics profile on;
+go
+select 1;
+go
+set statistics profile off;
+go
+
+-- clean up
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_showplan_all', 'strict';
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'on', false);
+go


### PR DESCRIPTION
Currently, we support `SET BABELFISH_SHOWPLAN_ALL` to generate PG queryplan
output for T-SQL queries. The original T-SQL `SET SHOWPLAN_ALL` is
silently ignored by Babelfish.

This commit introduces an escape hatch
`babelfish_pgtsql.escape_hatch_showplan_all`. When set to `strict`
(=default) then `SET SHOWPLAN_ALL` is silently ignored as currently. When
set to `ignore`, then generate the same output as `SET BABELFISH_SHOWPLAN_ALL`.

It also applies to `SET BABELFISH_STATISTICS PROFILE` under the same
escape hatch.

Task: BABEL-3248
Signed-off-by: Jungkook Lee <jungkook@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).