### PR TITLE
Fixed issue with DATABASE_DEFAULT or CATALOG_DEFAULT not being able to use with certain collations

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -543,38 +543,21 @@ find_any_collation(const char *collation_name, bool check_for_server_collation_n
 }
 
 /*
- * translate_collation - Returns index of babelfish collation corresponding to supplied collation_name
+ * translate_collation_utility - utility to find index of babelfish collation corresponding to supplied collation_name
  * by looking into coll_translations array or returns NOT_FOUND.
  */
-int
-translate_collation(const char *collname, bool check_for_server_collation_name_guc)
+static int
+translate_collation_utility(const char *collname)
 {
 	int first = 0;
 	int last = TOTAL_COLL_TRANSLATION_COUNT - 1;
 	int middle = 25; /* optimization: usually it's the default collation (first + last) / 2; */
-	int compare;
-	char *collation_name = NULL;
 	int idx = NOT_FOUND;
-
-	/* Special case handling for database_default and catalog_default collations which should be translated to server_collation_name. */
-	if (!check_for_server_collation_name_guc && (pg_strcasecmp(collname, DATABASE_DEFAULT) == 0 || pg_strcasecmp(collname, CATALOG_DEFAULT) == 0))
-	{
-		init_server_collation_name();
-		if (server_collation_name)
-			collation_name = pstrdup(server_collation_name);
-		else
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("invalid setting detected for babelfishpg_tsql.server_collation_name")));
-	}
-	else
-	{
-		collation_name = pstrdup(collname);
-	}
+	int compare;
 
 	while (first <= last)
 	{
-		compare = pg_strcasecmp(coll_translations[middle].from_collname, collation_name);
+		compare = pg_strcasecmp(coll_translations[middle].from_collname, collname);
 		if (compare < 0)
 			first = middle + 1;
 		else if (compare == 0)
@@ -587,10 +570,38 @@ translate_collation(const char *collname, bool check_for_server_collation_name_g
 
 		middle = (first + last) / 2;
 	}
-
-	if (collation_name)
-		pfree(collation_name);
-
+	return idx;
+}
+/*
+ * translate_collation - Returns index of babelfish collation corresponding to supplied collation_name
+ * by looking into coll_translations array or returns NOT_FOUND.
+ * Here, we handle DATABASE_DEFAULT and CATALOG_DEFAULT somewhat differently. If we encounter such collation
+ * then we have to return index of server_collation_name setting either by translating server_collation_name to
+ * actual collation or by looking into coll_infos table through find_collation().
+ */
+int
+translate_collation(const char *collname, bool check_for_server_collation_name_guc)
+{
+	int idx = NOT_FOUND;
+	/* Special case handling for database_default and catalog_default collations which should be translated to server_collation_name. */
+	if (!check_for_server_collation_name_guc && (pg_strcasecmp(collname, DATABASE_DEFAULT) == 0 || pg_strcasecmp(collname, CATALOG_DEFAULT) == 0))
+	{
+		init_server_collation_name();
+		if (server_collation_name)
+		{
+			idx = translate_collation_utility(collname);
+			if (idx == NOT_FOUND)
+				idx = find_collation(server_collation_name);
+		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("invalid setting detected for babelfishpg_tsql.server_collation_name")));
+	}
+	else
+	{
+		idx = translate_collation_utility(collname);
+	}
 	return idx;
 }
 

--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -589,7 +589,7 @@ translate_collation(const char *collname, bool check_for_server_collation_name_g
 		init_server_collation_name();
 		if (server_collation_name)
 		{
-			idx = translate_collation_utility(collname);
+			idx = translate_collation_utility(server_collation_name);
 			if (idx == NOT_FOUND)
 				idx = find_collation(server_collation_name);
 		}


### PR DESCRIPTION
Fixed issue with DATABASE_DEFAULT or CATALOG_DEFAULT not being able to use with certain collations

### Description
Previously, Use of DATABASE_DEFAULT or CATALOG_DEFAULT was being resolved to default server collation name and then  we try to find corresponding Babelfish collation by looking up in coll_translations table. But that logic was not enough and was failing if Babelfish specific collation was specified as default server collation name (For example, arabic_ci_as and japanese_ci_as). 
This commit updates that logic by doing additional lookup into coll_infos through find_collation() if translation was failed. This way, it is ensure that DATABASE_DEFAULT  or CATALOG_DEFAULT is being resolved to original Babelfish specific collation.

 ### Testing

- Use case based - Tested through existing JDBC test cases which covers DATABASE_DEFAULT or CATALOG_DEFAULT
-  Use case based - Repeated the same test case by setting babelfishpg_tsql.server_collation_name to arabic_ci_as
- Boundary conditions - N/A
- Arbitrary inputs -N/A
- Negative test cases -N/A
- Minor version upgrade tests - N/A
- Major version upgrade tests - N/A
- Performance tests - N/A
- Tooling impact - N/A
- Client tests - N/A

Task: BABEL-3300
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).