### PR TITLE
Fix behavior with FOR XML PATH('')

### DIFF
--- a/contrib/babelfishpg_tsql/src/forxml.c
+++ b/contrib/babelfishpg_tsql/src/forxml.c
@@ -151,7 +151,8 @@ SPI_sql_row_to_xmlelement_path(uint64 rownum, StringInfo result,
 		}
 	}
 
-	appendStringInfo(result, "<%s>", element_name);
+	if (element_name[0] != '\0') // if "''" is the input path, ignore it per SQL Server behavior
+		appendStringInfo(result, "<%s>", element_name);
 
 	for (i = 1; i <= SPI_tuptable->tupdesc->natts; i++)
 	{
@@ -185,7 +186,7 @@ SPI_sql_row_to_xmlelement_path(uint64 rownum, StringInfo result,
 		result->data[result->len-1] = '/';
 		appendStringInfoString(result, ">");
 	}
-	else
+	else if (element_name[0] != '\0')
 		appendStringInfo(result, "</%s>", element_name);
 }
 

--- a/test/JDBC/expected/BABEL-3529.out
+++ b/test/JDBC/expected/BABEL-3529.out
@@ -1,0 +1,22 @@
+create table t07y (y int, b int)
+go
+insert into t07y values (10, 1), (20, 1), (30,2), (40,2)
+go
+~~ROW COUNT: 4~~
+
+SELECT y FROM t07y FOR XML PATH ('')
+go
+~~START~~
+ntext
+<y>10</y><y>20</y><y>30</y><y>40</y>
+~~END~~
+
+SELECT y FROM t07y FOR XML PATH ('row')
+go
+~~START~~
+ntext
+<row><y>10</y></row><row><y>20</y></row><row><y>30</y></row><row><y>40</y></row>
+~~END~~
+
+drop table t07y
+go

--- a/test/JDBC/input/BABEL-3529.sql
+++ b/test/JDBC/input/BABEL-3529.sql
@@ -1,0 +1,10 @@
+create table t07y (y int, b int)
+go
+insert into t07y values (10, 1), (20, 1), (30,2), (40,2)
+go
+SELECT y FROM t07y FOR XML PATH ('')
+go
+SELECT y FROM t07y FOR XML PATH ('row')
+go
+drop table t07y
+go


### PR DESCRIPTION
In SQL Server, when FOR XML PATH is used with an empty string, SQL Server will ignore the path element completely. This commit fixes Babelfish to have the same behavior.

Signed-off-by: Jason Teng <jasonten@amazon.com>
 
### Issues Resolved

BABEL-3529


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).