### PR TITLE
Check for bbf_view_def_idx_oid instead of bbf_authid_user_ext_idx_oid in get_bbf_view_def_idx_oid()

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -948,7 +948,7 @@ get_bbf_view_def_oid()
 Oid
 get_bbf_view_def_idx_oid()
 {
-	if (!OidIsValid(bbf_authid_user_ext_idx_oid))
+	if (!OidIsValid(bbf_view_def_idx_oid))
 		bbf_view_def_idx_oid = get_relname_relid(BBF_VIEW_DEF_IDX_NAME,
 												 get_namespace_oid("sys", false));
 


### PR DESCRIPTION
### Description

Current implementation checks bbf_authid_user_ext_idx_oid is valid or not.
Instead of that it should check for bbf_view_def_idx_oid. Currently, it
is not failing any testcases or it is hard to form any negative testcases
because lifecycle/initialisation order of both catalog authid_user_ext and
view_def catalog is in such a way that it won't cause any problems.

This commits fixes above issue.

Task: BABEL-3480
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>
 
### Issues Resolved

BABEL-3480


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).