### PR TITLE
Fix RAISERROR params limit issue

### DIFF
--- a/test/JDBC/expected/BABEL-2251.out
+++ b/test/JDBC/expected/BABEL-2251.out
@@ -1,0 +1,62 @@
+-- 21 format specifiers and  21 additional parameters
+RAISERROR(N'test %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s', 1, 1, N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1');
+GO
+~~ERROR (Code: 2747)~~
+
+~~ERROR (Message: Too many substitution parameters for RAISERROR. Cannot exceed 20 substitution parameters.)~~
+
+
+-- 21 format specifiers and 3 additional parameters
+RAISERROR(N'test %d %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s', 1, 1, 100,N'1',N'1')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Message text expects more than the maximum number of arguments (20).)~~
+
+
+-- 20 format specifiers and 20 additional parameters
+RAISERROR(N'test %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s', 1, 1, N'a', N'a', N'a', N'a',N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a')
+GO
+
+-- 20 format specifiers and no additional parameters
+RAISERROR(N'test %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s', 1, 1)
+GO
+
+-- 20 format specifiers and no additional parameters, but message contains escaped % (invalid message string)
+RAISERROR(N'escaped %% with other additional parameters %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s', 1, 1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Message text expects more than the maximum number of arguments (20).)~~
+
+
+-- message string does not contain any parameters
+RAISERROR(N'message string does not contain any parameter', 1, 1)
+GO
+
+--invalid message string
+RAISERROR(N'contains an invalid message%', 1, 1, N'123')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Param 1 expected format type % but received type nvarchar)~~
+
+
+--empty message string
+RAISERROR(N'', 1, 1)
+GO
+
+--message string of length 1
+RAISERROR(N'a', 1, 1)
+GO
+
+--BABEL-2251
+RAISERROR('Hello 
+%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s 
+%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s 
+', 16, 1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Message text expects more than the maximum number of arguments (20).)~~
+

--- a/test/JDBC/input/BABEL-2251.sql
+++ b/test/JDBC/input/BABEL-2251.sql
@@ -1,0 +1,42 @@
+-- 21 format specifiers and  21 additional parameters
+RAISERROR(N'test %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s', 1, 1, N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1',N'1');
+GO
+
+-- 21 format specifiers and 3 additional parameters
+RAISERROR(N'test %d %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s', 1, 1, 100,N'1',N'1')
+GO
+
+-- 20 format specifiers and 20 additional parameters
+RAISERROR(N'test %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s', 1, 1, N'a', N'a', N'a', N'a',N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a', N'a')
+GO
+
+-- 20 format specifiers and no additional parameters
+RAISERROR(N'test %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s', 1, 1)
+GO
+
+-- 20 format specifiers and no additional parameters, but message contains escaped % (invalid message string)
+RAISERROR(N'escaped %% with other additional parameters %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s', 1, 1)
+GO
+
+-- message string does not contain any parameters
+RAISERROR(N'message string does not contain any parameter', 1, 1)
+GO
+
+--invalid message string
+RAISERROR(N'contains an invalid message%', 1, 1, N'123')
+GO
+
+--empty message string
+RAISERROR(N'', 1, 1)
+GO
+
+--message string of length 1
+RAISERROR(N'a', 1, 1)
+GO
+
+--BABEL-2251
+RAISERROR('Hello 
+%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s 
+%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s 
+', 16, 1)
+GO


### PR DESCRIPTION
### Description

RAISERROR should not allow more than 20 arguments for the message string. This commit adds a check to parse through the error message string and count the number of format specifiers i.e the arguments. An error is thrown if the number of arguments exceeds the limit i.e 20

The logic to count the number of format specifiers is tightly coupled with the validation/preparation of error message string(prepare_format_string in string.c)

This commit also adds JDBC tests for the changes mentioned above

Task: BABEL-2251

Signed-off-by: Amith Kamath <amithkam@amazon.com>
 
### Issues Resolved

BABEL-2251


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).