### PR TITLE
Check and initialise ht_oid2collid hash table before we access it

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -1180,6 +1180,9 @@ int get_persist_collation_id(Oid coll_oid)
 	bool found_coll;
 	int collidx;
 
+	if (ht_oid2collid == NULL)
+		init_collid_trans_tab_internal();
+
 	entry = hash_search(ht_oid2collid, &coll_oid, HASH_FIND, &found_coll);
 
 	if (found_coll)

--- a/contrib/babelfishpg_tsql/expected/test/babel_collation.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_collation.out
@@ -6,6 +6,18 @@ LINE 1: create table testing1(col nvarchar(60));
 CREATE EXTENSION IF NOT EXISTS "babelfishpg_tsql" CASCADE;
 NOTICE:  extension "babelfishpg_tsql" already exists, skipping
 set babelfishpg_tsql.sql_dialect = "tsql";
+-- check the babelfish version
+select cast(
+    case
+        when cast(sys.SERVERPROPERTY('BabelfishVersion') as varchar(20)) LIKE '_._._'
+             THEN 'valid'
+    else 'invalid'
+    end as sys.varchar(20));
+ varchar 
+---------
+ valid
+(1 row)
+
 -- nvarchar is supported in tsql dialect
 create table testing1(col nvarchar(60));
 insert into testing1 (col) select N'Muffler';

--- a/contrib/babelfishpg_tsql/sql/test/babel_collation.sql
+++ b/contrib/babelfishpg_tsql/sql/test/babel_collation.sql
@@ -4,6 +4,14 @@ create table testing1(col nvarchar(60)); -- expect this to fail in the Postgres 
 CREATE EXTENSION IF NOT EXISTS "babelfishpg_tsql" CASCADE;
 set babelfishpg_tsql.sql_dialect = "tsql";
 
+-- check the babelfish version
+select cast(
+    case
+        when cast(sys.SERVERPROPERTY('BabelfishVersion') as varchar(20)) LIKE '_._._'
+             THEN 'valid'
+    else 'invalid'
+    end as sys.varchar(20));
+
 -- nvarchar is supported in tsql dialect
 create table testing1(col nvarchar(60));
 insert into testing1 (col) select N'Muffler';

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,6 +8,8 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
+# check babelfish version first
+cmd#!#postgresql#!#select cast(case when cast(sys.SERVERPROPERTY('BabelfishVersion') as varchar(20)) LIKE '_._._' THEN 'valid' else 'invalid' end as sys.varchar(20));
 all
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.


### PR DESCRIPTION
### Description

Check and initialise ht_oid2collid hash table before we access it

Previously, ht_oid2collid hash was made to initialise on demand. We missed to handle one case where we are trying to access ht_oid2collid without checking if it is initialised which is causing backend to crash. 

This commit fixes it by appropriately checking and initialising ht_oid2collid hash table before attempt to hash_search is made.

Task: BABEL-3514
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).