### PR TITLE
Revert GitHub Actions Cancellation

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,11 +1,5 @@
 name: Dotnet Framework Tests
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-babelfish-dotnet-tests:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -1,11 +1,9 @@
 name: Babelfish Smoke Tests
 on:
-  pull_request:
   push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    branches:
+  pull_request:
+    branches:
 
 jobs:
   isolation-tests:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,11 +1,5 @@
 name: JDBC Tests
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,11 +1,5 @@
 name: Major Version Upgrade Tests for empty database
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-babelfish-mvu-tests:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,11 +1,6 @@
 name: Minor Version Upgrade Tests for empty database
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
+
 jobs:
   extension-tests:
     env:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,11 +1,5 @@
 name: ODBC Tests
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-babelfish-odbc-tests:

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,11 +1,5 @@
 name: pg-hint-plan Tests
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-pg-hint-plan-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,11 +1,5 @@
 name: Python Tests
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-babelfish-python-tests:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,11 +1,5 @@
 name: Major Version Upgrade Tests for singledb mode
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-babelfish-mvu-tests-singledb:

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,11 +1,5 @@
 name: Validate Installation/Upgrade Scripts
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   run-sql-validation-tests:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,11 +1,5 @@
 name: Version Upgrade Test Framework
-on:
-  pull_request:
-  push:
-    branches: [ 'BABEL_*' ]
-concurrency: # Cancel previous runs in the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
   generate-version-upgrade-tests:


### PR DESCRIPTION
This reverts commit 18eabd00a4483c6662b1d8489453fdd4c33237c7.

### Description
Revert GitHub Actions Cancellation using Concurrency due to tests being cancelled in the main branch
Signed-off-by: Colin Yuen [yuenhcol@amazon.com](mailto:yuenhcol@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).