### PR TITLE
statement_timeout parameter dose not cancel Babelfish session

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -293,7 +293,10 @@ GetTDSRequest(bool *resetProtocol)
 			return NULL;
 		}
 
+		/* Enable statement timeout. Note we add this function here to
+		 * include the time taken by the protocol in the timeout  */
 		enable_statement_timeout();
+
 		/* Parse the packet */
 		switch (messageType)
 		{
@@ -403,7 +406,10 @@ ProcessTDSRequest(TDSRequest request)
 				Assert(0);
 				break;
 		}
+
+		/* Disabling statement timeout after processing */
 		disable_statement_timeout();
+
 		CommitTransactionCommand();
 		MemoryContextSwitchTo(MessageContext);
 
@@ -718,6 +724,9 @@ TestGetTdsRequest(uint8_t reqType, const char *expectedStr)
 	return res;
 }
 
+/*
+ * Start statement timeout timer, if enabled.
+ */
 static void
 enable_statement_timeout(void)
 {

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -293,8 +293,10 @@ GetTDSRequest(bool *resetProtocol)
 			return NULL;
 		}
 
-		/* Enable statement timeout. Note we add this function here to
-		 * include the time taken by the protocol in the timeout  */
+		/*
+		 * Enable statement timeout. Note we add this function here to
+		 * include the time taken by the protocol in the timeout
+		 */
 		enable_statement_timeout();
 
 		/* Parse the packet */
@@ -407,7 +409,7 @@ ProcessTDSRequest(TDSRequest request)
 				break;
 		}
 
-		/* Disabling statement timeout after processing */
+		/* Disabling statement timeout after processing. */
 		disable_statement_timeout();
 
 		CommitTransactionCommand();

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -295,7 +295,7 @@ GetTDSRequest(bool *resetProtocol)
 
 		/*
 		 * Enable statement timeout. Note we add this function here to
-		 * include the time taken by the protocol in the timeout
+		 * include the time taken by the protocol in the timeout.
 		 */
 		enable_statement_timeout();
 
@@ -421,6 +421,7 @@ ProcessTDSRequest(TDSRequest request)
 		int token_type;
 		int command_type = TDS_CMD_UNKNOWN;
 
+		disable_statement_timeout();
 		CommitTransactionCommand();
 		MemoryContextSwitchTo(MessageContext);
 

--- a/test/JDBC/expected/BABEL-1914.out
+++ b/test/JDBC/expected/BABEL-1914.out
@@ -1,0 +1,53 @@
+-- psql
+show statement_timeout;
+GO
+~~START~~
+text
+0
+~~END~~
+
+
+ALTER SYSTEM SET statement_timeout=3000;
+GO
+
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+-- execution should get terminated due to statement timeout
+exec pg_sleep 10;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: canceling statement due to statement timeout)~~
+
+
+exec pg_sleep 1;
+GO
+
+-- psql
+
+-- reset guc value to default
+ALTER SYSTEM SET statement_timeout=0;
+GO
+
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+

--- a/test/JDBC/expected/BABEL-1914.out
+++ b/test/JDBC/expected/BABEL-1914.out
@@ -30,6 +30,26 @@ GO
 exec pg_sleep 1;
 GO
 
+-- should time out for execution_time = statement_timeout
+exec pg_sleep 3;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: canceling statement due to statement timeout)~~
+
+
+exec pg_sleep 2.9;
+GO
+
+-- psql
+-- should throw error as negative values aren't permitted 
+ALTER SYSTEM SET statement_timeout=-1000;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: -1000 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)
+    Server SQLState: 22023)~~
+
 -- psql
 
 -- reset guc value to default
@@ -51,3 +71,8 @@ void
 
 ~~END~~
 
+
+-- tsql
+-- no timeout for t = 0
+exec pg_sleep 0;
+GO

--- a/test/JDBC/input/BABEL-1914.mix
+++ b/test/JDBC/input/BABEL-1914.mix
@@ -16,6 +16,17 @@ GO
 exec pg_sleep 1;
 GO
 
+-- should time out for execution_time = statement_timeout
+exec pg_sleep 3;
+GO
+
+exec pg_sleep 2.9;
+GO
+
+-- psql
+-- should throw error as negative values aren't permitted 
+ALTER SYSTEM SET statement_timeout=-1000;
+GO
 -- psql
 -- reset guc value to default
 
@@ -26,4 +37,9 @@ SELECT pg_reload_conf();
 GO
 
 SELECT pg_sleep(1);
+GO
+
+-- tsql
+-- no timeout for t = 0
+exec pg_sleep 0;
 GO

--- a/test/JDBC/input/BABEL-1914.mix
+++ b/test/JDBC/input/BABEL-1914.mix
@@ -1,0 +1,29 @@
+-- psql
+show statement_timeout;
+GO
+
+ALTER SYSTEM SET statement_timeout=3000;
+GO
+
+SELECT pg_reload_conf();
+GO
+
+-- tsql
+-- execution should get terminated due to statement timeout
+exec pg_sleep 10;
+GO
+
+exec pg_sleep 1;
+GO
+
+-- psql
+-- reset guc value to default
+
+ALTER SYSTEM SET statement_timeout=0;
+GO
+
+SELECT pg_reload_conf();
+GO
+
+SELECT pg_sleep(1);
+GO


### PR DESCRIPTION
### Description

statement_timeout parameter aborts any statement that takes more than the specified amount of time, currently it does not kill Babelfish session when it exceeds the timeout. We have added enable_statement_timeout and disable_statement_timeout to fix this.

Task: BABEL-1914

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
- tests with query execution time more than statement_timeout parameter value
- tests with query execution time less than statement_timeout parameter value
- test behaviour when statement_timeout is disabled and when it is equal to guc value 

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).