### PR TITLE
Fix DEFINITION column in information_schema.views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -473,12 +473,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.views AS
 	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
 			CAST(ext.orig_name AS sys.nvarchar(128)) AS  "TABLE_SCHEMA",
 			CAST(c.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
-
-			CAST(
-				CASE WHEN LENGTH(vd.definition) <= 4000
-					THEN vd.definition
-					ELSE NULL END
-				AS sys.nvarchar(4000)) AS "VIEW_DEFINITION",
+			CAST(vd.definition AS sys.nvarchar(4000)) AS "VIEW_DEFINITION",
 
 			CAST(
 				CASE WHEN 'check_option=cascaded' = ANY (c.reloptions)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -652,12 +652,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.views AS
 	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
 			CAST(ext.orig_name AS sys.nvarchar(128)) AS  "TABLE_SCHEMA",
 			CAST(c.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
-
-			CAST(
-				CASE WHEN LENGTH(vd.definition) <= 4000
-					THEN vd.definition
-					ELSE NULL END
-				AS sys.nvarchar(4000)) AS "VIEW_DEFINITION",
+			CAST(vd.definition AS sys.nvarchar(4000)) AS "VIEW_DEFINITION",
 
 			CAST(
 				CASE WHEN 'check_option=cascaded' = ANY (c.reloptions)

--- a/test/JDBC/expected/ISC-Views.out
+++ b/test/JDBC/expected/ISC-Views.out
@@ -296,16 +296,16 @@ nlview#!#4000
 ~~END~~
 
 
--- This should be NULL
-select view_definition from information_schema.views where TABLE_NAME = 'lview';
+-- This should be truncated
+select length(view_definition) from information_schema.views where TABLE_NAME = 'lview';
 go
 ~~START~~
-nvarchar
-<NULL>
+int
+4000
 ~~END~~
 
 
--- This should not be NULL and also shouldn't be truncated
+-- This shouldn't be truncated
 select length(view_definition) from information_schema.views where TABLE_NAME = 'nlview';
 go
 ~~START~~

--- a/test/JDBC/input/ISC-Views.sql
+++ b/test/JDBC/input/ISC-Views.sql
@@ -191,11 +191,11 @@ go
 select object_name,length(definition) from sys.babelfish_view_def where object_name in ('lview','nlview') order by object_name;
 go
 
--- This should be NULL
-select view_definition from information_schema.views where TABLE_NAME = 'lview';
+-- This should be truncated
+select length(view_definition) from information_schema.views where TABLE_NAME = 'lview';
 go
 
--- This should not be NULL and also shouldn't be truncated
+-- This shouldn't be truncated
 select length(view_definition) from information_schema.views where TABLE_NAME = 'nlview';
 go
 


### PR DESCRIPTION
### Description

Previously, DEFINITION column was returning NULL when length was more
than 4000. This commit fixes DEFINITION column such that it returns
truncated definition when length is more than 4000.

Task: BABEL-2889
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>
 
### Issues Resolved

BABEL-2889


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).