### PR TITLE
Added Support for TSQL's column_privileges

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -723,10 +723,10 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 */
 
 CREATE OR REPLACE VIEW information_schema_tsql.column_privileges
-AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_grantor.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTOR",
-    CAST((select orig_username from sys.babelfish_authid_user_ext where grantee.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTEE",
-    CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+AS SELECT CAST(extc.orig_username AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST(extr.orig_username AS sys.nvarchar(128)) AS "GRANTEE",
+    CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(ext.orig_name  AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(x.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(x.attname AS sys.sysname) AS "COLUMN_NAME",
     CAST(x.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
@@ -747,11 +747,12 @@ AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_
                     pg_class.relnamespace,
                     pg_class.relowner,
                     (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).grantor AS grantor,
-                    (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).grantee as grantee,
                     (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).privilege_type AS privilege_type,
                     (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).is_grantable AS is_grantable
-                   FROM pg_class
-                  WHERE pg_class.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('v' AS "char"), CAST('f' AS "char"), CAST('p' AS "char")])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
+                   FROM pg_class 
+                  WHERE
+                  pg_class.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('v' AS "char"), CAST('f' AS "char"), CAST('p' AS "char")])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
             pg_attribute a
           WHERE a.attrelid = pr_c.oid AND a.attnum > 0 AND NOT a.attisdropped
         UNION
@@ -774,16 +775,17 @@ AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_
                   WHERE a.attnum > 0 AND NOT a.attisdropped) pr_a(attrelid, attname, grantor, grantee, prtype, grantable),
             pg_class c
           WHERE pr_a.attrelid = c.oid AND (c.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('v' AS "char"), CAST('f' AS "char"), CAST('p' AS "char")]))) x,
-    pg_namespace nc,
-    pg_roles u_grantor,
+    sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext ext ON nc.nspname = ext.nspname,
+    pg_roles u_grantor LEFT OUTER JOIN sys.babelfish_authid_user_ext extc ON u_grantor.rolname = extc.rolname,
     ( SELECT pg_roles.oid,
             pg_roles.rolname
            FROM pg_roles
         UNION ALL
          SELECT CAST(0 AS oid) AS oid,
-            CAST('PUBLIC' AS name) AS name) grantee(oid, rolname)
+            CAST('PUBLIC' AS name) AS name) grantee(oid, rolname) LEFT OUTER JOIN sys.babelfish_authid_user_ext extr ON grantee.rolname = extr.rolname
 WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid 
 AND (x.prtype = ANY (ARRAY[CAST('INSERT' AS text), CAST('SELECT' AS text), CAST('UPDATE' AS text), CAST('REFERENCES' AS text)])) 
-AND (pg_has_role(u_grantor.oid, CAST('USAGE' AS text)) OR pg_has_role(grantee.oid, CAST('USAGE' AS text)) OR grantee.rolname = CAST('PUBLIC' AS name));
+AND (pg_has_role(u_grantor.oid, CAST('USAGE' AS text)) OR pg_has_role(grantee.oid, CAST('USAGE' AS text)) OR grantee.rolname = CAST('PUBLIC' AS name))
+AND ext.dbid = CAST(sys.db_id() AS oid);
 
 GRANT SELECT ON information_schema_tsql.column_privileges TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -717,3 +717,73 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+/*
+* COLUMN PRIVILEGES
+*/
+
+CREATE OR REPLACE VIEW information_schema_tsql.column_privileges
+AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST(grantee.rolname AS sys.nvarchar(128)) AS "GRANTEE",
+    CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(nc.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST(x.relname AS sys.sysname) AS "TABLE_NAME",
+    CAST(x.attname AS sys.sysname) AS "COLUMN_NAME",
+    CAST(x.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
+        CASE
+            WHEN pg_has_role(x.grantee, x.relowner, 'USAGE'::text) OR x.grantable THEN 'YES'::text
+            ELSE 'NO'::text
+        END::sys."varchar"(3) AS "IS_GRANTABLE"
+   FROM ( SELECT pr_c.grantor,
+            pr_c.grantee,
+            a.attname,
+            pr_c.relname,
+            pr_c.relnamespace,
+            pr_c.prtype,
+            pr_c.grantable,
+            pr_c.relowner
+           FROM ( SELECT pg_class.oid,
+                    pg_class.relname,
+                    pg_class.relnamespace,
+                    pg_class.relowner,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
+                   FROM pg_class
+                  WHERE pg_class.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
+            pg_attribute a
+          WHERE a.attrelid = pr_c.oid AND a.attnum > 0 AND NOT a.attisdropped
+        UNION
+         SELECT pr_a.grantor,
+            pr_a.grantee,
+            pr_a.attname,
+            c.relname,
+            c.relnamespace,
+            pr_a.prtype,
+            pr_a.grantable,
+            c.relowner
+           FROM ( SELECT a.attrelid,
+                    a.attname,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).is_grantable AS is_grantable
+                   FROM pg_attribute a
+                     JOIN pg_class cc ON a.attrelid = cc.oid
+                  WHERE a.attnum > 0 AND NOT a.attisdropped) pr_a(attrelid, attname, grantor, grantee, prtype, grantable),
+            pg_class c
+          WHERE pr_a.attrelid = c.oid AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"]))) x,
+    pg_namespace nc,
+    pg_roles u_grantor,
+    ( SELECT pg_roles.oid,
+            pg_roles.rolname
+           FROM pg_roles
+        UNION ALL
+         SELECT 0::oid AS oid,
+            'PUBLIC'::name AS name) grantee(oid, rolname)
+WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid 
+AND (x.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'REFERENCES'::text])) 
+AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+
+GRANT SELECT ON information_schema_tsql.column_privileges TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -723,10 +723,10 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 */
 
 CREATE OR REPLACE VIEW information_schema_tsql.column_privileges
-AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
-    CAST(grantee.rolname AS sys.nvarchar(128)) AS "GRANTEE",
+AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_grantor.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST((select orig_username from sys.babelfish_authid_user_ext where grantee.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTEE",
     CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST(nc.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(x.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(x.attname AS sys.sysname) AS "COLUMN_NAME",
     CAST(x.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
@@ -780,7 +780,7 @@ AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
             pg_roles.rolname
            FROM pg_roles
         UNION ALL
-         SELECT 0::oid AS oid,
+         SELECT CAST(0 AS oid) AS oid,
             CAST('PUBLIC' AS name) AS name) grantee(oid, rolname)
 WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid 
 AND (x.prtype = ANY (ARRAY[CAST('INSERT' AS text), CAST('SELECT' AS text), CAST('UPDATE' AS text), CAST('REFERENCES' AS text)])) 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -166,10 +166,10 @@ GRANT SELECT ON information_schema_tsql.COLUMN_DOMAIN_USAGE TO PUBLIC;
 */
 
 CREATE OR REPLACE VIEW information_schema_tsql.column_privileges
-AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
-    CAST(grantee.rolname AS sys.nvarchar(128)) AS "GRANTEE",
+AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_grantor.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST((select orig_username from sys.babelfish_authid_user_ext where grantee.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTEE",
     CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST(nc.nspname AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(x.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(x.attname AS sys.sysname) AS "COLUMN_NAME",
     CAST(x.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
@@ -223,7 +223,7 @@ AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
             pg_roles.rolname
            FROM pg_roles
         UNION ALL
-         SELECT 0::oid AS oid,
+         SELECT CAST(0 AS oid) AS oid,
             CAST('PUBLIC' AS name) AS name) grantee(oid, rolname)
 WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid 
 AND (x.prtype = ANY (ARRAY[CAST('INSERT' AS text), CAST('SELECT' AS text), CAST('UPDATE' AS text), CAST('REFERENCES' AS text)])) 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -173,10 +173,10 @@ AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
     CAST(x.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(x.attname AS sys.sysname) AS "COLUMN_NAME",
     CAST(x.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
-        CASE
-            WHEN pg_has_role(x.grantee, x.relowner, 'USAGE'::text) OR x.grantable THEN 'YES'::text
-            ELSE 'NO'::text
-        END::sys."varchar"(3) AS "IS_GRANTABLE"
+        CAST(CASE
+            WHEN pg_has_role(x.grantee, x.relowner, CAST('USAGE' AS text)) OR x.grantable THEN CAST('YES' AS text)
+            ELSE CAST('NO' AS text)
+        END AS sys.varchar(3)) AS "IS_GRANTABLE"
    FROM ( SELECT pr_c.grantor,
             pr_c.grantee,
             a.attname,
@@ -189,12 +189,12 @@ AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
                     pg_class.relname,
                     pg_class.relnamespace,
                     pg_class.relowner,
-                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantor AS grantor,
-                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantee AS grantee,
-                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
-                    (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(pg_class.relacl, acldefault(CAST('r' AS "char"), pg_class.relowner)))).is_grantable AS is_grantable
                    FROM pg_class
-                  WHERE pg_class.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
+                  WHERE pg_class.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('v' AS "char"), CAST('f' AS "char"), CAST('p' AS "char")])) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
             pg_attribute a
           WHERE a.attrelid = pr_c.oid AND a.attnum > 0 AND NOT a.attisdropped
         UNION
@@ -208,15 +208,15 @@ AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
             c.relowner
            FROM ( SELECT a.attrelid,
                     a.attname,
-                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantor AS grantor,
-                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).grantee AS grantee,
-                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).privilege_type AS privilege_type,
-                    (aclexplode(COALESCE(a.attacl, acldefault('c'::"char", cc.relowner)))).is_grantable AS is_grantable
+                    (aclexplode(COALESCE(a.attacl, acldefault(CAST('c' AS "char"), cc.relowner)))).grantor AS grantor,
+                    (aclexplode(COALESCE(a.attacl, acldefault(CAST('c' AS "char"), cc.relowner)))).grantee AS grantee,
+                    (aclexplode(COALESCE(a.attacl, acldefault(CAST('c' AS "char"), cc.relowner)))).privilege_type AS privilege_type,
+                    (aclexplode(COALESCE(a.attacl, acldefault(CAST('c' AS "char"), cc.relowner)))).is_grantable AS is_grantable
                    FROM pg_attribute a
                      JOIN pg_class cc ON a.attrelid = cc.oid
                   WHERE a.attnum > 0 AND NOT a.attisdropped) pr_a(attrelid, attname, grantor, grantee, prtype, grantable),
             pg_class c
-          WHERE pr_a.attrelid = c.oid AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"]))) x,
+          WHERE pr_a.attrelid = c.oid AND (c.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('v' AS "char"), CAST('f' AS "char"), CAST('p' AS "char")]))) x,
     pg_namespace nc,
     pg_roles u_grantor,
     ( SELECT pg_roles.oid,
@@ -224,10 +224,10 @@ AS SELECT CAST(u_grantor.rolname AS sys.nvarchar(128)) AS "GRANTOR",
            FROM pg_roles
         UNION ALL
          SELECT 0::oid AS oid,
-            'PUBLIC'::name AS name) grantee(oid, rolname)
+            CAST('PUBLIC' AS name) AS name) grantee(oid, rolname)
 WHERE x.relnamespace = nc.oid AND x.grantee = grantee.oid AND x.grantor = u_grantor.oid 
-AND (x.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'REFERENCES'::text])) 
-AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+AND (x.prtype = ANY (ARRAY[CAST('INSERT' AS text), CAST('SELECT' AS text), CAST('UPDATE' AS text), CAST('REFERENCES' AS text)])) 
+AND (pg_has_role(u_grantor.oid, CAST('USAGE' AS text)) OR pg_has_role(grantee.oid, CAST('USAGE' AS text)) OR grantee.rolname = CAST('PUBLIC' AS name));
 
 GRANT SELECT ON information_schema_tsql.column_privileges TO PUBLIC;
 

--- a/test/JDBC/expected/column_privileges-database-test.out
+++ b/test/JDBC/expected/column_privileges-database-test.out
@@ -59,6 +59,30 @@ go
 use master;
 go
 
+create schema column_privileges_db_test_sc;
+go
+
+create table column_privileges_db_test_sc.column_privileges_db_test_tb3(arg1 int, arg2 int);
+go
+
+grant SELECT on column_privileges_db_test_sc.column_privileges_db_test_tb3(arg2) to column_privileges_db_test_u1;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_db_test_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#column_privileges_db_test_u1#!#master#!#dbo#!#column_privileges_db_test_tb1#!#arg1#!#SELECT#!#NO
+dbo#!#column_privileges_db_test_u1#!#master#!#column_privileges_db_test_sc#!#column_privileges_db_test_tb3#!#arg2#!#SELECT#!#NO
+~~END~~
+
+
+drop table column_privileges_db_test_sc.column_privileges_db_test_tb3;
+go
+
+drop schema column_privileges_db_test_sc;
+go
+
 drop table column_privileges_db_test_tb1;
 go
 

--- a/test/JDBC/expected/column_privileges-database-test.out
+++ b/test/JDBC/expected/column_privileges-database-test.out
@@ -1,0 +1,74 @@
+use master;
+go
+
+create login column_privileges_db_test_log WITH PASSWORD = 'YourSecretPassword1234#';
+go
+
+create user column_privileges_db_test_u1 for login column_privileges_db_test_log;
+go
+
+create table column_privileges_db_test_tb1(arg1 int, arg2 int);
+go
+
+grant SELECT on column_privileges_db_test_tb1(arg1) to column_privileges_db_test_u1;
+go
+
+create database column_privileges_db_test_db;
+go
+
+use column_privileges_db_test_db;
+go
+
+create user column_privileges_db_test_u2 for login column_privileges_db_test_log;
+go
+
+create table column_privileges_db_test_tb2(arg3 int, arg4 int);
+go
+
+grant SELECT on column_privileges_db_test_tb2(arg3) to column_privileges_db_test_u2;
+go
+
+use master;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_db_test_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#column_privileges_db_test_u1#!#master#!#dbo#!#column_privileges_db_test_tb1#!#arg1#!#SELECT#!#NO
+~~END~~
+
+
+use column_privileges_db_test_db;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_db_test_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#column_privileges_db_test_u2#!#column_privileges_db_test_db#!#dbo#!#column_privileges_db_test_tb2#!#arg3#!#SELECT#!#NO
+~~END~~
+
+
+drop table column_privileges_db_test_tb2;
+go
+
+drop user column_privileges_db_test_u2;
+go
+
+use master;
+go
+
+drop table column_privileges_db_test_tb1;
+go
+
+drop user column_privileges_db_test_u1;
+go
+
+drop database column_privileges_db_test_db;
+go
+
+drop login column_privileges_db_test_log;
+go
+
+

--- a/test/JDBC/expected/column_privileges-privilege-test.out
+++ b/test/JDBC/expected/column_privileges-privilege-test.out
@@ -1,0 +1,103 @@
+-- tsql
+
+use master;
+go
+
+create login column_privileges_privilege_test_user with password='';
+go
+
+create database column_privileges_privilege_test_db;
+go
+
+use column_privileges_privilege_test_db;
+go
+
+create table column_privileges_privilege_test_tb(arg1 int, arg2 int);
+go
+
+create user column_privileges_privilege_test_user for login column_privileges_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=column_privileges_privilege_test_user password=''
+
+use column_privileges_privilege_test_db;
+go
+
+select * from information_schema.column_privileges where table_name='column_privileges_privilege_test_tb';
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+use master;
+go
+
+-- tsql
+
+use column_privileges_privilege_test_db;
+go
+
+grant select on column_privileges_privilege_test_tb(arg1) to column_privileges_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=column_privileges_privilege_test_user password=''
+
+use column_privileges_privilege_test_db;
+go
+
+select * from information_schema.column_privileges where table_name='column_privileges_privilege_test_tb';
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#column_privileges_privilege_test_user#!#column_privileges_privilege_test_db#!#dbo#!#column_privileges_privilege_test_tb#!#arg1#!#SELECT#!#NO
+~~END~~
+
+
+use master;
+go
+
+-- tsql
+
+use column_privileges_privilege_test_db;
+go
+
+drop table column_privileges_privilege_test_tb;
+go
+
+use master;
+go
+
+drop database column_privileges_privilege_test_db;
+go
+
+-- psql
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'column_privileges_privilege_test_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login column_privileges_privilege_test_user;
+go

--- a/test/JDBC/expected/column_privileges-vu-prepare.out
+++ b/test/JDBC/expected/column_privileges-vu-prepare.out
@@ -1,0 +1,35 @@
+use master;
+go
+
+create database column_privileges_vu_prepare_db;
+go
+
+use column_privileges_vu_prepare_db;
+go
+
+create table column_privileges_vu_prepare_tb1(arg1 int, arg2 int);
+go
+
+create table column_privileges_vu_prepare_tb2(arg3 int, arg4 int);
+go
+
+create login column_privileges_vu_prepare_log with password = 'EmptyPassword#';
+go
+
+create user column_privileges_vu_prepare_user for login column_privileges_vu_prepare_log;
+go
+
+grant SELECT on column_privileges_vu_prepare_tb1(arg1) to column_privileges_vu_prepare_user;
+go
+
+grant UPDATE on column_privileges_vu_prepare_tb1(arg2) to column_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on column_privileges_vu_prepare_tb2(arg3) to column_privileges_vu_prepare_user;
+go
+
+grant INSERT on column_privileges_vu_prepare_tb2(arg4) to column_privileges_vu_prepare_user;
+go
+
+use master;
+go

--- a/test/JDBC/expected/column_privileges-vu-prepare.out
+++ b/test/JDBC/expected/column_privileges-vu-prepare.out
@@ -1,17 +1,5 @@
-use master;
-go
-
-create database column_privileges_vu_prepare_db;
-go
-
-use column_privileges_vu_prepare_db;
-go
-
 create table column_privileges_vu_prepare_tb1(arg1 int, arg2 int);
 go
 
 create table column_privileges_vu_prepare_tb2(arg3 int, arg4 int);
-go
-
-use master;
 go

--- a/test/JDBC/expected/column_privileges-vu-prepare.out
+++ b/test/JDBC/expected/column_privileges-vu-prepare.out
@@ -13,23 +13,5 @@ go
 create table column_privileges_vu_prepare_tb2(arg3 int, arg4 int);
 go
 
-create login column_privileges_vu_prepare_log with password = 'EmptyPassword#';
-go
-
-create user column_privileges_vu_prepare_user for login column_privileges_vu_prepare_log;
-go
-
-grant SELECT on column_privileges_vu_prepare_tb1(arg1) to column_privileges_vu_prepare_user;
-go
-
-grant UPDATE on column_privileges_vu_prepare_tb1(arg2) to column_privileges_vu_prepare_user;
-go
-
-grant REFERENCES on column_privileges_vu_prepare_tb2(arg3) to column_privileges_vu_prepare_user;
-go
-
-grant INSERT on column_privileges_vu_prepare_tb2(arg4) to column_privileges_vu_prepare_user;
-go
-
 use master;
 go

--- a/test/JDBC/expected/column_privileges-vu-verify.out
+++ b/test/JDBC/expected/column_privileges-vu-verify.out
@@ -30,13 +30,13 @@ dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_p
 ~~END~~
 
 
-create view column_privileges_vu_prepare_view as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+create view column_privileges_vu_verify_view as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-create procedure column_privileges_vu_prepare_proc as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+create procedure column_privileges_vu_verify_proc as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-create function column_privileges_vu_prepare_func() returns table as return(select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type);
+create function column_privileges_vu_verify_func() returns table as return(select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type);
 go
 
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
@@ -85,13 +85,13 @@ dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare
 ~~END~~
 
 
-drop function column_privileges_vu_prepare_func;
+drop function column_privileges_vu_verify_func;
 go
 
-drop procedure column_privileges_vu_prepare_proc;
+drop procedure column_privileges_vu_verify_proc;
 go
 
-drop view column_privileges_vu_prepare_view;
+drop view column_privileges_vu_verify_view;
 go
 
 drop table column_privileges_vu_prepare_tb1;

--- a/test/JDBC/expected/column_privileges-vu-verify.out
+++ b/test/JDBC/expected/column_privileges-vu-verify.out
@@ -1,21 +1,42 @@
 use column_privileges_vu_prepare_db;
 go
 
+create login column_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
+GO
+
+create user column_privileges_vu_prepare_user FOR LOGIN column_privileges_vu_prepare_log;
+GO
+
+grant SELECT on column_privileges_vu_prepare_tb1(arg1) to column_privileges_vu_prepare_user;
+go
+
+grant UPDATE on column_privileges_vu_prepare_tb1(arg2) to column_privileges_vu_prepare_user;
+go
+
+grant INSERT on column_privileges_vu_prepare_tb2(arg3) to column_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on column_privileges_vu_prepare_tb2(arg4) to column_privileges_vu_prepare_user;
+go
+
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
 dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
 ~~END~~
 
 
-revoke REFERENCES on column_privileges_vu_prepare_tb2(arg3) from column_privileges_vu_prepare_user;
+create view column_privileges_vu_prepare_view as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-revoke INSERT on column_privileges_vu_prepare_tb2(arg4) from column_privileges_vu_prepare_user;
+create procedure column_privileges_vu_prepare_proc as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+create function column_privileges_vu_prepare_func() returns table as return(select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type);
 go
 
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
@@ -24,6 +45,8 @@ go
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
 dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
 ~~END~~
 
 
@@ -31,6 +54,12 @@ revoke SELECT on column_privileges_vu_prepare_tb1(arg1) from column_privileges_v
 go
 
 revoke UPDATE on column_privileges_vu_prepare_tb1(arg2) from column_privileges_vu_prepare_user;
+go
+
+revoke INSERT on column_privileges_vu_prepare_tb2(arg3) from column_privileges_vu_prepare_user;
+go
+
+revoke REFERENCES on column_privileges_vu_prepare_tb2(arg4) from column_privileges_vu_prepare_user;
 go
 
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' order by table_name,column_name,privilege_type;
@@ -55,6 +84,15 @@ dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare
 dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#UPDATE#!#YES
 ~~END~~
 
+
+drop function column_privileges_vu_prepare_func;
+go
+
+drop procedure column_privileges_vu_prepare_proc;
+go
+
+drop view column_privileges_vu_prepare_view;
+go
 
 drop table column_privileges_vu_prepare_tb1;
 go

--- a/test/JDBC/expected/column_privileges-vu-verify.out
+++ b/test/JDBC/expected/column_privileges-vu-verify.out
@@ -1,6 +1,3 @@
-use column_privileges_vu_prepare_db;
-go
-
 create login column_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
 GO
 
@@ -23,10 +20,10 @@ select * from information_schema.column_privileges where table_name like 'column
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
 ~~END~~
 
 
@@ -43,10 +40,10 @@ select * from information_schema.column_privileges where table_name like 'column
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
-dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
+master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
 ~~END~~
 
 
@@ -66,22 +63,22 @@ select * from information_schema.column_privileges where table_name like 'column
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#INSERT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#REFERENCES#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#UPDATE#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#INSERT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#REFERENCES#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#SELECT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#SELECT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#UPDATE#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#SELECT#!#YES
-dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#UPDATE#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#INSERT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#REFERENCES#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#UPDATE#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#INSERT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#REFERENCES#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#SELECT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#SELECT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#UPDATE#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#SELECT#!#YES
+master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -104,11 +101,5 @@ drop user column_privileges_vu_prepare_user;
 go
 
 drop login column_privileges_vu_prepare_log;
-go
-
-use master;
-go
-
-drop database column_privileges_vu_prepare_db;
 go
 

--- a/test/JDBC/expected/column_privileges-vu-verify.out
+++ b/test/JDBC/expected/column_privileges-vu-verify.out
@@ -20,10 +20,10 @@ select * from information_schema.column_privileges where table_name like 'column
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
 ~~END~~
 
 
@@ -40,10 +40,10 @@ select * from information_schema.column_privileges where table_name like 'column
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
-master_dbo#!#master_column_privileges_vu_prepare_user#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#NO
+dbo#!#column_privileges_vu_prepare_user#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#NO
 ~~END~~
 
 
@@ -63,22 +63,22 @@ select * from information_schema.column_privileges where table_name like 'column
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#INSERT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#REFERENCES#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#UPDATE#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#INSERT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#REFERENCES#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#SELECT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#SELECT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#UPDATE#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#SELECT#!#YES
-master_dbo#!#master_dbo#!#master#!#master_dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#UPDATE#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#INSERT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#REFERENCES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#UPDATE#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#INSERT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#REFERENCES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#SELECT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#SELECT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#UPDATE#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#SELECT#!#YES
+dbo#!#dbo#!#master#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#UPDATE#!#YES
 ~~END~~
 
 

--- a/test/JDBC/expected/column_privileges-vu-verify.out
+++ b/test/JDBC/expected/column_privileges-vu-verify.out
@@ -1,0 +1,76 @@
+use column_privileges_vu_prepare_db;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#NO
+~~END~~
+
+
+revoke REFERENCES on column_privileges_vu_prepare_tb2(arg3) from column_privileges_vu_prepare_user;
+go
+
+revoke INSERT on column_privileges_vu_prepare_tb2(arg4) from column_privileges_vu_prepare_user;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#NO
+dbo#!#column_privileges_vu_prepare_db194c07eed72a57fea7ea9473e84dbe96#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#NO
+~~END~~
+
+
+revoke SELECT on column_privileges_vu_prepare_tb1(arg1) from column_privileges_vu_prepare_user;
+go
+
+revoke UPDATE on column_privileges_vu_prepare_tb1(arg2) from column_privileges_vu_prepare_user;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' order by table_name,column_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#INSERT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#REFERENCES#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#SELECT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg1#!#UPDATE#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#INSERT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#REFERENCES#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#SELECT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb1#!#arg2#!#UPDATE#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#INSERT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#REFERENCES#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#SELECT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg3#!#UPDATE#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#INSERT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#REFERENCES#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#SELECT#!#YES
+dbo#!#dbo#!#column_privileges_vu_prepare_db#!#dbo#!#column_privileges_vu_prepare_tb2#!#arg4#!#UPDATE#!#YES
+~~END~~
+
+
+drop table column_privileges_vu_prepare_tb1;
+go
+
+drop table column_privileges_vu_prepare_tb2;
+go
+
+drop user column_privileges_vu_prepare_user;
+go
+
+drop login column_privileges_vu_prepare_log;
+go
+
+use master;
+go
+
+drop database column_privileges_vu_prepare_db;
+go
+

--- a/test/JDBC/input/column_privileges-database-test.sql
+++ b/test/JDBC/input/column_privileges-database-test.sql
@@ -49,6 +49,24 @@ go
 use master;
 go
 
+create schema column_privileges_db_test_sc;
+go
+
+create table column_privileges_db_test_sc.column_privileges_db_test_tb3(arg1 int, arg2 int);
+go
+
+grant SELECT on column_privileges_db_test_sc.column_privileges_db_test_tb3(arg2) to column_privileges_db_test_u1;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_db_test_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+drop table column_privileges_db_test_sc.column_privileges_db_test_tb3;
+go
+
+drop schema column_privileges_db_test_sc;
+go
+
 drop table column_privileges_db_test_tb1;
 go
 

--- a/test/JDBC/input/column_privileges-database-test.sql
+++ b/test/JDBC/input/column_privileges-database-test.sql
@@ -1,0 +1,64 @@
+use master;
+go
+
+create login column_privileges_db_test_log WITH PASSWORD = 'YourSecretPassword1234#';
+go
+
+create user column_privileges_db_test_u1 for login column_privileges_db_test_log;
+go
+
+create table column_privileges_db_test_tb1(arg1 int, arg2 int);
+go
+
+grant SELECT on column_privileges_db_test_tb1(arg1) to column_privileges_db_test_u1;
+go
+
+create database column_privileges_db_test_db;
+go
+
+use column_privileges_db_test_db;
+go
+
+create user column_privileges_db_test_u2 for login column_privileges_db_test_log;
+go
+
+create table column_privileges_db_test_tb2(arg3 int, arg4 int);
+go
+
+grant SELECT on column_privileges_db_test_tb2(arg3) to column_privileges_db_test_u2;
+go
+
+use master;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_db_test_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+use column_privileges_db_test_db;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_db_test_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+drop table column_privileges_db_test_tb2;
+go
+
+drop user column_privileges_db_test_u2;
+go
+
+use master;
+go
+
+drop table column_privileges_db_test_tb1;
+go
+
+drop user column_privileges_db_test_u1;
+go
+
+drop database column_privileges_db_test_db;
+go
+
+drop login column_privileges_db_test_log;
+go
+
+

--- a/test/JDBC/input/column_privileges-privilege-test.mix
+++ b/test/JDBC/input/column_privileges-privilege-test.mix
@@ -1,0 +1,84 @@
+-- tsql
+
+use master;
+go
+
+create login column_privileges_privilege_test_user with password='';
+go
+
+create database column_privileges_privilege_test_db;
+go
+
+use column_privileges_privilege_test_db;
+go
+
+create table column_privileges_privilege_test_tb(arg1 int, arg2 int);
+go
+
+create user column_privileges_privilege_test_user for login column_privileges_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=column_privileges_privilege_test_user password=''
+
+use column_privileges_privilege_test_db;
+go
+
+select * from information_schema.column_privileges where table_name='column_privileges_privilege_test_tb';
+go
+
+use master;
+go
+
+-- tsql
+
+use column_privileges_privilege_test_db;
+go
+
+grant select on column_privileges_privilege_test_tb(arg1) to column_privileges_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=column_privileges_privilege_test_user password=''
+
+use column_privileges_privilege_test_db;
+go
+
+select * from information_schema.column_privileges where table_name='column_privileges_privilege_test_tb';
+go
+
+use master;
+go
+
+-- tsql
+
+use column_privileges_privilege_test_db;
+go
+
+drop table column_privileges_privilege_test_tb;
+go
+
+use master;
+go
+
+drop database column_privileges_privilege_test_db;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'column_privileges_privilege_test_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+drop login column_privileges_privilege_test_user;
+go

--- a/test/JDBC/input/column_privileges-vu-prepare.sql
+++ b/test/JDBC/input/column_privileges-vu-prepare.sql
@@ -1,0 +1,35 @@
+use master;
+go
+
+create database column_privileges_vu_prepare_db;
+go
+
+use column_privileges_vu_prepare_db;
+go
+
+create table column_privileges_vu_prepare_tb1(arg1 int, arg2 int);
+go
+
+create table column_privileges_vu_prepare_tb2(arg3 int, arg4 int);
+go
+
+create login column_privileges_vu_prepare_log with password = 'EmptyPassword#';
+go
+
+create user column_privileges_vu_prepare_user for login column_privileges_vu_prepare_log;
+go
+
+grant SELECT on column_privileges_vu_prepare_tb1(arg1) to column_privileges_vu_prepare_user;
+go
+
+grant UPDATE on column_privileges_vu_prepare_tb1(arg2) to column_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on column_privileges_vu_prepare_tb2(arg3) to column_privileges_vu_prepare_user;
+go
+
+grant INSERT on column_privileges_vu_prepare_tb2(arg4) to column_privileges_vu_prepare_user;
+go
+
+use master;
+go

--- a/test/JDBC/input/column_privileges-vu-prepare.sql
+++ b/test/JDBC/input/column_privileges-vu-prepare.sql
@@ -1,17 +1,5 @@
-use master;
-go
-
-create database column_privileges_vu_prepare_db;
-go
-
-use column_privileges_vu_prepare_db;
-go
-
 create table column_privileges_vu_prepare_tb1(arg1 int, arg2 int);
 go
 
 create table column_privileges_vu_prepare_tb2(arg3 int, arg4 int);
-go
-
-use master;
 go

--- a/test/JDBC/input/column_privileges-vu-prepare.sql
+++ b/test/JDBC/input/column_privileges-vu-prepare.sql
@@ -13,23 +13,5 @@ go
 create table column_privileges_vu_prepare_tb2(arg3 int, arg4 int);
 go
 
-create login column_privileges_vu_prepare_log with password = 'EmptyPassword#';
-go
-
-create user column_privileges_vu_prepare_user for login column_privileges_vu_prepare_log;
-go
-
-grant SELECT on column_privileges_vu_prepare_tb1(arg1) to column_privileges_vu_prepare_user;
-go
-
-grant UPDATE on column_privileges_vu_prepare_tb1(arg2) to column_privileges_vu_prepare_user;
-go
-
-grant REFERENCES on column_privileges_vu_prepare_tb2(arg3) to column_privileges_vu_prepare_user;
-go
-
-grant INSERT on column_privileges_vu_prepare_tb2(arg4) to column_privileges_vu_prepare_user;
-go
-
 use master;
 go

--- a/test/JDBC/input/column_privileges-vu-verify.sql
+++ b/test/JDBC/input/column_privileges-vu-verify.sql
@@ -1,13 +1,34 @@
 use column_privileges_vu_prepare_db;
 go
 
+create login column_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
+GO
+
+create user column_privileges_vu_prepare_user FOR LOGIN column_privileges_vu_prepare_log;
+GO
+
+grant SELECT on column_privileges_vu_prepare_tb1(arg1) to column_privileges_vu_prepare_user;
+go
+
+grant UPDATE on column_privileges_vu_prepare_tb1(arg2) to column_privileges_vu_prepare_user;
+go
+
+grant INSERT on column_privileges_vu_prepare_tb2(arg3) to column_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on column_privileges_vu_prepare_tb2(arg4) to column_privileges_vu_prepare_user;
+go
+
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-revoke REFERENCES on column_privileges_vu_prepare_tb2(arg3) from column_privileges_vu_prepare_user;
+create view column_privileges_vu_prepare_view as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-revoke INSERT on column_privileges_vu_prepare_tb2(arg4) from column_privileges_vu_prepare_user;
+create procedure column_privileges_vu_prepare_proc as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+create function column_privileges_vu_prepare_func() returns table as return(select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type);
 go
 
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
@@ -19,7 +40,22 @@ go
 revoke UPDATE on column_privileges_vu_prepare_tb1(arg2) from column_privileges_vu_prepare_user;
 go
 
+revoke INSERT on column_privileges_vu_prepare_tb2(arg3) from column_privileges_vu_prepare_user;
+go
+
+revoke REFERENCES on column_privileges_vu_prepare_tb2(arg4) from column_privileges_vu_prepare_user;
+go
+
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' order by table_name,column_name,privilege_type;
+go
+
+drop function column_privileges_vu_prepare_func;
+go
+
+drop procedure column_privileges_vu_prepare_proc;
+go
+
+drop view column_privileges_vu_prepare_view;
 go
 
 drop table column_privileges_vu_prepare_tb1;

--- a/test/JDBC/input/column_privileges-vu-verify.sql
+++ b/test/JDBC/input/column_privileges-vu-verify.sql
@@ -1,0 +1,42 @@
+use column_privileges_vu_prepare_db;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+revoke REFERENCES on column_privileges_vu_prepare_tb2(arg3) from column_privileges_vu_prepare_user;
+go
+
+revoke INSERT on column_privileges_vu_prepare_tb2(arg4) from column_privileges_vu_prepare_user;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+go
+
+revoke SELECT on column_privileges_vu_prepare_tb1(arg1) from column_privileges_vu_prepare_user;
+go
+
+revoke UPDATE on column_privileges_vu_prepare_tb1(arg2) from column_privileges_vu_prepare_user;
+go
+
+select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' order by table_name,column_name,privilege_type;
+go
+
+drop table column_privileges_vu_prepare_tb1;
+go
+
+drop table column_privileges_vu_prepare_tb2;
+go
+
+drop user column_privileges_vu_prepare_user;
+go
+
+drop login column_privileges_vu_prepare_log;
+go
+
+use master;
+go
+
+drop database column_privileges_vu_prepare_db;
+go
+

--- a/test/JDBC/input/column_privileges-vu-verify.sql
+++ b/test/JDBC/input/column_privileges-vu-verify.sql
@@ -22,13 +22,13 @@ go
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-create view column_privileges_vu_prepare_view as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+create view column_privileges_vu_verify_view as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-create procedure column_privileges_vu_prepare_proc as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
+create procedure column_privileges_vu_verify_proc as select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
 go
 
-create function column_privileges_vu_prepare_func() returns table as return(select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type);
+create function column_privileges_vu_verify_func() returns table as return(select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type);
 go
 
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,column_name,privilege_type;
@@ -49,13 +49,13 @@ go
 select * from information_schema.column_privileges where table_name like 'column_privileges_vu_prepare_tb%' order by table_name,column_name,privilege_type;
 go
 
-drop function column_privileges_vu_prepare_func;
+drop function column_privileges_vu_verify_func;
 go
 
-drop procedure column_privileges_vu_prepare_proc;
+drop procedure column_privileges_vu_verify_proc;
 go
 
-drop view column_privileges_vu_prepare_view;
+drop view column_privileges_vu_verify_view;
 go
 
 drop table column_privileges_vu_prepare_tb1;

--- a/test/JDBC/input/column_privileges-vu-verify.sql
+++ b/test/JDBC/input/column_privileges-vu-verify.sql
@@ -1,6 +1,3 @@
-use column_privileges_vu_prepare_db;
-go
-
 create login column_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
 GO
 
@@ -68,11 +65,5 @@ drop user column_privileges_vu_prepare_user;
 go
 
 drop login column_privileges_vu_prepare_log;
-go
-
-use master;
-go
-
-drop database column_privileges_vu_prepare_db;
 go
 

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -108,4 +108,5 @@ BABEL-741
 BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
+column_privileges
 BABEL-1683

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -119,4 +119,5 @@ BABEL-3147-before-14_5
 BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
+column_privileges
 BABEL-1683

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -152,4 +152,5 @@ tdscollation
 sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
+column_privileges
 BABEL-1683

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -154,4 +154,5 @@ tdscollation
 sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
+column_privileges
 BABEL-1683

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -167,4 +167,5 @@ sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
 bitwise_not-operator
+column_privileges
 BABEL-1683

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -1008,6 +1008,7 @@ Type sys.cursor
 Type sys.rowversion
 View information_schema_tsql.check_constraints
 View information_schema_tsql.column_domain_usage
+View information_schema_tsql.column_privileges
 View information_schema_tsql.columns
 View information_schema_tsql.constraint_column_usage
 View information_schema_tsql.domains


### PR DESCRIPTION
### Description

Currently Babelfish does not support
information_schema_tsql.column_privileges. This commit updates this
state by implementing the view.

TASK:

Author: Ozzy Nolen <oscarno@amazon.com>
Signed-off by:
 
### Issues Resolved

- The view information_schema_tsql.column_privileges not implemented


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).