### PR TITLE
Fix unstable output of ownership test files

### DIFF
--- a/test/JDBC/expected/babelfish_authid_login_ext-vu-verify.out
+++ b/test/JDBC/expected/babelfish_authid_login_ext-vu-verify.out
@@ -26,6 +26,7 @@ int
 
 SELECT rolname FROM sys.babelfish_authid_login_ext 
 WHERE rolname LIKE 'babelfish_authid_login_ext_vu_prepare_login%'
+ORDER BY rolname
 GO
 ~~START~~
 varchar

--- a/test/JDBC/expected/babelfish_authid_user_ext-vu-verify.out
+++ b/test/JDBC/expected/babelfish_authid_user_ext-vu-verify.out
@@ -26,6 +26,7 @@ int
 
 SELECT rolname FROM sys.babelfish_authid_user_ext
 WHERE rolname LIKE '%babelfish_authid_user_ext_vu_prepare_%'
+ORDER BY rolname
 GO
 ~~START~~
 varchar

--- a/test/JDBC/expected/babelfish_namespace_ext-vu-verify.out
+++ b/test/JDBC/expected/babelfish_namespace_ext-vu-verify.out
@@ -25,6 +25,7 @@ int
 
 
 SELECT nspname FROM sys.babelfish_namespace_ext WHERE nspname LIKE '%test_babelfish_namespace_sch%'
+ORDER BY nspname
 GO
 ~~START~~
 varchar

--- a/test/JDBC/expected/babelfish_sysdatabases-vu-verify.out
+++ b/test/JDBC/expected/babelfish_sysdatabases-vu-verify.out
@@ -23,6 +23,7 @@ int
 
 
 SELECT name FROM sys.babelfish_sysdatabases WHERE name LIKE 'babelfish_sysdatabases_vu_prepare_db%'
+ORDER BY name
 GO
 ~~START~~
 text

--- a/test/JDBC/input/ownership/babelfish_authid_login_ext-vu-verify.sql
+++ b/test/JDBC/input/ownership/babelfish_authid_login_ext-vu-verify.sql
@@ -9,4 +9,5 @@ GO
 
 SELECT rolname FROM sys.babelfish_authid_login_ext 
 WHERE rolname LIKE 'babelfish_authid_login_ext_vu_prepare_login%'
+ORDER BY rolname
 GO

--- a/test/JDBC/input/ownership/babelfish_authid_user_ext-vu-verify.sql
+++ b/test/JDBC/input/ownership/babelfish_authid_user_ext-vu-verify.sql
@@ -9,4 +9,5 @@ GO
 
 SELECT rolname FROM sys.babelfish_authid_user_ext
 WHERE rolname LIKE '%babelfish_authid_user_ext_vu_prepare_%'
+ORDER BY rolname
 GO

--- a/test/JDBC/input/ownership/babelfish_namespace_ext-vu-verify.sql
+++ b/test/JDBC/input/ownership/babelfish_namespace_ext-vu-verify.sql
@@ -8,4 +8,5 @@ SELECT babelfish_namespace_ext_vu_prepare_func()
 GO
 
 SELECT nspname FROM sys.babelfish_namespace_ext WHERE nspname LIKE '%test_babelfish_namespace_sch%'
+ORDER BY nspname
 GO

--- a/test/JDBC/input/ownership/babelfish_sysdatabases-vu-verify.sql
+++ b/test/JDBC/input/ownership/babelfish_sysdatabases-vu-verify.sql
@@ -8,4 +8,5 @@ SELECT babelfish_sysdatabases_vu_prepare_func()
 GO
 
 SELECT name FROM sys.babelfish_sysdatabases WHERE name LIKE 'babelfish_sysdatabases_vu_prepare_db%'
+ORDER BY name
 GO


### PR DESCRIPTION
### Description

This commit adds ORDER BY clause to all the SELECT statements to ensure that the output is always in a fixed order.

Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).