### PR TITLE
Fix os and pyodbc versions for github action

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -8,5 +8,5 @@ runs:
         sudo apt-get update
         curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
-        sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison mssql-tools unixodbc-dev
+        sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python2-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison mssql-tools unixodbc-dev
       shell: bash

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-dotnet-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   isolation-tests:
     name: Isolation-Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/minor-version-upgrade-tests.yml
+++ b/.github/workflows/minor-version-upgrade-tests.yml
@@ -11,7 +11,7 @@ jobs:
       scheduleFile: ./jdbc_upgrade_schedule
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-odbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout
@@ -48,7 +48,7 @@ jobs:
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           cd ~/work/babelfish_extensions/babelfish_extensions/test/python
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
-          pip3 install pyodbc pymssql pytest pytest-xdist
+          pip3 install pyodbc==4.0.35 pymssql pytest pytest-xdist
       
       - name: Run Python Tests
         if: always() && steps.configure-python-environment.outcome == 'success'
@@ -64,4 +64,5 @@ jobs:
             fileGenerator_databaseName=master \
             fileGenerator_user=jdbc_user \
             fileGenerator_password=12345678 \
+            LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/odbc/ \
             pytest -s --tb=long -q .

--- a/test/python/expected/pyodbc/TestAuth.out
+++ b/test/python/expected/pyodbc/TestAuth.out
@@ -1,26 +1,26 @@
 #database name, username and password should not exceed 128 characters
 py_auth#!#database|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 3701)~~
-~~ERROR (Message: [42S02] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (3701) (SQLDriverConnect))~~
+~~ERROR (Message: [42S02] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (3701) (SQLDriverConnect))~~
 
 py_auth#!#database|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
 
 py_auth#!#user|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
 
 py_auth#!#user|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
 
 #not sure why any password is accepted during authentication through cloud desktop
 #This test should throw error but from cloud desktop a connection is successfully established
 #py_auth#!#password|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 py_auth#!#password|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
 
 py_auth#!#others|-|packetSize=0
 ~~SUCCESS~~
@@ -30,5 +30,5 @@ py_auth#!#others|-|packetSize=4096
 ~~SUCCESS~~
 py_auth#!#database|-|test1 SELECT 1
 ~~ERROR (Code: 3701)~~
-~~ERROR (Message: [42S02] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (3701) (SQLDriverConnect))~~
+~~ERROR (Message: [42S02] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (3701) (SQLDriverConnect))~~
 


### PR DESCRIPTION
### Description
The Github Actions for Python Framework and Upgrade Validation framework started Failing Due to new release of Pyodbc. There is a diff in expected output file due to this version Change More details about the issue can be found here - mkleehammer/pyodbc#1082

We're running the github actions on ubuntu-latest. Previously, it was ubuntu-20.04, but in any recently created fork, it's pointing to ubuntu-22.04. This is causing dependency/build failure in the github actions running in the fork. So, let's fix the os version.

Task: BABEL-OSS
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
Co-authored-by: Nirmit Shah <nirmisha@amazon.com>
Co-authored-by: Kuntal Ghosh <kuntalgh@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).