### PR TITLE
Support for SELECT FOR JSON PATH

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -1450,7 +1450,7 @@ TsqlForJSONMakeFuncCall(TSQL_ForClause* forclause, char* src_query, size_t start
 	 * processed by the babelfishpg_tsql parser at this point and is surrounded by quote
 	 * such as in \"@pid"\.
 	 *
-	 * We achieve the above transformation by extacting all parameters starting
+	 * We achieve the above transformation by extracting all parameters starting
 	 * with \"@ from the query string, and replace them with %s. The StringInfo
 	 * variable format_query is used to assemble the new query in this process.
 	 * end_param points the remaiming query string after the parameter, initially

--- a/contrib/babelfishpg_tsql/src/forjson.c
+++ b/contrib/babelfishpg_tsql/src/forjson.c
@@ -39,7 +39,7 @@ tsql_query_to_json_text(PG_FUNCTION_ARGS)
 
 	StringInfo result = tsql_query_to_json_internal(query, mode, include_null_value,
 											without_array_wrapper, root_name);
-	
+	pfree(query);
 	PG_RETURN_TEXT_P(cstring_to_text_with_len(result->data, result->len));
 }
 


### PR DESCRIPTION
### Description

- Freeing pointer memory in forjson.c
- nit edit in gram-tsql-epilogue.y.c

TASK: BABEL-3669
Signed-off-by: Anuj Sarda <sardanuj@amazon.com>
 
### Issues Resolved

BABEL-3669

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).