### PR TITLE
Cancel previous GitHub Action workflows on same branch with new commits

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,7 +1,10 @@
 name: Dotnet Framework Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,5 +1,8 @@
 name: Dotnet Framework Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-dotnet-tests:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -1,11 +1,10 @@
 name: Babelfish Smoke Tests
 on:
-  push:
-    branches:
   pull_request:
-    branches:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -4,6 +4,9 @@ on:
     branches:
   pull_request:
     branches:
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   isolation-tests:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,5 +1,8 @@
 name: JDBC Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-jdbc-tests:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,7 +1,10 @@
 name: JDBC Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,7 +1,10 @@
 name: Major Version Upgrade Tests for empty database
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,5 +1,8 @@
 name: Major Version Upgrade Tests for empty database
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-mvu-tests:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,9 +1,11 @@
 name: Minor Version Upgrade Tests for empty database
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   extension-tests:
     env:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,5 +1,8 @@
 name: Minor Version Upgrade Tests for empty database
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   extension-tests:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,7 +1,10 @@
 name: ODBC Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,5 +1,8 @@
 name: ODBC Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-odbc-tests:

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,7 +1,10 @@
 name: pg-hint-plan Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,5 +1,8 @@
 name: pg-hint-plan Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-pg-hint-plan-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,8 @@
 name: Python Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-python-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,10 @@
 name: Python Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,7 +1,10 @@
 name: Major Version Upgrade Tests for singledb mode
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,5 +1,8 @@
 name: Major Version Upgrade Tests for singledb mode
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-mvu-tests-singledb:

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,7 +1,10 @@
 name: Validate Installation/Upgrade Scripts
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,5 +1,8 @@
 name: Validate Installation/Upgrade Scripts
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-sql-validation-tests:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,5 +1,8 @@
 name: Version Upgrade Test Framework
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   generate-version-upgrade-tests:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,7 +1,10 @@
 name: Version Upgrade Test Framework
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description
#### Current Behaviour
Actions will run **twice** (push & PR, clarification: for places with write access i.e. forked repositories) per commit and will queue up causing a long wait if there are multiple commits to the same branch.

#### Changes
- Cancels previous GH Action workflows in the **same branch** when there is a new commit to it.
- Pushes to PR only run the actions once rather than twice (Push & PR), clarification: this is more for forked repositories with write access.

#### Benefits
- Reduce wait time for actions to run if there are multiple commits to the same branch
- Reduces costs of using Github Action minutes

#### Note
- It runs on whenever a PR is created / has a new push (to the same branch)
- It runs whenever a branch with the following prefix `BABEL_*` is pushed to, this is to have it still run on default branch.
 
### Issues Resolved
n/a

Signed-off-by: Colin Yuen [yuenhcol@amazon.com](mailto:yuenhcol@.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).