### PR TITLE
MVU fails in multi-db migration mode when there is one or more user databases

### DIFF
--- a/.github/composite-actions/run-pg-upgrade/action.yml
+++ b/.github/composite-actions/run-pg-upgrade/action.yml
@@ -36,6 +36,7 @@ runs:
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "\dx"
         echo 'Reset bbf database settings...'
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
         export PATH=/opt/mssql-tools/bin:$PATH
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"

--- a/.github/composite-actions/run-pg-upgrade/action.yml
+++ b/.github/composite-actions/run-pg-upgrade/action.yml
@@ -32,9 +32,6 @@ runs:
         echo 'Updating babelfish extensions...'
         cd ~/work/babelfish_extensions/babelfish_extensions/
         ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile14 start
-        echo 'Set the migration_mode before running the upgrade scripts..'
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER EXTENSION babelfishpg_common UPDATE; ALTER EXTENSION babelfishpg_tsql UPDATE;"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "\dx"
         echo 'Reset bbf database settings...'

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3826,6 +3826,7 @@ CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'get_max_id_from_ta
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
+DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest;
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3048,6 +3048,9 @@ AS 'babelfishpg_tsql', 'update_user_catalog_for_guest';
  
 CALL sys.babelfish_update_user_catalog_for_guest();
 
+-- Drop this procedure after it is executed once during upgrade.
+DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest();
+
 ALTER VIEW sys.sp_sproc_columns_view RENAME TO sp_sproc_columns_view_deprecated_in_2_3_0;
 
 CREATE OR REPLACE VIEW sys.sp_sproc_columns_view

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3826,7 +3826,6 @@ CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'get_max_id_from_ta
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
-DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest;
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2267,6 +2267,11 @@ create_guest_role_for_db(char *dbname)
 	bbf_set_current_user(prev_current_user);
 }
 
+/*
+ * Retrieve the db_owner role name of a specific
+ * database from the catalog, it doesn't rely on the
+ * migration mode GUC.
+ */
 static char *
 get_db_owner_role_name(char *dbname)
 {

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1316,6 +1316,7 @@ static void update_report(Rule *rule, Tuplestorestate *res_tupstore, TupleDesc r
 static void init_catalog_data(void);
 static void get_catalog_info(Rule *rule);
 static void create_guest_role_for_db(char *dbname);
+static char *get_db_owner_role_name(char *dbname);
 
 /*****************************************
  * 			Catalog Extra Info
@@ -2181,7 +2182,7 @@ static void
 create_guest_role_for_db(char *dbname)
 {
 	const char		*guest = get_guest_role_name(dbname);
-	const char		*db_owner_role = get_db_owner_name(dbname);
+	const char		*db_owner_role = get_db_owner_role_name(dbname);
 	List			*logins = NIL;
 	List			*res;
 	StringInfoData	query;
@@ -2264,4 +2265,38 @@ create_guest_role_for_db(char *dbname)
 
 	/* Set current user back to previous user */
 	bbf_set_current_user(prev_current_user);
+}
+
+static char *
+get_db_owner_role_name(char *dbname)
+{
+	Relation	bbf_authid_user_ext_rel;
+	HeapTuple	tuple_user_ext;
+	ScanKeyData		key[2];
+	TableScanDesc		scan;
+	char		*db_owner_role;
+
+	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
+										 RowExclusiveLock);
+	ScanKeyInit(&key[0],
+				Anum_bbf_authid_user_ext_orig_username,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum("db_owner"));
+	ScanKeyInit(&key[1],
+				Anum_bbf_authid_user_ext_database_name,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum(dbname));
+
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
+
+	tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
+	if (HeapTupleIsValid(tuple_user_ext))
+		{
+			Form_authid_user_ext userform = (Form_authid_user_ext) GETSTRUCT(tuple_user_ext);
+			db_owner_role = NameStr(userform->rolname);
+		}
+
+	table_endscan(scan);
+	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	return db_owner_role;
 }


### PR DESCRIPTION


Remove the upgrade dependency on the migration-mode GUC and get the db_owner rolename from the catalog.

Task: BABEL-3665
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

