### PR TITLE
Improvements for sp_addrole, sp_droprole, sp_addrolemember, sp_droprolemember

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -165,9 +165,9 @@ GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_configure(
 	IN varchar(128), IN varchar(128), IN varchar(128)
 ) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME, IN sys.SYSNAME DEFAULT NULL)
+CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
+GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolname" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -165,9 +165,9 @@ GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_configure(
 	IN varchar(128), IN varchar(128), IN varchar(128)
 ) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME, IN sys.SYSNAME DEFAULT NULL)
 AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
+GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolname" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1466,7 +1466,7 @@ create_xp_instance_regread_in_master_dbo_internal(PG_FUNCTION_ARGS)
 
 Datum sp_addrole(PG_FUNCTION_ARGS)
 {
-	char *rolname, *lowercase_rolname, *rolname_arg1;
+	char *rolname, *lowercase_rolname;
 	char *physical_role_name;
 	Oid role_oid;
 	List *parsetree_list;
@@ -1480,41 +1480,11 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
-		rolname_arg1= PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
 		/* Role name is not NULL */
 		if (strlen(rolname) == 0)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
-
-		/*
-		 * If argument 1 exists and if it is empty throwing object or column missing
-		 * or empty and if that passed role does not exist then throw an error specifying
-		 * user, role or group does not exist
-		 */
-		if(rolname_arg1)
-		{
-			if(strlen(rolname_arg1)==0)
-				ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
-					errmsg("An object or column name is missing or empty."
-					" For SELECT INTO statements, verify each column has a name."
-					" For other statements, look for empty alias names."
-					" Aliases defined as \"\" or [] are not allowed."
-					" Change the alias to a valid name.")));
-
-			/* Ensure the database name input argument is lower-case, as all Babel role names are lower-case */
-			lowercase_rolname = lowerstr(rolname_arg1);
-
-			/* Map the logical role name to its physical name in the database.*/
-			physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
-			role_oid = get_role_oid(physical_role_name, true);
-
-			/* Check if the user, group or role already exists */
-			if (!role_oid)
-				ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					errmsg("User, group, or role '%s' does not exists in the current database.", rolname_arg1)));
-		}
 
 		/* Role name cannot contain '\' */
 		if (strchr(rolname, '\\') != NULL)
@@ -1587,7 +1557,7 @@ gen_sp_addrole_subcmds(const char *user)
 	StringInfoData query;
 	List *res;
 	Node *stmt;
-	CreateRoleStmt	*rolestmt;
+	CreateRoleStmt *rolestmt;
 	List *user_options = NIL;
 
 	initStringInfo(&query);
@@ -1625,7 +1595,7 @@ gen_sp_addrole_subcmds(const char *user)
 Datum sp_droprole(PG_FUNCTION_ARGS)
 {
 	char *rolname, *lowercase_rolname;
-	char	*physical_role_name;
+	char *physical_role_name;
 	Oid role_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;
@@ -1742,8 +1712,8 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 {
 	char *rolname, *lowercase_rolname;
 	char *membername, *lowercase_membername;
-	char	*physical_member_name;
-	char	*physical_role_name;
+	char *physical_member_name;
+	char *physical_role_name;
 	Oid role_oid, member_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;
@@ -1852,8 +1822,8 @@ gen_sp_addrolemember_subcmds(const char *user, const char *member)
 	StringInfoData query;
 	List *res;
 	Node *stmt;
-	AccessPriv		*granted;
-	RoleSpec		*grantee;
+	AccessPriv *granted;
+	RoleSpec *grantee;
 	GrantRoleStmt *grant_role;
 
 	initStringInfo(&query);
@@ -1888,7 +1858,7 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 {
 	char *rolname, *lowercase_rolname;
 	char *membername, *lowercase_membername;
-	char	*physical_name;
+	char *physical_name;
 	Oid role_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -22,6 +22,7 @@
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/value.h"
+#include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/rel.h"
@@ -31,8 +32,11 @@
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"
 #include "tcop/utility.h"
+#include "tsearch/ts_locale.h"
 
+#include "catalog.h"
 #include "multidb.h"
+#include "session.h"
 
 PG_FUNCTION_INFO_V1(sp_unprepare);
 PG_FUNCTION_INFO_V1(sp_prepare);
@@ -57,7 +61,6 @@ static List *gen_sp_addrole_subcmds(const char *user);
 static List *gen_sp_droprole_subcmds(const char *user);
 static List *gen_sp_addrolemember_subcmds(const char *user, const char *member);
 static List *gen_sp_droprolemember_subcmds(const char *user, const char *member);
-static void rolname_check(char* rolname);
 
 char *sp_describe_first_result_set_view_name = NULL;
 
@@ -1461,37 +1464,11 @@ create_xp_instance_regread_in_master_dbo_internal(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(0);
 }
 
-/*
- * Internal function to tim leading/trailing whitespaces and check rolname
- * doesn't contain whitespace or backslah
- */
-static void rolname_check(char* rolname)
-{
-	size_t len;
-	char * str = rolname;
-	len = strlen(str);
-
-	while(isspace(str[len - 1])) str[--len] = 0;
-	while(* str && isspace(* str)) ++str, --len;
-
-	memmove(rolname, str, len + 1);
-
-	if (!len)
-		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
-			errmsg("query argument of procedure is null")));
-
-	/* Role name cannot contain '\' */
-	if(strchr(rolname, ' ') != NULL)
-		ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),errmsg("query argument of procedure contains whitespace")));
-
-	/* Role name cannot contain '\' */
-	if(strchr(rolname, '\\') != NULL)
-		ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),errmsg("query argument of procedure contains \\")));
-}
-
 Datum sp_addrole(PG_FUNCTION_ARGS)
 {
-	char *rolname;
+	char *rolname, *lowercase_rolname;
+	char *physical_role_name;
+	Oid role_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;
 	const char *saved_dialect = GetConfigOption("babelfishpg_tsql.sql_dialect", true, true);
@@ -1504,16 +1481,33 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 
-		/*
-		 * Trim leading/trailing whitespaces and check rolname
-		 * doesn't contain whitespace or backslah
-		 */
-		rolname_check(rolname);
+		/* Role name is not NULL */
+		if (strlen(rolname) == 0)
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
+
+		/* Role name cannot contain '\' */
+		if (strchr(rolname, '\\') != NULL)
+			ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("'%s' is not a valid name because it contains invalid characters.", rolname)));
+
+		/* Ensure the database name input argument is lower-case, as all Babel role names are lower-case */
+		lowercase_rolname = lowerstr(rolname);
+
+		/* Map the logical role name to its physical name in the database.*/
+		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		role_oid = get_role_oid(physical_role_name, true);
+
+		/* Check if the user, group or role already exists */
+		if (role_oid)
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("User, group, or role '%s' already exists in the current database.", rolname)));
 
 		/* Advance cmd counter to make the delete visible */
 		CommandCounterIncrement();
 
-		parsetree_list = gen_sp_addrole_subcmds(rolname);
+		parsetree_list = gen_sp_addrole_subcmds(lowercase_rolname);
 
 		/* Run all subcommands */
 		foreach(parsetree_item, parsetree_list)
@@ -1572,9 +1566,8 @@ gen_sp_addrole_subcmds(const char *user)
 
 	if (list_length(res) != 1)
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("Expected 1 statement but get %d statements after parsing",
-						list_length(res))));
+			(errcode(ERRCODE_SYNTAX_ERROR),
+			 errmsg("Expected 1 statement but get %d statements after parsing", list_length(res))));
 
 	stmt = parsetree_nth_stmt(res, 0);
 
@@ -1601,7 +1594,9 @@ gen_sp_addrole_subcmds(const char *user)
 
 Datum sp_droprole(PG_FUNCTION_ARGS)
 {
-	char *rolname;
+	char *rolname, *lowercase_rolname;
+	char	*physical_role_name;
+	Oid role_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;
 	const char *saved_dialect = GetConfigOption("babelfishpg_tsql.sql_dialect", true, true);
@@ -1614,16 +1609,28 @@ Datum sp_droprole(PG_FUNCTION_ARGS)
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 
-		/*
-		 * Trim leading/trailing whitespaces and check rolname
-		 * doesn't contain whitespace or backslah
-		 */
-		rolname_check(rolname);
+		/* Role name is not NULL */
+		if (strlen(rolname) == 0)
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
+
+		/* Ensure the database name input argument is lower-case, as all Babel role names are lower-case */
+		lowercase_rolname = lowerstr(rolname);
+
+		/* Map the logical role name to its physical name in the database.*/
+		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		role_oid = get_role_oid(physical_role_name, true);
+
+		/* Check if the role does not exists*/
+		if(role_oid == InvalidOid || !is_role(role_oid))
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("Cannot drop the role '%s', because it does not exist or you do not have permission.", rolname)));
 
 		/* Advance cmd counter to make the delete visible */
 		CommandCounterIncrement();
 
-		parsetree_list = gen_sp_droprole_subcmds(rolname);
+		parsetree_list = gen_sp_droprole_subcmds(lowercase_rolname);
 
 		/* Run all subcommands */
 		foreach(parsetree_item, parsetree_list)
@@ -1681,9 +1688,8 @@ gen_sp_droprole_subcmds(const char *user)
 
 	if (list_length(res) != 1)
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("Expected 1 statement but get %d statements after parsing",
-						list_length(res))));
+			(errcode(ERRCODE_SYNTAX_ERROR),
+			 errmsg("Expected 1 statement but get %d statements after parsing", list_length(res))));
 
 	stmt = parsetree_nth_stmt(res, 0);
 	dropstmt = (DropRoleStmt *) stmt;
@@ -1704,8 +1710,11 @@ gen_sp_droprole_subcmds(const char *user)
 
 Datum sp_addrolemember(PG_FUNCTION_ARGS)
 {
-	char *rolname;
-	char *membername;
+	char *rolname, *lowercase_rolname;
+	char *membername, *lowercase_membername;
+	char	*physical_member_name;
+	char	*physical_role_name;
+	Oid role_oid, member_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;
 	const char *saved_dialect = GetConfigOption("babelfishpg_tsql.sql_dialect", true, true);
@@ -1719,17 +1728,51 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 		membername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
-		/*
-		 * Trim leading/trailing whitespaces and check rolname,
-		 * membername doesn't contain whitespace or backslah
-		 */
-		rolname_check(rolname);
-		rolname_check(membername);
+		/* Role name, member name is not NULL */
+		if ((strlen(rolname) == 0) || (strlen(membername) == 0))
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
+
+		/* Ensure the database name input argument is lower-case, as all Babel role names, user names are lower-case */
+		lowercase_rolname = lowerstr(rolname);
+		lowercase_membername = lowerstr(membername);
+
+		/* Throws an error if role name and member name are same*/
+		if(strcmp(lowercase_rolname,lowercase_membername)==0)
+			ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("Cannot make a role a member of itself")));
+
+		/* Map the logical member name to its physical name in the database.*/
+		physical_member_name = get_physical_user_name(get_cur_db_name(), lowercase_membername);
+		member_oid = get_role_oid(physical_member_name, true);
+
+		/* Check if the user, group or role does not exists and given member name is an role or user*/
+		if(member_oid == InvalidOid || ( !is_role(member_oid) && !is_user(member_oid) ))
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("User or role '%s' does not exist in this database.", membername)));
+
+		/* Map the logical role name to its physical name in the database.*/
+		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		role_oid = get_role_oid(physical_role_name, true);
+
+		/* Check if the role does not exists and given role name is an role*/
+		if(role_oid == InvalidOid || !is_role(role_oid))
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("Cannot alter the role '%s', because it does not exist or you do not have permission.", rolname)));
+
+		/* Check if the member oid is already a member of given role oid*/
+		if(is_member_of_role_nosuper( role_oid, member_oid))
+			ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("Cannot make a role a member of itself")));
 
 		/* Advance cmd counter to make the delete visible */
 		CommandCounterIncrement();
 
-		parsetree_list = gen_sp_addrolemember_subcmds(rolname, membername);
+		parsetree_list = gen_sp_addrolemember_subcmds(lowercase_rolname, lowercase_membername);
 
 		/* Run all subcommands */
 		foreach(parsetree_item, parsetree_list)
@@ -1789,9 +1832,8 @@ gen_sp_addrolemember_subcmds(const char *user, const char *member)
 
 	if (list_length(res) != 1)
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("Expected 1 statement but get %d statements after parsing",
-						list_length(res))));
+			(errcode(ERRCODE_SYNTAX_ERROR),
+			 errmsg("Expected 1 statement but get %d statements after parsing", list_length(res))));
 
 	stmt = parsetree_nth_stmt(res, 0);
 	grant_role = (GrantRoleStmt *) stmt;
@@ -1814,8 +1856,10 @@ gen_sp_addrolemember_subcmds(const char *user, const char *member)
 
 Datum sp_droprolemember(PG_FUNCTION_ARGS)
 {
-	char *rolname;
-	char *membername;
+	char *rolname, *lowercase_rolname;
+	char *membername, *lowercase_membername;
+	char	*physical_name;
+	Oid role_oid;
 	List *parsetree_list;
 	ListCell *parsetree_item;
 	const char *saved_dialect = GetConfigOption("babelfishpg_tsql.sql_dialect", true, true);
@@ -1829,12 +1873,34 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 		membername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
-		/*
-		 * Trim leading/trailing whitespaces and check rolname,
-		 * membername doesn't contain whitespace or backslah
-		 */
-		rolname_check(rolname);
-		rolname_check(membername);
+		/* Role name, member name is not NULL */
+		if ((strlen(rolname) == 0) || (strlen(membername) == 0))
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
+
+		/* Ensure the database name input argument is lower-case, as all Babel role names, user names are lower-case */
+		lowercase_rolname = lowerstr(rolname);
+		lowercase_membername = lowerstr(membername);
+
+		/* Map the logical role name to its physical name in the database.*/
+		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		role_oid = get_role_oid(physical_name, true);
+
+		/* Throw an error id the given role name doesn't exist or isn't a role*/
+		if(role_oid == InvalidOid || !is_role(role_oid))
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("Cannot alter the role '%s', because it does not exist or you do not have permission.", rolname)));
+
+		/* Map the logical member name to its physical name in the database.*/
+		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_membername);
+		role_oid = get_role_oid(physical_name, true);
+
+		/* Throw an error id the given member name doesn't exist or isn't a role or user*/
+		if(role_oid == InvalidOid || ( !is_role(role_oid) && !is_user(role_oid) ))
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("Cannot drop the principal '%s', because it does not exist or you do not have permission.", membername)));
 
 		/* Advance cmd counter to make the delete visible */
 		CommandCounterIncrement();
@@ -1899,9 +1965,8 @@ gen_sp_droprolemember_subcmds(const char *user, const char *member)
 
 	if (list_length(res) != 1)
 		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("Expected 1 statement but get %d statements after parsing",
-						list_length(res))));
+			(errcode(ERRCODE_SYNTAX_ERROR),
+			 errmsg("Expected 1 statement but get %d statements after parsing", list_length(res))));
 
 	stmt = parsetree_nth_stmt(res, 0);
 	grant_role = (GrantRoleStmt *) stmt;
@@ -1918,6 +1983,5 @@ gen_sp_droprolemember_subcmds(const char *user, const char *member)
 	grantee->rolename = (char *) member;
 
 	rewrite_object_refs(stmt);
-
 	return res;
 }

--- a/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
@@ -2,7 +2,8 @@
 DROP ROLE sp_addrole_r3;
 GO
 
-DROP ROLE sp_addrole_r2;
+-- Cannot drop the role which contains leading/trailing whitespaces, special characters from DROP ROLE cmd
+Exec sp_droprole '   @sp_addrole_r2   ';
 GO
 
 DROP ROLE sp_addrole_r1;

--- a/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
@@ -1,12 +1,9 @@
 -- tsql
-DROP ROLE sp_addrole_r4;
+DROP ROLE sp_addrole_r3;
 GO
 
 -- Cannot drop the role name contains leading/trailing whitespaces, special characters using DROP ROLE cmd
-Exec sp_droprole '   @sp_addrole_r3   ';
-GO
-
-DROP ROLE sp_addrole_r2;
+Exec sp_droprole '   @sp_addrole_r2   ';
 GO
 
 DROP USER sp_addrole_user;

--- a/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
@@ -1,9 +1,18 @@
 -- tsql
-DROP ROLE sp_addrole_r3;
+DROP ROLE sp_addrole_r4;
 GO
 
--- Cannot drop the role which contains leading/trailing whitespaces, special characters from DROP ROLE cmd
-Exec sp_droprole '   @sp_addrole_r2   ';
+-- Cannot drop the role name contains leading/trailing whitespaces, special characters using DROP ROLE cmd
+Exec sp_droprole '   @sp_addrole_r3   ';
+GO
+
+DROP ROLE sp_addrole_r2;
+GO
+
+DROP USER sp_addrole_user;
+GO
+
+DROP LOGIN sp_addrole_login;
 GO
 
 DROP ROLE sp_addrole_r1;

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -2,46 +2,61 @@
 CREATE ROLE sp_addrole_r1;
 GO
 
+--Throws an error if the argument is empty or contains backslash(\)
+Exec sp_addrole '';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+Exec sp_addrole '\';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: '\' is not a valid name because it contains invalid characters.)~~
+
+
 -- Throws an error when role exists
 Exec sp_addrole 'sp_addrole_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: role "master_sp_addrole_r1" already exists)~~
+~~ERROR (Message: User, group, or role 'sp_addrole_r1' already exists in the current database.)~~
 
 
--- Creates role by removing leading and trailing whitespaces
-Exec sp_addrole '   sp_addrole_r2   ';
+-- Creates role even if it contains leading/trailing spaces, special characters(except \)
+Exec sp_addrole '   @sp_addrole_r2   ';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_addrole_r2'
+WHERE orig_username = '   @sp_addrole_r2   '
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_sp_addrole_r2#!#R#!#sp_addrole_r2#!#master
+master_   @sp_addrole_r2   #!#R#!#   @sp_addrole_r2   #!#master
 ~~END~~
 
 
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_addrole 'sp_addrole_\r3';
+-- sp_addrole is case insensitive, storing all role values in lower case in DB
+EXEC sp_addrole 'SP_ADDROLE_R3';
+GO
+
+-- Throws an error when role exists
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: query argument of procedure contains \)~~
-
-
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_addrole 'sp_addrole_ r3';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: query argument of procedure contains whitespace)~~
+~~ERROR (Message: User, group, or role 'SP_ADDROLE_R3' already exists in the current database.)~~
 
 
 EXEC sp_addrole 'sp_addrole_r3';
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User, group, or role 'sp_addrole_r3' already exists in the current database.)~~
+
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
@@ -51,12 +66,4 @@ GO
 varchar#!#char#!#nvarchar#!#nvarchar
 master_sp_addrole_r3#!#R#!#sp_addrole_r3#!#master
 ~~END~~
-
-
--- Throws an error when role exists
-EXEC sp_addrole 'sp_addrole_r3';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "master_sp_addrole_r3" already exists)~~
 

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -23,7 +23,7 @@ GO
 ~~ERROR (Message: '\' is not a valid name because it contains invalid characters.)~~
 
 
--- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
+-- Throw error if no argument or more than 1 arguments are passed to sp_addrole procedure
 EXEC sp_addrole;
 GO
 ~~ERROR (Code: 201)~~
@@ -38,63 +38,12 @@ GO
 ~~ERROR (Message: procedure sp_addrole has too many arguments specified.)~~
 
 
---If there are 2 arguments then the procedure first checks for whether argument1 name is empty or not
--- If argument is empty throw an error
-EXEC sp_addrole '','';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Name cannot be NULL.)~~
-
-
-EXEC sp_addrole '','sp_addrole_doesnot_exist';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Name cannot be NULL.)~~
-
-
--- Throw an error if 2nd argument is empty or does not exist
-EXEC sp_addrole 'sp_addrole_doesnot_exist','';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
-
-
-EXEC sp_addrole 'sp_addrole_r1','sp_addrole_doesnot_exist';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: User, group, or role 'sp_addrole_doesnot_exist' does not exists in the current database.)~~
-
-
--- If second argument is not empty and contains in database
--- Throws an error if first argument already exists in DB
-EXEC sp_addrole 'sp_addrole_r1','sp_addrole_r1';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: User, group, or role 'sp_addrole_r1' already exists in the current database.)~~
-
-
--- Succesfully executes if first argument does not exist in DB
-EXEC sp_addrole 'sp_addrole_r2','sp_addrole_r1';
-GO
-
 -- Throws an error when role exists in DB
 EXEC sp_addrole 'sp_addrole_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: User, group, or role 'sp_addrole_r1' already exists in the current database.)~~
-
-
-EXEC sp_addrole 'sp_addrole_r2';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: User, group, or role 'sp_addrole_r2' already exists in the current database.)~~
 
 
 EXEC sp_addrole 'sp_addrole_user';
@@ -105,44 +54,44 @@ GO
 
 
 -- Creates role even if it contains leading/trailing spaces, special characters(except \)
-EXEC sp_addrole '   @sp_addrole_r3   ';
+EXEC sp_addrole '   @sp_addrole_r2   ';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = '   @sp_addrole_r3   '
+WHERE orig_username = '   @sp_addrole_r2   '
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_   @sp_addrole_r3   #!#R#!#   @sp_addrole_r3   #!#master
+master_   @sp_addrole_r2   #!#R#!#   @sp_addrole_r2   #!#master
 ~~END~~
 
 
 -- sp_addrole is case insensitive, storing all role values in lower case in DB
-EXEC sp_addrole 'SP_ADDROLE_R4';
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
 -- Throws an error when role exists
-EXEC sp_addrole 'SP_ADDROLE_R4';
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User, group, or role 'SP_ADDROLE_R4' already exists in the current database.)~~
+~~ERROR (Message: User, group, or role 'SP_ADDROLE_R3' already exists in the current database.)~~
 
 
-EXEC sp_addrole 'sp_addrole_r4';
+EXEC sp_addrole 'sp_addrole_r3';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User, group, or role 'sp_addrole_r4' already exists in the current database.)~~
+~~ERROR (Message: User, group, or role 'sp_addrole_r3' already exists in the current database.)~~
 
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_addrole_r4'
+WHERE orig_username = 'sp_addrole_r3'
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_sp_addrole_r4#!#R#!#sp_addrole_r4#!#master
+master_sp_addrole_r3#!#R#!#sp_addrole_r3#!#master
 ~~END~~
 

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -2,68 +2,147 @@
 CREATE ROLE sp_addrole_r1;
 GO
 
+CREATE LOGIN sp_addrole_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_addrole_user FOR LOGIN sp_addrole_login;
+GO
+
 --Throws an error if the argument is empty or contains backslash(\)
-Exec sp_addrole '';
+EXEC sp_addrole '';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Name cannot be NULL.)~~
 
 
-Exec sp_addrole '\';
+EXEC sp_addrole '\';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: '\' is not a valid name because it contains invalid characters.)~~
 
 
--- Throws an error when role exists
-Exec sp_addrole 'sp_addrole_r1';
+-- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
+EXEC sp_addrole;
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_addrole expects parameter "@rolname", which was not supplied.)~~
+
+
+EXEC sp_addrole '','','';
+GO
+~~ERROR (Code: 8144)~~
+
+~~ERROR (Message: procedure sp_addrole has too many arguments specified.)~~
+
+
+--If there are 2 arguments then the procedure first checks for whether argument1 name is empty or not
+-- If argument is empty throw an error
+EXEC sp_addrole '','';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_addrole '','sp_addrole_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+-- Throw an error if 2nd argument is empty or does not exist
+EXEC sp_addrole 'sp_addrole_doesnot_exist','';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
+
+
+EXEC sp_addrole 'sp_addrole_r1','sp_addrole_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User, group, or role 'sp_addrole_doesnot_exist' does not exists in the current database.)~~
+
+
+-- If second argument is not empty and contains in database
+-- Throws an error if first argument already exists in DB
+EXEC sp_addrole 'sp_addrole_r1','sp_addrole_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: User, group, or role 'sp_addrole_r1' already exists in the current database.)~~
 
 
+-- Succesfully executes if first argument does not exist in DB
+EXEC sp_addrole 'sp_addrole_r2','sp_addrole_r1';
+GO
+
+-- Throws an error when role exists in DB
+EXEC sp_addrole 'sp_addrole_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User, group, or role 'sp_addrole_r1' already exists in the current database.)~~
+
+
+EXEC sp_addrole 'sp_addrole_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User, group, or role 'sp_addrole_r2' already exists in the current database.)~~
+
+
+EXEC sp_addrole 'sp_addrole_user';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User, group, or role 'sp_addrole_user' already exists in the current database.)~~
+
+
 -- Creates role even if it contains leading/trailing spaces, special characters(except \)
-Exec sp_addrole '   @sp_addrole_r2   ';
+EXEC sp_addrole '   @sp_addrole_r3   ';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = '   @sp_addrole_r2   '
+WHERE orig_username = '   @sp_addrole_r3   '
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_   @sp_addrole_r2   #!#R#!#   @sp_addrole_r2   #!#master
+master_   @sp_addrole_r3   #!#R#!#   @sp_addrole_r3   #!#master
 ~~END~~
 
 
 -- sp_addrole is case insensitive, storing all role values in lower case in DB
-EXEC sp_addrole 'SP_ADDROLE_R3';
+EXEC sp_addrole 'SP_ADDROLE_R4';
 GO
 
 -- Throws an error when role exists
-EXEC sp_addrole 'SP_ADDROLE_R3';
+EXEC sp_addrole 'SP_ADDROLE_R4';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User, group, or role 'SP_ADDROLE_R3' already exists in the current database.)~~
+~~ERROR (Message: User, group, or role 'SP_ADDROLE_R4' already exists in the current database.)~~
 
 
-EXEC sp_addrole 'sp_addrole_r3';
+EXEC sp_addrole 'sp_addrole_r4';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User, group, or role 'sp_addrole_r3' already exists in the current database.)~~
+~~ERROR (Message: User, group, or role 'sp_addrole_r4' already exists in the current database.)~~
 
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_addrole_r3'
+WHERE orig_username = 'sp_addrole_r4'
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_sp_addrole_r3#!#R#!#sp_addrole_r3#!#master
+master_sp_addrole_r4#!#R#!#sp_addrole_r4#!#master
 ~~END~~
 

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-cleanup.out
@@ -1,4 +1,10 @@
 -- tsql
+DROP USER sp_addrolemember_user;
+GO
+
+DROP LOGIN sp_addrolemember_login;
+GO
+
 DROP ROLE sp_addrolemember_r3;
 GO
 

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
@@ -8,6 +8,34 @@ GO
 CREATE ROLE sp_addrolemember_r3;
 GO
 
+CREATE LOGIN sp_addrolemember_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_addrolemember_user FOR LOGIN sp_addrolemember_login;
+GO
+
+-- Throw error if no argument or more than 2 argument are passed to sp_addrolemember procedure
+EXEC sp_addrolemember;
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_addrolemember expects parameter "@rolname", which was not supplied.)~~
+
+
+EXEC sp_addrolemember '';
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_addrolemember expects parameter "@membername", which was not supplied.)~~
+
+
+EXEC sp_addrolemember '','','';
+GO
+~~ERROR (Code: 8144)~~
+
+~~ERROR (Message: procedure sp_addrolemember has too many arguments specified.)~~
+
+
 -- Throw an error is role/member is empty
 EXEC sp_addrolemember '', '';
 GO
@@ -46,11 +74,26 @@ GO
 ~~ERROR (Message: User or role 'sp_addrolemember_role_doesnot_exist' does not exist in this database.)~~
 
 
+-- Throw an error when role doesn't exist or when an user/login is passed
 Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role 'sp_addrolemember_role_doesnot_exist', because it does not exist or you do not have permission.)~~
+
+
+Exec sp_addrolemember 'sp_addrolemember_user', 'sp_addrolemember_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_addrolemember_user', because it does not exist or you do not have permission.)~~
+
+
+Exec sp_addrolemember 'sp_addrolemember_login', 'sp_addrolemember_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_addrolemember_login', because it does not exist or you do not have permission.)~~
 
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -80,4 +123,17 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot make a role a member of itself)~~
+
+
+-- Can add user, role or group as an member for a role
+Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_user';
+GO
+
+-- Check whether sp_addrolemember_user is rolemember of sp_addrolemember_r1
+SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_user')
+GO
+~~START~~
+int
+1
+~~END~~
 

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
@@ -8,19 +8,26 @@ GO
 CREATE ROLE sp_addrolemember_r3;
 GO
 
--- Throw an error if passed rolename or membername contains \ or between whitespaces
-Exec sp_addrolemember 'sp_addrolemember_ r1', 'sp_addrolemember_r2';
+-- Throw an error is role/member is empty
+EXEC sp_addrolemember '', '';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: query argument of procedure contains whitespace)~~
+~~ERROR (Message: Name cannot be NULL.)~~
 
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_\r2';
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', '';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: query argument of procedure contains \)~~
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_addrolemember '', 'sp_addrolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
 
 
 -- Throw an error when same roles are passed
@@ -28,7 +35,22 @@ Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: role "master_sp_addrolemember_r1" is a member of role "master_sp_addrolemember_r1")~~
+~~ERROR (Message: Cannot make a role a member of itself)~~
+
+
+-- Throw an error when member doesn't exist
+Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User or role 'sp_addrolemember_role_doesnot_exist' does not exist in this database.)~~
+
+
+Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_addrolemember_role_doesnot_exist', because it does not exist or you do not have permission.)~~
 
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -52,23 +74,10 @@ int
 ~~END~~
 
 
--- Executes even if rolename or membername contains leading and trailing whitespaces
-Exec sp_addrolemember '    sp_addrolemember_r1   ', '    sp_addrolemember_r3    ';
-GO
-
--- Check whether sp_addrolemember_r3 is rolemember of sp_addrolemember_r1
-SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_r3')
-GO
-~~START~~
-int
-1
-~~END~~
-
-
--- Throw an error when member doesn't exist
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r4';
+-- Throw an error if role is already a member of member
+Exec sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: role "master_sp_addrolemember_r4" does not exist)~~
+~~ERROR (Message: Cannot make a role a member of itself)~~
 

--- a/test/JDBC/expected/Test-sp_droprole-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_droprole-vu-cleanup.out
@@ -1,3 +1,9 @@
+DROP USER sp_droprole_user;
+GO
+
+DROP LOGIN sp_droprole_login;
+GO
+
 -- Check if catalog is cleaned up
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext

--- a/test/JDBC/expected/Test-sp_droprole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprole-vu-verify.out
@@ -2,53 +2,32 @@
 CREATE ROLE sp_droprole_r1;
 GO
 
-CREATE ROLE sp_droprole_r2;
-GO
-
-DROP ROLE sp_droprole_r1;
-GO
-
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_droprole 'sp_droprole_\r1';
+--Throws an error if the argument is empty or contains backslash(\)
+Exec sp_droprole '';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: query argument of procedure contains \)~~
-
-
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_droprole 'sp_droprole_ r1';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: query argument of procedure contains whitespace)~~
+~~ERROR (Message: Name cannot be NULL.)~~
 
 
 -- Throws an error when the role doesn't exist
-EXEC sp_droprole 'sp_droprole_r1';
+EXEC sp_droprole 'sp_droprole_doesnot_exist';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: role "master_sp_droprole_r1" does not exist)~~
+~~ERROR (Message: Cannot drop the role 'sp_droprole_doesnot_exist', because it does not exist or you do not have permission.)~~
 
 
--- Drops role by removing leading and trailing whitespaces
-EXEC sp_droprole '   sp_droprole_r2   ';
+-- Drops the role when exists
+EXEC sp_droprole 'sp_droprole_r1';
 GO
 
+-- Check role is present in DB
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_droprole_r2'
+WHERE orig_username = 'sp_droprole_r1'
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
 ~~END~~
-
-
--- Throws an error when the role doesn't exist
-EXEC sp_droprole 'sp_droprole_r2';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "master_sp_droprole_r2" does not exist)~~
 

--- a/test/JDBC/expected/Test-sp_droprole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprole-vu-verify.out
@@ -2,12 +2,48 @@
 CREATE ROLE sp_droprole_r1;
 GO
 
+CREATE LOGIN sp_droprole_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_droprole_user FOR LOGIN sp_droprole_login;
+GO
+
+-- Throw error if no argument or more than 1 argument are passed to sp_droprole procedure
+EXEC sp_droprole;
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_droprole expects parameter "@rolname", which was not supplied.)~~
+
+
+EXEC sp_droprole '','','';
+GO
+~~ERROR (Code: 8144)~~
+
+~~ERROR (Message: procedure sp_droprole has too many arguments specified.)~~
+
+
 --Throws an error if the argument is empty or contains backslash(\)
 Exec sp_droprole '';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Name cannot be NULL.)~~
+
+
+--Throw an error when passed argument is not an role
+EXEC sp_droprole 'sp_droprole_user';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'sp_droprole_user', because it does not exist or you do not have permission.)~~
+
+
+EXEC sp_droprole 'sp_droprole_login';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'sp_droprole_login', because it does not exist or you do not have permission.)~~
 
 
 -- Throws an error when the role doesn't exist

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-cleanup.out
@@ -1,7 +1,4 @@
 -- tsql
-DROP ROLE sp_droprolemember_r3;
-GO
-
 DROP ROLE sp_droprolemember_r2;
 GO
 

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-cleanup.out
@@ -1,4 +1,10 @@
 -- tsql
+DROP USER sp_droprolemember_user;
+GO
+
+DROP LOGIN sp_droprolemember_login;
+GO
+
 DROP ROLE sp_droprolemember_r2;
 GO
 

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
@@ -5,9 +5,41 @@ GO
 CREATE ROLE sp_droprolemember_r2;
 GO
 
+CREATE LOGIN sp_droprolemember_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_droprolemember_user FOR LOGIN sp_droprolemember_login;
+GO
+
 -- sp_droprolemember_r1 -> sp_droprolemember_r2
 ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_r2;
 GO
+
+-- sp_droprolemember_r1 -> sp_droprolemember_user
+ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_user;
+GO
+
+-- Throw error if no argument or more than 1 argument are passed to sp_droprolemember procedure
+EXEC sp_droprolemember;
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_droprolemember expects parameter "@rolname", which was not supplied.)~~
+
+
+EXEC sp_droprolemember '';
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_droprolemember expects parameter "@membername", which was not supplied.)~~
+
+
+EXEC sp_droprolemember '','','';
+GO
+~~ERROR (Code: 8144)~~
+
+~~ERROR (Message: procedure sp_droprolemember has too many arguments specified.)~~
+
 
 -- Throw an error is role/member is empty
 EXEC sp_droprolemember '', '';
@@ -39,7 +71,7 @@ GO
 ~~ERROR (Message: Cannot drop the principal 'sp_droprolemember_role_doesnot_exist', because it does not exist or you do not have permission.)~~
 
 
--- Throw an error if role does not exist or user is passed as role
+-- Throw an error if role does not exist or user/login is passed as role
 EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', 'sp_droprolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
@@ -52,6 +84,13 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role 'sp_droprolemember_user', because it does not exist or you do not have permission.)~~
+
+
+EXEC sp_droprolemember 'sp_droprolemember_login', 'sp_droprolemember_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_droprolemember_login', because it does not exist or you do not have permission.)~~
 
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
@@ -68,6 +107,18 @@ GO
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
 SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r2')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_user';
+GO
+
+-- Test whether sp_droprolemember_user is rolemember of sp_droprolemember_r1
+SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_user')
 GO
 ~~START~~
 int

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
@@ -5,30 +5,53 @@ GO
 CREATE ROLE sp_droprolemember_r2;
 GO
 
-CREATE ROLE sp_droprolemember_r3;
-GO
-
 -- sp_droprolemember_r1 -> sp_droprolemember_r2
 ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_r2;
 GO
 
--- sp_droprolemember_r1 -> sp_droprolemember_r3
-ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_r3;
-GO
-
--- Throw an error if passed rolename or membername contains \ or between whitespaces
-Exec sp_droprolemember 'sp_droprolemember_ r1', 'sp_droprolemember_r2';
+-- Throw an error is role/member is empty
+EXEC sp_droprolemember '', '';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: query argument of procedure contains whitespace)~~
+~~ERROR (Message: Name cannot be NULL.)~~
 
 
-Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_\r2';
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', '';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: query argument of procedure contains \)~~
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_droprolemember '', 'sp_droprolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+-- Throw an error if member does not exist
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the principal 'sp_droprolemember_role_doesnot_exist', because it does not exist or you do not have permission.)~~
+
+
+-- Throw an error if role does not exist or user is passed as role
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', 'sp_droprolemember_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_droprolemember_role_doesnot_exist', because it does not exist or you do not have permission.)~~
+
+
+EXEC sp_droprolemember 'sp_droprolemember_user', 'sp_droprolemember_r1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_droprolemember_user', because it does not exist or you do not have permission.)~~
 
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
@@ -50,34 +73,4 @@ GO
 int
 0
 ~~END~~
-
-
--- Check whether sp_droprolemember_r3 is rolemember of sp_droprolemember_r1
-SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r3')
-GO
-~~START~~
-int
-1
-~~END~~
-
-
--- Executes even if rolename or membername contains leading and trailing whitespaces
-Exec sp_droprolemember '    sp_droprolemember_r1   ', '    sp_droprolemember_r3    ';
-GO
-
--- Check whether sp_droprolemember_r3 is rolemember of sp_droprolemember_r1
-SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r3')
-GO
-~~START~~
-int
-0
-~~END~~
-
-
--- Throw an error when member doesn't exist
-Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r4';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "master_sp_droprolemember_r4" does not exist)~~
 

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
@@ -2,7 +2,8 @@
 DROP ROLE sp_addrole_r3;
 GO
 
-DROP ROLE sp_addrole_r2;
+-- Cannot drop the role which contains leading/trailing whitespaces, special characters from DROP ROLE cmd
+Exec sp_droprole '   @sp_addrole_r2   ';
 GO
 
 DROP ROLE sp_addrole_r1;

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
@@ -1,12 +1,9 @@
 -- tsql
-DROP ROLE sp_addrole_r4;
+DROP ROLE sp_addrole_r3;
 GO
 
 -- Cannot drop the role name contains leading/trailing whitespaces, special characters using DROP ROLE cmd
-Exec sp_droprole '   @sp_addrole_r3   ';
-GO
-
-DROP ROLE sp_addrole_r2;
+Exec sp_droprole '   @sp_addrole_r2   ';
 GO
 
 DROP USER sp_addrole_user;

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
@@ -1,9 +1,18 @@
 -- tsql
-DROP ROLE sp_addrole_r3;
+DROP ROLE sp_addrole_r4;
 GO
 
--- Cannot drop the role which contains leading/trailing whitespaces, special characters from DROP ROLE cmd
-Exec sp_droprole '   @sp_addrole_r2   ';
+-- Cannot drop the role name contains leading/trailing whitespaces, special characters using DROP ROLE cmd
+Exec sp_droprole '   @sp_addrole_r3   ';
+GO
+
+DROP ROLE sp_addrole_r2;
+GO
+
+DROP USER sp_addrole_user;
+GO
+
+DROP LOGIN sp_addrole_login;
 GO
 
 DROP ROLE sp_addrole_r1;

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -2,38 +2,81 @@
 CREATE ROLE sp_addrole_r1;
 GO
 
+CREATE LOGIN sp_addrole_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_addrole_user FOR LOGIN sp_addrole_login;
+GO
+
 --Throws an error if the argument is empty or contains backslash(\)
-Exec sp_addrole '';
+EXEC sp_addrole '';
 GO
 
-Exec sp_addrole '\';
+EXEC sp_addrole '\';
 GO
 
--- Throws an error when role exists
-Exec sp_addrole 'sp_addrole_r1';
+-- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
+EXEC sp_addrole;
+GO
+
+EXEC sp_addrole '','','';
+GO
+
+--If there are 2 arguments then the procedure first checks for whether argument1 name is empty or not
+-- If argument is empty throw an error
+EXEC sp_addrole '','';
+GO
+
+EXEC sp_addrole '','sp_addrole_doesnot_exist';
+GO
+
+-- Throw an error if 2nd argument is empty or does not exist
+EXEC sp_addrole 'sp_addrole_doesnot_exist','';
+GO
+
+EXEC sp_addrole 'sp_addrole_r1','sp_addrole_doesnot_exist';
+GO
+
+-- If second argument is not empty and contains in database
+-- Throws an error if first argument already exists in DB
+EXEC sp_addrole 'sp_addrole_r1','sp_addrole_r1';
+GO
+
+-- Succesfully executes if first argument does not exist in DB
+EXEC sp_addrole 'sp_addrole_r2','sp_addrole_r1';
+GO
+
+-- Throws an error when role exists in DB
+EXEC sp_addrole 'sp_addrole_r1';
+GO
+
+EXEC sp_addrole 'sp_addrole_r2';
+GO
+
+EXEC sp_addrole 'sp_addrole_user';
 GO
 
 -- Creates role even if it contains leading/trailing spaces, special characters(except \)
-Exec sp_addrole '   @sp_addrole_r2   ';
+EXEC sp_addrole '   @sp_addrole_r3   ';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = '   @sp_addrole_r2   '
+WHERE orig_username = '   @sp_addrole_r3   '
 GO
 
 -- sp_addrole is case insensitive, storing all role values in lower case in DB
-EXEC sp_addrole 'SP_ADDROLE_R3';
+EXEC sp_addrole 'SP_ADDROLE_R4';
 GO
 
 -- Throws an error when role exists
-EXEC sp_addrole 'SP_ADDROLE_R3';
+EXEC sp_addrole 'SP_ADDROLE_R4';
 GO
 
-EXEC sp_addrole 'sp_addrole_r3';
+EXEC sp_addrole 'sp_addrole_r4';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_addrole_r3'
+WHERE orig_username = 'sp_addrole_r4'
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -15,68 +15,41 @@ GO
 EXEC sp_addrole '\';
 GO
 
--- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
+-- Throw error if no argument or more than 1 arguments are passed to sp_addrole procedure
 EXEC sp_addrole;
 GO
 
 EXEC sp_addrole '','','';
 GO
 
---If there are 2 arguments then the procedure first checks for whether argument1 name is empty or not
--- If argument is empty throw an error
-EXEC sp_addrole '','';
-GO
-
-EXEC sp_addrole '','sp_addrole_doesnot_exist';
-GO
-
--- Throw an error if 2nd argument is empty or does not exist
-EXEC sp_addrole 'sp_addrole_doesnot_exist','';
-GO
-
-EXEC sp_addrole 'sp_addrole_r1','sp_addrole_doesnot_exist';
-GO
-
--- If second argument is not empty and contains in database
--- Throws an error if first argument already exists in DB
-EXEC sp_addrole 'sp_addrole_r1','sp_addrole_r1';
-GO
-
--- Succesfully executes if first argument does not exist in DB
-EXEC sp_addrole 'sp_addrole_r2','sp_addrole_r1';
-GO
-
 -- Throws an error when role exists in DB
 EXEC sp_addrole 'sp_addrole_r1';
-GO
-
-EXEC sp_addrole 'sp_addrole_r2';
 GO
 
 EXEC sp_addrole 'sp_addrole_user';
 GO
 
 -- Creates role even if it contains leading/trailing spaces, special characters(except \)
-EXEC sp_addrole '   @sp_addrole_r3   ';
+EXEC sp_addrole '   @sp_addrole_r2   ';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = '   @sp_addrole_r3   '
+WHERE orig_username = '   @sp_addrole_r2   '
 GO
 
 -- sp_addrole is case insensitive, storing all role values in lower case in DB
-EXEC sp_addrole 'SP_ADDROLE_R4';
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
 -- Throws an error when role exists
-EXEC sp_addrole 'SP_ADDROLE_R4';
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
-EXEC sp_addrole 'sp_addrole_r4';
+EXEC sp_addrole 'sp_addrole_r3';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_addrole_r4'
+WHERE orig_username = 'sp_addrole_r3'
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -2,25 +2,32 @@
 CREATE ROLE sp_addrole_r1;
 GO
 
+--Throws an error if the argument is empty or contains backslash(\)
+Exec sp_addrole '';
+GO
+
+Exec sp_addrole '\';
+GO
+
 -- Throws an error when role exists
 Exec sp_addrole 'sp_addrole_r1';
 GO
 
--- Creates role by removing leading and trailing whitespaces
-Exec sp_addrole '   sp_addrole_r2   ';
+-- Creates role even if it contains leading/trailing spaces, special characters(except \)
+Exec sp_addrole '   @sp_addrole_r2   ';
 GO
 
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_addrole_r2'
+WHERE orig_username = '   @sp_addrole_r2   '
 GO
 
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_addrole 'sp_addrole_\r3';
+-- sp_addrole is case insensitive, storing all role values in lower case in DB
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_addrole 'sp_addrole_ r3';
+-- Throws an error when role exists
+EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
 EXEC sp_addrole 'sp_addrole_r3';
@@ -29,8 +36,4 @@ GO
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
 WHERE orig_username = 'sp_addrole_r3'
-GO
-
--- Throws an error when role exists
-EXEC sp_addrole 'sp_addrole_r3';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-cleanup.sql
@@ -1,4 +1,10 @@
 -- tsql
+DROP USER sp_addrolemember_user;
+GO
+
+DROP LOGIN sp_addrolemember_login;
+GO
+
 DROP ROLE sp_addrolemember_r3;
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
@@ -8,6 +8,22 @@ GO
 CREATE ROLE sp_addrolemember_r3;
 GO
 
+CREATE LOGIN sp_addrolemember_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_addrolemember_user FOR LOGIN sp_addrolemember_login;
+GO
+
+-- Throw error if no argument or more than 2 argument are passed to sp_addrolemember procedure
+EXEC sp_addrolemember;
+GO
+
+EXEC sp_addrolemember '';
+GO
+
+EXEC sp_addrolemember '','','';
+GO
+
 -- Throw an error is role/member is empty
 EXEC sp_addrolemember '', '';
 GO
@@ -26,7 +42,14 @@ GO
 Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
 GO
 
+-- Throw an error when role doesn't exist or when an user/login is passed
 Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_user', 'sp_addrolemember_r1';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_login', 'sp_addrolemember_r1';
 GO
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -42,4 +65,12 @@ GO
 
 -- Throw an error if role is already a member of member
 Exec sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
+GO
+
+-- Can add user, role or group as an member for a role
+Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_user';
+GO
+
+-- Check whether sp_addrolemember_user is rolemember of sp_addrolemember_r1
+SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_user')
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
@@ -8,15 +8,25 @@ GO
 CREATE ROLE sp_addrolemember_r3;
 GO
 
--- Throw an error if passed rolename or membername contains \ or between whitespaces
-Exec sp_addrolemember 'sp_addrolemember_ r1', 'sp_addrolemember_r2';
+-- Throw an error is role/member is empty
+EXEC sp_addrolemember '', '';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_\r2';
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', '';
+GO
+
+EXEC sp_addrolemember '', 'sp_addrolemember_role_doesnot_exist';
 GO
 
 -- Throw an error when same roles are passed
 Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r1';
+GO
+
+-- Throw an error when member doesn't exist
+Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
 GO
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -30,14 +40,6 @@ GO
 SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_r2')
 GO
 
--- Executes even if rolename or membername contains leading and trailing whitespaces
-Exec sp_addrolemember '    sp_addrolemember_r1   ', '    sp_addrolemember_r3    ';
-GO
-
--- Check whether sp_addrolemember_r3 is rolemember of sp_addrolemember_r1
-SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_r3')
-GO
-
--- Throw an error when member doesn't exist
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r4';
+-- Throw an error if role is already a member of member
+Exec sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-cleanup.sql
@@ -1,3 +1,9 @@
+DROP USER sp_droprole_user;
+GO
+
+DROP LOGIN sp_droprole_login;
+GO
+
 -- Check if catalog is cleaned up
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext

--- a/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
@@ -2,33 +2,20 @@
 CREATE ROLE sp_droprole_r1;
 GO
 
-CREATE ROLE sp_droprole_r2;
-GO
-
-DROP ROLE sp_droprole_r1;
-GO
-
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_droprole 'sp_droprole_\r1';
-GO
-
--- Throw an error if rolname contains whitespaces or \ in it
-Exec sp_droprole 'sp_droprole_ r1';
+--Throws an error if the argument is empty or contains backslash(\)
+Exec sp_droprole '';
 GO
 
 -- Throws an error when the role doesn't exist
+EXEC sp_droprole 'sp_droprole_doesnot_exist';
+GO
+
+-- Drops the role when exists
 EXEC sp_droprole 'sp_droprole_r1';
 GO
 
--- Drops role by removing leading and trailing whitespaces
-EXEC sp_droprole '   sp_droprole_r2   ';
-GO
-
+-- Check role is present in DB
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
-WHERE orig_username = 'sp_droprole_r2'
-GO
-
--- Throws an error when the role doesn't exist
-EXEC sp_droprole 'sp_droprole_r2';
+WHERE orig_username = 'sp_droprole_r1'
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
@@ -2,8 +2,28 @@
 CREATE ROLE sp_droprole_r1;
 GO
 
+CREATE LOGIN sp_droprole_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_droprole_user FOR LOGIN sp_droprole_login;
+GO
+
+-- Throw error if no argument or more than 1 argument are passed to sp_droprole procedure
+EXEC sp_droprole;
+GO
+
+EXEC sp_droprole '','','';
+GO
+
 --Throws an error if the argument is empty or contains backslash(\)
 Exec sp_droprole '';
+GO
+
+--Throw an error when passed argument is not an role
+EXEC sp_droprole 'sp_droprole_user';
+GO
+
+EXEC sp_droprole 'sp_droprole_login';
 GO
 
 -- Throws an error when the role doesn't exist

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-cleanup.sql
@@ -1,7 +1,4 @@
 -- tsql
-DROP ROLE sp_droprolemember_r3;
-GO
-
 DROP ROLE sp_droprolemember_r2;
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-cleanup.sql
@@ -1,4 +1,10 @@
 -- tsql
+DROP USER sp_droprolemember_user;
+GO
+
+DROP LOGIN sp_droprolemember_login;
+GO
+
 DROP ROLE sp_droprolemember_r2;
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
@@ -5,22 +5,29 @@ GO
 CREATE ROLE sp_droprolemember_r2;
 GO
 
-CREATE ROLE sp_droprolemember_r3;
-GO
-
 -- sp_droprolemember_r1 -> sp_droprolemember_r2
 ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_r2;
 GO
 
--- sp_droprolemember_r1 -> sp_droprolemember_r3
-ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_r3;
+-- Throw an error is role/member is empty
+EXEC sp_droprolemember '', '';
 GO
 
--- Throw an error if passed rolename or membername contains \ or between whitespaces
-Exec sp_droprolemember 'sp_droprolemember_ r1', 'sp_droprolemember_r2';
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', '';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_\r2';
+EXEC sp_droprolemember '', 'sp_droprolemember_role_doesnot_exist';
+GO
+
+-- Throw an error if member does not exist
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_role_doesnot_exist';
+GO
+
+-- Throw an error if role does not exist or user is passed as role
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', 'sp_droprolemember_r1';
+GO
+
+EXEC sp_droprolemember 'sp_droprolemember_user', 'sp_droprolemember_r1';
 GO
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
@@ -32,20 +39,4 @@ GO
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
 SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r2')
-GO
-
--- Check whether sp_droprolemember_r3 is rolemember of sp_droprolemember_r1
-SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r3')
-GO
-
--- Executes even if rolename or membername contains leading and trailing whitespaces
-Exec sp_droprolemember '    sp_droprolemember_r1   ', '    sp_droprolemember_r3    ';
-GO
-
--- Check whether sp_droprolemember_r3 is rolemember of sp_droprolemember_r1
-SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r3')
-GO
-
--- Throw an error when member doesn't exist
-Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r4';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
@@ -5,8 +5,28 @@ GO
 CREATE ROLE sp_droprolemember_r2;
 GO
 
+CREATE LOGIN sp_droprolemember_login WITH PASSWORD = '123';
+GO
+
+CREATE USER sp_droprolemember_user FOR LOGIN sp_droprolemember_login;
+GO
+
 -- sp_droprolemember_r1 -> sp_droprolemember_r2
 ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_r2;
+GO
+
+-- sp_droprolemember_r1 -> sp_droprolemember_user
+ALTER ROLE sp_droprolemember_r1 ADD MEMBER sp_droprolemember_user;
+GO
+
+-- Throw error if no argument or more than 1 argument are passed to sp_droprolemember procedure
+EXEC sp_droprolemember;
+GO
+
+EXEC sp_droprolemember '';
+GO
+
+EXEC sp_droprolemember '','','';
 GO
 
 -- Throw an error is role/member is empty
@@ -23,11 +43,14 @@ GO
 EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_role_doesnot_exist';
 GO
 
--- Throw an error if role does not exist or user is passed as role
+-- Throw an error if role does not exist or user/login is passed as role
 EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', 'sp_droprolemember_r1';
 GO
 
 EXEC sp_droprolemember 'sp_droprolemember_user', 'sp_droprolemember_r1';
+GO
+
+EXEC sp_droprolemember 'sp_droprolemember_login', 'sp_droprolemember_r1';
 GO
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
@@ -39,4 +62,11 @@ GO
 
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
 SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r2')
+GO
+
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_user';
+GO
+
+-- Test whether sp_droprolemember_user is rolemember of sp_droprolemember_r1
+SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_user')
 GO


### PR DESCRIPTION
Signed-off-by: vasavi suthapalli <svasusri@amazon.com>

### Description
Previously the sp_addrole, sp_droprole, sp_addrolemember, sp_droprolemember doesn't consider case insensitivity and removes trailing/leading whitespaces when rolname is passed as an argument, throws error if the rolname contains between spaces.

Now the procedures follow case insensitivity by converting rolname to lower case and storing them in DB, not removing trailing/leading whitespaces for argument. Followed SQL server for behaviour of procedures and implemented the same. Add tests related to empty argument, invalid rolname for procedures.
 
### Issues Resolved
BABEL-3660

### Testing scenarios covered
- Use case based - Add tests in JDBC
- Boundary conditions - The arguments for the procedures are required, throws error if didn't pass required arguments or if given name is empty
- Arbitrary inputs
   - sp_addrole :  Throw error when name is empty or it contains invalid characters(\)
   - sp_droprole: Throw error when name is empty
   - sp_addrolemember, sp_droprolemember: Throw error is any of the argument is empty
- Negative test cases
   - sp_addrole: Throw error when role exists in DB
   - sp_droprole: Throw error when role doesn't exists in DB
   - sp_addrolemember, sp_droprolemember: Throw error when role doesn't exists in DB
- Minor version upgrade tests - Add dependency, vu tests
- Major version upgrade tests - Add dependency, vu tests
- Performance tests - N/A
- Tooling impact - N/A
- Client tests - N/A
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).