### PR TITLE
In cross-db procedure call, permission error on select query after create statement

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1492,9 +1492,6 @@ public:
 		Assert(stmt);
 		// record that the stmt is ddl
 	 	stmt->is_ddl = true;
-		// record if the schema is specified for the create statement
-		if (is_schema_specified)
-			stmt->is_schema_specified = true;
 
 		if (is_compiling_create_function())
 		{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1636,10 +1636,6 @@ public:
 
 	void exitTable_name(TSqlParser::Table_nameContext *ctx) override
 	{
-		if (ctx && ctx->schema)
-			is_schema_specified = true;
-		else
-			is_schema_specified = false;
 		tsqlCommonMutator::exitTable_name(ctx);
 		if (ctx && ctx->database)
 		{

--- a/test/JDBC/expected/schema_resolution_proc-vu-prepare.out
+++ b/test/JDBC/expected/schema_resolution_proc-vu-prepare.out
@@ -44,3 +44,18 @@ select * from dbo.schema_resolution_proc_t1;
 select * from schema_resolution_proc_t1;
 select * from schema_resolution_proc_sch2.schema_resolution_proc_t1;
 go
+
+create proc schema_resolution_proc_sch1.schema_resolution_proc_create_insert
+as
+create table schema_resolution_proc_table1(a int);
+create table schema_resolution_proc_sch1.schema_resolution_proc_table1(a int);
+insert into schema_resolution_proc_table1 values(1);
+insert into schema_resolution_proc_sch1.schema_resolution_proc_table1 values(2);
+insert into dbo.schema_resolution_proc_table1 values(3);
+select * from schema_resolution_proc_table1;
+select * from dbo.schema_resolution_proc_table1;
+select * from schema_resolution_proc_sch1.schema_resolution_proc_table1;
+go
+
+create database schema_resolution_proc_d1;
+go

--- a/test/JDBC/expected/schema_resolution_proc-vu-verify.out
+++ b/test/JDBC/expected/schema_resolution_proc-vu-verify.out
@@ -108,6 +108,59 @@ go
 	 
 drop table schema_resolution_proc_t1
 go
+
+use schema_resolution_proc_d1;
+go
+
+exec master.schema_resolution_proc_sch1.schema_resolution_proc_create_insert
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+1
+2
+~~END~~
+
+
+use master;
+go
+
+select * from schema_resolution_proc_sch1.schema_resolution_proc_table1;
+select * from schema_resolution_proc_table1;
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
 	 
+drop table schema_resolution_proc_sch1.schema_resolution_proc_table1;
+drop table schema_resolution_proc_table1;
+go
+
+drop procedure schema_resolution_proc_sch1.schema_resolution_proc_create_insert
 drop schema schema_resolution_proc_sch1
+drop database schema_resolution_proc_d1
 go

--- a/test/JDBC/input/schema_resolution_proc-vu-prepare.sql
+++ b/test/JDBC/input/schema_resolution_proc-vu-prepare.sql
@@ -44,3 +44,18 @@ select * from dbo.schema_resolution_proc_t1;
 select * from schema_resolution_proc_t1;
 select * from schema_resolution_proc_sch2.schema_resolution_proc_t1;
 go
+
+create proc schema_resolution_proc_sch1.schema_resolution_proc_create_insert
+as
+create table schema_resolution_proc_table1(a int);
+create table schema_resolution_proc_sch1.schema_resolution_proc_table1(a int);
+insert into schema_resolution_proc_table1 values(1);
+insert into schema_resolution_proc_sch1.schema_resolution_proc_table1 values(2);
+insert into dbo.schema_resolution_proc_table1 values(3);
+select * from schema_resolution_proc_table1;
+select * from dbo.schema_resolution_proc_table1;
+select * from schema_resolution_proc_sch1.schema_resolution_proc_table1;
+go
+
+create database schema_resolution_proc_d1;
+go

--- a/test/JDBC/input/schema_resolution_proc-vu-verify.sql
+++ b/test/JDBC/input/schema_resolution_proc-vu-verify.sql
@@ -59,6 +59,25 @@ go
 	 
 drop table schema_resolution_proc_t1
 go
+
+use schema_resolution_proc_d1;
+go
+
+exec master.schema_resolution_proc_sch1.schema_resolution_proc_create_insert
+go
+
+use master;
+go
+
+select * from schema_resolution_proc_sch1.schema_resolution_proc_table1;
+select * from schema_resolution_proc_table1;
+go
 	 
+drop table schema_resolution_proc_sch1.schema_resolution_proc_table1;
+drop table schema_resolution_proc_table1;
+go
+
+drop procedure schema_resolution_proc_sch1.schema_resolution_proc_create_insert
 drop schema schema_resolution_proc_sch1
+drop database schema_resolution_proc_d1
 go


### PR DESCRIPTION
In cross-db procedure call, permission error on select query after create statement

### Description
In cross database procedure call, when select/insert takes place on a table which is created previously in the procedure itself. The permission is denied for the table by the select/insert query. 
Reason: We were changing the current role ID before with session properties but not resetting it back correctly which is throwing permission denied error on table.

> 1> create proc s1.p6
> 2> as
> 3> create table t4(a int)
> 4> select * from t4;
> 5> go
> 1> use db1
> 2> go
> Changed database context to 'db1'.
> 1> exec master.s1.p6
> 2> go
> Msg 33557097, Level 16, State 1, Server BABELFISH, Line 4
> permission denied for table t4

Task: BABEL-3403
Signed-off-by: Shalini Lohia <lshalini@amazon.com>