### PR TITLE
Implement information_schema.column_privileges

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -676,3 +676,71 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+/*
+* COLUMN_PRIVILEGES
+*/
+
+CREATE OR REPLACE VIEW information_schema_tsql.column_privileges AS
+SELECT u_grantor.rolname::sys.nvarchar(128) AS grantor,
+    grantee.rolname::sys.nvarchar(128) AS grantee,
+    sys.db_name()::sys.nvarchar(128) AS table_catalog,
+    sys.schema_name(x.relnamespace)::sys.nvarchar(128) AS table_schema,
+    x.relname::sys.sysname AS table_name,
+    x.attname::sys.sysname AS column_name,
+    x.prtype::sys."varchar"(10) AS privilege_type,
+        CASE
+            WHEN pg_has_role(x.grantee, x.relowner, 'USAGE'::text) OR x.grantable THEN 'YES'::text
+            ELSE 'NO'::text
+        END::sys."varchar"(3) AS is_grantable
+   FROM ( SELECT pr_c.grantor,
+            pr_c.grantee,
+            a.attname,
+            pr_c.relname,
+            pr_c.relnamespace,
+            pr_c.prtype,
+            pr_c.grantable,
+            pr_c.relowner
+           FROM ( SELECT pg_class.oid,
+                    pg_class.relname,
+                    pg_class.relnamespace,
+                    pg_class.relowner,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
+                   FROM pg_class
+                  WHERE pg_class.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
+            pg_attribute a
+          WHERE a.attrelid = pr_c.oid AND a.attnum > 0 AND NOT a.attisdropped
+        UNION
+         SELECT pr_a.grantor,
+            pr_a.grantee,
+            pr_a.attname,
+            c.relname,
+            c.relnamespace,
+            pr_a.prtype,
+            pr_a.grantable,
+            c.relowner
+           FROM ( SELECT a.attrelid,
+                    a.attname,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).is_grantable AS is_grantable
+                   FROM pg_attribute a
+                     JOIN pg_class cc ON a.attrelid = cc.oid
+                  WHERE a.attnum > 0 AND NOT a.attisdropped) pr_a(attrelid, attname, grantor, grantee, prtype, grantable),
+            pg_class c
+          WHERE pr_a.attrelid = c.oid AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"]))) x,
+    pg_namespace nc,
+    pg_roles u_grantor,
+    ( SELECT pg_roles.oid,
+            pg_roles.rolname
+           FROM pg_roles
+        UNION ALL
+         SELECT 0::oid AS oid,
+            'PUBLIC'::name AS name) grantee(oid, rolname)
+WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid AND (x.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'REFERENCES'::text])) AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+
+GRANT SELECT ON information_schema_tsql.column_privileges TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -161,6 +161,74 @@ CREATE OR REPLACE VIEW information_schema_tsql.COLUMN_DOMAIN_USAGE AS
 
 GRANT SELECT ON information_schema_tsql.COLUMN_DOMAIN_USAGE TO PUBLIC;
 
+/*
+* COLUMN_PRIVILEGES
+*/
+
+CREATE OR REPLACE VIEW information_schema_tsql.column_privileges AS
+SELECT u_grantor.rolname::sys.nvarchar(128) AS grantor,
+    grantee.rolname::sys.nvarchar(128) AS grantee,
+    sys.db_name()::sys.nvarchar(128) AS table_catalog,
+    sys.schema_name(x.relnamespace)::sys.nvarchar(128) AS table_schema,
+    x.relname::sys.sysname AS table_name,
+    x.attname::sys.sysname AS column_name,
+    x.prtype::sys."varchar"(10) AS privilege_type,
+        CASE
+            WHEN pg_has_role(x.grantee, x.relowner, 'USAGE'::text) OR x.grantable THEN 'YES'::text
+            ELSE 'NO'::text
+        END::sys."varchar"(3) AS is_grantable
+   FROM ( SELECT pr_c.grantor,
+            pr_c.grantee,
+            a.attname,
+            pr_c.relname,
+            pr_c.relnamespace,
+            pr_c.prtype,
+            pr_c.grantable,
+            pr_c.relowner
+           FROM ( SELECT pg_class.oid,
+                    pg_class.relname,
+                    pg_class.relnamespace,
+                    pg_class.relowner,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
+                   FROM pg_class
+                  WHERE pg_class.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
+            pg_attribute a
+          WHERE a.attrelid = pr_c.oid AND a.attnum > 0 AND NOT a.attisdropped
+        UNION
+         SELECT pr_a.grantor,
+            pr_a.grantee,
+            pr_a.attname,
+            c.relname,
+            c.relnamespace,
+            pr_a.prtype,
+            pr_a.grantable,
+            c.relowner
+           FROM ( SELECT a.attrelid,
+                    a.attname,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).is_grantable AS is_grantable
+                   FROM pg_attribute a
+                     JOIN pg_class cc ON a.attrelid = cc.oid
+                  WHERE a.attnum > 0 AND NOT a.attisdropped) pr_a(attrelid, attname, grantor, grantee, prtype, grantable),
+            pg_class c
+          WHERE pr_a.attrelid = c.oid AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"]))) x,
+    pg_namespace nc,
+    pg_roles u_grantor,
+    ( SELECT pg_roles.oid,
+            pg_roles.rolname
+           FROM pg_roles
+        UNION ALL
+         SELECT 0::oid AS oid,
+            'PUBLIC'::name AS name) grantee(oid, rolname)
+WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid AND (x.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'REFERENCES'::text])) AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+
+GRANT SELECT ON information_schema_tsql.column_privileges TO PUBLIC;
+
 CREATE OR replace view sys.foreign_keys AS
 SELECT
   CAST(c.conname AS sys.SYSNAME) AS name

--- a/test/JDBC/input/isc-column_privileges.mix
+++ b/test/JDBC/input/isc-column_privileges.mix
@@ -1,0 +1,16 @@
+-- tsql
+
+create database simple_test;
+go
+
+use simple_test;
+go
+
+select * from information_schema.column_privileges;
+go
+
+use master;
+go
+
+drop database simple_test;
+go


### PR DESCRIPTION
This is an attempt at implementing the given view. The definition
has been added to the information_schema_tsql.sql and the upgrade file.
The corresponding test file is a .mix file, using tsql. Unfortunately,
the output is registering the view as non-existent.

TASK:

Signed-off-by: Ozzy Nolen <oscarno@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).