### PR TITLE
PSQLODBC Datatype Test for BYTEA

### DIFF
--- a/test/odbc/psqlodbc/bytea.cpp
+++ b/test/odbc/psqlodbc/bytea.cpp
@@ -1,0 +1,377 @@
+#include "psqlodbc_tests_common.h"
+
+const string BBF_TABLE_NAME = "master.dbo.bytea_table_odbc_test";
+// For BBF Connection
+//   Cannot prepend database name when creating/dropping view
+//   Must prepend database name when selecting from view
+const string BBF_VIEW_NAME = "dbo.bytea_view_odbc_test";
+const string PG_TABLE_NAME = "master_dbo.bytea_table_odbc_test";
+const string PG_VIEW_NAME = "master_dbo.bytea_view_odbc_test";
+const string COL1_NAME = "pk";
+const string COL2_NAME = "data";
+const string DATATYPE_NAME = "bytea";
+const vector<pair<string, string>> TABLE_COLUMNS = {
+  {COL1_NAME, "INT PRIMARY KEY"},
+  {COL2_NAME, DATATYPE_NAME}
+};
+
+class PSQL_DataTypes_ByteA : public testing::Test {
+  void SetUp() override {
+    if (!Drivers::DriverExists(ServerType::PSQL)) {
+      GTEST_SKIP() << "PSQL Driver not present: skipping all tests for this fixture.";
+    }
+    if (!Drivers::DriverExists(ServerType::MSSQL)) {
+      GTEST_SKIP() << "MSSQL Driver not present: skipping all tests for this fixture.";
+    }
+
+    OdbcHandler bbf_test_setup(Drivers::GetDriver(ServerType::MSSQL));
+    bbf_test_setup.ConnectAndExecQuery(DropObjectStatement("TABLE", BBF_TABLE_NAME));
+
+    OdbcHandler pg_test_setup(Drivers::GetDriver(ServerType::PSQL));
+    pg_test_setup.ConnectAndExecQuery(DropObjectStatement("TABLE", PG_TABLE_NAME));
+  }
+
+  void TearDown() override {
+    if (!Drivers::DriverExists(ServerType::PSQL)) {
+      GTEST_SKIP() << "PSQL Driver not present: skipping all tests for this fixture.";
+    }
+    if (!Drivers::DriverExists(ServerType::MSSQL)) {
+      GTEST_SKIP() << "MSSQL Driver not present: skipping all tests for this fixture.";
+    }
+
+    OdbcHandler bbf_test_setup(Drivers::GetDriver(ServerType::MSSQL));
+    bbf_test_setup.ConnectAndExecQuery(DropObjectStatement("VIEW", BBF_VIEW_NAME));
+    bbf_test_setup.CloseStmt();
+    bbf_test_setup.ExecQuery(DropObjectStatement("TABLE", BBF_TABLE_NAME));
+    
+    OdbcHandler pg_test_setup(Drivers::GetDriver(ServerType::PSQL));
+    pg_test_setup.ConnectAndExecQuery(DropObjectStatement("VIEW", PG_VIEW_NAME));
+    pg_test_setup.CloseStmt();
+    pg_test_setup.ExecQuery(DropObjectStatement("TABLE", PG_TABLE_NAME));
+  }
+};
+
+string stringToHex(string input) {
+    std::ostringstream result;
+    result << std::setw(2) << std::setfill('0') << std::hex << std::uppercase;
+    std::copy(input.begin(), input.end(), std::ostream_iterator<unsigned int>(result, ""));
+    return result.str();   
+}
+
+vector<string> getExpectedResults(const vector<string> &input) {
+  vector<string> ret = {};
+
+  for (int i = 0; i < input.size(); i++) {
+    ret.push_back(stringToHex(input[i]));
+  }
+
+  return ret;
+}
+
+vector<string> duplicateElements(vector<string> input) {
+  typedef std::move_iterator<decltype(input)::iterator> VecMoveIter;
+  std::vector<string> duplicated(input);
+  std::copy(VecMoveIter(input.begin()), VecMoveIter(input.end()), std::back_inserter(duplicated));
+  return duplicated;
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Table_Creation) {
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  const vector<int> BBF_LENGTH_EXPECTED = {10, 0};
+  const vector<int> BBF_PRECISION_EXPECTED = {10, 0};
+  const vector<int> BBF_SCALE_EXPECTED = {0, 0};
+  const vector<string> BBF_NAME_EXPECTED = {"int", "varbinary"};
+
+  testCommonColumnAttributes(ServerType::MSSQL, BBF_TABLE_NAME, 
+    TABLE_COLUMNS.size(), COL1_NAME, 
+    BBF_LENGTH_EXPECTED, BBF_PRECISION_EXPECTED, 
+    BBF_SCALE_EXPECTED, BBF_NAME_EXPECTED);
+
+  const vector<int> PG_LENGTH_EXPECTED = {4, -4};
+  const vector<int> PG_PRECISION_EXPECTED = {0, 0};
+  const vector<int> PG_SCALE_EXPECTED = {0, 0};
+  const vector<string> PG_NAME_EXPECTED = {"int4", "bytea"};
+
+  testCommonColumnAttributes(ServerType::PSQL, PG_TABLE_NAME, 
+    TABLE_COLUMNS.size(), COL1_NAME, 
+    PG_LENGTH_EXPECTED, PG_PRECISION_EXPECTED, 
+    PG_SCALE_EXPECTED, PG_NAME_EXPECTED);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Insertion_Success) {
+  vector<string> inserted_values = {
+    "NULL",
+    "",
+    "A",
+    "123"
+  };
+  const int NUM_OF_DATA = inserted_values.size();
+
+  vector<string> expected_values = getExpectedResults(inserted_values);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, inserted_values, expected_values);
+  insertValuesInTable(ServerType::PSQL, PG_TABLE_NAME, inserted_values, false, NUM_OF_DATA);
+
+  inserted_values = duplicateElements(inserted_values);
+  expected_values = duplicateElements(expected_values);
+
+  verifyValuesInObject(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, inserted_values, expected_values);
+  verifyValuesInObject(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, inserted_values, expected_values);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Update_Success) {
+  const vector<string> INSERTED_VALUES = {
+    "123"
+  };
+  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+
+  const vector<string> UPDATED_VALUES = {
+    "",
+    "A",
+    "123"
+  };
+  const vector<string> EXPECTED_UPDATED_VALUES = getExpectedResults(UPDATED_VALUES);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  testUpdateSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, COL2_NAME, UPDATED_VALUES, EXPECTED_UPDATED_VALUES);
+  testUpdateSuccess(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, COL2_NAME, UPDATED_VALUES, EXPECTED_UPDATED_VALUES);
+
+  verifyValuesInObject(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, View_creation) {
+  const vector<string> INSERTED_VALUES = {
+    "NULL",
+    "",
+    "A",
+    "123"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+
+  const string BBF_VIEW_QUERY = "SELECT * FROM " + BBF_TABLE_NAME;
+  const string PG_VIEW_QUERY = "SELECT * FROM " + PG_TABLE_NAME;
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  createView(ServerType::MSSQL, BBF_VIEW_NAME, BBF_VIEW_QUERY);
+
+  verifyValuesInObject(ServerType::MSSQL, BBF_VIEW_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+  verifyValuesInObject(ServerType::PSQL, PG_VIEW_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  dropObject(ServerType::MSSQL, "VIEW", BBF_VIEW_NAME);
+  dropObject(ServerType::PSQL, "VIEW", PG_VIEW_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Table_Single_Primary_Keys) {
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, "INT"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  
+  const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
+  const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
+
+  const vector<string> PK_COLUMNS = {
+    COL2_NAME
+  };
+
+  string tableConstraints = createTableConstraint("PRIMARY KEY ", PK_COLUMNS);
+
+  const vector<string> INSERTED_VALUES = {
+    "",
+    "A",
+    "123"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
+
+  testPrimaryKeys(ServerType::MSSQL, BBF_SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+  testPrimaryKeys(ServerType::PSQL, SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, false, NUM_OF_DATA, false);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INSERTED_VALUES, false, NUM_OF_DATA, false);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Table_Composite_Keys) {
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, "INT"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  
+  const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
+  const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
+
+  const vector<string> PK_COLUMNS = {
+    COL1_NAME,
+    COL2_NAME
+  };
+
+  string tableConstraints = createTableConstraint("PRIMARY KEY ", PK_COLUMNS);
+
+  const vector<string> INSERTED_VALUES = {
+    "",
+    "A",
+    "123"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
+
+  testPrimaryKeys(ServerType::MSSQL, BBF_SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+  testPrimaryKeys(ServerType::PSQL, SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, false, 0, false);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INSERTED_VALUES, false, 0, false);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Table_Unique_Constraint) {
+
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, "INT"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  
+  const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
+  const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
+
+  const vector<string> UNIQUE_COLUMNS = {
+    COL2_NAME
+  };
+
+  string tableConstraints = createTableConstraint("UNIQUE", UNIQUE_COLUMNS);
+
+  const vector<string> INSERTED_VALUES = {
+    "",
+    "A",
+    "123"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
+
+  testUniqueConstraint(ServerType::MSSQL, TABLE_NAME, UNIQUE_COLUMNS);
+  testUniqueConstraint(ServerType::PSQL, TABLE_NAME, UNIQUE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, EXPECTED_VALUES);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, false, NUM_OF_DATA, false);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INSERTED_VALUES, false, NUM_OF_DATA, false);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_ByteA, Comparison_Operators) {
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, DATATYPE_NAME + " PRIMARY KEY"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const vector<string> INSERTED_PK = {
+    "A",
+    "123",
+    "smaller"
+  };
+
+  const vector<string> INSERTED_DATA = {
+    "B",
+    "123",
+    "LARGER"
+  };
+  const int NUM_OF_DATA = INSERTED_DATA.size();
+
+  // insertString initialization
+  string insertString{};
+  string comma{};
+  for (int i = 0; i < NUM_OF_DATA; i++) {
+    insertString += comma + "(\'" + INSERTED_PK[i] + "\',\'" + INSERTED_DATA[i] + "\')";
+    comma = ",";
+  }
+
+  const vector<string> BBF_OPERATIONS_QUERY = {
+    "IIF(" + COL1_NAME + " = " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " <> " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " < " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " <= " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " > " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " >= " + COL2_NAME + ", '1', '0')"
+  };
+
+  const vector<string> PG_OPERATIONS_QUERY = {
+    COL1_NAME + "=" + COL2_NAME,
+    COL1_NAME + "<>" + COL2_NAME,
+    COL1_NAME + "<" + COL2_NAME,
+    COL1_NAME + "<=" + COL2_NAME,
+    COL1_NAME + ">" + COL2_NAME,
+    COL1_NAME + ">=" + COL2_NAME
+  };
+
+  // initialization of expected_results
+  vector<vector<char>> expected_results = {};
+
+  for (int i = 0; i < NUM_OF_DATA; i++) {
+    expected_results.push_back({});
+    const char *data_A = INSERTED_PK[i].data();
+    const char *data_B = INSERTED_DATA[i].data();
+    expected_results[i].push_back(strcmp(data_A, data_B) == 0 ? '1' : '0');
+    expected_results[i].push_back(strcmp(data_A, data_B) != 0 ? '1' : '0');
+    expected_results[i].push_back(strcmp(data_A, data_B) < 0 ? '1' : '0');
+    expected_results[i].push_back(strcmp(data_A, data_B) <= 0 ? '1' : '0');
+    expected_results[i].push_back(strcmp(data_A, data_B) > 0 ? '1' : '0');
+    expected_results[i].push_back(strcmp(data_A, data_B) >= 0 ? '1' : '0');
+  }
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  insertValuesInTable(ServerType::MSSQL, BBF_TABLE_NAME, insertString, NUM_OF_DATA);
+
+  testComparisonOperators(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, COL2_NAME, 
+                          INSERTED_PK, INSERTED_DATA, BBF_OPERATIONS_QUERY, expected_results);
+
+  testComparisonOperators(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, COL2_NAME, 
+                          INSERTED_PK, INSERTED_DATA, PG_OPERATIONS_QUERY, expected_results);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}

--- a/test/odbc/psqlodbc/bytea.cpp
+++ b/test/odbc/psqlodbc/bytea.cpp
@@ -62,7 +62,7 @@ string stringToHex(string input) {
     return result.str();
 }
 
-vector<string> getExpectedResults(const vector<string> &input) {
+vector<string> getExpectedResults_Bytea(const vector<string> &input) {
   vector<string> ret = {};
 
   for (int i = 0; i < input.size(); i++) {
@@ -118,7 +118,7 @@ TEST_F(PSQL_DataTypes_ByteA, Insertion_Success) {
   };
   const int NUM_OF_DATA = inserted_values.size();
 
-  vector<string> expected_values = getExpectedResults(inserted_values);
+  vector<string> expected_values = getExpectedResults_Bytea(inserted_values);
 
   createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
 
@@ -139,7 +139,7 @@ TEST_F(PSQL_DataTypes_ByteA, Update_Success) {
   const vector<string> INSERTED_VALUES = {
     "123"
   };
-  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+  const vector<string> EXPECTED_VALUES = getExpectedResults_Bytea(INSERTED_VALUES);
 
   const vector<string> UPDATED_VALUES = {
     "NULL",
@@ -151,7 +151,7 @@ TEST_F(PSQL_DataTypes_ByteA, Update_Success) {
     // Normal range
     "123"
   };
-  const vector<string> EXPECTED_UPDATED_VALUES = getExpectedResults(UPDATED_VALUES);
+  const vector<string> EXPECTED_UPDATED_VALUES = getExpectedResults_Bytea(UPDATED_VALUES);
 
   createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
 
@@ -178,7 +178,7 @@ TEST_F(PSQL_DataTypes_ByteA, View_creation) {
   };
   const int NUM_OF_DATA = INSERTED_VALUES.size();
 
-  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+  const vector<string> EXPECTED_VALUES = getExpectedResults_Bytea(INSERTED_VALUES);
 
   const string BBF_VIEW_QUERY = "SELECT * FROM " + BBF_TABLE_NAME;
   const string PG_VIEW_QUERY = "SELECT * FROM " + PG_TABLE_NAME;
@@ -224,7 +224,7 @@ TEST_F(PSQL_DataTypes_ByteA, Table_Single_Primary_Keys) {
   };
   const int NUM_OF_DATA = INSERTED_VALUES.size();
 
-  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+  const vector<string> EXPECTED_VALUES = getExpectedResults_Bytea(INSERTED_VALUES);
 
   createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
 
@@ -267,7 +267,7 @@ TEST_F(PSQL_DataTypes_ByteA, Table_Composite_Keys) {
   };
   const int NUM_OF_DATA = INSERTED_VALUES.size();
 
-  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+  const vector<string> EXPECTED_VALUES = getExpectedResults_Bytea(INSERTED_VALUES);
 
   createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
 
@@ -309,7 +309,7 @@ TEST_F(PSQL_DataTypes_ByteA, Table_Unique_Constraint) {
   };
   const int NUM_OF_DATA = INSERTED_VALUES.size();
 
-  const vector<string> EXPECTED_VALUES = getExpectedResults(INSERTED_VALUES);
+  const vector<string> EXPECTED_VALUES = getExpectedResults_Bytea(INSERTED_VALUES);
 
   createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
 

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.h
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.h
@@ -114,7 +114,7 @@ void insertValuesInTable(ServerType serverType, const string &tableName, const s
  * @param pkStartingValue Optional. The primary key value the object starts incrementing at. The default value is 0.
 */
 void verifyValuesInObject(ServerType serverType, const string &objectName, const string &orderByColumnName, 
-  const vector<string> &insertedValues, const vector<string> &expectedInsertedValues, int pkStartingValue = 0);
+  const vector<string> &insertedValues, const vector<string> &expectedInsertedValues, int pkStartingValue = 0, bool caseInsensitive = false);
 
 /**
  * Verify that all data in an object (like table or view) are of expected values.
@@ -200,9 +200,10 @@ void testTableCreationFailure(ServerType serverType, const string &tableName, co
  * @param insertedValues Vector of data to be inserted. e.g. {"NULL", "5", "9568546", "-1"}
  * @param expectedInsertedValues The values expected from the table when selecting all from it.
  * @param pkStartingValue Optional. The primary key value the object starts incrementing at. The default value is 0.
+ * @param caseInsensitive Optional. String comparision for data and expected can be case-insensitive. The default value is false.
 */
 void testInsertionSuccess(ServerType serverType, const string &tableName, const string &orderByColumnName, 
-  const vector<string> &insertedValues, const vector<string> &expectedInsertedValues, int pkStartingValue = 0);
+  const vector<string> &insertedValues, const vector<string> &expectedInsertedValues, int pkStartingValue = 0, bool caseInsensitive = false);
 
 /**
  * Insert values in a table given a vector of values to insert, and validate that all data in the table are of expected values.
@@ -254,9 +255,10 @@ void testInsertionFailure(ServerType serverType, const string &tableName, const 
  * @param colNameToUpdate The name of the column to update.
  * @param updatedValues A vector of values to update some data in the table with one by one.
  * @param expectedUpdatedValues A vector containing expected values after a successful update.
+ * @param caseInsensitive Optional. String comparision for data and expected can be case-insensitive. The default value is false.
 */
 void testUpdateSuccess(ServerType serverType, const string &tableName, const string &orderByColumnName, 
-  const string &colNameToUpdate, const vector<string> &updatedValues, const vector<string> &expectedUpdatedValues);
+  const string &colNameToUpdate, const vector<string> &updatedValues, const vector<string> &expectedUpdatedValues, bool caseInsensitive = false);
 
 /**
  * Given a vector of values, test that some data in the table can be updated successfully with each value.


### PR DESCRIPTION
### Description

Adds ODBC Breakthrough Datatype Test for `BYTEA`
- Create Table
- Insert valid values
- Update table with valid values
- Comparison Operators
- Table View
- Unique Constraint
- Composite Key

Task: BABELFISH-580
Signed-off-by: Colin Yuen [yuenhcol@amazon.com](mailto:yuenhcol@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).