### PR TITLE
MVU fails in multi-db migration mode when there is one or more user databases

### DIFF
--- a/.github/composite-actions/run-pg-upgrade/action.yml
+++ b/.github/composite-actions/run-pg-upgrade/action.yml
@@ -32,13 +32,11 @@ runs:
         echo 'Updating babelfish extensions...'
         cd ~/work/babelfish_extensions/babelfish_extensions/
         ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile14 start
-        echo 'Set the migration_mode before running the upgrade scripts..'
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER EXTENSION babelfishpg_common UPDATE; ALTER EXTENSION babelfishpg_tsql UPDATE;"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "\dx"
         echo 'Reset bbf database settings...'
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
         export PATH=/opt/mssql-tools/bin:$PATH
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3048,6 +3048,9 @@ AS 'babelfishpg_tsql', 'update_user_catalog_for_guest';
  
 CALL sys.babelfish_update_user_catalog_for_guest();
 
+-- Drop this procedure after it is executed once during upgrade.
+DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest();
+
 ALTER VIEW sys.sp_sproc_columns_view RENAME TO sp_sproc_columns_view_deprecated_in_2_3_0;
 
 CREATE OR REPLACE VIEW sys.sp_sproc_columns_view

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3050,9 +3050,6 @@ AS 'babelfishpg_tsql', 'update_user_catalog_for_guest';
  
 CALL sys.babelfish_update_user_catalog_for_guest();
 
--- Drop this procedure after it gets executed once.
-DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest();
-
 ALTER VIEW sys.sp_sproc_columns_view RENAME TO sp_sproc_columns_view_deprecated_in_2_3_0;
 
 CREATE OR REPLACE VIEW sys.sp_sproc_columns_view
@@ -3831,6 +3828,9 @@ CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'get_max_id_from_ta
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
+
+-- Drop this procedure after it gets executed once.
+DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest();
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3042,13 +3042,15 @@ ALTER TABLE sys.babelfish_authid_user_ext add COLUMN IF NOT EXISTS user_can_conn
 
 GRANT SELECT ON sys.babelfish_authid_user_ext TO PUBLIC;
 
+-- This is a temporary procedure which is called during upgrade to create guest users
+-- for the user created databases if it doesn't have guest user already.
 CREATE OR REPLACE PROCEDURE sys.babelfish_update_user_catalog_for_guest()
 LANGUAGE C
 AS 'babelfishpg_tsql', 'update_user_catalog_for_guest';
  
 CALL sys.babelfish_update_user_catalog_for_guest();
 
--- Drop this procedure after it is executed once during upgrade.
+-- Drop this procedure after it gets executed once.
 DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest();
 
 ALTER VIEW sys.sp_sproc_columns_view RENAME TO sp_sproc_columns_view_deprecated_in_2_3_0;

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2202,6 +2202,7 @@ create_guest_role_for_db(char *dbname)
 	/* Replace dummy elements in parsetree with real values */
 	stmt = parsetree_nth_stmt(res, i++);
 	update_CreateRoleStmt(stmt, guest, db_owner_role, NULL);
+	pfree(db_owner_role);
 
 	if (list_length(logins) > 0)
 	{
@@ -2279,7 +2280,7 @@ get_db_owner_role_name(char *dbname)
 	HeapTuple	tuple_user_ext;
 	ScanKeyData		key[2];
 	TableScanDesc		scan;
-	char		*db_owner_role;
+	char		*db_owner_role = NULL;
 
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
 										 RowExclusiveLock);
@@ -2298,7 +2299,7 @@ get_db_owner_role_name(char *dbname)
 	if (HeapTupleIsValid(tuple_user_ext))
 		{
 			Form_authid_user_ext userform = (Form_authid_user_ext) GETSTRUCT(tuple_user_ext);
-			db_owner_role = NameStr(userform->rolname);
+			db_owner_role = pstrdup(NameStr(userform->rolname));
 		}
 
 	table_endscan(scan);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1316,6 +1316,7 @@ static void update_report(Rule *rule, Tuplestorestate *res_tupstore, TupleDesc r
 static void init_catalog_data(void);
 static void get_catalog_info(Rule *rule);
 static void create_guest_role_for_db(char *dbname);
+static char *get_db_owner_role_name(char *dbname);
 
 /*****************************************
  * 			Catalog Extra Info
@@ -2181,7 +2182,7 @@ static void
 create_guest_role_for_db(char *dbname)
 {
 	const char		*guest = get_guest_role_name(dbname);
-	const char		*db_owner_role = get_db_owner_name(dbname);
+	const char		*db_owner_role = get_db_owner_role_name(dbname);
 	List			*logins = NIL;
 	List			*res;
 	StringInfoData	query;
@@ -2264,4 +2265,43 @@ create_guest_role_for_db(char *dbname)
 
 	/* Set current user back to previous user */
 	bbf_set_current_user(prev_current_user);
+}
+
+/*
+ * Retrieve the db_owner role name of a specific
+ * database from the catalog, it doesn't rely on the
+ * migration mode GUC.
+ */
+static char *
+get_db_owner_role_name(char *dbname)
+{
+	Relation	bbf_authid_user_ext_rel;
+	HeapTuple	tuple_user_ext;
+	ScanKeyData		key[2];
+	TableScanDesc		scan;
+	char		*db_owner_role;
+
+	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
+										 RowExclusiveLock);
+	ScanKeyInit(&key[0],
+				Anum_bbf_authid_user_ext_orig_username,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum("db_owner"));
+	ScanKeyInit(&key[1],
+				Anum_bbf_authid_user_ext_database_name,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum(dbname));
+
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
+
+	tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
+	if (HeapTupleIsValid(tuple_user_ext))
+		{
+			Form_authid_user_ext userform = (Form_authid_user_ext) GETSTRUCT(tuple_user_ext);
+			db_owner_role = NameStr(userform->rolname);
+		}
+
+	table_endscan(scan);
+	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	return db_owner_role;
 }

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -15,5 +15,6 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_table in file 
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--1.0.0--1.1.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--2.1.0--2.2.0.sql
+Unexpected drop found for procedure sys.babelfish_update_user_catalog_for_guest in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.create_xp_qv_in_master_dbo in file babelfishpg_tsql--1.1.0--1.2.0.sql
 Unexpected drop found for procedure sys.sp_babelfish_grant_usage_to_all in file babelfishpg_tsql--1.1.0--1.2.0.sql


### PR DESCRIPTION

Remove the upgrade dependency on the migration-mode GUC and get the db_owner rolename from the catalog.

Task: BABEL-3665
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

