### PR TITLE
Add pg_catalog in front of format in upgrade script

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -14,8 +14,8 @@ DECLARE
     query1 text;
     query2 text;
 BEGIN
-    query1 := format('alter extension babelfishpg_tsql drop view %s.%s', schema_name, view_name);
-    query2 := format('drop view %s.%s', schema_name, view_name);
+    query1 := pg_catalog.format('alter extension babelfishpg_tsql drop view %s.%s', schema_name, view_name);
+    query2 := pg_catalog.format('drop view %s.%s', schema_name, view_name);
     execute query1;
     execute query2;
 EXCEPTION


### PR DESCRIPTION
Signed-off-by: Tim Chang <changti@amazon.com>

### Description

Fixing issue in upgrade script.
 
### Issues Resolved

Fixed an issue introduced in https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/a5e6c0ef8807487e44f5660329c6ca805bfad9a2 with FORMAT() in the 2.2.0-2.3.0 upgrade script.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).