### PR TITLE
Fix psqlodbc test framework `double` equality comparison

### DIFF
--- a/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
@@ -761,3 +761,11 @@ void formatNumericExpected(vector<string> &vec, const int &scale, const bool &is
     vec[i] = formatNumericWithScale(vec[i], scale, is_bbf);
   }
 }
+
+void compareDoubleEquality(double actual, double expected) {
+  std::string errorstmt = "Actual value:" + std::to_string(actual)
+          + "\nExpected valuee:" + std::to_string(expected);
+
+  EXPECT_TRUE(std::fabs(actual - expected) < std::numeric_limits<double>::epsilon()
+          ) << errorstmt;    
+}

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.h
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.h
@@ -543,6 +543,7 @@ void verifyValuesInObject(ServerType serverType, string objectName, string order
     EXPECT_EQ(pk, i);
     if (insertedValues[i] != "NULL") {
       EXPECT_EQ(data_len, expectedLen[i]);
+
       if (type == SQL_C_DOUBLE) {
         compareDoubleEquality(data, expectedInsertedValues[i]);
       }
@@ -621,6 +622,7 @@ void testUpdateSuccess(ServerType serverType, const string &tableName, const str
     
     if (updatedValues[i] != "NULL") {
       EXPECT_EQ(data_len, expectedUpdatedLen[i]);
+
       if (type == SQL_C_DOUBLE) {
         compareDoubleEquality(data, expectedUpdatedValues[i]);
       }
@@ -733,8 +735,7 @@ void testComparisonFunctions(ServerType serverType, const string &tableName, int
     }
     else {
       EXPECT_EQ(colResults[i], expectedResults[i]);
-    }
-    
+    } 
   }
   // Assert that there is no more data
   rcode = SQLFetch(odbcHandler.GetStatementHandle());

--- a/test/odbc/psqlodbc/psqlodbc_tests_common.h
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.h
@@ -484,7 +484,7 @@ vector<string> getVectorBasedOnColumn(const vector<vector<string>> &vec, const i
  * @param scale The scale of the 
  * @param is_bbf True if we want it to correspond to Babelfish, false if we want the output to be formatted for postgres
  * @return string which is the formatted number
- */
+*/
 string formatNumericWithScale(string decimal, const int &scale, const bool &is_bbf);
 
 /**
@@ -494,8 +494,17 @@ string formatNumericWithScale(string decimal, const int &scale, const bool &is_b
  * @param scale Scale of the numeric or decimal column
  * @param is_bbf True if the output is to correspond with Babelfish's result set,
  *    False for Postgres
- */
+*/
 void formatNumericExpected(vector<string> &vec, const int &scale, const bool &is_bbf);
+
+/**
+ * Checks to see if the actual and expected values of two doubles
+ * are equal or not (based on machine epsilon differences).
+ * 
+ * @param actual The actual value from the test
+ * @param expect The expected value 
+*/
+void compareDoubleEquality(double actual, double expected);
 
 /** Implementation of templated functions below **/
 template <typename T>
@@ -534,7 +543,12 @@ void verifyValuesInObject(ServerType serverType, string objectName, string order
     EXPECT_EQ(pk, i);
     if (insertedValues[i] != "NULL") {
       EXPECT_EQ(data_len, expectedLen[i]);
-      EXPECT_EQ(data, expectedInsertedValues[i]);
+      if (type == SQL_C_DOUBLE) {
+        compareDoubleEquality(data, expectedInsertedValues[i]);
+      }
+      else {
+        EXPECT_EQ(data, expectedInsertedValues[i]);
+      }
     }
     else {
       EXPECT_EQ(data_len, SQL_NULL_DATA);
@@ -607,7 +621,12 @@ void testUpdateSuccess(ServerType serverType, const string &tableName, const str
     
     if (updatedValues[i] != "NULL") {
       EXPECT_EQ(data_len, expectedUpdatedLen[i]);
-      EXPECT_EQ(data, expectedUpdatedValues[i]);
+      if (type == SQL_C_DOUBLE) {
+        compareDoubleEquality(data, expectedUpdatedValues[i]);
+      }
+      else {
+        EXPECT_EQ(data, expectedUpdatedValues[i]);
+      }
     }
     else {
       EXPECT_EQ(data_len, SQL_NULL_DATA);
@@ -663,6 +682,13 @@ void testUpdateFail(ServerType serverType, const string &tableName, const string
     EXPECT_EQ(pk_len, INT_BYTES_EXPECTED);
     EXPECT_EQ(pk, pkValue);
     EXPECT_EQ(data_len, expectedInsertedLen[0]);
+
+    if (type == SQL_C_DOUBLE) {
+      compareDoubleEquality(data, expectedInsertedValues[0]);
+    }
+    else {
+      EXPECT_EQ(data, expectedInsertedValues[0]);
+    }
     EXPECT_EQ(data, expectedInsertedValues[0]);
 
     rcode = SQLFetch(odbcHandler.GetStatementHandle());
@@ -701,9 +727,15 @@ void testComparisonFunctions(ServerType serverType, const string &tableName, int
   EXPECT_EQ(rcode, SQL_SUCCESS);
   for (int i = 0; i < NUM_OF_OPERATIONS; i++) {
     EXPECT_EQ(col_len[i], expectedLen[i]);
-    EXPECT_EQ(colResults[i], expectedResults[i]);
-  }
 
+    if (type == SQL_C_DOUBLE) {
+        compareDoubleEquality(colResults[i], expectedResults[i]);
+    }
+    else {
+      EXPECT_EQ(colResults[i], expectedResults[i]);
+    }
+    
+  }
   // Assert that there is no more data
   rcode = SQLFetch(odbcHandler.GetStatementHandle());
   EXPECT_EQ(rcode, SQL_NO_DATA);
@@ -741,7 +773,13 @@ void testArithmeticOperators(ServerType serverType, const string &tableName, con
 
     for (int j = 0; j < NUM_OF_OPERATIONS; j++) {
       EXPECT_EQ(col_len[j], expectedLen[j]);
-      EXPECT_EQ(colResults[j], expectedResults[i][j]);
+
+      if (type == SQL_C_DOUBLE) {
+        compareDoubleEquality(colResults[j], expectedResults[i][j]);
+      }
+      else {
+        EXPECT_EQ(colResults[j], expectedResults[i][j]);
+      }
     }
   }
 


### PR DESCRIPTION
### Description
Fix psqlodbc test framework `double` equality comparison

Previously, the template psqlodbc_common functions utilized the regular `=` operator to check for two values of type double. This can cause issues due to floating point inaccuarcy. This commit mitigates this issue by creating a helper function that compares two doubles by taking the difference of the two values and comparing it to the machine's epsilon value.

Task: BABELFISH-560
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).