### PR TITLE
Missing privilege on the constraint_column_usage view

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -564,6 +564,9 @@ FROM (
           AND c.contype = 'c'
           AND r.relkind IN ('r', 'p')
           AND NOT a.attisdropped
+	  AND (pg_has_role(r.relowner, 'USAGE')
+		OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+		OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
 
        UNION ALL
 
@@ -582,10 +585,11 @@ FROM (
           AND NOT a.attisdropped
           AND c.contype IN ('p', 'u', 'f')
           AND r.relkind IN ('r', 'p')
+	  AND (pg_has_role(r.relowner, 'USAGE')
+		OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+		OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
 
-      ) AS x (tblschema, tblname, tblowner, colname, cstrschema, cstrname, tblcat, cstrcat)
-
-WHERE pg_has_role(x.tblowner, 'USAGE');
+      ) AS x (tblschema, tblname, tblowner, colname, cstrschema, cstrname, tblcat, cstrcat);
 
 GRANT SELECT ON information_schema_tsql.CONSTRAINT_COLUMN_USAGE TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -1298,7 +1298,7 @@ FROM (
           AND c.contype = 'c'
           AND r.relkind IN ('r', 'p')
           AND NOT a.attisdropped
-	AND (pg_has_role(r.relowner, 'USAGE')
+	  AND (pg_has_role(r.relowner, 'USAGE')
 		OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
 		OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
 
@@ -1319,7 +1319,7 @@ FROM (
           AND NOT a.attisdropped
           AND c.contype IN ('p', 'u', 'f')
           AND r.relkind IN ('r', 'p')
-	AND (pg_has_role(r.relowner, 'USAGE')
+	  AND (pg_has_role(r.relowner, 'USAGE')
 		OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
 		OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -1298,6 +1298,9 @@ FROM (
           AND c.contype = 'c'
           AND r.relkind IN ('r', 'p')
           AND NOT a.attisdropped
+	AND (pg_has_role(r.relowner, 'USAGE')
+		OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+		OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
 
        UNION ALL
 
@@ -1316,10 +1319,11 @@ FROM (
           AND NOT a.attisdropped
           AND c.contype IN ('p', 'u', 'f')
           AND r.relkind IN ('r', 'p')
+	AND (pg_has_role(r.relowner, 'USAGE')
+		OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+		OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
 
-      ) AS x (tblschema, tblname, tblowner, colname, cstrschema, cstrname, tblcat, cstrcat)
-
-WHERE pg_has_role(x.tblowner, 'USAGE');
+      ) AS x (tblschema, tblname, tblowner, colname, cstrschema, cstrname, tblcat, cstrcat);
 
 GRANT SELECT ON information_schema_tsql.CONSTRAINT_COLUMN_USAGE TO PUBLIC;
 

--- a/test/JDBC/expected/constraint_column_usage.out
+++ b/test/JDBC/expected/constraint_column_usage.out
@@ -1,3 +1,4 @@
+-- tsql
 create database db_constraint_column_usage;
 go
 
@@ -41,6 +42,9 @@ db_constraint_column_usage#!#constraint_column_usage_sc1#!#constraint_column_usa
 Use master;
 go
 
+create login user_const_col_usage with password='123456789';
+go
+
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 ~~START~~
@@ -65,6 +69,58 @@ go
 use db_constraint_column_usage;
 go
 
+create user user_const_col_usage for login user_const_col_usage;
+go
+
+use master;
+go
+
+-- tsql user=user_const_col_usage password=123456789
+-- should return 0 since user_const_col_usage doesn't have any privileges
+use db_constraint_column_usage;
+go
+
+select count(*) from information_schema.constraint_column_usage where table_name='constraint_column_usage_tbl2';
+go
+~~START~~
+int
+0
+~~END~~
+
+
+use master
+go
+
+-- tsql
+use db_constraint_column_usage;
+go
+
+grant select on constraint_column_usage_tbl2 to user_const_col_usage;
+go
+
+use master;
+go
+
+-- tsql user=user_const_col_usage password=123456789
+-- should return 2 since user_const_col_usage has select privileges
+use db_constraint_column_usage;
+go
+
+select count(*) from information_schema.constraint_column_usage where table_name='constraint_column_usage_tbl2';
+go
+~~START~~
+int
+2
+~~END~~
+
+
+use master
+go
+
+-- tsql
+use db_constraint_column_usage;
+go
+
 drop table constraint_column_usage_tbl2;
 go
 drop table constraint_column_usage_tbl1;
@@ -83,3 +139,28 @@ go
 
 drop database db_constraint_column_usage;
 go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'user_const_col_usage' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login user_const_col_usage;
+go
+

--- a/test/JDBC/input/constraint_column_usage.mix
+++ b/test/JDBC/input/constraint_column_usage.mix
@@ -1,3 +1,4 @@
+-- tsql
 create database db_constraint_column_usage;
 go
 
@@ -28,6 +29,9 @@ go
 Use master;
 go
 
+create login user_const_col_usage with password='123456789';
+go
+
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
@@ -40,6 +44,48 @@ go
 drop table constraint_column_usage_tbl6;
 go
 
+use db_constraint_column_usage;
+go
+
+create user user_const_col_usage for login user_const_col_usage;
+go
+
+use master;
+go
+
+-- tsql user=user_const_col_usage password=123456789
+-- should return 0 since user_const_col_usage doesn't have any privileges
+use db_constraint_column_usage;
+go
+
+select count(*) from information_schema.constraint_column_usage where table_name='constraint_column_usage_tbl2';
+go
+
+use master
+go
+
+-- tsql
+use db_constraint_column_usage;
+go
+
+grant select on constraint_column_usage_tbl2 to user_const_col_usage;
+go
+
+use master;
+go
+
+-- tsql user=user_const_col_usage password=123456789
+-- should return 2 since user_const_col_usage has select privileges
+use db_constraint_column_usage;
+go
+
+select count(*) from information_schema.constraint_column_usage where table_name='constraint_column_usage_tbl2';
+go
+
+use master
+go
+
+-- tsql
 use db_constraint_column_usage;
 go
 
@@ -61,3 +107,18 @@ go
 
 drop database db_constraint_column_usage;
 go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'user_const_col_usage' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+drop login user_const_col_usage;
+go
+


### PR DESCRIPTION
The user that can access a table should be able to see its data in the view.
Added tests to verify this behaviour.

Task: BABEL-3439
Signed-off-by: Shalini Lohia <lshalini@amazon.com>
