### PR TITLE
Added support for tsql referential constraints

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -717,3 +717,5 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+<<<<<<< HEAD
+=======

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -717,5 +717,47 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
-<<<<<<< HEAD
-=======
+
+
+CREATE OR REPLACE VIEW information_schema_tsql.referential_constraints
+AS SELECT sys.db_name()::information_schema.sql_identifier AS constraint_catalog,
+    ncon.nspname::information_schema.sql_identifier AS constraint_schema,
+    con.conname::information_schema.sql_identifier AS constraint_name,
+        CASE
+            WHEN npkc.nspname IS NULL THEN NULL::name
+            ELSE current_database()
+        END::information_schema.sql_identifier AS unique_constraint_catalog,
+    npkc.nspname::information_schema.sql_identifier AS unique_constraint_schema,
+    pkc.conname::information_schema.sql_identifier AS unique_constraint_name,
+        CASE con.confmatchtype
+            WHEN 'f'::"char" THEN 'FULL'::text
+            WHEN 'p'::"char" THEN 'PARTIAL'::text
+            WHEN 's'::"char" THEN 'NONE'::text
+            ELSE NULL::text
+        END::information_schema.character_data AS match_option,
+        CASE con.confupdtype
+            WHEN 'c'::"char" THEN 'CASCADE'::text
+            WHEN 'n'::"char" THEN 'SET NULL'::text
+            WHEN 'd'::"char" THEN 'SET DEFAULT'::text
+            WHEN 'r'::"char" THEN 'RESTRICT'::text
+            WHEN 'a'::"char" THEN 'NO ACTION'::text
+            ELSE NULL::text
+        END::information_schema.character_data AS update_rule,
+        CASE con.confdeltype
+            WHEN 'c'::"char" THEN 'CASCADE'::text
+            WHEN 'n'::"char" THEN 'SET NULL'::text
+            WHEN 'd'::"char" THEN 'SET DEFAULT'::text
+            WHEN 'r'::"char" THEN 'RESTRICT'::text
+            WHEN 'a'::"char" THEN 'NO ACTION'::text
+            ELSE NULL::text
+        END::information_schema.character_data AS delete_rule
+   FROM pg_namespace ncon
+     JOIN pg_constraint con ON ncon.oid = con.connamespace
+     JOIN pg_class c ON con.conrelid = c.oid AND con.contype = 'f'::"char"
+     LEFT JOIN pg_depend d1 ON d1.objid = con.oid AND d1.classid = 'pg_constraint'::regclass::oid AND d1.refclassid = 'pg_class'::regclass::oid AND d1.refobjsubid = 0
+     LEFT JOIN pg_depend d2 ON d2.refclassid = 'pg_constraint'::regclass::oid AND d2.classid = 'pg_class'::regclass::oid AND d2.objid = d1.refobjid AND d2.objsubid = 0 AND d2.deptype = 'i'::"char"
+     LEFT JOIN pg_constraint pkc ON pkc.oid = d2.refobjid AND (pkc.contype = ANY (ARRAY['p'::"char", 'u'::"char"])) AND pkc.conrelid = con.confrelid
+     LEFT JOIN pg_namespace npkc ON pkc.connamespace = npkc.oid
+  WHERE pg_has_role(c.relowner, 'USAGE'::text) OR has_table_privilege(c.oid, 'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR has_any_column_privilege(c.oid, 'INSERT, UPDATE, REFERENCES'::text);
+  
+  GRANT SELECT ON information_schema_tsql.referential_constraints TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -3508,3 +3508,5 @@ DROP PROCEDURE sys.babelfish_drop_deprecated_table(varchar, varchar);
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
+<<<<<<< HEAD
+=======

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -3508,5 +3508,47 @@ DROP PROCEDURE sys.babelfish_drop_deprecated_table(varchar, varchar);
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
-<<<<<<< HEAD
-=======
+
+CREATE OR REPLACE VIEW information_schema_tsql.referential_constraints
+AS SELECT sys.db_name()::information_schema.sql_identifier AS constraint_catalog,
+    ncon.nspname::information_schema.sql_identifier AS constraint_schema,
+    con.conname::information_schema.sql_identifier AS constraint_name,
+        CASE
+            WHEN npkc.nspname IS NULL THEN NULL::name
+            ELSE current_database()
+        END::information_schema.sql_identifier AS unique_constraint_catalog,
+    npkc.nspname::information_schema.sql_identifier AS unique_constraint_schema,
+    pkc.conname::information_schema.sql_identifier AS unique_constraint_name,
+        CASE con.confmatchtype
+            WHEN 'f'::"char" THEN 'FULL'::text
+            WHEN 'p'::"char" THEN 'PARTIAL'::text
+            WHEN 's'::"char" THEN 'NONE'::text
+            ELSE NULL::text
+        END::information_schema.character_data AS match_option,
+        CASE con.confupdtype
+            WHEN 'c'::"char" THEN 'CASCADE'::text
+            WHEN 'n'::"char" THEN 'SET NULL'::text
+            WHEN 'd'::"char" THEN 'SET DEFAULT'::text
+            WHEN 'r'::"char" THEN 'RESTRICT'::text
+            WHEN 'a'::"char" THEN 'NO ACTION'::text
+            ELSE NULL::text
+        END::information_schema.character_data AS update_rule,
+        CASE con.confdeltype
+            WHEN 'c'::"char" THEN 'CASCADE'::text
+            WHEN 'n'::"char" THEN 'SET NULL'::text
+            WHEN 'd'::"char" THEN 'SET DEFAULT'::text
+            WHEN 'r'::"char" THEN 'RESTRICT'::text
+            WHEN 'a'::"char" THEN 'NO ACTION'::text
+            ELSE NULL::text
+        END::information_schema.character_data AS delete_rule
+   FROM pg_namespace ncon
+     JOIN pg_constraint con ON ncon.oid = con.connamespace
+     JOIN pg_class c ON con.conrelid = c.oid AND con.contype = 'f'::"char"
+     LEFT JOIN pg_depend d1 ON d1.objid = con.oid AND d1.classid = 'pg_constraint'::regclass::oid AND d1.refclassid = 'pg_class'::regclass::oid AND d1.refobjsubid = 0
+     LEFT JOIN pg_depend d2 ON d2.refclassid = 'pg_constraint'::regclass::oid AND d2.classid = 'pg_class'::regclass::oid AND d2.objid = d1.refobjid AND d2.objsubid = 0 AND d2.deptype = 'i'::"char"
+     LEFT JOIN pg_constraint pkc ON pkc.oid = d2.refobjid AND (pkc.contype = ANY (ARRAY['p'::"char", 'u'::"char"])) AND pkc.conrelid = con.confrelid
+     LEFT JOIN pg_namespace npkc ON pkc.connamespace = npkc.oid
+  WHERE pg_has_role(c.relowner, 'USAGE'::text) OR has_table_privilege(c.oid, 'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR has_any_column_privilege(c.oid, 'INSERT, UPDATE, REFERENCES'::text);
+  
+
+  GRANT SELECT ON information_schema_tsql.referential_constraints TO PUBLIC;

--- a/test/JDBC/expected/referential_constraints.out
+++ b/test/JDBC/expected/referential_constraints.out
@@ -1,0 +1,44 @@
+drop database if exists db_referential_constraints;
+go
+
+create database db_referential_constraints;
+go
+
+Use db_referential_constraints;
+go
+
+select * from information_schema.referential_constraints where constraint_schema not like 'sys%';
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+drop table if exists referential_constraints_tb1;
+go
+
+create table referential_constraints_tb1(arg1 int, arg2 char, arg3 varchar);
+go
+
+drop view if exists referential_constraints_v1;
+go
+
+create view referential_constraints_v1 as select * from referential_constraints_tb1;
+go
+
+select * from information_schema.referential_constraints where constraint_schema not like 'sys';
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+drop view referential_constraints_v1
+go
+
+drop table referential_constraints_tb1
+go
+
+use master;
+go
+

--- a/test/JDBC/input/referential_constraints.sql
+++ b/test/JDBC/input/referential_constraints.sql
@@ -1,0 +1,38 @@
+drop database if exists db_referential_constraints;
+go
+
+create database db_referential_constraints;
+go
+
+Use db_referential_constraints;
+go
+
+select * from information_schema.referential_constraints where constraint_schema not like 'sys%';
+go
+
+drop table if exists referential_constraints_tb1;
+go
+
+create table referential_constraints_tb1(arg1 int, arg2 char, arg3 varchar);
+go
+
+drop view if exists referential_constraints_v1;
+go
+
+create view referential_constraints_v1 as select * from referential_constraints_tb1;
+go
+
+select * from information_schema.referential_constraints where constraint_schema not like 'sys';
+go
+
+drop view referential_constraints_v1
+go
+
+drop table referential_constraints_tb1
+go
+
+use master;
+go
+
+drop database db_referential_constraints;
+go 


### PR DESCRIPTION
Currently Babelfish does not support
information_schema_tsql.referential_constraints. This commit updates this
state by implementing the view.

TASK: JIRA pending
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).