### PR TITLE
Add JDBC tests for CONVERT

### DIFF
--- a/test/JDBC/expected/BABEL-2054.out
+++ b/test/JDBC/expected/BABEL-2054.out
@@ -1,0 +1,23 @@
+select convert(datetime, '2021-12-30')
+go
+~~START~~
+datetime
+2021-12-30 00:00:00.0
+~~END~~
+
+
+select convert(datetime, '2021.12.30')
+go
+~~START~~
+datetime
+2021-12-30 00:00:00.0
+~~END~~
+
+
+select convert(datetime, '2021/12/30')
+go
+~~START~~
+datetime
+2021-12-30 00:00:00.0
+~~END~~
+

--- a/test/JDBC/input/BABEL-2054.sql
+++ b/test/JDBC/input/BABEL-2054.sql
@@ -1,0 +1,8 @@
+select convert(datetime, '2021-12-30')
+go
+
+select convert(datetime, '2021.12.30')
+go
+
+select convert(datetime, '2021/12/30')
+go


### PR DESCRIPTION
### Description

An issue BABEL-2054 was reported where CONVERT(datetime, string) failed intermittently. However, this issue is not reproducible and this commit adds JDBC tests to validate the scenario mentioned in the JIRA

Task: BABEL-2054

Signed-off-by: Amith Kamath <amithkam@amazon.com>
 
### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).