### PR TITLE
Fix: CREATE USER should not be allowed for the login owning the database

### DIFF
--- a/test/JDBC/expected/BABEL-3549.out
+++ b/test/JDBC/expected/BABEL-3549.out
@@ -1,0 +1,93 @@
+-- tsql
+USE master
+GO
+CREATE LOGIN babel_3549_login1 WITH PASSWORD='12345678';
+GO
+CREATE LOGIN babel_3549_login2 WITH PASSWORD='12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3549_login1;
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3549_login2;
+GO
+
+-- tsql user=babel_3549_login1 password=12345678
+SELECT SUSER_NAME()
+GO
+~~START~~
+nvarchar
+babel_3549_login1
+~~END~~
+
+
+CREATE DATABASE babel_3549_db1
+GO
+USE babel_3549_db1
+GO
+
+SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('master', 'babel_3549_db1');
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#smallint
+master#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
+babel_3549_db1#!#<NULL>#!#babel_3549_login1#!#<NULL>#!#<NULL>
+~~END~~
+
+
+CREATE USER babel_3549_login1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The login already has an account under a different user name.)~~
+
+USE master
+GO
+
+-- tsql user=babel_3549_login2 password=12345678
+SELECT SUSER_NAME()
+GO
+~~START~~
+nvarchar
+babel_3549_login2
+~~END~~
+
+
+USE babel_3549_db1
+GO
+CREATE USER babel_3549_login2
+GO
+
+USE master
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) in ('babel_3549_login1','babel_3549_login2') AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+t
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP DATABASE babel_3549_db1
+GO
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3549_login1;
+GO
+DROP LOGIN babel_3549_login1;
+GO
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3549_login2;
+GO
+DROP LOGIN babel_3549_login2;
+GO

--- a/test/JDBC/input/BABEL-3549.mix
+++ b/test/JDBC/input/BABEL-3549.mix
@@ -1,0 +1,62 @@
+-- tsql
+USE master
+GO
+CREATE LOGIN babel_3549_login1 WITH PASSWORD='12345678';
+GO
+CREATE LOGIN babel_3549_login2 WITH PASSWORD='12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3549_login1;
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3549_login2;
+GO
+
+-- tsql user=babel_3549_login1 password=12345678
+SELECT SUSER_NAME()
+GO
+
+CREATE DATABASE babel_3549_db1
+GO
+USE babel_3549_db1
+GO
+
+SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('master', 'babel_3549_db1');
+GO
+
+CREATE USER babel_3549_login1
+GO
+USE master
+GO
+
+-- tsql user=babel_3549_login2 password=12345678
+SELECT SUSER_NAME()
+GO
+
+USE babel_3549_db1
+GO
+CREATE USER babel_3549_login2
+GO
+
+USE master
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) in ('babel_3549_login1','babel_3549_login2') AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+DROP DATABASE babel_3549_db1
+GO
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3549_login1;
+GO
+DROP LOGIN babel_3549_login1;
+GO
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3549_login2;
+GO
+DROP LOGIN babel_3549_login2;
+GO


### PR DESCRIPTION
In SQL Server, a login that owns a database is not allowed to create a DB user in that owning database. However, Babelfish allowed this behavior, not throwing an appropriate error when a DB-owning login tries to create a DB user in the database. Now, it follows the behavior of SQL Server, not allowing db-owning login to create a user in the database, by checking if current login name and current database’s owner name match.

Task: BABEL-3549

Signed-off-by: Ray Kim <raydhkim@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).