### PR TITLE
Fix flaky test caused by sys-sql_modules tests and sys-events tests

### DIFF
--- a/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
@@ -1,3 +1,8 @@
+
+-- NOTE: Some tests will be marked as "DISABLED DUE TO NON-UNIQUE OBJECT_ID"
+-- This is because during MVU, items in pg_class an pg_proc could have the same OBJECT_ID
+-- Some tests have no way of identification except for OBJECT_ID since definition will be missing
+-- These will be tested in the regular JDBC test
 USE sys_all_sql_modules_vu_prepare_db
 GO
 
@@ -13,7 +18,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_f1', 'FN')
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_all_sql_modules_vu_prepare_f1()%'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -33,7 +38,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2', 'V')
+WHERE definition LIKE 'CREATE VIEW sys_all_sql_modules_vu_prepare_v2%'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -41,26 +46,22 @@ CREATE VIEW sys_all_sql_modules_vu_prepare_v2 AS<newline>SELECT 1#!#1#!#1#!#0#!#
 ~~END~~
 
 
+
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for triggers
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sys_all_sql_modules_vu_prepare_tr1')
-GO
-~~START~~
-nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sys_all_sql_modules_vu_prepare_tr1')
+-- GO
 -- Test for proc
 SELECT
     definition,
@@ -81,102 +82,83 @@ CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1#!#1#!#1#!#0#!
 ~~END~~
 
 
+
+
+
+
+
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system function
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
-GO
-~~START~~
-bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
+-- GO
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system views
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.tables', 'V')
-GO
-~~START~~
-bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.tables', 'V')
+-- GO
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system proc
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
-GO
-~~START~~
-bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
+-- GO
+-- DISABLED DUE TO DUPLICATED OBJECT_ID
 -- Test for system function written in c 
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
-GO
-~~START~~
-nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
+-- GO
+-- DISABLED DUE TO DUPLICATED OBJECT_ID
 -- Test that sys.all_sql_modules is database-scoped
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
-GO
-~~START~~
-nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-~~END~~
-
-
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
+-- GO
 USE master
 GO
 

--- a/test/JDBC/expected/sys-all_sql_modules.out
+++ b/test/JDBC/expected/sys-all_sql_modules.out
@@ -1,0 +1,297 @@
+-- Setup
+CREATE DATABASE sys_all_sql_modules_vu_prepare_db
+GO
+
+CREATE VIEW sys_all_sql_modules_vu_prepare_v1 AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE sys_all_sql_modules_vu_prepare_db
+GO
+
+CREATE TABLE sys_all_sql_modules_vu_prepare_t1(a int)
+GO
+
+CREATE TABLE sys_all_sql_modules_vu_prepare_t2(a int)
+GO
+
+CREATE TRIGGER sys_all_sql_modules_vu_prepare_tr1 ON sys_all_sql_modules_vu_prepare_t2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM sys_all_sql_modules_vu_prepare_t1;
+END
+GO
+
+CREATE VIEW sys_all_sql_modules_vu_prepare_v2 AS
+SELECT 1
+GO
+
+CREATE FUNCTION sys_all_sql_modules_vu_prepare_f1() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC sys_all_sql_modules_vu_prepare_p1 AS
+SELECT 1
+GO
+
+-- Test permission for all_sql_modules (query should not have any results)
+CREATE LOGIN sys_all_sql_modules_vu_prepare_user WITH PASSWORD='test'
+GO
+
+CREATE USER sys_all_sql_modules_vu_prepare_user FOR LOGIN sys_all_sql_modules_vu_prepare_user
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_all_sql_modules_vu_prepare_f1()%'
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE FUNCTION dbo.sys_all_sql_modules_vu_prepare_f1() RETURNS int AS BEGIN<newline>    RETURN 1;<newline>END#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2', 'V')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE VIEW sys_all_sql_modules_vu_prepare_v2 AS<newline>SELECT 1#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sys_all_sql_modules_vu_prepare_tr1')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables', 'V')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system function written in c 
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test that sys.all_sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+use master
+GO
+
+-- tsql user=sys_all_sql_modules_vu_prepare_user password=test
+
+USE sys_all_sql_modules_vu_prepare_db
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+use master
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'sys_all_sql_modules_vu_prepare_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+USE sys_all_sql_modules_vu_prepare_db
+GO
+
+DROP LOGIN sys_all_sql_modules_vu_prepare_user
+GO
+
+-- Cleanup
+DROP PROC sys_all_sql_modules_vu_prepare_p1
+GO
+
+DROP TRIGGER sys_all_sql_modules_vu_prepare_tr1
+GO
+
+DROP TABLE sys_all_sql_modules_vu_prepare_t1
+GO
+
+DROP TABLE sys_all_sql_modules_vu_prepare_t2
+GO
+
+DROP VIEW sys_all_sql_modules_vu_prepare_v2
+GO
+
+DROP FUNCTION sys_all_sql_modules_vu_prepare_f1
+GO
+
+USE master
+GO
+
+DROP VIEW sys_all_sql_modules_vu_prepare_v1
+GO
+
+DROP DATABASE sys_all_sql_modules_vu_prepare_db
+GO

--- a/test/JDBC/expected/sys-events-vu-verify.out
+++ b/test/JDBC/expected/sys-events-vu-verify.out
@@ -14,6 +14,7 @@ int#!#nvarchar#!#bit#!#int#!#nvarchar
 -- check trigger's object ID in sys.all_objects and sys.events view match up
 SELECT ao.name FROM sys.all_objects ao
 JOIN sys.events e ON e.object_id = ao.object_id
+WHERE name = 'sys_events_vu_prepare_trig3'
 GO
 ~~START~~
 varchar

--- a/test/JDBC/expected/sys-sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-sql_modules-vu-verify.out
@@ -1,3 +1,8 @@
+
+-- NOTE: Some tests will be marked as "DISABLED DUE TO NON-UNIQUE OBJECT_ID"
+-- This is because during MVU, items in pg_class an pg_proc could have the same OBJECT_ID
+-- Some tests have no way of identification except for OBJECT_ID since definition will be missing
+-- These will be tested in the regular JDBC test
 USE sys_sql_modules_vu_prepare_db
 GO
 
@@ -13,7 +18,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_f1')
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_sql_modules_vu_prepare_f1()%'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -33,108 +38,91 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v2')
+WHERE definition LIKE 'CREATE VIEW sys_all_sql_modules_vu_prepare_v2%'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-CREATE VIEW sys_sql_modules_vu_prepare_v2 AS<newline>SELECT 1#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
 
+
+
+
+
+
+
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for triggers
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sql_modules_vu_prepare_tr1')
-GO
-~~START~~
-nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sql_modules_vu_prepare_tr1')
+-- GO
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for proc
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_p1')
-GO
-~~START~~
-nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
-~~END~~
-
-
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
+-- GO
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system function
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
-GO
-~~START~~
-bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-~~END~~
-
-
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+-- GO
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system views
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys.tables')
-GO
-~~START~~
-bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-~~END~~
-
-
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = OBJECT_ID('sys.tables')
+-- GO
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system proc
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables')
-GO
-~~START~~
-bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-~~END~~
-
-
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = OBJECT_ID('sys.sp_tables')
+-- GO
 -- Test that sys.sql_modules is database-scoped
 SELECT
     definition,
@@ -147,7 +135,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v1')
+WHERE definition LIKE 'CREATE VIEW sys_all_sql_modules_vu_prepare_v1%'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -173,7 +161,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_p1')
+WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
@@ -182,4 +170,3 @@ nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
 
 USE master
 GO
-

--- a/test/JDBC/expected/sys-sql_modules.out
+++ b/test/JDBC/expected/sys-sql_modules.out
@@ -1,0 +1,274 @@
+-- Setup
+CREATE DATABASE sys_sql_modules_vu_prepare_db
+GO
+
+CREATE VIEW sys_sql_modules_vu_prepare_v1 AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE sys_sql_modules_vu_prepare_db
+GO
+
+CREATE TABLE sys_sql_modules_vu_prepare_t1(a int)
+GO
+
+CREATE TABLE sys_sql_modules_vu_prepare_t2(a int)
+GO
+
+CREATE TRIGGER sys_sql_modules_vu_prepare_tr1 ON sys_sql_modules_vu_prepare_t2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM sys_sql_modules_vu_prepare_t1;
+END
+GO
+
+CREATE VIEW sys_sql_modules_vu_prepare_v2 AS
+SELECT 1
+GO
+
+CREATE FUNCTION sys_sql_modules_vu_prepare_f1() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC sys_sql_modules_vu_prepare_p1 AS
+SELECT 1
+GO
+
+-- Test permission for all_sql_modules (query should not have any results)
+CREATE LOGIN sys_sql_modules_vu_prepare_user WITH PASSWORD='test'
+GO
+
+CREATE USER sys_sql_modules_vu_prepare_user FOR LOGIN sys_sql_modules_vu_prepare_user
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_sql_modules_vu_prepare_f1()%'
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE FUNCTION dbo.sys_sql_modules_vu_prepare_f1() RETURNS int AS BEGIN<newline>    RETURN 1;<newline>END#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v2')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE VIEW sys_sql_modules_vu_prepare_v2 AS<newline>SELECT 1#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sql_modules_vu_prepare_tr1')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables')
+GO
+~~START~~
+bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+-- Test that sys.sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v1')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+USE master
+GO
+
+-- tsql user=sys_sql_modules_vu_prepare_user password=test
+
+USE sys_sql_modules_vu_prepare_db
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+~~END~~
+
+
+USE master
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'sys_sql_modules_vu_prepare_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+USE sys_sql_modules_vu_prepare_db
+GO
+
+DROP LOGIN sys_sql_modules_vu_prepare_user
+GO
+
+-- Cleanup
+DROP PROC sys_sql_modules_vu_prepare_p1
+GO
+
+DROP TRIGGER sys_sql_modules_vu_prepare_tr1
+GO
+
+DROP TABLE sys_sql_modules_vu_prepare_t1
+GO
+
+DROP TABLE sys_sql_modules_vu_prepare_t2
+GO
+
+DROP VIEW sys_sql_modules_vu_prepare_v2
+GO
+
+DROP FUNCTION sys_sql_modules_vu_prepare_f1
+GO
+
+USE master
+GO
+
+DROP VIEW sys_sql_modules_vu_prepare_v1
+GO
+
+DROP DATABASE sys_sql_modules_vu_prepare_db
+GO

--- a/test/JDBC/expected/sys-system_sql_modules.out
+++ b/test/JDBC/expected/sys-system_sql_modules.out
@@ -1,41 +1,43 @@
-
-
-
-
--- NOTE: Some tests will be marked as "DISABLED DUE TO NON-UNIQUE OBJECT_ID"
--- This is because during MVU, items in pg_class an pg_proc could have the same OBJECT_ID
--- Some tests have no way of identification except for OBJECT_ID since definition will be missing
--- These will be tested in the regular JDBC test
--- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system function
--- SELECT
---     definition,
---     uses_ansi_nulls,
---     uses_quoted_identifier,
---     is_schema_bound,
---     uses_database_collation,
---     is_recompiled,
---     null_on_null_input,
---     execute_as_principal_id,
---     uses_native_compilation
--- FROM sys.system_sql_modules
--- WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
--- GO
--- DISABLED DUE TO NON-UNIQUE OBJECT_ID
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
 -- Test for system views
--- SELECT
---     definition,
---     uses_ansi_nulls,
---     uses_quoted_identifier,
---     is_schema_bound,
---     uses_database_collation,
---     is_recompiled,
---     null_on_null_input,
---     execute_as_principal_id,
---     uses_native_compilation
--- FROM sys.system_sql_modules
--- WHERE object_id = OBJECT_ID('sys.tables')
--- GO
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
+
+
 -- Test for system proc
 SELECT
     definition,
@@ -55,4 +57,23 @@ nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
 CREATE PROCEDURE sp_tables(@table_name nvarchar(384)= ''::"varchar", @table_owner nvarchar(384)= ''::"varchar", @table_qualifier sysname= ''::"varchar", @table_type nvarchar(100)= ''::"varchar", @fusepattern bit= '1'::"bit") AS <newline> DECLARE @opt_table sys.varchar(16) = '';<newline> DECLARE @opt_view sys.varchar(16) = '';<newline>BEGIN<newline> IF (@table_qualifier != '') AND (LOWER(@table_qualifier) != LOWER(sys.db_name()))<newline> BEGIN<newline>  THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;<newline> END<newline> SELECT<newline> CAST(out_table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,<newline> CAST(out_table_owner AS sys.sysname) AS TABLE_OWNER,<newline> CAST(out_table_name AS sys.sysname) AS TABLE_NAME,<newline> CAST(out_table_type AS sys.varchar(32)) AS TABLE_TYPE,<newline> CAST(out_remarks AS sys.varchar(254)) AS REMARKS<newline> FROM sys.sp_tables_internal(@table_name, @table_owner, @table_qualifier, CAST(@table_type AS varchar(100)), @fusepattern);<newline>END;<newline>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
+
+-- Test for system function written in c 
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.user_name')
+GO
+~~START~~
+nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
+<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+~~END~~
 

--- a/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules-vu-verify.mix
@@ -1,3 +1,8 @@
+-- NOTE: Some tests will be marked as "DISABLED DUE TO NON-UNIQUE OBJECT_ID"
+-- This is because during MVU, items in pg_class an pg_proc could have the same OBJECT_ID
+-- Some tests have no way of identification except for OBJECT_ID since definition will be missing
+-- These will be tested in the regular JDBC test
+
 USE sys_all_sql_modules_vu_prepare_db
 GO
 
@@ -13,7 +18,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_f1', 'FN')
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_all_sql_modules_vu_prepare_f1()%'
 GO
 
 -- Test for views
@@ -28,23 +33,24 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2', 'V')
+WHERE definition LIKE 'CREATE VIEW sys_all_sql_modules_vu_prepare_v2%'
 GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for triggers
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sys_all_sql_modules_vu_prepare_tr1')
-GO
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sys_all_sql_modules_vu_prepare_tr1')
+-- GO
 
 -- Test for proc
 SELECT
@@ -61,77 +67,82 @@ FROM sys.all_sql_modules
 WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system function
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
-GO
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
+-- GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system views
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.tables', 'V')
-GO
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.tables', 'V')
+-- GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system proc
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
-GO
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
+-- GO
 
+-- DISABLED DUE TO DUPLICATED OBJECT_ID
 -- Test for system function written in c 
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
-GO
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
+-- GO
 
+-- DISABLED DUE TO DUPLICATED OBJECT_ID
 -- Test that sys.all_sql_modules is database-scoped
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.all_sql_modules
-WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
-GO
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.all_sql_modules
+-- WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
+-- GO
 
 USE master
 GO

--- a/test/JDBC/input/views/sys-all_sql_modules.mix
+++ b/test/JDBC/input/views/sys-all_sql_modules.mix
@@ -1,0 +1,244 @@
+-- Setup
+CREATE DATABASE sys_all_sql_modules_vu_prepare_db
+GO
+
+CREATE VIEW sys_all_sql_modules_vu_prepare_v1 AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE sys_all_sql_modules_vu_prepare_db
+GO
+
+CREATE TABLE sys_all_sql_modules_vu_prepare_t1(a int)
+GO
+
+CREATE TABLE sys_all_sql_modules_vu_prepare_t2(a int)
+GO
+
+CREATE TRIGGER sys_all_sql_modules_vu_prepare_tr1 ON sys_all_sql_modules_vu_prepare_t2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM sys_all_sql_modules_vu_prepare_t1;
+END
+GO
+
+CREATE VIEW sys_all_sql_modules_vu_prepare_v2 AS
+SELECT 1
+GO
+
+CREATE FUNCTION sys_all_sql_modules_vu_prepare_f1() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC sys_all_sql_modules_vu_prepare_p1 AS
+SELECT 1
+GO
+
+-- Test permission for all_sql_modules (query should not have any results)
+CREATE LOGIN sys_all_sql_modules_vu_prepare_user WITH PASSWORD='test'
+GO
+
+CREATE USER sys_all_sql_modules_vu_prepare_user FOR LOGIN sys_all_sql_modules_vu_prepare_user
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_all_sql_modules_vu_prepare_f1()%'
+GO
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v2', 'V')
+GO
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sys_all_sql_modules_vu_prepare_tr1')
+GO
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty', 'FN')
+GO
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables', 'V')
+GO
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables', 'P')
+GO
+
+-- Test for system function written in c 
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys.user_name', 'FN')
+GO
+
+-- Test that sys.all_sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE object_id = OBJECT_ID('sys_all_sql_modules_vu_prepare_v1', 'V')
+GO
+
+use master
+GO
+
+-- tsql user=sys_all_sql_modules_vu_prepare_user password=test
+
+USE sys_all_sql_modules_vu_prepare_db
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.all_sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_all_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+
+use master
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'sys_all_sql_modules_vu_prepare_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- tsql
+USE sys_all_sql_modules_vu_prepare_db
+GO
+
+DROP LOGIN sys_all_sql_modules_vu_prepare_user
+GO
+
+-- Cleanup
+DROP PROC sys_all_sql_modules_vu_prepare_p1
+GO
+
+DROP TRIGGER sys_all_sql_modules_vu_prepare_tr1
+GO
+
+DROP TABLE sys_all_sql_modules_vu_prepare_t1
+GO
+
+DROP TABLE sys_all_sql_modules_vu_prepare_t2
+GO
+
+DROP VIEW sys_all_sql_modules_vu_prepare_v2
+GO
+
+DROP FUNCTION sys_all_sql_modules_vu_prepare_f1
+GO
+
+USE master
+GO
+
+DROP VIEW sys_all_sql_modules_vu_prepare_v1
+GO
+
+DROP DATABASE sys_all_sql_modules_vu_prepare_db
+GO

--- a/test/JDBC/input/views/sys-events-vu-verify.sql
+++ b/test/JDBC/input/views/sys-events-vu-verify.sql
@@ -9,6 +9,7 @@ GO
 -- check trigger's object ID in sys.all_objects and sys.events view match up
 SELECT ao.name FROM sys.all_objects ao
 JOIN sys.events e ON e.object_id = ao.object_id
+WHERE name = 'sys_events_vu_prepare_trig3'
 GO
 
 USE master

--- a/test/JDBC/input/views/sys-sql_modules-vu-verify.mix
+++ b/test/JDBC/input/views/sys-sql_modules-vu-verify.mix
@@ -1,3 +1,8 @@
+-- NOTE: Some tests will be marked as "DISABLED DUE TO NON-UNIQUE OBJECT_ID"
+-- This is because during MVU, items in pg_class an pg_proc could have the same OBJECT_ID
+-- Some tests have no way of identification except for OBJECT_ID since definition will be missing
+-- These will be tested in the regular JDBC test
+
 USE sys_sql_modules_vu_prepare_db
 GO
 
@@ -13,7 +18,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_f1')
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_sql_modules_vu_prepare_f1()%'
 GO
 
 -- Test for views
@@ -28,80 +33,86 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v2')
+WHERE definition LIKE 'CREATE VIEW sys_all_sql_modules_vu_prepare_v2%'
 GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for triggers
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sql_modules_vu_prepare_tr1')
-GO
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sql_modules_vu_prepare_tr1')
+-- GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for proc
-SELECT
-    definition,
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_p1')
-GO
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
+-- GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system function
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
-GO
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+-- GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system views
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys.tables')
-GO
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = OBJECT_ID('sys.tables')
+-- GO
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system proc
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables')
-GO
+-- SELECT
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.sql_modules
+-- WHERE object_id = OBJECT_ID('sys.sp_tables')
+-- GO
+
 
 -- Test that sys.sql_modules is database-scoped
 SELECT
@@ -115,7 +126,7 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v1')
+WHERE definition LIKE 'CREATE VIEW sys_all_sql_modules_vu_prepare_v1%'
 GO
 
 USE master
@@ -137,9 +148,8 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.sql_modules
-WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_p1')
+WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
 GO
 
 USE master
 GO
-

--- a/test/JDBC/input/views/sys-sql_modules.mix
+++ b/test/JDBC/input/views/sys-sql_modules.mix
@@ -1,0 +1,229 @@
+-- Setup
+CREATE DATABASE sys_sql_modules_vu_prepare_db
+GO
+
+CREATE VIEW sys_sql_modules_vu_prepare_v1 AS -- This view should not be seen as we will be using a different database for the test
+SELECT 1
+GO
+
+USE sys_sql_modules_vu_prepare_db
+GO
+
+CREATE TABLE sys_sql_modules_vu_prepare_t1(a int)
+GO
+
+CREATE TABLE sys_sql_modules_vu_prepare_t2(a int)
+GO
+
+CREATE TRIGGER sys_sql_modules_vu_prepare_tr1 ON sys_sql_modules_vu_prepare_t2 INSTEAD OF INSERT
+AS
+BEGIN
+SELECT * FROM sys_sql_modules_vu_prepare_t1;
+END
+GO
+
+CREATE VIEW sys_sql_modules_vu_prepare_v2 AS
+SELECT 1
+GO
+
+CREATE FUNCTION sys_sql_modules_vu_prepare_f1() 
+RETURNS INT
+AS 
+BEGIN
+    RETURN 1;
+END
+GO
+
+CREATE PROC sys_sql_modules_vu_prepare_p1 AS
+SELECT 1
+GO
+
+-- Test permission for all_sql_modules (query should not have any results)
+CREATE LOGIN sys_sql_modules_vu_prepare_user WITH PASSWORD='test'
+GO
+
+CREATE USER sys_sql_modules_vu_prepare_user FOR LOGIN sys_sql_modules_vu_prepare_user
+GO
+
+-- Test for function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE definition LIKE 'CREATE FUNCTION dbo.sys_sql_modules_vu_prepare_f1()%'
+GO
+
+-- Test for views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v2')
+GO
+
+-- Test for triggers
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sql_modules_vu_prepare_tr1')
+GO
+
+-- Test for proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+
+-- Test for system function
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+
+-- Test for system views
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+
+-- Test for system proc
+SELECT
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys.sp_tables')
+GO
+
+-- Test that sys.sql_modules is database-scoped
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE object_id = OBJECT_ID('sys_sql_modules_vu_prepare_v1')
+GO
+
+USE master
+GO
+
+-- tsql user=sys_sql_modules_vu_prepare_user password=test
+
+USE sys_sql_modules_vu_prepare_db
+GO
+
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.sql_modules
+WHERE definition = 'CREATE PROCEDURE dbo.sys_sql_modules_vu_prepare_p1 AS SELECT 1'
+GO
+
+USE master
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'sys_sql_modules_vu_prepare_user' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- tsql
+USE sys_sql_modules_vu_prepare_db
+GO
+
+DROP LOGIN sys_sql_modules_vu_prepare_user
+GO
+
+-- Cleanup
+DROP PROC sys_sql_modules_vu_prepare_p1
+GO
+
+DROP TRIGGER sys_sql_modules_vu_prepare_tr1
+GO
+
+DROP TABLE sys_sql_modules_vu_prepare_t1
+GO
+
+DROP TABLE sys_sql_modules_vu_prepare_t2
+GO
+
+DROP VIEW sys_sql_modules_vu_prepare_v2
+GO
+
+DROP FUNCTION sys_sql_modules_vu_prepare_f1
+GO
+
+USE master
+GO
+
+DROP VIEW sys_sql_modules_vu_prepare_v1
+GO
+
+DROP DATABASE sys_sql_modules_vu_prepare_db
+GO

--- a/test/JDBC/input/views/sys-system_sql_modules-vu-verify.sql
+++ b/test/JDBC/input/views/sys-system_sql_modules-vu-verify.sql
@@ -1,46 +1,42 @@
--- Test for system function
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
-GO
+-- NOTE: Some tests will be marked as "DISABLED DUE TO NON-UNIQUE OBJECT_ID"
+-- This is because during MVU, items in pg_class an pg_proc could have the same OBJECT_ID
+-- Some tests have no way of identification except for OBJECT_ID since definition will be missing
+-- These will be tested in the regular JDBC test
 
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
+-- Test for system function
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.system_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+-- GO
+
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
 -- Test for system views
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.tables')
-GO
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.system_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.tables')
+-- GO
+
 
 -- Test for system proc
-SELECT
-    uses_ansi_nulls,
-    uses_quoted_identifier,
-    is_schema_bound,
-    uses_database_collation,
-    is_recompiled,
-    null_on_null_input,
-    execute_as_principal_id,
-    uses_native_compilation
-FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.sp_tables')
-GO
-
--- Test for system function written in c 
 SELECT
     definition,
     uses_ansi_nulls,
@@ -52,5 +48,21 @@ SELECT
     execute_as_principal_id,
     uses_native_compilation
 FROM sys.system_sql_modules
-WHERE object_id = OBJECT_ID('sys.user_name')
+WHERE definition LIKE 'CREATE PROCEDURE sp_tables%'
 GO
+
+-- DISABLED DUE TO NON-UNIQUE OBJECT_ID
+-- Test for system function written in c 
+-- SELECT
+--     definition,
+--     uses_ansi_nulls,
+--     uses_quoted_identifier,
+--     is_schema_bound,
+--     uses_database_collation,
+--     is_recompiled,
+--     null_on_null_input,
+--     execute_as_principal_id,
+--     uses_native_compilation
+-- FROM sys.system_sql_modules
+-- WHERE object_id = OBJECT_ID('sys.user_name')
+-- GO

--- a/test/JDBC/input/views/sys-system_sql_modules.sql
+++ b/test/JDBC/input/views/sys-system_sql_modules.sql
@@ -1,0 +1,59 @@
+-- Test for system function
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.fn_listextendedproperty')
+GO
+
+-- Test for system views
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.tables')
+GO
+
+-- Test for system proc
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE definition LIKE 'CREATE PROCEDURE sp_tables%'
+GO
+
+-- Test for system function written in c 
+SELECT
+    definition,
+    uses_ansi_nulls,
+    uses_quoted_identifier,
+    is_schema_bound,
+    uses_database_collation,
+    is_recompiled,
+    null_on_null_input,
+    execute_as_principal_id,
+    uses_native_compilation
+FROM sys.system_sql_modules
+WHERE object_id = OBJECT_ID('sys.user_name')
+GO


### PR DESCRIPTION


### Description

Previously, the GH actions had several flaky tests in the upgrade workflow due to multiple objects sharing the same object ids. This is because in objects in pg_proc and pg_class may have the ame oids after MVU. This commit fixes the following tests: 
- sys.sql_modules
- sys.all_sql_modules
- sys.system_sql_modules
- sys.events

For sys.events, a stricter query was used. For the sql modules view, tests were disabled for the upgrade process, and regular JDBC non-upgrade tests were added. This is because sql_modules only has 2 fields that can uniquely identify an object: object_id, and the definition. However, not all the definition is supported for all objects which could make these queries still flaky.  So objects without a supported definition will not be tested in the upgrade path. 

Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Issues Resolved

FIx flakiness for the following tests: 
- sys.sql_modules
- sys.all_sql_modules
- sys.system_sql_modules
- sys.events


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).