### PR TITLE
Fix IS_ROLEMEMBER() and IS_MEMBER() function output

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -34,6 +34,7 @@
 #include "libpq/crypt.h"
 #include "miscadmin.h"
 #include "parser/parser.h"
+#include "parser/scansup.h"
 #include "storage/lmgr.h"
 #include "tcop/utility.h"
 #include "utils/acl.h"
@@ -1516,6 +1517,8 @@ is_rolemember(PG_FUNCTION_ARGS)
 	Oid		principal_oid;
 	Oid		cur_user_oid = GetUserId();
 	char	*role;
+	char 	*dc_role;
+	char 	*dc_principal;
 	char	*physical_role_name;
 	char	*physical_principal_name;
 
@@ -1524,7 +1527,8 @@ is_rolemember(PG_FUNCTION_ARGS)
 
 	/* Do role name mapping */
 	role = text_to_cstring(PG_GETARG_TEXT_P(0));
-	physical_role_name = get_physical_user_name(get_cur_db_name(), role);
+	dc_role = downcase_identifier(role, strlen(role), false, false);
+	physical_role_name = get_physical_user_name(get_cur_db_name(), dc_role);
 	role_oid = get_role_oid(physical_role_name, true);
 
 	/* If principal name is NULL, take current user instead */
@@ -1534,9 +1538,15 @@ is_rolemember(PG_FUNCTION_ARGS)
 	{
 		/* Do principal name mapping */
 		char *principal = text_to_cstring(PG_GETARG_TEXT_P(1));
-		physical_principal_name = get_physical_user_name(get_cur_db_name(), principal);
+		dc_principal = downcase_identifier(principal, strlen(principal), false, false);
+		physical_principal_name = get_physical_user_name(get_cur_db_name(), dc_principal);
 		principal_oid = get_role_oid(physical_principal_name, true);
 	}
+
+	/* Return 1 if given role is PUBLIC */
+	if (strcmp(dc_role, "public") == 0 && 
+		(principal_oid != InvalidOid || strcmp(dc_principal, "public") == 0))
+		PG_RETURN_INT32(1);
 
 	/* Return NULL if given role or principal doesn't exist */
 	if (role_oid == InvalidOid || principal_oid == InvalidOid)

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER.out
@@ -173,6 +173,36 @@ int
 1
 ~~END~~
 
+SELECT IS_ROLEMEMBER('public', 'public')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Every db principal is member of PUBLIC
+SELECT IS_MEMBER('public')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_ROLEMEMBER('public', 'test_role1')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_ROLEMEMBER('public', 'test_user1')
+GO
+~~START~~
+int
+1
+~~END~~
+
 
 -- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'test_role1')
@@ -284,6 +314,29 @@ GO
 ~~START~~
 int
 <NULL>
+~~END~~
+
+
+-- Case insensitive check
+SELECT IS_ROLEMEMBER('PUBLIC', 'Test_User1')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_ROLEMEMBER('Test_role1', 'test_ROLE3')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_MEMBER('Public')
+GO
+~~START~~
+int
+1
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-ROLE-MEMBER.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER.mix
@@ -97,6 +97,16 @@ SELECT IS_ROLEMEMBER('test_role1', 'test_role1')
 GO
 SELECT IS_ROLEMEMBER('test_user1', 'test_user1')
 GO
+SELECT IS_ROLEMEMBER('public', 'public')
+GO
+
+-- Every db principal is member of PUBLIC
+SELECT IS_MEMBER('public')
+GO
+SELECT IS_ROLEMEMBER('public', 'test_role1')
+GO
+SELECT IS_ROLEMEMBER('public', 'test_user1')
+GO
 
 -- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'test_role1')
@@ -134,6 +144,14 @@ GO
 SELECT IS_ROLEMEMBER('test_role1', NULL)
 GO
 SELECT IS_ROLEMEMBER(NULL, NULL)
+GO
+
+-- Case insensitive check
+SELECT IS_ROLEMEMBER('PUBLIC', 'Test_User1')
+GO
+SELECT IS_ROLEMEMBER('Test_role1', 'test_ROLE3')
+GO
+SELECT IS_MEMBER('Public')
 GO
 
 -- Connect with different logins to test membership view permission


### PR DESCRIPTION
With this change,
1. IS_ROLEMEMBER() and IS_MEMBER() will return 1 when input role is PUBLIC.
2. IS_ROLEMEMBER() and IS_MEMBER() will be case-insensitive.

Task: BABEL-3228/3229
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).