### PR TITLE
Removing unnecessary initialisation of function pointer pltsql_plugin_handler_ptr->TdsGetEncodingFromLcid

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -196,7 +196,6 @@ pe_tds_init(void)
 	pltsql_plugin_handler_ptr->set_db_stat_var = &TdsSetDatabaseStatVariable;
 	pltsql_plugin_handler_ptr->get_stat_values = &tds_stat_get_activity;
 	pltsql_plugin_handler_ptr->invalidate_stat_view = &invalidate_stat_table;
-	pltsql_plugin_handler_ptr->TdsGetEncodingFromLcid = &TdsLookupEncodingByLCID;
 	pltsql_plugin_handler_ptr->get_host_name = &get_tds_host_name;
 
 	invalidate_stat_table_hook = invalidate_stat_table;


### PR DESCRIPTION
### Description

Removing unnecessary initialisation of function pointer pltsql_plugin_handler_ptr->TdsGetEncodingFromLcid

Removing unnecessary initialisation of function pointer pltsql_plugin_handler_ptr->TdsGetEncodingFromLcid because it is of no use
and same if removed from PLtsql_protocol_plugin structure also.

Task: No-jira
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).