### PR TITLE
Nullable DATETIME column does not store NULL

### DIFF
--- a/test/JDBC/expected/latest__verification_cleanup__13_6__BABEL-2769-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_6__BABEL-2769-vu-verify.out
@@ -6,6 +6,20 @@ First#!#1900-01-01 00:00:00.0
 Second#!#1900-01-01 00:00:00.0
 ~~END~~
 
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Smalldatetime;
+go
+~~START~~
+varchar#!#smalldatetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+Third#!#<NULL>
+~~END~~
+
 
 SELECT * FROM BABEL_2769_vu_prepare_Datetime;
 go
@@ -13,6 +27,20 @@ go
 varchar#!#datetime
 First#!#1900-01-01 00:00:00.0
 Second#!#1900-01-01 00:00:00.0
+~~END~~
+
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Datetime;
+go
+~~START~~
+varchar#!#datetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+Third#!#<NULL>
 ~~END~~
 
 
@@ -24,6 +52,20 @@ First#!#1900-01-01 00:00:00.000
 Second#!#1900-01-01 00:00:00.000
 ~~END~~
 
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Datetime2;
+go
+~~START~~
+varchar#!#datetime2
+First#!#1900-01-01 00:00:00.000
+Second#!#1900-01-01 00:00:00.000
+Third#!#<NULL>
+~~END~~
+
 
 SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
 go
@@ -31,5 +73,19 @@ go
 varchar#!#datetimeoffset
 First#!#1900-01-01 00:00:00.00000 +00:00
 Second#!#1900-01-01 00:00:00.00000 +00:00
+~~END~~
+
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
+go
+~~START~~
+varchar#!#datetimeoffset
+First#!#1900-01-01 00:00:00.00000 +00:00
+Second#!#1900-01-01 00:00:00.00000 +00:00
+Third#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__BABEL-2769-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__BABEL-2769-vu-verify.out
@@ -6,6 +6,20 @@ First#!#1900-01-01 00:00:00.0
 Second#!#1900-01-01 00:00:00.0
 ~~END~~
 
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Smalldatetime;
+go
+~~START~~
+varchar#!#smalldatetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+Third#!#<NULL>
+~~END~~
+
 
 SELECT * FROM BABEL_2769_vu_prepare_Datetime;
 go
@@ -13,6 +27,20 @@ go
 varchar#!#datetime
 First#!#1900-01-01 00:00:00.0
 Second#!#1900-01-01 00:00:00.0
+~~END~~
+
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Datetime;
+go
+~~START~~
+varchar#!#datetime
+First#!#1900-01-01 00:00:00.0
+Second#!#1900-01-01 00:00:00.0
+Third#!#<NULL>
 ~~END~~
 
 
@@ -24,6 +52,20 @@ First#!#1900-01-01 00:00:00.000
 Second#!#1900-01-01 00:00:00.000
 ~~END~~
 
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Datetime2;
+go
+~~START~~
+varchar#!#datetime2
+First#!#1900-01-01 00:00:00.000
+Second#!#1900-01-01 00:00:00.000
+Third#!#<NULL>
+~~END~~
+
 
 SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
 go
@@ -31,5 +73,19 @@ go
 varchar#!#datetimeoffset
 First#!#1900-01-01 00:00:00.00000 +00:00
 Second#!#1900-01-01 00:00:00.00000 +00:00
+~~END~~
+
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Third');
+go
+~~ROW COUNT: 1~~
+
+SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
+go
+~~START~~
+varchar#!#datetimeoffset
+First#!#1900-01-01 00:00:00.00000 +00:00
+Second#!#1900-01-01 00:00:00.00000 +00:00
+Third#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/BABEL-2769-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/BABEL-2769-vu-verify.sql
@@ -1,11 +1,31 @@
 SELECT * FROM BABEL_2769_vu_prepare_Smalldatetime;
 go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Third');
+go
+SELECT * FROM BABEL_2769_vu_prepare_Smalldatetime;
+go
 
+SELECT * FROM BABEL_2769_vu_prepare_Datetime;
+go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Third');
+go
 SELECT * FROM BABEL_2769_vu_prepare_Datetime;
 go
 
 SELECT * FROM BABEL_2769_vu_prepare_Datetime2;
 go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Third');
+go
+SELECT * FROM BABEL_2769_vu_prepare_Datetime2;
+go
 
+SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
+go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Third');
+go
 SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
 go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/BABEL-2769-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/BABEL-2769-vu-verify.sql
@@ -1,11 +1,31 @@
 SELECT * FROM BABEL_2769_vu_prepare_Smalldatetime;
 go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Smalldatetime ( c1 ) VALUES ('Third');
+go
+SELECT * FROM BABEL_2769_vu_prepare_Smalldatetime;
+go
 
+SELECT * FROM BABEL_2769_vu_prepare_Datetime;
+go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime ( c1 ) VALUES ('Third');
+go
 SELECT * FROM BABEL_2769_vu_prepare_Datetime;
 go
 
 SELECT * FROM BABEL_2769_vu_prepare_Datetime2;
 go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetime2 ( c1 ) VALUES ('Third');
+go
+SELECT * FROM BABEL_2769_vu_prepare_Datetime2;
+go
 
+SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
+go
+-- Inserting new data into existing table
+INSERT INTO BABEL_2769_vu_prepare_Datetimeoffset ( c1 ) VALUES ('Third');
+go
 SELECT * FROM BABEL_2769_vu_prepare_Datetimeoffset;
 go


### PR DESCRIPTION
Before Fix:
Nullable datetime column was storing default datetime value '1900-01-01 *' instead of NULL

After Fix:
Nullable datetime column is returning NULL value for all datetime related datatypes. Fix includes dropping default stored value for new tables on these datatypes and setting typdefault to null on upgrade-script for existing tables.

Adding testcase to check if the above behaviour is correct for existing table with new data, i.e., old data would contain default datetime value '1900-01-01 *' however new data in existing table would store default value NULL.

Task: BABEL-2769
Signed-off-by: Satarupa Biswas satarupb@amazon.com

### Description
Adding an extra upgrade testcase to check what happens when new nullable data is inserted in pre-existing table.
 
### Issues Resolved

[List any issues this PR will resolve]
https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/316

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).