### PR TITLE
Add metadata integrity check for change in sys.babelfish_authid_user_ext

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1387,7 +1387,9 @@ Rule must_have_rules[] =
 	{"msdb_dbo must exist in babelfish_authid_user_ext",
 	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_dbo, NULL, check_exist, NULL},
 	{"msdb_guest must exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_guest, NULL, check_exist, NULL}
+	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_guest, NULL, check_exist, NULL},
+	{"In single-db mode, if user db exists, <name>_guest must also exist in babelfish_authid_user_ext",
+	 "babelfish_authid_user_ext", "rolname", NULL, get_name_guest, is_singledb_exists_userdb, check_exist, NULL}
 };
 
 /* Must match rules, MUST comply with metadata_inconsistency_check() */

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1289,11 +1289,8 @@ static Datum get_msdb_dbo(HeapTuple tuple, TupleDesc dsc);
 static Datum get_dbo(HeapTuple tuple, TupleDesc dsc);
 static Datum get_db_owner(HeapTuple tuple, TupleDesc dsc);
 static Datum get_master_db_owner(HeapTuple tuple, TupleDesc dsc);
-static Datum get_master_guest(HeapTuple tuple, TupleDesc dsc);
 static Datum get_tempdb_db_owner(HeapTuple tuple, TupleDesc dsc);
-static Datum get_tempdb_guest(HeapTuple tuple, TupleDesc dsc);
 static Datum get_msdb_db_owner(HeapTuple tuple, TupleDesc dsc);
-static Datum get_msdb_guest(HeapTuple tuple, TupleDesc dsc);
 static Datum get_owner(HeapTuple tuple, TupleDesc dsc);
 static Datum get_name_db_owner(HeapTuple tuple, TupleDesc dsc);
 static Datum get_name_dbo(HeapTuple tuple, TupleDesc dsc);
@@ -1374,22 +1371,14 @@ Rule must_have_rules[] =
 	 "babelfish_authid_user_ext", "rolname", NULL, get_master_db_owner, NULL, check_exist, NULL},
 	{"master_dbo must exist in babelfish_authid_user_ext",
 	 "babelfish_authid_user_ext", "rolname", NULL, get_master_dbo, NULL, check_exist, NULL},
-	{"master_guest must exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_master_guest, NULL, check_exist, NULL},
 	{"tempdb_db_owner must exist in babelfish_authid_user_ext",
 	 "babelfish_authid_user_ext", "rolname", NULL, get_tempdb_db_owner, NULL, check_exist, NULL},
 	{"tempdb_dbo must exist in babelfish_authid_user_ext",
 	 "babelfish_authid_user_ext", "rolname", NULL, get_tempdb_dbo, NULL, check_exist, NULL},
-	{"tempdb_guest must exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_tempdb_guest, NULL, check_exist, NULL},
 	{"msdb_db_owner must exist in babelfish_authid_user_ext",
 	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_db_owner, NULL, check_exist, NULL},
 	{"msdb_dbo must exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_dbo, NULL, check_exist, NULL},
-	{"msdb_guest must exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_guest, NULL, check_exist, NULL},
-	{"In single-db mode, if user db exists, <name>_guest must also exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_name_guest, is_singledb_exists_userdb, check_exist, NULL}
+	 "babelfish_authid_user_ext", "rolname", NULL, get_msdb_dbo, NULL, check_exist, NULL}
 };
 
 /* Must match rules, MUST comply with metadata_inconsistency_check() */
@@ -1405,7 +1394,9 @@ Rule must_match_rules_sysdb[] =
 	{"In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext",
 	 "babelfish_namespace_ext", "nspname", NULL, get_name_dbo, is_multidb, check_exist, NULL},
 	{"In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext",
-	 "babelfish_authid_user_ext", "rolname", NULL, get_name_guest, is_multidb, check_exist, NULL}
+	 "babelfish_authid_user_ext", "rolname", NULL, get_name_guest, is_multidb, check_exist, NULL},
+	{"In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext",
+         "babelfish_authid_user_ext", "rolname", NULL, get_name_guest, !is_multidb, check_exist, NULL}
 };
 
 /* babelfish_namespace_ext */
@@ -1722,33 +1713,15 @@ get_master_db_owner(HeapTuple tuple, TupleDesc dsc)
 }
 
 static Datum
-get_master_guest(HeapTuple tuple, TupleDesc dsc)
-{
-	return CStringGetDatum("master_guest");
-}
-
-static Datum
 get_tempdb_db_owner(HeapTuple tuple, TupleDesc dsc)
 {
 	return CStringGetDatum("tempdb_db_owner");
 }
 
 static Datum
-get_tempdb_guest(HeapTuple tuple, TupleDesc dsc)
-{
-	return CStringGetDatum("tempdb_guest");
-}
-
-static Datum
 get_msdb_db_owner(HeapTuple tuple, TupleDesc dsc)
 {
 	return CStringGetDatum("msdb_db_owner");
-}
-
-static Datum
-get_msdb_guest(HeapTuple tuple, TupleDesc dsc)
-{
-	return CStringGetDatum("msdb_guest");
 }
 
 static Datum

--- a/test/JDBC/expected/BABEL-2403.out
+++ b/test/JDBC/expected/BABEL-2403.out
@@ -155,14 +155,17 @@ name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exi
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_db_owner must also exist in pg_authid"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_db_owner must also exist in pg_authid"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_db_owner must also exist in pg_authid"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}

--- a/test/JDBC/expected/BABEL-2403.out
+++ b/test/JDBC/expected/BABEL-2403.out
@@ -59,16 +59,16 @@ name#!#sys#!#nspname#!#{"Rule": "tempdb_dbo must exist in babelfish_namespace_ex
 name#!#sys#!#nspname#!#{"Rule": "msdb_dbo must exist in babelfish_namespace_ext"}
 name#!#sys#!#rolname#!#{"Rule": "master_db_owner must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "master_dbo must exist in babelfish_authid_user_ext"}
-name#!#sys#!#rolname#!#{"Rule": "master_guest must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "tempdb_db_owner must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "tempdb_dbo must exist in babelfish_authid_user_ext"}
-name#!#sys#!#rolname#!#{"Rule": "tempdb_guest must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "msdb_db_owner must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "msdb_dbo must exist in babelfish_authid_user_ext"}
-name#!#sys#!#rolname#!#{"Rule": "msdb_guest must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
@@ -144,28 +144,28 @@ name#!#sys#!#nspname#!#{"Rule": "tempdb_dbo must exist in babelfish_namespace_ex
 name#!#sys#!#nspname#!#{"Rule": "msdb_dbo must exist in babelfish_namespace_ext"}
 name#!#sys#!#rolname#!#{"Rule": "master_db_owner must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "master_dbo must exist in babelfish_authid_user_ext"}
-name#!#sys#!#rolname#!#{"Rule": "master_guest must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "tempdb_db_owner must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "tempdb_dbo must exist in babelfish_authid_user_ext"}
-name#!#sys#!#rolname#!#{"Rule": "tempdb_guest must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "msdb_db_owner must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "msdb_dbo must exist in babelfish_authid_user_ext"}
-name#!#sys#!#rolname#!#{"Rule": "msdb_guest must exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_db_owner must also exist in pg_authid"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
 name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_db_owner must also exist in pg_authid"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
 name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#sys#!#rolname#!#{"Rule": "<owner> in babelfish_sysdatabases must also exist in babelfish_authid_login_ext"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_db_owner must also exist in pg_authid"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
 name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
+name#!#sys#!#rolname#!#{"Rule": "In single-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}


### PR DESCRIPTION
Add a rule for metadata integrity check to check if all the newly created databases have a guest user.

### Test Scenarios Covered ###
* **Use case based -** Yes
* **Boundary conditions -** N/A
* **Arbitrary inputs -** N/A
* **Negative test cases -** N/A
* **Minor version upgrade tests -** N/A
* **Major version upgrade tests -** N/A
* **Performance tests -** N/A
* **Tooling impact -** N/A
* **Client tests -** N/A

Task: BABEL-3600
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

