### PR TITLE
Fix IS_MEMBER() to return correct result

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1592,11 +1592,16 @@ is_rolemember(PG_FUNCTION_ARGS)
 	Oid		role_oid;
 	Oid		principal_oid;
 	Oid		cur_user_oid = GetUserId();
+	Oid		db_owner_oid;
+	Oid		dbo_role_oid;
 	char	*role;
 	char 	*dc_role;
 	char 	*dc_principal;
 	char	*physical_role_name;
 	char	*physical_principal_name;
+	char	*cur_db_name;
+	char	*db_owner_name;
+	char	*dbo_role_name;
 	int idx;
 
 	if (PG_ARGISNULL(0))
@@ -1655,10 +1660,18 @@ is_rolemember(PG_FUNCTION_ARGS)
 	 * Recursively check if the given principal is a member of the role, not
 	 * considering superuserness
 	 */
-	if (is_member_of_role_nosuper(principal_oid, role_oid))
-		PG_RETURN_INT32(1);
-	else
+	cur_db_name = get_cur_db_name();
+	db_owner_name = get_db_owner_name(cur_db_name);
+	dbo_role_name = get_dbo_role_name(cur_db_name);
+	db_owner_oid = get_role_oid(db_owner_name, false);
+	dbo_role_oid = get_role_oid(dbo_role_name, false);
+	if ((principal_oid == db_owner_oid) || (principal_oid == dbo_role_oid))
 		PG_RETURN_INT32(0);
+	else 
+		if (is_member_of_role_nosuper(principal_oid, role_oid))
+			PG_RETURN_INT32(1);
+		else
+			PG_RETURN_INT32(0);
 }
 
 /*

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER-vu-verify.out
@@ -154,6 +154,69 @@ int
 0
 ~~END~~
 
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', 'db_owner')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2', 'db_owner')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role3', 'db_owner')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', 'dbo')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2', 'dbo')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role3', 'dbo')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_role3')
+GO
+~~START~~
+int
+0
+~~END~~
+
 
 -- Invalid role/principal name, should return NULL
 SELECT IS_MEMBER('xxx')

--- a/test/JDBC/input/BABEL-ROLE-MEMBER-vu-verify.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER-vu-verify.mix
@@ -53,6 +53,24 @@ SELECT IS_ROLEMEMBER('db_owner', 'BABEL_ROLE_MEMBER_vu_prepare_role1')
 GO
 SELECT IS_ROLEMEMBER('db_owner', 'BABEL_ROLE_MEMBER_vu_prepare_user1')
 GO
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', 'db_owner')
+GO
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2', 'db_owner')
+GO
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role3', 'db_owner')
+GO
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', 'dbo')
+GO
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2', 'dbo')
+GO
+SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role3', 'dbo')
+GO
+SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1')
+GO
+SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_role2')
+GO
+SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_role3')
+GO
 
 -- Invalid role/principal name, should return NULL
 SELECT IS_MEMBER('xxx')


### PR DESCRIPTION
Previously, is_member() returned wrong result on ceratin cases, due to the design of Babelfish. As a part of the design, there is a indirect ownership relationship from db_owner and dbo_role, and this was not taken into account for implementation of is_member(), which cause the function to return wrong results in certain cases. Now, an additional check is included, so that the indirect ownership relationship is also taken into account and the function behaves correctly in those specific cases too.

Task: BABEL-3625

Signed-off-by: Ray Kim <raydhkim@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).