### PR TITLE
Restructure resolve_numeric_typmod_from_exp() and rectify precision, scale calculation to avoid unexpected dataloss

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -437,6 +437,13 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			int32 typmod1 = -1, typmod2 = -1;
 			uint8_t scale1, scale2, precision1, precision2;
 			uint8_t scale, precision;
+			uint8_t integralDigitCount = 0;
+			/*
+			 * If one of the operands is part of aggregate function SUM() or AVG(),
+			 * set has_aggregate_operand to true; in those cases
+			 * resultant precision and scale calculation would be a bit different
+			 */
+			bool has_aggregate_operand = false;
 
 			Assert(list_length(op->args) == 2 ||  list_length(op->args) == 1);
 			if (list_length(op->args) == 2)
@@ -500,16 +507,39 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			 * Refer to details of precision and scale calculation in the following link:
 			 * https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/data-types/precision-scale-and-length-transact-sql.md
 			 */
+			has_aggregate_operand = arg1->type == T_Aggref ||
+						(list_length(op->args) == 2 && arg2->type == T_Aggref);
+
 			switch (op->opfuncid)
 			{
 				case NUMERIC_ADD_OID:
 				case NUMERIC_SUB_OID:
+					integralDigitCount = Max(precision1 - scale1, precision2 - scale2);
 					scale = Max(scale1, scale2);
-					precision = Max(precision1 - scale1, precision2 - scale2) + 1 + scale;
+					precision = integralDigitCount + 1 + scale;
+					/*
+					 * For addition and subtraction, skip scale adjustment when none of the
+					 * operands is part of any aggregate function
+					 */
+					if (has_aggregate_operand &&
+					    integralDigitCount < (Min(TDS_MAX_NUM_PRECISION, precision) - scale))
+						scale = Min(precision, TDS_MAX_NUM_PRECISION) - integralDigitCount;
+
+					/*
+					 * precisionn adjustment to TDS_MAX_NUM_PRECISION
+					 */
+					if (precision > TDS_MAX_NUM_PRECISION)
+						precision = TDS_MAX_NUM_PRECISION;
 					break;
 				case NUMERIC_MUL_OID:
 					scale = scale1 + scale2;
 					precision = precision1 + precision2 + 1;
+					/*
+					 * For multiplication, skip scale adjustment when atleast one of the
+					 * operands is part of aggregate function
+					 */
+					if (has_aggregate_operand && precision > TDS_MAX_NUM_PRECISION)
+						precision = TDS_MAX_NUM_PRECISION;
 					break;
 				case NUMERIC_DIV_OID:
 					scale = Max(6, scale1 + precision2 + 1);
@@ -537,6 +567,10 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			if (precision > TDS_MAX_NUM_PRECISION &&
 			    precision - scale <= TDS_MAX_NUM_PRECISION)
 			{
+			    /*
+			     * scale adjustment by delta is only applicable for division
+			     * and (multiplcation having no aggregate operand)
+			     */
 			    int delta = precision - TDS_MAX_NUM_PRECISION;
 			    precision = TDS_MAX_NUM_PRECISION;
 			    scale = Max(scale - delta, 0);

--- a/test/JDBC/expected/TestDecimal.out
+++ b/test/JDBC/expected/TestDecimal.out
@@ -559,6 +559,72 @@ int#!#numeric
 2#!#11000.00
 ~~END~~
 
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#11100.00
+~~END~~
+
+SELECT count(*), sum(amount) - 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#10900.00
+~~END~~
+
+SELECT count(*), sum(amount) * 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#1100000.00
+~~END~~
+
+SELECT count(*), sum(amount) / 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#110.00
+~~END~~
+
+SELECT count(*), sum(amount) % 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#0.00
+~~END~~
+
+SELECT count(*), avg(amount) + 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#5600.000000
+~~END~~
+
+SELECT count(*), avg(amount) - 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#5400.000000
+~~END~~
+
+SELECT count(*), avg(amount) * 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#550000.000000
+~~END~~
+
+SELECT count(*), avg(amount) / 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#55.000000
+~~END~~
+
+SELECT count(*), avg(amount) % 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#0.000000
+~~END~~
+
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
+~~START~~
+numeric
+1.16363636363636360000000000
+~~END~~
+
 DROP TABLE overflow_test;
 
 # BABEL-3157
@@ -648,6 +714,78 @@ With Top11 as (select top (11) * from overflow_test) select sum(amount1), sum(am
 ~~START~~
 numeric#!#numeric#!#numeric#!#numeric#!#numeric#!#numeric
 109999.89#!#10999.989#!#10990.35802458#!#9999.990000#!#999.999000#!#999.12345678
+~~END~~
+
+DROP TABLE overflow_test;
+
+#BABEL-3180
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount decimal(38, 2));
+INSERT INTO overflow_test VALUES (1, 555555555555555555555555555555555555.23);
+~~ROW COUNT: 1~~
+
+SELECT amount + 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+555555555555555555555555555555555655.23
+~~END~~
+
+SELECT amount - 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+555555555555555555555555555555555455.23
+~~END~~
+
+SELECT amount * 100 FROM overflow_test where id = 1;
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+SELECT amount / 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+5555555555555555555555555555555555.55
+~~END~~
+
+SELECT amount % 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+55.23
+~~END~~
+
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 decimal(38,0), num2 decimal(38, 0));
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 55555555555555555555555555555555555);
+~~ROW COUNT: 1~~
+
+SELECT num1 + num2 from overflow_test;
+~~START~~
+numeric
+111111111111111111111111111111111110
+~~END~~
+
+SELECT num1 - num2 from overflow_test;
+~~START~~
+numeric
+0
+~~END~~
+
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 decimal(38,0), num2 int);
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 555555555);
+~~ROW COUNT: 1~~
+
+SELECT num1 + num2 from overflow_test;
+~~START~~
+numeric
+55555555555555555555555556111111110
+~~END~~
+
+SELECT num1 - num2 from overflow_test;
+~~START~~
+numeric
+55555555555555555555555555000000000
 ~~END~~
 
 DROP TABLE overflow_test;

--- a/test/JDBC/expected/TestNumeric.out
+++ b/test/JDBC/expected/TestNumeric.out
@@ -747,6 +747,72 @@ int#!#numeric
 2#!#11000.00
 ~~END~~
 
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#11100.00
+~~END~~
+
+SELECT count(*), sum(amount) - 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#10900.00
+~~END~~
+
+SELECT count(*), sum(amount) * 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#1100000.00
+~~END~~
+
+SELECT count(*), sum(amount) / 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#110.00
+~~END~~
+
+SELECT count(*), sum(amount) % 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#0.00
+~~END~~
+
+SELECT count(*), avg(amount) + 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#5600.000000
+~~END~~
+
+SELECT count(*), avg(amount) - 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#5400.000000
+~~END~~
+
+SELECT count(*), avg(amount) * 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#550000.000000
+~~END~~
+
+SELECT count(*), avg(amount) / 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#55.000000
+~~END~~
+
+SELECT count(*), avg(amount) % 100 FROM overflow_test;
+~~START~~
+int#!#numeric
+2#!#0.000000
+~~END~~
+
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
+~~START~~
+numeric
+1.16363636363636360000000000
+~~END~~
+
 DROP TABLE overflow_test;
 
 # BABEL-3157
@@ -835,6 +901,78 @@ With Top11 as (select top (11) * from overflow_test) select sum(amount1), sum(am
 ~~START~~
 numeric#!#numeric#!#numeric#!#numeric#!#numeric#!#numeric
 109999.89#!#10999.989#!#10990.35802458#!#9999.990000#!#999.999000#!#999.12345678
+~~END~~
+
+DROP TABLE overflow_test;
+
+#BABEL-3180
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount numeric(38, 2));
+INSERT INTO overflow_test VALUES (1, 555555555555555555555555555555555555.23);
+~~ROW COUNT: 1~~
+
+SELECT amount + 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+555555555555555555555555555555555655.23
+~~END~~
+
+SELECT amount - 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+555555555555555555555555555555555455.23
+~~END~~
+
+SELECT amount * 100 FROM overflow_test where id = 1;
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+SELECT amount / 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+5555555555555555555555555555555555.55
+~~END~~
+
+SELECT amount % 100 FROM overflow_test where id = 1;
+~~START~~
+numeric
+55.23
+~~END~~
+
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 numeric(38,0), num2 numeric(38, 0));
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 55555555555555555555555555555555555);
+~~ROW COUNT: 1~~
+
+SELECT num1 + num2 from overflow_test;
+~~START~~
+numeric
+111111111111111111111111111111111110
+~~END~~
+
+SELECT num1 - num2 from overflow_test;
+~~START~~
+numeric
+0
+~~END~~
+
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 numeric(38,0), num2 int);
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 555555555);
+~~ROW COUNT: 1~~
+
+SELECT num1 + num2 from overflow_test;
+~~START~~
+numeric
+55555555555555555555555556111111110
+~~END~~
+
+SELECT num1 - num2 from overflow_test;
+~~START~~
+numeric
+55555555555555555555555555000000000
 ~~END~~
 
 DROP TABLE overflow_test;

--- a/test/JDBC/input/datatypes/TestDecimal.txt
+++ b/test/JDBC/input/datatypes/TestDecimal.txt
@@ -184,6 +184,17 @@ CREATE TABLE overflow_test (id integer PRIMARY KEY, amount decimal(6, 2));
 INSERT INTO overflow_test VALUES (1, 5000.00);
 INSERT INTO overflow_test VALUES (2, 6000.00);
 SELECT count(*), sum(amount) FROM overflow_test;
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+SELECT count(*), sum(amount) - 100 FROM overflow_test;
+SELECT count(*), sum(amount) * 100 FROM overflow_test;
+SELECT count(*), sum(amount) / 100 FROM overflow_test;
+SELECT count(*), sum(amount) % 100 FROM overflow_test;
+SELECT count(*), avg(amount) + 100 FROM overflow_test;
+SELECT count(*), avg(amount) - 100 FROM overflow_test;
+SELECT count(*), avg(amount) * 100 FROM overflow_test;
+SELECT count(*), avg(amount) / 100 FROM overflow_test;
+SELECT count(*), avg(amount) % 100 FROM overflow_test;
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
 DROP TABLE overflow_test;
 
 # BABEL-3157
@@ -218,4 +229,26 @@ INSERT INTO overflow_test VALUES (1, 9999.99, 999.999, 999.12345678), (2, 9999.9
 select sum(amount1), sum(amount2), sum(amount3), avg(amount1), avg(amount2), avg(amount3) from overflow_test;
 With Top10 as (select top (10) * from overflow_test) select sum(amount1), sum(amount2), sum(amount3), avg(amount1), avg(amount2), avg(amount3) from Top10;
 With Top11 as (select top (11) * from overflow_test) select sum(amount1), sum(amount2), sum(amount3), avg(amount1), avg(amount2), avg(amount3) from Top11;
+DROP TABLE overflow_test;
+
+#BABEL-3180
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount decimal(38, 2));
+INSERT INTO overflow_test VALUES (1, 555555555555555555555555555555555555.23);
+SELECT amount + 100 FROM overflow_test where id = 1;
+SELECT amount - 100 FROM overflow_test where id = 1;
+SELECT amount * 100 FROM overflow_test where id = 1;
+SELECT amount / 100 FROM overflow_test where id = 1;
+SELECT amount % 100 FROM overflow_test where id = 1;
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 decimal(38,0), num2 decimal(38, 0));
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 55555555555555555555555555555555555);
+SELECT num1 + num2 from overflow_test;
+SELECT num1 - num2 from overflow_test;
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 decimal(38,0), num2 int);
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 555555555);
+SELECT num1 + num2 from overflow_test;
+SELECT num1 - num2 from overflow_test;
 DROP TABLE overflow_test;

--- a/test/JDBC/input/datatypes/TestNumeric.txt
+++ b/test/JDBC/input/datatypes/TestNumeric.txt
@@ -232,6 +232,17 @@ CREATE TABLE overflow_test (id integer PRIMARY KEY, amount numeric(6, 2));
 INSERT INTO overflow_test VALUES (1, 5000.00);
 INSERT INTO overflow_test VALUES (2, 6000.00);
 SELECT count(*), sum(amount) FROM overflow_test;
+SELECT count(*), sum(amount) + 100 FROM overflow_test;
+SELECT count(*), sum(amount) - 100 FROM overflow_test;
+SELECT count(*), sum(amount) * 100 FROM overflow_test;
+SELECT count(*), sum(amount) / 100 FROM overflow_test;
+SELECT count(*), sum(amount) % 100 FROM overflow_test;
+SELECT count(*), avg(amount) + 100 FROM overflow_test;
+SELECT count(*), avg(amount) - 100 FROM overflow_test;
+SELECT count(*), avg(amount) * 100 FROM overflow_test;
+SELECT count(*), avg(amount) / 100 FROM overflow_test;
+SELECT count(*), avg(amount) % 100 FROM overflow_test;
+SELECT (100 / SUM((((amount) * 8.00) / 1024))) FROM overflow_test;
 DROP TABLE overflow_test;
 
 # BABEL-3157
@@ -265,4 +276,26 @@ INSERT INTO overflow_test VALUES (1, 9999.99, 999.999, 999.12345678), (2, 9999.9
 select sum(amount1), sum(amount2), sum(amount3), avg(amount1), avg(amount2), avg(amount3) from overflow_test;
 With Top10 as (select top (10) * from overflow_test) select sum(amount1), sum(amount2), sum(amount3), avg(amount1), avg(amount2), avg(amount3) from Top10;
 With Top11 as (select top (11) * from overflow_test) select sum(amount1), sum(amount2), sum(amount3), avg(amount1), avg(amount2), avg(amount3) from Top11;
+DROP TABLE overflow_test;
+
+#BABEL-3180
+CREATE TABLE overflow_test (id integer PRIMARY KEY, amount numeric(38, 2));
+INSERT INTO overflow_test VALUES (1, 555555555555555555555555555555555555.23);
+SELECT amount + 100 FROM overflow_test where id = 1;
+SELECT amount - 100 FROM overflow_test where id = 1;
+SELECT amount * 100 FROM overflow_test where id = 1;
+SELECT amount / 100 FROM overflow_test where id = 1;
+SELECT amount % 100 FROM overflow_test where id = 1;
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 numeric(38,0), num2 numeric(38, 0));
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 55555555555555555555555555555555555);
+SELECT num1 + num2 from overflow_test;
+SELECT num1 - num2 from overflow_test;
+DROP TABLE overflow_test;
+
+CREATE TABLE overflow_test (num1 numeric(38,0), num2 int);
+INSERT INTO overflow_test VALUES (55555555555555555555555555555555555, 555555555);
+SELECT num1 + num2 from overflow_test;
+SELECT num1 - num2 from overflow_test;
 DROP TABLE overflow_test;


### PR DESCRIPTION
### Description
Restructure resolve_numeric_typmod_from_exp() and rectify precision, scale calculation to avoid unexpected dataloss

Before Fix:
Observed numeric behavior mismatch on Babelfish; getting unnecessary overflow in arithmetic expression having multiple numeric-type operands.

After Fix:
Added conditions for rounding resultant scale and precision in arithmetic expression having multiple numeric-type operands to avoid unnecessary dataloss.

Task: BABEL-3180
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).