### PR TITLE
Fixed the default encoding in case of collation lookup failed

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -872,7 +872,7 @@ lookup_collation_table(Oid coll_oid)
 	{
 		coll_info invalid;
 		invalid.oid = InvalidOid;
-		invalid.enc = PG_UTF8;
+		invalid.enc = coll_infos[server_collation_collidx].enc;
 		elog(DEBUG2, "collation oid %d not found, using default collation", coll_oid);
 		return invalid;
 	}

--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -870,9 +870,18 @@ lookup_collation_table(Oid coll_oid)
 	 */
 	if (!found)
 	{
+		int collidx;
+
 		coll_info invalid;
 		invalid.oid = InvalidOid;
-		invalid.enc = coll_infos[server_collation_collidx].enc;
+
+		collidx = get_server_collation_collidx();
+		if (collidx == NOT_FOUND)
+			ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("Encoding corresponding to default server collation could not be found.")));
+		else
+			invalid.enc = coll_infos[collidx].enc;
 		elog(DEBUG2, "collation oid %d not found, using default collation", coll_oid);
 		return invalid;
 	}


### PR DESCRIPTION
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Description
Previously We hardcoded the Server encoding to be used for string datatypes when the collation Lookup failed (Ex PG Default(100), "C"(950) collations). This leads to improper cast of special chars. (Ex pound sign)  to varchar datatype when called in PG_Dialect .With this change we set the encoding based on default server collation in case collation could not be found

### Test Description
- Use case based - InstallCheck-Extensions Tests
- Boundary conditions - N/A
- Arbitrary inputs -N/A
- Negative test cases -N/A
- Minor version upgrade tests - N/A
- Major version upgrade tests - N/A
- Performance tests - N/A
- Tooling impact - N/A
- Client tests - N/A

```
============== dropping database "contrib_regression" ==============
NOTICE:  database "contrib_regression" does not exist, skipping
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test/babel_like              ... ok           31 ms
test test/babel_219               ... ok          105 ms
test test/babel_init              ... ok         5672 ms
test test/babel_select_distinct_top ... ok          120 ms
test test/babel_transaction       ... ok          165 ms
test test/babel_typecode          ... ok          106 ms
test test/babel_uniqueidentifier  ... ok          210 ms
test test/babel_collation         ... ok          343 ms
test test/babel_ddl               ... ok          551 ms
test test/babel_delete            ... ok          206 ms
test test/babel_set_command       ... ok          122 ms
test test/babel_datatype          ... ok     (test process exited with exit code 2)     3915 ms
```
[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).