### PR TITLE
Revert "In case of cross-db procedure call, incorrect schema resolution when the object inside the procedure is schema qualified"

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -460,7 +460,7 @@ static void pltsql_clean_table_variables(PLtsql_execstate *estate, PLtsql_functi
 static void pltsql_init_exec_error_data(PLtsqlErrorData *error_data);
 static void pltsql_copy_exec_error_data(PLtsqlErrorData *src, PLtsqlErrorData *dst, MemoryContext dstCxt);
 PLtsql_estate_err *pltsql_clone_estate_err(PLtsql_estate_err *err);
-bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* reset_session_properties);
+bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path);
 
 extern void pltsql_init_anonymous_cursors(PLtsql_execstate *estate);
 extern void pltsql_cleanup_local_cursors(PLtsql_execstate *estate);
@@ -4601,7 +4601,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	Oid			current_user_id = GetUserId();
 	bool		need_path_reset = false;
 	char		*cur_dbname = get_cur_db_name();
-	bool            reset_session_properties = false;
 	/* fetch current search_path */
 	List 		*path_oids = fetch_search_path(false);
 	char 		*old_search_path = flatten_search_path(path_oids);
@@ -4610,7 +4609,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		SetCurrentRoleId(GetSessionUserId(), false);
 	
 	if(stmt->is_dml || stmt->is_ddl)
-		need_path_reset = reset_search_path(stmt, old_search_path, &reset_session_properties);
+		need_path_reset = reset_search_path(stmt, old_search_path);
 
 	PG_TRY();
 	{
@@ -4988,8 +4987,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	 		(void) set_config_option("search_path", old_search_path,
 	 					PGC_USERSET, PGC_S_SESSION,
 	 					GUC_ACTION_SAVE, true, 0, false);
-		if(reset_session_properties)
-			set_session_properties(cur_dbname);
 		if (stmt->is_cross_db)
 			SetCurrentRoleId(current_user_id, false);
 		list_free(path_oids);
@@ -5001,8 +4998,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	 	(void) set_config_option("search_path", old_search_path,
 	 				PGC_USERSET, PGC_S_SESSION,
 	 				GUC_ACTION_SAVE, true, 0, false);
-	if(reset_session_properties)
-		set_session_properties(cur_dbname);
 	if (stmt->is_cross_db)
 		SetCurrentRoleId(current_user_id, false);
 	list_free(path_oids);
@@ -10040,7 +10035,7 @@ pltsql_clone_estate_err(PLtsql_estate_err *err)
 	return clone;
 }
 
-bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* reset_session_properties)
+bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path)
 {
 	PLExecStateCallStack *top_es_entry;
 	char		*cur_dbname = get_cur_db_name();
@@ -10051,6 +10046,22 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* r
 	const char	*schema;
 	top_es_entry = exec_state_call_stack->next;
 
+	/*
+	 * When there is a function call:
+	 * search the specified schema for the object. If not found,
+	 * then search the dbo schema. Don't update the path for "sys" schema.
+	 */
+	if (stmt->func_call && stmt->schema_name != NULL && strncmp(stmt->schema_name, "sys", strlen(stmt->schema_name)) != 0)
+	{
+		physical_schema = get_physical_schema_name(cur_dbname, stmt->schema_name);
+		dbo_schema = get_dbo_schema_name(cur_dbname);
+		new_search_path = psprintf("%s, %s, %s", physical_schema, dbo_schema, old_search_path);
+		/* Add the schema where the object is referenced and dbo schema to the new search path */
+		(void) set_config_option("search_path", new_search_path,
+						PGC_USERSET, PGC_S_SESSION,
+						GUC_ACTION_SAVE, true, 0, false);
+		return true;
+	}
 	while(top_es_entry != NULL)
 	{
 		/* traverse through the estate stack. If the occurrence of
@@ -10065,9 +10076,9 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* r
 				{
 					/*
 					 * Don't change the search path, if the statement inside
-					 * the procedure is a function or schema qualified.
+					 * the procedure is schema qualified.
 					 */
-					if(stmt->func_call || stmt->is_schema_specified)
+					if(stmt->is_schema_specified)
 						break;
 					else
 					{
@@ -10077,17 +10088,8 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* r
 				}
 				else
 				{
-					if (stmt->func_call || stmt->is_schema_specified)
-					{
-						set_session_properties(top_es_entry->estate->db_name);
-						*reset_session_properties = true;
-						break;
-					}
-					else
-					{
-						physical_schema = get_physical_schema_name(top_es_entry->estate->db_name, top_es_entry->estate->schema_name);
-						dbo_schema = get_dbo_schema_name(top_es_entry->estate->db_name);
-					}
+					physical_schema = get_physical_schema_name(top_es_entry->estate->db_name, top_es_entry->estate->schema_name);
+					dbo_schema = get_dbo_schema_name(top_es_entry->estate->db_name);
 				}
 				new_search_path = psprintf("%s, %s, %s", physical_schema, dbo_schema, old_search_path);
 				/* Add the schema where the object is referenced and dbo schema to the new search path */
@@ -10098,23 +10100,14 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* r
 			}
 			else if(top_es_entry->estate->db_name != NULL && stmt->is_ddl)
 			{
-				if (stmt->is_schema_specified)
-				{
-					set_session_properties(top_es_entry->estate->db_name);
-					*reset_session_properties = true;
-					break;
-				}
-				else
-				{
-					user = get_user_for_database(top_es_entry->estate->db_name);
-					schema = get_authid_user_ext_schema_name(top_es_entry->estate->db_name, user);
-					physical_schema = get_physical_schema_name(top_es_entry->estate->db_name, schema);
-					new_search_path = psprintf("%s, %s", physical_schema, old_search_path);
-					/* Add default schema to the new search path */
-					(void) set_config_option("search_path", new_search_path,
-									PGC_USERSET, PGC_S_SESSION,
-									GUC_ACTION_SAVE, true, 0, false);
-				}
+				user = get_user_for_database(top_es_entry->estate->db_name);
+				schema = get_authid_user_ext_schema_name(top_es_entry->estate->db_name, user);
+				physical_schema = get_physical_schema_name(top_es_entry->estate->db_name, schema);
+				new_search_path = psprintf("%s, %s", physical_schema, old_search_path);
+				/* Add default schema to the new search path */
+				(void) set_config_option("search_path", new_search_path,
+								PGC_USERSET, PGC_S_SESSION,
+								GUC_ACTION_SAVE, true, 0, false);
 				return true;
 			}
 		}
@@ -10123,25 +10116,6 @@ bool reset_search_path(PLtsql_stmt_execsql *stmt, char *old_search_path, bool* r
 				top_es_entry->estate->err_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			return false;
 		top_es_entry = top_es_entry->next;
-	}
-	/*
-	 * When there is a function call:
-	 * search the specified schema for the object. If not found,
-	 * then search the dbo schema. Don't update the path for "sys" schema.
-	 */
-	if (stmt->func_call && stmt->schema_name != NULL &&
-			((strncmp(stmt->schema_name, "sys", strlen(stmt->schema_name)) != 0 && strlen(stmt->schema_name) == 3)
-			|| strlen(stmt->schema_name) != 3))
-	{
-		cur_dbname = get_cur_db_name();
-		physical_schema = get_physical_schema_name(cur_dbname, stmt->schema_name);
-		dbo_schema = get_dbo_schema_name(cur_dbname);
-		new_search_path = psprintf("%s, %s, %s", physical_schema, dbo_schema, old_search_path);
-		/* Add the schema where the object is referenced and dbo schema to the new search path */
-		(void) set_config_option("search_path", new_search_path,
-						PGC_USERSET, PGC_S_SESSION,
-						GUC_ACTION_SAVE, true, 0, false);
-		return true;
 	}
 	return false;
 }

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1492,9 +1492,6 @@ public:
 		Assert(stmt);
 		// record that the stmt is ddl
 	 	stmt->is_ddl = true;
-		// record if the schema is specified for the create statement
-		if (is_schema_specified)
-			stmt->is_schema_specified = true;
 
 		if (is_compiling_create_function())
 		{
@@ -1639,10 +1636,6 @@ public:
 
 	void exitTable_name(TSqlParser::Table_nameContext *ctx) override
 	{
-		if (ctx && ctx->schema)
-			is_schema_specified = true;
-		else
-			is_schema_specified = false;
 		tsqlCommonMutator::exitTable_name(ctx);
 		if (ctx && ctx->database)
 		{

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -72,12 +72,12 @@ int#!#int
 ~~END~~
 
 
+-- TODO: BABEL-3403 Expects error due to incorrect schema resolution when the object inside the procedure is schema qualified
 EXEC master.dbo.master_p1
 GO
-~~START~~
-int
-10
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.master_t1" does not exist)~~
 
 
 EXEC master.dbo.master_p2
@@ -207,15 +207,12 @@ GO
 ~~ERROR (Message: cross-database references are not implemented: master.dbo.master_p1)~~
 
 
+-- Expect an error
 EXECUTE master.dbo.master_p1;
 GO
-~~START~~
-int
-10
-10
-10
-30
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.master_t1" does not exist)~~
 
 
 SELECT current_user;

--- a/test/JDBC/expected/schema_resolution_func-vu-prepare.out
+++ b/test/JDBC/expected/schema_resolution_func-vu-prepare.out
@@ -72,6 +72,3 @@ select schema_resolution_func_vu_prepare_s1.schema_resolution_func_vu_prepare_f1
 select * from dbo.schema_resolution_func_vu_prepare_v1;
 go
 
-create database schema_resolution_func_vu_prepare_d1;
-go
-

--- a/test/JDBC/expected/schema_resolution_func-vu-verify.out
+++ b/test/JDBC/expected/schema_resolution_func-vu-verify.out
@@ -39,26 +39,6 @@ int
 ~~END~~
 
 
--- cross-db procedure call with a function
-use schema_resolution_func_vu_prepare_d1;
-go
-
-exec master.schema_resolution_func_vu_prepare_s2.schema_resolution_func_vu_prepare_p1;
-go
-~~START~~
-int
-1
-~~END~~
-
-~~START~~
-int
-2
-~~END~~
-
-
-use master;
-go
-
 --resolves to schema_resolution_func_vu_prepare_s1.schema_resolution_func_vu_prepare_t1 - gives 1 as an output
 select schema_resolution_func_vu_prepare_s1.schema_resolution_func_vu_prepare_f4();
 go
@@ -116,6 +96,5 @@ go
 
 drop schema schema_resolution_func_vu_prepare_s1;
 drop schema schema_resolution_func_vu_prepare_s2;
-drop database schema_resolution_func_vu_prepare_d1;
 go
 

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -55,6 +55,7 @@ GO
 SELECT * FROM master..master_t1 ORDER BY id;
 GO
 
+-- TODO: BABEL-3403 Expects error due to incorrect schema resolution when the object inside the procedure is schema qualified
 EXEC master.dbo.master_p1
 GO
 
@@ -128,6 +129,7 @@ INSERT INTO dbo.db1_t1 (a)
 EXECUTE master.dbo.master_p1;
 GO
 
+-- Expect an error
 EXECUTE master.dbo.master_p1;
 GO
 

--- a/test/JDBC/input/schema_resolution_func-vu-prepare.sql
+++ b/test/JDBC/input/schema_resolution_func-vu-prepare.sql
@@ -66,6 +66,3 @@ select schema_resolution_func_vu_prepare_s1.schema_resolution_func_vu_prepare_f1
 select * from dbo.schema_resolution_func_vu_prepare_v1;
 go
 
-create database schema_resolution_func_vu_prepare_d1;
-go
-

--- a/test/JDBC/input/schema_resolution_func-vu-verify.sql
+++ b/test/JDBC/input/schema_resolution_func-vu-verify.sql
@@ -14,16 +14,6 @@ go
 exec schema_resolution_func_vu_prepare_s2.schema_resolution_func_vu_prepare_p1;
 go
 
--- cross-db procedure call with a function
-use schema_resolution_func_vu_prepare_d1;
-go
-
-exec master.schema_resolution_func_vu_prepare_s2.schema_resolution_func_vu_prepare_p1;
-go
-
-use master;
-go
-
 --resolves to schema_resolution_func_vu_prepare_s1.schema_resolution_func_vu_prepare_t1 - gives 1 as an output
 select schema_resolution_func_vu_prepare_s1.schema_resolution_func_vu_prepare_f4();
 go
@@ -60,6 +50,5 @@ go
 
 drop schema schema_resolution_func_vu_prepare_s1;
 drop schema schema_resolution_func_vu_prepare_s2;
-drop database schema_resolution_func_vu_prepare_d1;
 go
 


### PR DESCRIPTION
This commit was failing an upgrade test related to sys.objects. When a table is created in 13.4 or 13.5 and the instance is upgraded to 14.latest, sys.objects doesn't have any details for the table.

Authored-by: Kuntal Ghosh <kuntalgh@amazon.com>