### PR TITLE
Use pstrdup for server_collation_name and default_locale

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -35,7 +35,7 @@ runs:
 
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
         cd postgresql_modified_for_babelfish
-        ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+        ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         make -j 4 2>error.txt
         make install
         make check

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Run JDBC Tests
         id: jdbc
-        timeout-minutes: 25
+        timeout-minutes: 30
         if: always() && steps.run-pg_upgrade.outcome == 'success'
         run: |
           cd test/JDBC/

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -25,7 +25,7 @@ jobs:
           cd ..
           git clone --branch ${{env.ENGINE_BRANCH_FROM}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           cd postgresql_modified_for_babelfish
-          ./configure --prefix=$HOME/${{env.OLD_INSTALL_DIR}} --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          ./configure --prefix=$HOME/${{env.OLD_INSTALL_DIR}} --with-python PYTHON=/usr/bin/python2.7 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
           make clean
           make -j 4 2>error.txt
           make install

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -39,7 +39,7 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
 
 2. Now it's time to build the Postgres engine. In the Postgres engine directory, run these sequence of commands to build the PG engine modified for Babelfish (Github repo: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish):
     ```
-    ./configure --prefix=$HOME/postgres/ --without-readline --without-zlib --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+    ./configure --prefix=$HOME/postgres/ --without-readline --without-zlib --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
     make -j 4 2>error.txt
     make install
     make check

--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -437,7 +437,7 @@ init_default_locale(void)
 	}
 
 	/* babelfishpg_tsql.default_locale should not be changed once babelfish db is initialised. */
-	Assert(strcmp(default_locale, GetConfigOption("babelfishpg_tsql.default_locale", true, false)) == 0);
+	Assert(!default_locale || strcmp(default_locale, GetConfigOption("babelfishpg_tsql.default_locale", true, false)) == 0);
 
 	return;
 }
@@ -457,7 +457,7 @@ init_server_collation_name(void)
 	}
 
 	/* babelfishpg_tsql.server_collation_name should not be changed once babelfish db is initialised. */
-	Assert(strcmp(server_collation_name, GetConfigOption("babelfishpg_tsql.server_collation_name", true, false)) == 0);
+	Assert(!server_collation_name || strcmp(server_collation_name, GetConfigOption("babelfishpg_tsql.server_collation_name", true, false)) == 0);
 
 	return;
 }

--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -426,7 +426,11 @@ static void
 init_default_locale(void)
 {
 	if (!default_locale)
-		default_locale = GetConfigOption("babelfishpg_tsql.default_locale", true, false);
+		default_locale = strdup(GetConfigOption("babelfishpg_tsql.default_locale", true, false));
+
+	/* babelfishpg_tsql.default_locale should not be changed once babelfish db is initialised. */
+	Assert(strcmp(default_locale, GetConfigOption("babelfishpg_tsql.default_locale", true, false)) == 0);
+
 	return;
 }
 
@@ -434,7 +438,11 @@ static void
 init_server_collation_name(void)
 {
 	if (!server_collation_name)
-		server_collation_name = GetConfigOption("babelfishpg_tsql.server_collation_name", true, false);
+		server_collation_name = strdup(GetConfigOption("babelfishpg_tsql.server_collation_name", true, false));
+
+	/* babelfishpg_tsql.server_collation_name should not be changed once babelfish db is initialised. */
+	Assert(strcmp(server_collation_name, GetConfigOption("babelfishpg_tsql.server_collation_name", true, false)) == 0);
+
 	return;
 }
 

--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -426,7 +426,15 @@ static void
 init_default_locale(void)
 {
 	if (!default_locale)
-		default_locale = strdup(GetConfigOption("babelfishpg_tsql.default_locale", true, false));
+	{
+		const char *val = GetConfigOption("babelfishpg_tsql.default_locale", true, false);
+		if (val)
+		{
+			MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
+			default_locale = pstrdup(val);
+			MemoryContextSwitchTo(oldContext);
+		}
+	}
 
 	/* babelfishpg_tsql.default_locale should not be changed once babelfish db is initialised. */
 	Assert(strcmp(default_locale, GetConfigOption("babelfishpg_tsql.default_locale", true, false)) == 0);
@@ -438,7 +446,15 @@ static void
 init_server_collation_name(void)
 {
 	if (!server_collation_name)
-		server_collation_name = strdup(GetConfigOption("babelfishpg_tsql.server_collation_name", true, false));
+	{
+		const char *val = GetConfigOption("babelfishpg_tsql.server_collation_name", true, false);
+		if (val)
+		{
+			MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
+			server_collation_name = pstrdup(val);
+			MemoryContextSwitchTo(oldContext);
+		}
+	}
 
 	/* babelfishpg_tsql.server_collation_name should not be changed once babelfish db is initialised. */
 	Assert(strcmp(server_collation_name, GetConfigOption("babelfishpg_tsql.server_collation_name", true, false)) == 0);

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -117,7 +117,7 @@ init_db() {
 
 init_pg() {
     cd $1/postgresql_modified_for_babelfish
-    ./configure --prefix=$2/postgres/ --without-readline --without-zlib --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+    ./configure --prefix=$2/postgres/ --without-readline --without-zlib --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
     make -j 4
     make install
     cd contrib && make && sudo make install

--- a/test/JDBC/expected/BABEL-2280.out
+++ b/test/JDBC/expected/BABEL-2280.out
@@ -66,11 +66,3 @@ go
 
 ~~ERROR (Message: param definition mismatches with inputs)~~
 
-
--- HResult 0x1FD2
-exec sp_executesql N'SELECT 1', N'', N''
-go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: unexpected parameter mode )~~
-

--- a/test/JDBC/input/BABEL-2280.sql
+++ b/test/JDBC/input/BABEL-2280.sql
@@ -33,7 +33,3 @@ go
 -- error code 8178
 exec sp_executesql N'', N'@var1 varchar(20)'
 go
-
--- HResult 0x1FD2
-exec sp_executesql N'SELECT 1', N'', N''
-go


### PR DESCRIPTION
### Description

Previously, we cached server_collation_name and default_locale from
GetConfigOption(). However, the returned pointers can become invalid if some
configuration related functions are called, e.g., ProcessConfigFile().

This commit makes those returned string pstrdup'd and adds assertions to
check server_collation_name and default_locale are not changed after the
first assignments.

Also, it adds --enable-cassert for all dev/test-related build scripts and 
remove an unstable test.

Signed-off-by: Jungkook Lee <jungkook@amazon.com>
 
### Issues Resolved

BABEL-3451

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).