### PR TITLE
Fix the os version for github action

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-dotnet-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   isolation-tests:
     name: Isolation-Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -17,7 +17,7 @@ jobs:
       scheduleFile: ./jdbc_upgrade_schedule
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-odbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout


### PR DESCRIPTION
We're running the github actions on ubuntu-latest.  Previously, it was ubuntu-20.04, but in any recently created fork, it's pointing to ubuntu-22.04.  This is causing dependency/build failure in the github actions running in the fork.  So, let's fix the os version.

Signed-off by: Kuntal Ghosh <kuntalgh@amazon.com>