### PR TITLE
Fix: Unable to connect through SSMS - When Create Login with sysadmin role

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -755,6 +755,7 @@ tsql_stat_get_activity_deprecated_in_2_2_0(PG_FUNCTION_ARGS)
 Datum
 tsql_stat_get_activity(PG_FUNCTION_ARGS)
 {
+	Oid sysadmin_oid = get_role_oid("sysadmin", false);
 	int			num_backends = pgstat_fetch_stat_numbackends();
 	int			curr_backend;
 	char*			view_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
@@ -775,14 +776,14 @@ tsql_stat_get_activity(PG_FUNCTION_ARGS)
 	 */
 	if (strcmp(view_name, "sessions") == 0)
 	{
-		if (role_is_sa(GetSessionUserId()))
+		if (has_privs_of_role(GetSessionUserId(), sysadmin_oid))
 			pid = -1;
 		else
 			pid = MyProcPid;
 	}
 	else if (strcmp(view_name, "connections") == 0)
 	{
-		if (role_is_sa(GetSessionUserId()))
+		if (has_privs_of_role(GetSessionUserId(), sysadmin_oid))
 			pid = -1;
 		else
 			ereport(ERROR,

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -755,6 +755,7 @@ tsql_stat_get_activity_deprecated_in_2_2_0(PG_FUNCTION_ARGS)
 Datum
 tsql_stat_get_activity(PG_FUNCTION_ARGS)
 {
+	Oid 		sysadmin_oid = get_role_oid("sysadmin", false);
 	int			num_backends = pgstat_fetch_stat_numbackends();
 	int			curr_backend;
 	char*			view_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
@@ -775,14 +776,14 @@ tsql_stat_get_activity(PG_FUNCTION_ARGS)
 	 */
 	if (strcmp(view_name, "sessions") == 0)
 	{
-		if (role_is_sa(GetSessionUserId()))
+		if (has_privs_of_role(GetSessionUserId(), sysadmin_oid))
 			pid = -1;
 		else
 			pid = MyProcPid;
 	}
 	else if (strcmp(view_name, "connections") == 0)
 	{
-		if (role_is_sa(GetSessionUserId()))
+		if (has_privs_of_role(GetSessionUserId(), sysadmin_oid))
 			pid = -1;
 		else
 			ereport(ERROR,

--- a/test/JDBC/expected/BABEL-3550.out
+++ b/test/JDBC/expected/BABEL-3550.out
@@ -1,0 +1,52 @@
+-- tsql
+USE master
+GO
+CREATE LOGIN babel_3550_login1 WITH PASSWORD='12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3550_login1;
+GO
+
+-- tsql  user=babel_3550_login1  password='12345678'
+SELECT SUSER_NAME();
+GO
+~~START~~
+nvarchar
+babel_3550_login1
+~~END~~
+
+
+DECLARE @a INT
+SELECT @a = COUNT(*) FROM sys.dm_exec_connections;
+SELECT (CASE WHEN @a >= 0 THEN 'true' ELSE 'false' END) AS result
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3550_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3550_login1;
+GO
+DROP LOGIN babel_3550_login1;
+GO

--- a/test/JDBC/input/BABEL-3550.mix
+++ b/test/JDBC/input/BABEL-3550.mix
@@ -1,0 +1,32 @@
+-- tsql
+USE master
+GO
+CREATE LOGIN babel_3550_login1 WITH PASSWORD='12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3550_login1;
+GO
+
+-- tsql  user=babel_3550_login1  password=12345678
+SELECT SUSER_NAME();
+GO
+
+DECLARE @a INT
+SELECT @a = COUNT(*) FROM sys.dm_exec_connections;
+SELECT (CASE WHEN @a >= 0 THEN 'true' ELSE 'false' END) AS result
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3550_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3550_login1;
+GO
+DROP LOGIN babel_3550_login1;
+GO

--- a/test/JDBC/input/BABEL-3550.mix
+++ b/test/JDBC/input/BABEL-3550.mix
@@ -1,0 +1,32 @@
+-- tsql
+USE master
+GO
+CREATE LOGIN babel_3550_login1 WITH PASSWORD='12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3550_login1;
+GO
+
+-- tsql  user=babel_3550_login1  password='12345678'
+SELECT SUSER_NAME();
+GO
+
+DECLARE @a INT
+SELECT @a = COUNT(*) FROM sys.dm_exec_connections;
+SELECT (CASE WHEN @a >= 0 THEN 'true' ELSE 'false' END) AS result
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3550_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3550_login1;
+GO
+DROP LOGIN babel_3550_login1;
+GO


### PR DESCRIPTION
Previously, when user created a login with sysadmin role and connected through SSMS, permission error was thrown. Now, user can successfully connect using SSMS with a login with sysadmin role.

Task: BABEL-3550
Signed-off-by: Ray Kim <raydhkim@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).