### PR TITLE
sp_helpuser 'guest' shows SID = NULL

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2342,6 +2342,7 @@ BEGIN
 					ELSE Ext2.orig_username END 
 					AS SYS.SYSNAME) AS 'RoleName',
 			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN Base4.rolname
+					WHEN Ext1.orig_username = 'guest' THEN CAST(0 AS INT)
 					ELSE Base3.rolname END
 					AS SYS.SYSNAME) AS 'LoginName',
 			   CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2342,13 +2342,13 @@ BEGIN
 					ELSE Ext2.orig_username END 
 					AS SYS.SYSNAME) AS 'RoleName',
 			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN Base4.rolname
-					WHEN Ext1.orig_username = 'guest' THEN CAST(0 AS INT)
 					ELSE Base3.rolname END
 					AS SYS.SYSNAME) AS 'LoginName',
 			   CAST(LogExt.default_database_name AS SYS.SYSNAME) AS 'DefDBName',
 			   CAST(Ext1.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
 			   CAST(Base1.oid AS INT) AS 'UserID',
 			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN CAST(Base4.oid AS INT)
+					WHEN Ext1.orig_username = 'guest' THEN CAST(0 AS INT)
 					ELSE CAST(Base3.oid AS INT) END
 					AS SYS.VARBINARY(85)) AS 'SID'
 		FROM sys.babelfish_authid_user_ext AS Ext1

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3789,6 +3789,7 @@ BEGIN
 			   CAST(Ext1.default_schema_name AS SYS.SYSNAME) AS 'DefSchemaName',
 			   CAST(Base1.oid AS INT) AS 'UserID',
 			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN CAST(Base4.oid AS INT)
+					WHEN Ext1.orig_username = 'guest' THEN CAST(0 AS INT)
 					ELSE CAST(Base3.oid AS INT) END
 					AS SYS.VARBINARY(85)) AS 'SID'
 		FROM sys.babelfish_authid_user_ext AS Ext1


### PR DESCRIPTION
Currently, the SID value for sp_helpuser 'guest' is coming as NULL. It should be 0 instead. With this change, we are returning SID as 0, not NULL.

### Test Scenarios Covered ###
* **Use case based -**
```
1> sp_helpuser 'guest'
2> go
UserName RoleName LoginName DefDBName DefSchemaName UserID SID
-------- -------- --------- --------- ------------- ------ ---
guest public NULL NULL  19112 0x00000000

(1 rows affected)
1> 
```
* **Boundary conditions - N/A**
* **Arbitrary inputs -N/A**
* **Negative test cases -N/A**
* **Minor version upgrade tests -N/A**
* **Major version upgrade tests -N/A**
* **Performance tests -N/A**
* **Tooling impact -N/A**
* **Client tests -N/A**


Task: BABEL-3625
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

