### PR TITLE
Fix the syntax error in the upgrade script

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -2343,7 +2343,7 @@ BEGIN
 		WHERE Ext1.database_name = DB_NAME()
 		AND Ext2.database_name = DB_NAME()
 		AND Ext1.type = 'R'
-		AND Ext2.orig_username != 'db_owner';
+		AND Ext2.orig_username != 'db_owner'
 		AND (Ext1.orig_username = @rolename OR lower(Ext1.orig_username) = lower(@rolename))
 		ORDER BY RoleName, MemberName;
 	END


### PR DESCRIPTION
Fix the syntax error in the procedure sp_helprolemember in the upgrade script babelfishpg_tsql--2.0.0--2.1.0.

Task: BABEL-3056
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

