### PR TITLE
Added Support for TSQL's constraint_table_usage

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -717,3 +717,23 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+/*
+* CONSTRAINT TABLE USAGE
+*/
+CREATE OR REPLACE VIEW information_schema_tsql.constraint_table_usage
+AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(nr.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
+    CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+    CAST(nc.nspname AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+    CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME"
+   FROM pg_constraint c,
+    pg_namespace nc,
+    pg_class r,
+    pg_namespace nr
+WHERE c.connamespace = nc.oid AND r.relnamespace = nr.oid 
+AND (c.contype = 'f'::"char" AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY['p'::"char", 'u'::"char"])) AND c.conrelid = r.oid) 
+AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"])) AND pg_has_role(r.relowner, 'USAGE'::text);
+
+GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -732,8 +732,14 @@ AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
     pg_namespace nc,
     pg_class r,
     pg_namespace nr
-WHERE c.connamespace = nc.oid AND r.relnamespace = nr.oid 
-AND (c.contype = CAST('f' AS "char") AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) AND c.conrelid = r.oid) 
-AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) AND pg_has_role(r.relowner, CAST('USAGE' AS text));
+WHERE c.connamespace = nc.oid 
+AND r.relnamespace = nr.oid 
+AND (c.contype = CAST('f' AS "char") 
+AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) 
+AND c.conrelid = r.oid) 
+AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) 
+AND (pg_has_role(r.relowner, CAST('USAGE' AS text))
+	OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+	OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'));
 
 GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -723,10 +723,10 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 */
 CREATE OR REPLACE VIEW information_schema_tsql.constraint_table_usage
 AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST(nr.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nr.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
-    CAST(nc.nspname AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
     CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME"
    FROM pg_constraint c,
     pg_namespace nc,

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -733,7 +733,7 @@ AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
     pg_class r,
     pg_namespace nr
 WHERE c.connamespace = nc.oid AND r.relnamespace = nr.oid 
-AND (c.contype = 'f'::"char" AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY['p'::"char", 'u'::"char"])) AND c.conrelid = r.oid) 
-AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"])) AND pg_has_role(r.relowner, 'USAGE'::text);
+AND (c.contype = CAST('f' AS "char") AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) AND c.conrelid = r.oid) 
+AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) AND pg_has_role(r.relowner, CAST('USAGE' AS text));
 
 GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -161,6 +161,26 @@ CREATE OR REPLACE VIEW information_schema_tsql.COLUMN_DOMAIN_USAGE AS
 
 GRANT SELECT ON information_schema_tsql.COLUMN_DOMAIN_USAGE TO PUBLIC;
 
+/*
+* CONSTRAINT TABLE USAGE
+*/
+CREATE OR REPLACE VIEW information_schema_tsql.constraint_table_usage
+AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(nr.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
+    CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+    CAST(nc.nspname AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+    CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME"
+   FROM pg_constraint c,
+    pg_namespace nc,
+    pg_class r,
+    pg_namespace nr
+WHERE c.connamespace = nc.oid AND r.relnamespace = nr.oid 
+AND (c.contype = 'f'::"char" AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY['p'::"char", 'u'::"char"])) AND c.conrelid = r.oid) 
+AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"])) AND pg_has_role(r.relowner, 'USAGE'::text);
+
+GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;
+
 CREATE OR replace view sys.foreign_keys AS
 SELECT
   CAST(c.conname AS sys.SYSNAME) AS name

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -175,9 +175,15 @@ AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
     pg_namespace nc,
     pg_class r,
     pg_namespace nr
-WHERE c.connamespace = nc.oid AND r.relnamespace = nr.oid 
-AND (c.contype = CAST('f' AS "char") AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) AND c.conrelid = r.oid) 
-AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) AND pg_has_role(r.relowner, CAST('USAGE' AS text));
+WHERE c.connamespace = nc.oid 
+AND r.relnamespace = nr.oid 
+AND (c.contype = CAST('f' AS "char") 
+AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) 
+AND c.conrelid = r.oid) 
+AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) 
+AND (pg_has_role(r.relowner, CAST('USAGE' AS text))
+	OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+	OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'));
 
 GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -176,8 +176,8 @@ AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
     pg_class r,
     pg_namespace nr
 WHERE c.connamespace = nc.oid AND r.relnamespace = nr.oid 
-AND (c.contype = 'f'::"char" AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY['p'::"char", 'u'::"char"])) AND c.conrelid = r.oid) 
-AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"])) AND pg_has_role(r.relowner, 'USAGE'::text);
+AND (c.contype = CAST('f' AS "char") AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) AND c.conrelid = r.oid) 
+AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) AND pg_has_role(r.relowner, CAST('USAGE' AS text));
 
 GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -166,10 +166,10 @@ GRANT SELECT ON information_schema_tsql.COLUMN_DOMAIN_USAGE TO PUBLIC;
 */
 CREATE OR REPLACE VIEW information_schema_tsql.constraint_table_usage
 AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST(nr.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nr.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
-    CAST(nc.nspname AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
     CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME"
    FROM pg_constraint c,
     pg_namespace nc,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -165,25 +165,26 @@ GRANT SELECT ON information_schema_tsql.COLUMN_DOMAIN_USAGE TO PUBLIC;
 * CONSTRAINT TABLE USAGE
 */
 CREATE OR REPLACE VIEW information_schema_tsql.constraint_table_usage
-AS SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST((select orig_name from sys.babelfish_namespace_ext where nr.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+AS SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(extc.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
-    CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
-    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+    CAST(nr.dbname AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+    CAST(extr.orig_name  AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
     CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME"
-   FROM pg_constraint c,
-    pg_namespace nc,
-    pg_class r,
-    pg_namespace nr
+   FROM sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
+    sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+    pg_constraint c,
+    pg_class r
 WHERE c.connamespace = nc.oid 
 AND r.relnamespace = nr.oid 
 AND (c.contype = CAST('f' AS "char") 
 AND c.confrelid = r.oid OR (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char")])) 
 AND c.conrelid = r.oid) 
 AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) 
-AND (pg_has_role(r.relowner, CAST('USAGE' AS text))
+AND (pg_has_role(r.relowner, 'USAGE')
 	OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-	OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'));
+	OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))
+AND extc.dbid = CAST(sys.db_id() AS oid);
 
 GRANT SELECT ON information_schema_tsql.constraint_table_usage TO PUBLIC;
 

--- a/test/JDBC/expected/constraint_table_usage-database-test.out
+++ b/test/JDBC/expected/constraint_table_usage-database-test.out
@@ -41,6 +41,27 @@ go
 use master;
 go
 
+create schema constraint_table_usage_db_test_sc;
+go
+
+create table constraint_table_usage_db_test_sc.constraint_table_usage_db_test_tb3(arg3 char(10) NOT NULL, arg4 char(10), UNIQUE(arg3,arg4));
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_db_test_tb%' order by table_name,constraint_name,table_schema;
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+master#!#dbo#!#constraint_table_usage_db_test_tb1#!#master#!#dbo#!#constraint_table_usage_db_test_tb1_arg1_arg2_key
+master#!#constraint_table_usage_db_test_sc#!#constraint_table_usage_db_test_tb3#!#master#!#constraint_table_usage_db_test_sc#!#constraint_table_usage_db_test_tb3_arg3_arg4_key
+~~END~~
+
+
+drop table constraint_table_usage_db_test_sc.constraint_table_usage_db_test_tb3;
+go
+
+drop schema constraint_table_usage_db_test_sc;
+go
+
 drop table constraint_table_usage_db_test_tb1;
 go
 

--- a/test/JDBC/expected/constraint_table_usage-database-test.out
+++ b/test/JDBC/expected/constraint_table_usage-database-test.out
@@ -1,0 +1,49 @@
+use master;
+go
+
+create table constraint_table_usage_db_test_tb1(arg1 char(10) NOT NULL, arg2 char(10), UNIQUE(arg1,arg2));
+go
+
+create database constraint_table_usage_db_test_db;
+go
+
+use constraint_table_usage_db_test_db;
+go
+
+create table constraint_table_usage_db_test_tb2(arg3 char(10) NOT NULL, arg4 char(10), UNIQUE(arg3,arg4));
+go
+
+use master;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_db_test_tb%' order by table_name,constraint_name,table_schema;
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+master#!#dbo#!#constraint_table_usage_db_test_tb1#!#master#!#dbo#!#constraint_table_usage_db_test_tb1_arg1_arg2_key
+~~END~~
+
+
+use constraint_table_usage_db_test_db;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_db_test_tb%' order by table_name,constraint_name,table_schema;
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_db_test_db#!#dbo#!#constraint_table_usage_db_test_tb2#!#constraint_table_usage_db_test_db#!#dbo#!#constraint_table_usage_db_test_tb2_arg3_arg4_key
+~~END~~
+
+
+drop table constraint_table_usage_db_test_tb2;
+go
+
+use master;
+go
+
+drop table constraint_table_usage_db_test_tb1;
+go
+
+drop database constraint_table_usage_db_test_db;
+go
+

--- a/test/JDBC/expected/constraint_table_usage-privilege-test.out
+++ b/test/JDBC/expected/constraint_table_usage-privilege-test.out
@@ -1,0 +1,104 @@
+-- tsql
+
+use master;
+go
+
+create login constraint_table_usage_privilege_test_user with password='';
+go
+
+create database constraint_table_usage_privilege_test_db;
+go
+
+use constraint_table_usage_privilege_test_db;
+go
+
+create table constraint_table_usage_privilege_test_tb(arg1 int, arg2 int, primary key(arg1));
+go
+
+create user constraint_table_usage_privilege_test_user for login constraint_table_usage_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=constraint_table_usage_privilege_test_user password=''
+
+use constraint_table_usage_privilege_test_db;
+go
+
+select * from information_schema.constraint_column_usage where table_name='constraint_table_usage_privilege_test_tb';
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+~~END~~
+
+
+use master;
+go
+
+-- tsql
+
+use constraint_table_usage_privilege_test_db;
+go
+
+grant select on constraint_table_usage_privilege_test_tb to constraint_table_usage_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=constraint_table_usage_privilege_test_user password=''
+
+use constraint_table_usage_privilege_test_db;
+go
+
+select * from information_schema.constraint_column_usage where table_name='constraint_table_usage_privilege_test_tb';
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+constraint_table_usage_privilege_test_db#!#dbo#!#constraint_table_usage_privilege_test_tb#!#arg1#!#constraint_table_usage_privilege_test_db#!#dbo#!#constraint_table_usage_privilege_test_tb_pkey
+~~END~~
+
+
+use master;
+go
+
+-- tsql
+
+use constraint_table_usage_privilege_test_db;
+go
+
+drop table constraint_table_usage_privilege_test_tb;
+go
+
+use master;
+go
+
+drop database constraint_table_usage_privilege_test_db;
+go
+
+-- psql
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'constraint_table_usage_privilege_test_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login constraint_table_usage_privilege_test_user;
+go
+

--- a/test/JDBC/expected/constraint_table_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-prepare.out
@@ -7,16 +7,16 @@ go
 use constraint_table_usage_vu_prepare_db;
 go
 
-create table constraint_table_usage_vu_prepare_tb1(name char(10) NOT NULL, id char(10) NOT NULL, UNIQUE(name,id));
+create table constraint_table_usage_vu_prepare_tb1(arg1 char(10) NOT NULL, arg2 char(10), UNIQUE(arg1,arg2));
 go
 
-create table constraint_table_usage_vu_prepare_tb2(book char(10), subject char(10) NOT NULL CONSTRAINT TEST_CONST PRIMARY KEY);
+create table constraint_table_usage_vu_prepare_tb2(redID INT PRIMARY KEY);
 go
 
-create table constraint_table_usage_vu_prepare_tb3(name char(10) NOT NULL, id char(10) NOT NULL, PRIMARY KEY(name, id));
+CREATE TABLE constraint_table_usage_vu_prepare_tb3(redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES constraint_table_usage_vu_prepare_tb2 (redID));
 go
 
-create table constraint_table_usage_vu_prepare_tb4(movie char(10), description char(1000));
+create table constraint_table_usage_vu_prepare_tb4(arg3 int CHECK (arg3 > 10), arg4 int DEFAULT 100.00);
 go
 
 use master;

--- a/test/JDBC/expected/constraint_table_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-prepare.out
@@ -1,0 +1,23 @@
+use master;
+go
+
+create database constraint_table_usage_vu_prepare_db;
+go
+
+use constraint_table_usage_vu_prepare_db;
+go
+
+create table constraint_table_usage_vu_prepare_tb1(name char(10) NOT NULL, id char(10) NOT NULL, UNIQUE(name,id));
+go
+
+create table constraint_table_usage_vu_prepare_tb2(book char(10), subject char(10) NOT NULL CONSTRAINT TEST_CONST PRIMARY KEY);
+go
+
+create table constraint_table_usage_vu_prepare_tb3(name char(10) NOT NULL, id char(10) NOT NULL, PRIMARY KEY(name, id));
+go
+
+create table constraint_table_usage_vu_prepare_tb4(movie char(10), description char(1000));
+go
+
+use master;
+go

--- a/test/JDBC/expected/constraint_table_usage-vu-prepare.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-prepare.out
@@ -1,23 +1,11 @@
-use master;
-go
-
-create database constraint_table_usage_vu_prepare_db;
-go
-
-use constraint_table_usage_vu_prepare_db;
-go
-
 create table constraint_table_usage_vu_prepare_tb1(arg1 char(10) NOT NULL, arg2 char(10), UNIQUE(arg1,arg2));
 go
 
 create table constraint_table_usage_vu_prepare_tb2(redID INT PRIMARY KEY);
 go
 
-CREATE TABLE constraint_table_usage_vu_prepare_tb3(redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES constraint_table_usage_vu_prepare_tb2 (redID));
+create table constraint_table_usage_vu_prepare_tb3(redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES constraint_table_usage_vu_prepare_tb2 (redID));
 go
 
 create table constraint_table_usage_vu_prepare_tb4(arg3 int CHECK (arg3 > 10), arg4 int DEFAULT 100.00);
-go
-
-use master;
 go

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -1,13 +1,10 @@
-use constraint_table_usage_vu_prepare_db;
-go
-
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
 ~~END~~
 
 
@@ -24,9 +21,9 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
 ~~END~~
 
 
@@ -49,8 +46,8 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
 ~~END~~
 
 
@@ -58,10 +55,4 @@ drop table constraint_table_usage_vu_prepare_tb2;
 go
 
 drop table constraint_table_usage_vu_prepare_tb1;
-go
-
-use master;
-go
-
-drop database constraint_table_usage_vu_prepare_db;
 go

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -11,13 +11,13 @@ constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_t
 ~~END~~
 
 
-create view constraint_table_usage_vu_prepare_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create view constraint_table_usage_vu_verify_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-create procedure constraint_table_usage_vu_prepare_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create procedure constraint_table_usage_vu_verify_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-create function constraint_table_usage_vu_prepare_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
+create function constraint_table_usage_vu_verify_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
 go
 
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
@@ -30,13 +30,13 @@ constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_t
 ~~END~~
 
 
-drop function constraint_table_usage_vu_prepare_func;
+drop function constraint_table_usage_vu_verify_func;
 go
 
-drop procedure constraint_table_usage_vu_prepare_proc;
+drop procedure constraint_table_usage_vu_verify_proc;
 go
 
-drop view constraint_table_usage_vu_prepare_view;
+drop view constraint_table_usage_vu_verify_view;
 go
 
 drop table constraint_table_usage_vu_prepare_tb4;

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -5,24 +5,42 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3_pkey
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
 ~~END~~
 
 
-drop table constraint_table_usage_vu_prepare_tb4;
+create view constraint_table_usage_vu_prepare_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+create procedure constraint_table_usage_vu_prepare_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+create function constraint_table_usage_vu_prepare_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
 go
 
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3_pkey
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
 ~~END~~
 
+
+drop function constraint_table_usage_vu_prepare_func;
+go
+
+drop procedure constraint_table_usage_vu_prepare_proc;
+go
+
+drop view constraint_table_usage_vu_prepare_view;
+go
+
+drop table constraint_table_usage_vu_prepare_tb4;
+go
 
 drop table constraint_table_usage_vu_prepare_tb3;
 go
@@ -31,21 +49,13 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
 ~~END~~
 
 
 drop table constraint_table_usage_vu_prepare_tb2;
 go
-
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
-go
-~~START~~
-nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
-~~END~~
-
 
 drop table constraint_table_usage_vu_prepare_tb1;
 go

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -1,4 +1,4 @@
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
@@ -8,16 +8,16 @@ master#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#dbo#!#fk_redcons
 ~~END~~
 
 
-create view constraint_table_usage_vu_verify_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create view constraint_table_usage_vu_verify_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
-create procedure constraint_table_usage_vu_verify_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create procedure constraint_table_usage_vu_verify_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
-create function constraint_table_usage_vu_verify_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
+create function constraint_table_usage_vu_verify_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema);
 go
 
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
@@ -42,7 +42,7 @@ go
 drop table constraint_table_usage_vu_prepare_tb3;
 go
 
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -1,0 +1,57 @@
+use constraint_table_usage_vu_prepare_db;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3_pkey
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
+~~END~~
+
+
+drop table constraint_table_usage_vu_prepare_tb4;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3_pkey
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
+~~END~~
+
+
+drop table constraint_table_usage_vu_prepare_tb3;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
+~~END~~
+
+
+drop table constraint_table_usage_vu_prepare_tb2;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
+~~END~~
+
+
+drop table constraint_table_usage_vu_prepare_tb1;
+go
+
+use master;
+go
+
+drop database constraint_table_usage_vu_prepare_db;
+go

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -5,9 +5,9 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
 constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
 constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3_pkey
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
 ~~END~~
 
 
@@ -18,9 +18,9 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
 constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
 constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb3_pkey
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
 ~~END~~
 
 
@@ -31,8 +31,8 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
 constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb1_name_id_key
+constraint_table_usage_vu_prepare_db#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#constraint_table_usage_vu_prepare_db#!#dbo#!#test_const
 ~~END~~
 
 

--- a/test/JDBC/expected/constraint_table_usage-vu-verify.out
+++ b/test/JDBC/expected/constraint_table_usage-vu-verify.out
@@ -2,9 +2,9 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
 ~~END~~
 
 
@@ -21,9 +21,9 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#dbo#!#fk_redconstraint_table_usage_vu5c9039a3fc5324c27cc0d4025b46a025
 ~~END~~
 
 
@@ -46,8 +46,8 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
-master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#master_dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb1#!#master#!#dbo#!#constraint_table_usage_vu_prepare_tb1_arg1_arg2_key
+master#!#dbo#!#constraint_table_usage_vu_prepare_tb2#!#master#!#dbo#!#constraint_table_usage_vu_prepare_tb2_pkey
 ~~END~~
 
 

--- a/test/JDBC/input/constraint_table_usage-database-test.sql
+++ b/test/JDBC/input/constraint_table_usage-database-test.sql
@@ -1,0 +1,39 @@
+use master;
+go
+
+create table constraint_table_usage_db_test_tb1(arg1 char(10) NOT NULL, arg2 char(10), UNIQUE(arg1,arg2));
+go
+
+create database constraint_table_usage_db_test_db;
+go
+
+use constraint_table_usage_db_test_db;
+go
+
+create table constraint_table_usage_db_test_tb2(arg3 char(10) NOT NULL, arg4 char(10), UNIQUE(arg3,arg4));
+go
+
+use master;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_db_test_tb%' order by table_name,constraint_name,table_schema;
+go
+
+use constraint_table_usage_db_test_db;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_db_test_tb%' order by table_name,constraint_name,table_schema;
+go
+
+drop table constraint_table_usage_db_test_tb2;
+go
+
+use master;
+go
+
+drop table constraint_table_usage_db_test_tb1;
+go
+
+drop database constraint_table_usage_db_test_db;
+go
+

--- a/test/JDBC/input/constraint_table_usage-database-test.sql
+++ b/test/JDBC/input/constraint_table_usage-database-test.sql
@@ -31,6 +31,21 @@ go
 use master;
 go
 
+create schema constraint_table_usage_db_test_sc;
+go
+
+create table constraint_table_usage_db_test_sc.constraint_table_usage_db_test_tb3(arg3 char(10) NOT NULL, arg4 char(10), UNIQUE(arg3,arg4));
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_db_test_tb%' order by table_name,constraint_name,table_schema;
+go
+
+drop table constraint_table_usage_db_test_sc.constraint_table_usage_db_test_tb3;
+go
+
+drop schema constraint_table_usage_db_test_sc;
+go
+
 drop table constraint_table_usage_db_test_tb1;
 go
 

--- a/test/JDBC/input/constraint_table_usage-privilege-test.mix
+++ b/test/JDBC/input/constraint_table_usage-privilege-test.mix
@@ -1,0 +1,85 @@
+-- tsql
+
+use master;
+go
+
+create login constraint_table_usage_privilege_test_user with password='';
+go
+
+create database constraint_table_usage_privilege_test_db;
+go
+
+use constraint_table_usage_privilege_test_db;
+go
+
+create table constraint_table_usage_privilege_test_tb(arg1 int, arg2 int, primary key(arg1));
+go
+
+create user constraint_table_usage_privilege_test_user for login constraint_table_usage_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=constraint_table_usage_privilege_test_user password=''
+
+use constraint_table_usage_privilege_test_db;
+go
+
+select * from information_schema.constraint_column_usage where table_name='constraint_table_usage_privilege_test_tb';
+go
+
+use master;
+go
+
+-- tsql
+
+use constraint_table_usage_privilege_test_db;
+go
+
+grant select on constraint_table_usage_privilege_test_tb to constraint_table_usage_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=constraint_table_usage_privilege_test_user password=''
+
+use constraint_table_usage_privilege_test_db;
+go
+
+select * from information_schema.constraint_column_usage where table_name='constraint_table_usage_privilege_test_tb';
+go
+
+use master;
+go
+
+-- tsql
+
+use constraint_table_usage_privilege_test_db;
+go
+
+drop table constraint_table_usage_privilege_test_tb;
+go
+
+use master;
+go
+
+drop database constraint_table_usage_privilege_test_db;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'constraint_table_usage_privilege_test_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+drop login constraint_table_usage_privilege_test_user;
+go
+

--- a/test/JDBC/input/constraint_table_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-prepare.sql
@@ -7,16 +7,16 @@ go
 use constraint_table_usage_vu_prepare_db;
 go
 
-create table constraint_table_usage_vu_prepare_tb1(name char(10) NOT NULL, id char(10) NOT NULL, UNIQUE(name,id));
+create table constraint_table_usage_vu_prepare_tb1(arg1 char(10) NOT NULL, arg2 char(10), UNIQUE(arg1,arg2));
 go
 
-create table constraint_table_usage_vu_prepare_tb2(book char(10), subject char(10) NOT NULL CONSTRAINT TEST_CONST PRIMARY KEY);
+create table constraint_table_usage_vu_prepare_tb2(redID INT PRIMARY KEY);
 go
 
-create table constraint_table_usage_vu_prepare_tb3(name char(10) NOT NULL, id char(10) NOT NULL, PRIMARY KEY(name, id));
+CREATE TABLE constraint_table_usage_vu_prepare_tb3(redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES constraint_table_usage_vu_prepare_tb2 (redID));
 go
 
-create table constraint_table_usage_vu_prepare_tb4(movie char(10), description char(1000));
+create table constraint_table_usage_vu_prepare_tb4(arg3 int CHECK (arg3 > 10), arg4 int DEFAULT 100.00);
 go
 
 use master;

--- a/test/JDBC/input/constraint_table_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-prepare.sql
@@ -1,0 +1,23 @@
+use master;
+go
+
+create database constraint_table_usage_vu_prepare_db;
+go
+
+use constraint_table_usage_vu_prepare_db;
+go
+
+create table constraint_table_usage_vu_prepare_tb1(name char(10) NOT NULL, id char(10) NOT NULL, UNIQUE(name,id));
+go
+
+create table constraint_table_usage_vu_prepare_tb2(book char(10), subject char(10) NOT NULL CONSTRAINT TEST_CONST PRIMARY KEY);
+go
+
+create table constraint_table_usage_vu_prepare_tb3(name char(10) NOT NULL, id char(10) NOT NULL, PRIMARY KEY(name, id));
+go
+
+create table constraint_table_usage_vu_prepare_tb4(movie char(10), description char(1000));
+go
+
+use master;
+go

--- a/test/JDBC/input/constraint_table_usage-vu-prepare.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-prepare.sql
@@ -1,23 +1,11 @@
-use master;
-go
-
-create database constraint_table_usage_vu_prepare_db;
-go
-
-use constraint_table_usage_vu_prepare_db;
-go
-
 create table constraint_table_usage_vu_prepare_tb1(arg1 char(10) NOT NULL, arg2 char(10), UNIQUE(arg1,arg2));
 go
 
 create table constraint_table_usage_vu_prepare_tb2(redID INT PRIMARY KEY);
 go
 
-CREATE TABLE constraint_table_usage_vu_prepare_tb3(redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES constraint_table_usage_vu_prepare_tb2 (redID));
+create table constraint_table_usage_vu_prepare_tb3(redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES constraint_table_usage_vu_prepare_tb2 (redID));
 go
 
 create table constraint_table_usage_vu_prepare_tb4(arg3 int CHECK (arg3 > 10), arg4 int DEFAULT 100.00);
-go
-
-use master;
 go

--- a/test/JDBC/input/constraint_table_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-verify.sql
@@ -4,25 +4,25 @@ go
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-create view constraint_table_usage_vu_prepare_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create view constraint_table_usage_vu_verify_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-create procedure constraint_table_usage_vu_prepare_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create procedure constraint_table_usage_vu_verify_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-create function constraint_table_usage_vu_prepare_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
+create function constraint_table_usage_vu_verify_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
 go
 
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-drop function constraint_table_usage_vu_prepare_func;
+drop function constraint_table_usage_vu_verify_func;
 go
 
-drop procedure constraint_table_usage_vu_prepare_proc;
+drop procedure constraint_table_usage_vu_verify_proc;
 go
 
-drop view constraint_table_usage_vu_prepare_view;
+drop view constraint_table_usage_vu_verify_view;
 go
 
 drop table constraint_table_usage_vu_prepare_tb4;

--- a/test/JDBC/input/constraint_table_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-verify.sql
@@ -1,6 +1,3 @@
-use constraint_table_usage_vu_prepare_db;
-go
-
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
@@ -38,10 +35,4 @@ drop table constraint_table_usage_vu_prepare_tb2;
 go
 
 drop table constraint_table_usage_vu_prepare_tb1;
-go
-
-use master;
-go
-
-drop database constraint_table_usage_vu_prepare_db;
 go

--- a/test/JDBC/input/constraint_table_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-verify.sql
@@ -4,10 +4,28 @@ go
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
-drop table constraint_table_usage_vu_prepare_tb4;
+create view constraint_table_usage_vu_prepare_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+create procedure constraint_table_usage_vu_prepare_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+create function constraint_table_usage_vu_prepare_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
 go
 
 select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+drop function constraint_table_usage_vu_prepare_func;
+go
+
+drop procedure constraint_table_usage_vu_prepare_proc;
+go
+
+drop view constraint_table_usage_vu_prepare_view;
+go
+
+drop table constraint_table_usage_vu_prepare_tb4;
 go
 
 drop table constraint_table_usage_vu_prepare_tb3;
@@ -17,9 +35,6 @@ select * from information_schema.constraint_table_usage where table_name like 'c
 go
 
 drop table constraint_table_usage_vu_prepare_tb2;
-go
-
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
 go
 
 drop table constraint_table_usage_vu_prepare_tb1;

--- a/test/JDBC/input/constraint_table_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-verify.sql
@@ -1,0 +1,32 @@
+use constraint_table_usage_vu_prepare_db;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+drop table constraint_table_usage_vu_prepare_tb4;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+drop table constraint_table_usage_vu_prepare_tb3;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+drop table constraint_table_usage_vu_prepare_tb2;
+go
+
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+go
+
+drop table constraint_table_usage_vu_prepare_tb1;
+go
+
+use master;
+go
+
+drop database constraint_table_usage_vu_prepare_db;
+go

--- a/test/JDBC/input/constraint_table_usage-vu-verify.sql
+++ b/test/JDBC/input/constraint_table_usage-vu-verify.sql
@@ -1,16 +1,16 @@
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
-create view constraint_table_usage_vu_verify_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create view constraint_table_usage_vu_verify_view as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
-create procedure constraint_table_usage_vu_verify_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+create procedure constraint_table_usage_vu_verify_proc as select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
-create function constraint_table_usage_vu_verify_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%');
+create function constraint_table_usage_vu_verify_func() returns table as return(select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema);
 go
 
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
 drop function constraint_table_usage_vu_verify_func;
@@ -28,7 +28,7 @@ go
 drop table constraint_table_usage_vu_prepare_tb3;
 go
 
-select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%';
+select * from information_schema.constraint_table_usage where table_name like 'constraint_table_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
 go
 
 drop table constraint_table_usage_vu_prepare_tb2;

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -108,4 +108,4 @@ BABEL-741
 BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
-BABEL-1683
+constraint_table_usage

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -109,3 +109,4 @@ BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
 constraint_table_usage
+BABEL-1683

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -121,3 +121,4 @@ BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
 constraint_table_usage
+BABEL-1683

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -120,4 +120,4 @@ BABEL-3147-before-14_5
 BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
-BABEL-1683
+constraint_table_usage

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -153,4 +153,4 @@ tdscollation
 sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
-BABEL-1683
+constraint_table_usage

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -154,3 +154,4 @@ sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
 constraint_table_usage
+BABEL-1683

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -155,4 +155,4 @@ tdscollation
 sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
-BABEL-1683
+constraint_table_usage

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -156,3 +156,4 @@ sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
 constraint_table_usage
+BABEL-1683

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -169,3 +169,4 @@ sys-assemblies
 BABEL-LOGIN-USER-EXT
 bitwise_not-operator
 constraint_table_usage
+BABEL-1683

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -168,4 +168,4 @@ sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
 bitwise_not-operator
-BABEL-1683
+constraint_table_usage

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -1009,6 +1009,7 @@ View information_schema_tsql.check_constraints
 View information_schema_tsql.column_domain_usage
 View information_schema_tsql.columns
 View information_schema_tsql.constraint_column_usage
+View information_schema_tsql.constraint_table_usage
 View information_schema_tsql.domains
 View information_schema_tsql.routines
 View information_schema_tsql.table_constraints


### PR DESCRIPTION
### Description

Currently, Babelfish does not support
information_schema_tsql.constraint_table_usage. This commit updates this
state by implementing the view.

TASK:

Author: Ozzy Nolen <oscarno@amazon.com>
Signed-off by:
 
### Issues Resolved

- The view information_schema_tsql.constraint_table_usage not implemented


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).