### PR TITLE
Handle the MAXDOP hint specially if the hint value is 0

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -3248,7 +3248,17 @@ void extractQueryHintsFromOptionClause(TSqlParser::Option_clauseContext *octx)
 		{
 			std::string value = ::getFullText(option->DECIMAL());
 			if (!value.empty())
+			{
+				/* 
+				 * The MAXDOP hint should be handled specially the hint value is 0
+				 * This is because in T-SQL, setting MAXDOP to 0 allows SQL Server to use all the available processors up to 64 processors
+ 				 * However, if we set the GUC max_parallel_workers_per_gather to 0, it disables parallelism in P-SQL
+ 				 * Thus, we need to set the GUC value to 64 instead.
+ 				 */
+				if (stoi(value) == 0)
+					value = "64";
 				query_hints.push_back("Set(max_parallel_workers_per_gather " + value + ")");
+			}
 		}
 	}
 

--- a/test/JDBC/expected/BABEL-3294.out
+++ b/test/JDBC/expected/BABEL-3294.out
@@ -51,6 +51,43 @@ off
 set babelfish_showplan_all on
 go
 
+/*
+ * Run a SELECT query without any hints to ensure that un-hinted queries still work
+ * It uses 2 workers as it is the deault value for the GUC max_parallel_workers_per_gather
+ */
+select * from babel_3294_t1 t1 where a1 = 1
+go
+~~START~~
+text
+Query Text: select * from babel_3294_t1 t1 where a1 = 1
+Gather
+  Workers Planned: 2
+  ->  Parallel Seq Scan on babel_3294_t1 t1
+        Filter: (a1 = 1)
+~~END~~
+
+
+/*
+ * The MAXDOP hint should be handled specially the hint value is 0
+ * This is because in T-SQL, setting MAXDOP to 0 allows SQL Server to use all the available processors up to 64 processors
+ * However, if we set the GUC max_parallel_workers_per_gather to 0, it disables parallelism in P-SQL
+ * Thus, we need to set the GUC value to 64 instead. The planner however will use 16 workers as we only have 16 workers available
+ */
+select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 0)
+go
+~~START~~
+text
+Query Text: /*+ Set(max_parallel_workers_per_gather 64) */ select * from babel_3294_t1 t1 where a1 = 1                 
+Gather
+  Workers Planned: 16
+  ->  Parallel Seq Scan on babel_3294_t1 t1
+        Filter: (a1 = 1)
+~~END~~
+
+
+/*
+ * Run SELECT queries and give the MAXDOP hint with different values to verify the hint is actually getting mapped
+ */
 select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 1)
 go
 ~~START~~

--- a/test/JDBC/pg_hint_plan/BABEL-3294.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3294.sql
@@ -26,6 +26,25 @@ go
 set babelfish_showplan_all on
 go
 
+/*
+ * Run a SELECT query without any hints to ensure that un-hinted queries still work
+ * It uses 2 workers as it is the deault value for the GUC max_parallel_workers_per_gather
+ */
+select * from babel_3294_t1 t1 where a1 = 1
+go
+
+/*
+ * The MAXDOP hint should be handled specially the hint value is 0
+ * This is because in T-SQL, setting MAXDOP to 0 allows SQL Server to use all the available processors up to 64 processors
+ * However, if we set the GUC max_parallel_workers_per_gather to 0, it disables parallelism in P-SQL
+ * Thus, we need to set the GUC value to 64 instead. The planner however will use 16 workers as we only have 16 workers available
+ */
+select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 0)
+go
+
+/*
+ * Run SELECT queries and give the MAXDOP hint with different values to verify the hint is actually getting mapped
+ */
 select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 1)
 go
 


### PR DESCRIPTION
### Description

In T-SQL, Setting max degree of parallelism (MAXDOP) to 0 allows SQL Server to use all the available processors up to 64 processors. However, we map the MAXDOP hint by setting the GUC max_parallel_workers_per_gather to the value given in the hint. Setting max_parallel_workers_per_gather to 0 however disables the use of parallel workers by utility commands.
To address this, we need to set max_parallel_workers_per_gather  to 64

 
### Issues Resolved

Task: BABEL-3475


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).