### PR TITLE
Dummy change

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2505,7 +2505,7 @@ BEGIN
 	END
 	-- If the specified server role is not valid
 	ELSE
-		RAISERROR('%s is not a known fixed role.', 16, 1, @srvrolename);
+		RAISERROR('%s dummy change.', 16, 1, @srvrolename);
 END;
 $$
 LANGUAGE 'pltsql';

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2505,7 +2505,7 @@ BEGIN
 	END
 	-- If the specified server role is not valid
 	ELSE
-		RAISERROR('%s dummy change.', 16, 1, @srvrolename);
+		RAISERROR('%s dummy change syntax.', 16, 1, @srvrolename);
 END;
 $$
 LANGUAGE 'pltsql';

--- a/test/JDBC/expected/Test-sp_helpsrvrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_helpsrvrolemember-vu-verify.out
@@ -54,5 +54,5 @@ EXEC sp_helpsrvrolemember 'error'
 GO
 ~~ERROR (Code: 50000)~~
 
-~~ERROR (Message: error is not a known fixed role.)~~
+~~ERROR (Message: error dummy change.)~~
 

--- a/test/JDBC/input/storedProcedures/Test-sp_helpsrvrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_helpsrvrolemember-vu-verify.sql
@@ -28,5 +28,19 @@ GO
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
 GO
 
+Insert into table () exec sp_helpsrvrolemember 'sysadmin    '
+GO
+
+SELECT from table ..
+GO
+
+truncate 
+
+ Insert into table () exec sp_helpsrvrolemember 'securityadmin'
+GO
+
+Select from
+go
+
 EXEC sp_helpsrvrolemember 'error'
 GO


### PR DESCRIPTION
Previously, the error msg xxx, in this commit, we change it into dummy.

Task: BABEL-3455
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).