### PR TITLE
[BABEL-3156] Support UPDATE, DELETE for sp_describe_undeclared_parameters

### DIFF
--- a/test/JDBC/expected/BABEL-3156.out
+++ b/test/JDBC/expected/BABEL-3156.out
@@ -1,0 +1,141 @@
+CREATE TABLE dbo.performancetable (
+ id int NOT NULL,
+ col21 xml NULL,
+ CONSTRAINT PK__gen_tabl__3213E83FCC22F19F PRIMARY KEY (id)
+);
+GO
+
+exec sp_describe_undeclared_parameters
+ N'UPDATE [dbo].[performancetable] SET [col21]=@P1 WHERE [id]=@P2';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#241#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#241#!#8100
+2#!#@p2#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+~~END~~
+
+
+exec sp_describe_undeclared_parameters
+ N'DELETE [dbo].[performancetable] WHERE [id]=@P1';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+~~END~~
+
+
+CREATE TABLE BABEL_3156(
+a int,
+b nvarchar,
+c xml, 
+d datetime,
+e money,
+f varbinary);
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1 WHERE B=@P2';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@p2#!#231#!#nvarchar(1)#!#2#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#231#!#2
+~~END~~
+
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2 WHERE c=@P3';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@p2#!#231#!#nvarchar(1)#!#2#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#231#!#2
+3#!#@p3#!#241#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#241#!#8100
+~~END~~
+
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2, c=@P3, d=@P4, e=@P5 WHERE f=@P6';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@p2#!#231#!#nvarchar(1)#!#2#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#231#!#2
+3#!#@p3#!#241#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#241#!#8100
+4#!#@p4#!#61#!#datetime#!#8#!#23#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#111#!#8
+5#!#@p5#!#60#!#money#!#8#!#19#!#4#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#110#!#8
+6#!#@p6#!#165#!#varbinary(1)#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#165#!#1
+~~END~~
+
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2 WHERE c=@P3 AND d=@P4';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@p2#!#231#!#nvarchar(1)#!#2#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#231#!#2
+3#!#@p3#!#241#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#241#!#8100
+4#!#@p4#!#61#!#datetime#!#8#!#23#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#111#!#8
+~~END~~
+
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2 WHERE c=@P3 AND d=@P4 AND e=@P5 AND f=@P6';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@p2#!#231#!#nvarchar(1)#!#2#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#231#!#2
+3#!#@p3#!#241#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#241#!#8100
+4#!#@p4#!#61#!#datetime#!#8#!#23#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#111#!#8
+5#!#@p5#!#60#!#money#!#8#!#19#!#4#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#110#!#8
+6#!#@p6#!#165#!#varbinary(1)#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#165#!#1
+~~END~~
+
+
+exec sp_describe_undeclared_parameters 
+    N'DELETE FROM BABEL_3156 WHERE a=@P1';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+~~END~~
+
+
+exec sp_describe_undeclared_parameters 
+    N'DELETE FROM BABEL_3156 WHERE a=@P1 AND b=@P2 AND c=@P3 AND d=@P4 AND e=@P5 AND f=@P6';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+1#!#@p1#!#56#!#int#!#4#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#38#!#4
+2#!#@p2#!#231#!#nvarchar(1)#!#2#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#231#!#2
+3#!#@p3#!#241#!#xml#!#-1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#241#!#8100
+4#!#@p4#!#61#!#datetime#!#8#!#23#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#111#!#8
+5#!#@p5#!#60#!#money#!#8#!#19#!#4#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#110#!#8
+6#!#@p6#!#165#!#varbinary(1)#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0#!#1#!#0#!#<NULL>#!#165#!#1
+~~END~~
+
+
+exec sp_describe_undeclared_parameters
+    N'UPDATE BABEL_3156 SET not_a_col=@P1';
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "not_a_col" of relation "babel_3156" does not exist)~~
+
+
+
+exec sp_describe_undeclared_parameters
+    N'UPDATE BABEL_3156 SET a=@P1 WHERE not_a_col=@P2';
+G
+DROP TABLE BABEL_3156;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'DROP' at line 4 and character position 0)~~
+
+DROP TABLE dbo.performancetable;
+GO

--- a/test/JDBC/input/BABEL-3156.sql
+++ b/test/JDBC/input/BABEL-3156.sql
@@ -1,0 +1,64 @@
+CREATE TABLE dbo.performancetable (
+ id int NOT NULL,
+ col21 xml NULL,
+ CONSTRAINT PK__gen_tabl__3213E83FCC22F19F PRIMARY KEY (id)
+);
+GO
+
+exec sp_describe_undeclared_parameters
+ N'UPDATE [dbo].[performancetable] SET [col21]=@P1 WHERE [id]=@P2';
+GO
+
+exec sp_describe_undeclared_parameters
+ N'DELETE [dbo].[performancetable] WHERE [id]=@P1';
+GO
+
+CREATE TABLE BABEL_3156(
+a int,
+b nvarchar,
+c xml, 
+d datetime,
+e money,
+f varbinary);
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1 WHERE B=@P2';
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2 WHERE c=@P3';
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2, c=@P3, d=@P4, e=@P5 WHERE f=@P6';
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2 WHERE c=@P3 AND d=@P4';
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'UPDATE BABEL_3156 SET a=@P1, b=@P2 WHERE c=@P3 AND d=@P4 AND e=@P5 AND f=@P6';
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'DELETE FROM BABEL_3156 WHERE a=@P1';
+GO
+
+exec sp_describe_undeclared_parameters 
+    N'DELETE FROM BABEL_3156 WHERE a=@P1 AND b=@P2 AND c=@P3 AND d=@P4 AND e=@P5 AND f=@P6';
+GO
+
+exec sp_describe_undeclared_parameters
+    N'UPDATE BABEL_3156 SET not_a_col=@P1';
+GO
+
+exec sp_describe_undeclared_parameters
+    N'UPDATE BABEL_3156 SET a=@P1 WHERE not_a_col=@P2';
+G
+
+DROP TABLE BABEL_3156;
+GO
+DROP TABLE dbo.performancetable;
+GO


### PR DESCRIPTION


### Description

Support UPDATE, DELETE for sp_describe_undeclared_parameters. sp_describe_undeclared_parameters previously only supported the `INSERT ... VALUES` syntax. In this PR we add support for UPDATE and DELETE statements as well. 
 
### Issues Resolved

BABEL-3156


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).