### PR TITLE
Added potential fix in README for inability to run init.sh and cleanup.sh scripts

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -218,4 +218,8 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
       ./init.sh
       mvn test
       ```
+        - If you run into errors connecting to psql such as `psql: error: could not connect to server: No such file or directory` try re-appending `postgres/bin` to your path by running this command and retrying the above code block:
+            ```
+            export PATH="~/postgres/bin:$PATH"
+            ```
 For detailed instructions on how to write, add, and run tests in JDBC test framework, refer [to the online instructions](../test/JDBC/README.md).


### PR DESCRIPTION
Task: JIRA pending
Signed-off-by: Sid Patllollu <sidred@amazon.com>

### Description

Interns faced an issue running init.sh and cleanup.sh scripts because `postgres/bin` is removed occasionally from the path variable. This PR adds the suggestion of re-appending `postgres/bin` to the path variable in the README in case other developers are facing the same issue.
 
### Issues Resolved

Potential reason for not being able to run init.sh and cleanup.sh


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).