### PR TITLE
Fix user_name() to properly close the opened table by this function

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -582,13 +582,20 @@ user_name(PG_FUNCTION_ARGS)
 
 	tuple = systable_getnext(scan);
 	if (!HeapTupleIsValid(tuple))
+	{	
+		systable_endscan(scan);
+		table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
 		PG_RETURN_NULL();
+	}
 
 	datum = heap_getattr(tuple,
 						 Anum_bbf_authid_user_ext_orig_username,
 						 bbf_authid_user_ext_rel->rd_att,
 						 &is_null);
 	user = pstrdup(TextDatumGetCString(datum));
+
+	systable_endscan(scan);
+	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
 
 	PG_RETURN_TEXT_P(CStringGetTextDatum(user));
 }

--- a/test/JDBC/expected/BABEL-3391.out
+++ b/test/JDBC/expected/BABEL-3391.out
@@ -1,0 +1,16 @@
+BEGIN TRANSACTION;
+select user_name();
+select relname from pg_locks l, pg_class c
+where l.relation = c.oid 
+and relname like 'babelfish_authid_user_%';
+commit;
+go
+~~START~~
+nvarchar
+dbo
+~~END~~
+
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/input/BABEL-3391.sql
+++ b/test/JDBC/input/BABEL-3391.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+select user_name();
+select relname from pg_locks l, pg_class c
+where l.relation = c.oid 
+and relname like 'babelfish_authid_user_%';
+commit;
+go


### PR DESCRIPTION
…#539)

“babelfish_authid_user_ext” table was getting opened inside user_name() function and after that the function should also close that table, which wasn't done in the code.

Task: BABEL-3391
Authored-by: Kuntal Ghosh <kuntalgh@amazon.com>
Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).