### PR TITLE
Fix minor version upgrade WF to use dependent engine branch if it exists

### DIFF
--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -50,20 +50,13 @@ jobs:
         id: install-extensions-older
         if: always() && steps.build-extensions-older.outcome == 'success'
         uses: ./.github/composite-actions/install-extensions
-
-      - name: Build and run tests for Postgres engine using ${{env.ENGINE_VER_TO}}
-        if: always() && steps.install-extensions-older.outcome == 'success'
-        run: |
-          cd ../postgresql_modified_for_babelfish
-          git checkout ${{env.ENGINE_VER_TO}}
-          ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
-          make clean
-          make -j 4 2>error.txt
-          make install
-          make check
-          cd contrib && make && sudo make install
-
+        
       - uses: actions/checkout@v2
+
+      - name: Build and run tests for Postgres engine using latest engine
+        id: build-modified-postgres-newer
+        if: always() && steps.install-extensions-older.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
 
       - name: Set env variables and build extensions
         id: build-extensions-newer


### PR DESCRIPTION
### Description

Previously the minor version upgrade WF for empty database was using the BABEL_2_X_DEV__PG_14_3 as the new engine branch. However, if there is a dependent engine repository change for an extension repository change then this logic would fail. Replaced this logic by just using the build-modified-postgres composite action with default arguments. By default, the build-modified-postgres composite action will do an intelligent lookup for any dependent engine repository branch.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).