### PR TITLE
Support TSQLs information_schema_tsql.table_privileges view

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -716,4 +716,46 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
+CREATE OR REPLACE VIEW information_schema_tsql.table_privileges
+AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_grantor.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST((select orig_username from sys.babelfish_authid_user_ext where grantee.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTEE",
+    CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST(c.relname AS sys.sysname) AS "TABLE_NAME",
+    CAST(c.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
+        CASE
+            WHEN pg_has_role(grantee.oid, c.relowner, 'USAGE'::text) OR c.grantable THEN 'YES'::text
+            ELSE 'NO'::text
+        END::sys."varchar"(3) AS is_grantable,
+        CASE
+            WHEN c.prtype = 'SELECT'::text THEN 'YES'::text
+            ELSE 'NO'::text
+        END::information_schema.yes_or_no AS with_hierarchy
+   FROM ( SELECT pg_class.oid,
+            pg_class.relname,
+            pg_class.relnamespace,
+            pg_class.relkind,
+            pg_class.relowner,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantor AS grantor,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantee AS grantee,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
+           FROM pg_class) c(oid, relname, relnamespace, relkind, relowner, grantor, grantee, prtype, grantable),
+    pg_namespace nc,
+    pg_roles u_grantor,
+    ( SELECT pg_roles.oid,
+            pg_roles.rolname
+           FROM pg_roles
+        UNION ALL
+         SELECT 0::oid AS oid,
+            'PUBLIC'::name) grantee(oid, rolname)
+  WHERE c.relnamespace = nc.oid 
+ AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) 
+AND c.grantee = grantee.oid AND c.grantor = u_grantor.oid 
+AND (c.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'DELETE'::text, 'TRUNCATE'::text, 'REFERENCES'::text, 'TRIGGER'::text])) 
+AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+  
+  
+GRANT SELECT ON information_schema_tsql.table_privileges TO PUBLIC;
+
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -717,10 +717,10 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
 CREATE OR REPLACE VIEW information_schema_tsql.table_privileges
-AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_grantor.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTOR",
-    CAST((select orig_username from sys.babelfish_authid_user_ext where grantee.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTEE",
-    CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+AS SELECT CAST(extc.orig_username AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST(extr.orig_username AS sys.nvarchar(128)) AS "GRANTEE",
+    CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(c.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(c.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
         CAST(CASE
@@ -741,19 +741,20 @@ AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_
             (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
             (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
            FROM pg_class) c(oid, relname, relnamespace, relkind, relowner, grantor, grantee, prtype, grantable),
-    pg_namespace nc,
-    pg_roles u_grantor,
+    sys.pg_namespace_ext nc  LEFT OUTER JOIN sys.babelfish_namespace_ext ext ON nc.nspname = ext.nspname,
+    pg_roles u_grantor LEFT OUTER JOIN sys.babelfish_authid_user_ext extc ON u_grantor.rolname = extc.rolname,
     ( SELECT pg_roles.oid,
             pg_roles.rolname
            FROM pg_roles
         UNION ALL
          SELECT 0::oid AS oid,
-            'PUBLIC'::name) grantee(oid, rolname)
+            'PUBLIC'::name) grantee(oid, rolname) LEFT OUTER JOIN sys.babelfish_authid_user_ext extr ON grantee.rolname = extr.rolname
   WHERE c.relnamespace = nc.oid 
  AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) 
 AND c.grantee = grantee.oid AND c.grantor = u_grantor.oid 
 AND (c.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'DELETE'::text, 'TRUNCATE'::text, 'REFERENCES'::text, 'TRIGGER'::text])) 
-AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name)
+AND ext.dbid = CAST(sys.db_id() AS oid);
   
    
 GRANT SELECT ON information_schema_tsql.table_privileges TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -723,14 +723,14 @@ AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_
     CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(c.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(c.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
-        CASE
-            WHEN pg_has_role(grantee.oid, c.relowner, 'USAGE'::text) OR c.grantable THEN 'YES'::text
-            ELSE 'NO'::text
-        END::sys."varchar"(3) AS is_grantable,
-        CASE
-            WHEN c.prtype = 'SELECT'::text THEN 'YES'::text
-            ELSE 'NO'::text
-        END::information_schema.yes_or_no AS with_hierarchy
+        CAST(CASE
+            WHEN pg_has_role(grantee.oid, c.relowner, CAST('USAGE' AS text)) OR c.grantable THEN CAST('YES' AS text)
+            ELSE CAST('NO' AS text)
+        END AS sys."varchar"(3)) AS "IS_GRANTABLE",
+        CAST(CASE
+            WHEN c.prtype = CAST('SELECT' AS text) THEN CAST('YES' AS text)
+            ELSE CAST('NO' AS text)
+        END AS sys."varchar"(3)) AS "WITH_HIERARCHY"
    FROM ( SELECT pg_class.oid,
             pg_class.relname,
             pg_class.relnamespace,
@@ -755,7 +755,7 @@ AND c.grantee = grantee.oid AND c.grantor = u_grantor.oid
 AND (c.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'DELETE'::text, 'TRUNCATE'::text, 'REFERENCES'::text, 'TRIGGER'::text])) 
 AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
   
-  
+   
 GRANT SELECT ON information_schema_tsql.table_privileges TO PUBLIC;
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -1324,6 +1324,48 @@ FROM (
 
 GRANT SELECT ON information_schema_tsql.CONSTRAINT_COLUMN_USAGE TO PUBLIC;
 
+CREATE OR REPLACE VIEW information_schema_tsql.table_privileges
+AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_grantor.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTOR",
+    CAST((select orig_username from sys.babelfish_authid_user_ext where grantee.rolname = rolname) AS sys.nvarchar(128)) AS "GRANTEE",
+    CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST(c.relname AS sys.sysname) AS "TABLE_NAME",
+    CAST(c.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
+        CASE
+            WHEN pg_has_role(grantee.oid, c.relowner, 'USAGE'::text) OR c.grantable THEN 'YES'::text
+            ELSE 'NO'::text
+        END::sys."varchar"(3) AS is_grantable,
+        CASE
+            WHEN c.prtype = 'SELECT'::text THEN 'YES'::text
+            ELSE 'NO'::text
+        END::information_schema.yes_or_no AS with_hierarchy
+   FROM ( SELECT pg_class.oid,
+            pg_class.relname,
+            pg_class.relnamespace,
+            pg_class.relkind,
+            pg_class.relowner,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantor AS grantor,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).grantee AS grantee,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).privilege_type AS privilege_type,
+            (aclexplode(COALESCE(pg_class.relacl, acldefault('r'::"char", pg_class.relowner)))).is_grantable AS is_grantable
+           FROM pg_class) c(oid, relname, relnamespace, relkind, relowner, grantor, grantee, prtype, grantable),
+    pg_namespace nc,
+    pg_roles u_grantor,
+    ( SELECT pg_roles.oid,
+            pg_roles.rolname
+           FROM pg_roles
+        UNION ALL
+         SELECT 0::oid AS oid,
+            'PUBLIC'::name) grantee(oid, rolname)
+  WHERE c.relnamespace = nc.oid 
+ AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])) 
+AND c.grantee = grantee.oid AND c.grantor = u_grantor.oid 
+AND (c.prtype = ANY (ARRAY['INSERT'::text, 'SELECT'::text, 'UPDATE'::text, 'DELETE'::text, 'TRUNCATE'::text, 'REFERENCES'::text, 'TRIGGER'::text])) 
+AND (pg_has_role(u_grantor.oid, 'USAGE'::text) OR pg_has_role(grantee.oid, 'USAGE'::text) OR grantee.rolname = 'PUBLIC'::name);
+  
+  
+GRANT SELECT ON information_schema_tsql.table_privileges TO PUBLIC;
+
 CREATE OR REPLACE VIEW sys.filetables
 AS
 SELECT 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -1331,14 +1331,14 @@ AS SELECT CAST((select orig_username from sys.babelfish_authid_user_ext where u_
     CAST((select orig_name from sys.babelfish_namespace_ext where nc.nspname = nspname) AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
     CAST(c.relname AS sys.sysname) AS "TABLE_NAME",
     CAST(c.prtype AS sys."varchar"(10)) AS "PRIVILEGE_TYPE",
-        CASE
-            WHEN pg_has_role(grantee.oid, c.relowner, 'USAGE'::text) OR c.grantable THEN 'YES'::text
-            ELSE 'NO'::text
-        END::sys."varchar"(3) AS is_grantable,
-        CASE
-            WHEN c.prtype = 'SELECT'::text THEN 'YES'::text
-            ELSE 'NO'::text
-        END::information_schema.yes_or_no AS with_hierarchy
+        CAST(CASE
+            WHEN pg_has_role(grantee.oid, c.relowner, CAST('USAGE' AS text)) OR c.grantable THEN CAST('YES' AS text)
+            ELSE CAST('NO' AS text)
+        END AS sys."varchar"(3)) AS "IS_GRANTABLE",
+        CAST(CASE
+            WHEN c.prtype = CAST('SELECT' AS text) THEN CAST('YES' AS text)
+            ELSE CAST('NO' AS text)
+        END AS sys."varchar"(3)) AS "WITH_HIERARCHY"
    FROM ( SELECT pg_class.oid,
             pg_class.relname,
             pg_class.relnamespace,

--- a/test/JDBC/expected/table_privileges-vu-prepare.out
+++ b/test/JDBC/expected/table_privileges-vu-prepare.out
@@ -1,0 +1,5 @@
+create table table_privileges_vu_prepare_tb1(arg1 int, arg2 int);
+go
+
+create table table_privileges_vu_prepare_tb2(arg3 int, arg4 int);
+go

--- a/test/JDBC/expected/table_privileges-vu-verify.out
+++ b/test/JDBC/expected/table_privileges-vu-verify.out
@@ -1,0 +1,95 @@
+create login table_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
+GO
+
+create user table_privileges_vu_prepare_user FOR LOGIN table_privileges_vu_prepare_log;
+GO
+
+grant SELECT on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant UPDATE on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on table_privileges_vu_prepare_tb2 to table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#SELECT#!#NO#!#YES
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#UPDATE#!#NO#!#NO
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#REFERENCES#!#NO#!#NO
+~~END~~
+
+
+
+create view table_privileges_vu_verify_view as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create procedure table_privileges_vu_verify_proc as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create function table_privileges_vu_verify_func() returns table as return(select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type);
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#SELECT#!#NO#!#YES
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#UPDATE#!#NO#!#NO
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#REFERENCES#!#NO#!#NO
+~~END~~
+
+
+revoke SELECT on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke UPDATE on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke REFERENCES on table_privileges_vu_prepare_tb2 from table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#DELETE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#INSERT#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#REFERENCES#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#SELECT#!#YES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#TRIGGER#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#TRUNCATE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#UPDATE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#DELETE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#INSERT#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#REFERENCES#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#SELECT#!#YES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#TRIGGER#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#TRUNCATE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#UPDATE#!#YES#!#NO
+~~END~~
+
+
+drop function table_privileges_vu_verify_func;
+go
+
+drop procedure table_privileges_vu_verify_proc;
+go
+
+drop view table_privileges_vu_verify_view;
+go
+
+drop table table_privileges_vu_prepare_tb1;
+go
+
+drop table table_privileges_vu_prepare_tb2;
+go
+
+drop user table_privileges_vu_prepare_user;
+go
+
+drop login table_privileges_vu_prepare_log;
+go

--- a/test/JDBC/expected/table_privileges.out
+++ b/test/JDBC/expected/table_privileges.out
@@ -1,0 +1,101 @@
+create table table_privileges_vu_prepare_tb1(arg1 int, arg2 int);
+go
+
+create table table_privileges_vu_prepare_tb2(arg3 int, arg4 int);
+go
+
+create login table_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
+GO
+
+create user table_privileges_vu_prepare_user FOR LOGIN table_privileges_vu_prepare_log;
+GO
+
+grant SELECT on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant UPDATE on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on table_privileges_vu_prepare_tb2 to table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#SELECT#!#NO#!#YES
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#UPDATE#!#NO#!#NO
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#REFERENCES#!#NO#!#NO
+~~END~~
+
+
+
+create view table_privileges_vu_verify_view as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create procedure table_privileges_vu_verify_proc as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create function table_privileges_vu_verify_func() returns table as return(select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type);
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#SELECT#!#NO#!#YES
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#UPDATE#!#NO#!#NO
+dbo#!#table_privileges_vu_prepare_user#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#REFERENCES#!#NO#!#NO
+~~END~~
+
+
+revoke SELECT on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke UPDATE on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke REFERENCES on table_privileges_vu_prepare_tb2 from table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#DELETE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#INSERT#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#REFERENCES#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#SELECT#!#YES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#TRIGGER#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#TRUNCATE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb1#!#UPDATE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#DELETE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#INSERT#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#REFERENCES#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#SELECT#!#YES#!#YES
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#TRIGGER#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#TRUNCATE#!#YES#!#NO
+dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#UPDATE#!#YES#!#NO
+~~END~~
+
+
+drop function table_privileges_vu_verify_func;
+go
+
+drop procedure table_privileges_vu_verify_proc;
+go
+
+drop view table_privileges_vu_verify_view;
+go
+
+drop table table_privileges_vu_prepare_tb1;
+go
+
+drop table table_privileges_vu_prepare_tb2;
+go
+
+drop user table_privileges_vu_prepare_user;
+go
+
+drop login table_privileges_vu_prepare_log;
+go

--- a/test/JDBC/expected/table_privileges.out
+++ b/test/JDBC/expected/table_privileges.out
@@ -1,3 +1,6 @@
+use master;
+go
+
 create table table_privileges_vu_prepare_tb1(arg1 int, arg2 int);
 go
 
@@ -6,6 +9,9 @@ go
 
 create login table_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
 GO
+
+create database table_privileges_test_db;
+go
 
 create user table_privileges_vu_prepare_user FOR LOGIN table_privileges_vu_prepare_log;
 GO
@@ -79,6 +85,29 @@ dbo#!#dbo#!#master#!#dbo#!#table_privileges_vu_prepare_tb2#!#UPDATE#!#YES#!#NO
 ~~END~~
 
 
+create schema table_privileges_test_sc;
+go
+
+create table table_privileges_test_sc.table_privileges_tb3(arg1 int, arg2 int);
+go
+
+grant SELECT on table_privileges_test_sc.table_privileges_tb3 to table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_tb%' and is_grantable='NO' order by table_name,privilege_type;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#table_privileges_vu_prepare_user#!#master#!#table_privileges_test_sc#!#table_privileges_tb3#!#SELECT#!#NO#!#YES
+~~END~~
+
+
+drop table table_privileges_test_sc.table_privileges_tb3;
+go
+
+drop schema table_privileges_test_sc;
+go
+
 drop function table_privileges_vu_verify_func;
 go
 
@@ -98,4 +127,7 @@ drop user table_privileges_vu_prepare_user;
 go
 
 drop login table_privileges_vu_prepare_log;
+go
+
+drop database table_privileges_test_db;
 go

--- a/test/JDBC/input/views/table_privileges-vu-prepare.sql
+++ b/test/JDBC/input/views/table_privileges-vu-prepare.sql
@@ -1,0 +1,5 @@
+create table table_privileges_vu_prepare_tb1(arg1 int, arg2 int);
+go
+
+create table table_privileges_vu_prepare_tb2(arg3 int, arg4 int);
+go

--- a/test/JDBC/input/views/table_privileges-vu-verify.sql
+++ b/test/JDBC/input/views/table_privileges-vu-verify.sql
@@ -1,0 +1,63 @@
+create login table_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
+GO
+
+create user table_privileges_vu_prepare_user FOR LOGIN table_privileges_vu_prepare_log;
+GO
+
+grant SELECT on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant UPDATE on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on table_privileges_vu_prepare_tb2 to table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+
+
+create view table_privileges_vu_verify_view as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create procedure table_privileges_vu_verify_proc as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create function table_privileges_vu_verify_func() returns table as return(select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type);
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+
+revoke SELECT on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke UPDATE on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke REFERENCES on table_privileges_vu_prepare_tb2 from table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' order by table_name,privilege_type;
+go
+
+drop function table_privileges_vu_verify_func;
+go
+
+drop procedure table_privileges_vu_verify_proc;
+go
+
+drop view table_privileges_vu_verify_view;
+go
+
+drop table table_privileges_vu_prepare_tb1;
+go
+
+drop table table_privileges_vu_prepare_tb2;
+go
+
+drop user table_privileges_vu_prepare_user;
+go
+
+drop login table_privileges_vu_prepare_log;
+go

--- a/test/JDBC/input/views/table_privileges.sql
+++ b/test/JDBC/input/views/table_privileges.sql
@@ -1,3 +1,6 @@
+use master;
+go
+
 create table table_privileges_vu_prepare_tb1(arg1 int, arg2 int);
 go
 
@@ -6,6 +9,9 @@ go
 
 create login table_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
 GO
+
+create database table_privileges_test_db;
+go
 
 create user table_privileges_vu_prepare_user FOR LOGIN table_privileges_vu_prepare_log;
 GO
@@ -47,6 +53,24 @@ go
 select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' order by table_name,privilege_type;
 go
 
+create schema table_privileges_test_sc;
+go
+
+create table table_privileges_test_sc.table_privileges_tb3(arg1 int, arg2 int);
+go
+
+grant SELECT on table_privileges_test_sc.table_privileges_tb3 to table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_tb%' and is_grantable='NO' order by table_name,privilege_type;
+go
+
+drop table table_privileges_test_sc.table_privileges_tb3;
+go
+
+drop schema table_privileges_test_sc;
+go
+
 drop function table_privileges_vu_verify_func;
 go
 
@@ -66,4 +90,7 @@ drop user table_privileges_vu_prepare_user;
 go
 
 drop login table_privileges_vu_prepare_log;
+go
+
+drop database table_privileges_test_db;
 go

--- a/test/JDBC/input/views/table_privileges.sql
+++ b/test/JDBC/input/views/table_privileges.sql
@@ -1,0 +1,69 @@
+create table table_privileges_vu_prepare_tb1(arg1 int, arg2 int);
+go
+
+create table table_privileges_vu_prepare_tb2(arg3 int, arg4 int);
+go
+
+create login table_privileges_vu_prepare_log WITH PASSWORD = 'YourSecretPassword1234#';
+GO
+
+create user table_privileges_vu_prepare_user FOR LOGIN table_privileges_vu_prepare_log;
+GO
+
+grant SELECT on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant UPDATE on table_privileges_vu_prepare_tb1 to table_privileges_vu_prepare_user;
+go
+
+grant REFERENCES on table_privileges_vu_prepare_tb2 to table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+
+
+create view table_privileges_vu_verify_view as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create procedure table_privileges_vu_verify_proc as select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type;
+go
+
+create function table_privileges_vu_verify_func() returns table as return(select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable='NO' order by table_name,table_name,privilege_type);
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' and is_grantable = 'NO' order by table_name,privilege_type;
+go
+
+revoke SELECT on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke UPDATE on table_privileges_vu_prepare_tb1 from table_privileges_vu_prepare_user;
+go
+
+revoke REFERENCES on table_privileges_vu_prepare_tb2 from table_privileges_vu_prepare_user;
+go
+
+select * from information_schema.table_privileges where table_name like 'table_privileges_vu_prepare_tb%' order by table_name,privilege_type;
+go
+
+drop function table_privileges_vu_verify_func;
+go
+
+drop procedure table_privileges_vu_verify_proc;
+go
+
+drop view table_privileges_vu_verify_view;
+go
+
+drop table table_privileges_vu_prepare_tb1;
+go
+
+drop table table_privileges_vu_prepare_tb2;
+go
+
+drop user table_privileges_vu_prepare_user;
+go
+
+drop login table_privileges_vu_prepare_log;
+go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -168,3 +168,4 @@ sys-assemblies
 BABEL-LOGIN-USER-EXT
 bitwise_not-operator
 BABEL-1683
+table_privileges

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -1013,6 +1013,7 @@ View information_schema_tsql.constraint_column_usage
 View information_schema_tsql.domains
 View information_schema_tsql.routines
 View information_schema_tsql.table_constraints
+View information_schema_tsql.table_privileges
 View information_schema_tsql.tables
 View information_schema_tsql.views
 View sys.all_columns


### PR DESCRIPTION
Task: JIRA pending
Authored-by: Sid Patllollu [sidred@amazon.com](mailto:sidred@amazon.com)
Signed-off-by:

### Description

Currently, Babelfish does not support TSQL's
information_schema_tsql.table_privileges. This commit implements this
view and provides testing.
 
### Issues Resolved

The view information_schema_tsql.table_privileges not implemented

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).