### PR TITLE
Re-enable passing ODBC tests

### DIFF
--- a/test/odbc/mssqlodbc/test_metadata.cpp
+++ b/test/odbc/mssqlodbc/test_metadata.cpp
@@ -460,8 +460,7 @@ TEST_F(MSSQL_Metadata, DISABLED_SQLColumns) {
 }
 
 // Tests SQLProcedures for success
-// DISABLED: PLEASE SEE BABELFISH-119
-TEST_F(MSSQL_Metadata, DISABLED_SQLProcedures) {
+TEST_F(MSSQL_Metadata, SQLProcedures) {
 
   OdbcHandler odbcHandler(Drivers::GetDriver(ServerType::MSSQL));
   RETCODE rcode;
@@ -534,8 +533,7 @@ TEST_F(MSSQL_Metadata, DISABLED_SQLProcedures) {
 }
 
 // Tests SQLProcedureColumns for success
-// DISABLED: PLEASE SEE BABELFISH-120
-TEST_F(MSSQL_Metadata, DISABLED_SQLProcedureColumns) {
+TEST_F(MSSQL_Metadata, SQLProcedureColumns) {
 
   OdbcHandler odbcHandler(Drivers::GetDriver(ServerType::MSSQL));
   RETCODE rcode;
@@ -812,8 +810,7 @@ TEST_F(MSSQL_Metadata, SQLGetTypeInfo) {
 }
 
 // Test SQLTables to retrieve catalogs
-// DISABLED: PLEASE SEE BABELFISH-132
-TEST_F(MSSQL_Metadata, DISABLED_SQLTables_Catalogs) {
+TEST_F(MSSQL_Metadata, SQLTables_Catalogs) {
 	 
   OdbcHandler odbcHandler(Drivers::GetDriver(ServerType::MSSQL));
   RETCODE rcode = -1;
@@ -836,8 +833,7 @@ TEST_F(MSSQL_Metadata, DISABLED_SQLTables_Catalogs) {
 }
 
 // Test SQLTables to retrieve tables
-// DISABLED: PLEASE SEE BABELFISH-132
-TEST_F(MSSQL_Metadata, DISABLED_SQLTables_Tables) {
+TEST_F(MSSQL_Metadata, SQLTables_Tables) {
 	 
   OdbcHandler odbcHandler(Drivers::GetDriver(ServerType::MSSQL));
   RETCODE rcode = -1;
@@ -883,8 +879,7 @@ TEST_F(MSSQL_Metadata, DISABLED_SQLTables_Tables) {
 }
 
 // Test SQLTables to retrieve views
-// DISABLED: PLEASE SEE BABELFISH-132
-TEST_F(MSSQL_Metadata, DISABLED_SQLTables_Views) {
+TEST_F(MSSQL_Metadata, SQLTables_Views) {
 	 
   OdbcHandler odbcHandler(Drivers::GetDriver(ServerType::MSSQL));
   RETCODE rcode = -1;


### PR DESCRIPTION
### Description
This commit re-enables the following ODBC tests as it now passes:

- SQLTables_Views
- SQLTables_Tables
- SQLTables_Catalogs
- SQLProcedureColumns
- SQLProcedures

Task: BABELFISH-524
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).