### PR TITLE
Add a GUC to disable metadata inconsistency check function.

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1454,12 +1454,7 @@ babelfish_inconsistent_metadata(PG_FUNCTION_ARGS)
     Tuplestorestate 	*tupstore;
 
 	return_consistency = PG_GETARG_BOOL(0);
-
-
-	if(!metadata_inconsistency_check_enabled())
-			return true;
-
-
+	
     /* check to see if caller supports us returning a tuplestore */
     if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
         ereport(ERROR,

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1454,7 +1454,7 @@ babelfish_inconsistent_metadata(PG_FUNCTION_ARGS)
     Tuplestorestate 	*tupstore;
 
 	return_consistency = PG_GETARG_BOOL(0);
-	
+
     /* check to see if caller supports us returning a tuplestore */
     if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
         ereport(ERROR,

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1455,6 +1455,11 @@ babelfish_inconsistent_metadata(PG_FUNCTION_ARGS)
 
 	return_consistency = PG_GETARG_BOOL(0);
 
+
+	if(!metadata_inconsistency_check_enabled())
+			return true;
+
+
     /* check to see if caller supports us returning a tuplestore */
     if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
         ereport(ERROR,
@@ -1491,9 +1496,11 @@ babelfish_inconsistent_metadata(PG_FUNCTION_ARGS)
 
 	PG_TRY();
 	{
-		/* Check metadata inconsistency */
-		metadata_inconsistency_check(tupstore, tupdesc);
-
+		if(metadata_inconsistency_check_enabled())		
+		{
+			/* Check metadata inconsistency */
+			metadata_inconsistency_check(tupstore, tupdesc);
+		}
 		/* clean up and return the tuplestore */
 		tuplestore_donestoring(tupstore);
 

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -16,6 +16,8 @@
 static int migration_mode = SINGLE_DB;
 bool   enable_ownership_structure = false;
 
+bool enable_metadata_inconsistency_check = true;
+
 bool pltsql_dump_antlr_query_graph = false;
 bool pltsql_enable_antlr_detailed_log = false;
 bool pltsql_allow_antlr_to_unsupported_grammar_for_testing = false;
@@ -1084,6 +1086,16 @@ define_custom_variables(void)
 				PGC_USERSET,
 				GUC_NOT_IN_SAMPLE,
 				NULL, NULL, NULL);
+
+
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_metadata_inconsistency_check",
+				 gettext_noop("Enables babelfish_inconsistent_metadata"),
+				 NULL,
+				 &enable_metadata_inconsistency_check,
+				 true,
+				 PGC_USERSET,
+				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+				 NULL, NULL, NULL);
 }
 
 int escape_hatch_storage_options = EH_IGNORE;
@@ -1481,3 +1493,8 @@ get_migration_mode(void)
 }
 
 
+bool
+metadata_inconsistency_check_enabled(void)
+{
+	return enable_metadata_inconsistency_check;
+}

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -15,5 +15,6 @@ extern void pltsql_validate_set_config_function(char *name, char *value);
  ************************************/
 extern MigrationMode get_migration_mode(void);
 
+extern bool metadata_inconsistency_check_enabled(void); 
 
 #endif

--- a/test/JDBC/expected/BABEL-2967.out
+++ b/test/JDBC/expected/BABEL-2967.out
@@ -22,15 +22,7 @@ off
 ~~END~~
 
 
-SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','false',true)
-GO
-~~START~~
-text
-off
-~~END~~
-
-
-SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','true',false)
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','on',true)
 GO
 ~~START~~
 text

--- a/test/JDBC/expected/BABEL-2967.out
+++ b/test/JDBC/expected/BABEL-2967.out
@@ -29,3 +29,11 @@ text
 off
 ~~END~~
 
+
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','true',false)
+GO
+~~START~~
+text
+on
+~~END~~
+

--- a/test/JDBC/expected/BABEL-2967.out
+++ b/test/JDBC/expected/BABEL-2967.out
@@ -1,0 +1,32 @@
+select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','off',true)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+ select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','false',true)
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/expected/BABEL-2967.out
+++ b/test/JDBC/expected/BABEL-2967.out
@@ -1,10 +1,9 @@
-select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+SELECT current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
 GO
 ~~START~~
 text
 on
 ~~END~~
-
 
 
 SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','off',true)
@@ -15,7 +14,7 @@ off
 ~~END~~
 
 
- select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+SELECT current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
 GO
 ~~START~~
 text

--- a/test/JDBC/input/BABEL-2967.sql
+++ b/test/JDBC/input/BABEL-2967.sql
@@ -7,8 +7,5 @@ GO
 SELECT current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
 GO
 
-SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','false',true)
-GO
-
-SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','true',false)
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','on',true)
 GO

--- a/test/JDBC/input/BABEL-2967.sql
+++ b/test/JDBC/input/BABEL-2967.sql
@@ -9,3 +9,6 @@ GO
 
 SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','false',true)
 GO
+
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','true',false)
+GO

--- a/test/JDBC/input/BABEL-2967.sql
+++ b/test/JDBC/input/BABEL-2967.sql
@@ -1,11 +1,10 @@
-select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+SELECT current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
 GO
-
 
 SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','off',true)
 GO
 
- select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+SELECT current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
 GO
 
 SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','false',true)

--- a/test/JDBC/input/BABEL-2967.sql
+++ b/test/JDBC/input/BABEL-2967.sql
@@ -1,0 +1,12 @@
+select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+GO
+
+
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','off',true)
+GO
+
+ select current_setting( 'babelfishpg_tsql.enable_metadata_inconsistency_check')
+GO
+
+SELECT SET_CONFIG('babelfishpg_tsql.enable_metadata_inconsistency_check','false',true)
+GO


### PR DESCRIPTION
For Babelfish instances, CP would stop the upgrade workflow when 
there are some metadata inconsistencies detected. 
Now we have a disable 
the metadata check function babelfish_inconsistent_metadata in the guc file. 

Task: BABEL-2967
Signed-off-by: pratikzode <pratik.zode@gmail.com>