### PR TITLE
Fix crash in numeric_add_opt_error for TSQL hook

### DIFF
--- a/test/JDBC/expected/numericOverflow.out
+++ b/test/JDBC/expected/numericOverflow.out
@@ -100,3 +100,31 @@ numeric
 
 ~~ERROR (Message: numeric field overflow)~~
 
+
+drop table num_t1;
+go
+
+-- BABEL-3450 (Zero produced as result of numeric operation is causing crash)
+create table num_zero(a numeric(5, 2));
+go
+
+insert into num_zero values(123.45);
+go
+~~ROW COUNT: 1~~
+
+
+insert into num_zero values(-123.45);
+go
+~~ROW COUNT: 1~~
+
+
+select sum(a) from num_zero;
+go
+~~START~~
+numeric
+0.00
+~~END~~
+
+
+drop table num_zero;
+go

--- a/test/JDBC/input/numericOverflow.sql
+++ b/test/JDBC/input/numericOverflow.sql
@@ -52,3 +52,22 @@ go
 
 select cast(a as numeric) from num_t1;
 go
+
+drop table num_t1;
+go
+
+-- BABEL-3450 (Zero produced as result of numeric operation is causing crash)
+create table num_zero(a numeric(5, 2));
+go
+
+insert into num_zero values(123.45);
+go
+
+insert into num_zero values(-123.45);
+go
+
+select sum(a) from num_zero;
+go
+
+drop table num_zero;
+go


### PR DESCRIPTION
###Description

Fix includes adding NULL check on NumericVar.digits before calling
numeric overflow detection function

Task: BABEL-3450
Signed-off-by: Satarupa Biswas [satarupb@amazon.com](mailto:satarupb@amazon.com)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).