### PR TITLE
Adding basic test cases like sys.SERVERPROPERTY(BabelfishVersion) for BABEL-3514

### DIFF
--- a/test/JDBC/expected/BABEL-3514.out
+++ b/test/JDBC/expected/BABEL-3514.out
@@ -1,0 +1,11 @@
+-- psql
+select 
+    cast(case when cast(sys.SERVERPROPERTY('BabelfishVersion') as varchar(20)) LIKE '_._._' 
+        THEN 'valid babelfish version' 
+    else 'invalid babelfish version' end as text);
+GO
+~~START~~
+text
+valid babelfish version
+~~END~~
+

--- a/test/JDBC/input/BABEL-3514.mix
+++ b/test/JDBC/input/BABEL-3514.mix
@@ -1,0 +1,6 @@
+-- psql
+select 
+    cast(case when cast(sys.SERVERPROPERTY('BabelfishVersion') as varchar(20)) LIKE '_._._' 
+        THEN 'valid babelfish version' 
+    else 'invalid babelfish version' end as text);
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,8 +8,6 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-# check babelfish version first
-cmd#!#postgresql#!#select cast(case when cast(sys.SERVERPROPERTY('BabelfishVersion') as varchar(20)) LIKE '_._._' THEN 'valid' else 'invalid' end as sys.varchar(20));
 all
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.


### PR DESCRIPTION
### Description

Adding basic test cases like sys.SERVERPROPERTY(BabelfishVersion) for BABEL-3514

Task: BABEL-3514
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).