### PR TITLE
Remove failing BABEL-2701 MVU scripts from 13.4 and 13.5

### DIFF
--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -75,7 +75,6 @@ babel_char
 BABEL-SQUARE
 BABEL-728
 babel_function_string
-BABEL-2701
 babel_isnumeric
 HAS_DBACCESS
 BABEL-1475

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -90,3 +90,4 @@ BABEL-741
 TestTableType
 schema_resolution_func
 BABEL-3147-before-14_5
+

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -80,7 +80,6 @@ babel_char
 BABEL-SQUARE
 BABEL-728
 babel_function_string
-BABEL-2701
 babel_isnumeric
 HAS_DBACCESS
 BABEL-1475


### PR DESCRIPTION
### Description
Remove failing BABEL-2701 MVU scripts from 13.4 and 13.5 schedule files.

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).