### PR TITLE
Replace publicly unreadable pg_catalog view instances to publicly readable one in SQL scripts

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1185,7 +1185,7 @@ $$
 LANGUAGE 'pltsql';
 GRANT ALL on PROCEDURE sys.sp_pkeys TO PUBLIC;
 
-CREATE VIEW sys.sp_statistics_view AS
+CREATE OR REPLACE VIEW sys.sp_statistics_view AS
 SELECT
 CAST(t3."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
 CAST(t3."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
@@ -1221,17 +1221,13 @@ WHEN t8.oid > 0 THEN CAST(t6.relname AS sys.sysname)
 ELSE CAST(SUBSTRING(t6.relname,1,LENGTH(t6.relname)-32-LENGTH(t1.relname)) AS sys.sysname) 
 END AS INDEX_NAME,
 CASE
-WHEN t7.starelid > 0 THEN CAST(0 AS smallint)
-ELSE
-	CASE
-	WHEN t5.indisclustered = 't' THEN CAST(1 AS smallint)
-	ELSE CAST(3 AS smallint)
-	END
+WHEN t5.indisclustered = 't' THEN CAST(1 AS smallint)
+ELSE CAST(3 AS smallint)
 END AS TYPE,
 CAST(seq + 1 AS smallint) AS SEQ_IN_INDEX,
 CAST(t4."COLUMN_NAME" AS sys.sysname) AS COLUMN_NAME,
 CAST('A' AS sys.varchar(1)) AS COLLATION,
-CAST(t7.stadistinct AS int) AS CARDINALITY,
+CAST(t7.n_distinct AS int) AS CARDINALITY,
 CAST(0 AS int) AS PAGES, --not supported
 CAST(NULL AS sys.varchar(128)) AS FILTER_CONDITION
 FROM pg_catalog.pg_class t1
@@ -1240,7 +1236,8 @@ FROM pg_catalog.pg_class t1
     JOIN information_schema_tsql.columns t4 ON (t1.relname = t4."TABLE_NAME" AND s1.name = t4."TABLE_SCHEMA")
 	JOIN (pg_catalog.pg_index t5 JOIN
 		pg_catalog.pg_class t6 ON t5.indexrelid = t6.oid) ON t1.oid = t5.indrelid
-	LEFT JOIN pg_catalog.pg_statistic t7 ON t1.oid = t7.starelid
+	JOIN pg_catalog.pg_namespace nsp ON (t1.relnamespace = nsp.oid)
+	LEFT JOIN pg_catalog.pg_stats t7 ON (t1.relname = t7.tablename AND t7.schemaname = nsp.nspname)
 	LEFT JOIN pg_catalog.pg_constraint t8 ON t5.indexrelid = t8.conindid
     , generate_series(0,31) seq -- SQL server has max 32 columns per index
 WHERE CAST(t4."ORDINAL_POSITION" AS smallint) = ANY (t5.indkey)

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -244,7 +244,7 @@ SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_login_ext', '')
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_configurations', '');
 
 -- SERVER_PRINCIPALS
-CREATE VIEW sys.server_principals
+CREATE OR REPLACE VIEW sys.server_principals
 AS SELECT
 CAST(Base.rolname AS sys.SYSNAME) AS name,
 CAST(Base.oid As INT) AS principal_id,
@@ -261,7 +261,7 @@ CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
 CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.credential_id END AS INT) AS credential_id,
 CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.owning_principal_id END AS INT) AS owning_principal_id,
 CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.is_fixed_role END AS sys.BIT) AS is_fixed_role
-FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname;
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname;
 
 GRANT SELECT ON sys.server_principals TO PUBLIC;
 
@@ -290,9 +290,9 @@ CREATE INDEX babelfish_authid_user_ext_login_db_idx ON sys.babelfish_authid_user
 GRANT SELECT ON sys.babelfish_authid_user_ext TO PUBLIC;
 
 -- DATABASE_PRINCIPALS
-CREATE VIEW sys.database_principals AS SELECT
+CREATE OR REPLACE VIEW sys.database_principals AS SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
-CAST(Base.OID AS INT) AS principal_id,
+CAST(Base.oid AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
 CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_USER'
 WHEN Ext.type = 'R' THEN 'DATABASE_ROLE'
@@ -308,7 +308,7 @@ CAST(Ext.authentication_type_desc AS SYS.NVARCHAR(60)) AS authentication_type_de
 CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
 CAST(Ext.default_language_lcid AS INT) AS default_language_lcid,
 CAST(Ext.allow_encrypted_value_modifications AS SYS.BIT) AS allow_encrypted_value_modifications
-FROM pg_catalog.pg_authid AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
 ON Base.rolname = Ext.rolname
 LEFT OUTER JOIN pg_catalog.pg_roles Base2
 ON Ext.login_name = Base2.rolname
@@ -317,13 +317,13 @@ WHERE Ext.database_name = DB_NAME();
 GRANT SELECT ON sys.database_principals TO PUBLIC;
 
 -- DATABASE_ROLE_MEMBERS
-CREATE VIEW sys.database_role_members AS
+CREATE OR REPLACE VIEW sys.database_role_members AS
 SELECT
 CAST(Auth1.oid AS INT) AS role_principal_id,
 CAST(Auth2.oid AS INT) AS member_principal_id
 FROM pg_catalog.pg_auth_members AS Authmbr
-INNER JOIN pg_catalog.pg_authid AS Auth1 ON Auth1.oid = Authmbr.roleid
-INNER JOIN pg_catalog.pg_authid AS Auth2 ON Auth2.oid = Authmbr.member
+INNER JOIN pg_catalog.pg_roles AS Auth1 ON Auth1.oid = Authmbr.roleid
+INNER JOIN pg_catalog.pg_roles AS Auth2 ON Auth2.oid = Authmbr.member
 INNER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Auth1.rolname = Ext1.rolname
 INNER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Auth2.rolname = Ext2.rolname
 WHERE Ext1.database_name = DB_NAME() 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.2.1--1.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--1.2.1--1.3.0.sql
@@ -1,7 +1,109 @@
- -- complain if script is sourced in psql, rather than via ALTER EXTENSION
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_tsql"" UPDATE TO '1.3.0'" to load this file. \quit
-
+ 
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
 
+CREATE OR REPLACE VIEW sys.server_principals
+AS SELECT
+CAST(Base.rolname AS sys.SYSNAME) AS name,
+CAST(Base.oid As INT) AS principal_id,
+CAST(CAST(Base.oid as INT) as sys.varbinary(85)) AS sid,
+Ext.type,
+CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_LOGIN' ELSE NULL END AS NVARCHAR(60)) AS type_desc,
+Ext.is_disabled,
+Ext.create_date,
+Ext.modify_date,
+Ext.default_database_name,
+Ext.default_language_name,
+Ext.credential_id,
+Ext.owning_principal_id,
+CAST(Ext.is_fixed_role AS sys.BIT) AS is_fixed_role
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname;
+
+GRANT SELECT ON sys.server_principals TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.database_principals AS SELECT
+Ext.orig_username AS name,
+CAST(Base.oid AS INT) AS principal_id,
+Ext.type,
+CAST(CASE WHEN Ext.type = 'S' THEN 'SQL_USER' ELSE NULL END AS SYS.NVARCHAR(60)) AS type_desc,
+Ext.default_schema_name,
+Ext.create_date,
+Ext.modify_date,
+Ext.owning_principal_id,
+CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(Ext.is_fixed_role AS SYS.BIT) AS is_fixed_role,
+Ext.authentication_type,
+Ext.authentication_type_desc,
+Ext.default_language_name,
+Ext.default_language_lcid,
+CAST(Ext.allow_encrypted_value_modifications AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
+ON Base.rolname = Ext.rolname
+LEFT OUTER JOIN pg_catalog.pg_roles Base2
+ON Ext.login_name = Base2.rolname
+WHERE Ext.database_name = DB_NAME();
+
+GRANT SELECT ON sys.database_principals TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.sp_statistics_view AS
+SELECT
+CAST(t3."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
+CAST(t3."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
+CAST(t3."TABLE_NAME" AS sys.sysname) AS TABLE_NAME,
+CAST(NULL AS smallint) AS NON_UNIQUE,
+CAST(NULL AS sys.sysname) AS INDEX_QUALIFIER,
+CAST(NULL AS sys.sysname) AS INDEX_NAME,
+CAST(0 AS smallint) AS TYPE,
+CAST(NULL AS smallint) AS SEQ_IN_INDEX,
+CAST(NULL AS sys.sysname) AS COLUMN_NAME,
+CAST(NULL AS sys.varchar(1)) AS COLLATION,
+CAST(t1.reltuples AS int) AS CARDINALITY,
+CAST(t1.relpages AS int) AS PAGES,
+CAST(NULL AS sys.varchar(128)) AS FILTER_CONDITION
+FROM pg_catalog.pg_class t1
+    JOIN sys.schemas s1 ON s1.schema_id = t1.relnamespace
+    JOIN information_schema_tsql.columns t3 ON (t1.relname = t3."TABLE_NAME" AND s1.name = t3."TABLE_SCHEMA")
+    , generate_series(0,31) seq -- SQL server has max 32 columns per index
+UNION
+SELECT
+CAST(t4."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
+CAST(t4."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
+CAST(t4."TABLE_NAME" AS sys.sysname) AS TABLE_NAME,
+CASE
+WHEN t5.indisunique = 't' THEN CAST(0 AS smallint)
+ELSE CAST(1 AS smallint)
+END AS NON_UNIQUE,
+CAST(t1.relname AS sys.sysname) AS INDEX_QUALIFIER,
+-- the index name created by CREATE INDEX is re-mapped, find it (by checking
+-- the ones not in pg_constraint) and restoring it back before display
+CASE 
+WHEN t8.oid > 0 THEN CAST(t6.relname AS sys.sysname)
+ELSE CAST(SUBSTRING(t6.relname,1,LENGTH(t6.relname)-32-LENGTH(t1.relname)) AS sys.sysname) 
+END AS INDEX_NAME,
+CASE
+WHEN t5.indisclustered = 't' THEN CAST(1 AS smallint)
+ELSE CAST(3 AS smallint)
+END AS TYPE,
+CAST(seq + 1 AS smallint) AS SEQ_IN_INDEX,
+CAST(t4."COLUMN_NAME" AS sys.sysname) AS COLUMN_NAME,
+CAST('A' AS sys.varchar(1)) AS COLLATION,
+CAST(t7.n_distinct AS int) AS CARDINALITY,
+CAST(0 AS int) AS PAGES, --not supported
+CAST(NULL AS sys.varchar(128)) AS FILTER_CONDITION
+FROM pg_catalog.pg_class t1
+    JOIN sys.schemas s1 ON s1.schema_id = t1.relnamespace
+    JOIN pg_catalog.pg_roles t3 ON t1.relowner = t3.oid
+    JOIN information_schema_tsql.columns t4 ON (t1.relname = t4."TABLE_NAME" AND s1.name = t4."TABLE_SCHEMA")
+	JOIN (pg_catalog.pg_index t5 JOIN
+		pg_catalog.pg_class t6 ON t5.indexrelid = t6.oid) ON t1.oid = t5.indrelid
+	JOIN pg_catalog.pg_namespace nsp ON (t1.relnamespace = nsp.oid)
+	LEFT JOIN pg_catalog.pg_stats t7 ON (t1.relname = t7.tablename AND t7.schemaname = nsp.nspname)
+	LEFT JOIN pg_catalog.pg_constraint t8 ON t5.indexrelid = t8.conindid
+    , generate_series(0,31) seq -- SQL server has max 32 columns per index
+WHERE CAST(t4."ORDINAL_POSITION" AS smallint) = ANY (t5.indkey)
+    AND CAST(t4."ORDINAL_POSITION" AS smallint) = t5.indkey[seq];
+GRANT SELECT on sys.sp_statistics_view TO PUBLIC;
+ 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/sys_database_principals_dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys_database_principals_dep-vu-cleanup.out
@@ -1,0 +1,21 @@
+DROP VIEW database_principals_dep_vu_prepare_view
+GO
+
+DROP PROC database_principals_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION database_principals_dep_vu_prepare_func
+GO
+
+DROP USER database_principals_dep_vu_prepare_user1
+GO
+
+DROP USER database_principals_dep_vu_prepare_user2
+GO
+
+DROP LOGIN database_principals_dep_vu_prepare_login1
+GO
+
+DROP LOGIN database_principals_dep_vu_prepare_login2
+GO
+

--- a/test/JDBC/expected/sys_database_principals_dep-vu-prepare.out
+++ b/test/JDBC/expected/sys_database_principals_dep-vu-prepare.out
@@ -1,0 +1,36 @@
+CREATE LOGIN database_principals_dep_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_vu_prepare_user1 FOR LOGIN database_principals_dep_vu_prepare_login1
+GO
+
+CREATE LOGIN database_principals_dep_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_vu_prepare_user2 FOR LOGIN database_principals_dep_vu_prepare_login2
+GO
+
+CREATE VIEW database_principals_dep_vu_prepare_view
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE PROC database_principals_dep_vu_prepare_proc
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE FUNCTION database_principals_dep_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.database_principals WHERE name LIKE '%database_principals_dep_vu_prepare_%')
+END
+GO
+

--- a/test/JDBC/expected/sys_database_principals_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_database_principals_dep-vu-verify.out
@@ -1,0 +1,37 @@
+SELECT * FROM database_principals_dep_vu_prepare_view
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#varchar#!#bit#!#int#!#varchar#!#bit
+database_principals_dep_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+~~END~~
+
+
+EXEC database_principals_dep_vu_prepare_proc
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#varchar#!#bit#!#int#!#varchar#!#bit
+database_principals_dep_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+~~END~~
+
+
+SELECT database_principals_dep_vu_prepare_func()
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT name FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_vu_prepare_%'
+ORDER BY name
+GO
+~~START~~
+varchar
+database_principals_dep_vu_prepare_user1
+database_principals_dep_vu_prepare_user2
+~~END~~
+
+

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-cleanup.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-cleanup.out
@@ -1,0 +1,21 @@
+DROP VIEW database_principals_dep_for_13_x_vu_prepare_view
+GO
+
+DROP PROC database_principals_dep_for_13_x_vu_prepare_proc
+GO
+
+DROP FUNCTION database_principals_dep_for_13_x_vu_prepare_func
+GO
+
+DROP USER database_principals_dep_for_13_x_vu_prepare_user1
+GO
+
+DROP USER database_principals_dep_for_13_x_vu_prepare_user2
+GO
+
+DROP LOGIN database_principals_dep_for_13_x_vu_prepare_login1
+GO
+
+DROP LOGIN database_principals_dep_for_13_x_vu_prepare_login2
+GO
+

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-prepare.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-prepare.out
@@ -1,0 +1,36 @@
+CREATE LOGIN database_principals_dep_for_13_x_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_for_13_x_vu_prepare_user1 FOR LOGIN database_principals_dep_for_13_x_vu_prepare_login1
+GO
+
+CREATE LOGIN database_principals_dep_for_13_x_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_for_13_x_vu_prepare_user2 FOR LOGIN database_principals_dep_for_13_x_vu_prepare_login2
+GO
+
+CREATE VIEW database_principals_dep_for_13_x_vu_prepare_view
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE PROC database_principals_dep_for_13_x_vu_prepare_proc
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE FUNCTION database_principals_dep_for_13_x_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.database_principals WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%')
+END
+GO
+

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
@@ -1,0 +1,37 @@
+SELECT * FROM database_principals_dep_for_13_x_vu_prepare_view
+GO
+~~START~~
+nvarchar#!#char#!#nvarchar#!#nvarchar#!#bit#!#int#!#nvarchar#!#bit
+database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+~~END~~
+
+
+EXEC database_principals_dep_for_13_x_vu_prepare_proc
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#varchar#!#bit#!#int#!#varchar#!#bit
+database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+~~END~~
+
+
+SELECT database_principals_dep_for_13_x_vu_prepare_func()
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT name FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
+ORDER BY name
+GO
+~~START~~
+varchar
+database_principals_dep_for_13_x_vu_prepare_user1
+database_principals_dep_for_13_x_vu_prepare_user2
+~~END~~
+
+

--- a/test/JDBC/expected/sys_server_principals_dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys_server_principals_dep-vu-cleanup.out
@@ -1,0 +1,15 @@
+DROP VIEW sys_server_principals_dep_vu_prepare_view
+GO
+
+DROP PROC sys_server_principals_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_server_principals_dep_vu_prepare_func
+GO
+
+DROP LOGIN sys_server_principals_dep_vu_prepare_login1
+GO
+
+DROP LOGIN sys_server_principals_dep_vu_prepare_login2
+GO
+

--- a/test/JDBC/expected/sys_server_principals_dep-vu-prepare.out
+++ b/test/JDBC/expected/sys_server_principals_dep-vu-prepare.out
@@ -1,0 +1,30 @@
+CREATE LOGIN sys_server_principals_dep_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE LOGIN sys_server_principals_dep_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE VIEW sys_server_principals_dep_vu_prepare_view
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE PROC sys_server_principals_dep_vu_prepare_proc
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_server_principals_dep_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.server_principals WHERE name LIKE '%sys_server_principals_dep_vu_prepare%')
+END
+GO
+

--- a/test/JDBC/expected/sys_server_principals_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_server_principals_dep-vu-verify.out
@@ -1,0 +1,37 @@
+SELECT * FROM sys_server_principals_dep_vu_prepare_view
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#int#!#varchar#!#varchar#!#bit
+sys_server_principals_dep_vu_prepare_login1#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+sys_server_principals_dep_vu_prepare_login2#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+~~END~~
+
+
+EXEC sys_server_principals_dep_vu_prepare_proc
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#int#!#varchar#!#varchar#!#bit
+sys_server_principals_dep_vu_prepare_login1#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+sys_server_principals_dep_vu_prepare_login2#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+~~END~~
+
+
+SELECT sys_server_principals_dep_vu_prepare_func()
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT name FROM sys.server_principals
+WHERE name LIKE 'sys_server_principals_dep_vu_prepare_login%'
+ORDER BY name
+GO
+~~START~~
+varchar
+sys_server_principals_dep_vu_prepare_login1
+sys_server_principals_dep_vu_prepare_login2
+~~END~~
+
+

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-cleanup.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-cleanup.out
@@ -1,0 +1,15 @@
+DROP VIEW sys_server_principals_dep_for_13_x_vu_prepare_view
+GO
+
+DROP PROC sys_server_principals_dep_for_13_x_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_server_principals_dep_for_13_x_vu_prepare_func
+GO
+
+DROP LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login1
+GO
+
+DROP LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login2
+GO
+

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-prepare.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-prepare.out
@@ -1,0 +1,30 @@
+CREATE LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE VIEW sys_server_principals_dep_for_13_x_vu_prepare_view
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_for_13_x_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE PROC sys_server_principals_dep_for_13_x_vu_prepare_proc
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_for_13_x_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_server_principals_dep_for_13_x_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.server_principals WHERE name LIKE '%sys_server_principals_dep_for_13_x_vu_prepare%')
+END
+GO
+

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-verify.out
@@ -1,0 +1,37 @@
+SELECT * FROM sys_server_principals_dep_for_13_x_vu_prepare_view
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#bit
+sys_server_principals_dep_for_13_x_vu_prepare_login1#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+sys_server_principals_dep_for_13_x_vu_prepare_login2#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+~~END~~
+
+
+EXEC sys_server_principals_dep_for_13_x_vu_prepare_proc
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#int#!#varchar#!#varchar#!#bit
+sys_server_principals_dep_for_13_x_vu_prepare_login1#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+sys_server_principals_dep_for_13_x_vu_prepare_login2#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
+~~END~~
+
+
+SELECT sys_server_principals_dep_for_13_x_vu_prepare_func()
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT name FROM sys.server_principals
+WHERE name LIKE 'sys_server_principals_dep_for_13_x_vu_prepare_login%'
+ORDER BY name
+GO
+~~START~~
+varchar
+sys_server_principals_dep_for_13_x_vu_prepare_login1
+sys_server_principals_dep_for_13_x_vu_prepare_login2
+~~END~~
+
+

--- a/test/JDBC/input/ownership/sys_database_principals_dep-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep-vu-cleanup.sql
@@ -1,0 +1,21 @@
+DROP VIEW database_principals_dep_vu_prepare_view
+GO
+
+DROP PROC database_principals_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION database_principals_dep_vu_prepare_func
+GO
+
+DROP USER database_principals_dep_vu_prepare_user1
+GO
+
+DROP USER database_principals_dep_vu_prepare_user2
+GO
+
+DROP LOGIN database_principals_dep_vu_prepare_login1
+GO
+
+DROP LOGIN database_principals_dep_vu_prepare_login2
+GO
+

--- a/test/JDBC/input/ownership/sys_database_principals_dep-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep-vu-prepare.sql
@@ -1,0 +1,36 @@
+CREATE LOGIN database_principals_dep_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_vu_prepare_user1 FOR LOGIN database_principals_dep_vu_prepare_login1
+GO
+
+CREATE LOGIN database_principals_dep_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_vu_prepare_user2 FOR LOGIN database_principals_dep_vu_prepare_login2
+GO
+
+CREATE VIEW database_principals_dep_vu_prepare_view
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE PROC database_principals_dep_vu_prepare_proc
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE FUNCTION database_principals_dep_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.database_principals WHERE name LIKE '%database_principals_dep_vu_prepare_%')
+END
+GO
+

--- a/test/JDBC/input/ownership/sys_database_principals_dep-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep-vu-verify.sql
@@ -1,0 +1,14 @@
+SELECT * FROM database_principals_dep_vu_prepare_view
+GO
+
+EXEC database_principals_dep_vu_prepare_proc
+GO
+
+SELECT database_principals_dep_vu_prepare_func()
+GO
+
+SELECT name FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_vu_prepare_%'
+ORDER BY name
+GO
+

--- a/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-cleanup.sql
@@ -1,0 +1,21 @@
+DROP VIEW database_principals_dep_for_13_x_vu_prepare_view
+GO
+
+DROP PROC database_principals_dep_for_13_x_vu_prepare_proc
+GO
+
+DROP FUNCTION database_principals_dep_for_13_x_vu_prepare_func
+GO
+
+DROP USER database_principals_dep_for_13_x_vu_prepare_user1
+GO
+
+DROP USER database_principals_dep_for_13_x_vu_prepare_user2
+GO
+
+DROP LOGIN database_principals_dep_for_13_x_vu_prepare_login1
+GO
+
+DROP LOGIN database_principals_dep_for_13_x_vu_prepare_login2
+GO
+

--- a/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-prepare.sql
@@ -1,0 +1,36 @@
+CREATE LOGIN database_principals_dep_for_13_x_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_for_13_x_vu_prepare_user1 FOR LOGIN database_principals_dep_for_13_x_vu_prepare_login1
+GO
+
+CREATE LOGIN database_principals_dep_for_13_x_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE USER database_principals_dep_for_13_x_vu_prepare_user2 FOR LOGIN database_principals_dep_for_13_x_vu_prepare_login2
+GO
+
+CREATE VIEW database_principals_dep_for_13_x_vu_prepare_view
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE PROC database_principals_dep_for_13_x_vu_prepare_proc
+AS
+SELECT name, type, type_desc, default_schema_name, is_fixed_role, authentication_type, default_language_name, allow_encrypted_value_modifications
+FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE FUNCTION database_principals_dep_for_13_x_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.database_principals WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%')
+END
+GO
+

--- a/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-verify.sql
@@ -1,0 +1,14 @@
+SELECT * FROM database_principals_dep_for_13_x_vu_prepare_view
+GO
+
+EXEC database_principals_dep_for_13_x_vu_prepare_proc
+GO
+
+SELECT database_principals_dep_for_13_x_vu_prepare_func()
+GO
+
+SELECT name FROM sys.database_principals
+WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
+ORDER BY name
+GO
+

--- a/test/JDBC/input/ownership/sys_server_principals_dep-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep-vu-cleanup.sql
@@ -1,0 +1,15 @@
+DROP VIEW sys_server_principals_dep_vu_prepare_view
+GO
+
+DROP PROC sys_server_principals_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_server_principals_dep_vu_prepare_func
+GO
+
+DROP LOGIN sys_server_principals_dep_vu_prepare_login1
+GO
+
+DROP LOGIN sys_server_principals_dep_vu_prepare_login2
+GO
+

--- a/test/JDBC/input/ownership/sys_server_principals_dep-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep-vu-prepare.sql
@@ -1,0 +1,30 @@
+CREATE LOGIN sys_server_principals_dep_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE LOGIN sys_server_principals_dep_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE VIEW sys_server_principals_dep_vu_prepare_view
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE PROC sys_server_principals_dep_vu_prepare_proc
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_server_principals_dep_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.server_principals WHERE name LIKE '%sys_server_principals_dep_vu_prepare%')
+END
+GO
+

--- a/test/JDBC/input/ownership/sys_server_principals_dep-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep-vu-verify.sql
@@ -1,0 +1,14 @@
+SELECT * FROM sys_server_principals_dep_vu_prepare_view
+GO
+
+EXEC sys_server_principals_dep_vu_prepare_proc
+GO
+
+SELECT sys_server_principals_dep_vu_prepare_func()
+GO
+
+SELECT name FROM sys.server_principals
+WHERE name LIKE 'sys_server_principals_dep_vu_prepare_login%'
+ORDER BY name
+GO
+

--- a/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-cleanup.sql
@@ -1,0 +1,15 @@
+DROP VIEW sys_server_principals_dep_for_13_x_vu_prepare_view
+GO
+
+DROP PROC sys_server_principals_dep_for_13_x_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_server_principals_dep_for_13_x_vu_prepare_func
+GO
+
+DROP LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login1
+GO
+
+DROP LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login2
+GO
+

--- a/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-prepare.sql
@@ -1,0 +1,30 @@
+CREATE LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE LOGIN sys_server_principals_dep_for_13_x_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE VIEW sys_server_principals_dep_for_13_x_vu_prepare_view
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_for_13_x_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE PROC sys_server_principals_dep_for_13_x_vu_prepare_proc
+AS
+SELECT name, type, type_desc, is_disabled, default_database_name, default_language_name, is_fixed_role
+FROM sys.server_principals 
+WHERE name LIKE '%sys_server_principals_dep_for_13_x_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_server_principals_dep_for_13_x_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.server_principals WHERE name LIKE '%sys_server_principals_dep_for_13_x_vu_prepare%')
+END
+GO
+

--- a/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-verify.sql
@@ -1,0 +1,14 @@
+SELECT * FROM sys_server_principals_dep_for_13_x_vu_prepare_view
+GO
+
+EXEC sys_server_principals_dep_for_13_x_vu_prepare_proc
+GO
+
+SELECT sys_server_principals_dep_for_13_x_vu_prepare_func()
+GO
+
+SELECT name FROM sys.server_principals
+WHERE name LIKE 'sys_server_principals_dep_for_13_x_vu_prepare_login%'
+ORDER BY name
+GO
+

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -52,3 +52,12 @@ ignore#!#BABEL-CHECK-CONSTRAINT-before-14_6-vu-verify
 ignore#!#BABEL-CHECK-CONSTRAINT-before-14_6-vu-cleanup
 ignore#!#BABEL-3646-before-14_6-vu-prepare
 ignore#!#BABEL-3646-before-14_6-vu-verify
+
+# These tests are meant for upgrade scenario where source version is 13_X
+ignore#!#sys_database_principals_dep_for_13_x-vu-cleanup
+ignore#!#sys_database_principals_dep_for_13_x-vu-prepare
+ignore#!#sys_database_principals_dep_for_13_x-vu-verify
+ignore#!#sys_server_principals_dep_for_13_x-vu-cleanup
+ignore#!#sys_server_principals_dep_for_13_x-vu-prepare
+ignore#!#sys_server_principals_dep_for_13_x-vu-verify
+

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -191,3 +191,4 @@ BABEL-PG-SYSTEM-FUNCTIONS
 BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
+sys_server_principals_dep_for_13_x

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -241,3 +241,4 @@ BABEL-PG-SYSTEM-FUNCTIONS
 BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
+sys_server_principals_dep_for_13_x

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -284,3 +284,5 @@ BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
 BABEL-3640
+sys_server_principals_dep_for_13_x
+sys_database_principals_dep_for_13_x

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -283,3 +283,5 @@ BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
 BABEL-3640
+sys_server_principals_dep_for_13_x
+sys_database_principals_dep_for_13_x

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -283,3 +283,5 @@ BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
 BABEL-3640
+sys_server_principals_dep_for_13_x
+sys_database_principals_dep_for_13_x

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -282,3 +282,5 @@ BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
 BABEL-3640
+sys_server_principals_dep_for_13_x
+sys_database_principals_dep_for_13_x

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -287,3 +287,5 @@ BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
 BABEL-3640
+sys_server_principals_dep
+sys_database_principals_dep

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -300,3 +300,5 @@ BABEL-3655
 sys-table_types_internal
 BABEL-CHECK-CONSTRAINT-before-14_6
 BABEL-3640
+sys_server_principals_dep
+sys_database_principals_dep

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -337,3 +337,5 @@ sys-table_types_internal
 sys-table_types_internal-dep
 BABEL-CHECK-CONSTRAINT
 BABEL-3640
+sys_server_principals_dep
+sys_database_principals_dep

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -972,7 +972,6 @@ View sys.change_tracking_tables
 View sys.data_spaces
 View sys.database_files
 View sys.database_filestream_options
-View sys.database_principals
 View sys.database_recovery_status
 View sys.database_role_members
 View sys.dm_hadr_cluster
@@ -988,7 +987,6 @@ View sys.master_files
 View sys.pg_namespace_ext
 View sys.registered_search_property_lists
 View sys.selective_xml_index_paths
-View sys.server_principals
 View sys.shipped_objects_not_in_sys
 View sys.sp_column_privileges_view
 View sys.sp_columns_100_view


### PR DESCRIPTION
### Description

Some of the pg_catalogs that are not publicly readable are replaced with publicly
readable views. Replaced instance of pg_authid with pg_roles and pg_statistics
to pg_stats in the sql scripts.

Signed-off-by: Ray Kim <raydhkim@amazon.com>
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).