### PR TITLE
FIx failing all_sql_modules-vu-verify test

### DIFF
--- a/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
@@ -13,7 +13,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_f1')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_f1', 'FN')
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -33,7 +33,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2', 'V')
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -73,7 +73,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1', 'P')
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -170,7 +170,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'P')
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit

--- a/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
@@ -170,7 +170,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'P')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit

--- a/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
@@ -73,7 +73,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1', 'P')
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -196,7 +196,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit

--- a/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
@@ -92,7 +92,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
 GO
 ~~START~~
 bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -111,7 +111,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.tables')
+WHERE object_id = OBJECT_ID('sys.tables', 'V')
 GO
 ~~START~~
 bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -130,7 +130,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables')
+WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
 GO
 ~~START~~
 bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -150,7 +150,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.user_name')
+WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -157,3 +157,6 @@ GO
 
 USE master
 GO
+
+SELECT * FROM sys.all_objects where object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
+GO

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -61,6 +61,9 @@ FROM sys.all_sql_modules
 WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 
+SELECT * FROM sys.all_objects where object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
+GO
+
 -- Test for system function
 SELECT
     uses_ansi_nulls,

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -61,9 +61,6 @@ FROM sys.all_sql_modules
 WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 
-SELECT * FROM sys.all_objects where object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
-GO
-
 -- Test for system function
 SELECT
     uses_ansi_nulls,
@@ -160,3 +157,4 @@ GO
 
 USE master
 GO
+

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -157,6 +157,3 @@ GO
 
 USE master
 GO
-
-SELECT * FROM sys.all_objects where object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
-GO

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -13,7 +13,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_f1')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_f1', 'FN')
 GO
 
 -- Test for views
@@ -28,7 +28,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2', 'V')
 GO
 
 -- Test for triggers
@@ -58,7 +58,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1', 'P')
 GO
 
 -- Test for system function
@@ -130,7 +130,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'P')
 GO
 
 USE master

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -157,4 +157,3 @@ GO
 
 USE master
 GO
-

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -72,7 +72,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
 GO
 
 -- Test for system views
@@ -86,7 +86,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.tables')
+WHERE object_id = OBJECT_ID('sys.tables', 'V')
 GO
 
 -- Test for system proc
@@ -100,7 +100,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables')
+WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
 GO
 
 -- Test for system function written in c 
@@ -115,7 +115,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.user_name')
+WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
 GO
 
 -- Test that sys.all_sql_modules is database-scoped

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -58,7 +58,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1', 'P')
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 
 -- Test for system function
@@ -152,7 +152,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_p1')
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 
 USE master

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -130,7 +130,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'P')
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
 GO
 
 USE master


### PR DESCRIPTION
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Description

Previously, the `all_sql_modules-vu-verify` test was failing due to an upgrade error which resulted in having multiple `procedure` objects sharing the same object id when upgrading from latest -> latest test. This commit modifies the test so that it queries the procedure by their definition instead of the object_id which would eliminate the flakiness element.
 
### Issues Resolved

Resolve failing `all_sql_modules-vu-verify` test in main branch.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).