### PR TITLE
Fix the os version for github action

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-dotnet-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   isolation-tests:
     name: Isolation-Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -9,7 +9,7 @@ jobs:
       ENGINE_BRANCH_FROM: BABEL_1_X_DEV__PG_13_X
       EXTENSION_BRANCH_FROM: BABEL_1_X_DEV
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -8,7 +8,7 @@ jobs:
       EXTENSION_VER_FROM: BABEL_2_1_STABLE
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-odbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -10,7 +10,7 @@ jobs:
       ENGINE_BRANCH_FROM: BABEL_1_2_STABLE__PG_13_6
       EXTENSION_BRANCH_FROM: BABEL_1_2_STABLE
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-sql-validation-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   generate-version-upgrade-tests:
     name: Generate Version Upgrade Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       upgrade-path-list: ${{ steps.generate-upgrade-path.outputs.upgrade-path-list }}
     steps:
@@ -25,7 +25,7 @@ jobs:
       matrix:
         upgrade-path: ${{ fromJson(needs.generate-version-upgrade-tests.outputs.upgrade-path-list) }}
     name: Run Version Upgrade Test for ${{ matrix.upgrade-path.title }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We're running the github actions on ubuntu-latest.  Previously, it was ubuntu-20.04, but in any recently created fork, it's pointing to ubuntu-22.04.  This is causing dependency/build failure in the github actions running in the fork.  So, let's fix the os version.

Signed-off by: Kuntal Ghosh <kuntalgh@amazon.com>