### PR TITLE
Disallow db user to add/drop itself to/from a role and update upgrade tests

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1462,6 +1462,7 @@ check_alter_role_stmt(GrantRoleStmt *stmt)
 	grantee_name = grantee_spec->rolename;
 	grantee = get_role_oid(grantee_name, false);
 
+	/* Disallow ALTER ROLE if the grantee is not a db principal */
 	if (!is_user(grantee) && !is_role(grantee))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1473,7 +1474,13 @@ check_alter_role_stmt(GrantRoleStmt *stmt)
 	granted_name = granted_spec->rolename;
 	granted = get_role_oid(granted_name, false);
 
-	if (!has_privs_of_role(GetSessionUserId(), granted))
+	/*
+	 * Disallow ALTER ROLE if
+	 * 1. Current login doesn't have permission on the granted role, or
+	 * 2. The current user is trying to add/drop itself from the granted role
+	 */
+	if (!has_privs_of_role(GetSessionUserId(), granted) ||
+		grantee == GetUserId())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("Current login %s does not have permission to alter role %s", 

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER-vu-verify.out
@@ -108,6 +108,36 @@ int
 1
 ~~END~~
 
+SELECT IS_ROLEMEMBER('public', 'public')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Every db principal is member of PUBLIC
+SELECT IS_MEMBER('public')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_ROLEMEMBER('public', 'BABEL_ROLE_MEMBER_vu_prepare_role1')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_ROLEMEMBER('public', 'BABEL_ROLE_MEMBER_vu_prepare_user1')
+GO
+~~START~~
+int
+1
+~~END~~
+
 
 -- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'BABEL_ROLE_MEMBER_vu_prepare_role1')
@@ -219,6 +249,29 @@ GO
 ~~START~~
 int
 <NULL>
+~~END~~
+
+
+-- Case insensitive check
+SELECT IS_ROLEMEMBER('PUBLIC', 'Babel_role_member_vu_prepare_User1')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_ROLEMEMBER('Babel_role_member_vu_prepare_role1', 'babel_role_member_vu_prepare_ROLE3')
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT IS_MEMBER('Public')
+GO
+~~START~~
+int
+1
 ~~END~~
 
 
@@ -458,5 +511,6 @@ int
 ~~END~~
 
 
+-- tsql
 USE master
 GO

--- a/test/JDBC/expected/BABEL-ROLE-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-ROLE-vu-cleanup.out
@@ -1,3 +1,4 @@
+-- tsql
 USE babel_role_vu_prepare_db
 GO
 

--- a/test/JDBC/expected/BABEL-ROLE-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-ROLE-vu-prepare.out
@@ -1,3 +1,4 @@
+-- tsql
 CREATE PROC babel_role_vu_prepare_user_ext_master AS
 BEGIN 
 	SELECT rolname, type, orig_username, database_name

--- a/test/JDBC/expected/BABEL-ROLE-vu-verify.out
+++ b/test/JDBC/expected/BABEL-ROLE-vu-verify.out
@@ -1,3 +1,4 @@
+-- tsql
 SELECT DB_NAME()
 GO
 ~~START~~
@@ -239,6 +240,49 @@ babel_role_vu_prepare_role1_new#!#R#!#babel_role_vu_prepare_role2#!#R
 babel_role_vu_prepare_role1_new#!#R#!#babel_role_vu_prepare_user2#!#S
 babel_role_vu_prepare_role2#!#R#!#babel_role_vu_prepare_user3#!#S
 ~~END~~
+
+
+-- tsql		user=babel_role_vu_prepare_login2		password=123
+-- DB user is disallowed to add/drop itself to/from a role
+USE babel_role_vu_prepare_db
+GO
+SELECT USER_NAME()
+GO
+~~START~~
+nvarchar
+babel_role_vu_prepare_user2
+~~END~~
+
+-- should fail
+ALTER ROLE babel_role_vu_prepare_role1_new DROP MEMBER babel_role_vu_prepare_user2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_role_vu_prepare_login2 does not have permission to alter role babel_role_vu_prepare_db_babel_role_vu_prepare_role1_new)~~
+
+ALTER ROLE babel_role_vu_prepare_role2 ADD MEMBER babel_role_vu_prepare_user2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_role_vu_prepare_login2 does not have permission to alter role babel_role_vu_prepare_db_babel_role_vu_prepare_role2)~~
+
+
+-- tsql
+USE babel_role_vu_prepare_db
+GO
+-- Role with members is disallowed to be dropped
+-- should fail
+DROP ROLE babel_role_vu_prepare_role1_new
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The role has members. It must be empty before it can be dropped.)~~
+
+DROP ROLE babel_role_vu_prepare_role2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The role has members. It must be empty before it can be dropped.)~~
 
 
 -- Drop role from member

--- a/test/JDBC/input/BABEL-ROLE-MEMBER-vu-verify.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER-vu-verify.mix
@@ -37,6 +37,16 @@ SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', 'BABEL_ROLE_MEMBER_vu
 GO
 SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_user1', 'BABEL_ROLE_MEMBER_vu_prepare_user1')
 GO
+SELECT IS_ROLEMEMBER('public', 'public')
+GO
+
+-- Every db principal is member of PUBLIC
+SELECT IS_MEMBER('public')
+GO
+SELECT IS_ROLEMEMBER('public', 'BABEL_ROLE_MEMBER_vu_prepare_role1')
+GO
+SELECT IS_ROLEMEMBER('public', 'BABEL_ROLE_MEMBER_vu_prepare_user1')
+GO
 
 -- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'BABEL_ROLE_MEMBER_vu_prepare_role1')
@@ -74,6 +84,14 @@ GO
 SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', NULL)
 GO
 SELECT IS_ROLEMEMBER(NULL, NULL)
+GO
+
+-- Case insensitive check
+SELECT IS_ROLEMEMBER('PUBLIC', 'Babel_role_member_vu_prepare_User1')
+GO
+SELECT IS_ROLEMEMBER('Babel_role_member_vu_prepare_role1', 'babel_role_member_vu_prepare_ROLE3')
+GO
+SELECT IS_MEMBER('Public')
 GO
 
 -- Connect with different logins to test membership view permission
@@ -172,5 +190,6 @@ GO
 SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2', 'BABEL_ROLE_MEMBER_vu_prepare_user2')
 GO
 
+-- tsql
 USE master
 GO

--- a/test/JDBC/input/ownership/BABEL-ROLE-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-ROLE-vu-cleanup.mix
@@ -1,3 +1,4 @@
+-- tsql
 USE babel_role_vu_prepare_db
 GO
 

--- a/test/JDBC/input/ownership/BABEL-ROLE-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-ROLE-vu-prepare.mix
@@ -1,3 +1,4 @@
+-- tsql
 CREATE PROC babel_role_vu_prepare_user_ext_master AS
 BEGIN 
 	SELECT rolname, type, orig_username, database_name

--- a/test/JDBC/input/ownership/BABEL-ROLE-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-ROLE-vu-verify.mix
@@ -1,3 +1,4 @@
+-- tsql
 SELECT DB_NAME()
 GO
 
@@ -115,6 +116,28 @@ EXEC babel_role_vu_prepare_db_principal
 GO
 
 EXEC babel_role_vu_prepare_role_members
+GO
+
+-- DB user is disallowed to add/drop itself to/from a role
+-- tsql		user=babel_role_vu_prepare_login2		password=123
+USE babel_role_vu_prepare_db
+GO
+SELECT USER_NAME()
+GO
+-- should fail
+ALTER ROLE babel_role_vu_prepare_role1_new DROP MEMBER babel_role_vu_prepare_user2
+GO
+ALTER ROLE babel_role_vu_prepare_role2 ADD MEMBER babel_role_vu_prepare_user2
+GO
+
+-- tsql
+USE babel_role_vu_prepare_db
+GO
+-- Role with members is disallowed to be dropped
+-- should fail
+DROP ROLE babel_role_vu_prepare_role1_new
+GO
+DROP ROLE babel_role_vu_prepare_role2
 GO
 
 -- Drop role from member


### PR DESCRIPTION
Previously a db user can add/drop itself to/from a role, with this
commit, the behavior is disallowed.

This commit also adds three test cases to upgrade tests, which
corresponds to
1. Disallow db user to add/drop itself to/from a role
2. Role with members should not be allowed to be dropped (implemented in
   previous commit)
3. Fix IS_ROLEMEMBER() and IS_MEMBER() function output (implemented in
   previous commit)

Task: BABEL-3361
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).