### PR TITLE
Remove babelfishpg_tsql.enable_ownership_structure.

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -558,15 +558,6 @@ define_custom_variables(void)
 							  GUC_NO_RESET_ALL,
 							  NULL, NULL, NULL);
 
-	DefineCustomBoolVariable("babelfishpg_tsql.enable_ownership_structure",
-				 gettext_noop("Enable Babelfish Ownership Structure"),
-				 NULL,
-				 &enable_ownership_structure,
-				 true,
-				 PGC_SUSET,  /* only superuser can set */
-				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-				 NULL, NULL, NULL);
-
 	/* ANTLR parser */
 	DefineCustomBoolVariable("babelfishpg_tsql.dump_antlr_query_graph",
 				 gettext_noop("dump query graph parsed by ANTLR parser to local disk"),
@@ -600,7 +591,7 @@ define_custom_variables(void)
 				   gettext_noop("Name of the default server collation."),
 				   NULL,
 				   &pltsql_server_collation_name,
-				   "sql_latin1_general_cp1_ci_as",
+				   "sql_latin1_general_cp1_ci_as",	
 				   PGC_SIGHUP,
 				   GUC_NO_RESET_ALL,
 				   check_server_collation_name, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -558,6 +558,7 @@ define_custom_variables(void)
 							  GUC_NO_RESET_ALL,
 							  NULL, NULL, NULL);
 
+
 	/* ANTLR parser */
 	DefineCustomBoolVariable("babelfishpg_tsql.dump_antlr_query_graph",
 				 gettext_noop("dump query graph parsed by ANTLR parser to local disk"),
@@ -591,7 +592,7 @@ define_custom_variables(void)
 				   gettext_noop("Name of the default server collation."),
 				   NULL,
 				   &pltsql_server_collation_name,
-				   "sql_latin1_general_cp1_ci_as",	
+				   "sql_latin1_general_cp1_ci_as",
 				   PGC_SIGHUP,
 				   GUC_NO_RESET_ALL,
 				   check_server_collation_name, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -562,7 +562,7 @@ define_custom_variables(void)
 				 gettext_noop("Enable Babelfish Ownership Structure"),
 				 NULL,
 				 &enable_ownership_structure,
-				 false,
+				 true,
 				 PGC_SUSET,  /* only superuser can set */
 				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);
@@ -1472,8 +1472,4 @@ get_migration_mode(void)
 	return (MigrationMode) migration_mode;
 }
 
-bool
-ownership_structure_enabled(void)
-{
-	return enable_ownership_structure;
-}
+

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -14,6 +14,6 @@ extern void pltsql_validate_set_config_function(char *name, char *value);
  * 				Getters
  ************************************/
 extern MigrationMode get_migration_mode(void);
-extern bool ownership_structure_enabled(void);
+
 
 #endif

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -44,9 +44,6 @@ static void truncate_tsql_identifier(char *ident);
 bool
 enable_schema_mapping(void)
 {
-	if (!ownership_structure_enabled())
-		return false;
-
 	if (!DbidIsValid(get_cur_db_id()))  /* TODO: remove it after cur_db_oid() is enforeced */
 		return false;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -285,7 +285,7 @@ assign_identity_insert(const char *newval, void *extra)
                 {
                         schema_name = (char *) lthird(elemlist);
 
-						if (ownership_structure_enabled() && cur_db_name)
+						if (cur_db_name)
 							schema_name = get_physical_schema_name(cur_db_name,
 																   schema_name);
 
@@ -2279,8 +2279,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		}
 		case T_CreateRoleStmt:
 		{
-			if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+			if (sql_dialect == SQL_DIALECT_TSQL)
 			{
 				const char      *prev_current_user;
 				CreateRoleStmt	*stmt = (CreateRoleStmt *) parsetree;
@@ -2488,8 +2487,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		}
 		case T_AlterRoleStmt:
 		{
-			if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+			if (sql_dialect == SQL_DIALECT_TSQL)
 			{
 				AlterRoleStmt	*stmt = (AlterRoleStmt *) parsetree;
 				List			*login_options = NIL;
@@ -2712,8 +2710,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		}
 		case T_DropRoleStmt:
 		{
-			if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+			if (sql_dialect == SQL_DIALECT_TSQL)
 			{
 				const char      *prev_current_user;
 				DropRoleStmt	*stmt = (DropRoleStmt *) parsetree;
@@ -2888,8 +2885,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		}
 		case T_CreateSchemaStmt:
 		{
-            if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+            if (sql_dialect == SQL_DIALECT_TSQL)
             {
 				CreateSchemaStmt	*create_schema = (CreateSchemaStmt *) parsetree;
 				const char			*orig_schema = NULL;
@@ -2952,8 +2948,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 			if (drop_stmt->removeType != OBJECT_SCHEMA)
 				break;
 
-            if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+            if (sql_dialect == SQL_DIALECT_TSQL)
 			{
 				del_ns_ext_info(strVal(lfirst(list_head(drop_stmt->objects))), drop_stmt->missing_ok);
 
@@ -2978,16 +2973,14 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 			}
 		}
 		case T_CreatedbStmt:
-            if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+            if (sql_dialect == SQL_DIALECT_TSQL)
             {
 				create_bbf_db(pstate, (CreatedbStmt *) parsetree);
 				return;
 			}
 			break;
         case T_DropdbStmt:
-            if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+            if (sql_dialect == SQL_DIALECT_TSQL)
             {
                 DropdbStmt *stmt = (DropdbStmt *) parsetree;
                 drop_bbf_db(stmt->dbname, stmt->missing_ok, false);
@@ -2995,8 +2988,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
             }
             break;
 		case T_GrantRoleStmt:
-            if (sql_dialect == SQL_DIALECT_TSQL
-				&& ownership_structure_enabled())
+            if (sql_dialect == SQL_DIALECT_TSQL)
             {
 				GrantRoleStmt *grant_role = (GrantRoleStmt *) parsetree;
 				if (is_alter_server_stmt(grant_role))

--- a/contrib/babelfishpg_tsql/src/schemacmds.c
+++ b/contrib/babelfishpg_tsql/src/schemacmds.c
@@ -103,7 +103,7 @@ del_ns_ext_info(const char *schemaname, bool missing_ok)
 void
 check_extra_schema_restrictions(Node *stmt)
 {
-	if (sql_dialect == SQL_DIALECT_PG && ownership_structure_enabled())
+	if (sql_dialect == SQL_DIALECT_PG)
 	{
 		switch(nodeTag(stmt))
 		{


### PR DESCRIPTION
Previously, The GUC babelfishpg_tsql.enable_ownership_structure no longer serves a purpose as Babelfish cannot run without the ownership structure. Now have removed ownership structure. 

Task: BABEL-3154
Signed-off-by: pratikzode <pratik.zode@gmail.com>