### PR TITLE
Revert disallow ALTER ROLE in PG for Babelfish-created roles

### DIFF
--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -18,126 +18,9 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 RENAME TO master_ownership_restrictions_from_pg_role2;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
--- Give a bbf role the ability to create other roles, login, nologin and new databases should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE CREATEDB;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
--- Change bbf role's password should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 PASSWORD '123';
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH PASSWORD '123';
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH PASSWORD NULL;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
--- Make a password valid until a particular period for bbf role should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'NOV 4 12:00:00 2022 +1';
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
--- Give a bbf role a non-default setting of the x parameter should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 SET x =false;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
--- Give a bbf role a non-default, database-specific setting of the x parameter should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE postgres set x=false;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 -- psql
 -- Dropping login from psql port should fail
 DROP ROLE ownership_restrictions_from_pg_login1;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created login cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 55006)~~
-
-
-ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_login2;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created login cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 55006)~~
-
-
-ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -158,22 +41,31 @@ GO
     Server SQLState: 55006)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_role2 RENAME TO ownership_restrictions_from_pg_role3;
+SET enable_drop_babelfish_role = true;
+GO
+
+DROP ROLE ownership_restrictions_from_pg_role2;
+GO
+
+SET enable_drop_babelfish_role = false;
+GO
+
+
+CREATE ROLE ownership_restrictions_from_pg_role3;
+GO
+
+GRANT master_guest TO ownership_restrictions_from_pg_role3;
+GRANT tempdb_guest TO ownership_restrictions_from_pg_role3;
+GRANT msdb_guest TO ownership_restrictions_from_pg_role3;
+GO
+
+DROP ROLE ownership_restrictions_from_pg_role3;
 GO
 ~~ERROR (Code: 0)~~
 
 ~~ERROR (Message: ERROR: Babelfish-created login cannot be dropped or altered outside of a Babelfish session
     Server SQLState: 55006)~~
 
-
-SET enable_drop_babelfish_role = true;
-GO
-
-ALTER ROLE ownership_restrictions_from_pg_role2 RENAME TO ownership_restrictions_from_pg_role3;
-GO
-
-SET enable_drop_babelfish_role = false;
-GO
 
 SET enable_drop_babelfish_role = true;
 GO
@@ -184,54 +76,11 @@ GO
 SET enable_drop_babelfish_role = false;
 GO
 
-
+-- Test a regular role
 CREATE ROLE ownership_restrictions_from_pg_role4;
 GO
 
-GRANT master_guest TO ownership_restrictions_from_pg_role4;
-GRANT tempdb_guest TO ownership_restrictions_from_pg_role4;
-GRANT msdb_guest TO ownership_restrictions_from_pg_role4;
-GO
-
 DROP ROLE ownership_restrictions_from_pg_role4;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created login cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 55006)~~
-
-
-ALTER ROLE ownership_restrictions_from_pg_role4 RENAME TO ownership_restrictions_from_pg_role5;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created login cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 55006)~~
-
-
-SET enable_drop_babelfish_role = true;
-GO
-
-ALTER ROLE ownership_restrictions_from_pg_role4 RENAME TO ownership_restrictions_from_pg_role5;
-GO
-
-SET enable_drop_babelfish_role = false;
-GO
-
-SET enable_drop_babelfish_role = true;
-GO
-
-DROP ROLE ownership_restrictions_from_pg_role5;
-GO
-
-SET enable_drop_babelfish_role = false;
-GO
-
--- Test a regular role
-CREATE ROLE ownership_restrictions_from_pg_role6;
-GO
-
-DROP ROLE ownership_restrictions_from_pg_role6;
 GO
 
 DROP USER ownership_restrictions_from_pg_test_user;

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -13,56 +13,9 @@ go
 DROP ROLE master_ownership_restrictions_from_pg_role1;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 RENAME TO master_ownership_restrictions_from_pg_role2;
-GO
-
--- Give a bbf role the ability to create other roles, login, nologin and new databases should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE CREATEDB;
-GO
-
--- Change bbf role's password should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 PASSWORD '123';
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH PASSWORD '123';
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH PASSWORD NULL;
-GO
-
--- Make a password valid until a particular period for bbf role should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'NOV 4 12:00:00 2022 +1';
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
-GO
-
--- Give a bbf role a non-default setting of the x parameter should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 SET x =false;
-GO
-
--- Give a bbf role a non-default, database-specific setting of the x parameter should fail
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE postgres set x=false;
-GO
-
 -- psql
 -- Dropping login from psql port should fail
 DROP ROLE ownership_restrictions_from_pg_login1;
-GO
-
-ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_login2;
-GO
-
-ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
 GO
 
 -- Create a non babelfish role that is a member of master_guest
@@ -73,16 +26,25 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role2;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_role2 RENAME TO ownership_restrictions_from_pg_role3;
-GO
-
 SET enable_drop_babelfish_role = true;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_role2 RENAME TO ownership_restrictions_from_pg_role3;
+DROP ROLE ownership_restrictions_from_pg_role2;
 GO
 
 SET enable_drop_babelfish_role = false;
+GO
+
+
+CREATE ROLE ownership_restrictions_from_pg_role3;
+GO
+
+GRANT master_guest TO ownership_restrictions_from_pg_role3;
+GRANT tempdb_guest TO ownership_restrictions_from_pg_role3;
+GRANT msdb_guest TO ownership_restrictions_from_pg_role3;
+GO
+
+DROP ROLE ownership_restrictions_from_pg_role3;
 GO
 
 SET enable_drop_babelfish_role = true;
@@ -94,44 +56,11 @@ GO
 SET enable_drop_babelfish_role = false;
 GO
 
-
+-- Test a regular role
 CREATE ROLE ownership_restrictions_from_pg_role4;
 GO
 
-GRANT master_guest TO ownership_restrictions_from_pg_role4;
-GRANT tempdb_guest TO ownership_restrictions_from_pg_role4;
-GRANT msdb_guest TO ownership_restrictions_from_pg_role4;
-GO
-
 DROP ROLE ownership_restrictions_from_pg_role4;
-GO
-
-ALTER ROLE ownership_restrictions_from_pg_role4 RENAME TO ownership_restrictions_from_pg_role5;
-GO
-
-SET enable_drop_babelfish_role = true;
-GO
-
-ALTER ROLE ownership_restrictions_from_pg_role4 RENAME TO ownership_restrictions_from_pg_role5;
-GO
-
-SET enable_drop_babelfish_role = false;
-GO
-
-SET enable_drop_babelfish_role = true;
-GO
-
-DROP ROLE ownership_restrictions_from_pg_role5;
-GO
-
-SET enable_drop_babelfish_role = false;
-GO
-
--- Test a regular role
-CREATE ROLE ownership_restrictions_from_pg_role6;
-GO
-
-DROP ROLE ownership_restrictions_from_pg_role6;
 GO
 
 DROP USER ownership_restrictions_from_pg_test_user;


### PR DESCRIPTION
Previously, for a PG user to break a Babelfish instance by using ALTER ROLE to block logins, change role membership, change passwords, and other changes that would have a dramatic effect on Babelfish functionality. ALTER ROLE been disabled for Babelfish-created PG roles.

Now reverting the disabling of ALTER ROLE for Babelfish-created PG roles changes as there were other interoperability related operations to be considered.

Signed-off-by: vasavi suthapalli <svasusri@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).