### PR TITLE
 Update minor-version-upgrade.yml 

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -12,6 +12,7 @@ runs:
     - name: Checkout, Build, and Install the Modified PostgreSQL Instance and Run Tests
       run: |
         cd ..
+        rm -rf postgresql_modified_for_babelfish
         git clone --branch ${{inputs.engine_branch}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
         cd postgresql_modified_for_babelfish
         ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu

--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -3,7 +3,7 @@ name: 'Build Modified Postgres'
 inputs:
   engine_branch:
     description: 'Engine Branch'
-    required: yes
+    required: no
     default: 'BABEL_1_X_DEV__PG_13_X'
 
 runs:

--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -3,7 +3,7 @@ name: 'Build Modified Postgres'
 inputs:
   engine_branch:
     description: 'Engine Branch'
-    required: no
+    required: yes
     default: 'BABEL_1_X_DEV__PG_13_X'
 
 runs:

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -87,20 +87,13 @@ jobs:
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
 
-      - name: Build and run tests for Postgres engine using ${{env.ENGINE_VER_TO}}
-        run: |
-          cd ../postgresql_modified_for_babelfish
-          git checkout ${{env.ENGINE_VER_TO}}
-          ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
-          make clean
-          make -j 4 2>error.txt
-          make install
-          make check
-          cd contrib && make && sudo make install
+      - name: Build and run tests for Postgres engine using latest version
+        id: build-modified-postgres-newer
+        uses: ./.github/composite-actions/build-modified-postgres
 
       - uses: actions/checkout@v2
 
-      - name: Set env variables and build extensions using ${{env.EXTENSION_VER_TO}}
+      - name: Set env variables and build extensions using latest version
         id: build-extensions-newer
         uses: ./.github/composite-actions/build-extensions
 

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -1,11 +1,5 @@
 name: Minor Version Upgrade Tests
-on:
-  push:
-    branches:
-      - BABEL_1_X_DEV
-  pull_request:
-    branches:
-      - BABEL_1_X_DEV
+on: [push, pull_request]
 
 jobs:
   extension-tests:

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -81,6 +81,8 @@ jobs:
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
 
+      - uses: actions/checkout@v2
+      
       - name: Build and run tests for Postgres engine using latest version
         id: build-modified-postgres-newer
         uses: ./.github/composite-actions/build-modified-postgres

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -87,13 +87,20 @@ jobs:
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
 
-      - name: Build and run tests for Postgres engine using latest version
-        id: build-modified-postgres-newer
-        uses: ./.github/composite-actions/build-modified-postgres
+      - name: Build and run tests for Postgres engine using ${{env.ENGINE_VER_TO}}
+        run: |
+          cd ../postgresql_modified_for_babelfish
+          git checkout ${{env.ENGINE_VER_TO}}
+          ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          make clean
+          make -j 4 2>error.txt
+          make install
+          make check
+          cd contrib && make && sudo make install
 
       - uses: actions/checkout@v2
 
-      - name: Set env variables and build extensions using latest version
+      - name: Set env variables and build extensions using ${{env.EXTENSION_VER_TO}}
         id: build-extensions-newer
         uses: ./.github/composite-actions/build-extensions
 


### PR DESCRIPTION
### Description

Previously the minor version upgrade WF for empty database was using the BABEL_1_X_DEV__PG_13_X as the new engine branch. However, if there is a dependent engine repository change for an extension repository change then this logic would fail. Replaced this logic by just using the build-modified-postgres composite action with default arguments. By default, the build-modified-postgres composite action will do an intelligent lookup for any dependent engine repository branch.
 
### Issues Resolved

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).