### PR TITLE
Update ownership upgrade tests

### DIFF
--- a/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
@@ -1,8 +1,3 @@
--- psql
-DROP USER IF EXISTS babel_login_vu_prepare_foo;
-DROP USER IF EXISTS babel_login_vu_prepare_su_user;
-go
-
 -- tsql
 DROP PROC babel_login_vu_prepare_proc
 go

--- a/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
@@ -1,8 +1,3 @@
--- psql
-CREATE USER babel_login_vu_prepare_foo WITH LOGIN PASSWORD 'abc';
-CREATE USER babel_login_vu_prepare_su_user WITH SUPERUSER LOGIN PASSWORD 'abc';
-go
-
 -- tsql
 -- Create Login through tsql
 CREATE LOGIN babel_login_vu_prepare_r1 WITH PASSWORD = 'abc';

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -1,21 +1,3 @@
--- tsql      user=babel_login_vu_prepare_foo      password=abc
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: "babel_login_vu_prepare_foo" is not a Babelfish user )~~
-
--- Login with non babelfish user should fail
-go
-
--- tsql      user=babel_login_vu_prepare_su_user      password=abc
--- Login with a superuser should succeed
-SELECT 1;
-go
-~~START~~
-int
-1
-~~END~~
-
-
 -- tsql
 CREATE USER babel_login_vu_prepare_r1;
 go

--- a/test/JDBC/expected/BABEL-ROLE-vu-verify.out
+++ b/test/JDBC/expected/BABEL-ROLE-vu-verify.out
@@ -242,7 +242,7 @@ babel_role_vu_prepare_role2#!#R#!#babel_role_vu_prepare_user3#!#S
 ~~END~~
 
 
--- tsql		user=babel_role_vu_prepare_login2		password=123
+-- tsql		user=babel_role_vu_prepare_login2		password=abc
 -- DB user is disallowed to add/drop itself to/from a role
 USE babel_role_vu_prepare_db
 GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
@@ -1,8 +1,3 @@
--- psql
-DROP USER IF EXISTS babel_login_vu_prepare_foo;
-DROP USER IF EXISTS babel_login_vu_prepare_su_user;
-go
-
 -- tsql
 DROP PROC babel_login_vu_prepare_proc
 go

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
@@ -1,8 +1,3 @@
--- psql
-CREATE USER babel_login_vu_prepare_foo WITH LOGIN PASSWORD 'abc';
-CREATE USER babel_login_vu_prepare_su_user WITH SUPERUSER LOGIN PASSWORD 'abc';
-go
-
 -- Create Login through tsql
 -- tsql
 CREATE LOGIN babel_login_vu_prepare_r1 WITH PASSWORD = 'abc';

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -1,12 +1,3 @@
--- tsql      user=babel_login_vu_prepare_foo      password=abc
--- Login with non babelfish user should fail
-go
-
--- Login with a superuser should succeed
--- tsql      user=babel_login_vu_prepare_su_user      password=abc
-SELECT 1;
-go
-
 -- tsql
 CREATE USER babel_login_vu_prepare_r1;
 go

--- a/test/JDBC/input/ownership/BABEL-ROLE-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-ROLE-vu-verify.mix
@@ -119,7 +119,7 @@ EXEC babel_role_vu_prepare_role_members
 GO
 
 -- DB user is disallowed to add/drop itself to/from a role
--- tsql		user=babel_role_vu_prepare_login2		password=123
+-- tsql		user=babel_role_vu_prepare_login2		password=abc
 USE babel_role_vu_prepare_db
 GO
 SELECT USER_NAME()


### PR DESCRIPTION
This commit updates ownership upgrade tests in order to
1. Fix BABEL-ROLE-vu-verify test failure on pre-prod instance
2. Remove one test case from BABEL-LOGIN since it's GitFarm only feature

Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).