### PR TITLE
Login who owns database should always be dbo also without sysadmin role

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -23,6 +23,7 @@
 #include "utils/timestamp.h"
 #include "nodes/execnodes.h"
 #include "catalog.h"
+#include "dbcmds.h"
 #include "guc.h"
 #include "hooks.h"
 #include "multidb.h"
@@ -227,24 +228,6 @@ char *get_db_name(int16 dbid)
       ReleaseSysCache(tuple);
 
 	return name;
-}
-
-char *get_owner_of_db(const char *dbname)
-{
-	char				*owner = NULL;
-	HeapTuple 			tuple;
-	Form_sysdatabases 	sysdb;
-
-	  tuple = SearchSysCache1(SYSDATABASENAME, CStringGetTextDatum(dbname));
-
-	  if (!HeapTupleIsValid(tuple))
-		  return InvalidDbid;
-
-	  sysdb = ((Form_sysdatabases) GETSTRUCT(tuple));
-	  owner = NameStr(sysdb->owner);
-	  ReleaseSysCache(tuple);
-
-	return owner;
 }
 
 const char *get_one_user_db_name(void)

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -941,7 +941,7 @@ get_user_for_database(const char *db_name)
 
 	login = GetUserNameFromId(GetSessionUserId(), false);
 	user = get_authid_user_ext_physical_name(db_name, login);
-	login_is_db_owner = 0 == strcmp(login, get_owner_of_db(db_name));
+	login_is_db_owner = 0 == strncmp(login, get_owner_of_db(db_name), NAMEDATALEN);
 
 	if (!user)
 	{
@@ -954,7 +954,8 @@ get_user_for_database(const char *db_name)
 			user = get_guest_role_name(db_name);
 	}
 
-	if (user && !(is_member_of_role(GetSessionUserId(), get_role_oid(user, false)) || login_is_db_owner))
+	if (user && !(is_member_of_role(GetSessionUserId(), get_role_oid(user, false)) 
+					|| login_is_db_owner))
 		user = NULL;
 
 	return user;

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -80,6 +80,7 @@ extern int16 get_db_id(const char *dbname);
 extern char *get_db_name(int16 dbid);
 extern void initTsqlSyscache(void);
 extern const char *get_one_user_db_name(void);
+extern char *get_owner_of_db(const char *dbname);
 
 #define DEFAULT_DATABASE_COMPATIBILITY_LEVEL 80
 

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -80,7 +80,6 @@ extern int16 get_db_id(const char *dbname);
 extern char *get_db_name(int16 dbid);
 extern void initTsqlSyscache(void);
 extern const char *get_one_user_db_name(void);
-extern char *get_owner_of_db(const char *dbname);
 
 #define DEFAULT_DATABASE_COMPATIBILITY_LEVEL 80
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -540,7 +540,7 @@ drop_bbf_db(const char *dbname, bool missing_ok, bool force_drop)
 	{
 		Oid roleid = GetSessionUserId();
 		const char *login = GetUserNameFromId(roleid, false);
-		bool login_is_db_owner = 0 == strcmp(login, get_owner_of_db(dbname));
+		bool login_is_db_owner = 0 == strncmp(login, get_owner_of_db(dbname), NAMEDATALEN);
 		
 		if (!(has_privs_of_role(roleid, get_role_oid("sysadmin", false)) || login_is_db_owner))
 			aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_DATABASE,
@@ -835,6 +835,10 @@ drop_related_bbf_namespace_entries(int16 dbid)
 	table_close(namespace_rel, RowExclusiveLock);
 }
 
+/* 
+ * Helper function to get the owner from a given database name
+ * Caller is responsible for validating that the given database exists
+ */
 const char *
 get_owner_of_db(const char *dbname)
 {
@@ -845,7 +849,9 @@ get_owner_of_db(const char *dbname)
 	tuple = SearchSysCache1(SYSDATABASENAME, CStringGetTextDatum(dbname));
 
 	if (!HeapTupleIsValid(tuple))
-		return InvalidDbid;
+		ereport(ERROR, 
+				(errcode(ERRCODE_UNDEFINED_DATABASE),
+				errmsg("database \"%s\" does not exist", dbname)));
 
 	sysdb = ((Form_sysdatabases) GETSTRUCT(tuple));
 	owner = NameStr(sysdb->owner);

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -539,8 +539,10 @@ drop_bbf_db(const char *dbname, bool missing_ok, bool force_drop)
 	PG_TRY();
 	{
 		Oid roleid = GetSessionUserId();
-
-		if (!has_privs_of_role(roleid, get_role_oid("sysadmin", false)))
+		const char *login = GetUserNameFromId(roleid, false);
+		bool login_is_db_owner = 0 == strcmp(login, get_owner_of_db(dbname));
+		
+		if (!(has_privs_of_role(roleid, get_role_oid("sysadmin", false)) || login_is_db_owner))
 			aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_DATABASE,
 						   dbname);
 
@@ -831,4 +833,23 @@ drop_related_bbf_namespace_entries(int16 dbid)
 	}
 	table_endscan(scan);
 	table_close(namespace_rel, RowExclusiveLock);
+}
+
+const char *
+get_owner_of_db(const char *dbname)
+{
+	char				*owner = NULL;
+	HeapTuple 			tuple;
+	Form_sysdatabases 	sysdb;
+
+	  tuple = SearchSysCache1(SYSDATABASENAME, CStringGetTextDatum(dbname));
+
+	  if (!HeapTupleIsValid(tuple))
+		  return InvalidDbid;
+
+	  sysdb = ((Form_sysdatabases) GETSTRUCT(tuple));
+	  owner = NameStr(sysdb->owner);
+	  ReleaseSysCache(tuple);
+
+	return owner;
 }

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -842,14 +842,14 @@ get_owner_of_db(const char *dbname)
 	HeapTuple 			tuple;
 	Form_sysdatabases 	sysdb;
 
-	  tuple = SearchSysCache1(SYSDATABASENAME, CStringGetTextDatum(dbname));
+	tuple = SearchSysCache1(SYSDATABASENAME, CStringGetTextDatum(dbname));
 
-	  if (!HeapTupleIsValid(tuple))
-		  return InvalidDbid;
+	if (!HeapTupleIsValid(tuple))
+		return InvalidDbid;
 
-	  sysdb = ((Form_sysdatabases) GETSTRUCT(tuple));
-	  owner = NameStr(sysdb->owner);
-	  ReleaseSysCache(tuple);
+	sysdb = ((Form_sysdatabases) GETSTRUCT(tuple));
+	owner = NameStr(sysdb->owner);
+	ReleaseSysCache(tuple);
 
 	return owner;
 }

--- a/contrib/babelfishpg_tsql/src/dbcmds.h
+++ b/contrib/babelfishpg_tsql/src/dbcmds.h
@@ -4,5 +4,6 @@
 #include "nodes/parsenodes.h"
 extern Oid create_bbf_db(ParseState *pstate, const CreatedbStmt *stmt);
 extern void drop_bbf_db(const char *dbname, bool missing_ok, bool force_drop);
+extern const char *get_owner_of_db(const char *dbname);
 
 #endif

--- a/test/JDBC/expected/BABEL-3548.out
+++ b/test/JDBC/expected/BABEL-3548.out
@@ -1,0 +1,79 @@
+-- tsql
+create login test_login1 with password='123';
+go
+
+alter server role sysadmin add member test_login1;
+go
+
+-- tsql      user=test_login1      password=123
+create database login1_db;
+go
+
+-- tsql
+alter server role sysadmin drop member test_login1;
+go
+
+-- tsql      user=test_login1      password=123
+-- Shouldn't cause error as login is the db owner
+use login1_db;
+go
+
+select CURRENT_USER;
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+use master;
+go
+
+select CURRENT_USER;
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+
+-- tsql
+drop database login1_db;
+go
+
+create database sysadmin_only_db;
+go
+
+-- tsql      user=test_login1      password=123
+-- Should fail
+use sysadmin_only_db;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The server principal "test_login1" is not able to access the database "sysadmin_only_db" under the current security context)~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'test_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop database sysadmin_only_db;
+drop login test_login1;
+go
+

--- a/test/JDBC/expected/BABEL-3548.out
+++ b/test/JDBC/expected/BABEL-3548.out
@@ -1,21 +1,21 @@
 -- tsql
-create login test_login1 with password='123';
+create login babel_3548_l1 with password='123';
 go
 
-alter server role sysadmin add member test_login1;
+alter server role sysadmin add member babel_3548_l1;
 go
 
--- tsql      user=test_login1      password=123
-create database login1_db;
+-- tsql      user=babel_3548_l1      password=123
+create database babel_3548_db;
 go
 
 -- tsql
-alter server role sysadmin drop member test_login1;
+alter server role sysadmin drop member babel_3548_l1;
 go
 
--- tsql      user=test_login1      password=123
+-- tsql      user=babel_3548_l1      password=123
 -- Shouldn't cause error as login is the db owner
-use login1_db;
+use babel_3548_db;
 go
 
 select CURRENT_USER;
@@ -37,37 +37,37 @@ guest
 ~~END~~
 
 
-drop database login1_db;
+drop database babel_3548_db;
 go
 
 -- tsql
-create database sysadmin_only_db;
+create database babel_3548_sysadm_db;
 go
 
--- tsql      user=test_login1      password=123
+-- tsql      user=babel_3548_l1      password=123
 -- Should fail
-use sysadmin_only_db;
+use babel_3548_sysadm_db;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: The server principal "test_login1" is not able to access the database "sysadmin_only_db" under the current security context)~~
+~~ERROR (Message: The server principal "babel_3548_l1" is not able to access the database "babel_3548_sysadm_db" under the current security context)~~
 
 
 use master;
 go
 
 -- Should fail
-drop database sysadmin_only_db;
+drop database babel_3548_sysadm_db;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: must be owner of database sysadmin_only_db)~~
+~~ERROR (Message: must be owner of database babel_3548_sysadm_db)~~
 
 
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
-WHERE sys.suser_name(usesysid) = 'test_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+WHERE sys.suser_name(usesysid) = 'babel_3548_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 ~~START~~
 bool
@@ -84,7 +84,7 @@ void
 
 
 -- tsql
-drop database sysadmin_only_db;
-drop login test_login1;
+drop database babel_3548_sysadm_db;
+drop login babel_3548_l1;
 go
 

--- a/test/JDBC/expected/BABEL-3548.out
+++ b/test/JDBC/expected/BABEL-3548.out
@@ -37,10 +37,10 @@ guest
 ~~END~~
 
 
--- tsql
 drop database login1_db;
 go
 
+-- tsql
 create database sysadmin_only_db;
 go
 
@@ -51,6 +51,17 @@ go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The server principal "test_login1" is not able to access the database "sysadmin_only_db" under the current security context)~~
+
+
+use master;
+go
+
+-- Should fail
+drop database sysadmin_only_db;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: must be owner of database sysadmin_only_db)~~
 
 
 -- psql

--- a/test/JDBC/input/BABEL-3548.mix
+++ b/test/JDBC/input/BABEL-3548.mix
@@ -27,16 +27,23 @@ go
 select CURRENT_USER;
 go
 
--- tsql
 drop database login1_db;
 go
 
+-- tsql
 create database sysadmin_only_db;
 go
 
 -- tsql      user=test_login1      password=123
 -- Should fail
 use sysadmin_only_db;
+go
+
+use master;
+go
+
+-- Should fail
+drop database sysadmin_only_db;
 go
 
 -- psql

--- a/test/JDBC/input/BABEL-3548.mix
+++ b/test/JDBC/input/BABEL-3548.mix
@@ -1,21 +1,21 @@
 -- tsql
-create login test_login1 with password='123';
+create login babel_3548_l1 with password='123';
 go
 
-alter server role sysadmin add member test_login1;
+alter server role sysadmin add member babel_3548_l1;
 go
 
--- tsql      user=test_login1      password=123
-create database login1_db;
+-- tsql      user=babel_3548_l1      password=123
+create database babel_3548_db;
 go
 
 -- tsql
-alter server role sysadmin drop member test_login1;
+alter server role sysadmin drop member babel_3548_l1;
 go
 
--- tsql      user=test_login1      password=123
+-- tsql      user=babel_3548_l1      password=123
 -- Shouldn't cause error as login is the db owner
-use login1_db;
+use babel_3548_db;
 go
 
 select CURRENT_USER;
@@ -27,36 +27,36 @@ go
 select CURRENT_USER;
 go
 
-drop database login1_db;
+drop database babel_3548_db;
 go
 
 -- tsql
-create database sysadmin_only_db;
+create database babel_3548_sysadm_db;
 go
 
--- tsql      user=test_login1      password=123
+-- tsql      user=babel_3548_l1      password=123
 -- Should fail
-use sysadmin_only_db;
+use babel_3548_sysadm_db;
 go
 
 use master;
 go
 
 -- Should fail
-drop database sysadmin_only_db;
+drop database babel_3548_sysadm_db;
 go
 
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
-WHERE sys.suser_name(usesysid) = 'test_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+WHERE sys.suser_name(usesysid) = 'babel_3548_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 -- Wait to sync with another session
 SELECT pg_sleep(1);
 GO
 
 -- tsql
-drop database sysadmin_only_db;
-drop login test_login1;
+drop database babel_3548_sysadm_db;
+drop login babel_3548_l1;
 go
 

--- a/test/JDBC/input/BABEL-3548.mix
+++ b/test/JDBC/input/BABEL-3548.mix
@@ -1,0 +1,55 @@
+-- tsql
+create login test_login1 with password='123';
+go
+
+alter server role sysadmin add member test_login1;
+go
+
+-- tsql      user=test_login1      password=123
+create database login1_db;
+go
+
+-- tsql
+alter server role sysadmin drop member test_login1;
+go
+
+-- tsql      user=test_login1      password=123
+-- Shouldn't cause error as login is the db owner
+use login1_db;
+go
+
+select CURRENT_USER;
+go
+
+use master;
+go
+
+select CURRENT_USER;
+go
+
+-- tsql
+drop database login1_db;
+go
+
+create database sysadmin_only_db;
+go
+
+-- tsql      user=test_login1      password=123
+-- Should fail
+use sysadmin_only_db;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'test_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+drop database sysadmin_only_db;
+drop login test_login1;
+go
+


### PR DESCRIPTION
### Description

In SQL Server, the login that creates a database is automatically the
database owner. This means that the login can always access the
databases they create.

However, previously in babelfish, if a login is stripped of the sysadmin
role after creating a database, and the login does not have a
user associated with the database, then the login can no longer access
the database. Now, when a login attempts to access and there
is not an associated user, the login will be considered the dbo and
allowed access.

Task: BABEL-3548

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).