### PR TITLE
Fix crash in prepare_exec_codes

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -2131,6 +2131,13 @@ read_param_def(InlineCodeBlockArgs *args, const char *paramdefstr)
 	 */
 	params = ((CreateFunctionStmt *) (((RawStmt *) linitial(parsetree))->stmt))->parameters;
 
+	/* Throw error if the provided number of arguments are more than the max allowed limit. */
+	if (list_length(params) > FUNC_MAX_ARGS)
+			ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+						errmsg("Too many arguments were provided: %d. The maximum allowed limit is %d",
+							list_length(params), FUNC_MAX_ARGS)));
+
 	args->numargs = list_length(params);
 	args->argtypes = (Oid *) palloc(sizeof(Oid) * args->numargs);
 	args->argtypmods = (int32 *) palloc(sizeof(int32) * args->numargs);

--- a/test/JDBC/expected/TestSPPrepare.out
+++ b/test/JDBC/expected/TestSPPrepare.out
@@ -748,3 +748,69 @@ int
 
 Drop table dbo.tnullvarcharmaxblob
 GO
+
+
+-- Testing With More than 100 bind params
+create table sp_prepare_table (
+c0 int,  c1 int,  c2 int,  c3 int,  c4 int,  c5 int,  c6 int,  c7 int,  c8 int,  c9 int,
+c10 int,  c11 int,  c12 int,  c13 int,  c14 int,  c15 int,  c16 int,  c17 int,  c18 int,  c19 int,
+c20 int,  c21 int,  c22 int,  c23 int,  c24 int,  c25 int,  c26 int,  c27 int,  c28 int,  c29 int,
+c30 int,  c31 int,  c32 int,  c33 int,  c34 int,  c35 int,  c36 int,  c37 int,  c38 int,  c39 int,
+c40 int,  c41 int,  c42 int,  c43 int,  c44 int,  c45 int,  c46 int,  c47 int,  c48 int,  c49 int,
+c50 int,  c51 int,  c52 int,  c53 int,  c54 int,  c55 int,  c56 int,  c57 int,  c58 int,  c59 int,
+c60 int,  c61 int,  c62 int,  c63 int,  c64 int,  c65 int,  c66 int,  c67 int,  c68 int,  c69 int,
+c70 int,  c71 int,  c72 int,  c73 int,  c74 int,  c75 int,  c76 int,  c77 int,  c78 int,  c79 int,
+c80 int,  c81 int,  c82 int,  c83 int,  c84 int,  c85 int,  c86 int,  c87 int,  c88 int,  c89 int,
+c90 int,  c91 int,  c92 int,  c93 int,  c94 int,  c95 int,  c96 int,  c97 int,  c98 int,  c99 int,
+c100 int,  c101 int,  c102 int,  c103 int,  c104 int,  c105 int,  c106 int,  c107 int,  c108 int,  c109 int);
+GO
+
+declare @handle int;
+EXEC sp_prepare @handle output,
+N'
+@c0  int, @c1  int, @c2  int, @c3  int, @c4  int, @c5  int, @c6  int, @c7  int, @c8  int, @c9  int,
+@c10  int, @c11  int, @c12  int, @c13  int, @c14  int, @c15  int, @c16  int, @c17  int, @c18  int, @c19  int,
+@c20  int, @c21  int, @c22  int, @c23  int, @c24  int, @c25  int, @c26  int, @c27  int, @c28  int, @c29  int,
+@c30  int, @c31  int, @c32  int, @c33  int, @c34  int, @c35  int, @c36  int, @c37  int, @c38  int, @c39  int,
+@c40  int, @c41  int, @c42  int, @c43  int, @c44  int, @c45  int, @c46  int, @c47  int, @c48  int, @c49  int,
+@c50  int, @c51  int, @c52  int, @c53  int, @c54  int, @c55  int, @c56  int, @c57  int, @c58  int, @c59  int,
+@c60  int, @c61  int, @c62  int, @c63  int, @c64  int, @c65  int, @c66  int, @c67  int, @c68  int, @c69  int,
+@c70  int, @c71  int, @c72  int, @c73  int, @c74  int, @c75  int, @c76  int, @c77  int, @c78  int, @c79  int,
+@c80  int, @c81  int, @c82  int, @c83  int, @c84  int, @c85  int, @c86  int, @c87  int, @c88  int, @c89  int,
+@c90  int, @c91  int, @c92  int, @c93  int, @c94  int, @c95  int, @c96  int, @c97  int, @c98  int, @c99  int,
+@c100  int, @c101  int, @c102  int, @c103  int, @c104  int, @c105  int, @c106  int, @c107  int, @c108  int, @c109 int
+',
+N'
+insert into sp_prepare_table (
+c0 ,  c1 ,  c2 ,  c3 ,  c4 ,  c5 ,  c6 ,  c7 ,  c8 ,  c9 ,
+c10 ,  c11 ,  c12 ,  c13 ,  c14 ,  c15 ,  c16 ,  c17 ,  c18 ,  c19 ,
+c20 ,  c21 ,  c22 ,  c23 ,  c24 ,  c25 ,  c26 ,  c27 ,  c28 ,  c29 ,
+c30 ,  c31 ,  c32 ,  c33 ,  c34 ,  c35 ,  c36 ,  c37 ,  c38 ,  c39 ,
+c40 ,  c41 ,  c42 ,  c43 ,  c44 ,  c45 ,  c46 ,  c47 ,  c48 ,  c49 ,
+c50 ,  c51 ,  c52 ,  c53 ,  c54 ,  c55 ,  c56 ,  c57 ,  c58 ,  c59 ,
+c60 ,  c61 ,  c62 ,  c63 ,  c64 ,  c65 ,  c66 ,  c67 ,  c68 ,  c69 ,
+c70 ,  c71 ,  c72 ,  c73 ,  c74 ,  c75 ,  c76 ,  c77 ,  c78 ,  c79 ,
+c80 ,  c81 ,  c82 ,  c83 ,  c84 ,  c85 ,  c86 ,  c87 ,  c88 ,  c89 ,
+c90 ,  c91 ,  c92 ,  c93 ,  c94 ,  c95 ,  c96 ,  c97 ,  c98 ,  c99 ,
+c100 ,  c101 ,  c102 ,  c103 ,  c104 ,  c105 ,  c106 ,  c107 ,  c108 ,  c109
+) values (
+@c0 ,  @c1 ,  @c2 ,  @c3 ,  @c4 ,  @c5 ,  @c6 ,  @c7 ,  @c8 ,  @c9 ,
+@c10 ,  @c11 ,  @c12 ,  @c13 ,  @c14 ,  @c15 ,  @c16 ,  @c17 ,  @c18 ,  @c19 ,
+@c20 ,  @c21 ,  @c22 ,  @c23 ,  @c24 ,  @c25 ,  @c26 ,  @c27 ,  @c28 ,  @c29 ,
+@c30 ,  @c31 ,  @c32 ,  @c33 ,  @c34 ,  @c35 ,  @c36 ,  @c37 ,  @c38 ,  @c39 ,
+@c40 ,  @c41 ,  @c42 ,  @c43 ,  @c44 ,  @c45 ,  @c46 ,  @c47 ,  @c48 ,  @c49 ,
+@c50 ,  @c51 ,  @c52 ,  @c53 ,  @c54 ,  @c55 ,  @c56 ,  @c57 ,  @c58 ,  @c59 ,
+@c60 ,  @c61 ,  @c62 ,  @c63 ,  @c64 ,  @c65 ,  @c66 ,  @c67 ,  @c68 ,  @c69 ,
+@c70 ,  @c71 ,  @c72 ,  @c73 ,  @c74 ,  @c75 ,  @c76 ,  @c77 ,  @c78 ,  @c79 ,
+@c80 ,  @c81 ,  @c82 ,  @c83 ,  @c84 ,  @c85 ,  @c86 ,  @c87 ,  @c88 ,  @c89 ,
+@c90 ,  @c91 ,  @c92 ,  @c93 ,  @c94 ,  @c95 ,  @c96 ,  @c97 ,  @c98 ,  @c99 ,
+@c100 ,  @c101 ,  @c102 ,  @c103 ,  @c104 ,  @c105 ,  @c106 ,  @c107 ,  @c108 ,  @c109
+)'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Too many arguments were provided: 110. The maximum allowed limit is 100)~~
+
+
+DROP Table sp_prepare_table
+GO

--- a/test/JDBC/input/storedProcedures/TestSPPrepare.sql
+++ b/test/JDBC/input/storedProcedures/TestSPPrepare.sql
@@ -376,3 +376,65 @@ GO
 
 Drop table dbo.tnullvarcharmaxblob
 GO
+
+
+-- Testing With More than 100 bind params
+create table sp_prepare_table (
+c0 int,  c1 int,  c2 int,  c3 int,  c4 int,  c5 int,  c6 int,  c7 int,  c8 int,  c9 int,
+c10 int,  c11 int,  c12 int,  c13 int,  c14 int,  c15 int,  c16 int,  c17 int,  c18 int,  c19 int,
+c20 int,  c21 int,  c22 int,  c23 int,  c24 int,  c25 int,  c26 int,  c27 int,  c28 int,  c29 int,
+c30 int,  c31 int,  c32 int,  c33 int,  c34 int,  c35 int,  c36 int,  c37 int,  c38 int,  c39 int,
+c40 int,  c41 int,  c42 int,  c43 int,  c44 int,  c45 int,  c46 int,  c47 int,  c48 int,  c49 int,
+c50 int,  c51 int,  c52 int,  c53 int,  c54 int,  c55 int,  c56 int,  c57 int,  c58 int,  c59 int,
+c60 int,  c61 int,  c62 int,  c63 int,  c64 int,  c65 int,  c66 int,  c67 int,  c68 int,  c69 int,
+c70 int,  c71 int,  c72 int,  c73 int,  c74 int,  c75 int,  c76 int,  c77 int,  c78 int,  c79 int,
+c80 int,  c81 int,  c82 int,  c83 int,  c84 int,  c85 int,  c86 int,  c87 int,  c88 int,  c89 int,
+c90 int,  c91 int,  c92 int,  c93 int,  c94 int,  c95 int,  c96 int,  c97 int,  c98 int,  c99 int,
+c100 int,  c101 int,  c102 int,  c103 int,  c104 int,  c105 int,  c106 int,  c107 int,  c108 int,  c109 int);
+GO
+
+declare @handle int;
+EXEC sp_prepare @handle output,
+N'
+@c0  int, @c1  int, @c2  int, @c3  int, @c4  int, @c5  int, @c6  int, @c7  int, @c8  int, @c9  int,
+@c10  int, @c11  int, @c12  int, @c13  int, @c14  int, @c15  int, @c16  int, @c17  int, @c18  int, @c19  int,
+@c20  int, @c21  int, @c22  int, @c23  int, @c24  int, @c25  int, @c26  int, @c27  int, @c28  int, @c29  int,
+@c30  int, @c31  int, @c32  int, @c33  int, @c34  int, @c35  int, @c36  int, @c37  int, @c38  int, @c39  int,
+@c40  int, @c41  int, @c42  int, @c43  int, @c44  int, @c45  int, @c46  int, @c47  int, @c48  int, @c49  int,
+@c50  int, @c51  int, @c52  int, @c53  int, @c54  int, @c55  int, @c56  int, @c57  int, @c58  int, @c59  int,
+@c60  int, @c61  int, @c62  int, @c63  int, @c64  int, @c65  int, @c66  int, @c67  int, @c68  int, @c69  int,
+@c70  int, @c71  int, @c72  int, @c73  int, @c74  int, @c75  int, @c76  int, @c77  int, @c78  int, @c79  int,
+@c80  int, @c81  int, @c82  int, @c83  int, @c84  int, @c85  int, @c86  int, @c87  int, @c88  int, @c89  int,
+@c90  int, @c91  int, @c92  int, @c93  int, @c94  int, @c95  int, @c96  int, @c97  int, @c98  int, @c99  int,
+@c100  int, @c101  int, @c102  int, @c103  int, @c104  int, @c105  int, @c106  int, @c107  int, @c108  int, @c109 int
+',
+N'
+insert into sp_prepare_table (
+c0 ,  c1 ,  c2 ,  c3 ,  c4 ,  c5 ,  c6 ,  c7 ,  c8 ,  c9 ,
+c10 ,  c11 ,  c12 ,  c13 ,  c14 ,  c15 ,  c16 ,  c17 ,  c18 ,  c19 ,
+c20 ,  c21 ,  c22 ,  c23 ,  c24 ,  c25 ,  c26 ,  c27 ,  c28 ,  c29 ,
+c30 ,  c31 ,  c32 ,  c33 ,  c34 ,  c35 ,  c36 ,  c37 ,  c38 ,  c39 ,
+c40 ,  c41 ,  c42 ,  c43 ,  c44 ,  c45 ,  c46 ,  c47 ,  c48 ,  c49 ,
+c50 ,  c51 ,  c52 ,  c53 ,  c54 ,  c55 ,  c56 ,  c57 ,  c58 ,  c59 ,
+c60 ,  c61 ,  c62 ,  c63 ,  c64 ,  c65 ,  c66 ,  c67 ,  c68 ,  c69 ,
+c70 ,  c71 ,  c72 ,  c73 ,  c74 ,  c75 ,  c76 ,  c77 ,  c78 ,  c79 ,
+c80 ,  c81 ,  c82 ,  c83 ,  c84 ,  c85 ,  c86 ,  c87 ,  c88 ,  c89 ,
+c90 ,  c91 ,  c92 ,  c93 ,  c94 ,  c95 ,  c96 ,  c97 ,  c98 ,  c99 ,
+c100 ,  c101 ,  c102 ,  c103 ,  c104 ,  c105 ,  c106 ,  c107 ,  c108 ,  c109
+) values (
+@c0 ,  @c1 ,  @c2 ,  @c3 ,  @c4 ,  @c5 ,  @c6 ,  @c7 ,  @c8 ,  @c9 ,
+@c10 ,  @c11 ,  @c12 ,  @c13 ,  @c14 ,  @c15 ,  @c16 ,  @c17 ,  @c18 ,  @c19 ,
+@c20 ,  @c21 ,  @c22 ,  @c23 ,  @c24 ,  @c25 ,  @c26 ,  @c27 ,  @c28 ,  @c29 ,
+@c30 ,  @c31 ,  @c32 ,  @c33 ,  @c34 ,  @c35 ,  @c36 ,  @c37 ,  @c38 ,  @c39 ,
+@c40 ,  @c41 ,  @c42 ,  @c43 ,  @c44 ,  @c45 ,  @c46 ,  @c47 ,  @c48 ,  @c49 ,
+@c50 ,  @c51 ,  @c52 ,  @c53 ,  @c54 ,  @c55 ,  @c56 ,  @c57 ,  @c58 ,  @c59 ,
+@c60 ,  @c61 ,  @c62 ,  @c63 ,  @c64 ,  @c65 ,  @c66 ,  @c67 ,  @c68 ,  @c69 ,
+@c70 ,  @c71 ,  @c72 ,  @c73 ,  @c74 ,  @c75 ,  @c76 ,  @c77 ,  @c78 ,  @c79 ,
+@c80 ,  @c81 ,  @c82 ,  @c83 ,  @c84 ,  @c85 ,  @c86 ,  @c87 ,  @c88 ,  @c89 ,
+@c90 ,  @c91 ,  @c92 ,  @c93 ,  @c94 ,  @c95 ,  @c96 ,  @c97 ,  @c98 ,  @c99 ,
+@c100 ,  @c101 ,  @c102 ,  @c103 ,  @c104 ,  @c105 ,  @c106 ,  @c107 ,  @c108 ,  @c109
+)'
+GO
+
+DROP Table sp_prepare_table
+GO


### PR DESCRIPTION
We should throw error for SP_PREPARE execution using RPC with bind parameters more than 100. PG has a limitation of 100 parameters (handle + 98 bind parameters + query ). Internally we build a query "create temporary_procedure" with the number of bind parameters provided for creating the parse-tree out of it. We resolve the crash by checking the parse-tree for the number of params and throw an error instead of continuing.

authored-by: Kushaal Shroff kushaal@amazon.com


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).