### PR TITLE
Fix babel_function file

### DIFF
--- a/contrib/babelfishpg_tsql/expected/test/babel_function.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_function.out
@@ -109,6 +109,12 @@ SELECT * FROM employee_audits;
   1 |           2 | D
 (1 row)
 
+-- cleanup
+drop function test_func;
+drop table employees;
+drop table employee_audits;
+drop function log_last_name_changes;
+
 -- test executing a plpgsql function in tsql dialect
 CREATE OR REPLACE FUNCTION test_increment(i integer) RETURNS integer AS $$
 BEGIN
@@ -2603,10 +2609,6 @@ LINE 1: SELECT COUNT(ALL *) from t3;
 DROP TABLE t2;
 DROP TABLE t3;
 -- clean up
-drop function test_func;
-drop table employees;
-drop table employee_audits;
-drop function log_last_name_changes;
 drop function test_increment;
 drop function test_increment1;
 drop table dateadd_table;

--- a/contrib/babelfishpg_tsql/sql/test/babel_function.sql
+++ b/contrib/babelfishpg_tsql/sql/test/babel_function.sql
@@ -70,6 +70,13 @@ show babelfishpg_tsql.sql_dialect;
 SELECT * FROM employees;
 SELECT * FROM employee_audits;
 
+-- cleanup
+drop function test_func;
+drop table employees;
+drop table employee_audits;
+drop function log_last_name_changes;
+
+
 -- test executing a plpgsql function in tsql dialect
 CREATE OR REPLACE FUNCTION test_increment(i integer) RETURNS integer AS $$
 BEGIN
@@ -635,10 +642,6 @@ DROP TABLE t2;
 DROP TABLE t3;
 
 -- clean up
-drop function test_func;
-drop table employees;
-drop table employee_audits;
-drop function log_last_name_changes;
 drop function test_increment;
 drop function test_increment1;
 drop table dateadd_table;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1302,6 +1302,10 @@ get_tsql_trigger_oid(List *object, const char *tsql_trigger_name, bool object_fr
 			relation = RelationIdGetRelation(reloid);
 			pg_trigger_physical_schema = get_namespace_name(get_rel_namespace(pg_trigger->tgrelid));
 			pg_trigger_logical_schema = get_logical_schema_name(pg_trigger_physical_schema, true);
+			if(pg_trigger_physical_schema == NULL || cur_physical_schema == NULL)
+				ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					errmsg("trigger \"%s\" does not exist", tsql_trigger_name)));
 			if(strcasecmp(pg_trigger_physical_schema,cur_physical_schema) == 0)
 			{
 				trigger_rel_oid = reloid;

--- a/test/JDBC/expected/BABEL-2455.out
+++ b/test/JDBC/expected/BABEL-2455.out
@@ -267,9 +267,9 @@ go
 
 DROP TRIGGER .tr2455;
 go
-~~ERROR (Code: 3701)~~
+~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: trigger "tr2455" does not exist)~~
+~~ERROR (Message: trigger "dbo.tr2455" does not exist)~~
 
 
 CREATE TRIGGER ..tr2455 on t2455_base AFTER INSERT AS print 'triggered';
@@ -310,9 +310,9 @@ go
 
 DROP TRIGGER .s2455.tr2455;
 go
-~~ERROR (Code: 3701)~~
+~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: trigger "tr2455" does not exist)~~
+~~ERROR (Message: trigger "s2455.tr2455" does not exist)~~
 
 
 -- servername (not supported)


### PR DESCRIPTION
Task:BABEL-3656
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description

Test is failed due to incorrect sql_dialect when dropping trigger. get_tsql_trigger_oid function will crush using strcasecmp if one of the compared string is NULL. In this PR, we move the drop trigger query to psql dialect and also add a check in get_tsql_trigger_oid function.
 
### Issues Resolved

BABEL-3656


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).