### PR TITLE
Fix JDBC tests to no longer hang when the server crashes during testing

### DIFF
--- a/test/JDBC/src/main/java/com/sqlsamples/CompareResults.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/CompareResults.java
@@ -130,6 +130,8 @@ public class CompareResults {
                     exceptionOccurred = false;
                     updateCount = stmt.getUpdateCount();
                 } catch (SQLException e) {
+                    if (e.getMessage().equals("The connection is closed."))
+                        return;
                     handleSQLExceptionWithFile(e, bw, logger);
                 }
                 resultsProcessed++;


### PR DESCRIPTION
Signed-off-by: Jason Teng <jasonten@amazon.com>

### Description

Previously, if the server crashed during test execution, JDBC would get into an infinite loop. This commit adds a check for 
that case so that JDBC can terminate.
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).