### PR TITLE
Fix Test Failures in Github Action Due to new version of pyodbc

### DIFF
--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -143,6 +143,7 @@ runs:
         fileGenerator_databaseName=jdbc_testdb \
         fileGenerator_user=jdbc_user \
         fileGenerator_password=12345678 \
+        LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/odbc/ \
         python3 upgrade_validation.py
       shell: bash
 

--- a/test/python/expected/pyodbc/TestAuth.out
+++ b/test/python/expected/pyodbc/TestAuth.out
@@ -1,26 +1,26 @@
 #database name, username and password should not exceed 128 characters
 py_auth#!#database|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 911)~~
-~~ERROR (Message: [08004] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (911) (SQLDriverConnect))~~
+~~ERROR (Message: [08004] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (911) (SQLDriverConnect))~~
 
 py_auth#!#database|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
 
 py_auth#!#user|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
 
 py_auth#!#user|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
 
 #not sure why any password is accepted during authentication through cloud desktop
 #This test should throw error but from cloud desktop a connection is successfully established
 #py_auth#!#password|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 py_auth#!#password|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
 
 py_auth#!#others|-|packetSize=0
 ~~SUCCESS~~
@@ -30,5 +30,5 @@ py_auth#!#others|-|packetSize=4096
 ~~SUCCESS~~
 py_auth#!#database|-|test1 SELECT 1
 ~~ERROR (Code: 911)~~
-~~ERROR (Message: [08004] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (911) (SQLDriverConnect))~~
+~~ERROR (Message: [08004] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (911) (SQLDriverConnect))~~
 


### PR DESCRIPTION
The Github Actions for Python Framework and Upgrade Validation framework started Failing Due to new release of Pyodbc. There is a diff in expected output file due to this version Change

More details about the issue can be found here - https://github.com/mkleehammer/pyodbc/issues/1082

Task: BABEL-OSS
Author: Nirmit Shah <nirmisha@amazon.com>
Signed-off-by: Shalini Lohia <lshalini@amazon.com>
