### PR TITLE
BABEL-3504,3452: Support UDTs for sequences & ISC-sequences view

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -716,4 +716,36 @@ CREATE OR REPLACE VIEW information_schema_tsql.routines AS
 
 GRANT SELECT ON information_schema_tsql.routines TO PUBLIC;
 
+CREATE OR REPLACE VIEW information_schema_tsql.SEQUENCES AS
+    SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "SEQUENCE_CATALOG",
+            CAST(extc.orig_name AS sys.nvarchar(128)) AS "SEQUENCE_SCHEMA",
+            CAST(r.relname AS sys.nvarchar(128)) AS "SEQUENCE_NAME",
+            CAST(CASE WHEN tsql_type_name = 'sysname' THEN sys.translate_pg_type_to_tsql(t.typbasetype) ELSE tsql_type_name END
+                    AS sys.nvarchar(128))AS "DATA_TYPE",  -- numeric and decimal data types are converted into bigint which is due to Postgres' inherent implementation
+            CAST(information_schema_tsql._pgtsql_numeric_precision(tsql_type_name, t.oid, -1)
+                        AS smallint) AS "NUMERIC_PRECISION",
+            CAST(information_schema_tsql._pgtsql_numeric_precision_radix(tsql_type_name, case when t.typtype = 'd' THEN t.typbasetype ELSE t.oid END, -1)
+                        AS smallint) AS "NUMERIC_PRECISION_RADIX",
+            CAST(information_schema_tsql._pgtsql_numeric_scale(tsql_type_name, t.oid, -1)
+                        AS int) AS "NUMERIC_SCALE",
+            CAST(s.seqstart AS int) AS "START_VALUE",
+            CAST(s.seqmin AS int) AS "MINIMUM_VALUE",
+            CAST(s.seqmax AS int) AS "MAXIMUM_VALUE",
+            CAST(s.seqincrement  AS int) AS "INCREMENT",
+            CAST( CASE WHEN s.seqcycle = 't' THEN 1 ELSE 0 END AS int) AS "CYCLE_OPTION",
+            CAST(NULL AS sys.nvarchar(128)) AS "DECLARED_DATA_TYPE",
+            CAST(NULL AS int) AS "DECLARED_NUMERIC_PRECISION",
+            CAST(NULL AS int) AS "DECLARED_NUMERIC_SCALE"
+        FROM sys.pg_namespace_ext nc JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+            pg_sequence s join pg_class r on s.seqrelid = r.oid join pg_type t on s.seqtypid=t.oid,
+            sys.translate_pg_type_to_tsql(s.seqtypid) AS tsql_type_name
+        WHERE nc.oid = r.relnamespace
+        AND extc.dbid = cast(sys.db_id() as oid)
+            AND r.relkind = 'S'
+            AND (NOT pg_is_other_temp_schema(nc.oid))
+            AND (pg_has_role(r.relowner, 'USAGE')
+                OR has_sequence_privilege(r.oid, 'SELECT, UPDATE, USAGE'));
+
+GRANT SELECT ON information_schema_tsql.sequences TO PUBLIC; 
+
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -201,5 +201,37 @@ SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_function_ext', '');
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);
 
+CREATE OR REPLACE VIEW information_schema_tsql.SEQUENCES AS
+    SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "SEQUENCE_CATALOG",
+            CAST(extc.orig_name AS sys.nvarchar(128)) AS "SEQUENCE_SCHEMA",
+            CAST(r.relname AS sys.nvarchar(128)) AS "SEQUENCE_NAME",
+            CAST(CASE WHEN tsql_type_name = 'sysname' THEN sys.translate_pg_type_to_tsql(t.typbasetype) ELSE tsql_type_name END
+                    AS sys.nvarchar(128))AS "DATA_TYPE",  -- numeric and decimal data types are converted into bigint which is due to Postgres' inherent implementation
+            CAST(information_schema_tsql._pgtsql_numeric_precision(tsql_type_name, t.oid, -1)
+                        AS smallint) AS "NUMERIC_PRECISION",
+            CAST(information_schema_tsql._pgtsql_numeric_precision_radix(tsql_type_name, case when t.typtype = 'd' THEN t.typbasetype ELSE t.oid END, -1)
+                        AS smallint) AS "NUMERIC_PRECISION_RADIX",
+            CAST(information_schema_tsql._pgtsql_numeric_scale(tsql_type_name, t.oid, -1)
+                        AS int) AS "NUMERIC_SCALE",
+            CAST(s.seqstart AS int) AS "START_VALUE",
+            CAST(s.seqmin AS int) AS "MINIMUM_VALUE",
+            CAST(s.seqmax AS int) AS "MAXIMUM_VALUE",
+            CAST(s.seqincrement  AS int) AS "INCREMENT",
+            CAST( CASE WHEN s.seqcycle = 't' THEN 1 ELSE 0 END AS int) AS "CYCLE_OPTION",
+            CAST(NULL AS sys.nvarchar(128)) AS "DECLARED_DATA_TYPE",
+            CAST(NULL AS int) AS "DECLARED_NUMERIC_PRECISION",
+            CAST(NULL AS int) AS "DECLARED_NUMERIC_SCALE"
+        FROM sys.pg_namespace_ext nc JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
+            pg_sequence s join pg_class r on s.seqrelid = r.oid join pg_type t on s.seqtypid=t.oid,
+            sys.translate_pg_type_to_tsql(s.seqtypid) AS tsql_type_name
+        WHERE nc.oid = r.relnamespace
+        AND extc.dbid = cast(sys.db_id() as oid)
+            AND r.relkind = 'S'
+            AND (NOT pg_is_other_temp_schema(nc.oid))
+            AND (pg_has_role(r.relowner, 'USAGE')
+                OR has_sequence_privilege(r.oid, 'SELECT, UPDATE, USAGE'));
+
+GRANT SELECT ON information_schema_tsql.sequences TO PUBLIC; 
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1753,6 +1753,7 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 	typ = typenameType(pstate, type_def, &typmod_p);
 	typname = typeTypeName(typ);
 	tsqlSeqTypOid = pltsql_seq_type_map(*newtypid);
+	AclResult aclresult = pg_type_aclcheck(*newtypid, GetUserId(), ACL_USAGE);
 
 	if (type_def->typemod != -1)
 		typmod_p = type_def->typemod;
@@ -1820,6 +1821,9 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 		 */
 		if (!for_identity || typmod_p != -1)
 		{
+			if (typmod_p == -1)
+                typmod_p = 1179652;
+
 			uint8_t scale = (typmod_p - VARHDRSZ) & 0xffff;
 			uint8_t precision = ((typmod_p - VARHDRSZ) >> 16) & 0xffff;
 
@@ -1838,6 +1842,12 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 		ereport(WARNING,
 				(errmsg("NUMERIC or DECIMAL type is cast to BIGINT")));
 	}
+
+	if (aclresult != ACLCHECK_OK)
+		aclcheck_error_type(aclresult, *newtypid);
+
+	if(getBaseType(*newtypid)!=INT2OID || getBaseType(*newtypid)!=INT4OID || getBaseType(*newtypid)!=INT8OID) *newtypid = getBaseType(*newtypid);
+
 }
 
 static Oid
@@ -2201,9 +2211,6 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 					}
 
 					address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);
-
-					/* Store function default positions in babelfish catalog */
-					pltsql_store_func_default_positions(address, castNode(CreateFunctionStmt, parsetree)->parameters);
 
 					if (tbltypStmt || restore_tsql_tabletype)
 					{

--- a/test/JDBC/expected/13_4__preparation__ISC-sequences-vu-prepare.out
+++ b/test/JDBC/expected/13_4__preparation__ISC-sequences-vu-prepare.out
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/13_4__preparation__jira-BABEL-3504-vu-prepare.out
+++ b/test/JDBC/expected/13_4__preparation__jira-BABEL-3504-vu-prepare.out
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/13_5__preparation__ISC-sequences-vu-prepare.out
+++ b/test/JDBC/expected/13_5__preparation__ISC-sequences-vu-prepare.out
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/13_5__preparation__jira-BABEL-3504-vu-prepare.out
+++ b/test/JDBC/expected/13_5__preparation__jira-BABEL-3504-vu-prepare.out
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/13_6__preparation__ISC-sequences-vu-prepare.out
+++ b/test/JDBC/expected/13_6__preparation__ISC-sequences-vu-prepare.out
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/13_6__preparation__jira-BABEL-3504-vu-prepare.out
+++ b/test/JDBC/expected/13_6__preparation__jira-BABEL-3504-vu-prepare.out
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/14_3__preparation__ISC-sequences-vu-prepare.out
+++ b/test/JDBC/expected/14_3__preparation__ISC-sequences-vu-prepare.out
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/14_3__preparation__jira-BABEL-3504-vu-prepare.out
+++ b/test/JDBC/expected/14_3__preparation__jira-BABEL-3504-vu-prepare.out
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/ISC-sequences-vu-cleanup.out
+++ b/test/JDBC/expected/ISC-sequences-vu-cleanup.out
@@ -1,0 +1,68 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/expected/ISC-sequences-vu-prepare.out
+++ b/test/JDBC/expected/ISC-sequences-vu-prepare.out
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/ISC-sequences-vu-verify.out
+++ b/test/JDBC/expected/ISC-sequences-vu-verify.out
@@ -1,0 +1,75 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+
+select * from isc_sequences_view1;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#int#!#int
+isc_sequences_dbone#!#isc_sequences_sc1#!#isc_sequences_seq1#!#bigint#!#19#!#10#!#0#!#1#!#1#!#5#!#1#!#1#!#<NULL>#!#<NULL>#!#<NULL>
+isc_sequences_dbone#!#isc_sequences_sc1#!#isc_sequences_seq2#!#smallint#!#5#!#10#!#0#!#2#!#1#!#5#!#1#!#1#!#<NULL>#!#<NULL>#!#<NULL>
+isc_sequences_dbone#!#isc_sequences_sc1#!#isc_sequences_seq3#!#smallint#!#5#!#10#!#0#!#3#!#3#!#10#!#3#!#0#!#<NULL>#!#<NULL>#!#<NULL>
+isc_sequences_dbone#!#isc_sequences_sc1#!#isc_sequences_seq4#!#int#!#10#!#10#!#0#!#4#!#2#!#10#!#2#!#0#!#<NULL>#!#<NULL>#!#<NULL>
+isc_sequences_dbone#!#isc_sequences_sc2#!#isc_sequences_seq1#!#bigint#!#19#!#10#!#0#!#1#!#1#!#5#!#1#!#1#!#<NULL>#!#<NULL>#!#<NULL>
+isc_sequences_dbone#!#isc_sequences_sc2#!#isc_sequences_seq2#!#bigint#!#19#!#10#!#0#!#2#!#2#!#10#!#2#!#0#!#<NULL>#!#<NULL>#!#<NULL>
+isc_sequences_dbone#!#isc_sequences_sc2#!#isc_sequences_seq3#!#bigint#!#19#!#10#!#0#!#3#!#3#!#12#!#3#!#1#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#int#!#int
+master#!#dbo#!#isc_sequences_master_seq1#!#bigint#!#19#!#10#!#0#!#1#!#1#!#5#!#1#!#1#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#int#!#int
+~~END~~
+
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#int#!#int
+isc_sequences_dbone#!#isc_sequences_sc1#!#isc_sequences_seq1#!#bigint#!#19#!#10#!#0#!#1#!#1#!#5#!#1#!#1#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+

--- a/test/JDBC/expected/jira-BABEL-3504-vu-cleanup.out
+++ b/test/JDBC/expected/jira-BABEL-3504-vu-cleanup.out
@@ -1,0 +1,115 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/expected/jira-BABEL-3504-vu-prepare.out
+++ b/test/JDBC/expected/jira-BABEL-3504-vu-prepare.out
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/expected/jira-BABEL-3504-vu-verify.out
+++ b/test/JDBC/expected/jira-BABEL-3504-vu-verify.out
@@ -1,0 +1,63 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq1#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq3#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq4#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq6#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq7#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq1#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq3#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq4#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq6#!#bigint
+~~END~~
+
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for type jira_babel_3504_bigint2)~~
+
+
+-- psql
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__ISC-sequences-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__ISC-sequences-vu-cleanup.out
@@ -1,0 +1,68 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__ISC-sequences-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__ISC-sequences-vu-verify.out
@@ -1,0 +1,69 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+select * from isc_sequences_view1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "isc_sequences_view1" does not exist)~~
+
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__jira-BABEL-3504-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__jira-BABEL-3504-vu-cleanup.out
@@ -1,0 +1,115 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__jira-BABEL-3504-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__jira-BABEL-3504-vu-verify.out
@@ -1,0 +1,63 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq1#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq3#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq4#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq6#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq7#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq1#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq3#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq4#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq6#!#bigint
+~~END~~
+
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for type jira_babel_3504_bigint2)~~
+
+
+-- psql
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_5__ISC-sequences-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_5__ISC-sequences-vu-cleanup.out
@@ -1,0 +1,68 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_5__ISC-sequences-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_5__ISC-sequences-vu-verify.out
@@ -1,0 +1,70 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+select * from isc_sequences_view1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "isc_sequences_view1" does not exist)~~
+
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+

--- a/test/JDBC/expected/latest__verification_cleanup__13_5__jira-BABEL-3504-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_5__jira-BABEL-3504-vu-cleanup.out
@@ -1,0 +1,115 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_5__jira-BABEL-3504-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_5__jira-BABEL-3504-vu-verify.out
@@ -1,0 +1,63 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq1#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq3#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq4#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq6#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq7#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq1#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq3#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq4#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq6#!#bigint
+~~END~~
+
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for type jira_babel_3504_bigint2)~~
+
+
+-- psql
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_6__ISC-sequences-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_6__ISC-sequences-vu-cleanup.out
@@ -1,0 +1,68 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_6__ISC-sequences-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_6__ISC-sequences-vu-verify.out
@@ -1,0 +1,69 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+select * from isc_sequences_view1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "isc_sequences_view1" does not exist)~~
+
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~

--- a/test/JDBC/expected/latest__verification_cleanup__13_6__jira-BABEL-3504-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_6__jira-BABEL-3504-vu-cleanup.out
@@ -1,0 +1,115 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__13_6__jira-BABEL-3504-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_6__jira-BABEL-3504-vu-verify.out
@@ -1,0 +1,63 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq1#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq3#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq4#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq6#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq7#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq1#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq3#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq4#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq6#!#bigint
+~~END~~
+
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for type jira_babel_3504_bigint2)~~
+
+
+-- psql
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__ISC-sequences-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__ISC-sequences-vu-cleanup.out
@@ -1,0 +1,68 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__ISC-sequences-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__ISC-sequences-vu-verify.out
@@ -1,0 +1,69 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+select * from isc_sequences_view1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "isc_sequences_view1" does not exist)~~
+
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~
+
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.sequences" does not exist)~~

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__jira-BABEL-3504-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__jira-BABEL-3504-vu-cleanup.out
@@ -1,0 +1,115 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__jira-BABEL-3504-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__jira-BABEL-3504-vu-verify.out
@@ -1,0 +1,63 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq1#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq3#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq4#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq6#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch1#!#jira_babel_3504_seq7#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq1#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq2#!#smallint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq3#!#int
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq4#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq5#!#bigint
+jira_babel_3504_dbone#!#jira_babel_3504_sch2#!#jira_babel_3504_seq6#!#bigint
+~~END~~
+
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for type jira_babel_3504_bigint2)~~
+
+
+-- psql
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/input/ISC-sequences-vu-cleanup.mix
+++ b/test/JDBC/input/ISC-sequences-vu-cleanup.mix
@@ -1,0 +1,59 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/input/ISC-sequences-vu-prepare.mix
+++ b/test/JDBC/input/ISC-sequences-vu-prepare.mix
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/input/ISC-sequences-vu-verify.mix
+++ b/test/JDBC/input/ISC-sequences-vu-verify.mix
@@ -1,0 +1,50 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+
+select * from isc_sequences_view1;
+go
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go

--- a/test/JDBC/input/jira-BABEL-3504-vu-cleanup.mix
+++ b/test/JDBC/input/jira-BABEL-3504-vu-cleanup.mix
@@ -1,0 +1,106 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/input/jira-BABEL-3504-vu-prepare.mix
+++ b/test/JDBC/input/jira-BABEL-3504-vu-prepare.mix
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/input/jira-BABEL-3504-vu-verify.mix
+++ b/test/JDBC/input/jira-BABEL-3504-vu-verify.mix
@@ -1,0 +1,42 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+-- psql
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -9,7 +9,6 @@
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
 all
-
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
 ignore#!#insertbulk
 ignore#!#BABEL-SQLvariant

--- a/test/JDBC/upgrade/13_4/preparation/ISC-sequences-vu-prepare.mix
+++ b/test/JDBC/upgrade/13_4/preparation/ISC-sequences-vu-prepare.mix
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/13_4/preparation/jira-BABEL-3504-vu-prepare.mix
+++ b/test/JDBC/upgrade/13_4/preparation/jira-BABEL-3504-vu-prepare.mix
@@ -1,0 +1,78 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create type jira_babel_3504_tinyint1 from tinyint;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_tinyint1 start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_seq11 as jira_babel_3504_tinyint1 start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/13_5/preparation/ISC-sequences-vu-prepare.mix
+++ b/test/JDBC/upgrade/13_5/preparation/ISC-sequences-vu-prepare.mix
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/13_5/preparation/jira-BABEL-3504-vu-prepare.mix
+++ b/test/JDBC/upgrade/13_5/preparation/jira-BABEL-3504-vu-prepare.mix
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/13_6/preparation/ISC-sequences-vu-prepare.mix
+++ b/test/JDBC/upgrade/13_6/preparation/ISC-sequences-vu-prepare.mix
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/13_6/preparation/jira-BABEL-3504-vu-prepare.mix
+++ b/test/JDBC/upgrade/13_6/preparation/jira-BABEL-3504-vu-prepare.mix
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/14_3/preparation/ISC-sequences-vu-prepare.mix
+++ b/test/JDBC/upgrade/14_3/preparation/ISC-sequences-vu-prepare.mix
@@ -1,0 +1,36 @@
+-- tsql
+create database isc_sequences_dbone;
+go
+
+create sequence isc_sequences_master_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+Use isc_sequences_dbone;
+go
+
+create schema isc_sequences_sc1;
+go
+
+create schema isc_sequences_sc2;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence isc_sequences_sc1.isc_sequences_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq1 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq2 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence isc_sequences_sc2.isc_sequences_seq3 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/14_3/preparation/jira-BABEL-3504-vu-prepare.mix
+++ b/test/JDBC/upgrade/14_3/preparation/jira-BABEL-3504-vu-prepare.mix
@@ -1,0 +1,69 @@
+-- tsql
+create database jira_babel_3504_dbone;
+go
+
+Use jira_babel_3504_dbone;
+go
+
+create schema jira_babel_3504_sch1;
+go
+
+create schema jira_babel_3504_sch2;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq1 start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq2 as tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq3 as smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq4 as int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq5 as bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq6 as decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch1.jira_babel_3504_seq7 as numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_tinyint from tinyint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_smallint from smallint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_int from int;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_bigint from bigint;
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_decimal from decimal(10,0);
+go
+
+create type jira_babel_3504_sch2.jira_babel_3504_numeric from numeric(10,0);
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq1 as jira_babel_3504_sch2.jira_babel_3504_tinyint start with 2 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq2 as jira_babel_3504_sch2.jira_babel_3504_smallint start with 3 increment by 3 minvalue 3 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq3 as jira_babel_3504_sch2.jira_babel_3504_int start with 4 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq4 as jira_babel_3504_sch2.jira_babel_3504_bigint start with 1 minvalue 1 maxvalue 5 cycle;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq5 as jira_babel_3504_sch2.jira_babel_3504_decimal start with 2 increment by 2 minvalue 2 maxvalue 10;
+go
+
+create sequence jira_babel_3504_sch2.jira_babel_3504_seq6 as jira_babel_3504_sch2.jira_babel_3504_numeric start with 3 increment by 3 minvalue 3 maxvalue 12 cycle;
+go

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -276,3 +276,5 @@ BABEL-889
 babel_417
 babel_datatype_sqlvariant
 babel_sqlvariant_cast_compare
+ISC-sequences
+jira-BABEL-3504

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -285,3 +285,5 @@ babel_417
 babel_datatype_sqlvariant
 babel_sqlvariant_cast_compare
 BABEL-3144
+ISC-sequences
+jira-BABEL-3504

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/ISC-sequences-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/ISC-sequences-vu-cleanup.mix
@@ -1,0 +1,59 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/ISC-sequences-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/ISC-sequences-vu-verify.mix
@@ -1,0 +1,50 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+
+select * from isc_sequences_view1;
+go
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/jira-BABEL-3504-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/jira-BABEL-3504-vu-cleanup.mix
@@ -1,0 +1,106 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/jira-BABEL-3504-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/jira-BABEL-3504-vu-verify.mix
@@ -1,0 +1,42 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+-- psql
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_5/ISC-sequences-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_5/ISC-sequences-vu-cleanup.mix
@@ -1,0 +1,59 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_5/ISC-sequences-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_5/ISC-sequences-vu-verify.mix
@@ -1,0 +1,50 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+
+select * from isc_sequences_view1;
+go
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_5/jira-BABEL-3504-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_5/jira-BABEL-3504-vu-cleanup.mix
@@ -1,0 +1,106 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_5/jira-BABEL-3504-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_5/jira-BABEL-3504-vu-verify.mix
@@ -1,0 +1,42 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+-- psql
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/ISC-sequences-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/ISC-sequences-vu-cleanup.mix
@@ -1,0 +1,59 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/ISC-sequences-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/ISC-sequences-vu-verify.mix
@@ -1,0 +1,50 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+
+select * from isc_sequences_view1;
+go
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/jira-BABEL-3504-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/jira-BABEL-3504-vu-cleanup.mix
@@ -1,0 +1,106 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/jira-BABEL-3504-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/jira-BABEL-3504-vu-verify.mix
@@ -1,0 +1,42 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+-- psql
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/ISC-sequences-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/ISC-sequences-vu-cleanup.mix
@@ -1,0 +1,59 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq3;
+go
+
+drop sequence isc_sequences_sc1.isc_sequences_seq4;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq1;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq2;
+go
+
+drop sequence isc_sequences_sc2.isc_sequences_seq3;
+go
+
+drop schema isc_sequences_sc1;
+go
+
+drop schema isc_sequences_sc2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'isc_sequences_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use isc_sequences_dbone;
+go
+
+drop user isc_sequences_usr1;
+go
+
+drop login isc_sequences_log1;
+go
+
+use master;
+go
+
+drop sequence isc_sequences_master_seq1;
+go
+
+drop database isc_sequences_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/ISC-sequences-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/ISC-sequences-vu-verify.mix
@@ -1,0 +1,50 @@
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+create view isc_sequences_view1 as select * from information_schema.SEQUENCES;
+go
+
+select * from isc_sequences_view1;
+go
+
+use master;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+use isc_sequences_dbone;
+go
+
+--privilege testing
+create login isc_sequences_log1 with password='123456789';
+go
+
+create user isc_sequences_usr1 for login isc_sequences_log1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone;
+go
+
+select * from information_schema.SEQUENCES;
+go
+
+-- tsql
+
+use isc_sequences_dbone;
+go
+
+grant select on isc_sequences_sc1.isc_sequences_seq1 to isc_sequences_usr1;
+go
+
+-- tsql user=isc_sequences_log1 password=123456789
+
+use isc_sequences_dbone; 
+go
+
+select * from information_schema.SEQUENCES;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/jira-BABEL-3504-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/jira-BABEL-3504-vu-cleanup.mix
@@ -1,0 +1,106 @@
+-- psql 
+revoke create on schema dbo from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+revoke usage on type dbo.jira_babel_3504_bigint2 from jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql
+
+--cleanup
+use jira_babel_3504_dbone;
+go
+
+drop sequence jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq6;
+go
+
+drop sequence jira_babel_3504_sch1.jira_babel_3504_seq7;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq1;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq2;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq3;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq4;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq5;
+go
+
+drop sequence jira_babel_3504_sch2.jira_babel_3504_seq6;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_tinyint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_smallint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_int;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_bigint;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_decimal;
+go
+
+drop type jira_babel_3504_sch2.jira_babel_3504_numeric;
+go
+
+
+drop schema jira_babel_3504_sch1;
+go
+
+drop schema jira_babel_3504_sch2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'jira_babel_3504_log1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql 
+use jira_babel_3504_dbone;
+go
+
+drop login jira_babel_3504_log1;
+go
+
+drop user jira_babel_3504_usr1;
+go
+
+use master;
+go
+
+drop database jira_babel_3504_dbone;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/jira-BABEL-3504-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/jira-BABEL-3504-vu-verify.mix
@@ -1,0 +1,42 @@
+-- tsql 
+
+use jira_babel_3504_dbone;
+go
+
+--data type of UDT sequences will be the base type of the data type
+select sequence_catalog, sequence_schema, sequence_name, data_type from information_schema.sequences;
+go
+
+--privilege testing
+create login jira_babel_3504_log1 with password='123456789';
+go
+
+create user jira_babel_3504_usr1 for login jira_babel_3504_log1;
+go
+
+create type jira_babel_3504_bigint2 from bigint;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as jira_babel_3504_bigint2 start with 1;
+go
+
+--providing usage privilege to user via psql as grant to user is not currently supported in babelfish
+-- psql
+grant create on schema dbo to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+grant usage on type dbo.jira_babel_3504_bigint2 to jira_babel_3504_dbone_jira_babel_3504_usr1;
+go
+
+-- tsql user=jira_babel_3504_log1 password=123456789
+
+use jira_babel_3504_dbone;
+go
+
+create sequence jira_babel_3504_seq1 as dbo.jira_babel_3504_bigint2 start with 1;
+go


### PR DESCRIPTION

### Description

Creation of view information_schema_tsql.sequences to support for T-SQL INFORMATION_SCHEMA.SEQUENCES. 
Provide support for creation of a sequence using user-defined data types which is currently not supported in Babelfish.
Add upgrade test cases for both implementations

Signed-off-by: Aditya Verma <adiityav@amazon.com>

### Issues Resolved

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).