### PR TITLE
Fix issue with using strict/lax jsonpath with arrays

### DIFF
--- a/test/JDBC/expected/BABEL-OPENJSON.out
+++ b/test/JDBC/expected/BABEL-OPENJSON.out
@@ -302,3 +302,20 @@ int#!#varchar#!#varchar#!#nvarchar
 3#!#Scratch#!#Male#!#{"id": 3, "sex": "Male", "name": "Scratch"}
 ~~END~~
 
+
+
+DECLARE @json NVARCHAR(MAX);
+SET @json = N'[
+  {"id": 2, "info": {"name": "John", "surname": "Smith"}, "age": 25},
+  {"id": 5, "info": {"name": "Jane", "surname": "Smith"}, "dob": "2005-11-04T12:00:00"}
+]';
+SELECT *
+FROM OPENJSON(@json)
+  WITH ( id INT 'strict $.id', firstName NVARCHAR(50) '$.info.name', lastName NVARCHAR(50) '$.info.surname', age INT, dateOfBirth DATETIME2 '$.dob' );
+go
+~~START~~
+int#!#nvarchar#!#nvarchar#!#int#!#datetime2
+2#!#John#!#Smith#!#25#!#<NULL>
+5#!#Jane#!#Smith#!#<NULL>#!#2005-11-04 12:00:00.0000000
+~~END~~
+

--- a/test/JDBC/input/BABEL-OPENJSON.sql
+++ b/test/JDBC/input/BABEL-OPENJSON.sql
@@ -128,3 +128,14 @@ WITH  (
         [Cats]      nvarchar(max)   '$' AS JSON   
     );
 GO
+
+DECLARE @json NVARCHAR(MAX);
+SET @json = N'[
+  {"id": 2, "info": {"name": "John", "surname": "Smith"}, "age": 25},
+  {"id": 5, "info": {"name": "Jane", "surname": "Smith"}, "dob": "2005-11-04T12:00:00"}
+]';
+
+SELECT *
+FROM OPENJSON(@json)
+  WITH ( id INT 'strict $.id', firstName NVARCHAR(50) '$.info.name', lastName NVARCHAR(50) '$.info.surname', age INT, dateOfBirth DATETIME2 '$.dob' );
+go


### PR DESCRIPTION
Signed-off-by: Jason Teng <jasonten@amazon.com>

### Description

This commit adds tests to verify the matching commit in the engine repo.
 
### Issues Resolved

BABEL-3554


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).