### PR TITLE
Add a GUC to limit the recursion depth

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -12,6 +12,9 @@
 #define PLTSQL_SESSION_ISOLATION_LEVEL "default_transaction_isolation"
 #define PLTSQL_TRANSACTION_ISOLATION_LEVEL "transaction_isolation"
 #define PLTSQL_DEFAULT_LANGUAGE "us_english"
+#define DEFAULT_MAX_RECURSION_DEPTH 100
+#define MIN_ALLOWED_MAX_RECURSION_DEPTH 0
+#define MAX_ALLOWED_MAX_RECURSION_DEPTH 32767
 
 static int migration_mode = SINGLE_DB;
 bool   enable_ownership_structure = false;
@@ -76,6 +79,7 @@ bool restore_tsql_tabletype = false;
 
 /* T-SQL Hint Mapping */
 bool enable_hint_mapping = false;
+int max_recursion_depth = DEFAULT_MAX_RECURSION_DEPTH;
 
 static bool check_server_collation_name(char **newval, void **extra, GucSource source);
 static bool check_default_locale (char **newval, void **extra, GucSource source);
@@ -1043,6 +1047,15 @@ define_custom_variables(void)
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);
+
+	DefineCustomIntVariable("babelfishpg_tsql.max_recursion_depth",
+                gettext_noop("Default value for the max recursion depth"),
+                NULL,
+                &max_recursion_depth,
+                DEFAULT_MAX_RECURSION_DEPTH, MIN_ALLOWED_MAX_RECURSION_DEPTH, MAX_ALLOWED_MAX_RECURSION_DEPTH,
+                PGC_USERSET,
+                GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+                NULL, NULL, NULL);
 
 	DefineCustomIntVariable("babelfishpg_tsql.insert_bulk_rows_per_batch",
 				gettext_noop("Sets the number of rows per batch to be processed for Insert Bulk"),

--- a/test/JDBC/expected/BABEL-2202.out
+++ b/test/JDBC/expected/BABEL-2202.out
@@ -1,0 +1,293 @@
+drop table if exists babel_2202_t1
+go
+
+create table babel_2202_t1(a1 int PRIMARY KEY)
+go
+
+insert into babel_2202_t1 values(1)
+go
+~~ROW COUNT: 1~~
+
+
+insert into babel_2202_t1 values(2)
+go
+~~ROW COUNT: 1~~
+
+
+select set_config('babelfishpg_tsql.max_recursion_depth', '-1', false)
+go
+~~START~~
+text
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: -1 is outside the valid range for parameter "babelfishpg_tsql.max_recursion_depth" (0 .. 32767))~~
+
+
+select set_config('babelfishpg_tsql.max_recursion_depth', '32768', false)
+go
+~~START~~
+text
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 32768 is outside the valid range for parameter "babelfishpg_tsql.max_recursion_depth" (0 .. 32767))~~
+
+
+select set_config('babelfishpg_tsql.max_recursion_depth', '3', false)
+go
+~~START~~
+text
+3
+~~END~~
+
+
+-- Test an infinite recursive CTE with each cycle resulting in one row
+with babel_2202_cte(a1) as
+(
+    select 1 as a1 
+    union all
+    select * from babel_2202_cte
+)
+select * from babel_2202_cte
+go
+~~START~~
+int
+1
+1
+1
+1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+-- Test an infinite recursive CTE with each cycle resulting in multiple rows
+with babel_2202_cte as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte
+)
+select * from babel_2202_cte
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+-- Test a query having a select statement resulting in a few rows union with an infinite recursive CTE
+with babel_2202_cte as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte
+)
+select *, 1 from babel_2202_t1
+union all
+select * from babel_2202_cte
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+-- Test query having multiple CTE's
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select *, 1 from babel_2202_t1
+union all
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+    where number < 3
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+    where number < 3
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select *, 1 from babel_2202_t1
+union all
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#1
+2#!#1
+1#!#2
+1#!#2
+1#!#3
+1#!#3
+1#!#4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+-- Test query having nested CTE's
+with babel_2202_cte_1 as
+(
+    select 1 as number
+    union all
+    select number + 1 from babel_2202_cte_1
+),
+babel_2202_cte_2 as
+(
+    select 2 as number
+    union all
+    select * from babel_2202_cte_1
+)
+select * from babel_2202_cte_2
+go
+~~START~~
+int
+2
+1
+2
+3
+4
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The statement terminated. The maximum recursion 3 has been exhausted before statement completion.)~~
+
+
+-- cleanup
+select set_config('babelfishpg_tsql.max_recursion_depth', '100', false)
+go
+~~START~~
+text
+100
+~~END~~
+
+
+drop table babel_2202_t1
+go

--- a/test/JDBC/input/BABEL-2202.sql
+++ b/test/JDBC/input/BABEL-2202.sql
@@ -1,0 +1,150 @@
+drop table if exists babel_2202_t1
+go
+
+create table babel_2202_t1(a1 int PRIMARY KEY)
+go
+
+insert into babel_2202_t1 values(1)
+go
+
+insert into babel_2202_t1 values(2)
+go
+
+select set_config('babelfishpg_tsql.max_recursion_depth', '-1', false)
+go
+
+select set_config('babelfishpg_tsql.max_recursion_depth', '32768', false)
+go
+
+select set_config('babelfishpg_tsql.max_recursion_depth', '3', false)
+go
+
+-- Test an infinite recursive CTE with each cycle resulting in one row
+with babel_2202_cte(a1) as
+(
+    select 1 as a1 
+    union all
+    select * from babel_2202_cte
+)
+select * from babel_2202_cte
+go
+
+-- Test an infinite recursive CTE with each cycle resulting in multiple rows
+with babel_2202_cte as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte
+)
+select * from babel_2202_cte
+go
+
+-- Test a query having a select statement resulting in a few rows union with an infinite recursive CTE
+with babel_2202_cte as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte
+)
+select *, 1 from babel_2202_t1
+union all
+select * from babel_2202_cte
+go
+
+-- Test query having multiple CTE's
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select *, 1 from babel_2202_t1
+union all
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+    where number < 3
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+
+with babel_2202_cte_1 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_1
+    where number < 3
+),
+babel_2202_cte_2 as
+(
+    select *, 1 as number from babel_2202_t1
+    union all
+    select 1, number + 1 from babel_2202_cte_2
+)
+select *, 1 from babel_2202_t1
+union all
+select * from babel_2202_cte_1
+union all
+select * from babel_2202_cte_2
+go
+
+-- Test query having nested CTE's
+with babel_2202_cte_1 as
+(
+    select 1 as number
+    union all
+    select number + 1 from babel_2202_cte_1
+),
+babel_2202_cte_2 as
+(
+    select 2 as number
+    union all
+    select * from babel_2202_cte_1
+)
+select * from babel_2202_cte_2
+go
+
+-- cleanup
+select set_config('babelfishpg_tsql.max_recursion_depth', '100', false)
+go
+
+drop table babel_2202_t1
+go


### PR DESCRIPTION
### Description

Currently, recursive CTE has no limit on the recursion depth. This can cause it to run infinitely. T-SQL on the other hand has a default limit of 100 on the recursion depth. The change is to add a new GUC which can store the default maximum recursion depth
 
### Issues Resolved

Task: BABEL-2202


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).