### PR TITLE
Update the default branch

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -4,7 +4,7 @@ inputs:
   engine_branch:
     description: 'Engine Branch'
     required: yes
-    default: 'BABEL_1_X_DEV__PG_13_8'
+    default: 'BABEL_1_4_STABLE__PG_13_8'
 
 runs:
   using: "composite"


### PR DESCRIPTION
Update the default branch for Postgres modified repo as BABEL_1_4_STABLE__PG_13_8

### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).