### PR TITLE
Updated init.sh and cleanup.sh

### DIFF
--- a/test/JDBC/cleanup.sh
+++ b/test/JDBC/cleanup.sh
@@ -1,5 +1,5 @@
 echo "===================================== CLEANING UP ======================================"
-psql -d postgres -U "$USER" << EOF
+sudo ~/postgres/bin/psql -d postgres -U $USER << EOF
 \c jdbc_testdb
 CALL sys.remove_babelfish();
 ALTER SYSTEM RESET babelfishpg_tsql.database_name;

--- a/test/JDBC/init.sh
+++ b/test/JDBC/init.sh
@@ -1,7 +1,7 @@
  
 #create test user and database from psql terminal
 echo "============================== CREATING USER AND DATABASE =============================="
-psql -U "$USER" -d postgres -a << EOF
+sudo ~/postgres/bin/psql -d postgres -U $USER << EOF
 CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;
 DROP DATABASE IF EXISTS jdbc_testdb;
 CREATE DATABASE jdbc_testdb OWNER jdbc_user;


### PR DESCRIPTION

### Description

Currently, the command to connect to psql in
init.sh and cleanup.sh do not function properly.
When executed, this error arises: "psql: could not connect to server: No
such file or directory". This commit updates the command to connect to
psql properly and to execute the files themselves.

TASK:

Signed-off-by: Ozzy Nolen <oscarno@amazon.com>
 
### Issues Resolved

- Files init.sh and cleanup.sh not connecting to psql properly.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).