### PR TITLE
Proper implementation of sp_addrole, sp_droprolemember

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -165,18 +165,18 @@ GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_configure(
 	IN varchar(128), IN varchar(128), IN varchar(128)
 ) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolename" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolname" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolename" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_droprole(IN sys.SYSNAME) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrolemember(IN "@rolname" sys.SYSNAME, IN "@membername" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrolemember(IN "@rolename" sys.SYSNAME, IN "@membername" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_addrolemember' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_addrolemember(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_droprolemember(IN "@rolname" sys.SYSNAME, IN "@membername" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_droprolemember(IN "@rolename" sys.SYSNAME, IN "@membername" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprolemember' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_droprolemember(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -165,9 +165,9 @@ GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_configure(
 	IN varchar(128), IN varchar(128), IN varchar(128)
 ) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolename" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolename" sys.SYSNAME, IN "@ownername" sys.SYSNAME DEFAULT NULL)
 AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
+GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolename" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3307,9 +3307,9 @@ GRANT SELECT ON sys.sp_sproc_columns_view TO PUBLIC;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sp_sproc_columns_view_deprecated_in_2_3_0');
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolename" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolename" sys.SYSNAME, IN "@ownername" sys.SYSNAME DEFAULT NULL)
 AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
-GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
+GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolename" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.2.0--2.3.0.sql
@@ -3307,19 +3307,19 @@ GRANT SELECT ON sys.sp_sproc_columns_view TO PUBLIC;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sp_sproc_columns_view_deprecated_in_2_3_0');
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolname" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrole(IN "@rolename" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_addrole' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_addrole(IN sys.SYSNAME) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolname" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_droprole(IN "@rolename" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprole' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_droprole(IN sys.SYSNAME) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_addrolemember(IN "@rolname" sys.SYSNAME, IN "@membername" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_addrolemember(IN "@rolename" sys.SYSNAME, IN "@membername" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_addrolemember' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_addrolemember(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.sp_droprolemember(IN "@rolname" sys.SYSNAME, IN "@membername" sys.SYSNAME)
+CREATE OR REPLACE PROCEDURE sys.sp_droprolemember(IN "@rolename" sys.SYSNAME, IN "@membername" sys.SYSNAME)
 AS 'babelfishpg_tsql', 'sp_droprolemember' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_droprolemember(IN sys.SYSNAME, IN sys.SYSNAME) TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1483,7 +1483,7 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 
 		/* Role name is not NULL */
-		if (strlen(rolname) == 0)
+		if (rolname == NULL || strlen(rolname) == 0)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1620,7 +1620,7 @@ Datum sp_droprole(PG_FUNCTION_ARGS)
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 
 		/* Role name is not NULL */
-		if (strlen(rolname) == 0)
+		if (rolname == NULL || strlen(rolname) == 0)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1744,7 +1744,7 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 		membername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
 		/* Role name, member name is not NULL */
-		if ((strlen(rolname) == 0) || (strlen(membername) == 0))
+		if ((rolname == NULL || membername ==NULL) || (strlen(rolname) == 0) || (strlen(membername) == 0))
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1896,7 +1896,7 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 		membername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
 		/* Role name, member name is not NULL */
-		if ((strlen(rolname) == 0) || (strlen(membername) == 0))
+		if ((rolname == NULL || membername ==NULL) || (strlen(rolname) == 0) || (strlen(membername) == 0))
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 

--- a/test/JDBC/expected/Test-sp_addrole-dep-vu-prepare.out
+++ b/test/JDBC/expected/Test-sp_addrole-dep-vu-prepare.out
@@ -1,21 +1,25 @@
-CREATE PROC test_sp_addrole_proc @rolename AS sys.SYSNAME
+CREATE PROC test_sp_addrole_proc @rolename AS sys.SYSNAME, @ownername AS sys.SYSNAME = NULL
 AS
 BEGIN
+    IF @ownername IS NULL
 	EXEC sp_addrole @rolename;
+    ELSE
+	EXEC sp_addrole @rolename, @ownername;
 END
 GO
 
-
-CREATE FUNCTION dbo.test_sp_addrole_func(@rolename sys.SYSNAME) RETURNS INT
+CREATE FUNCTION dbo.test_sp_addrole_func(@rolename sys.SYSNAME, @ownername sys.SYSNAME = NULL) RETURNS INT
 AS
 BEGIN
 DECLARE
     @tmp_sp_addrole TABLE(addRole sys.SYSNAME);
+    IF @ownername IS NULL
 	INSERT INTO @tmp_sp_addrole (addRole) EXEC sp_addrole @rolename;
+    ELSE
+	INSERT INTO @tmp_sp_addrole (addRole) EXEC sp_addrole @rolename, @ownername;
     RETURN (SELECT count(*) FROM sys.babelfish_authid_user_ext where orig_username = @rolename);
 END
 GO
-
 
 CREATE VIEW test_sp_addrole_view AS
 SELECT dbo.test_sp_addrole_func('sp_addrole_dummy') AS Description

--- a/test/JDBC/expected/Test-sp_addrole-dep-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-dep-vu-verify.out
@@ -19,3 +19,19 @@ int
 
 EXEC test_sp_addrole_proc 'sp_addrole_role3'
 GO
+
+EXEC test_sp_addrole_proc 'sp_addrole_role1', ''
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The @ownername argument is not yet supported in Babelfish.)~~
+
+
+SELECT dbo.test_sp_addrole_func('sp_addrole_role2', '')
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The @ownername argument is not yet supported in Babelfish.)~~
+

--- a/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-cleanup.out
@@ -3,6 +3,7 @@ DROP ROLE sp_addrole_r3;
 GO
 
 -- Cannot drop the role name contains leading/trailing whitespaces, special characters using DROP ROLE cmd
+-- sp_droprole procedure removes trailing spaces
 Exec sp_droprole '   @sp_addrole_r2   ';
 GO
 

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -78,6 +78,14 @@ master_   @sp_addrole_r2#!#R#!#   @sp_addrole_r2#!#master
 EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
+select name from sys.database_principals where name = 'SP_ADDROLE_R3';
+GO
+~~START~~
+varchar
+SP_ADDROLE_R3
+~~END~~
+
+
 -- Throws an error when role exists
 EXEC sp_addrole 'SP_ADDROLE_R3';
 GO

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -9,6 +9,13 @@ CREATE USER sp_addrole_user FOR LOGIN sp_addrole_login;
 GO
 
 --Throws an error if the argument is empty or contains backslash(\)
+EXEC sp_addrole NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
 EXEC sp_addrole '';
 GO
 ~~ERROR (Code: 33557097)~~

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -28,7 +28,7 @@ EXEC sp_addrole;
 GO
 ~~ERROR (Code: 201)~~
 
-~~ERROR (Message: procedure sp_addrole expects parameter "@rolname", which was not supplied.)~~
+~~ERROR (Message: procedure sp_addrole expects parameter "@rolename", which was not supplied.)~~
 
 
 EXEC sp_addrole '','','';
@@ -53,7 +53,7 @@ GO
 ~~ERROR (Message: User, group, or role 'sp_addrole_user' already exists in the current database.)~~
 
 
--- Creates role even if it contains leading/trailing spaces, special characters(except \)
+-- Creates role even if rolename contains leading/trailing spaces, special characters(except \) by removing trailing spaces
 EXEC sp_addrole '   @sp_addrole_r2   ';
 GO
 
@@ -63,7 +63,7 @@ WHERE orig_username = '   @sp_addrole_r2   '
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_   @sp_addrole_r2   #!#R#!#   @sp_addrole_r2   #!#master
+master_   @sp_addrole_r2#!#R#!#   @sp_addrole_r2#!#master
 ~~END~~
 
 
@@ -92,6 +92,15 @@ WHERE orig_username = 'sp_addrole_r3'
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#nvarchar
-master_sp_addrole_r3#!#R#!#sp_addrole_r3#!#master
+~~END~~
+
+
+SELECT rolname, type, orig_username, database_name
+FROM sys.babelfish_authid_user_ext
+WHERE orig_username = 'SP_ADDROLE_R3'
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#nvarchar
+master_sp_addrole_r3#!#R#!#SP_ADDROLE_R3#!#master
 ~~END~~
 

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -30,7 +30,7 @@ GO
 ~~ERROR (Message: '\' is not a valid name because it contains invalid characters.)~~
 
 
--- Throw error if no argument or more than 1 arguments are passed to sp_addrole procedure
+-- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
 EXEC sp_addrole;
 GO
 ~~ERROR (Code: 201)~~
@@ -45,8 +45,24 @@ GO
 ~~ERROR (Message: procedure sp_addrole has too many arguments specified.)~~
 
 
+-- @ownername is not yet supported in babelfish
+EXEC sp_addrole 'sp_addrole_r1', '';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The @ownername argument is not yet supported in Babelfish.)~~
+
+
+EXEC sp_addrole 'sp_addrole_r1', 'sp_addrole_owner1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The @ownername argument is not yet supported in Babelfish.)~~
+
+
+-- The addrole procedure doesnot consider ownername if we pass NULL
 -- Throws an error when role exists in DB
-EXEC sp_addrole 'sp_addrole_r1';
+EXEC sp_addrole 'sp_addrole_r1', NULL;
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
@@ -37,6 +37,27 @@ GO
 
 
 -- Throw an error is role/member is empty
+EXEC sp_addrolemember NULL, NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_addrolemember NULL, 'sp_addrolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
 EXEC sp_addrolemember '', '';
 GO
 ~~ERROR (Code: 33557097)~~

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
@@ -22,6 +22,13 @@ GO
 ~~ERROR (Message: procedure sp_addrolemember expects parameter "@rolename", which was not supplied.)~~
 
 
+EXEC sp_addrolemember NULL;
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_addrolemember expects parameter "@membername", which was not supplied.)~~
+
+
 EXEC sp_addrolemember '';
 GO
 ~~ERROR (Code: 201)~~
@@ -80,15 +87,15 @@ GO
 
 
 -- Throw an error when same roles are passed
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot make a role a member of itself)~~
+~~ERROR (Message: Cannot make a role a member of itself.)~~
 
 
 -- Throw an error when member doesn't exist
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -96,25 +103,33 @@ GO
 
 
 -- Throw an error when role doesn't exist or when an user/login is passed as rolename
-Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role 'sp_addrolemember_role_doesnot_exist', because it does not exist or you do not have permission.)~~
 
 
-Exec sp_addrolemember 'sp_addrolemember_user', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_user', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role 'sp_addrolemember_user', because it does not exist or you do not have permission.)~~
 
 
-Exec sp_addrolemember 'sp_addrolemember_login', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_login', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role 'sp_addrolemember_login', because it does not exist or you do not have permission.)~~
+
+
+-- Throw an error when both role and member doesn't exist
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist_1', 'sp_addrolemember_role_doesnot_exist_2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User or role 'sp_addrolemember_role_doesnot_exist_2' does not exist in this database.)~~
 
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -126,7 +141,7 @@ int
 ~~END~~
 
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2';
 GO
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -139,15 +154,15 @@ int
 
 
 -- Throw an error if role is already a member of member
-Exec sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot make a role a member of itself)~~
+~~ERROR (Message: Cannot make a role a member of itself.)~~
 
 
 -- Can add user, role or group as an member for a role
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_user';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_user';
 GO
 
 -- Check whether sp_addrolemember_user is rolemember of sp_addrolemember_r1
@@ -161,29 +176,29 @@ int
 
 -- case insensitivity check
 -- role 'sp_addrolemember_r1', 'sp_addrolemember_r2' exists in DB
-Exec sp_addrolemember 'SP_ADDROLEMEMBER_R1', 'sp_addrolemember_r2';
+EXEC sp_addrolemember 'SP_ADDROLEMEMBER_R1', 'sp_addrolemember_r2';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'SP_ADDROLEMEMBER_R2';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'SP_ADDROLEMEMBER_R2';
 GO
 
 -- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
-Exec sp_addrolemember ' sp_addrolemember_r1', 'sp_addrolemember_r2';
+EXEC sp_addrolemember ' sp_addrolemember_r1', 'sp_addrolemember_r2';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role ' sp_addrolemember_r1', because it does not exist or you do not have permission.)~~
 
 
-Exec sp_addrolemember 'sp_addrolemember_r1 ', 'sp_addrolemember_r2';
+EXEC sp_addrolemember 'sp_addrolemember_r1 ', 'sp_addrolemember_r2';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', ' sp_addrolemember_r2';
+EXEC sp_addrolemember 'sp_addrolemember_r1', ' sp_addrolemember_r2';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: User or role ' sp_addrolemember_r2' does not exist in this database.)~~
 
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2 ';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2 ';
 GO

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
@@ -1,5 +1,5 @@
 -- tsql
-CREATE ROLE sp_addrolemember_r1;
+CREATE ROLE SP_ADDROLEMEMBER_R1;
 GO
 
 CREATE ROLE sp_addrolemember_r2;
@@ -19,7 +19,7 @@ EXEC sp_addrolemember;
 GO
 ~~ERROR (Code: 201)~~
 
-~~ERROR (Message: procedure sp_addrolemember expects parameter "@rolname", which was not supplied.)~~
+~~ERROR (Message: procedure sp_addrolemember expects parameter "@rolename", which was not supplied.)~~
 
 
 EXEC sp_addrolemember '';
@@ -74,7 +74,7 @@ GO
 ~~ERROR (Message: User or role 'sp_addrolemember_role_doesnot_exist' does not exist in this database.)~~
 
 
--- Throw an error when role doesn't exist or when an user/login is passed
+-- Throw an error when role doesn't exist or when an user/login is passed as rolename
 Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
 GO
 ~~ERROR (Code: 33557097)~~
@@ -137,3 +137,32 @@ int
 1
 ~~END~~
 
+
+-- case insensitivity check
+-- role 'sp_addrolemember_r1', 'sp_addrolemember_r2' exists in DB
+Exec sp_addrolemember 'SP_ADDROLEMEMBER_R1', 'sp_addrolemember_r2';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_r1', 'SP_ADDROLEMEMBER_R2';
+GO
+
+-- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
+Exec sp_addrolemember ' sp_addrolemember_r1', 'sp_addrolemember_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role ' sp_addrolemember_r1', because it does not exist or you do not have permission.)~~
+
+
+Exec sp_addrolemember 'sp_addrolemember_r1 ', 'sp_addrolemember_r2';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_r1', ' sp_addrolemember_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User or role ' sp_addrolemember_r2' does not exist in this database.)~~
+
+
+Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2 ';
+GO

--- a/test/JDBC/expected/Test-sp_droprole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprole-vu-verify.out
@@ -30,7 +30,14 @@ GO
 
 
 --Throws an error if the argument is empty or contains backslash(\)
-Exec sp_droprole '';
+EXEC sp_droprole '';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_droprole NULL;
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/Test-sp_droprole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprole-vu-verify.out
@@ -2,10 +2,16 @@
 CREATE ROLE sp_droprole_r1;
 GO
 
+CREATE ROLE sp_droprole_r2;
+GO
+
 CREATE LOGIN sp_droprole_login WITH PASSWORD = '123';
 GO
 
 CREATE USER sp_droprole_user FOR LOGIN sp_droprole_login;
+GO
+
+ALTER ROLE SP_DROPROLE_R1 ADD MEMBER SP_DROPROLE_R2;
 GO
 
 -- Throw error if no argument or more than 1 argument are passed to sp_droprole procedure
@@ -13,7 +19,7 @@ EXEC sp_droprole;
 GO
 ~~ERROR (Code: 201)~~
 
-~~ERROR (Message: procedure sp_droprole expects parameter "@rolname", which was not supplied.)~~
+~~ERROR (Message: procedure sp_droprole expects parameter "@rolename", which was not supplied.)~~
 
 
 EXEC sp_droprole '','','';
@@ -54,9 +60,38 @@ GO
 ~~ERROR (Message: Cannot drop the role 'sp_droprole_doesnot_exist', because it does not exist or you do not have permission.)~~
 
 
--- Drops the role when exists
+-- sp_droprole is case insensitive, drops the role when exists
+-- Cannot drop the role if member exists for a role
+EXEC sp_droprole 'SP_droprole_R1';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The role has members. It must be empty before it can be dropped.)~~
+
+
+ALTER ROLE SP_DROPROLE_R1 DROP MEMBER SP_DROPROLE_R2;
+GO
+
 EXEC sp_droprole 'sp_droprole_r1';
 GO
+
+-- Droprole procedure does not remove leading spaces but removes trailing spaces and check for the role in DB
+EXEC sp_droprole ' sp_droprole_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role ' sp_droprole_r2', because it does not exist or you do not have permission.)~~
+
+
+EXEC sp_droprole 'SP_DROPROLE_R2 ';
+GO
+
+EXEC sp_droprole 'sp_droprole_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'sp_droprole_r2', because it does not exist or you do not have permission.)~~
+
 
 -- Check role is present in DB
 SELECT rolname, type, orig_username, database_name

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
@@ -63,6 +63,27 @@ GO
 ~~ERROR (Message: Name cannot be NULL.)~~
 
 
+EXEC sp_droprolemember NULL, NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_droprolemember NULL, 'sp_droprolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
 -- Throw an error if member does not exist
 EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_role_doesnot_exist';
 GO

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
@@ -27,6 +27,13 @@ GO
 ~~ERROR (Message: procedure sp_droprolemember expects parameter "@rolename", which was not supplied.)~~
 
 
+EXEC sp_droprolemember NULL;
+GO
+~~ERROR (Code: 201)~~
+
+~~ERROR (Message: procedure sp_droprolemember expects parameter "@membername", which was not supplied.)~~
+
+
 EXEC sp_droprolemember '';
 GO
 ~~ERROR (Code: 201)~~
@@ -114,6 +121,13 @@ GO
 ~~ERROR (Message: Cannot alter the role 'sp_droprolemember_login', because it does not exist or you do not have permission.)~~
 
 
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist_1', 'sp_droprolemember_role_doesnot_exist_2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role 'sp_droprolemember_role_doesnot_exist_1', because it does not exist or you do not have permission.)~~
+
+
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
 SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r2')
 GO
@@ -149,29 +163,29 @@ int
 
 -- case insensitivity check
 -- role 'sp_droprolemember_r1', 'sp_droprolemember_r2' exists in DB
-Exec sp_droprolemember 'SP_DROPROLEMEMBER_R1', 'sp_droprolemember_r2';
+EXEC sp_droprolemember 'SP_DROPROLEMEMBER_R1', 'sp_droprolemember_r2';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1', 'SP_DROPROLEMEMBER_R2';
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'SP_DROPROLEMEMBER_R2';
 GO
 
 -- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
-Exec sp_droprolemember ' sp_droprolemember_r1', 'sp_droprolemember_r2';
+EXEC sp_droprolemember ' sp_droprolemember_r1', 'sp_droprolemember_r2';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role ' sp_droprolemember_r1', because it does not exist or you do not have permission.)~~
 
 
-Exec sp_droprolemember 'sp_droprolemember_r1 ', 'sp_droprolemember_r2';
+EXEC sp_droprolemember 'sp_droprolemember_r1 ', 'sp_droprolemember_r2';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1', ' sp_droprolemember_r2';
+EXEC sp_droprolemember 'sp_droprolemember_r1', ' sp_droprolemember_r2';
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot drop the principal ' sp_droprolemember_r2', because it does not exist or you do not have permission.)~~
 
 
-Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r2 ';
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r2 ';
 GO

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
@@ -24,7 +24,7 @@ EXEC sp_droprolemember;
 GO
 ~~ERROR (Code: 201)~~
 
-~~ERROR (Message: procedure sp_droprolemember expects parameter "@rolname", which was not supplied.)~~
+~~ERROR (Message: procedure sp_droprolemember expects parameter "@rolename", which was not supplied.)~~
 
 
 EXEC sp_droprolemember '';
@@ -125,3 +125,32 @@ int
 0
 ~~END~~
 
+
+-- case insensitivity check
+-- role 'sp_droprolemember_r1', 'sp_droprolemember_r2' exists in DB
+Exec sp_droprolemember 'SP_DROPROLEMEMBER_R1', 'sp_droprolemember_r2';
+GO
+
+Exec sp_droprolemember 'sp_droprolemember_r1', 'SP_DROPROLEMEMBER_R2';
+GO
+
+-- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
+Exec sp_droprolemember ' sp_droprolemember_r1', 'sp_droprolemember_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter the role ' sp_droprolemember_r1', because it does not exist or you do not have permission.)~~
+
+
+Exec sp_droprolemember 'sp_droprolemember_r1 ', 'sp_droprolemember_r2';
+GO
+
+Exec sp_droprolemember 'sp_droprolemember_r1', ' sp_droprolemember_r2';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the principal ' sp_droprolemember_r2', because it does not exist or you do not have permission.)~~
+
+
+Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r2 ';
+GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-dep-vu-prepare.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-dep-vu-prepare.sql
@@ -1,21 +1,25 @@
-CREATE PROC test_sp_addrole_proc @rolename AS sys.SYSNAME
+CREATE PROC test_sp_addrole_proc @rolename AS sys.SYSNAME, @ownername AS sys.SYSNAME = NULL
 AS
 BEGIN
+    IF @ownername IS NULL
 	EXEC sp_addrole @rolename;
+    ELSE
+	EXEC sp_addrole @rolename, @ownername;
 END
 GO
 
-
-CREATE FUNCTION dbo.test_sp_addrole_func(@rolename sys.SYSNAME) RETURNS INT
+CREATE FUNCTION dbo.test_sp_addrole_func(@rolename sys.SYSNAME, @ownername sys.SYSNAME = NULL) RETURNS INT
 AS
 BEGIN
 DECLARE
     @tmp_sp_addrole TABLE(addRole sys.SYSNAME);
+    IF @ownername IS NULL
 	INSERT INTO @tmp_sp_addrole (addRole) EXEC sp_addrole @rolename;
+    ELSE
+	INSERT INTO @tmp_sp_addrole (addRole) EXEC sp_addrole @rolename, @ownername;
     RETURN (SELECT count(*) FROM sys.babelfish_authid_user_ext where orig_username = @rolename);
 END
 GO
-
 
 CREATE VIEW test_sp_addrole_view AS
 SELECT dbo.test_sp_addrole_func('sp_addrole_dummy') AS Description

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-dep-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-dep-vu-verify.sql
@@ -9,3 +9,9 @@ GO
 
 EXEC test_sp_addrole_proc 'sp_addrole_role3'
 GO
+
+EXEC test_sp_addrole_proc 'sp_addrole_role1', ''
+GO
+
+SELECT dbo.test_sp_addrole_func('sp_addrole_role2', '')
+GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-cleanup.sql
@@ -3,6 +3,7 @@ DROP ROLE sp_addrole_r3;
 GO
 
 -- Cannot drop the role name contains leading/trailing whitespaces, special characters using DROP ROLE cmd
+-- sp_droprole procedure removes trailing spaces
 Exec sp_droprole '   @sp_addrole_r2   ';
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -45,6 +45,9 @@ GO
 EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 
+select name from sys.database_principals where name = 'SP_ADDROLE_R3';
+GO
+
 -- Throws an error when role exists
 EXEC sp_addrole 'SP_ADDROLE_R3';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -9,6 +9,9 @@ CREATE USER sp_addrole_user FOR LOGIN sp_addrole_login;
 GO
 
 --Throws an error if the argument is empty or contains backslash(\)
+EXEC sp_addrole NULL;
+GO
+
 EXEC sp_addrole '';
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -29,7 +29,7 @@ GO
 EXEC sp_addrole 'sp_addrole_user';
 GO
 
--- Creates role even if it contains leading/trailing spaces, special characters(except \)
+-- Creates role even if rolename contains leading/trailing spaces, special characters(except \) by removing trailing spaces
 EXEC sp_addrole '   @sp_addrole_r2   ';
 GO
 
@@ -52,4 +52,9 @@ GO
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext
 WHERE orig_username = 'sp_addrole_r3'
+GO
+
+SELECT rolname, type, orig_username, database_name
+FROM sys.babelfish_authid_user_ext
+WHERE orig_username = 'SP_ADDROLE_R3'
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -18,15 +18,23 @@ GO
 EXEC sp_addrole '\';
 GO
 
--- Throw error if no argument or more than 1 arguments are passed to sp_addrole procedure
+-- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
 EXEC sp_addrole;
 GO
 
 EXEC sp_addrole '','','';
 GO
 
+-- @ownername is not yet supported in babelfish
+EXEC sp_addrole 'sp_addrole_r1', '';
+GO
+
+EXEC sp_addrole 'sp_addrole_r1', 'sp_addrole_owner1';
+GO
+
+-- The addrole procedure doesnot consider ownername if we pass NULL
 -- Throws an error when role exists in DB
-EXEC sp_addrole 'sp_addrole_r1';
+EXEC sp_addrole 'sp_addrole_r1', NULL;
 GO
 
 EXEC sp_addrole 'sp_addrole_user';

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
@@ -25,6 +25,15 @@ EXEC sp_addrolemember '','','';
 GO
 
 -- Throw an error is role/member is empty
+EXEC sp_addrolemember NULL, NULL;
+GO
+
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', NULL;
+GO
+
+EXEC sp_addrolemember NULL, 'sp_addrolemember_role_doesnot_exist';
+GO
+
 EXEC sp_addrolemember '', '';
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
@@ -1,5 +1,5 @@
 -- tsql
-CREATE ROLE sp_addrolemember_r1;
+CREATE ROLE SP_ADDROLEMEMBER_R1;
 GO
 
 CREATE ROLE sp_addrolemember_r2;
@@ -42,7 +42,7 @@ GO
 Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
 GO
 
--- Throw an error when role doesn't exist or when an user/login is passed
+-- Throw an error when role doesn't exist or when an user/login is passed as rolename
 Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
 GO
 
@@ -73,4 +73,25 @@ GO
 
 -- Check whether sp_addrolemember_user is rolemember of sp_addrolemember_r1
 SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_user')
+GO
+
+-- case insensitivity check
+-- role 'sp_addrolemember_r1', 'sp_addrolemember_r2' exists in DB
+Exec sp_addrolemember 'SP_ADDROLEMEMBER_R1', 'sp_addrolemember_r2';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_r1', 'SP_ADDROLEMEMBER_R2';
+GO
+
+-- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
+Exec sp_addrolemember ' sp_addrolemember_r1', 'sp_addrolemember_r2';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_r1 ', 'sp_addrolemember_r2';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_r1', ' sp_addrolemember_r2';
+GO
+
+Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2 ';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
@@ -18,6 +18,9 @@ GO
 EXEC sp_addrolemember;
 GO
 
+EXEC sp_addrolemember NULL;
+GO
+
 EXEC sp_addrolemember '';
 GO
 
@@ -44,28 +47,32 @@ EXEC sp_addrolemember '', 'sp_addrolemember_role_doesnot_exist';
 GO
 
 -- Throw an error when same roles are passed
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r1';
 GO
 
 -- Throw an error when member doesn't exist
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_role_doesnot_exist';
 GO
 
 -- Throw an error when role doesn't exist or when an user/login is passed as rolename
-Exec sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', 'sp_addrolemember_r1';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_user', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_user', 'sp_addrolemember_r1';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_login', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_login', 'sp_addrolemember_r1';
+GO
+
+-- Throw an error when both role and member doesn't exist
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist_1', 'sp_addrolemember_role_doesnot_exist_2';
 GO
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
 SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_r2')
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2';
 GO
 
 -- Check whether sp_addrolemember_r2 is rolemember of sp_addrolemember_r1
@@ -73,11 +80,11 @@ SELECT IS_ROLEMEMBER('sp_addrolemember_r1', 'sp_addrolemember_r2')
 GO
 
 -- Throw an error if role is already a member of member
-Exec sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
+EXEC sp_addrolemember 'sp_addrolemember_r2', 'sp_addrolemember_r1';
 GO
 
 -- Can add user, role or group as an member for a role
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_user';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_user';
 GO
 
 -- Check whether sp_addrolemember_user is rolemember of sp_addrolemember_r1
@@ -86,21 +93,21 @@ GO
 
 -- case insensitivity check
 -- role 'sp_addrolemember_r1', 'sp_addrolemember_r2' exists in DB
-Exec sp_addrolemember 'SP_ADDROLEMEMBER_R1', 'sp_addrolemember_r2';
+EXEC sp_addrolemember 'SP_ADDROLEMEMBER_R1', 'sp_addrolemember_r2';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'SP_ADDROLEMEMBER_R2';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'SP_ADDROLEMEMBER_R2';
 GO
 
 -- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
-Exec sp_addrolemember ' sp_addrolemember_r1', 'sp_addrolemember_r2';
+EXEC sp_addrolemember ' sp_addrolemember_r1', 'sp_addrolemember_r2';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1 ', 'sp_addrolemember_r2';
+EXEC sp_addrolemember 'sp_addrolemember_r1 ', 'sp_addrolemember_r2';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', ' sp_addrolemember_r2';
+EXEC sp_addrolemember 'sp_addrolemember_r1', ' sp_addrolemember_r2';
 GO
 
-Exec sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2 ';
+EXEC sp_addrolemember 'sp_addrolemember_r1', 'sp_addrolemember_r2 ';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
@@ -2,10 +2,16 @@
 CREATE ROLE sp_droprole_r1;
 GO
 
+CREATE ROLE sp_droprole_r2;
+GO
+
 CREATE LOGIN sp_droprole_login WITH PASSWORD = '123';
 GO
 
 CREATE USER sp_droprole_user FOR LOGIN sp_droprole_login;
+GO
+
+ALTER ROLE SP_DROPROLE_R1 ADD MEMBER SP_DROPROLE_R2;
 GO
 
 -- Throw error if no argument or more than 1 argument are passed to sp_droprole procedure
@@ -30,8 +36,25 @@ GO
 EXEC sp_droprole 'sp_droprole_doesnot_exist';
 GO
 
--- Drops the role when exists
+-- sp_droprole is case insensitive, drops the role when exists
+-- Cannot drop the role if member exists for a role
+EXEC sp_droprole 'SP_droprole_R1';
+GO
+
+ALTER ROLE SP_DROPROLE_R1 DROP MEMBER SP_DROPROLE_R2;
+GO
+
 EXEC sp_droprole 'sp_droprole_r1';
+GO
+
+-- Droprole procedure does not remove leading spaces but removes trailing spaces and check for the role in DB
+EXEC sp_droprole ' sp_droprole_r2';
+GO
+
+EXEC sp_droprole 'SP_DROPROLE_R2 ';
+GO
+
+EXEC sp_droprole 'sp_droprole_r2';
 GO
 
 -- Check role is present in DB

--- a/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
@@ -22,7 +22,10 @@ EXEC sp_droprole '','','';
 GO
 
 --Throws an error if the argument is empty or contains backslash(\)
-Exec sp_droprole '';
+EXEC sp_droprole '';
+GO
+
+EXEC sp_droprole NULL;
 GO
 
 --Throw an error when passed argument is not an role

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
@@ -70,3 +70,24 @@ GO
 -- Test whether sp_droprolemember_user is rolemember of sp_droprolemember_r1
 SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_user')
 GO
+
+-- case insensitivity check
+-- role 'sp_droprolemember_r1', 'sp_droprolemember_r2' exists in DB
+Exec sp_droprolemember 'SP_DROPROLEMEMBER_R1', 'sp_droprolemember_r2';
+GO
+
+Exec sp_droprolemember 'sp_droprolemember_r1', 'SP_DROPROLEMEMBER_R2';
+GO
+
+-- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
+Exec sp_droprolemember ' sp_droprolemember_r1', 'sp_droprolemember_r2';
+GO
+
+Exec sp_droprolemember 'sp_droprolemember_r1 ', 'sp_droprolemember_r2';
+GO
+
+Exec sp_droprolemember 'sp_droprolemember_r1', ' sp_droprolemember_r2';
+GO
+
+Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r2 ';
+GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
@@ -39,6 +39,15 @@ GO
 EXEC sp_droprolemember '', 'sp_droprolemember_role_doesnot_exist';
 GO
 
+EXEC sp_droprolemember NULL, NULL;
+GO
+
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist', NULL;
+GO
+
+EXEC sp_droprolemember NULL, 'sp_droprolemember_role_doesnot_exist';
+GO
+
 -- Throw an error if member does not exist
 EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_role_doesnot_exist';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
@@ -23,6 +23,9 @@ GO
 EXEC sp_droprolemember;
 GO
 
+EXEC sp_droprolemember NULL;
+GO
+
 EXEC sp_droprolemember '';
 GO
 
@@ -62,6 +65,9 @@ GO
 EXEC sp_droprolemember 'sp_droprolemember_login', 'sp_droprolemember_r1';
 GO
 
+EXEC sp_droprolemember 'sp_droprolemember_role_doesnot_exist_1', 'sp_droprolemember_role_doesnot_exist_2';
+GO
+
 -- Test whether sp_droprolemember_r2 is rolemember of sp_droprolemember_r1
 SELECT IS_ROLEMEMBER('sp_droprolemember_r1', 'sp_droprolemember_r2')
 GO
@@ -82,21 +88,21 @@ GO
 
 -- case insensitivity check
 -- role 'sp_droprolemember_r1', 'sp_droprolemember_r2' exists in DB
-Exec sp_droprolemember 'SP_DROPROLEMEMBER_R1', 'sp_droprolemember_r2';
+EXEC sp_droprolemember 'SP_DROPROLEMEMBER_R1', 'sp_droprolemember_r2';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1', 'SP_DROPROLEMEMBER_R2';
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'SP_DROPROLEMEMBER_R2';
 GO
 
 -- procedure does not remove leading spaces but removes trailing whitespaces if exists in rolename/membername
-Exec sp_droprolemember ' sp_droprolemember_r1', 'sp_droprolemember_r2';
+EXEC sp_droprolemember ' sp_droprolemember_r1', 'sp_droprolemember_r2';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1 ', 'sp_droprolemember_r2';
+EXEC sp_droprolemember 'sp_droprolemember_r1 ', 'sp_droprolemember_r2';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1', ' sp_droprolemember_r2';
+EXEC sp_droprolemember 'sp_droprolemember_r1', ' sp_droprolemember_r2';
 GO
 
-Exec sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r2 ';
+EXEC sp_droprolemember 'sp_droprolemember_r1', 'sp_droprolemember_r2 ';
 GO


### PR DESCRIPTION
Signed-off-by: vasavi suthapalli <svasusri@amazon.com>
### Description
Previously sp_droprolemember doesnot handle case-insensitivity issues and sp_addrole stores the rolename in lowercase in database.
Now for sp_droprolemember case insensitivity is handled by passing lowercase rolename/membername to the gen_sp_droprolemember_subcmds function. sp_addrole procedure stores the original name without converting to lowercase by passing given rolname as argument for gen_sp_addrole_subcmd stores.
### Issues Resolved
BABEL-3660, BABEL-3673
### Testing scenarios covered
- Use case based - Add tests in JDBC
- Boundary conditions - The arguments for the procedures are required, throws error if didn't pass required arguments or if given name is empty
- Arbitrary inputs
   - sp_addrole :  Throw error when name is empty or it contains invalid characters(\), handle case insensitive roles
   - sp_droprole: Throw error when name is empty, handle case insensitive roles
   - sp_addrolemember, sp_droprolemember: Throw error is any of the argument is empty, handle case insensitive roles
- Negative test cases
   - sp_addrole: Throw error when role exists in DB
   - sp_droprole: Throw error when role doesn't exists in DB
   - sp_addrolemember, sp_droprolemember: Throw error when role doesn't exists in DB
- Minor version upgrade tests - Add dependency, vu tests
- Major version upgrade tests - Add dependency, vu tests
- Performance tests - N/A
- Tooling impact - N/A
- Client tests - N/A

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).