### PR TITLE
[BABEL-3338] Add planning and execution times to babelfish_statistics profile

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -989,7 +989,7 @@ define_custom_variables(void)
 				 gettext_noop("Include summary information (e.g., totaled timing information) after the query plan"),
 				 NULL,
 				 &pltsql_explain_summary,
-				 false,
+				 true,
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -980,7 +980,7 @@ define_custom_variables(void)
 				 gettext_noop("Include actual startup time and time spent in each node in the output"),
 				 NULL,
 				 &pltsql_explain_timing,
-				 false,
+				 true,
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -345,6 +345,14 @@ pltsql_GetNewObjectId(VariableCache variableCache)
 static void
 pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
+	if (pltsql_explain_analyze) {
+		PLtsql_execstate *estate;
+		PLExecStateCallStack * cur;
+		cur = exec_state_call_stack;
+		estate = cur->estate;
+		Assert(estate != NULL);
+		INSTR_TIME_SET_CURRENT(estate->execution_start);
+	}
 	int ef = pltsql_explain_only ? EXEC_FLAG_EXPLAIN_ONLY : eflags;
 	if (is_explain_analyze_mode())
 	{

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4678,7 +4678,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		return ret;
 	}
 
-	if (expr->plan == NULL || pltsql_explain_analyze)
+	if (expr->plan == NULL)
     {
         /*
          * If the set_fmtonly guc is set, we need to rewrite any statements as exec
@@ -7233,7 +7233,7 @@ exec_run_select(PLtsql_execstate *estate,
 	 * portal, the caller might do cursor operations, which parallel query
 	 * can't support.
 	 */
-	if (expr->plan == NULL || pltsql_explain_analyze)
+	if (expr->plan == NULL)
 		exec_prepare_plan(estate, expr, portalP == NULL ? CURSOR_OPT_PARALLEL_OK : 0, true);
 	/*
 	 * If we started an implicit_transaction for this statement but

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4678,7 +4678,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		return ret;
 	}
 
-	INSTR_TIME_SET_CURRENT(estate->planning_start);
 	if (expr->plan == NULL || pltsql_explain_analyze)
     {
         /*
@@ -4706,9 +4705,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	 * Check whether the statement is an INSERT/DELETE with RETURNING
 	 */
 	cp = SPI_plan_get_cached_plan(expr->plan);
-	INSTR_TIME_SET_CURRENT(estate->planning_end);
-	INSTR_TIME_SUBTRACT(estate->planning_end, estate->planning_start);
-
 	if (cp)
 	{
 		int i;

--- a/contrib/babelfishpg_tsql/src/pl_explain.c
+++ b/contrib/babelfishpg_tsql/src/pl_explain.c
@@ -7,7 +7,7 @@
 
 
 extern PLtsql_execstate *get_outermost_tsql_estate(int *nestlevel);
-
+extern PLtsql_execstate *get_current_tsql_estate();
 bool pltsql_explain_only = false;
 bool pltsql_explain_analyze = false;
 bool pltsql_explain_verbose = false;
@@ -144,11 +144,12 @@ void append_explain_info(QueryDesc *queryDesc, const char *queryString)
 			ExplainPrintTriggers(es, queryDesc);
 		if (es->costs)
 			ExplainPrintJITSummary(es, queryDesc);
-		if (es->analyze) {
-			ExplainPropertyFloat("Planning Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(pltsql_estate->planning_end), 3, es);
-			INSTR_TIME_SET_CURRENT(pltsql_estate->execution_end);
-			INSTR_TIME_SUBTRACT(pltsql_estate->execution_end, pltsql_estate->execution_start);
-			ExplainPropertyFloat("Execution Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(pltsql_estate->execution_end), 3, es);
+		if (es->summary) {
+			PLtsql_execstate *time_state = get_current_tsql_estate();
+			ExplainPropertyFloat("Planning Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(time_state->planning_end), 3, es);
+			INSTR_TIME_SET_CURRENT(time_state->execution_end);
+			INSTR_TIME_SUBTRACT(time_state->execution_end, time_state->execution_start);
+			ExplainPropertyFloat("Execution Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(time_state->execution_end), 3, es);
 		}
 
 	}

--- a/contrib/babelfishpg_tsql/src/pl_explain.c
+++ b/contrib/babelfishpg_tsql/src/pl_explain.c
@@ -144,6 +144,13 @@ void append_explain_info(QueryDesc *queryDesc, const char *queryString)
 			ExplainPrintTriggers(es, queryDesc);
 		if (es->costs)
 			ExplainPrintJITSummary(es, queryDesc);
+		if (es->analyze) {
+			ExplainPropertyFloat("Planning Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(pltsql_estate->planning_end), 3, es);
+			INSTR_TIME_SET_CURRENT(pltsql_estate->execution_end);
+			INSTR_TIME_SUBTRACT(pltsql_estate->execution_end, pltsql_estate->execution_start);
+			ExplainPropertyFloat("Execution Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(pltsql_estate->execution_end), 3, es);
+		}
+
 	}
 	else if (queryString)
 	{

--- a/contrib/babelfishpg_tsql/src/pl_explain.c
+++ b/contrib/babelfishpg_tsql/src/pl_explain.c
@@ -16,7 +16,7 @@ bool pltsql_explain_settings = false;
 bool pltsql_explain_buffers = false;
 bool pltsql_explain_wal = false;
 bool pltsql_explain_timing = true;
-bool pltsql_explain_summary = false;
+bool pltsql_explain_summary = true;
 int pltsql_explain_format = EXPLAIN_FORMAT_TEXT;
 
 static ExplainInfo *get_last_explain_info();

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1400,6 +1400,10 @@ typedef struct PLtsql_execstate
 	List 		*explain_infos;
 	char		*schema_name;
 	const char		*db_name;
+	instr_time	planning_start;
+	instr_time	planning_end;
+	instr_time execution_start;
+	instr_time execution_end;
 } PLtsql_execstate;
 
 /*

--- a/test/JDBC/expected/BABEL-2843.out
+++ b/test/JDBC/expected/BABEL-2843.out
@@ -1,5 +1,19 @@
 use master;
 go
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
 
 set babelfish_statistics profile On;
 go
@@ -364,3 +378,18 @@ drop table babel_2843_t2;
 go
 set babelfish_statistics profile oFf;
 go
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+go
+~~START~~
+text
+on
+~~END~~
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+go
+~~START~~
+text
+on
+~~END~~
+

--- a/test/JDBC/expected/BABEL-3248.out
+++ b/test/JDBC/expected/BABEL-3248.out
@@ -5,6 +5,20 @@ text
 off
 ~~END~~
 
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
 select current_setting('babelfishpg_tsql.escape_hatch_showplan_all');
 go
 ~~START~~
@@ -76,6 +90,20 @@ EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_showplan_all', 'stric
 go
 
 select set_config('babelfishpg_tsql.explain_costs', 'on', false);
+go
+~~START~~
+text
+on
+~~END~~
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+go
+~~START~~
+text
+on
+~~END~~
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
 go
 ~~START~~
 text

--- a/test/JDBC/input/BABEL-2843.sql
+++ b/test/JDBC/input/BABEL-2843.sql
@@ -1,5 +1,9 @@
 use master;
 go
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+go
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+go
 
 set babelfish_statistics profile On;
 go
@@ -105,4 +109,9 @@ go
 drop table babel_2843_t2;
 go
 set babelfish_statistics profile oFf;
+go
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+go
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
 go

--- a/test/JDBC/input/BABEL-3248.sql
+++ b/test/JDBC/input/BABEL-3248.sql
@@ -1,5 +1,9 @@
 select set_config('babelfishpg_tsql.explain_costs', 'off', false);
 go
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+go
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+go
 select current_setting('babelfishpg_tsql.escape_hatch_showplan_all');
 go
 
@@ -39,4 +43,8 @@ EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_showplan_all', 'stric
 go
 
 select set_config('babelfishpg_tsql.explain_costs', 'on', false);
+go
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+go
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
 go


### PR DESCRIPTION
This PR changes babelfish_statistics profile in two ways.  First it enables the summary and timing gucs by default to match postgres.  Second it implements the summary timings.  This is done through adding variables in estate that are set when the appropriate hook functions are called. 

For planning, a new hook was introduced as many babelfish code paths will invoke the planner from a SPI_exec function.  This makes mirroring postgres which during its explain analyze flow only calls through to the pg_plan_query function.  By adding this hook, we are able to time standard_planner which is the majority of the work done in pg_plan_query.

For execution time, we can simply time the existing executor hooks.  The closing calculation is located in append_explain_info as to match postgres, we must only stop the timer after we have written out the rest of the metrics.
 
### Testing

Note that for testing we currently lack an accurate way of testing timing as they change from run to run.  As such this PR was verified in the following ways.  BABEL-2843 testcases where executed with the timing and summary gucs on and output was examined to ensure it was reasonable.

The following 5 test cases were run against babelfish and postgres and timings were compared to be roughly similar. On larger queries especially with larger numbers of joins execution time depending more on the plan than whether or not it was a babelfish or a postgres connection.

1.) Joined two tables with 50k elements of random ints
2.) inserted into tables
3.) deleted from tables
4.) called built-in functions and user defined functions
5.) six way join of four tables of random ints

select count(*) from t1, t2, t3, t4, t5, t6 where t1.id = t2.id and t2.id = t3.id and t1.id = t4.id and t4.id = t5.id and t6.id = t3.id
  Planning Time: 3.181 ms
  Execution Time: 192736.826 ms

select count(*) from master_dbo.t1, master_dbo.t2, master_dbo.t3, master_dbo.t4, master_dbo.t5, master_dbo.t6 where master_dbo.t1.id = master_dbo.t2.id and master_dbo.t2.id = master_dbo.t3.id and master_dbo.t1.id = master_dbo.t4.id and master_dbo.t4.id = master_dbo.t5.id and master_dbo.t6.id = master_dbo.t3.id

  Planning Time: 6.656 ms
  Execution Time: 104341.627 ms

select count(*) from t1 join t2 on t1.id = t2.id;
  Planning Time: 0.283 ms
  Execution Time: 28531.977 ms

explain analyze select count(*) from master_dbo.t1 join master_dbo.t2 on master_dbo.t1.id = master_dbo.t2.id;
  Planning Time: 0.252 ms
  Execution Time: 28536.323 ms

DELETE FROM t1 where id < 10
  Planning Time: 0.077 ms
  Execution Time: 19.247 ms

explain analyze delete from master_dbo.t2 where id < 10
  Planning Time: 0.098 ms
  Execution Time: 20.204 ms

exec dbo.myf
  Planning Time: 0.025 ms
  Execution Time: 199.949 ms

explain analyze select master_dbo.myf();
 Planning Time: 0.032 ms
 Execution Time: 185.961 ms

### Issues Resolved

BABEL-3338
Signed-off-by: Justin Jossick [jusjosj@amazon.com](mailto:jusjosj@amazon.com)

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).