### PR TITLE
Fix DATEADD function when input type is datetimeoffset

### DIFF
--- a/contrib/babelfishpg_tsql/expected/test/babel_function.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_function.out
@@ -1567,15 +1567,12 @@ select dateadd(millisecond, 123, '20060830'::datetime);
 (1 row)
 
 select dateadd(microsecond, 123456, '20060830'::datetime);
-ERROR:  The datepart microsecond is not supported by date function dateadd for data type time.
-CONTEXT:  PL/pgSQL function sys.dateadd_internal(text,integer,anyelement) line 36 at RAISE
+ERROR:  The datepart microsecond is not supported by date function dateadd for data type datetime.
+CONTEXT:  PL/pgSQL function sys.dateadd_internal(text,integer,anyelement) line 43 at RAISE
 PL/pgSQL function sys.dateadd(text,integer,anyelement) line 7 at RETURN
-select dateadd(nanosecond, 123456, '20060830'::datetime);
-         dateadd          
---------------------------
- Wed Aug 30 00:00:00 2006
-(1 row)
-
+ERROR:  The datepart nanosecond is not supported by date function dateadd for data type datetime.
+CONTEXT:  PL/pgSQL function sys.dateadd_internal(text,integer,anyelement) line 53 at RAISE
+PL/pgSQL function sys.dateadd(text,integer,anyelement) line 7 at RETURN
 -- test different types of date/time arguments
 select dateadd(hour, 2, '23:12:34.876543'::time);
      dateadd     

--- a/contrib/babelfishpg_tsql/expected/test/babel_function.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_function.out
@@ -1570,6 +1570,7 @@ select dateadd(microsecond, 123456, '20060830'::datetime);
 ERROR:  The datepart microsecond is not supported by date function dateadd for data type datetime.
 CONTEXT:  PL/pgSQL function sys.dateadd_internal(text,integer,anyelement) line 43 at RAISE
 PL/pgSQL function sys.dateadd(text,integer,anyelement) line 7 at RETURN
+select dateadd(nanosecond, 123456, '20060830'::datetime);
 ERROR:  The datepart nanosecond is not supported by date function dateadd for data type datetime.
 CONTEXT:  PL/pgSQL function sys.dateadd_internal(text,integer,anyelement) line 53 at RAISE
 PL/pgSQL function sys.dateadd(text,integer,anyelement) line 7 at RETURN

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1205,7 +1205,7 @@ BEGIN
 	WHEN 'millisecond' THEN
 		RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.001);
 	WHEN 'microsecond' THEN
-        RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.000001);
+		RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.000001);
 	WHEN 'nanosecond' THEN
 		-- Best we can do - Postgres does not support nanosecond precision
 		RETURN startdate OPERATOR(sys.+) make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -577,7 +577,7 @@ BEGIN
 	WHEN 'millisecond' THEN
 		RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.001);
 	WHEN 'microsecond' THEN
-        RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.000001);
+		RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.000001);
 	WHEN 'nanosecond' THEN
 		-- Best we can do - Postgres does not support nanosecond precision
 		RETURN startdate OPERATOR(sys.+) make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -576,11 +576,11 @@ BEGIN
 		RETURN startdate OPERATOR(sys.+) make_interval(secs => num);
 	WHEN 'millisecond' THEN
 		RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.001);
-    WHEN 'microsecond' THEN
-        RETURN startdate + make_interval(secs => (num::numeric) * 0.000001);
+	WHEN 'microsecond' THEN
+        RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.000001);
 	WHEN 'nanosecond' THEN
 		-- Best we can do - Postgres does not support nanosecond precision
-		RETURN startdate + make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));
+		RETURN startdate OPERATOR(sys.+) make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));
 	ELSE
 		RAISE EXCEPTION '"%" is not a recognized dateadd option.', datepart;
 	END CASE;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -551,13 +551,42 @@ LEFT JOIN pg_proc p ON ao.object_id = CAST(p.oid AS INT)
 WHERE ao.type in ('P', 'RF', 'V', 'TR', 'FN', 'IF', 'TF', 'R');
 GRANT SELECT ON sys.all_sql_modules_internal TO PUBLIC;
 
-CREATE OR REPLACE FUNCTION sys.dateadd(IN datepart PG_CATALOG.TEXT, IN num INTEGER, IN startdate ANYELEMENT) RETURNS ANYELEMENT
-AS
-$body$
+CREATE OR REPLACE FUNCTION sys.dateadd_internal_df(IN datepart PG_CATALOG.TEXT, IN num INTEGER, IN startdate datetimeoffset) RETURNS datetimeoffset AS $$
 BEGIN
-    RETURN sys.dateadd_internal(datepart, num, startdate);
+	CASE datepart
+	WHEN 'year' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(years => num);
+	WHEN 'quarter' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(months => num * 3);
+	WHEN 'month' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(months => num);
+	WHEN 'dayofyear', 'y' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(days => num);
+	WHEN 'day' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(days => num);
+	WHEN 'week' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(weeks => num);
+	WHEN 'weekday' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(days => num);
+	WHEN 'hour' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(hours => num);
+	WHEN 'minute' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(mins => num);
+	WHEN 'second' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(secs => num);
+	WHEN 'millisecond' THEN
+		RETURN startdate OPERATOR(sys.+) make_interval(secs => (num::numeric) * 0.001);
+    WHEN 'microsecond' THEN
+        RETURN startdate + make_interval(secs => (num::numeric) * 0.000001);
+	WHEN 'nanosecond' THEN
+		-- Best we can do - Postgres does not support nanosecond precision
+		RETURN startdate + make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));
+	ELSE
+		RAISE EXCEPTION '"%" is not a recognized dateadd option.', datepart;
+	END CASE;
 END;
-$body$
+$$
+STRICT
 LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.dateadd_internal(IN datepart PG_CATALOG.TEXT, IN num INTEGER, IN startdate ANYELEMENT) RETURNS ANYELEMENT AS $$
@@ -595,9 +624,7 @@ BEGIN
 	WHEN 'millisecond' THEN
 		RETURN startdate + make_interval(secs => (num::numeric) * 0.001);
 	WHEN 'microsecond' THEN
-        IF pg_typeof(startdate) = 'sys.datetimeoffset'::regtype THEN
-            RETURN startdate + make_interval(secs => (num::numeric) * 0.000001);
-        ELSIF pg_typeof(startdate) = 'time'::regtype THEN
+        IF pg_typeof(startdate) = 'time'::regtype THEN
             RETURN startdate + make_interval(secs => (num::numeric) * 0.000001);
         ELSIF pg_typeof(startdate) = 'sys.datetime2'::regtype THEN
             RETURN startdate + make_interval(secs => (num::numeric) * 0.000001);
@@ -607,9 +634,7 @@ BEGIN
             RAISE EXCEPTION 'The datepart % is not supported by date function dateadd for data type datetime.', datepart;
         END IF;
 	WHEN 'nanosecond' THEN
-        IF pg_typeof(startdate) = 'sys.datetimeoffset'::regtype THEN
-            RETURN startdate + make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));
-        ELSIF pg_typeof(startdate) = 'time'::regtype THEN
+        IF pg_typeof(startdate) = 'time'::regtype THEN
             RETURN startdate + make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));
         ELSIF pg_typeof(startdate) = 'sys.datetime2'::regtype THEN
             RETURN startdate + make_interval(secs => TRUNC((num::numeric)* 0.000000001, 6));

--- a/test/JDBC/expected/BABEL-3474-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3474-vu-prepare.out
@@ -34,6 +34,12 @@ go
 create view BABEL_3474_vu_prepare_v12 as (SELECT DATEADD(second,150,cast('1955-12-13' as DATE)));
 go
 
+create view BABEL_3474_vu_prepare_v13 as (SELECT DATEADD(minute, 70, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+go
+
+create view BABEL_3474_vu_prepare_v14 as (SELECT DATEADD(month, 2, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+go
+
 create procedure  BABEL_3474_vu_prepare_p1 as (SELECT DATEADD(microsecond, 56, cast('2016-12-26 12:15:01' as DATETIMEOFFSET)));
 go
 
@@ -68,6 +74,12 @@ create procedure  BABEL_3474_vu_prepare_p11 as (SELECT DATEADD(day,150,cast('12:
 go
 
 create procedure  BABEL_3474_vu_prepare_p12 as (SELECT DATEADD(second,150,cast('1955-12-13' as DATE)));
+go
+
+create procedure  BABEL_3474_vu_prepare_p13 as (SELECT DATEADD(minute, 70, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+go
+
+create procedure  BABEL_3474_vu_prepare_p14 as (SELECT DATEADD(month, 2, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
 go
 
 create function BABEL_3474_vu_prepare_f1()
@@ -151,5 +163,19 @@ create function BABEL_3474_vu_prepare_f12()
 returns DATE as
 begin
 return (SELECT * from DATEADD(second,150,cast('1955-12-13' as DATE)));
+end
+go
+
+create function BABEL_3474_vu_prepare_f13()
+returns DATE as
+begin
+return (SELECT DATEADD(minute, 70, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+end
+go
+
+create function BABEL_3474_vu_prepare_f14()
+returns DATE as
+begin
+return (SELECT DATEADD(month, 2, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
 end
 go

--- a/test/JDBC/expected/BABEL-3474-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3474-vu-verify.out
@@ -112,6 +112,26 @@ GO
 DROP VIEW BABEL_3474_vu_prepare_v12
 GO
 
+SELECT * FROM BABEL_3474_vu_prepare_v13
+GO
+~~START~~
+datetimeoffset
+2016-12-26 16:40:05.5234560 +08:00
+~~END~~
+
+DROP VIEW BABEL_3474_vu_prepare_v13
+GO
+
+SELECT * FROM BABEL_3474_vu_prepare_v14
+GO
+~~START~~
+datetimeoffset
+2017-02-26 15:30:05.5234560 +08:00
+~~END~~
+
+DROP VIEW BABEL_3474_vu_prepare_v14
+GO
+
 EXEC BABEL_3474_vu_prepare_p1
 GO
 ~~START~~
@@ -224,6 +244,26 @@ GO
 ~~ERROR (Message: The datepart second is not supported by date function dateadd for data type date.)~~
 
 DROP procedure BABEL_3474_vu_prepare_p12
+GO
+
+EXEC BABEL_3474_vu_prepare_p13
+GO
+~~START~~
+datetimeoffset
+2016-12-26 16:40:05.5234560 +08:00
+~~END~~
+
+DROP procedure BABEL_3474_vu_prepare_p13
+GO
+
+EXEC BABEL_3474_vu_prepare_p14
+GO
+~~START~~
+datetimeoffset
+2017-02-26 15:30:05.5234560 +08:00
+~~END~~
+
+DROP procedure BABEL_3474_vu_prepare_p14
 GO
 
 SELECT BABEL_3474_vu_prepare_f1()
@@ -350,4 +390,24 @@ date
 ~~ERROR (Message: The datepart second is not supported by date function dateadd for data type date.)~~
 
 DROP FUNCTION BABEL_3474_vu_prepare_f12
+GO
+
+SELECT BABEL_3474_vu_prepare_f13()
+GO
+~~START~~
+date
+2016-12-26
+~~END~~
+
+DROP FUNCTION BABEL_3474_vu_prepare_f13
+GO
+
+SELECT BABEL_3474_vu_prepare_f14()
+GO
+~~START~~
+date
+2017-02-26
+~~END~~
+
+DROP FUNCTION BABEL_3474_vu_prepare_f14
 GO

--- a/test/JDBC/expected/dateadd_internal_df-vu-prepare.out
+++ b/test/JDBC/expected/dateadd_internal_df-vu-prepare.out
@@ -1,0 +1,15 @@
+CREATE VIEW dateadd_internal_df_view_vu_prepare AS
+SELECT dateadd_internal_df('minute',-70,cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+GO
+
+CREATE PROC dateadd_internal_df_proc_vu_prepare AS
+SELECT dateadd_internal_df('minute',-70,cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+GO
+
+CREATE FUNCTION dateadd_internal_df_func_vu_prepare()
+RETURNS sys.DATETIMEOFFSET
+AS
+BEGIN
+    RETURN dateadd_internal_df('minute',-70,cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+END
+GO

--- a/test/JDBC/expected/dateadd_internal_df-vu-verify.out
+++ b/test/JDBC/expected/dateadd_internal_df-vu-verify.out
@@ -1,0 +1,40 @@
+SELECT SYS.dateadd_internal_df('minute', -70, cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+GO
+~~START~~
+datetimeoffset
+2016-12-25 15:20:05.5234560 +08:00
+~~END~~
+
+
+SELECT * FROM dateadd_internal_df_view_vu_prepare
+GO
+~~START~~
+datetimeoffset
+2016-12-25 15:20:05.5234560 +08:00
+~~END~~
+
+
+EXEC dateadd_internal_df_proc_vu_prepare
+GO
+~~START~~
+datetimeoffset
+2016-12-25 15:20:05.5234560 +08:00
+~~END~~
+
+
+SELECT dateadd_internal_df_func_vu_prepare()
+GO
+~~START~~
+datetimeoffset
+2016-12-25 15:20:05.5234560 +08:00
+~~END~~
+
+
+DROP VIEW dateadd_internal_df_view_vu_prepare
+GO
+
+DROP PROC dateadd_internal_df_proc_vu_prepare
+GO
+
+DROP FUNCTION dateadd_internal_df_func_vu_prepare
+GO

--- a/test/JDBC/input/BABEL-3474-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-3474-vu-prepare.sql
@@ -34,6 +34,12 @@ go
 create view BABEL_3474_vu_prepare_v12 as (SELECT DATEADD(second,150,cast('1955-12-13' as DATE)));
 go
 
+create view BABEL_3474_vu_prepare_v13 as (SELECT DATEADD(minute, 70, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+go
+
+create view BABEL_3474_vu_prepare_v14 as (SELECT DATEADD(month, 2, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+go
+
 create procedure  BABEL_3474_vu_prepare_p1 as (SELECT DATEADD(microsecond, 56, cast('2016-12-26 12:15:01' as DATETIMEOFFSET)));
 go
 
@@ -68,6 +74,12 @@ create procedure  BABEL_3474_vu_prepare_p11 as (SELECT DATEADD(day,150,cast('12:
 go
 
 create procedure  BABEL_3474_vu_prepare_p12 as (SELECT DATEADD(second,150,cast('1955-12-13' as DATE)));
+go
+
+create procedure  BABEL_3474_vu_prepare_p13 as (SELECT DATEADD(minute, 70, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+go
+
+create procedure  BABEL_3474_vu_prepare_p14 as (SELECT DATEADD(month, 2, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
 go
 
 create function BABEL_3474_vu_prepare_f1()
@@ -151,5 +163,19 @@ create function BABEL_3474_vu_prepare_f12()
 returns DATE as
 begin
 return (SELECT * from DATEADD(second,150,cast('1955-12-13' as DATE)));
+end
+go
+
+create function BABEL_3474_vu_prepare_f13()
+returns DATE as
+begin
+return (SELECT DATEADD(minute, 70, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
+end
+go
+
+create function BABEL_3474_vu_prepare_f14()
+returns DATE as
+begin
+return (SELECT DATEADD(month, 2, cast('2016-12-26 23:30:05.523456+8' as DATETIMEOFFSET)));
 end
 go

--- a/test/JDBC/input/BABEL-3474-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3474-vu-verify.sql
@@ -58,6 +58,16 @@ GO
 DROP VIEW BABEL_3474_vu_prepare_v12
 GO
 
+SELECT * FROM BABEL_3474_vu_prepare_v13
+GO
+DROP VIEW BABEL_3474_vu_prepare_v13
+GO
+
+SELECT * FROM BABEL_3474_vu_prepare_v14
+GO
+DROP VIEW BABEL_3474_vu_prepare_v14
+GO
+
 EXEC BABEL_3474_vu_prepare_p1
 GO
 DROP procedure BABEL_3474_vu_prepare_p1
@@ -118,6 +128,16 @@ GO
 DROP procedure BABEL_3474_vu_prepare_p12
 GO
 
+EXEC BABEL_3474_vu_prepare_p13
+GO
+DROP procedure BABEL_3474_vu_prepare_p13
+GO
+
+EXEC BABEL_3474_vu_prepare_p14
+GO
+DROP procedure BABEL_3474_vu_prepare_p14
+GO
+
 SELECT BABEL_3474_vu_prepare_f1()
 GO
 DROP FUNCTION BABEL_3474_vu_prepare_f1
@@ -176,4 +196,14 @@ GO
 SELECT BABEL_3474_vu_prepare_f12()
 GO
 DROP FUNCTION BABEL_3474_vu_prepare_f12
+GO
+
+SELECT BABEL_3474_vu_prepare_f13()
+GO
+DROP FUNCTION BABEL_3474_vu_prepare_f13
+GO
+
+SELECT BABEL_3474_vu_prepare_f14()
+GO
+DROP FUNCTION BABEL_3474_vu_prepare_f14
 GO

--- a/test/JDBC/input/functions/dateadd_internal_df-vu-prepare.sql
+++ b/test/JDBC/input/functions/dateadd_internal_df-vu-prepare.sql
@@ -1,0 +1,15 @@
+CREATE VIEW dateadd_internal_df_view_vu_prepare AS
+SELECT dateadd_internal_df('minute',-70,cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+GO
+
+CREATE PROC dateadd_internal_df_proc_vu_prepare AS
+SELECT dateadd_internal_df('minute',-70,cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+GO
+
+CREATE FUNCTION dateadd_internal_df_func_vu_prepare()
+RETURNS sys.DATETIMEOFFSET
+AS
+BEGIN
+    RETURN dateadd_internal_df('minute',-70,cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+END
+GO

--- a/test/JDBC/input/functions/dateadd_internal_df-vu-verify.sql
+++ b/test/JDBC/input/functions/dateadd_internal_df-vu-verify.sql
@@ -1,0 +1,20 @@
+SELECT SYS.dateadd_internal_df('minute', -70, cast('2016-12-26 00:30:05.523456+8' as DATETIMEOFFSET))
+GO
+
+SELECT * FROM dateadd_internal_df_view_vu_prepare
+GO
+
+EXEC dateadd_internal_df_proc_vu_prepare
+GO
+
+SELECT dateadd_internal_df_func_vu_prepare()
+GO
+
+DROP VIEW dateadd_internal_df_view_vu_prepare
+GO
+
+DROP PROC dateadd_internal_df_proc_vu_prepare
+GO
+
+DROP FUNCTION dateadd_internal_df_func_vu_prepare
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -247,6 +247,7 @@ BABEL-SP_SPROC_COLUMNS-dep
 BABEL-3000-dep
 format
 msdb-dbo-syspolicy_system_health_state
+dateadd_internal_df
 sys-all_columns
 sys-all_sql_modules
 sys-assembly_modules


### PR DESCRIPTION
Task: Fix BABEL-3474 Error
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description

For data type datetimeoffset, we don't support datetimeoffset + interval, we need to use OPERATOR(sys.+) for datetimeoffset data type. So in the PR we still use two functions for dateadd function. Also revise babel_function.out file to show correct error message
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).