### PR TITLE
Fix execution order of JDBC tests

### DIFF
--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -174,15 +174,23 @@ public class TestQueryFile {
         // if this is a normal JDBC test run, we need to run the prepare, verify
         // and cleanup scripts for one use-case, one after the other
         if (!isUpgradeTestMode) {
+            // first sort all files based only on file prefix
             Collections.sort(fileList, new Comparator<String>() {
-                // sort in such a way that filenames that have same prefix should run
-                // prepare file first, verify file next and cleanup file at the end
+                @Override
+                public int compare (String file1, String file2) {
+                    return getFileNamePrefix(file1).compareTo(getFileNamePrefix(file2));
+                }
+            });
+
+            // next sort in such a way that filenames that have same prefix should
+            // run prepare file first, verify file next and cleanup file at the end
+            Collections.sort(fileList, new Comparator<String>() {
                 @Override
                 public int compare (String file1, String file2) {
                     if (getFileNamePrefix(file1).equals(getFileNamePrefix(file2))) {
                         return getFileOrderUtil(file1) - getFileOrderUtil(file2);
                     } else {
-                        return file1.compareTo(file2);
+                        return 0;
                     }
                 }
             });


### PR DESCRIPTION
### Description

Previously the test execution order was dependent on the order in which
the files were read and populated into the ArrayList. Fixed this by
first sorting the files based on file prefix and then later sorting them
based on the fact that prepare test scripts should be executed first
followed by verify and cleanup respectively.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).