### PR TITLE
PSQLODBC Datatype Test for SMALLINT

### DIFF
--- a/test/odbc/psqlodbc/conversion_functions_common.cpp
+++ b/test/odbc/psqlodbc/conversion_functions_common.cpp
@@ -151,6 +151,31 @@ vector<int> getExpectedResults_Int(const vector<string> &data) {
   return expectedResults;
 }
 
+short int stringToShortInt(const string &value) {
+  if (value == "NULL") {
+    // Return a dummy value of zero.
+    return 0;
+  }
+  int full_size = std::stoi(value.c_str(), NULL, 10);
+
+  // Convert to short int
+  if (full_size <= static_cast<int>(INT16_MAX) && full_size >= static_cast<int>(INT16_MIN)) {
+    return static_cast<short int>(full_size);
+  }
+
+  // Conversion failed / out of range, return dummy value
+  return 0;
+}
+
+vector<short int> getExpectedResults_ShortInt(const vector<string> &data) {
+  vector<short int> expectedResults{};
+
+  for (int i = 0; i < data.size(); i++) {
+    expectedResults.push_back(stringToShortInt(data[i]));
+  }
+  return expectedResults;
+}
+
 float stringToFloat(const string &value) {
   if (value == "NULL") {
     // Return a dummy value of zero.

--- a/test/odbc/psqlodbc/conversion_functions_common.h
+++ b/test/odbc/psqlodbc/conversion_functions_common.h
@@ -122,6 +122,22 @@ int stringToInt(const string &value);
 vector<int> getExpectedResults_Int(const vector<string> &data);
 
 /**
+ * Convert a string to an short int.
+ * 
+ * @param value The string to convert.
+ * @return The short int value converted from the string.
+*/
+short int stringToShortInt(const string &value);
+
+/**
+ * Convert a vector of strings to vector of short ints.
+ * 
+ * @param data The vector of strings to convert.
+ * @return The vector of short ints converted from the vector of strings.
+*/
+vector<short int> getExpectedResults_ShortInt(const vector<string> &data);
+
+/**
  * Convert a string to a float.
  * 
  * @param value The string to convert.

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
@@ -471,8 +471,8 @@ void testUpdateFail(ServerType serverType, const string &tableName, const string
     EXPECT_EQ(rcode, SQL_SUCCESS);
     EXPECT_EQ(pk_len, INT_BYTES_EXPECTED);
     EXPECT_EQ(pk, pkValue);
-    EXPECT_EQ(data_len, expectedInsertedValues[i].size());
-    EXPECT_EQ(data, expectedInsertedValues[i]);
+    EXPECT_EQ(data_len, expectedInsertedValues[0].size());
+    EXPECT_EQ(data, expectedInsertedValues[0]);
 
     rcode = SQLFetch(odbcHandler.GetStatementHandle());
     EXPECT_EQ(rcode, SQL_NO_DATA);

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
@@ -1,12 +1,5 @@
 #include "psqlodbc_tests_common.h"
 
-vector<string> duplicateElements(vector<string> input) {
-  typedef std::move_iterator<decltype(input)::iterator> VecMoveIter;
-  std::vector<string> duplicated(input);
-  std::copy(VecMoveIter(input.begin()), VecMoveIter(input.end()), std::back_inserter(duplicated));
-  return duplicated;
-}
-
 // helper function to initialize insert string (1, "", "", ""), etc.
 string InitializeInsertString(const vector<string>& insertedValues, bool isNumericInsert, int pkStartingValue) {
 

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.h
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.h
@@ -26,7 +26,7 @@ const int INT_BYTES_EXPECTED = 4;
  * @return vector which has the elements duplicated and appended
  */ 
 template <typename T>
-vector<string> duplicateElements(vector<string> input);
+vector<T> duplicateElements(vector<T> input);
 
 /**
  * Create a string that can be used in an insert statement. Assumes there is a column associated with

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.h
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.h
@@ -662,8 +662,8 @@ void testUpdateFail(ServerType serverType, const string &tableName, const string
     EXPECT_EQ(rcode, SQL_SUCCESS);
     EXPECT_EQ(pk_len, INT_BYTES_EXPECTED);
     EXPECT_EQ(pk, pkValue);
-    EXPECT_EQ(data_len, expectedInsertedLen[i]);
-    EXPECT_EQ(data, expectedInsertedValues[i]);
+    EXPECT_EQ(data_len, expectedInsertedLen[0]);
+    EXPECT_EQ(data, expectedInsertedValues[0]);
 
     rcode = SQLFetch(odbcHandler.GetStatementHandle());
     EXPECT_EQ(rcode, SQL_NO_DATA);

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.h
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.h
@@ -25,6 +25,7 @@ const int INT_BYTES_EXPECTED = 4;
  * @param input Vector of data to be duplicated
  * @return vector which has the elements duplicated and appended
  */ 
+template <typename T>
 vector<string> duplicateElements(vector<string> input);
 
 /**
@@ -497,6 +498,12 @@ string formatNumericWithScale(string decimal, const int &scale, const bool &is_b
 void formatNumericExpected(vector<string> &vec, const int &scale, const bool &is_bbf);
 
 /** Implementation of templated functions below **/
+template <typename T>
+vector<T> duplicateElements(vector<T> input) {
+  std::vector<T> duplicated(input);
+  duplicated.insert(duplicated.end(), input.begin(), input.end());
+  return duplicated;
+}
 
 template <typename T>
 void verifyValuesInObject(ServerType serverType, string objectName, string orderByColumnName, int type, T data, 

--- a/test/odbc/psqlodbc/smallint.cpp
+++ b/test/odbc/psqlodbc/smallint.cpp
@@ -178,6 +178,8 @@ TEST_F(PSQL_DataTypes_SmallInt, Update_Fail) {
   const vector<long> EXPECTED_INSERT_LEN(INSERTED_VALUES.size(), SMALLINT_BYTES_EXPECTED);
 
   const vector<string> UPDATED_VALUES = {
+    "-32769",       // Under Min
+    "32768",        // Over Max
     "9999999999999" // Over
   };
   const vector<long> EXPECTED_UPDATE_LEN(UPDATED_VALUES.size(), SMALLINT_BYTES_EXPECTED);

--- a/test/odbc/psqlodbc/smallint.cpp
+++ b/test/odbc/psqlodbc/smallint.cpp
@@ -1,0 +1,511 @@
+#include "conversion_functions_common.h"
+#include "psqlodbc_tests_common.h"
+
+const string BBF_TABLE_NAME = "master.dbo.smallint_table_odbc_test";
+// For BBF Connection
+//   Cannot prepend database name when creating/dropping view
+//   Must prepend database name when selecting from view
+const string BBF_VIEW_NAME = "dbo.smallint_view_odbc_test";
+const string PG_TABLE_NAME = "master_dbo.smallint_table_odbc_test";
+const string PG_VIEW_NAME = "master_dbo.smallint_view_odbc_test";
+const string COL1_NAME = "pk";
+const string COL2_NAME = "data";
+const string DATATYPE_NAME = "smallint";
+const vector<pair<string, string>> TABLE_COLUMNS = {
+  {COL1_NAME, "INT PRIMARY KEY"},
+  {COL2_NAME, DATATYPE_NAME}
+};
+
+const int SMALLINT_BYTES_EXPECTED = 2;
+
+class PSQL_DataTypes_SmallInt : public testing::Test {
+  void SetUp() override {
+    if (!Drivers::DriverExists(ServerType::PSQL)) {
+      GTEST_SKIP() << "PSQL Driver not present: skipping all tests for this fixture.";
+    }
+    if (!Drivers::DriverExists(ServerType::MSSQL)) {
+      GTEST_SKIP() << "MSSQL Driver not present: skipping all tests for this fixture.";
+    }
+
+    OdbcHandler bbf_test_setup(Drivers::GetDriver(ServerType::MSSQL));
+    bbf_test_setup.ConnectAndExecQuery(DropObjectStatement("TABLE", BBF_TABLE_NAME));
+
+    OdbcHandler pg_test_setup(Drivers::GetDriver(ServerType::PSQL));
+    pg_test_setup.ConnectAndExecQuery(DropObjectStatement("TABLE", PG_TABLE_NAME));
+  }
+
+  void TearDown() override {
+    if (!Drivers::DriverExists(ServerType::PSQL)) {
+      GTEST_SKIP() << "PSQL Driver not present: skipping all tests for this fixture.";
+    }
+    if (!Drivers::DriverExists(ServerType::MSSQL)) {
+      GTEST_SKIP() << "MSSQL Driver not present: skipping all tests for this fixture.";
+    }
+
+    OdbcHandler bbf_test_setup(Drivers::GetDriver(ServerType::MSSQL));
+    bbf_test_setup.ConnectAndExecQuery(DropObjectStatement("VIEW", BBF_VIEW_NAME));
+    bbf_test_setup.CloseStmt();
+    bbf_test_setup.ExecQuery(DropObjectStatement("TABLE", BBF_TABLE_NAME));
+    
+    OdbcHandler pg_test_setup(Drivers::GetDriver(ServerType::PSQL));
+    pg_test_setup.ConnectAndExecQuery(DropObjectStatement("VIEW", PG_VIEW_NAME));
+    pg_test_setup.CloseStmt();
+    pg_test_setup.ExecQuery(DropObjectStatement("TABLE", PG_TABLE_NAME));
+  }
+};
+
+TEST_F(PSQL_DataTypes_SmallInt, Table_Creation) {
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  const vector<int> BBF_LENGTH_EXPECTED = {10, 5};
+  const vector<int> BBF_PRECISION_EXPECTED = {10, 5};
+  const vector<int> BBF_SCALE_EXPECTED = {0, 0};
+  const vector<string> BBF_NAME_EXPECTED = {"int", "smallint"};
+
+  testCommonColumnAttributes(ServerType::MSSQL, BBF_TABLE_NAME, 
+    TABLE_COLUMNS.size(), COL1_NAME, 
+    BBF_LENGTH_EXPECTED, BBF_PRECISION_EXPECTED, 
+    BBF_SCALE_EXPECTED, BBF_NAME_EXPECTED);
+
+  const vector<int> PG_LENGTH_EXPECTED = {4, 2};
+  const vector<int> PG_PRECISION_EXPECTED = {0, 0};
+  const vector<int> PG_SCALE_EXPECTED = {0, 0};
+  const vector<string> PG_NAME_EXPECTED = {"int4", "int2"};
+
+  testCommonColumnAttributes(ServerType::PSQL, PG_TABLE_NAME, 
+    TABLE_COLUMNS.size(), COL1_NAME, 
+    PG_LENGTH_EXPECTED, PG_PRECISION_EXPECTED, 
+    PG_SCALE_EXPECTED, PG_NAME_EXPECTED);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Insertion_Success) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  vector<string> inserted_values = {
+    "NULL",
+    "0",
+    "530",
+    "-32768",
+    "32767"
+  };
+  const int NUM_OF_DATA = inserted_values.size();
+
+  vector<short int> expected_values = getExpectedResults_ShortInt(inserted_values);
+  const vector<long> EXPECTED_LEN(expected_values.size() * 2, SMALLINT_BYTES_EXPECTED);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, inserted_values, expected_values, EXPECTED_LEN, 0);
+  insertValuesInTable(ServerType::PSQL, PG_TABLE_NAME, inserted_values, true, NUM_OF_DATA);
+
+  inserted_values = duplicateElements(inserted_values);
+  expected_values = duplicateElements(expected_values);
+
+  verifyValuesInObject(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, SQL_C_SSHORT, 
+                      data, BUFFER_LEN, inserted_values, expected_values, EXPECTED_LEN);
+  verifyValuesInObject(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT, 
+                      data, BUFFER_LEN, inserted_values, expected_values, EXPECTED_LEN);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Insertion_Fail) {
+  const vector<string> INVALID_INSERTED_VALUES = {
+    "-32769", // Under Min
+    "32768"   // Over Max
+  };
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INVALID_INSERTED_VALUES, true);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INVALID_INSERTED_VALUES, true);
+
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Update_Success) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<string> INSERTED_VALUES = {
+    "530"
+  };
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_VALUES);
+  const vector<long> EXPECTED_INSERT_LEN(INSERTED_VALUES.size(), SMALLINT_BYTES_EXPECTED);
+
+  const vector<string> UPDATED_VALUES = {
+    "NULL",
+    "-32768",
+    "32767",
+    "0",
+    "530"
+  };
+  const vector<short int> EXPECTED_UPDATED_VALUES = getExpectedResults_ShortInt(UPDATED_VALUES);
+  const vector<long> EXPECTED_UPDATE_LEN(UPDATED_VALUES.size(), SMALLINT_BYTES_EXPECTED);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_INSERT_LEN);
+
+  testUpdateSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, COL2_NAME, SQL_C_SSHORT, 
+                    data, BUFFER_LEN, UPDATED_VALUES, EXPECTED_UPDATED_VALUES, EXPECTED_UPDATE_LEN);
+  testUpdateSuccess(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, COL2_NAME, SQL_C_SSHORT, 
+                    data, BUFFER_LEN, UPDATED_VALUES, EXPECTED_UPDATED_VALUES, EXPECTED_UPDATE_LEN);
+
+  verifyValuesInObject(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT, 
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_INSERT_LEN);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Update_Fail) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<string> INSERTED_VALUES = {
+    "530"
+  };
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_VALUES);
+  const vector<long> EXPECTED_INSERT_LEN(INSERTED_VALUES.size(), SMALLINT_BYTES_EXPECTED);
+
+  const vector<string> UPDATED_VALUES = {
+    "9999999999999" // Over
+  };
+  const vector<long> EXPECTED_UPDATE_LEN(UPDATED_VALUES.size(), SMALLINT_BYTES_EXPECTED);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_INSERT_LEN, 0);
+
+  testUpdateFail(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, COL2_NAME, SQL_C_SSHORT, 
+                data, BUFFER_LEN, EXPECTED_VALUES, EXPECTED_UPDATE_LEN, UPDATED_VALUES);
+  testUpdateFail(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, COL2_NAME, SQL_C_SSHORT, 
+                data, BUFFER_LEN, EXPECTED_VALUES, EXPECTED_UPDATE_LEN, UPDATED_VALUES);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, View_creation) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<string> INSERTED_VALUES = {
+    "NULL",
+    "0",
+    "530",
+    "-32768",
+    "32767"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_VALUES);
+  const vector<long> EXPECTED_LEN(EXPECTED_VALUES.size(), SMALLINT_BYTES_EXPECTED);
+
+
+  const string BBF_VIEW_QUERY = "SELECT * FROM " + BBF_TABLE_NAME;
+  const string PG_VIEW_QUERY = "SELECT * FROM " + PG_TABLE_NAME;
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_LEN, 0);
+
+  createView(ServerType::MSSQL, BBF_VIEW_NAME, BBF_VIEW_QUERY);
+
+  verifyValuesInObject(ServerType::MSSQL, BBF_VIEW_NAME, COL1_NAME, SQL_C_SSHORT, 
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_LEN);
+  verifyValuesInObject(ServerType::PSQL, PG_VIEW_NAME, COL1_NAME, SQL_C_SSHORT, 
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_LEN);
+
+  dropObject(ServerType::MSSQL, "VIEW", BBF_VIEW_NAME);
+  dropObject(ServerType::PSQL, "VIEW", PG_VIEW_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Table_Single_Primary_Keys) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, "INT"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  
+  const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
+  const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
+
+  const vector<string> PK_COLUMNS = {
+    COL2_NAME
+  };
+
+  string tableConstraints = createTableConstraint("PRIMARY KEY ", PK_COLUMNS);
+
+  const vector<string> INSERTED_VALUES = {
+    "0",
+    "530",
+    "-32768",
+    "32767"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_VALUES);
+  const vector<long> EXPECTED_LEN(NUM_OF_DATA, SMALLINT_BYTES_EXPECTED);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
+
+  testPrimaryKeys(ServerType::MSSQL, BBF_SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+  testPrimaryKeys(ServerType::PSQL, SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_LEN, 0);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, true, NUM_OF_DATA, false);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INSERTED_VALUES, true, NUM_OF_DATA, false);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Table_Composite_Keys) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, "INT"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  
+  const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
+  const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
+
+  const vector<string> PK_COLUMNS = {
+    COL1_NAME,
+    COL2_NAME
+  };
+
+  string tableConstraints = createTableConstraint("PRIMARY KEY ", PK_COLUMNS);
+
+  const vector<string> INSERTED_VALUES = {
+    "0",
+    "530",
+    "-32768",
+    "32767"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_VALUES);
+  const vector<long> EXPECTED_LEN(NUM_OF_DATA, SMALLINT_BYTES_EXPECTED);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
+
+  testPrimaryKeys(ServerType::MSSQL, BBF_SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+  testPrimaryKeys(ServerType::PSQL, SCHEMA_NAME, TABLE_NAME, PK_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_LEN, 0);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, true, 0, false);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INSERTED_VALUES, true, 0, false);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Table_Unique_Constraint) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, "INT"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  
+  const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
+  const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
+
+  const vector<string> UNIQUE_COLUMNS = {
+    COL2_NAME
+  };
+
+  string tableConstraints = createTableConstraint("UNIQUE", UNIQUE_COLUMNS);
+
+  const vector<string> INSERTED_VALUES = {
+    "0",
+    "530",
+    "-32768",
+    "32767"
+  };
+  const int NUM_OF_DATA = INSERTED_VALUES.size();
+
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_VALUES);
+  const vector<long> EXPECTED_LEN(NUM_OF_DATA, SMALLINT_BYTES_EXPECTED);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS, tableConstraints);
+
+  testUniqueConstraint(ServerType::MSSQL, TABLE_NAME, UNIQUE_COLUMNS);
+  testUniqueConstraint(ServerType::PSQL, TABLE_NAME, UNIQUE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_VALUES, EXPECTED_VALUES, EXPECTED_LEN, 0);
+
+  testInsertionFailure(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, INSERTED_VALUES, true, NUM_OF_DATA, false);
+  testInsertionFailure(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, INSERTED_VALUES, true, NUM_OF_DATA, false);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Comparison_Operators) {
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, DATATYPE_NAME + " PRIMARY KEY"},
+    {COL2_NAME, DATATYPE_NAME}
+  };
+
+  const vector<string> INSERTED_PK = {
+    "1000",   // A > B
+    "-60",    // A < B
+    "33"      // A = B
+  };
+
+  const vector<string> INSERTED_DATA = {
+    "-1000",
+    "-50",
+    "33"
+  };
+  const int NUM_OF_DATA = INSERTED_DATA.size();
+
+  // insertString initialization
+  string insertString{};
+  string comma{};
+  for (int i = 0; i < NUM_OF_DATA; i++) {
+    insertString += comma + "(" + INSERTED_PK[i] + "," + INSERTED_DATA[i] + ")";
+    comma = ",";
+  }
+
+  const vector<string> BBF_OPERATIONS_QUERY = {
+    "IIF(" + COL1_NAME + " = " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " <> " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " < " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " <= " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " > " + COL2_NAME + ", '1', '0')",
+    "IIF(" + COL1_NAME + " >= " + COL2_NAME + ", '1', '0')"
+  };
+
+  const vector<string> PG_OPERATIONS_QUERY = {
+    COL1_NAME + "=" + COL2_NAME,
+    COL1_NAME + "<>" + COL2_NAME,
+    COL1_NAME + "<" + COL2_NAME,
+    COL1_NAME + "<=" + COL2_NAME,
+    COL1_NAME + ">" + COL2_NAME,
+    COL1_NAME + ">=" + COL2_NAME
+  };
+
+  // initialization of expected_results
+  vector<vector<char>> expected_results = {};
+
+  for (int i = 0; i < NUM_OF_DATA; i++) {
+    expected_results.push_back({});
+
+    short int data_A = stringToShortInt(INSERTED_PK[i]);
+    short int data_B = stringToShortInt(INSERTED_DATA[i]);    
+
+    expected_results[i].push_back(data_A == data_B ? '1' : '0');
+    expected_results[i].push_back(data_A != data_B ? '1' : '0');
+    expected_results[i].push_back(data_A <  data_B ? '1' : '0');
+    expected_results[i].push_back(data_A <= data_B ? '1' : '0');
+    expected_results[i].push_back(data_A >  data_B ? '1' : '0');
+    expected_results[i].push_back(data_A >= data_B ? '1' : '0');
+  }
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  insertValuesInTable(ServerType::MSSQL, BBF_TABLE_NAME, insertString, NUM_OF_DATA);
+
+  testComparisonOperators(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, COL2_NAME, 
+                          INSERTED_PK, INSERTED_DATA, BBF_OPERATIONS_QUERY, expected_results);
+  testComparisonOperators(ServerType::PSQL, PG_TABLE_NAME, COL1_NAME, COL2_NAME, 
+                          INSERTED_PK, INSERTED_DATA, PG_OPERATIONS_QUERY, expected_results);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}
+
+TEST_F(PSQL_DataTypes_SmallInt, Comparison_Functions) {
+  short int data;
+  const int BUFFER_LEN = 0;
+
+  const vector<string> INSERTED_DATA = {
+    "0",
+    "530",
+    "-32768",
+    "32767"
+  };
+  const int NUM_OF_DATA = INSERTED_DATA.size();
+  const vector<short int> EXPECTED_VALUES = getExpectedResults_ShortInt(INSERTED_DATA);
+  const vector<long> EXPECTED_INSERT_LEN(NUM_OF_DATA, SMALLINT_BYTES_EXPECTED);
+
+  // insertString initialization
+  string insertString{};
+  string comma{};
+  for (int i = 0; i < NUM_OF_DATA; i++) {
+    insertString += comma + "(" + std::to_string(i) + "," + INSERTED_DATA[i] + ")";
+    comma = ",";
+  }
+
+  const vector<string> OPERATIONS_QUERY = {
+    "MIN(" + COL2_NAME + ")",
+    "MAX(" + COL2_NAME + ")",
+    "SUM(" + COL2_NAME + ")",
+    // "AVG(" + COL2_NAME + ")" // NOTE - AVG() causings BBF connection to close
+  };
+  const int NUM_OF_OPERATIONS = OPERATIONS_QUERY.size();
+  const vector<long> EXPECTED_OP_LEN(NUM_OF_OPERATIONS, SMALLINT_BYTES_EXPECTED);
+
+  // initialization of expected_results
+  vector<short int> expected_results = {};
+
+  short int curr = stringToShortInt(INSERTED_DATA[0]);
+  short int min_expected = curr, max_expected = curr, sum = curr;
+  for (int i = 1; i < NUM_OF_DATA; i++) {
+    curr = stringToShortInt(INSERTED_DATA[i]);
+    sum += curr;
+
+    min_expected = std::min(curr, min_expected);
+    max_expected = std::max(curr, max_expected);
+  }
+  expected_results.push_back(min_expected);
+  expected_results.push_back(max_expected);
+  expected_results.push_back(sum);
+  // expected_results.push_back(sum / NUM_OF_DATA);
+
+  // Create a vector of length NUM_OF_OPERATIONS with dumy value of -1 to store column results
+  vector<short int> col_results(NUM_OF_OPERATIONS, -1);
+
+  createTable(ServerType::MSSQL, BBF_TABLE_NAME, TABLE_COLUMNS);
+
+  testInsertionSuccess(ServerType::MSSQL, BBF_TABLE_NAME, COL1_NAME, SQL_C_SSHORT,
+                      data, BUFFER_LEN, INSERTED_DATA, EXPECTED_VALUES, EXPECTED_INSERT_LEN, 0);
+
+  testComparisonFunctions(ServerType::MSSQL, BBF_TABLE_NAME, SQL_C_SSHORT, col_results, 
+                          BUFFER_LEN, OPERATIONS_QUERY, expected_results, EXPECTED_OP_LEN);
+  testComparisonFunctions(ServerType::PSQL, PG_TABLE_NAME, SQL_C_SSHORT, col_results, 
+                          BUFFER_LEN, OPERATIONS_QUERY, expected_results, EXPECTED_OP_LEN);
+
+  dropObject(ServerType::PSQL, "TABLE", PG_TABLE_NAME);
+  dropObject(ServerType::MSSQL, "TABLE", BBF_TABLE_NAME);
+}


### PR DESCRIPTION
### Description
- Added psqlODBC tests for `smallint'
- Templated vector copying. No changes required to other files, use as is.
- Changed update fail function to allow for multiple failed updates. Again, no changes required to other files.

Task: BABELFISH-574
Signed-off-by: Colin Yuen [yuenhcol@amazon.com](mailto:yuenhcol@amazon.com)

#### Note
`AVG()` causes BBF connections to close.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).