### PR TITLE
Raise feature not supported error for SELECT FOR JSON for various datatypes

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
@@ -14,6 +14,7 @@
 #include "src/backend_parser/gramparse.h"
 #include "src/pltsql_instr.h"
 #include "src/multidb.h"
+#include "src/forjson.h"
 
 #define MD5_HASH_LEN 32
 

--- a/contrib/babelfishpg_tsql/src/forjson.h
+++ b/contrib/babelfishpg_tsql/src/forjson.h
@@ -1,0 +1,17 @@
+#ifndef FORJSON_H
+#define FORJSON_H
+
+/* Enum declaration to support FOR JSON clause */
+typedef enum
+{
+	TSQL_FORJSON_AUTO,
+	TSQL_FORJSON_PATH,
+} TSQLFORJSONMode;
+
+typedef enum
+{
+	TSQL_JSON_DIRECTIVE_INCLUDE_NULL_VALUES,
+	TSQL_JSON_DIRECTIVE_WITHOUT_ARRAY_WRAPPER
+} TSQLJSONDirective;
+
+#endif							/* FORJSON_H */

--- a/test/JDBC/expected/BABEL-3407-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3407-vu-verify.out
@@ -151,7 +151,7 @@ SELECT * FROM babel_3407_view13
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table)~~
+~~ERROR (Message: column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table)~~
 
 
 -- All null values test

--- a/test/JDBC/expected/BABEL-3691-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3691-vu-cleanup.out
@@ -1,0 +1,94 @@
+-- DROP TABLE
+DROP TABLE BABEL_3691_vu_prepare_t1
+GO
+
+-- Approximate numerics
+DROP TABLE BABEL_3691_vu_prepare_t2
+GO
+
+-- Date and time
+DROP TABLE BABEL_3691_vu_prepare_t3
+GO
+
+-- Character strings
+DROP TABLE BABEL_3691_vu_prepare_t4
+GO
+
+-- Unicode character strings
+DROP TABLE BABEL_3691_vu_prepare_t5
+GO
+
+-- Binary strings
+DROP TABLE BABEL_3691_vu_prepare_t6
+GO
+
+-- Return null string
+DROP TABLE BABEL_3691_vu_prepare_t7
+GO
+
+-- Rowversion and timestamp
+DROP TABLE BABEL_3691_vu_prepare_t8
+GO
+
+DROP TABLE BABEL_3691_vu_prepare_t9
+GO
+
+-- DIFFERENT CASES TO CHECK DATATYPES
+-- Exact Numerics
+DROP VIEW BABEL_3691_vu_prepare_view1
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view2
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view3
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view4
+GO
+
+-- Approximate numerics
+DROP VIEW BABEL_3691_vu_prepare_view5
+GO
+
+-- Date and time
+DROP VIEW BABEL_3691_vu_prepare_view6
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view7
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view8
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view9
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view10
+GO
+
+-- Character strings
+DROP VIEW BABEL_3691_vu_prepare_view11
+GO
+
+-- Unicode character strings
+DROP VIEW BABEL_3691_vu_prepare_view12
+GO
+
+-- Binary strings
+DROP VIEW BABEL_3691_vu_prepare_view13
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view14
+GO
+
+-- Return null string
+DROP VIEW BABEL_3691_vu_prepare_view15
+GO
+
+-- Rowversion and timestamp
+DROP VIEW BABEL_3691_vu_prepare_view16
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view17
+GO

--- a/test/JDBC/expected/BABEL-3691-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3691-vu-prepare.out
@@ -1,0 +1,181 @@
+-- DIFFERENT CASES TO CHECK DATATYPES
+-- Exact Numerics
+CREATE TABLE BABEL_3691_vu_prepare_t1(a bigint, b bit, c decimal, d int, e money, f numeric, g smallint, h smallmoney, i tinyint)
+GO
+INSERT BABEL_3691_vu_prepare_t1 VALUES(9223372036854775807, 1, 123.2, 2147483647, 3148.29, 12345.12, 32767, 3148.29, 255)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Approximate numerics
+CREATE TABLE BABEL_3691_vu_prepare_t2(a float, b real)
+GO
+INSERT BABEL_3691_vu_prepare_t2 VALUES(12.05, 120.53)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Date and time
+CREATE TABLE BABEL_3691_vu_prepare_t3(a time, b date, c smalldatetime, d datetime, e datetime2, f datetimeoffset)
+GO
+INSERT BABEL_3691_vu_prepare_t3 VALUES('2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Character strings
+CREATE TABLE BABEL_3691_vu_prepare_t4(a char, b varchar(3), c text)
+GO
+INSERT BABEL_3691_vu_prepare_t4 VALUES('a','abc','abc')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Unicode character strings
+CREATE TABLE BABEL_3691_vu_prepare_t5(a nchar(5), b nvarchar(5), c ntext)
+GO
+INSERT BABEL_3691_vu_prepare_t5 VALUES('abc','abc','abc')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Binary strings
+CREATE TABLE BABEL_3691_vu_prepare_t6(a binary, b varbinary(10))
+GO
+INSERT BABEL_3691_vu_prepare_t6 VALUES (123456,0x0a0b0c0d0e)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Return null string
+CREATE TABLE BABEL_3691_vu_prepare_t7(MyColumn int)
+GO
+
+-- Rowversion and timestamp
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'ignore';
+GO
+
+CREATE TABLE BABEL_3691_vu_prepare_t8 (myKey int, myValue int,RV rowversion);
+GO
+INSERT INTO BABEL_3691_vu_prepare_t8 (myKey, myValue) VALUES (1, 0);
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE BABEL_3691_vu_prepare_t9 (myKey int, myValue int, timestamp);
+GO
+INSERT INTO BABEL_3691_vu_prepare_t9 (myKey, myValue) VALUES (1, 0);
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- Exact Numerics
+CREATE VIEW BABEL_3691_vu_prepare_view1 AS
+SELECT a, c, d, f, g, i 
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view2 AS
+SELECT b 
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view3 AS
+SELECT e 
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view4 AS
+SELECT h
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+-- Approximate numerics
+CREATE VIEW BABEL_3691_vu_prepare_view5 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t2
+FOR JSON PATH;
+GO
+
+-- Date and time
+CREATE VIEW BABEL_3691_vu_prepare_view6 AS
+SELECT a,b 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view7 AS
+SELECT c
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view8 AS
+SELECT d 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view9 AS
+SELECT e 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view10 AS
+SELECT f 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+-- Character strings
+CREATE VIEW BABEL_3691_vu_prepare_view11 AS
+SELECT * 
+FROM BABEL_3691_vu_prepare_t4
+FOR JSON PATH;
+GO
+
+-- Unicode character strings
+CREATE VIEW BABEL_3691_vu_prepare_view12 AS
+SELECT * 
+FROM BABEL_3691_vu_prepare_t5
+FOR JSON PATH;
+GO
+
+-- Binary strings
+CREATE VIEW BABEL_3691_vu_prepare_view13 AS
+SELECT a 
+FROM BABEL_3691_vu_prepare_t6
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view14 AS
+SELECT b
+FROM BABEL_3691_vu_prepare_t6
+FOR JSON PATH;
+GO
+
+-- Return null string
+CREATE VIEW BABEL_3691_vu_prepare_view15 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t7
+FOR JSON PATH;
+GO
+
+-- Rowversion and timestamp
+CREATE VIEW BABEL_3691_vu_prepare_view16 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t8
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view17 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t9
+FOR JSON PATH;
+GO

--- a/test/JDBC/expected/BABEL-3691-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3691-vu-verify.out
@@ -1,0 +1,133 @@
+-- DIFFERENT CASES TO CHECK DATATYPES
+-- Exact Numerics
+SELECT * FROM BABEL_3691_vu_prepare_view1
+GO
+~~START~~
+nvarchar
+[{"a":9223372036854775807,"c":123,"d":2147483647,"f":12345,"g":32767,"i":255}]
+~~END~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: bit type is not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view3
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data types money or smallmoney are not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view4
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data types money or smallmoney are not supported with FOR JSON)~~
+
+
+-- Approximate numerics
+SELECT * FROM BABEL_3691_vu_prepare_view5
+GO
+~~START~~
+nvarchar
+[{"a":12.05,"b":120.53}]
+~~END~~
+
+
+-- Date and time
+SELECT * FROM BABEL_3691_vu_prepare_view6
+GO
+~~START~~
+nvarchar
+[{"a":"23:17:08.56","b":"2022-11-11"}]
+~~END~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view7
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: datetime types are not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view8
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: datetime types are not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view9
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: datetime types are not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view10
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: datetime types are not supported with FOR JSON)~~
+
+
+-- Character strings
+SELECT * FROM BABEL_3691_vu_prepare_view11
+GO
+~~START~~
+nvarchar
+[{"a":"a","b":"abc","c":"abc"}]
+~~END~~
+
+
+-- Unicode character strings
+SELECT * FROM BABEL_3691_vu_prepare_view12
+GO
+~~START~~
+nvarchar
+[{"a":"abc  ","b":"abc","c":"abc"}]
+~~END~~
+
+
+-- Binary strings
+SELECT * FROM BABEL_3691_vu_prepare_view13
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: binary types are not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view14
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: binary types are not supported with FOR JSON)~~
+
+
+-- Return null string
+SELECT * FROM BABEL_3691_vu_prepare_view15
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+-- Rowversion and timestamp
+SELECT * FROM BABEL_3691_vu_prepare_view16
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: binary types are not supported with FOR JSON)~~
+
+
+SELECT * FROM BABEL_3691_vu_prepare_view17
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: binary types are not supported with FOR JSON)~~
+

--- a/test/JDBC/input/BABEL-3691-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-3691-vu-cleanup.sql
@@ -1,0 +1,94 @@
+-- DROP TABLE
+DROP TABLE BABEL_3691_vu_prepare_t1
+GO
+
+-- Approximate numerics
+DROP TABLE BABEL_3691_vu_prepare_t2
+GO
+
+-- Date and time
+DROP TABLE BABEL_3691_vu_prepare_t3
+GO
+
+-- Character strings
+DROP TABLE BABEL_3691_vu_prepare_t4
+GO
+
+-- Unicode character strings
+DROP TABLE BABEL_3691_vu_prepare_t5
+GO
+
+-- Binary strings
+DROP TABLE BABEL_3691_vu_prepare_t6
+GO
+
+-- Return null string
+DROP TABLE BABEL_3691_vu_prepare_t7
+GO
+
+-- Rowversion and timestamp
+DROP TABLE BABEL_3691_vu_prepare_t8
+GO
+
+DROP TABLE BABEL_3691_vu_prepare_t9
+GO
+
+-- DIFFERENT CASES TO CHECK DATATYPES
+-- Exact Numerics
+DROP VIEW BABEL_3691_vu_prepare_view1
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view2
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view3
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view4
+GO
+
+-- Approximate numerics
+DROP VIEW BABEL_3691_vu_prepare_view5
+GO
+
+-- Date and time
+DROP VIEW BABEL_3691_vu_prepare_view6
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view7
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view8
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view9
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view10
+GO
+
+-- Character strings
+DROP VIEW BABEL_3691_vu_prepare_view11
+GO
+
+-- Unicode character strings
+DROP VIEW BABEL_3691_vu_prepare_view12
+GO
+
+-- Binary strings
+DROP VIEW BABEL_3691_vu_prepare_view13
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view14
+GO
+
+-- Return null string
+DROP VIEW BABEL_3691_vu_prepare_view15
+GO
+
+-- Rowversion and timestamp
+DROP VIEW BABEL_3691_vu_prepare_view16
+GO
+
+DROP VIEW BABEL_3691_vu_prepare_view17
+GO

--- a/test/JDBC/input/BABEL-3691-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-3691-vu-prepare.sql
@@ -1,0 +1,165 @@
+-- DIFFERENT CASES TO CHECK DATATYPES
+-- Exact Numerics
+CREATE TABLE BABEL_3691_vu_prepare_t1(a bigint, b bit, c decimal, d int, e money, f numeric, g smallint, h smallmoney, i tinyint)
+GO
+INSERT BABEL_3691_vu_prepare_t1 VALUES(9223372036854775807, 1, 123.2, 2147483647, 3148.29, 12345.12, 32767, 3148.29, 255)
+GO
+
+-- Approximate numerics
+CREATE TABLE BABEL_3691_vu_prepare_t2(a float, b real)
+GO
+INSERT BABEL_3691_vu_prepare_t2 VALUES(12.05, 120.53)
+GO
+
+-- Date and time
+CREATE TABLE BABEL_3691_vu_prepare_t3(a time, b date, c smalldatetime, d datetime, e datetime2, f datetimeoffset)
+GO
+INSERT BABEL_3691_vu_prepare_t3 VALUES('2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560','2022-11-11 23:17:08.560')
+GO
+
+-- Character strings
+CREATE TABLE BABEL_3691_vu_prepare_t4(a char, b varchar(3), c text)
+GO
+INSERT BABEL_3691_vu_prepare_t4 VALUES('a','abc','abc')
+GO
+
+-- Unicode character strings
+CREATE TABLE BABEL_3691_vu_prepare_t5(a nchar(5), b nvarchar(5), c ntext)
+GO
+INSERT BABEL_3691_vu_prepare_t5 VALUES('abc','abc','abc')
+GO
+
+-- Binary strings
+CREATE TABLE BABEL_3691_vu_prepare_t6(a binary, b varbinary(10))
+GO
+INSERT BABEL_3691_vu_prepare_t6 VALUES (123456,0x0a0b0c0d0e)
+GO
+
+-- Return null string
+CREATE TABLE BABEL_3691_vu_prepare_t7(MyColumn int)
+GO
+
+-- Rowversion and timestamp
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'ignore';
+GO
+
+CREATE TABLE BABEL_3691_vu_prepare_t8 (myKey int, myValue int,RV rowversion);
+GO
+INSERT INTO BABEL_3691_vu_prepare_t8 (myKey, myValue) VALUES (1, 0);
+GO
+
+CREATE TABLE BABEL_3691_vu_prepare_t9 (myKey int, myValue int, timestamp);
+GO
+INSERT INTO BABEL_3691_vu_prepare_t9 (myKey, myValue) VALUES (1, 0);
+GO
+
+
+-- Exact Numerics
+CREATE VIEW BABEL_3691_vu_prepare_view1 AS
+SELECT a, c, d, f, g, i 
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view2 AS
+SELECT b 
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view3 AS
+SELECT e 
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view4 AS
+SELECT h
+FROM BABEL_3691_vu_prepare_t1
+FOR JSON PATH;
+GO
+
+-- Approximate numerics
+CREATE VIEW BABEL_3691_vu_prepare_view5 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t2
+FOR JSON PATH;
+GO
+
+-- Date and time
+CREATE VIEW BABEL_3691_vu_prepare_view6 AS
+SELECT a,b 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view7 AS
+SELECT c
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view8 AS
+SELECT d 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view9 AS
+SELECT e 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view10 AS
+SELECT f 
+FROM BABEL_3691_vu_prepare_t3
+FOR JSON PATH;
+GO
+
+-- Character strings
+CREATE VIEW BABEL_3691_vu_prepare_view11 AS
+SELECT * 
+FROM BABEL_3691_vu_prepare_t4
+FOR JSON PATH;
+GO
+
+-- Unicode character strings
+CREATE VIEW BABEL_3691_vu_prepare_view12 AS
+SELECT * 
+FROM BABEL_3691_vu_prepare_t5
+FOR JSON PATH;
+GO
+
+-- Binary strings
+CREATE VIEW BABEL_3691_vu_prepare_view13 AS
+SELECT a 
+FROM BABEL_3691_vu_prepare_t6
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view14 AS
+SELECT b
+FROM BABEL_3691_vu_prepare_t6
+FOR JSON PATH;
+GO
+
+-- Return null string
+CREATE VIEW BABEL_3691_vu_prepare_view15 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t7
+FOR JSON PATH;
+GO
+
+-- Rowversion and timestamp
+CREATE VIEW BABEL_3691_vu_prepare_view16 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t8
+FOR JSON PATH;
+GO
+
+CREATE VIEW BABEL_3691_vu_prepare_view17 AS
+SELECT *
+FROM BABEL_3691_vu_prepare_t9
+FOR JSON PATH;
+GO

--- a/test/JDBC/input/BABEL-3691-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3691-vu-verify.sql
@@ -1,0 +1,59 @@
+-- DIFFERENT CASES TO CHECK DATATYPES
+-- Exact Numerics
+SELECT * FROM BABEL_3691_vu_prepare_view1
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view2
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view3
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view4
+GO
+
+-- Approximate numerics
+SELECT * FROM BABEL_3691_vu_prepare_view5
+GO
+
+-- Date and time
+SELECT * FROM BABEL_3691_vu_prepare_view6
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view7
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view8
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view9
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view10
+GO
+
+-- Character strings
+SELECT * FROM BABEL_3691_vu_prepare_view11
+GO
+
+-- Unicode character strings
+SELECT * FROM BABEL_3691_vu_prepare_view12
+GO
+
+-- Binary strings
+SELECT * FROM BABEL_3691_vu_prepare_view13
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view14
+GO
+
+-- Return null string
+SELECT * FROM BABEL_3691_vu_prepare_view15
+GO
+
+-- Rowversion and timestamp
+SELECT * FROM BABEL_3691_vu_prepare_view16
+GO
+
+SELECT * FROM BABEL_3691_vu_prepare_view17
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -134,6 +134,7 @@ BABEL-383
 BABEL-405
 BABEL-937
 BABEL-3407
+BABEL-3691
 BABEL-PROCID
 babel_trigger
 insteadoftriggers_with_transaction


### PR DESCRIPTION
### Description

- Raising feature not supported error for varbinary, binary, rowversion, image, timestamp, datetime2, datetime, smalldatetime, datetimeoffset, bit, money and smallmoney datatypes
- Added test cases to check each and every datatype
- Moving enum declaration for FOR JSON from engine's parser.h to extensions forjson.h
- This is not a complete fix for the issue, it raises featured not supported error for unsupported datatypes

PR Engine - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/63

TASK: BABEL-3691
Signed-off-by: Anuj Sarda sardanuj@amazon.com

### Issues Resolved

BABEL-3691

### Test Scenarios Covered ###
* **Boundary conditions -** N/A

* **Arbitrary inputs -** N/A

* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).