### PR TITLE
TEST PULL REQUEST - Support ATN2 Transact-SQL function

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -987,6 +987,18 @@ END;
 $BODY$
 LANGUAGE plpgsql PARALLEL SAFE IMMUTABLE RETURNS NULL ON NULL INPUT;
 
+create or replace function sys.atn2(in x double precision, in y double precision) returns double precision
+AS
+$BODY$
+DECLARE
+	res double precision;
+BEGIN
+	res = atan2(x, y);
+	return res;
+END;
+$BODY$
+LANGUAGE plpgsql PARALLEL SAFE IMMUTABLE RETURNS NULL ON NULL INPUT;
+
 CREATE OR REPLACE FUNCTION sys.datepart(IN datepart PG_CATALOG.TEXT, IN arg anyelement) RETURNS INTEGER
 AS
 $body$


### PR DESCRIPTION
Make use of PG's atan2() function to implement atn2 fuction.

Task: BABEL-725
Signed-off-by: Yuhao Wei <yuhaowei@amazon.com>

### Description

Added atn2() function support using pg's atan2() function.

### Issues Resolved

Previously babelfish do not support ATN2 Transact-SQL fucntion.

### Test Scenarios Covered ###
TO BE ADDED


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).