### PR TITLE
Convert the three part name to physical schema in TVP

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -67,5 +67,5 @@ jobs:
             babel_databaseName=master \
             babel_user=jdbc_user \
             babel_password=12345678 \
-            testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestTvp.txt;TestAuthentication.txt;TestText.txt" \
+            testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestAuthentication.txt;TestText.txt" \
             dotnet test

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2110,7 +2110,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 							values[i] = TdsTypeVarbinaryToDatum(temp);
 							argtypes[i] = tempFuncInfo->ttmtypeid;
 						break;
-						case TDS_RECV_DATE:
+						case TDS_TYPE_DATE:
 							values[i] = TdsTypeDateToDatum(temp);
 						break;
 						case TDS_TYPE_TIME:

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -478,7 +478,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	int i = 0;
 	char *messageData = message->data;
 	char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
-	char *physical_schema = "";
+	char *physical_schema = NULL;
 	StringInfo tempStringInfo = palloc( sizeof(StringInfoData));
 
 	/* Database-Name.Schema-Name.TableType-Name */
@@ -508,8 +508,12 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 			if(i==1)
 				physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name,tempStringInfo->data);
 			/* if schema name is specified */
-			else if(physical_schema != "")
+			else if(physical_schema)
+			{
 				temp->tvpInfo->tvpTypeName = psprintf("%s.%s", physical_schema, tempStringInfo->data);
+				pfree(physical_schema);
+				pfree(db_name);
+			}
 			/* if schema name not specified */
 			else
 				temp->tvpInfo->tvpTypeName = tempStringInfo->data;

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -467,6 +467,7 @@ SetTvpRowData(ParameterToken temp, const StringInfo message, uint64_t *offset)
 					 temp->paramOrdinal + 1, temp->paramMeta.colName.data, temp->tvpInfo->rowCount, temp->tvpInfo->colCount, temp->type)));
 	(*offset)++;
 }
+
 static inline void
 SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *offset)
 {
@@ -476,8 +477,9 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	char *tempString;
 	int i = 0;
 	char *messageData = message->data;
+	char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
+	char *physical_schema;
 	StringInfo tempStringInfo = palloc( sizeof(StringInfoData));
-	temp->tvpInfo->tvpTypeName = " ";
 
 	/* Database-Name.Schema-Name.TableType-Name */
 	for(; i < 3; i++)
@@ -502,8 +504,16 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 
 			*offset +=  len * 2;
 			temp->len += len;
+			
+			if(i==1)
+				physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name,tempStringInfo->data);
+			/* if schema name is specified */
+			else if(physical_schema)
+				temp->tvpInfo->tvpTypeName = psprintf("%s.%s", physical_schema, tempStringInfo->data);
+			/* if schema name not specified */
+			else
+				temp->tvpInfo->tvpTypeName = tempStringInfo->data;
 
-			temp->tvpInfo->tvpTypeName = psprintf("%s.%s", temp->tvpInfo->tvpTypeName, tempStringInfo->data);
 		}
 		else if (i == 2)
 		{
@@ -517,8 +527,6 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	}
 	temp->tvpInfo->tableName = tempStringInfo->data;
 	i = 0;
-
-	temp->tvpInfo->tvpTypeName += 2;
 
 	memcpy(&isTvpNull, &messageData[*offset], sizeof(uint16));
 	if (isTvpNull != TVP_NULL_TOKEN)

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -509,7 +509,10 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 				physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name,tempStringInfo->data);
 			/* if schema name is specified */
 			else if(physical_schema)
+			{
 				temp->tvpInfo->tvpTypeName = psprintf("%s.%s", physical_schema, tempStringInfo->data);
+				pfree(physical_schema);
+			}
 			/* if schema name not specified */
 			else
 				temp->tvpInfo->tvpTypeName = tempStringInfo->data;
@@ -525,9 +528,8 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 						 temp->paramOrdinal + 1)));
 		}
 	}
-	pfree(physical_schema);
 	pfree(db_name);
-	
+
 	temp->tvpInfo->tableName = tempStringInfo->data;
 	i = 0;
 

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -478,7 +478,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	int i = 0;
 	char *messageData = message->data;
 	char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
-	char *physical_schema;
+	char *physical_schema = "";
 	StringInfo tempStringInfo = palloc( sizeof(StringInfoData));
 
 	/* Database-Name.Schema-Name.TableType-Name */
@@ -508,7 +508,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 			if(i==1)
 				physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name,tempStringInfo->data);
 			/* if schema name is specified */
-			else if(physical_schema)
+			else if(physical_schema != "")
 				temp->tvpInfo->tvpTypeName = psprintf("%s.%s", physical_schema, tempStringInfo->data);
 			/* if schema name not specified */
 			else

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -509,11 +509,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 				physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name,tempStringInfo->data);
 			/* if schema name is specified */
 			else if(physical_schema)
-			{
 				temp->tvpInfo->tvpTypeName = psprintf("%s.%s", physical_schema, tempStringInfo->data);
-				pfree(physical_schema);
-				pfree(db_name);
-			}
 			/* if schema name not specified */
 			else
 				temp->tvpInfo->tvpTypeName = tempStringInfo->data;
@@ -529,6 +525,9 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 						 temp->paramOrdinal + 1)));
 		}
 	}
+	pfree(physical_schema);
+	pfree(db_name);
+	
 	temp->tvpInfo->tableName = tempStringInfo->data;
 	i = 0;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3513,6 +3513,8 @@ _PG_init(void)
 		(*pltsql_protocol_plugin_ptr)->get_insert_bulk_kilobytes_per_batch = &get_insert_bulk_kilobytes_per_batch;
 		(*pltsql_protocol_plugin_ptr)->tsql_varchar_input = &tsql_varchar_input;
 		(*pltsql_protocol_plugin_ptr)->tsql_char_input = &tsql_bpchar_input;
+		(*pltsql_protocol_plugin_ptr)->get_cur_db_name = &get_cur_db_name;
+		(*pltsql_protocol_plugin_ptr)->get_physical_schema_name = &get_physical_schema_name;
 	}
 
 	get_language_procs("pltsql", &lang_handler_oid, &lang_validator_oid);

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1626,6 +1626,10 @@ typedef struct PLtsql_protocol_plugin
 	void* (*tsql_varchar_input) (const char *s, size_t len, int32 atttypmod);
 
 	void* (*tsql_char_input) (const char *s, size_t len, int32 atttypmod);
+
+	char* (*get_cur_db_name) ();
+
+	char* (*get_physical_schema_name) (char *db_name, const char *schema_name);
 	
 } PLtsql_protocol_plugin;
 

--- a/test/dotnet/ExpectedOutput/TestTvp.out
+++ b/test/dotnet/ExpectedOutput/TestTvp.out
@@ -1,6 +1,5 @@
 #Q#create schema testtvp
-#Q#create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), j text, k ntext, l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+#Q#create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
-#E#schema "testtvp" does not exist
-#Q#drop type testtvp.tableType;
+#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!##Q#drop type testtvp.tableType;
 #Q#drop schema testtvp

--- a/test/dotnet/ExpectedOutput/TestTvp.out
+++ b/test/dotnet/ExpectedOutput/TestTvp.out
@@ -1,12 +1,12 @@
 #Q#create type tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
-1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 00:00:00#!#11/23/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
 #Q#drop type tableType
 #Q#create schema testtvp
 #Q#create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
-1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 00:00:00#!#11/23/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
 #Q#drop type testtvp.tableType
 #Q#drop schema testtvp

--- a/test/dotnet/ExpectedOutput/TestTvp.out
+++ b/test/dotnet/ExpectedOutput/TestTvp.out
@@ -1,12 +1,12 @@
 #Q#create type tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
-1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 12:00:00 AM#!#11/23/2022 10:10:10 AM#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10 AM
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 00:00:00#!#11/23/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10
 #Q#drop type tableType
 #Q#create schema testtvp
 #Q#create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
-1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 12:00:00 AM#!#11/23/2022 10:10:10 AM#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10 AM
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 00:00:00#!#11/23/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10
 #Q#drop type testtvp.tableType
 #Q#drop schema testtvp

--- a/test/dotnet/ExpectedOutput/TestTvp.out
+++ b/test/dotnet/ExpectedOutput/TestTvp.out
@@ -1,5 +1,12 @@
+#Q#create type tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+#Q#Select * from @a 
+#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 12:00:00 AM#!#11/23/2022 10:10:10 AM#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10 AM
+#Q#drop type tableType
 #Q#create schema testtvp
 #Q#create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
-#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!##Q#drop type testtvp.tableType;
+#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#11/23/2022 12:00:00 AM#!#11/23/2022 10:10:10 AM#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#11/23/2022 10:10:10 AM
+#Q#drop type testtvp.tableType
 #Q#drop schema testtvp

--- a/test/dotnet/input/Datatypes/TestTvp.txt
+++ b/test/dotnet/input/Datatypes/TestTvp.txt
@@ -1,5 +1,11 @@
+#test tvp without schema
+create type tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+prepst#!#Select * from @a #!#tvp|-|a|-|tableType|-|../../../utils/tvp-dotnet.csv
+drop type tableType
+
+#test tvp with schema
 create schema testtvp
 create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 prepst#!#Select * from @a #!#tvp|-|a|-|testtvp.tableType|-|../../../utils/tvp-dotnet.csv
-drop type testtvp.tableType;
+drop type testtvp.tableType
 drop schema testtvp

--- a/test/dotnet/input/Datatypes/TestTvp.txt
+++ b/test/dotnet/input/Datatypes/TestTvp.txt
@@ -1,5 +1,5 @@
 create schema testtvp
-create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), j text, k ntext, l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
-prepst#!#Select * from @a #!#tvp|-|a|-|testtvp.tableType|-|/Users/kushaal/Downloads/tvp-dotnet.csv
+create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+prepst#!#Select * from @a #!#tvp|-|a|-|testtvp.tableType|-|../../../utils/tvp-dotnet.csv
 drop type testtvp.tableType;
 drop schema testtvp

--- a/test/dotnet/utils/tvp-dotnet.csv
+++ b/test/dotnet/utils/tvp-dotnet.csv
@@ -1,0 +1,2 @@
+a-int,b-smallint,c-bigint,d-tinyint,e-bit,f-char-10,g-nchar-10,h-varchar-10,i-nvarchar-10,l-varbinary-10,m-binary-10,n-date,o-datetime,p-money,q-uniqueidentifier,r-float,s-real,t-numeric-4-3,u-decimal-5-3,v-time,w-datetime2
+1,1,1,1,TRUE,hi,hi,hi,hi,11,11,10:10:10,10:10:10,143.5,ce8af10a-2709-43b0-9e4e-a02753929d17,12.11,13.11,1.33,45.122,10:10:10,10:10:10

--- a/test/dotnet/utils/tvp-dotnet.csv
+++ b/test/dotnet/utils/tvp-dotnet.csv
@@ -1,2 +1,2 @@
 a-int,b-smallint,c-bigint,d-tinyint,e-bit,f-char-10,g-nchar-10,h-varchar-10,i-nvarchar-10,l-varbinary-10,m-binary-10,n-date,o-datetime,p-money,q-uniqueidentifier,r-float,s-real,t-numeric-4-3,u-decimal-5-3,v-time,w-datetime2
-1,1,1,1,TRUE,hi,hi,hi,hi,11,11,10:10:10,10:10:10,143.5,ce8af10a-2709-43b0-9e4e-a02753929d17,12.11,13.11,1.33,45.122,10:10:10,10:10:10
+1,1,1,1,TRUE,hi,hi,hi,hi,11,11,10/10/2022,10/10/2022 10:10:10,143.5,ce8af10a-2709-43b0-9e4e-a02753929d17,12.11,13.11,1.33,45.122,10:10:10,10/10/2022 10:10:10


### PR DESCRIPTION
### Description

In TVP we get 3 part name which we parse in TDS. Later we call SPI to create a temp table of this type. We need to convert the logical db name to physical schema name upfront during parsing the request.
For TVP we create a temp table in the current database using SPI. If user also uses database name then we werent creating the temp table in that database, So with this jira we want to convert the db.schema.type_name to db_schema.type_name and hence create the temp table in db_schema PG schema

Issues Resolved: BABEL-3573
Signed-off-by: Shlok Kyal [skkyal@amazon.com](mailto:skkyal@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**
  - Test for TVP for different datatypes with and without schema name specified


* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests -**

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).