### PR TITLE
Mitigate upgrade issue due to DROP OPERATOR CLASS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,5 @@
 name: JDBC Unit Tests
-on:
-  push:
-    branches:
-      - BABEL_1_X_DEV
-  pull_request:
-    branches:
-      - BABEL_1_X_DEV
+on: [push, pull_request]
 
 jobs:
   extension-tests:
@@ -35,6 +29,7 @@ jobs:
           wget http://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip
           unzip -d antlr4 antlr4-cpp-runtime-4.9.2-source.zip 
           cd antlr4
+          sed -i "s/git:/https:/g" runtime/CMakeLists.txt
           mkdir build && cd build 
           cmake .. -D ANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.2-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
           make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone, build, and run tests for Postgres engine
         run: |
           cd ..
-          git clone https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          git clone --branch BABEL_1_1_STABLE__PG_13_5 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           sudo apt-get update
           sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison 
           cd postgresql_modified_for_babelfish

--- a/.github/workflows/dotnet-framework.yml
+++ b/.github/workflows/dotnet-framework.yml
@@ -28,6 +28,7 @@ jobs:
           wget http://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip
           unzip -d antlr4 antlr4-cpp-runtime-4.9.2-source.zip 
           cd antlr4
+          sed -i "s/git:/https:/g" runtime/CMakeLists.txt
           mkdir build && cd build 
           cmake .. -D ANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.2-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
           make

--- a/.github/workflows/dotnet-framework.yml
+++ b/.github/workflows/dotnet-framework.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone, build, and run tests for Postgres engine
         run: |
           cd ..
-          git clone https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          git clone --branch BABEL_1_1_STABLE__PG_13_5 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           sudo apt-get update
           sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison 
           cd postgresql_modified_for_babelfish

--- a/.github/workflows/odbc-framework.yml
+++ b/.github/workflows/odbc-framework.yml
@@ -28,6 +28,7 @@ jobs:
           wget http://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip
           unzip -d antlr4 antlr4-cpp-runtime-4.9.2-source.zip 
           cd antlr4
+          sed -i "s/git:/https:/g" runtime/CMakeLists.txt
           mkdir build && cd build 
           cmake .. -D ANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.2-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
           make

--- a/.github/workflows/odbc-framework.yml
+++ b/.github/workflows/odbc-framework.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone, build, and run tests for Postgres engine
         run: |
           cd ..
-          git clone https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          git clone --branch BABEL_1_1_STABLE__PG_13_5 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           sudo apt-get update
           sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison 
           cd postgresql_modified_for_babelfish

--- a/.github/workflows/python-framework.yml
+++ b/.github/workflows/python-framework.yml
@@ -28,6 +28,7 @@ jobs:
           wget http://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip
           unzip -d antlr4 antlr4-cpp-runtime-4.9.2-source.zip 
           cd antlr4
+          sed -i "s/git:/https:/g" runtime/CMakeLists.txt
           mkdir build && cd build 
           cmake .. -D ANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.2-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
           make

--- a/.github/workflows/python-framework.yml
+++ b/.github/workflows/python-framework.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone, build, and run tests for Postgres engine
         run: |
           cd ..
-          git clone https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          git clone --branch BABEL_1_1_STABLE__PG_13_5 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           sudo apt-get update
           sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison 
           cd postgresql_modified_for_babelfish

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.0.0--1.1.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.0.0--1.1.0.sql
@@ -1,34 +1,32 @@
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '1.1.0'" to load this file. \quit
 
-DROP OPERATOR FAMILY IF EXISTS sys.fixeddecimal_ops USING btree;
-DROP OPERATOR FAMILY IF EXISTS sys.fixeddecimal_ops USING hash;
-
-CREATE OPERATOR FAMILY sys.fixeddecimal_ops USING btree;
-CREATE OPERATOR FAMILY sys.fixeddecimal_ops USING hash;
-
--- drop fixeddecimal_ops and re-create it in operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_ops USING hash;
-
-CREATE OPERATOR CLASS sys.fixeddecimal_ops
-DEFAULT FOR TYPE sys.FIXEDDECIMAL USING btree FAMILY sys.fixeddecimal_ops AS
-    OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    2   sys.<= (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    3   sys.=  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    4   sys.>= (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    5   sys.>  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    FUNCTION    1   sys.fixeddecimal_cmp(sys.FIXEDDECIMAL, sys.FIXEDDECIMAL);
-
-CREATE OPERATOR CLASS sys.fixeddecimal_ops
-DEFAULT FOR TYPE sys.FIXEDDECIMAL USING hash FAMILY sys.fixeddecimal_ops AS
-    OPERATOR    1   sys.=  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    FUNCTION    1   sys.fixeddecimal_hash(sys.FIXEDDECIMAL);
-
+-- Drops an operator class if it does not have any dependent objects.
+-- We will drop redundant operator classes since sys.fixeddecimal_ops operator family will now contain
+-- all the operators.
+-- It is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
+-- Please have this be one of the first statements executed in this upgrade script. 
+CREATE OR REPLACE PROCEDURE babelfish_drop_deprecated_opclass(schema_name varchar, opcname varchar) AS
+$$
+DECLARE
+    error_msg text;
+    query1 text;
+    query2 text;
+BEGIN
+    query1 := format('drop operator class if exists %s.%s using btree', schema_name, opcname);
+    query2 := format('drop operator class if exists %s.%s using hash', schema_name, opcname);
+    execute query1;
+    execute query2;
+EXCEPTION
+    when dependent_objects_still_exist then --if 'drop operator class' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+end
+$$
+LANGUAGE plpgsql;
 
 -- drop fixeddecimal_numeric_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_numeric_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_numeric_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_numeric_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, NUMERIC),
@@ -43,8 +41,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop numeric_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.numeric_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.numeric_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'numeric_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (NUMERIC, sys.FIXEDDECIMAL) FOR SEARCH,
@@ -59,8 +56,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop fixeddecimal_int8_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int8_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int8_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_int8_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, INT8),
@@ -75,8 +71,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop int8_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.int8_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.int8_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'int8_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (INT8, sys.FIXEDDECIMAL),
@@ -91,8 +86,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop fixeddecimal_int4_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int4_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int4_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_int4_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, INT4),
@@ -107,8 +101,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop int4_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.int4_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.int4_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'int4_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (INT4, sys.FIXEDDECIMAL),
@@ -123,8 +116,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop fixeddecimal_int2_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int2_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int2_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_int2_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, INT2),
@@ -139,8 +131,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop int2_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.int2_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.int2_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'int2_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (INT2, sys.FIXEDDECIMAL),
@@ -336,3 +327,7 @@ LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (sys.VARCHAR AS FLOAT8)
 WITH FUNCTION sys.varchar2float8(sys.VARCHAR) AS IMPLICIT;
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE babelfish_drop_deprecated_opclass(varchar, varchar);

--- a/test/python/expected/pyodbc/TestAuth.out
+++ b/test/python/expected/pyodbc/TestAuth.out
@@ -1,26 +1,26 @@
 #database name, username and password should not exceed 128 characters
 py_auth#!#database|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 3701)~~
-~~ERROR (Message: [42S02] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (3701) (SQLDriverConnect))~~
+~~ERROR (Message: [42S02] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (3701) (SQLDriverConnect))~~
 
 py_auth#!#database|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
 
 py_auth#!#user|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
+~~ERROR (Message: [42000] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
 
 py_auth#!#user|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
 
 #not sure why any password is accepted during authentication through cloud desktop
 #This test should throw error but from cloud desktop a connection is successfully established
 #py_auth#!#password|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 py_auth#!#password|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
 
 py_auth#!#others|-|packetSize=0
 ~~SUCCESS~~
@@ -30,5 +30,5 @@ py_auth#!#others|-|packetSize=4096
 ~~SUCCESS~~
 py_auth#!#database|-|test1 SELECT 1
 ~~ERROR (Code: 3701)~~
-~~ERROR (Message: [42S02] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (3701) (SQLDriverConnect))~~
+~~ERROR (Message: [42S02] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (3701) (SQLDriverConnect))~~
 


### PR DESCRIPTION
### Description
* Previously, we were dropping fixeddecimal_ops operator class
so that we can re-create it in operator family fixeddecimal_ops
but it is not required since PG automatically creates operator family
internally with same name for each operator class.
* So, this commit removes redundant operation of DROP/RECREATE
of fixeddecimal_ops operator class/family.
* Similarly, it is not mandatory to drop other operator classes since
we are adding all the operators into fixeddecimal_ops family so
other operator classes will mostly be unused and we will drop them
conditionally if no dependencies found for them.
* Manually tested with test case added with original change (BABEL-2089.sql)
as well as with primary key's dependency on fixeddecimal_ops class.
#### Additional changes
1. Modified github actions to fix antlr build and engine branch.
2. Fixed expected output for TestAuth in python framework.

Task: BABEL-3544
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).