### PR TITLE
Romove sys-syscolumns instead of BABEL-1493 from schedule files

### DIFF
--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -44,7 +44,6 @@ sys-schemas
 sys-sp_databases
 sys-sp_tables_view
 sys-syscharsets
-sys-syscolumns
 sys-sysforeignkeys
 sys-tables
 sys-types

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -31,6 +31,7 @@ TestUDD
 TestUniqueIdentifier
 TestVarChar
 TestXML
+BABEL-1493
 BABEL-2934
 BABEL-3121
 BABEL-3166
@@ -82,7 +83,6 @@ sys-spatial_indexes
 sys-stats
 sys-synonyms
 sys-system_sql_modules
-sys-syscolumns
 sys-syscharsets
 sys-sysforeignkeys
 sys-syslanguages

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -84,7 +84,6 @@ sys-spatial_indexes
 sys-stats
 sys-synonyms
 sys-syscharsets
-sys-syscolumns
 sys-sysforeignkeys
 sys-syslanguages
 sys-system_sql_modules

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -84,7 +84,6 @@ sys-spatial_indexes
 sys-stats
 sys-synonyms
 sys-syscharsets
-sys-syscolumns
 sys-sysforeignkeys
 sys-syslanguages
 sys-system_sql_modules

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -276,5 +276,6 @@ Could not find upgrade tests for view sys.sp_stored_procedures_view
 Could not find upgrade tests for view sys.sp_table_privileges_view
 Could not find upgrade tests for view sys.spt_columns_view_managed
 Could not find upgrade tests for view sys.spt_tablecollations_view
+Could not find upgrade tests for view sys.syscolumns
 Could not find upgrade tests for view sys.sysindexes
 Could not find upgrade tests for view sys.system_objects


### PR DESCRIPTION
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).