### PR TITLE
Add default case for tdsutils_ProcessUtility

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -709,6 +709,8 @@ void tdsutils_ProcessUtility(PlannedStmt *pstmt,
 		case T_DropdbStmt:
 			handle_result = handle_dropdb((DropdbStmt *)parsetree);
 			break;
+		default:
+			break;
 	}
 
 	/*


### PR DESCRIPTION

Signed-off-by: vasavi suthapalli <svasusri@amazon.com>

### Description

Previously, while building the babelfish_extensions package there are many warnings related to not including case. Resolved it by adding default case in function tdsutils_ProcessUtility.
 
### Issues Resolved

NA

### Testing scenarios covered
- Use case based - N/A
- Boundary conditions - N/A
- Arbitrary inputs - N/A
- Negative test cases - N/A
- Minor version upgrade tests - N/A
- Major version upgrade tests - N/A
- Performance tests - N/A
- Tooling impact - N/A
- Client tests - N/A
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).