### PR TITLE
Update expected_create.out

### DIFF
--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -224,7 +224,6 @@ Could not find upgrade tests for function sys.sp_special_columns_scale_helper
 Could not find upgrade tests for function sys.sp_statistics_internal
 Could not find upgrade tests for function sys.sp_tables_internal
 Could not find upgrade tests for function sys.space
-Could not find upgrade tests for function sys.spid
 Could not find upgrade tests for function sys.square
 Could not find upgrade tests for function sys.string_escape
 Could not find upgrade tests for function sys.string_split


### PR DESCRIPTION
### Description

Updated the expected output for expected_create.out. We have now tests that test @@SPID in upgrade so we should not have this line anymore.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).