### PR TITLE
Mitigate upgrade issue due to DROP OPERATOR-CLASS/VIEW

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.0.0--1.1.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--1.0.0--1.1.0.sql
@@ -1,34 +1,32 @@
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '1.1.0'" to load this file. \quit
 
-DROP OPERATOR FAMILY IF EXISTS sys.fixeddecimal_ops USING btree;
-DROP OPERATOR FAMILY IF EXISTS sys.fixeddecimal_ops USING hash;
-
-CREATE OPERATOR FAMILY sys.fixeddecimal_ops USING btree;
-CREATE OPERATOR FAMILY sys.fixeddecimal_ops USING hash;
-
--- drop fixeddecimal_ops and re-create it in operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_ops USING hash;
-
-CREATE OPERATOR CLASS sys.fixeddecimal_ops
-DEFAULT FOR TYPE sys.FIXEDDECIMAL USING btree FAMILY sys.fixeddecimal_ops AS
-    OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    2   sys.<= (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    3   sys.=  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    4   sys.>= (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    OPERATOR    5   sys.>  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    FUNCTION    1   sys.fixeddecimal_cmp(sys.FIXEDDECIMAL, sys.FIXEDDECIMAL);
-
-CREATE OPERATOR CLASS sys.fixeddecimal_ops
-DEFAULT FOR TYPE sys.FIXEDDECIMAL USING hash FAMILY sys.fixeddecimal_ops AS
-    OPERATOR    1   sys.=  (sys.FIXEDDECIMAL, sys.FIXEDDECIMAL),
-    FUNCTION    1   sys.fixeddecimal_hash(sys.FIXEDDECIMAL);
-
+-- Drops an operator class if it does not have any dependent objects.
+-- We will drop redundant operator classes since sys.fixeddecimal_ops operator family will now contain
+-- all the operators.
+-- It is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
+-- Please have this be one of the first statements executed in this upgrade script. 
+CREATE OR REPLACE PROCEDURE babelfish_drop_deprecated_opclass(schema_name varchar, opcname varchar) AS
+$$
+DECLARE
+    error_msg text;
+    query1 text;
+    query2 text;
+BEGIN
+    query1 := format('drop operator class if exists %s.%s using btree', schema_name, opcname);
+    query2 := format('drop operator class if exists %s.%s using hash', schema_name, opcname);
+    execute query1;
+    execute query2;
+EXCEPTION
+    when dependent_objects_still_exist then --if 'drop operator class' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+end
+$$
+LANGUAGE plpgsql;
 
 -- drop fixeddecimal_numeric_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_numeric_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_numeric_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_numeric_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, NUMERIC),
@@ -43,8 +41,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop numeric_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.numeric_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.numeric_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'numeric_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (NUMERIC, sys.FIXEDDECIMAL) FOR SEARCH,
@@ -59,8 +56,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop fixeddecimal_int8_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int8_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int8_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_int8_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, INT8),
@@ -75,8 +71,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop int8_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.int8_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.int8_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'int8_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (INT8, sys.FIXEDDECIMAL),
@@ -91,8 +86,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop fixeddecimal_int4_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int4_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int4_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_int4_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, INT4),
@@ -107,8 +101,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop int4_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.int4_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.int4_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'int4_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (INT4, sys.FIXEDDECIMAL),
@@ -123,8 +116,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop fixeddecimal_int2_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int2_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.fixeddecimal_int2_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'fixeddecimal_int2_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (sys.FIXEDDECIMAL, INT2),
@@ -139,8 +131,7 @@ ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING hash ADD
 
 
 -- drop int2_fixeddecimal_ops and add corresponding operators to operator family fixeddecimal_ops
-DROP OPERATOR CLASS IF EXISTS sys.int2_fixeddecimal_ops USING btree;
-DROP OPERATOR CLASS IF EXISTS sys.int2_fixeddecimal_ops USING hash;
+CALL babelfish_drop_deprecated_opclass('sys', 'int2_fixeddecimal_ops');
 
 ALTER OPERATOR FAMILY sys.fixeddecimal_ops USING btree ADD
     OPERATOR    1   sys.<  (INT2, sys.FIXEDDECIMAL),
@@ -336,3 +327,7 @@ LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (sys.VARCHAR AS FLOAT8)
 WITH FUNCTION sys.varchar2float8(sys.VARCHAR) AS IMPLICIT;
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE babelfish_drop_deprecated_opclass(varchar, varchar);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.0.0--1.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.0.0--1.1.0.sql
@@ -3,14 +3,33 @@
 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
 
-/* Caution: Be careful while dropping an object in a minor version upgrade
- *          script as the object might be getting used in some user defined
- *          objects and dropping it here might result in upgrade failure or
- *          even user defined objects getting dropped.
- * The following sys.sysindexes view was not working previously, so dropping
- * it here is ok.
- */
-DROP VIEW IF EXISTS sys.sysindexes;
+-- Drops a view if it does not have any dependent objects.
+-- Is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
+-- Please have this be one of the first statements executed in this upgrade script. 
+CREATE OR REPLACE PROCEDURE babelfish_drop_deprecated_view(schema_name varchar, view_name varchar) AS
+$$
+DECLARE
+    error_msg text;
+    query1 text;
+    query2 text;
+BEGIN
+    query1 := format('alter extension babelfishpg_tsql drop view %s.%s', schema_name, view_name);
+    query2 := format('drop view %s.%s', schema_name, view_name);
+    execute query1;
+    execute query2;
+EXCEPTION
+    when object_not_in_prerequisite_state then --if 'alter extension' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+    when dependent_objects_still_exist then --if 'drop view' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+end
+$$
+LANGUAGE plpgsql;
+
+ALTER VIEW sys.sysindexes RENAME TO sysindexes_deprecated_in_1_1_0;
+CALL babelfish_drop_deprecated_view('sys', 'sysindexes_deprecated_in_1_1_0');
 
 CREATE FUNCTION sys.columns_internal()
 RETURNS TABLE (

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.0.0--1.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.0.0--1.1.0.sql
@@ -1297,5 +1297,9 @@ SELECT p.name
 FROM sys.proc_param_helper() as p;
 GRANT SELECT ON sys.syscolumns TO PUBLIC;
 
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE sys.babelfish_drop_deprecated_view(varchar, varchar);
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);


### PR DESCRIPTION
### Description
* Previously, we were dropping fixeddecimal_ops operator class
so that we can re-create it in operator family fixeddecimal_ops
but it is not required since PG automatically creates operator family
internally with same name for each operator class.
* So, this commit removes redundant operation of DROP/RECREATE
of fixeddecimal_ops operator class/family.
* Similarly, it is not mandatory to drop other operator classes since
we are adding all the operators into fixeddecimal_ops family so
other operator classes will mostly be unused and we will drop them
conditionally if no dependencies found for them.
* Additionally, replaced DROP VIEW sys.sysindexes statement with
rename and recreate statements to fix possible upgrade failure.
* Manually tested with test case added with original change (BABEL-2089.sql)
as well as with primary key's dependency on fixeddecimal_ops class.

Task: BABEL-3544
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).