### PR TITLE
Re-enable several disabled ODBC tests

### DIFF
--- a/test/odbc/test_metadata.cpp
+++ b/test/odbc/test_metadata.cpp
@@ -460,8 +460,7 @@ TEST_F(Metadata, DISABLED_SQLColumns) {
 }
 
 // Tests SQLProcedures for success
-// DISABLED: PLEASE SEE BABELFISH-119
-TEST_F(Metadata, DISABLED_SQLProcedures) {
+TEST_F(Metadata, SQLProcedures) {
 
   OdbcHandler odbcHandler;
   RETCODE rcode;
@@ -534,8 +533,7 @@ TEST_F(Metadata, DISABLED_SQLProcedures) {
 }
 
 // Tests SQLProcedureColumns for success
-// DISABLED: PLEASE SEE BABELFISH-120
-TEST_F(Metadata, DISABLED_SQLProcedureColumns) {
+TEST_F(Metadata, SQLProcedureColumns) {
 
   OdbcHandler odbcHandler;
   RETCODE rcode;
@@ -812,8 +810,7 @@ TEST_F(Metadata, SQLGetTypeInfo) {
 }
 
 // Test SQLTables to retrieve catalogs
-// DISABLED: PLEASE SEE BABELFISH-132
-TEST_F(Metadata, DISABLED_SQLTables_Catalogs) {
+TEST_F(Metadata, SQLTables_Catalogs) {
 	 
 	OdbcHandler odbcHandler;
 	RETCODE rcode = -1;
@@ -836,8 +833,7 @@ TEST_F(Metadata, DISABLED_SQLTables_Catalogs) {
 }
 
 // Test SQLTables to retrieve tables
-// DISABLED: PLEASE SEE BABELFISH-132
-TEST_F(Metadata, DISABLED_SQLTables_Tables) {
+TEST_F(Metadata, SQLTables_Tables) {
 	 
 	OdbcHandler odbcHandler;
 	RETCODE rcode = -1;
@@ -883,8 +879,7 @@ TEST_F(Metadata, DISABLED_SQLTables_Tables) {
 }
 
 // Test SQLTables to retrieve views
-// DISABLED: PLEASE SEE BABELFISH-132
-TEST_F(Metadata, DISABLED_SQLTables_Views) {
+TEST_F(Metadata, SQLTables_Views) {
 	 
 	OdbcHandler odbcHandler;
 	RETCODE rcode = -1;

--- a/test/odbc/test_sqlgetinfo.cpp
+++ b/test/odbc/test_sqlgetinfo.cpp
@@ -62,8 +62,7 @@ string SqlGetInfoSupportError(string sqlgetinfo_option, string supported_feature
 }
 
 // Tests if SQLGetInfo retrieves the correct server name with SQL_SERVER_NAME option
-// DISABLED: PLEASE SEE BABELFISH-125
-TEST_F(SQLGetInfoTest, DISABLED_SQLGetInfo_SQL_SERVER_NAME) {
+TEST_F(SQLGetInfoTest, SQLGetInfo_SQL_SERVER_NAME) {
 
   OdbcHandler odbcHandler;
   char output[BUFFER];

--- a/test/odbc/test_sqlgetinfo.cpp
+++ b/test/odbc/test_sqlgetinfo.cpp
@@ -62,6 +62,7 @@ string SqlGetInfoSupportError(string sqlgetinfo_option, string supported_feature
 }
 
 // Tests if SQLGetInfo retrieves the correct server name with SQL_SERVER_NAME option
+// DISABLED: PLEASE SEE BABELFISH-125
 TEST_F(SQLGetInfoTest, DISABLED_SQLGetInfo_SQL_SERVER_NAME) {
 
   OdbcHandler odbcHandler;

--- a/test/odbc/test_sqlgetinfo.cpp
+++ b/test/odbc/test_sqlgetinfo.cpp
@@ -62,7 +62,7 @@ string SqlGetInfoSupportError(string sqlgetinfo_option, string supported_feature
 }
 
 // Tests if SQLGetInfo retrieves the correct server name with SQL_SERVER_NAME option
-TEST_F(SQLGetInfoTest, SQLGetInfo_SQL_SERVER_NAME) {
+TEST_F(SQLGetInfoTest, DISABLED_SQLGetInfo_SQL_SERVER_NAME) {
 
   OdbcHandler odbcHandler;
   char output[BUFFER];


### PR DESCRIPTION
### Description
The following tests were failing due to missing functionaliites in Babelfish. However, they are now passing as the implementation related to these changes are checked in:

- SQLProcedureColumns
- SQLProcedures
- SQLTables_Catalogs
- SQLTables_Tables
- SQLTables_Views

Task: BABELFISH-524/132/120/119
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).