### PR TITLE
Added Support for TSQL's key_column_usage

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.1.0--2.2.0.sql
@@ -161,6 +161,48 @@ CREATE OR REPLACE VIEW information_schema_tsql.COLUMN_DOMAIN_USAGE AS
 
 GRANT SELECT ON information_schema_tsql.COLUMN_DOMAIN_USAGE TO PUBLIC;
 
+/*
+* KEY COLUMN USAGE
+*/
+
+CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage
+AS SELECT CAST(ss.nc_dbname AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+    CAST(ss.nc_nspname AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+    CAST(ss.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
+    CAST(ss.nc_dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+    CAST(ss.nr_nspname  AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+    CAST(ss.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
+    CAST(a.attname AS sys.nvarchar(128)) AS "COLUMN_NAME",
+    CAST((ss.x).n AS sys."int") AS "ORDINAL_POSITION"
+   FROM pg_attribute a,
+    ( SELECT r.oid AS roid,
+            r.relname,
+            r.relowner,
+            extc.orig_name AS nc_nspname,
+            extr.orig_name AS nr_nspname,
+            nc.dbname as nc_dbname,
+            extc.dbid as extc_dbid,
+            c.oid AS coid,
+            c.conname,
+            c.contype,
+            c.confrelid,
+            information_schema._pg_expandarray(c.conkey) AS x
+           FROM sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+            sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
+            pg_class r,
+            pg_constraint c
+          WHERE nr.oid = r.relnamespace AND r.oid = c.conrelid 
+		  AND nc.oid = c.connamespace AND (c.contype = ANY (ARRAY[CAST('p' AS "char"), CAST('u' AS "char"), CAST('f' AS "char")])) 
+		  AND (r.relkind = ANY (ARRAY[CAST('r' AS "char"), CAST('p' AS "char")])) AND NOT pg_is_other_temp_schema(nr.oid)) ss
+WHERE ss.roid = a.attrelid AND a.attnum = (ss.x).x 
+AND NOT a.attisdropped 
+AND (pg_has_role(ss.roid, 'USAGE')
+     OR has_table_privilege(ss.roid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+     OR has_any_column_privilege(ss.roid, 'SELECT, INSERT, UPDATE, REFERENCES'))
+AND  ss.extc_dbid = cast(sys.db_id() as oid);
+
+GRANT SELECT ON information_schema_tsql.key_column_usage TO PUBLIC;
+
 CREATE OR replace view sys.foreign_keys AS
 SELECT
   CAST(c.conname AS sys.SYSNAME) AS name

--- a/test/JDBC/expected/key_column_usage-database-test.out
+++ b/test/JDBC/expected/key_column_usage-database-test.out
@@ -1,0 +1,67 @@
+use master;
+go
+
+create table key_column_usage_db_test_tb1(redID INT PRIMARY KEY, greenID INT NOT NULL UNIQUE, blueID INT NOT NULL, UNIQUE(greenID,blueID));
+go
+
+create table key_column_usage_db_test_tb2( greenID char(10) PRIMARY KEY, redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES key_column_usage_db_test_tb1 (redID));
+go
+
+create database key_column_usage_db_test_db;
+go
+
+use key_column_usage_db_test_db;
+go
+
+create table key_column_usage_db_test_tb3(blueID INT PRIMARY KEY, greenID char(10));
+go
+
+create table key_column_usage_db_test_tb4(purpleID INT PRIMARY KEY, blueID INT NOT NULL, CONSTRAINT FK_GREEN FOREIGN KEY (blueID) REFERENCES key_column_usage_db_test_tb3(blueID));
+go
+
+use master;
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_db_test_tb%' order by table_name,constraint_name,ordinal_position;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+master#!#dbo#!#key_column_usage_db_test_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_db_test_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#blueid#!#2
+master#!#dbo#!#key_column_usage_db_test_tb1_greenid_key#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_db_test_tb1_pkey#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#redid#!#1
+master#!#dbo#!#fk_redkey_column_usage_db_test_f4b37021aac7f0f215124b050a9b536a#!#master#!#dbo#!#key_column_usage_db_test_tb2#!#redid#!#1
+master#!#dbo#!#key_column_usage_db_test_tb2_pkey#!#master#!#dbo#!#key_column_usage_db_test_tb2#!#greenid#!#1
+~~END~~
+
+
+use key_column_usage_db_test_db;
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_db_test_tb%' order by table_name,constraint_name,ordinal_position;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+key_column_usage_db_test_db#!#dbo#!#key_column_usage_db_test_tb3_pkey#!#key_column_usage_db_test_db#!#dbo#!#key_column_usage_db_test_tb3#!#blueid#!#1
+key_column_usage_db_test_db#!#dbo#!#fk_greenkey_column_usage_db_tesae34995aa55534a3484caa64de5eb291#!#key_column_usage_db_test_db#!#dbo#!#key_column_usage_db_test_tb4#!#blueid#!#1
+key_column_usage_db_test_db#!#dbo#!#key_column_usage_db_test_tb4_pkey#!#key_column_usage_db_test_db#!#dbo#!#key_column_usage_db_test_tb4#!#purpleid#!#1
+~~END~~
+
+
+drop table key_column_usage_db_test_tb4;
+go
+
+drop table key_column_usage_db_test_tb3;
+go
+
+use master;
+go
+
+drop table key_column_usage_db_test_tb2;
+go
+
+drop table key_column_usage_db_test_tb1;
+go
+
+drop database key_column_usage_db_test_db;
+go

--- a/test/JDBC/expected/key_column_usage-database-test.out
+++ b/test/JDBC/expected/key_column_usage-database-test.out
@@ -57,6 +57,32 @@ go
 use master;
 go
 
+create schema key_column_usage_db_test_sc;
+go
+
+create table key_column_usage_db_test_sc.key_column_usage_db_test_tb5(blueID INT PRIMARY KEY, greenID char(10));
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_db_test_tb%' order by table_name,constraint_name,ordinal_position;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+master#!#dbo#!#key_column_usage_db_test_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_db_test_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#blueid#!#2
+master#!#dbo#!#key_column_usage_db_test_tb1_greenid_key#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_db_test_tb1_pkey#!#master#!#dbo#!#key_column_usage_db_test_tb1#!#redid#!#1
+master#!#dbo#!#fk_redkey_column_usage_db_test_f4b37021aac7f0f215124b050a9b536a#!#master#!#dbo#!#key_column_usage_db_test_tb2#!#redid#!#1
+master#!#dbo#!#key_column_usage_db_test_tb2_pkey#!#master#!#dbo#!#key_column_usage_db_test_tb2#!#greenid#!#1
+master#!#key_column_usage_db_test_sc#!#key_column_usage_db_test_tb5_pkey#!#master#!#key_column_usage_db_test_sc#!#key_column_usage_db_test_tb5#!#blueid#!#1
+~~END~~
+
+
+drop table key_column_usage_db_test_sc.key_column_usage_db_test_tb5;
+go
+
+drop schema key_column_usage_db_test_sc;
+go
+
 drop table key_column_usage_db_test_tb2;
 go
 

--- a/test/JDBC/expected/key_column_usage-privilege-test.out
+++ b/test/JDBC/expected/key_column_usage-privilege-test.out
@@ -1,0 +1,83 @@
+
+-- tsql
+use master;
+go
+
+create login key_column_usage_privilege_test_user with password='';
+go
+
+create database key_column_usage_privilege_test_db;
+go
+
+use key_column_usage_privilege_test_db;
+go
+
+create table key_column_usage_privilege_test_tb(arg1 int, arg2 int, primary key(arg1));
+go
+
+create user key_column_usage_privilege_test_user for login key_column_usage_privilege_test_user;
+go
+
+use master;
+go
+
+
+-- tsql user=key_column_usage_privilege_test_user password=''
+use key_column_usage_privilege_test_db;
+go
+
+select * from information_schema.key_column_usage where table_name='key_column_usage_privilege_test_tb';
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+key_column_usage_privilege_test_db#!#dbo#!#key_column_usage_privilege_test_tb_pkey#!#key_column_usage_privilege_test_db#!#dbo#!#key_column_usage_privilege_test_tb#!#arg1#!#1
+~~END~~
+
+
+use master;
+go
+
+
+-- tsql
+use key_column_usage_privilege_test_db;
+go
+
+grant select on key_column_usage_privilege_test_tb to key_column_usage_privilege_test_user;
+go
+
+use master;
+go
+
+
+-- tsql user=key_column_usage_privilege_test_user password=''
+use key_column_usage_privilege_test_db;
+go
+
+select * from information_schema.key_column_usage where table_name='key_column_usage_privilege_test_tb';
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+key_column_usage_privilege_test_db#!#dbo#!#key_column_usage_privilege_test_tb_pkey#!#key_column_usage_privilege_test_db#!#dbo#!#key_column_usage_privilege_test_tb#!#arg1#!#1
+~~END~~
+
+
+use master;
+go
+
+
+-- tsql
+use key_column_usage_privilege_test_db;
+go
+
+drop table key_column_usage_privilege_test_tb;
+go
+
+use master;
+go
+
+drop database key_column_usage_privilege_test_db;
+go
+
+-- tsql
+drop login key_column_usage_privilege_test_user;
+go

--- a/test/JDBC/expected/key_column_usage-vu-prepare.out
+++ b/test/JDBC/expected/key_column_usage-vu-prepare.out
@@ -1,0 +1,14 @@
+create table key_column_usage_vu_prepare_tb1(redID INT PRIMARY KEY, greenID INT NOT NULL UNIQUE, blueID INT NOT NULL, UNIQUE(greenID,blueID));
+go
+
+create table key_column_usage_vu_prepare_tb2( greenID char(10) PRIMARY KEY, redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES key_column_usage_vu_prepare_tb1 (redID));
+go
+
+create table key_column_usage_vu_prepare_tb3(blueID INT PRIMARY KEY, greenID char(10), CONSTRAINT FK_GREEN FOREIGN KEY (greenID) REFERENCES key_column_usage_vu_prepare_tb2(greenID));
+go
+
+create table key_column_usage_vu_prepare_tb4(purpleID INT PRIMARY KEY, blueID INT NOT NULL, CONSTRAINT FK_GREEN FOREIGN KEY (blueID) REFERENCES key_column_usage_vu_prepare_tb3(blueID));
+go
+
+create table key_column_usage_vu_prepare_tb5(arg1 int, arg2 int, PRIMARY KEY(arg1, arg2));
+go

--- a/test/JDBC/expected/key_column_usage-vu-verify.out
+++ b/test/JDBC/expected/key_column_usage-vu-verify.out
@@ -1,0 +1,83 @@
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,ordinal_position;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#blueid#!#2
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#redid#!#1
+master#!#dbo#!#fk_redkey_column_usage_vu_prepaa2e9818e50b326a6a0caaaa032d9113a#!#master#!#dbo#!#key_column_usage_vu_prepare_tb2#!#redid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb2_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb2#!#greenid#!#1
+master#!#dbo#!#fk_greenkey_column_usage_vu_pre415cd39ed98d3c509fdac88a28e495eb#!#master#!#dbo#!#key_column_usage_vu_prepare_tb3#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb3_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb3#!#blueid#!#1
+master#!#dbo#!#fk_greenkey_column_usage_vu_prea1fe8f8a2bc0c23700cc98cd215b1249#!#master#!#dbo#!#key_column_usage_vu_prepare_tb4#!#blueid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb4_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb4#!#purpleid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb5_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb5#!#arg1#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb5_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb5#!#arg2#!#2
+~~END~~
+
+
+create view key_column_usage_vu_verify_view as select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
+go
+
+create procedure key_column_usage_vu_verify_proc as select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
+go
+
+create function key_column_usage_vu_verify_func() returns table as return(select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema);
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,ordinal_position;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#blueid#!#2
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#redid#!#1
+master#!#dbo#!#fk_redkey_column_usage_vu_prepaa2e9818e50b326a6a0caaaa032d9113a#!#master#!#dbo#!#key_column_usage_vu_prepare_tb2#!#redid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb2_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb2#!#greenid#!#1
+master#!#dbo#!#fk_greenkey_column_usage_vu_pre415cd39ed98d3c509fdac88a28e495eb#!#master#!#dbo#!#key_column_usage_vu_prepare_tb3#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb3_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb3#!#blueid#!#1
+master#!#dbo#!#fk_greenkey_column_usage_vu_prea1fe8f8a2bc0c23700cc98cd215b1249#!#master#!#dbo#!#key_column_usage_vu_prepare_tb4#!#blueid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb4_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb4#!#purpleid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb5_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb5#!#arg1#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb5_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb5#!#arg2#!#2
+~~END~~
+
+
+drop function key_column_usage_vu_verify_func;
+go
+
+drop procedure key_column_usage_vu_verify_proc;
+go
+
+drop view key_column_usage_vu_verify_view;
+go
+
+drop table key_column_usage_vu_prepare_tb5;
+go
+
+drop table key_column_usage_vu_prepare_tb4;
+go
+
+drop table key_column_usage_vu_prepare_tb3;
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,ordinal_position;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_blueid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#blueid#!#2
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_greenid_key#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#greenid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb1_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb1#!#redid#!#1
+master#!#dbo#!#fk_redkey_column_usage_vu_prepaa2e9818e50b326a6a0caaaa032d9113a#!#master#!#dbo#!#key_column_usage_vu_prepare_tb2#!#redid#!#1
+master#!#dbo#!#key_column_usage_vu_prepare_tb2_pkey#!#master#!#dbo#!#key_column_usage_vu_prepare_tb2#!#greenid#!#1
+~~END~~
+
+
+drop table key_column_usage_vu_prepare_tb2;
+go
+
+drop table key_column_usage_vu_prepare_tb1;
+go

--- a/test/JDBC/input/key_column_usage-database-test.sql
+++ b/test/JDBC/input/key_column_usage-database-test.sql
@@ -1,0 +1,50 @@
+use master;
+go
+
+create table key_column_usage_db_test_tb1(redID INT PRIMARY KEY, greenID INT NOT NULL UNIQUE, blueID INT NOT NULL, UNIQUE(greenID,blueID));
+go
+
+create table key_column_usage_db_test_tb2( greenID char(10) PRIMARY KEY, redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES key_column_usage_db_test_tb1 (redID));
+go
+
+create database key_column_usage_db_test_db;
+go
+
+use key_column_usage_db_test_db;
+go
+
+create table key_column_usage_db_test_tb3(blueID INT PRIMARY KEY, greenID char(10));
+go
+
+create table key_column_usage_db_test_tb4(purpleID INT PRIMARY KEY, blueID INT NOT NULL, CONSTRAINT FK_GREEN FOREIGN KEY (blueID) REFERENCES key_column_usage_db_test_tb3(blueID));
+go
+
+use master;
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_db_test_tb%' order by table_name,constraint_name,ordinal_position;
+go
+
+use key_column_usage_db_test_db;
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_db_test_tb%' order by table_name,constraint_name,ordinal_position;
+go
+
+drop table key_column_usage_db_test_tb4;
+go
+
+drop table key_column_usage_db_test_tb3;
+go
+
+use master;
+go
+
+drop table key_column_usage_db_test_tb2;
+go
+
+drop table key_column_usage_db_test_tb1;
+go
+
+drop database key_column_usage_db_test_db;
+go

--- a/test/JDBC/input/key_column_usage-database-test.sql
+++ b/test/JDBC/input/key_column_usage-database-test.sql
@@ -40,6 +40,21 @@ go
 use master;
 go
 
+create schema key_column_usage_db_test_sc;
+go
+
+create table key_column_usage_db_test_sc.key_column_usage_db_test_tb5(blueID INT PRIMARY KEY, greenID char(10));
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_db_test_tb%' order by table_name,constraint_name,ordinal_position;
+go
+
+drop table key_column_usage_db_test_sc.key_column_usage_db_test_tb5;
+go
+
+drop schema key_column_usage_db_test_sc;
+go
+
 drop table key_column_usage_db_test_tb2;
 go
 

--- a/test/JDBC/input/key_column_usage-privilege-test.sql
+++ b/test/JDBC/input/key_column_usage-privilege-test.sql
@@ -1,0 +1,73 @@
+-- tsql
+
+use master;
+go
+
+create login key_column_usage_privilege_test_user with password='';
+go
+
+create database key_column_usage_privilege_test_db;
+go
+
+use key_column_usage_privilege_test_db;
+go
+
+create table key_column_usage_privilege_test_tb(arg1 int, arg2 int, primary key(arg1));
+go
+
+create user key_column_usage_privilege_test_user for login key_column_usage_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=key_column_usage_privilege_test_user password=''
+
+use key_column_usage_privilege_test_db;
+go
+
+select * from information_schema.key_column_usage where table_name='key_column_usage_privilege_test_tb';
+go
+
+use master;
+go
+
+-- tsql
+
+use key_column_usage_privilege_test_db;
+go
+
+grant select on key_column_usage_privilege_test_tb to key_column_usage_privilege_test_user;
+go
+
+use master;
+go
+
+-- tsql user=key_column_usage_privilege_test_user password=''
+
+use key_column_usage_privilege_test_db;
+go
+
+select * from information_schema.key_column_usage where table_name='key_column_usage_privilege_test_tb';
+go
+
+use master;
+go
+
+-- tsql
+
+use key_column_usage_privilege_test_db;
+go
+
+drop table key_column_usage_privilege_test_tb;
+go
+
+use master;
+go
+
+drop database key_column_usage_privilege_test_db;
+go
+
+-- tsql
+drop login key_column_usage_privilege_test_user;
+go

--- a/test/JDBC/input/key_column_usage-vu-prepare.sql
+++ b/test/JDBC/input/key_column_usage-vu-prepare.sql
@@ -1,0 +1,14 @@
+create table key_column_usage_vu_prepare_tb1(redID INT PRIMARY KEY, greenID INT NOT NULL UNIQUE, blueID INT NOT NULL, UNIQUE(greenID,blueID));
+go
+
+create table key_column_usage_vu_prepare_tb2( greenID char(10) PRIMARY KEY, redID INT NOT NULL, CONSTRAINT FK_RED FOREIGN KEY (redID) REFERENCES key_column_usage_vu_prepare_tb1 (redID));
+go
+
+create table key_column_usage_vu_prepare_tb3(blueID INT PRIMARY KEY, greenID char(10), CONSTRAINT FK_GREEN FOREIGN KEY (greenID) REFERENCES key_column_usage_vu_prepare_tb2(greenID));
+go
+
+create table key_column_usage_vu_prepare_tb4(purpleID INT PRIMARY KEY, blueID INT NOT NULL, CONSTRAINT FK_GREEN FOREIGN KEY (blueID) REFERENCES key_column_usage_vu_prepare_tb3(blueID));
+go
+
+create table key_column_usage_vu_prepare_tb5(arg1 int, arg2 int, PRIMARY KEY(arg1, arg2));
+go

--- a/test/JDBC/input/key_column_usage-vu-verify.sql
+++ b/test/JDBC/input/key_column_usage-vu-verify.sql
@@ -1,0 +1,41 @@
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,ordinal_position;
+go
+
+create view key_column_usage_vu_verify_view as select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
+go
+
+create procedure key_column_usage_vu_verify_proc as select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema;
+go
+
+create function key_column_usage_vu_verify_func() returns table as return(select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,table_schema);
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,ordinal_position;
+go
+
+drop function key_column_usage_vu_verify_func;
+go
+
+drop procedure key_column_usage_vu_verify_proc;
+go
+
+drop view key_column_usage_vu_verify_view;
+go
+
+drop table key_column_usage_vu_prepare_tb5;
+go
+
+drop table key_column_usage_vu_prepare_tb4;
+go
+
+drop table key_column_usage_vu_prepare_tb3;
+go
+
+select * from information_schema.key_column_usage where table_name like 'key_column_usage_vu_prepare_tb%' order by table_name,constraint_name,ordinal_position;
+go
+
+drop table key_column_usage_vu_prepare_tb2;
+go
+
+drop table key_column_usage_vu_prepare_tb1;
+go

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -109,3 +109,4 @@ BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
 BABEL-1683
+key_column_usage

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -121,3 +121,4 @@ BABEL-EXTENDEDPROPERTY
 TestErrorHelperFunctionsUpgrade
 tdscollation
 BABEL-1683
+key_column_usage

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -154,3 +154,4 @@ sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
 BABEL-1683
+key_column_usage

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -156,3 +156,4 @@ sp_tablecollations
 sys-assemblies
 BABEL-LOGIN-USER-EXT
 BABEL-1683
+key_column_usage

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -169,3 +169,4 @@ sys-assemblies
 BABEL-LOGIN-USER-EXT
 bitwise_not-operator
 BABEL-1683
+key_column_usage

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -1010,6 +1010,7 @@ View information_schema_tsql.column_domain_usage
 View information_schema_tsql.columns
 View information_schema_tsql.constraint_column_usage
 View information_schema_tsql.domains
+View information_schema_tsql.key_column_usage
 View information_schema_tsql.routines
 View information_schema_tsql.table_constraints
 View information_schema_tsql.tables


### PR DESCRIPTION
### Description

Currently, Babelfish does not support
information_schema_tsql.key_column_usage. This commit updates the state
by implementing the view.

TASK:

Author: Ozzy Nolen<oscarno@amazon.com>
Signed-off-by:
 
### Issues Resolved

- The view information_schema_tsql.key_column_usage not implemented


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).