### PR TITLE
Remove dependency on migration_mode for ownership_chain_procedure test

### DIFF
--- a/test/JDBC/expected/ownership_chain_procedure.out
+++ b/test/JDBC/expected/ownership_chain_procedure.out
@@ -27,10 +27,24 @@ use master
 go
 
 -- psql
-grant all on database jdbc_testdb to db3014_ownera_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownera%';
+  EXECUTE format('grant all on database jdbc_testdb to %I', username);
+end;
+$$
 go
 
-grant all on database jdbc_testdb to db3014_ownerb_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownerb%';
+  EXECUTE format('grant all on database jdbc_testdb to %I', username);
+end;
+$$
 go
 
 -- tsql user=lb_3014 password=123
@@ -763,10 +777,24 @@ void
 ~~END~~
 
 
-revoke all on database jdbc_testdb from db3014_ownera_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownera%';
+  EXECUTE format('revoke all on database jdbc_testdb from %I', username);
+end;
+$$
 go
 
-revoke all on database jdbc_testdb from db3014_ownerb_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownerb%';
+  EXECUTE format('revoke all on database jdbc_testdb from %I', username);
+end;
+$$
 go
 
 -- tsql

--- a/test/JDBC/input/ownership/ownership_chain_procedure.mix
+++ b/test/JDBC/input/ownership/ownership_chain_procedure.mix
@@ -27,10 +27,24 @@ use master
 go
 
 -- psql
-grant all on database jdbc_testdb to db3014_ownera_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownera%';
+  EXECUTE format('grant all on database jdbc_testdb to %I', username);
+end;
+$$
 go
 
-grant all on database jdbc_testdb to db3014_ownerb_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownerb%';
+  EXECUTE format('grant all on database jdbc_testdb to %I', username);
+end;
+$$
 go
 
 -- tsql user=lb_3014 password=123
@@ -535,10 +549,24 @@ GO
 SELECT pg_sleep(1);
 GO
 
-revoke all on database jdbc_testdb from db3014_ownera_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownera%';
+  EXECUTE format('revoke all on database jdbc_testdb from %I', username);
+end;
+$$
 go
 
-revoke all on database jdbc_testdb from db3014_ownerb_3014;
+do
+$$
+declare username text;
+begin
+  SELECT rolname INTO username FROM sys.babelfish_authid_user_ext WHERE orig_username like '%ownerb%';
+  EXECUTE format('revoke all on database jdbc_testdb from %I', username);
+end;
+$$
 go
 
 -- tsql


### PR DESCRIPTION
### Description

Earlier, ownership_chain_procedure test was using physical names of user in grant statements executed via psql due to which output of it was depending upon the migration mode. This commit fixes this issue by removing that dependecy from test.

Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).