### PR TITLE
Numeric testcase for precision overflow triggers known protocol violation

### DIFF
--- a/test/JDBC/expected/numericOverflow.out
+++ b/test/JDBC/expected/numericOverflow.out
@@ -1,0 +1,102 @@
+-- Numeric testcase for precision overflow triggers known protocol violation
+CREATE TABLE overflow_test (amount numeric(38, 0));
+go
+
+-- sum(38 9's + 1) -> should cause arithmetic overflow
+INSERT INTO overflow_test VALUES(99999999999999999999999999999999999999);
+go
+~~ROW COUNT: 1~~
+
+
+SELECT amount + 1 from overflow_test;
+go
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+SELECT amount * 10 from overflow_test;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+INSERT INTO overflow_test VALUES(1);
+go
+~~ROW COUNT: 1~~
+
+
+SELECT sum(amount) from overflow_test;
+go
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+SELECT avg(amount) from overflow_test;
+go
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+DROP TABLE overflow_test;
+go
+
+CREATE TABLE overflow_test (amount numeric(38, 5));
+go
+
+INSERT INTO overflow_test VALUES(999999999999999999999999999999999.99999);
+go
+~~ROW COUNT: 1~~
+
+
+INSERT INTO overflow_test VALUES(.00001);
+go
+~~ROW COUNT: 1~~
+
+
+SELECT sum(amount) from overflow_test;
+go
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+DROP TABLE overflow_test;
+go
+
+-- 39 9's
+select CAST(999999999999999999999999999999999999999 AS NUMERIC);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+create table num_t1(a varchar(39));
+go
+
+-- 39 9's
+insert into num_t1 values (999999999999999999999999999999999999999);
+go
+~~ROW COUNT: 1~~
+
+
+select cast(a as numeric) from num_t1;
+go
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+

--- a/test/JDBC/input/numericOverflow.sql
+++ b/test/JDBC/input/numericOverflow.sql
@@ -1,0 +1,54 @@
+-- Numeric testcase for precision overflow triggers known protocol violation
+CREATE TABLE overflow_test (amount numeric(38, 0));
+go
+
+-- sum(38 9's + 1) -> should cause arithmetic overflow
+INSERT INTO overflow_test VALUES(99999999999999999999999999999999999999);
+go
+
+SELECT amount + 1 from overflow_test;
+go
+
+SELECT amount * 10 from overflow_test;
+go
+
+INSERT INTO overflow_test VALUES(1);
+go
+
+SELECT sum(amount) from overflow_test;
+go
+
+SELECT avg(amount) from overflow_test;
+go
+
+DROP TABLE overflow_test;
+go
+
+CREATE TABLE overflow_test (amount numeric(38, 5));
+go
+
+INSERT INTO overflow_test VALUES(999999999999999999999999999999999.99999);
+go
+
+INSERT INTO overflow_test VALUES(.00001);
+go
+
+SELECT sum(amount) from overflow_test;
+go
+
+DROP TABLE overflow_test;
+go
+
+-- 39 9's
+select CAST(999999999999999999999999999999999999999 AS NUMERIC);
+go
+
+create table num_t1(a varchar(39));
+go
+
+-- 39 9's
+insert into num_t1 values (999999999999999999999999999999999999999);
+go
+
+select cast(a as numeric) from num_t1;
+go


### PR DESCRIPTION
### Description

Before Fix:
Numeric testcase for precision overflow triggers known protocol violation

After Fix:
Postgres can store numeric data upto 1000 digits but SQL server has a maximum limit of 38 digits. Since, adding the maximum numeric precision check on TDS sender side results into protocol violation, have addressed the issue on engine side by calculating exact numeric digits from Postgres numeric-blocks format and reporting error whenever #digits > TDS_MAX_NUMERIC_PRECISION(i.e. 38).

Task: BABEL-3179
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).