### PR TITLE
Extending sp_babelfish_configure

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -106,6 +106,8 @@ AS $$
 DECLARE
   normalized_name varchar(256);
   default_value text;
+  value_type text;
+  enum_value text[];
   cnt int;
   cur refcursor;
   eh_name varchar(256);
@@ -124,12 +126,18 @@ BEGIN
     RAISE EXCEPTION 'invalid option: %', "@option_scope";
   END IF;
 
-  SELECT COUNT(*) INTO cnt FROM pg_catalog.pg_settings WHERE name collate "C" like normalized_name and name collate "C" like '%escape_hatch%';
+  SELECT COUNT(*) INTO cnt FROM pg_catalog.pg_settings WHERE name collate "C" like normalized_name and 
+                                                             name collate "C" like 'babelfishpg_tsql.%' and 
+                                                             context collate "C" not like 'superuser' and 
+                                                             context collate "C" not like 'sighup';
   IF cnt = 0 THEN
     RAISE EXCEPTION 'unknown configuration: %', normalized_name;
   END IF;
 
-  OPEN cur FOR SELECT name FROM pg_catalog.pg_settings WHERE name collate "C" like normalized_name and name collate "C" like '%escape_hatch%';
+  OPEN cur FOR SELECT name FROM pg_catalog.pg_settings WHERE name collate "C" like normalized_name and 
+                                                             name collate "C" like 'babelfishpg_tsql.%' and 
+                                                             context collate "C" not like 'superuser' and 
+                                                             context collate "C" not like 'sighup';
 
   LOOP
     FETCH NEXT FROM cur into eh_name;
@@ -139,18 +147,33 @@ BEGIN
     -- Assuming that escape hatches cannot be modified using ALTER SYTEM/config file
     -- we are setting the boot_val as the default value for the escape hatches
     SELECT boot_val INTO default_value FROM pg_catalog.pg_settings WHERE name = eh_name;
+    SELECT vartype INTO value_type FROM pg_catalog.pg_settings WHERE name = eh_name;
+    SELECT enumvals INTO enum_value FROM pg_catalog.pg_settings WHERE name = eh_name;
     IF lower("@option_value") = 'default' THEN
         PERFORM pg_catalog.set_config(eh_name, default_value, 'false');
+    ELSIF lower("@option_value") = 'ignore' THEN
+      IF value_type = 'enum' AND enum_value && '{"ignore"}' THEN
+        PERFORM pg_catalog.set_config(eh_name, 'ignore', 'false');
+      ELSE
+        CONTINUE;
+      END IF;
+    ELSIF lower("@option_value") = 'strict' THEN
+      IF value_type = 'enum' AND enum_value && '{"strict"}' THEN
+        PERFORM pg_catalog.set_config(eh_name, 'strict', 'false');
+      ELSE
+        CONTINUE;
+      END IF;
     ELSE
         PERFORM pg_catalog.set_config(eh_name, "@option_value", 'false');
     END IF;
     IF server THEN
       SELECT current_user INTO prev_user;
       PERFORM sys.babelfish_set_role(session_user);
-      IF lower("@option_value") = 'default' THEN
+      IF lower("@option_value") = 'default' AND default_value != NULL THEN
         EXECUTE format('ALTER DATABASE %s SET %s = %s', CURRENT_DATABASE(), eh_name, default_value);
       ELSE
         -- store the setting in PG master database so that it can be applied to all bbf databases
+        RAISE NOTICE '### ELSE eh_name :% , default :% ', eh_name, default_value;
         EXECUTE format('ALTER DATABASE %s SET %s = %s', CURRENT_DATABASE(), eh_name, "@option_value");
       END IF;
       PERFORM sys.babelfish_set_role(prev_user);
@@ -164,19 +187,3 @@ $$ LANGUAGE plpgsql;
 GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_configure(
 	IN varchar(128), IN varchar(128), IN varchar(128)
 ) TO PUBLIC;
-
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME)
-AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
-
-CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolname" sys.SYSNAME)
-AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_droprole(IN sys.SYSNAME) TO PUBLIC;
-
-CREATE OR REPLACE PROCEDURE sys.sp_addrolemember(IN "@rolname" sys.SYSNAME, IN "@membername" sys.SYSNAME)
-AS 'babelfishpg_tsql', 'sp_addrolemember' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_addrolemember(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
-
-CREATE OR REPLACE PROCEDURE sys.sp_droprolemember(IN "@rolname" sys.SYSNAME, IN "@membername" sys.SYSNAME)
-AS 'babelfishpg_tsql', 'sp_droprolemember' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_droprolemember(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -167,7 +167,7 @@ sp_babelfish_configure(PG_FUNCTION_ARGS)
 	MemoryContext savedPortalCxt;
 
 	/* SPI call input */
-	const char* query = "SELECT name, setting, short_desc from pg_settings where name like 'babelfish%%escape_hatch%%' AND name like $1";
+	const char* query = "SELECT name, setting, short_desc from pg_settings where name like 'babelfishpg_tsql.%' AND name like $1";
 	Datum arg;
 	Oid argoid = TEXTOID;
 	char nulls = 0;

--- a/test/JDBC/expected/BABEL-3588-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3588-vu-verify.out
@@ -1,0 +1,269 @@
+-- Show all BABELFISH Gucs
+EXEC sp_babelfish_configure '%'
+GO
+~~START~~
+text#!#text#!#text
+babelfishpg_tsql.ansi_defaults#!#on#!#Controls a group of settings that collectively specify some ISO standard behavior. 
+babelfishpg_tsql.ansi_null_dflt_off#!#off#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is on.
+babelfishpg_tsql.ansi_null_dflt_on#!#on#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is false.
+babelfishpg_tsql.ansi_nulls#!#on#!#Specifies ISO compliant behavior of the Equals (=) and Not Equal To (<>) comparison operators when they are used with null values.
+babelfishpg_tsql.ansi_padding#!#on#!#Controls the way the column stores values shorter than the defined size of the column, and the way the column stores values that have trailing blanks in char, varchar, binary, and varbinary data.
+babelfishpg_tsql.ansi_warnings#!#on#!#Specifies ISO standard behavior for several error conditions
+babelfishpg_tsql.arithabort#!#on#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.arithignore#!#off#!#Controls whether error messages are returned from overflow or divide-by-zero errors during a query.
+babelfishpg_tsql.concat_null_yields_null#!#on#!#If enabled, concatenating a NULL value produces a NULL result
+babelfishpg_tsql.cursor_close_on_commit#!#off#!#Controls the behavior of the cursor during COMMIT TRANSACTION statement.
+babelfishpg_tsql.database_name#!#jdbc_testdb#!#Predefined Babelfish database name
+babelfishpg_tsql.datefirst#!#7#!#Sets the first day of the week to a number from 1 through 7.
+babelfishpg_tsql.default_locale#!#en_US#!#The default locale to use when creating a new collation.
+babelfishpg_tsql.dump_restore#!#off#!#Enable special handlings during dump and restore
+babelfishpg_tsql.dump_restore_min_oid#!##!#All new OIDs should be greater than this number during dump and restore
+babelfishpg_tsql.enable_create_alter_view_from_pg#!#off#!#Enables blocked DDL statements from PG endpoint
+babelfishpg_tsql.enable_hint_mapping#!#off#!#Enables T-SQL hint mapping
+babelfishpg_tsql.enable_metadata_inconsistency_check#!#on#!#Enables babelfish_inconsistent_metadata
+babelfishpg_tsql.enable_tsql_information_schema#!#on#!#toggles between the information_schema for postgres and tsql
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
+babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
+babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
+babelfishpg_tsql.escape_hatch_fulltext#!#strict#!#escape hatch for fulltext
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
+babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
+babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
+babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for login miscellaneous options
+babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
+babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#ignore#!#escape hatch for ROWGUIDCOL option
+babelfishpg_tsql.escape_hatch_rowversion#!#strict#!#escape hatch for TIMESTAMP/ROWVERSION columns
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE FUNCTION
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE PROCEDURE
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
+babelfishpg_tsql.escape_hatch_session_settings#!#ignore#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
+babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
+babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
+babelfishpg_tsql.escape_hatch_unique_constraint#!#strict#!#escape hatch for unique constraint
+babelfishpg_tsql.explain_buffers#!#off#!#Include information on buffer usage
+babelfishpg_tsql.explain_costs#!#on#!#Include information on estimated startup and total cost
+babelfishpg_tsql.explain_format#!#text#!#Specify the output format, which can be TEXT, XML, JSON, or YAML
+babelfishpg_tsql.explain_settings#!#off#!#Include information on configuration parameters
+babelfishpg_tsql.explain_summary#!#off#!#Include summary information (e.g., totaled timing information) after the query plan
+babelfishpg_tsql.explain_timing#!#off#!#Include actual startup time and time spent in each node in the output
+babelfishpg_tsql.explain_verbose#!#off#!#Display additional information regarding the plan
+babelfishpg_tsql.explain_wal#!#off#!#Include information on WAL record generation
+babelfishpg_tsql.fmtonly#!#off#!#SQL-Server compatibility FMTONLY option.
+babelfishpg_tsql.host_distribution#!##!#Sets host distribution
+babelfishpg_tsql.host_release#!##!#Sets host release
+babelfishpg_tsql.host_service_pack_level#!##!#Sets host service pack level
+babelfishpg_tsql.identity_insert#!##!#Enable inserts into identity columns.
+babelfishpg_tsql.implicit_transactions#!#off#!#enable implicit transactions
+babelfishpg_tsql.insert_bulk_kilobytes_per_batch#!#8#!#Sets the number of bytes per batch to be processed for Insert Bulk
+babelfishpg_tsql.insert_bulk_rows_per_batch#!#1000#!#Sets the number of rows per batch to be processed for Insert Bulk
+babelfishpg_tsql.language#!#us_english#!#T-SQL compatibility LANGUAGE option.
+babelfishpg_tsql.lock_timeout#!#-1#!#Specifies the number of milliseconds a statement waits for a lock to be released.
+babelfishpg_tsql.migration_mode#!#single-db#!#Defines if multiple user databases are supported
+babelfishpg_tsql.no_browsetable#!#on#!#SQL-Server compatibility NO_BROWSETABLE option.
+babelfishpg_tsql.nocount#!#off#!#Tsql compatibility NOCOUNT option.
+babelfishpg_tsql.noexec#!#off#!#SQL-Server compatibility NOEXEC option.
+babelfishpg_tsql.numeric_roundabort#!#off#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.recursive_triggers#!#off#!#SQL-Server compatibility recursive_triggers option
+babelfishpg_tsql.restore_tsql_tabletype#!#off#!#Shows that if a table is creating a T-SQL table type during restore
+babelfishpg_tsql.rowcount#!#0#!#Causes the DB engine to stop processing the query after the specified number of rows are returned.
+babelfishpg_tsql.server_collation_name#!#sql_latin1_general_cp1_ci_as#!#Name of the default server collation.
+babelfishpg_tsql.showplan_all#!#off#!#SQL-Server compatibility SHOWPLAN_ALL option.
+babelfishpg_tsql.showplan_text#!#off#!#SQL-Server compatibility SHOWPLAN_TEXT option.
+babelfishpg_tsql.showplan_xml#!#off#!#SQL-Server compatibility SHOWPLAN_XML option.
+babelfishpg_tsql.variable_conflict#!#error#!#Sets handling of conflicts between PL/tsql variable names and table column names.
+babelfishpg_tsql.version#!#default#!#Sets the output of @@VERSION variable
+babelfishpg_tsql.xact_abort#!#off#!#enable xact abort
+~~END~~
+
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Explain Gucs can set to on or off
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','off'
+GO
+
+-- Should set to off
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+-- Should set all Gucs to default value
+EXEC sp_babelfish_configure '%','default'
+GO
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Should throw error when trying to set to arbirary value
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','eee'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot set "babelfishpg_tsql.explain_costs" to "eee" - ignoring)~~
+
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict';
+GO
+
+-- All escape hatch set to strict
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+~~START~~
+text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#strict
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#strict
+babelfishpg_tsql.escape_hatch_database_misc_options#!#strict
+babelfishpg_tsql.escape_hatch_for_replication#!#strict
+babelfishpg_tsql.escape_hatch_fulltext#!#strict
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict
+babelfishpg_tsql.escape_hatch_index_clustering#!#strict
+babelfishpg_tsql.escape_hatch_index_columnstore#!#strict
+babelfishpg_tsql.escape_hatch_join_hints#!#strict
+babelfishpg_tsql.escape_hatch_language_non_english#!#strict
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict
+babelfishpg_tsql.escape_hatch_login_misc_options#!#strict
+babelfishpg_tsql.escape_hatch_login_old_password#!#strict
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict
+babelfishpg_tsql.escape_hatch_query_hints#!#strict
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#strict
+babelfishpg_tsql.escape_hatch_rowversion#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#strict
+babelfishpg_tsql.escape_hatch_session_settings#!#strict
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict
+babelfishpg_tsql.escape_hatch_storage_options#!#strict
+babelfishpg_tsql.escape_hatch_table_hints#!#strict
+babelfishpg_tsql.escape_hatch_unique_constraint#!#strict
+~~END~~
+
+
+-- Set all escape hatch to ignore 
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'ignore';
+GO
+
+-- All escape hatch set to ignore
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+~~START~~
+text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore
+babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_for_replication#!#ignore
+babelfishpg_tsql.escape_hatch_fulltext#!#ignore
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#ignore
+babelfishpg_tsql.escape_hatch_index_clustering#!#ignore
+babelfishpg_tsql.escape_hatch_index_columnstore#!#ignore
+babelfishpg_tsql.escape_hatch_join_hints#!#ignore
+babelfishpg_tsql.escape_hatch_language_non_english#!#ignore
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_login_old_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_query_hints#!#ignore
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#ignore
+babelfishpg_tsql.escape_hatch_rowversion#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore
+babelfishpg_tsql.escape_hatch_session_settings#!#ignore
+babelfishpg_tsql.escape_hatch_showplan_all#!#ignore
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#ignore
+babelfishpg_tsql.escape_hatch_storage_options#!#ignore
+babelfishpg_tsql.escape_hatch_table_hints#!#ignore
+babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore
+~~END~~
+
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict'
+GO
+
+-- Set all Gucs that vartype is enum and enumvals has ignore option to 'ignore'
+EXEC sp_babelfish_configure '%','ignore'
+GO
+
+-- All Gucs that vartype is enum and enumvals has ignore option is 'ignore'
+SELECT name, setting  FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.%' AND vartype = 'enum'
+GO
+~~START~~
+text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore
+babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_for_replication#!#ignore
+babelfishpg_tsql.escape_hatch_fulltext#!#ignore
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#ignore
+babelfishpg_tsql.escape_hatch_index_clustering#!#ignore
+babelfishpg_tsql.escape_hatch_index_columnstore#!#ignore
+babelfishpg_tsql.escape_hatch_join_hints#!#ignore
+babelfishpg_tsql.escape_hatch_language_non_english#!#ignore
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_login_old_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_query_hints#!#ignore
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#ignore
+babelfishpg_tsql.escape_hatch_rowversion#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore
+babelfishpg_tsql.escape_hatch_session_settings#!#ignore
+babelfishpg_tsql.escape_hatch_showplan_all#!#ignore
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#ignore
+babelfishpg_tsql.escape_hatch_storage_options#!#ignore
+babelfishpg_tsql.escape_hatch_table_hints#!#ignore
+babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore
+babelfishpg_tsql.explain_format#!#text
+babelfishpg_tsql.migration_mode#!#single-db
+babelfishpg_tsql.variable_conflict#!#error
+~~END~~
+
+
+-- Set all Gucs back to default value
+EXEC sp_babelfish_configure '%','ignore'
+GO

--- a/test/JDBC/expected/BABEL-3588.out
+++ b/test/JDBC/expected/BABEL-3588.out
@@ -1,0 +1,269 @@
+-- Show all BABELFISH Gucs
+EXEC sp_babelfish_configure '%'
+GO
+~~START~~
+text#!#text#!#text
+babelfishpg_tsql.ansi_defaults#!#on#!#Controls a group of settings that collectively specify some ISO standard behavior. 
+babelfishpg_tsql.ansi_null_dflt_off#!#off#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is on.
+babelfishpg_tsql.ansi_null_dflt_on#!#on#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is false.
+babelfishpg_tsql.ansi_nulls#!#on#!#Specifies ISO compliant behavior of the Equals (=) and Not Equal To (<>) comparison operators when they are used with null values.
+babelfishpg_tsql.ansi_padding#!#on#!#Controls the way the column stores values shorter than the defined size of the column, and the way the column stores values that have trailing blanks in char, varchar, binary, and varbinary data.
+babelfishpg_tsql.ansi_warnings#!#on#!#Specifies ISO standard behavior for several error conditions
+babelfishpg_tsql.arithabort#!#on#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.arithignore#!#off#!#Controls whether error messages are returned from overflow or divide-by-zero errors during a query.
+babelfishpg_tsql.concat_null_yields_null#!#on#!#If enabled, concatenating a NULL value produces a NULL result
+babelfishpg_tsql.cursor_close_on_commit#!#off#!#Controls the behavior of the cursor during COMMIT TRANSACTION statement.
+babelfishpg_tsql.database_name#!#jdbc_testdb#!#Predefined Babelfish database name
+babelfishpg_tsql.datefirst#!#7#!#Sets the first day of the week to a number from 1 through 7.
+babelfishpg_tsql.default_locale#!#en_US#!#The default locale to use when creating a new collation.
+babelfishpg_tsql.dump_restore#!#off#!#Enable special handlings during dump and restore
+babelfishpg_tsql.dump_restore_min_oid#!##!#All new OIDs should be greater than this number during dump and restore
+babelfishpg_tsql.enable_create_alter_view_from_pg#!#off#!#Enables blocked DDL statements from PG endpoint
+babelfishpg_tsql.enable_hint_mapping#!#off#!#Enables T-SQL hint mapping
+babelfishpg_tsql.enable_metadata_inconsistency_check#!#on#!#Enables babelfish_inconsistent_metadata
+babelfishpg_tsql.enable_tsql_information_schema#!#on#!#toggles between the information_schema for postgres and tsql
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
+babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
+babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
+babelfishpg_tsql.escape_hatch_fulltext#!#strict#!#escape hatch for fulltext
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
+babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
+babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
+babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for login miscellaneous options
+babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
+babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#ignore#!#escape hatch for ROWGUIDCOL option
+babelfishpg_tsql.escape_hatch_rowversion#!#strict#!#escape hatch for TIMESTAMP/ROWVERSION columns
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE FUNCTION
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE PROCEDURE
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
+babelfishpg_tsql.escape_hatch_session_settings#!#ignore#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
+babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
+babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
+babelfishpg_tsql.escape_hatch_unique_constraint#!#strict#!#escape hatch for unique constraint
+babelfishpg_tsql.explain_buffers#!#off#!#Include information on buffer usage
+babelfishpg_tsql.explain_costs#!#on#!#Include information on estimated startup and total cost
+babelfishpg_tsql.explain_format#!#text#!#Specify the output format, which can be TEXT, XML, JSON, or YAML
+babelfishpg_tsql.explain_settings#!#off#!#Include information on configuration parameters
+babelfishpg_tsql.explain_summary#!#off#!#Include summary information (e.g., totaled timing information) after the query plan
+babelfishpg_tsql.explain_timing#!#off#!#Include actual startup time and time spent in each node in the output
+babelfishpg_tsql.explain_verbose#!#off#!#Display additional information regarding the plan
+babelfishpg_tsql.explain_wal#!#off#!#Include information on WAL record generation
+babelfishpg_tsql.fmtonly#!#off#!#SQL-Server compatibility FMTONLY option.
+babelfishpg_tsql.host_distribution#!##!#Sets host distribution
+babelfishpg_tsql.host_release#!##!#Sets host release
+babelfishpg_tsql.host_service_pack_level#!##!#Sets host service pack level
+babelfishpg_tsql.identity_insert#!##!#Enable inserts into identity columns.
+babelfishpg_tsql.implicit_transactions#!#off#!#enable implicit transactions
+babelfishpg_tsql.insert_bulk_kilobytes_per_batch#!#8#!#Sets the number of bytes per batch to be processed for Insert Bulk
+babelfishpg_tsql.insert_bulk_rows_per_batch#!#1000#!#Sets the number of rows per batch to be processed for Insert Bulk
+babelfishpg_tsql.language#!#us_english#!#T-SQL compatibility LANGUAGE option.
+babelfishpg_tsql.lock_timeout#!#-1#!#Specifies the number of milliseconds a statement waits for a lock to be released.
+babelfishpg_tsql.migration_mode#!#single-db#!#Defines if multiple user databases are supported
+babelfishpg_tsql.no_browsetable#!#on#!#SQL-Server compatibility NO_BROWSETABLE option.
+babelfishpg_tsql.nocount#!#off#!#Tsql compatibility NOCOUNT option.
+babelfishpg_tsql.noexec#!#off#!#SQL-Server compatibility NOEXEC option.
+babelfishpg_tsql.numeric_roundabort#!#off#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.recursive_triggers#!#off#!#SQL-Server compatibility recursive_triggers option
+babelfishpg_tsql.restore_tsql_tabletype#!#off#!#Shows that if a table is creating a T-SQL table type during restore
+babelfishpg_tsql.rowcount#!#0#!#Causes the DB engine to stop processing the query after the specified number of rows are returned.
+babelfishpg_tsql.server_collation_name#!#sql_latin1_general_cp1_ci_as#!#Name of the default server collation.
+babelfishpg_tsql.showplan_all#!#off#!#SQL-Server compatibility SHOWPLAN_ALL option.
+babelfishpg_tsql.showplan_text#!#off#!#SQL-Server compatibility SHOWPLAN_TEXT option.
+babelfishpg_tsql.showplan_xml#!#off#!#SQL-Server compatibility SHOWPLAN_XML option.
+babelfishpg_tsql.variable_conflict#!#error#!#Sets handling of conflicts between PL/tsql variable names and table column names.
+babelfishpg_tsql.version#!#default#!#Sets the output of @@VERSION variable
+babelfishpg_tsql.xact_abort#!#off#!#enable xact abort
+~~END~~
+
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Explain Gucs can set to on or off
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','off'
+GO
+
+-- Should set to off
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+-- Should set all Gucs to default value
+EXEC sp_babelfish_configure '%','default'
+GO
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Should throw error when trying to set to arbirary value
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','eee'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot set "babelfishpg_tsql.explain_costs" to "eee" - ignoring)~~
+
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict';
+GO
+
+-- All escape hatch set to strict
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+~~START~~
+text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#strict
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#strict
+babelfishpg_tsql.escape_hatch_database_misc_options#!#strict
+babelfishpg_tsql.escape_hatch_for_replication#!#strict
+babelfishpg_tsql.escape_hatch_fulltext#!#strict
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict
+babelfishpg_tsql.escape_hatch_index_clustering#!#strict
+babelfishpg_tsql.escape_hatch_index_columnstore#!#strict
+babelfishpg_tsql.escape_hatch_join_hints#!#strict
+babelfishpg_tsql.escape_hatch_language_non_english#!#strict
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict
+babelfishpg_tsql.escape_hatch_login_misc_options#!#strict
+babelfishpg_tsql.escape_hatch_login_old_password#!#strict
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict
+babelfishpg_tsql.escape_hatch_query_hints#!#strict
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#strict
+babelfishpg_tsql.escape_hatch_rowversion#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#strict
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#strict
+babelfishpg_tsql.escape_hatch_session_settings#!#strict
+babelfishpg_tsql.escape_hatch_showplan_all#!#strict
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict
+babelfishpg_tsql.escape_hatch_storage_options#!#strict
+babelfishpg_tsql.escape_hatch_table_hints#!#strict
+babelfishpg_tsql.escape_hatch_unique_constraint#!#strict
+~~END~~
+
+
+-- Set all escape hatch to ignore 
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'ignore';
+GO
+
+-- All escape hatch set to ignore
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+~~START~~
+text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore
+babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_for_replication#!#ignore
+babelfishpg_tsql.escape_hatch_fulltext#!#ignore
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#ignore
+babelfishpg_tsql.escape_hatch_index_clustering#!#ignore
+babelfishpg_tsql.escape_hatch_index_columnstore#!#ignore
+babelfishpg_tsql.escape_hatch_join_hints#!#ignore
+babelfishpg_tsql.escape_hatch_language_non_english#!#ignore
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_login_old_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_query_hints#!#ignore
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#ignore
+babelfishpg_tsql.escape_hatch_rowversion#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore
+babelfishpg_tsql.escape_hatch_session_settings#!#ignore
+babelfishpg_tsql.escape_hatch_showplan_all#!#ignore
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#ignore
+babelfishpg_tsql.escape_hatch_storage_options#!#ignore
+babelfishpg_tsql.escape_hatch_table_hints#!#ignore
+babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore
+~~END~~
+
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict'
+GO
+
+-- Set all Gucs that vartype is enum and enumvals has ignore option to 'ignore'
+EXEC sp_babelfish_configure '%','ignore'
+GO
+
+-- All Gucs that vartype is enum and enumvals has ignore option is 'ignore'
+SELECT name, setting  FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.%' AND vartype = 'enum'
+GO
+~~START~~
+text#!#text
+babelfishpg_tsql.escape_hatch_checkpoint#!#ignore
+babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore
+babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_for_replication#!#ignore
+babelfishpg_tsql.escape_hatch_fulltext#!#ignore
+babelfishpg_tsql.escape_hatch_ignore_dup_key#!#ignore
+babelfishpg_tsql.escape_hatch_index_clustering#!#ignore
+babelfishpg_tsql.escape_hatch_index_columnstore#!#ignore
+babelfishpg_tsql.escape_hatch_join_hints#!#ignore
+babelfishpg_tsql.escape_hatch_language_non_english#!#ignore
+babelfishpg_tsql.escape_hatch_login_hashed_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_misc_options#!#ignore
+babelfishpg_tsql.escape_hatch_login_old_password#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_must_change#!#ignore
+babelfishpg_tsql.escape_hatch_login_password_unlock#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#ignore
+babelfishpg_tsql.escape_hatch_query_hints#!#ignore
+babelfishpg_tsql.escape_hatch_rowguidcol_column#!#ignore
+babelfishpg_tsql.escape_hatch_rowversion#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_function#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore
+babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore
+babelfishpg_tsql.escape_hatch_session_settings#!#ignore
+babelfishpg_tsql.escape_hatch_showplan_all#!#ignore
+babelfishpg_tsql.escape_hatch_storage_on_partition#!#ignore
+babelfishpg_tsql.escape_hatch_storage_options#!#ignore
+babelfishpg_tsql.escape_hatch_table_hints#!#ignore
+babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore
+babelfishpg_tsql.explain_format#!#text
+babelfishpg_tsql.migration_mode#!#single-db
+babelfishpg_tsql.variable_conflict#!#error
+~~END~~
+
+
+-- Set all Gucs back to default value
+EXEC sp_babelfish_configure '%','ignore'
+GO

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -1966,6 +1966,25 @@ EXEC sp_babelfish_configure;
 GO
 ~~START~~
 text#!#text#!#text
+babelfishpg_tsql.ansi_defaults#!#on#!#Controls a group of settings that collectively specify some ISO standard behavior. 
+babelfishpg_tsql.ansi_null_dflt_off#!#off#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is on.
+babelfishpg_tsql.ansi_null_dflt_on#!#on#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is false.
+babelfishpg_tsql.ansi_nulls#!#on#!#Specifies ISO compliant behavior of the Equals (=) and Not Equal To (<>) comparison operators when they are used with null values.
+babelfishpg_tsql.ansi_padding#!#on#!#Controls the way the column stores values shorter than the defined size of the column, and the way the column stores values that have trailing blanks in char, varchar, binary, and varbinary data.
+babelfishpg_tsql.ansi_warnings#!#on#!#Specifies ISO standard behavior for several error conditions
+babelfishpg_tsql.arithabort#!#on#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.arithignore#!#off#!#Controls whether error messages are returned from overflow or divide-by-zero errors during a query.
+babelfishpg_tsql.concat_null_yields_null#!#on#!#If enabled, concatenating a NULL value produces a NULL result
+babelfishpg_tsql.cursor_close_on_commit#!#off#!#Controls the behavior of the cursor during COMMIT TRANSACTION statement.
+babelfishpg_tsql.database_name#!#jdbc_testdb#!#Predefined Babelfish database name
+babelfishpg_tsql.datefirst#!#7#!#Sets the first day of the week to a number from 1 through 7.
+babelfishpg_tsql.default_locale#!#en_US#!#The default locale to use when creating a new collation.
+babelfishpg_tsql.dump_restore#!#off#!#Enable special handlings during dump and restore
+babelfishpg_tsql.dump_restore_min_oid#!##!#All new OIDs should be greater than this number during dump and restore
+babelfishpg_tsql.enable_create_alter_view_from_pg#!#off#!#Enables blocked DDL statements from PG endpoint
+babelfishpg_tsql.enable_hint_mapping#!#off#!#Enables T-SQL hint mapping
+babelfishpg_tsql.enable_metadata_inconsistency_check#!#on#!#Enables babelfish_inconsistent_metadata
+babelfishpg_tsql.enable_tsql_information_schema#!#on#!#toggles between the information_schema for postgres and tsql
 babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
 babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
@@ -1996,6 +2015,39 @@ babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for s
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
 babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore#!#escape hatch for unique constraint
+babelfishpg_tsql.explain_buffers#!#off#!#Include information on buffer usage
+babelfishpg_tsql.explain_costs#!#on#!#Include information on estimated startup and total cost
+babelfishpg_tsql.explain_format#!#text#!#Specify the output format, which can be TEXT, XML, JSON, or YAML
+babelfishpg_tsql.explain_settings#!#off#!#Include information on configuration parameters
+babelfishpg_tsql.explain_summary#!#off#!#Include summary information (e.g., totaled timing information) after the query plan
+babelfishpg_tsql.explain_timing#!#off#!#Include actual startup time and time spent in each node in the output
+babelfishpg_tsql.explain_verbose#!#off#!#Display additional information regarding the plan
+babelfishpg_tsql.explain_wal#!#off#!#Include information on WAL record generation
+babelfishpg_tsql.fmtonly#!#off#!#SQL-Server compatibility FMTONLY option.
+babelfishpg_tsql.host_distribution#!##!#Sets host distribution
+babelfishpg_tsql.host_release#!##!#Sets host release
+babelfishpg_tsql.host_service_pack_level#!##!#Sets host service pack level
+babelfishpg_tsql.identity_insert#!##!#Enable inserts into identity columns.
+babelfishpg_tsql.implicit_transactions#!#off#!#enable implicit transactions
+babelfishpg_tsql.insert_bulk_kilobytes_per_batch#!#8#!#Sets the number of bytes per batch to be processed for Insert Bulk
+babelfishpg_tsql.insert_bulk_rows_per_batch#!#1000#!#Sets the number of rows per batch to be processed for Insert Bulk
+babelfishpg_tsql.language#!#us_english#!#T-SQL compatibility LANGUAGE option.
+babelfishpg_tsql.lock_timeout#!#-1#!#Specifies the number of milliseconds a statement waits for a lock to be released.
+babelfishpg_tsql.migration_mode#!#single-db#!#Defines if multiple user databases are supported
+babelfishpg_tsql.no_browsetable#!#on#!#SQL-Server compatibility NO_BROWSETABLE option.
+babelfishpg_tsql.nocount#!#off#!#Tsql compatibility NOCOUNT option.
+babelfishpg_tsql.noexec#!#off#!#SQL-Server compatibility NOEXEC option.
+babelfishpg_tsql.numeric_roundabort#!#off#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.recursive_triggers#!#off#!#SQL-Server compatibility recursive_triggers option
+babelfishpg_tsql.restore_tsql_tabletype#!#off#!#Shows that if a table is creating a T-SQL table type during restore
+babelfishpg_tsql.rowcount#!#0#!#Causes the DB engine to stop processing the query after the specified number of rows are returned.
+babelfishpg_tsql.server_collation_name#!#sql_latin1_general_cp1_ci_as#!#Name of the default server collation.
+babelfishpg_tsql.showplan_all#!#off#!#SQL-Server compatibility SHOWPLAN_ALL option.
+babelfishpg_tsql.showplan_text#!#off#!#SQL-Server compatibility SHOWPLAN_TEXT option.
+babelfishpg_tsql.showplan_xml#!#off#!#SQL-Server compatibility SHOWPLAN_XML option.
+babelfishpg_tsql.variable_conflict#!#error#!#Sets handling of conflicts between PL/tsql variable names and table column names.
+babelfishpg_tsql.version#!#default#!#Sets the output of @@VERSION variable
+babelfishpg_tsql.xact_abort#!#off#!#enable xact abort
 ~~END~~
 
 
@@ -2022,6 +2074,25 @@ EXEC sp_babelfish_configure '%';
 GO
 ~~START~~
 text#!#text#!#text
+babelfishpg_tsql.ansi_defaults#!#on#!#Controls a group of settings that collectively specify some ISO standard behavior. 
+babelfishpg_tsql.ansi_null_dflt_off#!#off#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is on.
+babelfishpg_tsql.ansi_null_dflt_on#!#on#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is false.
+babelfishpg_tsql.ansi_nulls#!#on#!#Specifies ISO compliant behavior of the Equals (=) and Not Equal To (<>) comparison operators when they are used with null values.
+babelfishpg_tsql.ansi_padding#!#on#!#Controls the way the column stores values shorter than the defined size of the column, and the way the column stores values that have trailing blanks in char, varchar, binary, and varbinary data.
+babelfishpg_tsql.ansi_warnings#!#on#!#Specifies ISO standard behavior for several error conditions
+babelfishpg_tsql.arithabort#!#on#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.arithignore#!#off#!#Controls whether error messages are returned from overflow or divide-by-zero errors during a query.
+babelfishpg_tsql.concat_null_yields_null#!#on#!#If enabled, concatenating a NULL value produces a NULL result
+babelfishpg_tsql.cursor_close_on_commit#!#off#!#Controls the behavior of the cursor during COMMIT TRANSACTION statement.
+babelfishpg_tsql.database_name#!#jdbc_testdb#!#Predefined Babelfish database name
+babelfishpg_tsql.datefirst#!#7#!#Sets the first day of the week to a number from 1 through 7.
+babelfishpg_tsql.default_locale#!#en_US#!#The default locale to use when creating a new collation.
+babelfishpg_tsql.dump_restore#!#off#!#Enable special handlings during dump and restore
+babelfishpg_tsql.dump_restore_min_oid#!##!#All new OIDs should be greater than this number during dump and restore
+babelfishpg_tsql.enable_create_alter_view_from_pg#!#off#!#Enables blocked DDL statements from PG endpoint
+babelfishpg_tsql.enable_hint_mapping#!#off#!#Enables T-SQL hint mapping
+babelfishpg_tsql.enable_metadata_inconsistency_check#!#on#!#Enables babelfish_inconsistent_metadata
+babelfishpg_tsql.enable_tsql_information_schema#!#on#!#toggles between the information_schema for postgres and tsql
 babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
 babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
@@ -2052,6 +2123,39 @@ babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for s
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
 babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore#!#escape hatch for unique constraint
+babelfishpg_tsql.explain_buffers#!#off#!#Include information on buffer usage
+babelfishpg_tsql.explain_costs#!#on#!#Include information on estimated startup and total cost
+babelfishpg_tsql.explain_format#!#text#!#Specify the output format, which can be TEXT, XML, JSON, or YAML
+babelfishpg_tsql.explain_settings#!#off#!#Include information on configuration parameters
+babelfishpg_tsql.explain_summary#!#off#!#Include summary information (e.g., totaled timing information) after the query plan
+babelfishpg_tsql.explain_timing#!#off#!#Include actual startup time and time spent in each node in the output
+babelfishpg_tsql.explain_verbose#!#off#!#Display additional information regarding the plan
+babelfishpg_tsql.explain_wal#!#off#!#Include information on WAL record generation
+babelfishpg_tsql.fmtonly#!#off#!#SQL-Server compatibility FMTONLY option.
+babelfishpg_tsql.host_distribution#!##!#Sets host distribution
+babelfishpg_tsql.host_release#!##!#Sets host release
+babelfishpg_tsql.host_service_pack_level#!##!#Sets host service pack level
+babelfishpg_tsql.identity_insert#!##!#Enable inserts into identity columns.
+babelfishpg_tsql.implicit_transactions#!#off#!#enable implicit transactions
+babelfishpg_tsql.insert_bulk_kilobytes_per_batch#!#8#!#Sets the number of bytes per batch to be processed for Insert Bulk
+babelfishpg_tsql.insert_bulk_rows_per_batch#!#1000#!#Sets the number of rows per batch to be processed for Insert Bulk
+babelfishpg_tsql.language#!#us_english#!#T-SQL compatibility LANGUAGE option.
+babelfishpg_tsql.lock_timeout#!#-1#!#Specifies the number of milliseconds a statement waits for a lock to be released.
+babelfishpg_tsql.migration_mode#!#single-db#!#Defines if multiple user databases are supported
+babelfishpg_tsql.no_browsetable#!#on#!#SQL-Server compatibility NO_BROWSETABLE option.
+babelfishpg_tsql.nocount#!#off#!#Tsql compatibility NOCOUNT option.
+babelfishpg_tsql.noexec#!#off#!#SQL-Server compatibility NOEXEC option.
+babelfishpg_tsql.numeric_roundabort#!#off#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.recursive_triggers#!#off#!#SQL-Server compatibility recursive_triggers option
+babelfishpg_tsql.restore_tsql_tabletype#!#off#!#Shows that if a table is creating a T-SQL table type during restore
+babelfishpg_tsql.rowcount#!#0#!#Causes the DB engine to stop processing the query after the specified number of rows are returned.
+babelfishpg_tsql.server_collation_name#!#sql_latin1_general_cp1_ci_as#!#Name of the default server collation.
+babelfishpg_tsql.showplan_all#!#off#!#SQL-Server compatibility SHOWPLAN_ALL option.
+babelfishpg_tsql.showplan_text#!#off#!#SQL-Server compatibility SHOWPLAN_TEXT option.
+babelfishpg_tsql.showplan_xml#!#off#!#SQL-Server compatibility SHOWPLAN_XML option.
+babelfishpg_tsql.variable_conflict#!#error#!#Sets handling of conflicts between PL/tsql variable names and table column names.
+babelfishpg_tsql.version#!#default#!#Sets the output of @@VERSION variable
+babelfishpg_tsql.xact_abort#!#off#!#enable xact abort
 ~~END~~
 
 
@@ -2059,6 +2163,25 @@ EXEC sp_babelfish_configure 'babelfishpg_tsql.%';
 GO
 ~~START~~
 text#!#text#!#text
+babelfishpg_tsql.ansi_defaults#!#on#!#Controls a group of settings that collectively specify some ISO standard behavior. 
+babelfishpg_tsql.ansi_null_dflt_off#!#off#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is on.
+babelfishpg_tsql.ansi_null_dflt_on#!#on#!#Modifies the behavior of the session to override default nullability of new columns when the ANSI null default option for the database is false.
+babelfishpg_tsql.ansi_nulls#!#on#!#Specifies ISO compliant behavior of the Equals (=) and Not Equal To (<>) comparison operators when they are used with null values.
+babelfishpg_tsql.ansi_padding#!#on#!#Controls the way the column stores values shorter than the defined size of the column, and the way the column stores values that have trailing blanks in char, varchar, binary, and varbinary data.
+babelfishpg_tsql.ansi_warnings#!#on#!#Specifies ISO standard behavior for several error conditions
+babelfishpg_tsql.arithabort#!#on#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.arithignore#!#off#!#Controls whether error messages are returned from overflow or divide-by-zero errors during a query.
+babelfishpg_tsql.concat_null_yields_null#!#on#!#If enabled, concatenating a NULL value produces a NULL result
+babelfishpg_tsql.cursor_close_on_commit#!#off#!#Controls the behavior of the cursor during COMMIT TRANSACTION statement.
+babelfishpg_tsql.database_name#!#jdbc_testdb#!#Predefined Babelfish database name
+babelfishpg_tsql.datefirst#!#7#!#Sets the first day of the week to a number from 1 through 7.
+babelfishpg_tsql.default_locale#!#en_US#!#The default locale to use when creating a new collation.
+babelfishpg_tsql.dump_restore#!#off#!#Enable special handlings during dump and restore
+babelfishpg_tsql.dump_restore_min_oid#!##!#All new OIDs should be greater than this number during dump and restore
+babelfishpg_tsql.enable_create_alter_view_from_pg#!#off#!#Enables blocked DDL statements from PG endpoint
+babelfishpg_tsql.enable_hint_mapping#!#off#!#Enables T-SQL hint mapping
+babelfishpg_tsql.enable_metadata_inconsistency_check#!#on#!#Enables babelfish_inconsistent_metadata
+babelfishpg_tsql.enable_tsql_information_schema#!#on#!#toggles between the information_schema for postgres and tsql
 babelfishpg_tsql.escape_hatch_checkpoint#!#ignore#!#escape hatch for CHECKPOINT
 babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatch for DEFAULT option in alter table add constraint
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
@@ -2089,6 +2212,39 @@ babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for s
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_table_hints#!#ignore#!#escape hatch for table hints
 babelfishpg_tsql.escape_hatch_unique_constraint#!#ignore#!#escape hatch for unique constraint
+babelfishpg_tsql.explain_buffers#!#off#!#Include information on buffer usage
+babelfishpg_tsql.explain_costs#!#on#!#Include information on estimated startup and total cost
+babelfishpg_tsql.explain_format#!#text#!#Specify the output format, which can be TEXT, XML, JSON, or YAML
+babelfishpg_tsql.explain_settings#!#off#!#Include information on configuration parameters
+babelfishpg_tsql.explain_summary#!#off#!#Include summary information (e.g., totaled timing information) after the query plan
+babelfishpg_tsql.explain_timing#!#off#!#Include actual startup time and time spent in each node in the output
+babelfishpg_tsql.explain_verbose#!#off#!#Display additional information regarding the plan
+babelfishpg_tsql.explain_wal#!#off#!#Include information on WAL record generation
+babelfishpg_tsql.fmtonly#!#off#!#SQL-Server compatibility FMTONLY option.
+babelfishpg_tsql.host_distribution#!##!#Sets host distribution
+babelfishpg_tsql.host_release#!##!#Sets host release
+babelfishpg_tsql.host_service_pack_level#!##!#Sets host service pack level
+babelfishpg_tsql.identity_insert#!##!#Enable inserts into identity columns.
+babelfishpg_tsql.implicit_transactions#!#off#!#enable implicit transactions
+babelfishpg_tsql.insert_bulk_kilobytes_per_batch#!#8#!#Sets the number of bytes per batch to be processed for Insert Bulk
+babelfishpg_tsql.insert_bulk_rows_per_batch#!#1000#!#Sets the number of rows per batch to be processed for Insert Bulk
+babelfishpg_tsql.language#!#us_english#!#T-SQL compatibility LANGUAGE option.
+babelfishpg_tsql.lock_timeout#!#-1#!#Specifies the number of milliseconds a statement waits for a lock to be released.
+babelfishpg_tsql.migration_mode#!#single-db#!#Defines if multiple user databases are supported
+babelfishpg_tsql.no_browsetable#!#on#!#SQL-Server compatibility NO_BROWSETABLE option.
+babelfishpg_tsql.nocount#!#off#!#Tsql compatibility NOCOUNT option.
+babelfishpg_tsql.noexec#!#off#!#SQL-Server compatibility NOEXEC option.
+babelfishpg_tsql.numeric_roundabort#!#off#!#Ends a query when an overflow or divide-by-zero error occurs during query execution.
+babelfishpg_tsql.recursive_triggers#!#off#!#SQL-Server compatibility recursive_triggers option
+babelfishpg_tsql.restore_tsql_tabletype#!#off#!#Shows that if a table is creating a T-SQL table type during restore
+babelfishpg_tsql.rowcount#!#0#!#Causes the DB engine to stop processing the query after the specified number of rows are returned.
+babelfishpg_tsql.server_collation_name#!#sql_latin1_general_cp1_ci_as#!#Name of the default server collation.
+babelfishpg_tsql.showplan_all#!#off#!#SQL-Server compatibility SHOWPLAN_ALL option.
+babelfishpg_tsql.showplan_text#!#off#!#SQL-Server compatibility SHOWPLAN_TEXT option.
+babelfishpg_tsql.showplan_xml#!#off#!#SQL-Server compatibility SHOWPLAN_XML option.
+babelfishpg_tsql.variable_conflict#!#error#!#Sets handling of conflicts between PL/tsql variable names and table column names.
+babelfishpg_tsql.version#!#default#!#Sets the output of @@VERSION variable
+babelfishpg_tsql.xact_abort#!#off#!#enable xact abort
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-lock_timeout-vu-verify.out
+++ b/test/JDBC/expected/sys-lock_timeout-vu-verify.out
@@ -35,7 +35,7 @@ SET lock_timeout 2147483648; -- Shoud throw error
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: invalid value for parameter "babelfishpg_tsql.lock_timeout": "2147483648")~~
+~~ERROR (Message: Cannot set "babelfishpg_tsql.lock_timeout" to "2147483648" - ignoring)~~
 
 
 -- SET guc to min value (INT_MIN)
@@ -54,7 +54,7 @@ SET lock_timeout -2147483649; -- Shoud throw error
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: invalid value for parameter "babelfishpg_tsql.lock_timeout": "-2147483649")~~
+~~ERROR (Message: Cannot set "babelfishpg_tsql.lock_timeout" to "-2147483649" - ignoring)~~
 
 
 -- SET guc to 0

--- a/test/JDBC/expected/sys-lock_timeout.out
+++ b/test/JDBC/expected/sys-lock_timeout.out
@@ -35,7 +35,7 @@ SET lock_timeout 2147483648; -- Shoud throw error
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: invalid value for parameter "babelfishpg_tsql.lock_timeout": "2147483648")~~
+~~ERROR (Message: Cannot set "babelfishpg_tsql.lock_timeout" to "2147483648" - ignoring)~~
 
 
 -- SET guc to min value (INT_MIN)
@@ -54,7 +54,7 @@ SET lock_timeout -2147483649; -- Shoud throw error
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: invalid value for parameter "babelfishpg_tsql.lock_timeout": "-2147483649")~~
+~~ERROR (Message: Cannot set "babelfishpg_tsql.lock_timeout" to "-2147483649" - ignoring)~~
 
 
 -- SET guc to 0

--- a/test/JDBC/input/BABEL-3588-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3588-vu-verify.sql
@@ -1,0 +1,59 @@
+-- Show all BABELFISH Gucs
+EXEC sp_babelfish_configure '%'
+GO
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+
+-- Explain Gucs can set to on or off
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','off'
+GO
+
+-- Should set to off
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+
+-- Should set all Gucs to default value
+EXEC sp_babelfish_configure '%','default'
+GO
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+
+-- Should throw error when trying to set to arbirary value
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','eee'
+GO
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict';
+GO
+
+-- All escape hatch set to strict
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+
+-- Set all escape hatch to ignore 
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'ignore';
+GO
+
+-- All escape hatch set to ignore
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict'
+GO
+
+-- Set all Gucs that vartype is enum and enumvals has ignore option to 'ignore'
+EXEC sp_babelfish_configure '%','ignore'
+GO
+
+-- All Gucs that vartype is enum and enumvals has ignore option is 'ignore'
+SELECT name, setting  FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.%' AND vartype = 'enum'
+GO
+
+-- Set all Gucs back to default value
+EXEC sp_babelfish_configure '%','ignore'
+GO

--- a/test/JDBC/input/BABEL-3588.sql
+++ b/test/JDBC/input/BABEL-3588.sql
@@ -1,0 +1,59 @@
+-- Show all BABELFISH Gucs
+EXEC sp_babelfish_configure '%'
+GO
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+
+-- Explain Gucs can set to on or off
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','off'
+GO
+
+-- Should set to off
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+
+-- Should set all Gucs to default value
+EXEC sp_babelfish_configure '%','default'
+GO
+
+-- Default value is on
+SELECT CURRENT_SETTING('babelfishpg_tsql.explain_costs')
+GO
+
+-- Should throw error when trying to set to arbirary value
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs','eee'
+GO
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict';
+GO
+
+-- All escape hatch set to strict
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+
+-- Set all escape hatch to ignore 
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'ignore';
+GO
+
+-- All escape hatch set to ignore
+SELECT name,setting FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.escape_%'
+GO
+
+-- Set all escape hatch to strict
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_%', 'strict'
+GO
+
+-- Set all Gucs that vartype is enum and enumvals has ignore option to 'ignore'
+EXEC sp_babelfish_configure '%','ignore'
+GO
+
+-- All Gucs that vartype is enum and enumvals has ignore option is 'ignore'
+SELECT name, setting  FROM pg_catalog.pg_settings WHERE name collate "C" like 'babelfishpg_tsql.%' AND vartype = 'enum'
+GO
+
+-- Set all Gucs back to default value
+EXEC sp_babelfish_configure '%','ignore'
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -313,6 +313,7 @@ babel_sqlvariant_cast_compare
 BABEL-3144
 sys-all_parameters-dep
 BABEL-3556
+BABEL-3588
 BABEL-3268
 BABEL_GRANT_CONNECT
 BABEL-sp_helpdb


### PR DESCRIPTION
Task:BABEL-3588
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description

BABEL-3588
 
### Issues Resolved

This change allows user use sp_babelfish_configure to set all Gucs for EXPLAIN, except for babelfishpg_tsql.explain_format. The Guc name that can be specified with wildcars is extenped to all the babel gucs instead of just escape_hatch Gucs. When using '%' as input guc name, 'ingore' and 'strict' setting only applies to Gucs that allow these two options. When using '%' as input guc name, 'default' applies to all Gucs and set Gucs setting to their defult values.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).