### PR TITLE
Remove sanity checks for authentication after dropping login in BABEL…

### DIFF
--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -1204,20 +1204,7 @@ db2_lgn_2978_2#!#lgn_2978_2#!##!#db2#!#dbo
 ~~END~~
 
 
-
-java_auth#!#database|-|db1#!#user|-|lgn_2978#!#password|-|123
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "lgn_2978" does not exist )~~
-
-java_auth#!#database|-|db2#!#user|-|lgn_2978#!#password|-|123
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "lgn_2978" does not exist )~~
-
-
 -- tsql
--- It should be failed since there is no relevant login
 -- recreate the login with same name
 CREATE LOGIN lgn_2978 WITH PASSWORD='123';
 GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -367,14 +367,7 @@ babel_login_vu_prepare_db1_babel_login_vu_prepare_r4#!#babel_login_vu_prepare_r4
 ~~END~~
 
 
-java_auth#!#database|-|babel_login_vu_prepare_db1#!#user|-|babel_login_vu_prepare_r4#!#password|-|123
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "babel_login_vu_prepare_r4" does not exist )~~
-
-
 -- tsql
--- It should be failed since there is no relevant login
 -- recreate the login with same name
 CREATE LOGIN babel_login_vu_prepare_r4 WITH PASSWORD='123';
 go

--- a/test/JDBC/input/BABEL-LOGIN-USER-EXT.mix
+++ b/test/JDBC/input/BABEL-LOGIN-USER-EXT.mix
@@ -606,11 +606,6 @@ WHERE login_name LIKE 'lgn_2978%' OR rolname LIKE '%lgn_2978%'
 ORDER BY rolname;
 GO
 
--- It should be failed since there is no relevant login
-
-java_auth#!#database|-|db1#!#user|-|lgn_2978#!#password|-|123
-java_auth#!#database|-|db2#!#user|-|lgn_2978#!#password|-|123
-
 -- tsql
 -- recreate the login with same name
 CREATE LOGIN lgn_2978 WITH PASSWORD='123';

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -199,9 +199,6 @@ WHERE login_name LIKE 'babel_login_vu_prepare_r4%' OR rolname LIKE '%babel_login
 ORDER BY rolname;
 go
 
--- It should be failed since there is no relevant login
-java_auth#!#database|-|babel_login_vu_prepare_db1#!#user|-|babel_login_vu_prepare_r4#!#password|-|123
-
 -- tsql
 -- recreate the login with same name
 CREATE LOGIN babel_login_vu_prepare_r4 WITH PASSWORD='123';


### PR DESCRIPTION
…-LOGIN tests
### Description

Currently, Authentication attempt using invalid login throws different errors
based on which authentication method is being used. For example, In case
of md5 authentication, we're throwing 'Login failed for user %s'(Although
internally we're still getting 'role '%s' doesn't exist') and in case of
trust it is throwing 'role '%s' doesn't exist'.

This commit removes sanity checks for authentication added after dropping
login in BABEL-LOGIN-USER-EXT and BABEL-LOGIN-vu-verify until above issue
is resolved.

Task: BABEL-3515
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>
 
### Issues Resolved

Removed sanity check which were resulting in the diff due to BABEL-3515

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).