### PR TITLE
Better handling of SSL handshake failure on TDS side

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -237,7 +237,10 @@ pe_start(Port *port)
 	tdserrcontext.previous = error_context_stack;
 	error_context_stack = &tdserrcontext;
 
-	rc = TdsProcessLogin(port, LoadedSSL);
+	if ((rc = TdsProcessLogin(port, LoadedSSL)) == -1)
+	{
+		return STATUS_ERROR;
+	}
 
 	/* Pop the error context stack */
 	error_context_stack = tdserrcontext.previous;

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1872,14 +1872,28 @@ TdsProcessLogin(Port *port, bool loadedSsl)
 		if (loadEncryption == TDS_ENCRYPT_ON ||
 			loadEncryption == TDS_ENCRYPT_OFF ||
 			loadEncryption == TDS_ENCRYPT_REQ)
-			SecureOpenServer(port);
+			rc = SecureOpenServer(port);
+	}
+	PG_CATCH();
+	{
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
-		if (loadEncryption == TDS_ENCRYPT_ON)
-			TDSInstrumentation(INSTR_TDS_LOGIN_END_TO_END_ENCRYPT);
+	/*
+	 * If SSL handshake failure has occurred then no need to go ahead with login,
+	 * Just return from here.
+	 */
+	if (rc < 0)
+		return rc;
 
+	if (loadEncryption == TDS_ENCRYPT_ON)
+		TDSInstrumentation(INSTR_TDS_LOGIN_END_TO_END_ENCRYPT);
+
+	PG_TRY();
+	{
 		/* Login */
 		rc = ProcessLoginInternal(port);
-
 	}
 	PG_CATCH();
 	{


### PR DESCRIPTION
### Description

Better handling of SSL handshake failure on TDS side

This commit handles SSL handshake failure by terminating startup process gracefully and not going ahead with process which was causing crash previously.

This commit also adds few additional logs line by cherry-picking the code from community postgres.
 
### Issues Resolved

BABEL-3516

Task: BABEL-3316
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).