### PR TITLE
 Better handling of SSL handshake failure on TDS side

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -241,7 +241,10 @@ pe_start(Port *port)
 	tdserrcontext.previous = error_context_stack;
 	error_context_stack = &tdserrcontext;
 
-	rc = TdsProcessLogin(port, LoadedSSL);
+	if ((rc = TdsProcessLogin(port, LoadedSSL)) == -1)
+	{
+		return STATUS_ERROR;
+	}
 
 	/* Pop the error context stack */
 	error_context_stack = tdserrcontext.previous;


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
authored-by: Dipesh Dhameliya <dddhamel@amazon.com>
### Description

This commit handles SSL handshake failure by terminating startup process gracefully and not going ahead with process which was causing crash previously.
 
### Issues Resolved

[BABEL-3516] - Crash in Tds_be_tls_write


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).