### PR TITLE
Add allow hints for delete update and insert in stored procs

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -125,7 +125,7 @@ static void *makeBatch(TSqlParser::Tsql_fileContext *ctx, tsqlBuilder &builder);
 //static void *makeBatch(TSqlParser::Block_statementContext *ctx, tsqlBuilder &builder);
 
 static void process_execsql_destination(TSqlParser::Dml_statementContext *ctx, PLtsql_stmt_execsql *stmt);
-static void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext *ctx, PLtsql_stmt_execsql *stmt);
+static void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext *ctx, PLtsql_expr_query_mutator *exprMutator);
 static bool post_process_create_table(TSqlParser::Create_tableContext *ctx, PLtsql_stmt_execsql *stmt, TSqlParser::Ddl_statementContext *baseCtx);
 static bool post_process_alter_table(TSqlParser::Alter_tableContext *ctx, PLtsql_stmt_execsql *stmt, TSqlParser::Ddl_statementContext *baseCtx);
 static bool post_process_create_index(TSqlParser::Create_indexContext *ctx, PLtsql_stmt_execsql *stmt, TSqlParser::Ddl_statementContext *baseCtx);
@@ -1018,6 +1018,7 @@ public:
 
 	void exitDml_statement(TSqlParser::Dml_statementContext *ctx) override
 	{
+		process_execsql_remove_unsupported_tokens(ctx, mutator);
 		if (mutator && query_hints.size() && enable_hint_mapping)
 		{
 			add_query_hints(mutator, ctx->start->getStartIndex());
@@ -1450,7 +1451,7 @@ public:
 
 		process_execsql_destination(ctx, stmt);
 
-		process_execsql_remove_unsupported_tokens(ctx, stmt); // in-place query string modification. no mutator necessary
+		process_execsql_remove_unsupported_tokens(ctx, statementMutator.get());
 
 		// record whether the stmt is an INSERT-EXEC stmt
 		stmt->insert_exec =
@@ -5183,8 +5184,9 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 	}
 }
 
-void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext *ctx, PLtsql_stmt_execsql *stmt)
+void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext *ctx, PLtsql_expr_query_mutator *exprMutator)
 {
+	PLtsql_expr * sqlstmt = exprMutator->expr;
 	if (ctx->insert_statement())
 	{
 		auto ictx = ctx->insert_statement();
@@ -5195,11 +5197,11 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 				std::string table_name = extractTableName(ictx->ddl_object(), nullptr);
 				extractTableHints(ictx->with_table_hints(), table_name);
 			}
-			removeCtxStringFromQuery(stmt->sqlstmt, ictx->with_table_hints(), ctx);
+			removeCtxStringFromQuery(sqlstmt, ictx->with_table_hints(), exprMutator->ctx);
 		}
 		if (ictx->option_clause()) // query hints
 		{
-			removeCtxStringFromQuery(stmt->sqlstmt, ictx->option_clause(), ctx);
+			removeCtxStringFromQuery(sqlstmt, ictx->option_clause(), exprMutator->ctx);
 			extractQueryHintsFromOptionClause(ictx->option_clause());
 		}
 	}
@@ -5208,7 +5210,7 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 		auto uctx = ctx->update_statement();
 		if (uctx->table_sources())
 			for (auto tctx : uctx->table_sources()->table_source_item()) // from-clause (to remove hints)
-				post_process_table_source(tctx, stmt->sqlstmt, ctx);
+				post_process_table_source(tctx, sqlstmt, exprMutator->ctx);
 		if (uctx->with_table_hints()) // table hints
 		{
 			if (!uctx->with_table_hints()->sample_clause() && uctx->ddl_object())
@@ -5216,11 +5218,11 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 				std::string table_name = extractTableName(uctx->ddl_object(), nullptr);
 				extractTableHints(uctx->with_table_hints(), table_name);
 			}
-			removeCtxStringFromQuery(stmt->sqlstmt, uctx->with_table_hints(), ctx);
+			removeCtxStringFromQuery(sqlstmt, uctx->with_table_hints(), exprMutator->ctx);
 		}
 		if (uctx->option_clause()) // query hints
 		{
-			removeCtxStringFromQuery(stmt->sqlstmt, uctx->option_clause(), ctx);
+			removeCtxStringFromQuery(sqlstmt, uctx->option_clause(), exprMutator->ctx);
 			extractQueryHintsFromOptionClause(uctx->option_clause());
 		}
 	}
@@ -5230,7 +5232,7 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 		if (dctx->table_sources())
 		{
 			for (auto tctx : dctx->table_sources()->table_source_item()) // from-clause (to remove hints)
-				post_process_table_source(tctx, stmt->sqlstmt, ctx);
+				post_process_table_source(tctx, sqlstmt, exprMutator->ctx);
 		}
 		if (dctx->delete_statement_from()->table_alias() && dctx->delete_statement_from()->table_alias()->with_table_hints())
 		{
@@ -5239,7 +5241,7 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 				std::string table_name = ::getFullText(dctx->delete_statement_from()->table_alias()->id());
 				extractTableHints(dctx->delete_statement_from()->table_alias()->with_table_hints(), table_name);
 			}
-			removeCtxStringFromQuery(stmt->sqlstmt, dctx->delete_statement_from()->table_alias()->with_table_hints(), ctx);
+			removeCtxStringFromQuery(sqlstmt, dctx->delete_statement_from()->table_alias()->with_table_hints(), exprMutator->ctx);
 		}
 		if (dctx->with_table_hints()) // table hints
 		{
@@ -5248,11 +5250,11 @@ void process_execsql_remove_unsupported_tokens(TSqlParser::Dml_statementContext 
 				std::string table_name = extractTableName(dctx->delete_statement_from()->ddl_object(), nullptr);
 				extractTableHints(dctx->with_table_hints(), table_name);
 			}
-			removeCtxStringFromQuery(stmt->sqlstmt, dctx->with_table_hints(), ctx);
+			removeCtxStringFromQuery(sqlstmt, dctx->with_table_hints(), exprMutator->ctx);
 		}
 		if (dctx->option_clause()) // query hints
 		{
-			removeCtxStringFromQuery(stmt->sqlstmt, dctx->option_clause(), ctx);
+			removeCtxStringFromQuery(sqlstmt, dctx->option_clause(), exprMutator->ctx);
 			extractQueryHintsFromOptionClause(dctx->option_clause());
 		}
 	}

--- a/test/JDBC/expected/BABEL-3592.out
+++ b/test/JDBC/expected/BABEL-3592.out
@@ -1,0 +1,463 @@
+drop procedure if exists babel_3592_insert_multiline
+go
+
+drop table if exists babel_3592_t1
+go
+
+drop table if exists babel_3592_t2
+go
+
+drop table if exists babel_3592_t3
+go
+
+create table babel_3592_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3592_t1_b1 on babel_3592_t1(b1)
+go
+
+create table babel_3592_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3592_t2_b2 on babel_3592_t2(b2)
+go
+
+create table babel_3592_t3(a3 int PRIMARY KEY, b3 int)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
+-- TEST INSERT queries 
+CREATE PROCEDURE babel_3592_insert_multiline AS
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+insert into babel_3592_t2
+    select *
+    from babel_3592_t1 with(index(index_babel_3592_t1_b1))
+    where b1 = 1
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_insert_multiline';
+GO
+~~START~~
+text
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2<newline>    select *<newline>    from babel_3592_t1                                    <newline>    where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1                                                                 
+~~END~~
+
+
+CREATE PROCEDURE babel_3592_insert_singleline AS insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_insert_singleline
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_insert_multiline
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_insert_multiline
+  Query Text: insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Bitmap Heap Scan on babel_3592_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
+                    Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
+    select *
+    from babel_3592_t1                                    
+    where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+EXEC babel_3592_insert_singleline
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_insert_singleline
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- Test UPDATE queries
+CREATE PROCEDURE babel_3592_updates_multiline AS
+update babel_3592_t1 
+    set a1 = 1 where b1 = 1
+update babel_3592_t1 
+    with(index(index_babel_3592_t1_b1)) 
+    set a1 = 1 where b1 = 1
+update babel_3592_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+CREATE PROCEDURE babel_3592_updates_singleline AS update babel_3592_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_updates_multiline';
+GO
+~~START~~
+text
+update babel_3592_t1 <newline>    set a1 = 1 where b1 = 1<newline>update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 <newline>                                        <newline>    set a1 = 1 where b1 = 1<newline>update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 
+~~END~~
+
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_updates_singleline';
+GO
+~~START~~
+text
+update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 
+~~END~~
+
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_updates_singleline
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_insert_multiline
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_insert_multiline
+  Query Text: insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Bitmap Heap Scan on babel_3592_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
+                    Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
+    select *
+    from babel_3592_t1                                    
+    where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+EXEC babel_3592_updates_singleline
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_updates_singleline
+  Query Text: update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1
+  ->  Update on babel_3592_t1
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+-- Test DELETE queries with and without hints
+CREATE PROCEDURE babel_3592_delete_multiline AS
+delete from babel_3592_t1 where b1 = 1
+delete from babel_3592_t1 with
+    (index
+        (index_babel_3592_t1_b1)
+    )
+    where b1 = 1
+delete from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+CREATE PROCEDURE babel_3592_delete_singleline AS delete from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_delete_multiline';
+GO
+~~START~~
+text
+delete from babel_3592_t1 where b1 = 1<newline>delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1                                                       <newline>    where b1 = 1<newline>delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1                                                                 
+~~END~~
+
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_delete_singleline';
+GO
+~~START~~
+text
+delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1                                                                 
+~~END~~
+
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_delete_singleline
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_insert_multiline
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_insert_multiline
+  Query Text: insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Bitmap Heap Scan on babel_3592_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
+                    Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
+    select *
+    from babel_3592_t1                                    
+    where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+EXEC babel_3592_delete_singleline
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_delete_singleline
+  Query Text: delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1
+  ->  Delete on babel_3592_t1
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+~~END~~
+
+
+set babelfish_showplan_all off
+go
+
+
+
+
+
+-- Test mixed statements
+create procedure babel_3592_proc_mixed_statements AS
+    update babel_3592_t1 with(index(index_babel_3592_t1_b1)) set a1 = 1 where b1 = 1
+        select * from babel_3592_t1 inner loop join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2
+    select * from babel_3592_t1 inner merge
+     join babel_3592_t2
+      on babel_3592_t1.a1 = babel_3592_t2.a2
+    update babel_3592_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+    delete babel_3592_t1 from babel_3592_t1 inner merge join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+delete babel_3592_t1 from babel_3592_t1 with(index(index_babel_3592_t1_b1)) left outer merge join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+insert
+into
+babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+insert into babel_3592_t2 select * from babel_3592_t1 with(index(index_babel_3592_t1_b1)) where b1 = 1
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+-- comments inside the stored proc
+update babel_3592_t1 set a1 = 1 where b1 = 1
+/*
+ *multiline comment
+ */
+ select * from babel_3592_t1 with(index(index_babel_3592_t1_b1)), babel_3592_t2 with(index(index_babel_3592_t2_b2)) where b1 = 1 and b2 = 1
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_proc_mixed_statements';
+GO
+~~START~~
+text
+update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1                                     set a1 = 1 where b1 = 1<newline>        select/*+ NestLoop(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2<newline>    select/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      <newline>     join babel_3592_t2<newline>      on babel_3592_t1.a1 = babel_3592_t2.a2<newline>    update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 <newline>    delete/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1 inner       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1<newline>delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1                                     left outer       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1<newline>insert<newline>into<newline>babel_3592_t2 select * from babel_3592_t1 where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1                                     where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1                                                                 <newline>-- comments inside the stored proc<newline>update babel_3592_t1 set a1 = 1 where b1 = 1<newline>/*<newline> *multiline comment<newline> */<newline> select/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) IndexScan(babel_3592_t2 index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d) */ * from babel_3592_t1                                    , babel_3592_t2                                     where b1 = 1 and b2 = 1
+~~END~~
+
+
+EXEC babel_3592_proc_mixed_statements
+GO
+~~START~~
+int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int
+~~END~~
+
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_proc_mixed_statements
+GO
+~~START~~
+text
+Query Text: EXEC babel_3592_proc_mixed_statements
+  Query Text: update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1                                     set a1 = 1 where b1 = 1
+  ->  Update on babel_3592_t1
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: select/*+ NestLoop(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2
+  ->  Nested Loop
+        ->  Seq Scan on babel_3592_t1
+        ->  Index Scan using babel_3592_t2_pkey on babel_3592_t2
+              Index Cond: (a2 = babel_3592_t1.a1)
+  Query Text: select/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      
+     join babel_3592_t2
+      on babel_3592_t1.a1 = babel_3592_t2.a2
+  ->  Merge Join
+        Merge Cond: (babel_3592_t1.a1 = babel_3592_t2.a2)
+        ->  Index Scan using babel_3592_t1_pkey on babel_3592_t1
+        ->  Index Scan using babel_3592_t2_pkey on babel_3592_t2
+  Query Text: update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1
+  ->  Update on babel_3592_t1
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: delete/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1 inner       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+  ->  Delete on babel_3592_t1
+        ->  Nested Loop
+              ->  HashAggregate
+                    Group Key: babel_3592_t1_1.ctid
+                    ->  Hash Join
+                          Hash Cond: (babel_3592_t1_1.a1 = babel_3592_t2.a2)
+                          ->  Bitmap Heap Scan on babel_3592_t1 babel_3592_t1_1
+                                Recheck Cond: (b1 = 1)
+                                ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
+                                      Index Cond: (b1 = 1)
+                          ->  Hash
+                                ->  Bitmap Heap Scan on babel_3592_t2
+                                      Recheck Cond: (b2 = 1)
+                                      ->  Bitmap Index Scan on index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d
+                                            Index Cond: (b2 = 1)
+              ->  Tid Scan on babel_3592_t1
+                    TID Cond: (ctid = babel_3592_t1_1.ctid)
+  Query Text: delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1                                     left outer       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+  ->  Delete on babel_3592_t1
+        ->  Nested Loop
+              ->  HashAggregate
+                    Group Key: babel_3592_t1_1.ctid
+                    ->  Hash Join
+                          Hash Cond: (babel_3592_t1_1.a1 = babel_3592_t2.a2)
+                          ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1 babel_3592_t1_1
+                                Index Cond: (b1 = 1)
+                          ->  Hash
+                                ->  Bitmap Heap Scan on babel_3592_t2
+                                      Recheck Cond: (b2 = 1)
+                                      ->  Bitmap Index Scan on index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d
+                                            Index Cond: (b2 = 1)
+              ->  Tid Scan on babel_3592_t1
+                    TID Cond: (ctid = babel_3592_t1_1.ctid)
+  Query Text: insert
+into
+babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Bitmap Heap Scan on babel_3592_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
+                    Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1                                     where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  ->  Insert on babel_3592_t2
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+  Query Text: update babel_3592_t1 set a1 = 1 where b1 = 1
+  ->  Update on babel_3592_t1
+        ->  Bitmap Heap Scan on babel_3592_t1
+              Recheck Cond: (b1 = 1)
+              ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
+                    Index Cond: (b1 = 1)
+  Query Text: select/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) IndexScan(babel_3592_t2 index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d) */ * from babel_3592_t1                                    , babel_3592_t2                                     where b1 = 1 and b2 = 1
+  ->  Nested Loop
+        ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
+              Index Cond: (b1 = 1)
+        ->  Materialize
+              ->  Index Scan using index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d on babel_3592_t2
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+-- clean up
+set babelfish_showplan_all off
+go
+
+DROP PROCEDURE  babel_3592_insert_multiline
+GO
+
+DROP PROCEDURE  babel_3592_insert_singleline
+GO
+
+DROP PROCEDURE  babel_3592_updates_multiline
+GO
+
+DROP PROCEDURE  babel_3592_updates_singleline
+GO
+
+DROP PROCEDURE  babel_3592_delete_multiline
+GO
+
+DROP PROCEDURE  babel_3592_delete_singleline
+GO
+
+DROP PROCEDURE  babel_3592_proc_mixed_statements
+GO
+
+DROP TABLE babel_3592_t1
+GO
+
+DROP TABLE babel_3592_t2
+GO
+
+DROP TABLE babel_3592_t3
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+SELECT set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/pg_hint_plan/BABEL-3592.sql
+++ b/test/JDBC/pg_hint_plan/BABEL-3592.sql
@@ -1,0 +1,220 @@
+drop procedure if exists babel_3592_insert_multiline
+go
+
+drop table if exists babel_3592_t1
+go
+
+drop table if exists babel_3592_t2
+go
+
+drop table if exists babel_3592_t3
+go
+
+create table babel_3592_t1(a1 int PRIMARY KEY, b1 int)
+go
+
+create index index_babel_3592_t1_b1 on babel_3592_t1(b1)
+go
+
+create table babel_3592_t2(a2 int PRIMARY KEY, b2 int)
+go
+
+create index index_babel_3592_t2_b2 on babel_3592_t2(b2)
+go
+
+create table babel_3592_t3(a3 int PRIMARY KEY, b3 int)
+go
+
+select set_config('babelfishpg_tsql.explain_costs', 'off', false)
+go
+
+select set_config('babelfishpg_tsql.enable_hint_mapping', 'on', false)
+go
+
+-- TEST INSERT queries 
+CREATE PROCEDURE babel_3592_insert_multiline AS
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+insert into babel_3592_t2
+    select *
+    from babel_3592_t1 with(index(index_babel_3592_t1_b1))
+    where b1 = 1
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_insert_multiline';
+GO
+
+CREATE PROCEDURE babel_3592_insert_singleline AS insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_insert_singleline
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_insert_singleline
+GO
+
+set babelfish_showplan_all off
+go
+
+-- Test UPDATE queries
+CREATE PROCEDURE babel_3592_updates_multiline AS
+update babel_3592_t1 
+    set a1 = 1 where b1 = 1
+update babel_3592_t1 
+    with(index(index_babel_3592_t1_b1)) 
+    set a1 = 1 where b1 = 1
+update babel_3592_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+CREATE PROCEDURE babel_3592_updates_singleline AS update babel_3592_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_updates_multiline';
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_updates_singleline';
+GO
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_updates_singleline
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_updates_singleline
+GO
+
+set babelfish_showplan_all off
+go
+
+-- Test DELETE queries with and without hints
+CREATE PROCEDURE babel_3592_delete_multiline AS
+delete from babel_3592_t1 where b1 = 1
+delete from babel_3592_t1 with
+    (index
+        (index_babel_3592_t1_b1)
+    )
+    where b1 = 1
+delete from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+CREATE PROCEDURE babel_3592_delete_singleline AS delete from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_delete_multiline';
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_delete_singleline';
+GO
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_delete_singleline
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_insert_multiline
+GO
+
+EXEC babel_3592_delete_singleline
+GO
+
+set babelfish_showplan_all off
+go
+
+-- Test mixed statements
+create procedure babel_3592_proc_mixed_statements AS
+    update babel_3592_t1 with(index(index_babel_3592_t1_b1)) set a1 = 1 where b1 = 1
+        select * from babel_3592_t1 inner loop join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2
+    select * from babel_3592_t1 inner merge
+     join babel_3592_t2
+      on babel_3592_t1.a1 = babel_3592_t2.a2
+
+    update babel_3592_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+    delete babel_3592_t1 from babel_3592_t1 inner merge join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+delete babel_3592_t1 from babel_3592_t1 with(index(index_babel_3592_t1_b1)) left outer merge join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+insert
+into
+babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+
+insert into babel_3592_t2 select * from babel_3592_t1 with(index(index_babel_3592_t1_b1)) where b1 = 1
+
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1 option(table hint(babel_3592_t1, index(index_babel_3592_t1_b1)))
+
+-- comments inside the stored proc
+update babel_3592_t1 set a1 = 1 where b1 = 1
+/*
+ *multiline comment
+ */
+ select * from babel_3592_t1 with(index(index_babel_3592_t1_b1)), babel_3592_t2 with(index(index_babel_3592_t2_b2)) where b1 = 1 and b2 = 1
+GO
+
+SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_proc_mixed_statements';
+GO
+
+EXEC babel_3592_proc_mixed_statements
+GO
+
+set babelfish_showplan_all on
+go
+
+EXEC babel_3592_proc_mixed_statements
+GO
+
+-- clean up
+set babelfish_showplan_all off
+go
+
+DROP PROCEDURE  babel_3592_insert_multiline
+GO
+
+DROP PROCEDURE  babel_3592_insert_singleline
+GO
+
+DROP PROCEDURE  babel_3592_updates_multiline
+GO
+
+DROP PROCEDURE  babel_3592_updates_singleline
+GO
+
+DROP PROCEDURE  babel_3592_delete_multiline
+GO
+
+DROP PROCEDURE  babel_3592_delete_singleline
+GO
+
+DROP PROCEDURE  babel_3592_proc_mixed_statements
+GO
+
+DROP TABLE babel_3592_t1
+GO
+
+DROP TABLE babel_3592_t2
+GO
+
+DROP TABLE babel_3592_t3
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_hint_mapping', 'off', false)
+GO


### PR DESCRIPTION
### Description

Previously, using tsql style hints on non select statements inside of stored procs was not supported.  This commit allows for hints on update delete and insert statements inside of stored procedures.

This is enabled by calling the process_execsql_remove_unsupported_tokens inside of exitdml_statement in the select statement mutator. This will properly sanitize the query strings an extract the hints.

Further process_execsql_remove_unsupported_tokens was updated to consider the expression mutators context as the base context when rewritting queries.  For normal statements this was the same as the old behavior since the offset will be 0.  This is required for stored procs as the former behavior would not account for the "CREATE PROCEDURE <name> AS" in the expression thus causing a rewrite at the wrong location
 
### Issues Resolved
[BABEL-3592]


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).