### PR TITLE
Set pyodbc version to 4.0.35 for python test framework and upgrade validation framework

### DIFF
--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -129,7 +129,7 @@ runs:
       run: |
         cd ~
         sudo apt-get install odbc-postgresql
-        pip3 install pyodbc pymssql
+        pip3 install pyodbc==4.0.35 pymssql
       shell: bash
 
     - name: Run dependency check

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,7 +48,7 @@ jobs:
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           cd ~/work/babelfish_extensions/babelfish_extensions/test/python
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
-          pip3 install pyodbc pymssql pytest pytest-xdist
+          pip3 install pyodbc==4.0.35 pymssql pytest pytest-xdist
       
       - name: Run Python Tests
         if: always() && steps.configure-python-environment.outcome == 'success'


### PR DESCRIPTION
### Description

### Issues Resolved

This will resolve the issue of updating the updating the TestAuth Files in Python test framework for change in pyodbc version

Signed-off-by: Nirmit Shah [nirmisha@amazon.com](mailto:nirmisha@amazon.com)
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).