### PR TITLE
Fix pipeline failure for sp_addrole-dep test

### DIFF
--- a/test/JDBC/expected/Test-sp_addrole-dep-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_addrole-dep-vu-verify.out
@@ -26,12 +26,3 @@ GO
 
 ~~ERROR (Message: The @ownername argument is not yet supported in Babelfish.)~~
 
-
-SELECT dbo.test_sp_addrole_func('sp_addrole_role2', '')
-GO
-~~START~~
-int
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: The @ownername argument is not yet supported in Babelfish.)~~
-

--- a/test/JDBC/input/storedProcedures/Test-sp_addrole-dep-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_addrole-dep-vu-verify.sql
@@ -12,6 +12,3 @@ GO
 
 EXEC test_sp_addrole_proc 'sp_addrole_role1', ''
 GO
-
-SELECT dbo.test_sp_addrole_func('sp_addrole_role2', '')
-GO


### PR DESCRIPTION
### Description
Previously the sp_addrole-dep test was passing locally but failing on remote instances.The reason for this is that the [pg_stat_statements](https://www.postgresql.org/docs/current/pgstatstatements.html) module is not enabled locally, but is enabled on remote instances.
Problem only happens for error cases where error is raised inside a function while doing insert exec on a table variable.
This is not a valid SQL server use case as SQL server does not allow insert exec inside functions but allows only inside procedures. Fixed by removing failing test case.
Signed-off-by: vasavi suthapalli <svasusri@amazon.com>
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).