### PR TITLE
Create Escape Hatch 'escape_hatch_checkpoint' For CHECKPOINT STATEMENT

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1108,6 +1108,7 @@ int escape_hatch_unique_constraint = EH_STRICT;
 int escape_hatch_ignore_dup_key = EH_STRICT;
 int escape_hatch_rowversion = EH_STRICT;
 int escape_hatch_showplan_all = EH_STRICT;
+int escape_hatch_checkpoint = EH_IGNORE;
 
 void
 define_escape_hatch_variables(void)
@@ -1431,6 +1432,17 @@ define_escape_hatch_variables(void)
 							  NULL,
 							  &escape_hatch_showplan_all,
 							  EH_STRICT,
+							  escape_hatch_options,
+							  PGC_USERSET,
+							  GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							  NULL, NULL, NULL);
+
+	/* CHECKPOINT */
+	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_checkpoint",
+							  gettext_noop("escape hatch for CHECKPOINT"),
+							  NULL,
+							  &escape_hatch_checkpoint,
+							  EH_IGNORE,
 							  escape_hatch_options,
 							  PGC_USERSET,
 							  GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -58,6 +58,7 @@ declare_escape_hatch(escape_hatch_join_hints);
 declare_escape_hatch(escape_hatch_session_settings);
 declare_escape_hatch(escape_hatch_ignore_dup_key);
 declare_escape_hatch(escape_hatch_rowversion);
+declare_escape_hatch(escape_hatch_checkpoint);
 
 extern std::string getFullText(antlr4::ParserRuleContext *context);
 extern std::string stripQuoteFromId(TSqlParser::IdContext *context);
@@ -148,7 +149,7 @@ protected:
 		antlrcpp::Any visitDbcc_statement(TSqlParser::Dbcc_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_DBCC, "DBCC", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitBackup_statement(TSqlParser::Backup_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_BACKUP, "BACKUP", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitRestore_statement(TSqlParser::Restore_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_RESTORE, "RESTORE", getLineAndPos(ctx)); return visitChildren(ctx); }
-		antlrcpp::Any visitCheckpoint_statement(TSqlParser::Checkpoint_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_CHECKPOINT, "CHECKPOINT", getLineAndPos(ctx)); return visitChildren(ctx); }
+		antlrcpp::Any visitCheckpoint_statement(TSqlParser::Checkpoint_statementContext *ctx) override;
 		antlrcpp::Any visitReadtext_statement(TSqlParser::Readtext_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_READTEXT, "READTEXT", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitWritetext_statement(TSqlParser::Writetext_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_WRITETEXT, "WRITETEXT", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitUpdatetext_statement(TSqlParser::Updatetext_statementContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_UPDATETEXT, "UPDATETEXT", getLineAndPos(ctx)); return visitChildren(ctx); }
@@ -1204,6 +1205,12 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitSecurity_statement(TSqlPar
 	else if (ctx->create_certificate())
 		handle(INSTR_UNSUPPORTED_TSQL_CREATE_CERTIFICATE, "CREATE CERTIFICATE", getLineAndPos(ctx));
 
+	return visitChildren(ctx);
+}
+
+antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCheckpoint_statement(TSqlParser::Checkpoint_statementContext *ctx)
+{
+	handle(INSTR_UNSUPPORTED_TSQL_CHECKPOINT, "CHECKPOINT", &st_escape_hatch_checkpoint, getLineAndPos(ctx));
 	return visitChildren(ctx);
 }
 

--- a/test/JDBC/expected/BABEL-3527.out
+++ b/test/JDBC/expected/BABEL-3527.out
@@ -1,0 +1,65 @@
+-- Set escape_hatch_checkpoint to ignore
+SELECT set_config('babelfishpg_tsql.escape_hatch_checkpoint', 'ignore', 'false')
+GO
+~~START~~
+text
+ignore
+~~END~~
+
+
+CHECKPOINT 5
+GO
+
+CHECKPOINT -5
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '-' at line 1 and character position 11)~~
+
+
+CHECKPOINT 100000000
+GO
+
+CHECKPOINT "Invalid Input"
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '<EOF>' at line 2 and character position 0)~~
+
+
+-- Set escape_hatch_checkpoint to strict
+SELECT set_config('babelfishpg_tsql.escape_hatch_checkpoint', 'strict', 'false')
+GO
+~~START~~
+text
+strict
+~~END~~
+
+
+CHECKPOINT 5
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'CHECKPOINT' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_checkpoint to ignore)~~
+
+
+CHECKPOINT 100000000
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'CHECKPOINT' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_checkpoint to ignore)~~
+
+
+CHECKPOINT -5
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '-' at line 1 and character position 11)~~
+
+
+CHECKPOINT "Invalid Input"
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '<EOF>' at line 2 and character position 0)~~
+

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -1966,6 +1966,7 @@ EXEC sp_babelfish_configure;
 GO
 ~~START~~
 text#!#text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
 babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
 babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
@@ -2021,6 +2022,7 @@ EXEC sp_babelfish_configure '%';
 GO
 ~~START~~
 text#!#text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
 babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
 babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
@@ -2057,6 +2059,7 @@ EXEC sp_babelfish_configure 'babelfishpg_tsql.%';
 GO
 ~~START~~
 text#!#text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
 babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
 babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option

--- a/test/JDBC/input/BABEL-3527.sql
+++ b/test/JDBC/input/BABEL-3527.sql
@@ -1,0 +1,31 @@
+-- Set escape_hatch_checkpoint to ignore
+SELECT set_config('babelfishpg_tsql.escape_hatch_checkpoint', 'ignore', 'false')
+GO
+
+CHECKPOINT 5
+GO
+
+CHECKPOINT -5
+GO
+
+CHECKPOINT 100000000
+GO
+
+CHECKPOINT "Invalid Input"
+GO
+
+-- Set escape_hatch_checkpoint to strict
+SELECT set_config('babelfishpg_tsql.escape_hatch_checkpoint', 'strict', 'false')
+GO
+
+CHECKPOINT 5
+GO
+
+CHECKPOINT 100000000
+GO
+
+CHECKPOINT -5
+GO
+
+CHECKPOINT "Invalid Input"
+GO


### PR DESCRIPTION
### Description

Babelfish currently throws an error for the CHECKPOINT statement supported by tsql. This commit creates an escape hatch, 'escape_hatch_checkpoint', that gives the user the ability to control whether an error is thrown when CHECKPOINT is called. The default setting is 'ignore' which suppresses the error, but when set to 'strict' the error is thrown.

Task: BABEL-3527
Signed-off-by: Jake Owen <owjco@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).