### PR TITLE
Proper implementation of sp_addrole, sp_droprolemember, sp_addrolemember, sp_droprole

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1484,7 +1484,20 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 		ownername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
 		/* Role name is not NULL */
-		if (rolname == NULL || strlen(rolname) == 0)
+		if (rolname == NULL)
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
+
+		/* Ensure the database name input argument is lower-case, as all Babel role names are lower-case */
+		lowercase_rolname = lowerstr(rolname);
+
+		/* Remove trailing whitespaces */
+		len = strlen(lowercase_rolname);
+		while(isspace(lowercase_rolname[len - 1]))
+			lowercase_rolname[--len] = 0;
+
+		/* check if role name is empty after removing trailing spaces*/
+		if (strlen(lowercase_rolname) == 0)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1497,16 +1510,9 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 				errmsg("The @ownername argument is not yet supported in Babelfish.")));
 
 		/* Role name cannot contain '\' */
-		if (strchr(rolname, '\\') != NULL)
+		if (strchr(lowercase_rolname, '\\') != NULL)
 			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("'%s' is not a valid name because it contains invalid characters.", rolname)));
-
-		/* Ensure the database name input argument is lower-case, as all Babel role names are lower-case */
-		lowercase_rolname = lowerstr(rolname);
-
-		/* Remove trailing whitespaces */
-		len = strlen(lowercase_rolname);
-		while(isspace(lowercase_rolname[len - 1])) lowercase_rolname[--len] = 0;
 
 		/* Map the logical role name to its physical name in the database.*/
 		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
@@ -1629,7 +1635,7 @@ Datum sp_droprole(PG_FUNCTION_ARGS)
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
 
 		/* Role name is not NULL */
-		if (rolname == NULL || strlen(rolname) == 0)
+		if (rolname == NULL)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1638,7 +1644,13 @@ Datum sp_droprole(PG_FUNCTION_ARGS)
 
 		/* Remove trailing whitespaces */
 		len = strlen(lowercase_rolname);
-		while(isspace(lowercase_rolname[len - 1])) lowercase_rolname[--len] = 0;
+		while(isspace(lowercase_rolname[len - 1]))
+			lowercase_rolname[--len] = 0;
+
+		/* check if role name is empty after removing trailing spaces*/
+		if (strlen(lowercase_rolname) == 0)
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
 
 		/* Map the logical role name to its physical name in the database.*/
 		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
@@ -1753,7 +1765,7 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 		membername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
 		/* Role name, member name is not NULL */
-		if ((rolname == NULL || membername ==NULL) || (strlen(rolname) == 0) || (strlen(membername) == 0))
+		if (rolname == NULL || membername ==NULL)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1763,9 +1775,16 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 
 		/* Remove trailing whitespaces in rolename and membername*/
 		len = strlen(lowercase_rolname);
-		while(isspace(lowercase_rolname[len - 1])) lowercase_rolname[--len] = 0;
+		while(isspace(lowercase_rolname[len - 1]))
+			lowercase_rolname[--len] = 0;
 		len = strlen(lowercase_membername);
-		while(isspace(lowercase_membername[len - 1])) lowercase_membername[--len] = 0;
+		while(isspace(lowercase_membername[len - 1]))
+			lowercase_membername[--len] = 0;
+
+		/* check if rolename/membername is empty after removing trailing spaces*/
+		if (strlen(lowercase_rolname) == 0 || strlen(lowercase_membername) == 0)
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
 
 		/* Throws an error if role name and member name are same*/
 		if(strcmp(lowercase_rolname,lowercase_membername)==0)
@@ -1905,7 +1924,7 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 		membername = PG_ARGISNULL(1) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(1));
 
 		/* Role name, member name is not NULL */
-		if ((rolname == NULL || membername ==NULL) || (strlen(rolname) == 0) || (strlen(membername) == 0))
+		if (rolname == NULL || membername ==NULL)
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				errmsg("Name cannot be NULL.")));
 
@@ -1915,9 +1934,16 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 
 		/* Remove trailing whitespaces in rolename and membername*/
 		len = strlen(lowercase_rolname);
-		while(isspace(lowercase_rolname[len - 1])) lowercase_rolname[--len] = 0;
+		while(isspace(lowercase_rolname[len - 1]))
+			lowercase_rolname[--len] = 0;
 		len = strlen(lowercase_membername);
-		while(isspace(lowercase_membername[len - 1])) lowercase_membername[--len] = 0;
+		while(isspace(lowercase_membername[len - 1]))
+			lowercase_membername[--len] = 0;
+
+		/* check if rolename/membername is empty after removing trailing spaces*/
+		if (strlen(lowercase_rolname) == 0 || strlen(lowercase_membername) == 0)
+			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("Name cannot be NULL.")));
 
 		/* Map the logical role name to its physical name in the database.*/
 		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);

--- a/test/JDBC/expected/Test-sp_addrole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-vu-verify.out
@@ -8,7 +8,7 @@ GO
 CREATE USER sp_addrole_user FOR LOGIN sp_addrole_login;
 GO
 
---Throws an error if the argument is empty or contains backslash(\)
+-- Throws an error if the argument is empty or contains backslash(\)
 EXEC sp_addrole NULL;
 GO
 ~~ERROR (Code: 33557097)~~
@@ -28,6 +28,14 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: '\' is not a valid name because it contains invalid characters.)~~
+
+
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_addrole '     ';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
 
 
 -- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
@@ -90,7 +98,7 @@ master_   @sp_addrole_r2#!#R#!#   @sp_addrole_r2#!#master
 ~~END~~
 
 
--- sp_addrole is case insensitive, storing all role values in lower case in DB
+-- sp_addrole is case sensitive while storing the original username and stores the rolname in lowercase
 EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 

--- a/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrolemember-vu-verify.out
@@ -43,6 +43,21 @@ GO
 ~~ERROR (Message: procedure sp_addrolemember has too many arguments specified.)~~
 
 
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_addrolemember '     ', 'sp_addrolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', '     ';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
 -- Throw an error is role/member is empty
 EXEC sp_addrolemember NULL, NULL;
 GO

--- a/test/JDBC/expected/Test-sp_droprole-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprole-vu-verify.out
@@ -29,7 +29,7 @@ GO
 ~~ERROR (Message: procedure sp_droprole has too many arguments specified.)~~
 
 
---Throws an error if the argument is empty or contains backslash(\)
+--Throws an error if the argument is empty
 EXEC sp_droprole '';
 GO
 ~~ERROR (Code: 33557097)~~
@@ -38,6 +38,14 @@ GO
 
 
 EXEC sp_droprole NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_droprole '     ';
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_droprolemember-vu-verify.out
@@ -48,6 +48,21 @@ GO
 ~~ERROR (Message: procedure sp_droprolemember has too many arguments specified.)~~
 
 
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_droprolemember '     ', 'sp_addrolemember_role_doesnot_exist';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
+EXEC sp_droprolemember 'sp_addrolemember_role_doesnot_exist', '     ';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Name cannot be NULL.)~~
+
+
 -- Throw an error is role/member is empty
 EXEC sp_droprolemember '', '';
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-vu-verify.sql
@@ -8,7 +8,7 @@ GO
 CREATE USER sp_addrole_user FOR LOGIN sp_addrole_login;
 GO
 
---Throws an error if the argument is empty or contains backslash(\)
+-- Throws an error if the argument is empty or contains backslash(\)
 EXEC sp_addrole NULL;
 GO
 
@@ -16,6 +16,10 @@ EXEC sp_addrole '';
 GO
 
 EXEC sp_addrole '\';
+GO
+
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_addrole '     ';
 GO
 
 -- Throw error if no argument or more than 2 arguments are passed to sp_addrole procedure
@@ -49,7 +53,7 @@ FROM sys.babelfish_authid_user_ext
 WHERE orig_username = '   @sp_addrole_r2   '
 GO
 
--- sp_addrole is case insensitive, storing all role values in lower case in DB
+-- sp_addrole is case sensitive while storing the original username and stores the rolname in lowercase
 EXEC sp_addrole 'SP_ADDROLE_R3';
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrolemember-vu-verify.sql
@@ -27,6 +27,13 @@ GO
 EXEC sp_addrolemember '','','';
 GO
 
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_addrolemember '     ', 'sp_addrolemember_role_doesnot_exist';
+GO
+
+EXEC sp_addrolemember 'sp_addrolemember_role_doesnot_exist', '     ';
+GO
+
 -- Throw an error is role/member is empty
 EXEC sp_addrolemember NULL, NULL;
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprole-vu-verify.sql
@@ -21,11 +21,15 @@ GO
 EXEC sp_droprole '','','';
 GO
 
---Throws an error if the argument is empty or contains backslash(\)
+--Throws an error if the argument is empty
 EXEC sp_droprole '';
 GO
 
 EXEC sp_droprole NULL;
+GO
+
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_droprole '     ';
 GO
 
 --Throw an error when passed argument is not an role

--- a/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_droprolemember-vu-verify.sql
@@ -32,6 +32,13 @@ GO
 EXEC sp_droprolemember '','','';
 GO
 
+-- Throw error if rolename is empty after removing trailing spaces
+EXEC sp_droprolemember '     ', 'sp_addrolemember_role_doesnot_exist';
+GO
+
+EXEC sp_droprolemember 'sp_addrolemember_role_doesnot_exist', '     ';
+GO
+
 -- Throw an error is role/member is empty
 EXEC sp_droprolemember '', '';
 GO


### PR DESCRIPTION
Signed-off-by: vasavi suthapalli <svasusri@amazon.com>
### Description
Previously the procedures sp_addrole, sp_droprolemember, sp_addrolemmeber, sp_droprole does not handle the arguments which contains only whitespaces and result in crash because after removing the trailing spaces the string is empty.

Now the procedures sp_addrole, sp_droprole, sp_addrolemember, sp_droprolemember can handle the case where the arguments contains all whitespaces by throwing error that name cannot be null. This case is handled by placing the check of empty string at the start after removing trailing spaces.
 
### Issues Resolved
BABEL-3660

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).