### PR TITLE
In single-db, the schema resolution is incorrect when the object inside the procedure is schema qualified

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -10061,7 +10061,9 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path)
 					 * Don't change the search path, if the statement inside
 					 * the procedure is schema qualified.
 					 */
-					if(stmt->is_schema_specified != true)
+					if(stmt->is_schema_specified)
+						break;
+					else
 					{
 						physical_schema = get_physical_schema_name(cur_dbname, top_es_entry->estate->schema_name);
 						dbo_schema = get_dbo_schema_name(cur_dbname);

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -10057,8 +10057,15 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path)
 			{
 				if (top_es_entry->estate->db_name == NULL)
 				{
-					physical_schema = get_physical_schema_name(cur_dbname, top_es_entry->estate->schema_name);
-					dbo_schema = get_dbo_schema_name(cur_dbname);
+					/*
+					 * Don't change the search path, if the statement inside
+					 * the procedure is schema qualified.
+					 */
+					if(stmt->is_schema_specified != true)
+					{
+						physical_schema = get_physical_schema_name(cur_dbname, top_es_entry->estate->schema_name);
+						dbo_schema = get_dbo_schema_name(cur_dbname);
+					}
 				}
 				else
 				{

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1021,6 +1021,7 @@ typedef struct PLtsql_stmt_execsql
 	bool		is_cross_db;	/* cross database reference */
 	bool		is_dml;			/* DML statement? */
 	bool		is_ddl;			/* DDL statement? */
+	bool            is_schema_specified;    /*is schema name specified? */
 } PLtsql_stmt_execsql;
 
 /*

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -997,6 +997,7 @@ public:
     MyInputStream &stream;
 
 	bool is_cross_db = false;
+	bool is_schema_specified = false;
 
 	// We keep a stack of the containers that are active during a traversal.
 	// A container will correspond to a block or a batch - these are containers
@@ -1406,6 +1407,9 @@ public:
 			stmt->is_cross_db = true;
 		// record that the stmt is dml
 	 	stmt->is_dml = true;
+		// record if the SQL object is schema qualified
+		if (is_schema_specified)
+			stmt->is_schema_specified = true;
 
 		if (is_compiling_create_function())
 		{
@@ -1607,6 +1611,10 @@ public:
 
 	void exitFull_object_name(TSqlParser::Full_object_nameContext *ctx) override
 	{
+		if (ctx && ctx->schema)
+			is_schema_specified = true;
+		else
+			is_schema_specified = false;
 		tsqlCommonMutator::exitFull_object_name(ctx);
 		if (ctx && ctx->database)
 		{

--- a/test/JDBC/expected/schema_resolution_proc-vu-prepare.out
+++ b/test/JDBC/expected/schema_resolution_proc-vu-prepare.out
@@ -35,10 +35,12 @@ create table schema_resolution_proc_t1(dbo_t1 int);
 create table schema_resolution_proc_sch1.schema_resolution_proc_t1(sch1_t1 char, b int);
 insert into schema_resolution_proc_t1 values('a', 1);
 insert into dbo.schema_resolution_proc_t1 values(1);
+insert into schema_resolution_proc_sch2.schema_resolution_proc_t1 values(1, 'a');
 go
 	 
 create proc schema_resolution_proc_sch1.schema_resolution_proc_select_tab
 as 
 select * from dbo.schema_resolution_proc_t1;
 select * from schema_resolution_proc_t1;
+select * from schema_resolution_proc_sch2.schema_resolution_proc_t1;
 go

--- a/test/JDBC/expected/schema_resolution_proc-vu-verify.out
+++ b/test/JDBC/expected/schema_resolution_proc-vu-verify.out
@@ -99,7 +99,7 @@ int#!#char
 drop table schema_resolution_proc_sch2.schema_resolution_proc_t1;
 drop schema schema_resolution_proc_sch2;
 go
-	 
+
 drop proc schema_resolution_proc_sch1.schema_resolution_proc_select_tab
 go
 	 

--- a/test/JDBC/expected/schema_resolution_proc-vu-verify.out
+++ b/test/JDBC/expected/schema_resolution_proc-vu-verify.out
@@ -41,9 +41,15 @@ go
 drop table schema_resolution_proc_table1;
 go
 
+create schema schema_resolution_proc_sch2;
+create table schema_resolution_proc_sch2.schema_resolution_proc_t1(a int, b char);
+go
+
 -- Without schema specified, insert takes place in "schema_resolution_proc_sch1" while create takes place in default schema["dbo" in this case] 
 exec schema_resolution_proc_sch1.schema_resolution_proc_create_tab;
 go
+~~ROW COUNT: 1~~
+
 ~~ROW COUNT: 1~~
 
 ~~ROW COUNT: 1~~
@@ -60,6 +66,11 @@ int
 ~~START~~
 char#!#int
 a#!#1
+~~END~~
+
+~~START~~
+int#!#char
+1#!#a
 ~~END~~
 
 
@@ -79,6 +90,15 @@ int
 1
 ~~END~~
 
+~~START~~
+int#!#char
+1#!#a
+~~END~~
+
+
+drop table schema_resolution_proc_sch2.schema_resolution_proc_t1;
+drop schema schema_resolution_proc_sch2;
+go
 	 
 drop proc schema_resolution_proc_sch1.schema_resolution_proc_select_tab
 go

--- a/test/JDBC/input/schema_resolution_proc-vu-prepare.sql
+++ b/test/JDBC/input/schema_resolution_proc-vu-prepare.sql
@@ -35,10 +35,12 @@ create table schema_resolution_proc_t1(dbo_t1 int);
 create table schema_resolution_proc_sch1.schema_resolution_proc_t1(sch1_t1 char, b int);
 insert into schema_resolution_proc_t1 values('a', 1);
 insert into dbo.schema_resolution_proc_t1 values(1);
+insert into schema_resolution_proc_sch2.schema_resolution_proc_t1 values(1, 'a');
 go
 	 
 create proc schema_resolution_proc_sch1.schema_resolution_proc_select_tab
 as 
 select * from dbo.schema_resolution_proc_t1;
 select * from schema_resolution_proc_t1;
+select * from schema_resolution_proc_sch2.schema_resolution_proc_t1;
 go

--- a/test/JDBC/input/schema_resolution_proc-vu-verify.sql
+++ b/test/JDBC/input/schema_resolution_proc-vu-verify.sql
@@ -28,6 +28,10 @@ go
 drop table schema_resolution_proc_table1;
 go
 
+create schema schema_resolution_proc_sch2;
+create table schema_resolution_proc_sch2.schema_resolution_proc_t1(a int, b char);
+go
+
 -- Without schema specified, insert takes place in "schema_resolution_proc_sch1" while create takes place in default schema["dbo" in this case] 
 exec schema_resolution_proc_sch1.schema_resolution_proc_create_tab;
 go
@@ -42,7 +46,11 @@ go
 -- searches for t1 in "schema_resolution_proc_sch1" first, if not found then searches in default schema
 exec schema_resolution_proc_sch1.schema_resolution_proc_select_tab
 go
-	 
+
+drop table schema_resolution_proc_sch2.schema_resolution_proc_t1;
+drop schema schema_resolution_proc_sch2;
+go
+
 drop proc schema_resolution_proc_sch1.schema_resolution_proc_select_tab
 go
 	 


### PR DESCRIPTION
In single-db, the schema resolution is incorrect when the object inside the procedure is schema qualified.

### Change
The dml statement should check for the object in the schema specified
with the object, not the one specified in the procedure call

Task: BABEL-3403
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

