### PR TITLE
Increase the threshold for comparing doubles in psqlodbc tests

### DIFF
--- a/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
+++ b/test/odbc/psqlodbc/psqlodbc_tests_common.cpp
@@ -766,6 +766,6 @@ void compareDoubleEquality(double actual, double expected) {
   std::string errorstmt = "Actual value:" + std::to_string(actual)
           + "\nExpected valuee:" + std::to_string(expected);
 
-  EXPECT_TRUE(std::fabs(actual - expected) < std::numeric_limits<double>::epsilon()
+  EXPECT_TRUE(std::fabs(actual - expected) < (2 * std::numeric_limits<double>::epsilon())
           ) << errorstmt;    
 }


### PR DESCRIPTION
### Description

This commit increases the range of inacurracy that is used in the compareDoubleEquality function.

Task: BABELFISH-560
Signed-off-by: Favian (Ian) Samatha <ians@bitquilltech.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).