### PR TITLE
Upload logs when extension install fails

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -413,6 +413,12 @@ assign_textsize(int newval, void *extra)
 static void
 pltsql_pre_parse_analyze(ParseState *pstate, RawStmt *parseTree)
 {
+	ParseState *p = NULL;
+	if (p->p_target_relation)
+		ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_TABLE),
+						errmsg("dummy error")));
+
 	if (prev_pre_parse_analyze_hook)
 	  prev_pre_parse_analyze_hook(pstate, parseTree);
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,10 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+#all
+BABEL-2917-vu-prepare
+BABEL-2917-vu-verify
+BABEL-2917-vu-cleanup
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
 ignore#!#insertbulk


### PR DESCRIPTION
In jdbc tests the postgres logs are uploaded only if the tests fail. In this commit we upload the logs even when there is a failure in the extension installation step, for easier debugging.

Task: BABEL-3626
Signed-off-by: Avantika Dasgupta <davantik@amazon.com>
