### PR TITLE
Remove GetConfigOption call from TDSSendDone function

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2640,9 +2640,10 @@ TdsSendDone(int token, int status, int curcmd, uint64_t nprocessed)
 
 	TdsErrorContext->err_text = "Writing Done Token";
 
-	if (GetConfigOption("babelfishpg_tsql.nocount", true, false) &&
-		strcmp(GetConfigOption("babelfishpg_tsql.nocount", true, false), "on") == 0)
-		gucNocount = true;
+	/* should be initialized already */
+	Assert(pltsql_plugin_handler_ptr);
+	if (pltsql_plugin_handler_ptr->pltsql_nocount_addr)
+		gucNocount = *(pltsql_plugin_handler_ptr->pltsql_nocount_addr);
 
 	if (TdsRequestCtrl)
 		TdsRequestCtrl->isEmptyResponse = false;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -86,6 +86,7 @@ extern bool escape_hatch_unique_constraint;
 extern bool pltsql_recursive_triggers;
 extern bool restore_tsql_tabletype;
 extern bool babelfish_dump_restore;
+extern bool pltsql_nocount;
 
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
@@ -3473,6 +3474,7 @@ _PG_init(void)
 	/* If a protocol extension is loaded, initialize the inline handler. */
 	if (*pltsql_protocol_plugin_ptr)
 	{
+		(*pltsql_protocol_plugin_ptr)->pltsql_nocount_addr = &pltsql_nocount;
 		(*pltsql_protocol_plugin_ptr)->sql_batch_callback = &pltsql_inline_handler;
 		(*pltsql_protocol_plugin_ptr)->sp_executesql_callback = &pltsql_inline_handler;
         (*pltsql_protocol_plugin_ptr)->sp_prepare_callback = &sp_prepare;

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1511,6 +1511,18 @@ typedef struct PLtsql_protocol_plugin
 {
 	/* True if Protocol being used by client is TDS. */
 	bool is_tds_client;
+
+	/*
+	 * List of GUCs used/set by protocol plugin.  We can always use this pointer
+	 * to read the GUC value directly.  We've declared volatile so that the
+	 * compiler always reads the value from the memory location instead of
+	 * the register.
+	 * We should be careful while setting data using this pointer - as the value
+	 * will not be verified and changes can't be rolled back automatically in
+	 * case of an error.
+	 */
+	volatile bool *pltsql_nocount_addr;
+
 	/* 
 	 * stmt_need_logging checks whether stmt needs to be logged at babelfishpg_tsql parser
 	 * and logs the statement at the end of statement execution on TDS

--- a/test/JDBC/expected/BABEL_NOCOUNT.out
+++ b/test/JDBC/expected/BABEL_NOCOUNT.out
@@ -1,0 +1,96 @@
+-- Helper function to retrieve the value of NOCOUNT
+CREATE FUNCTION dbo.babel_nocount_getval()
+	RETURNS VARCHAR(3)
+AS
+BEGIN
+	DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
+	IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
+	RETURN @NOCOUNT;
+END
+GO
+
+-- table to check the rowcount
+CREATE TABLE babel_nocount_t1(a int);
+INSERT INTO babel_nocount_t1 VALUES(0)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Scenario: Check the default value
+SELECT dbo.babel_nocount_getval()
+GO
+~~START~~
+varchar
+OFF
+~~END~~
+
+
+-- Scenario: Check number of rows affected with nocount=on/off
+SET NOCOUNT ON
+GO
+
+-- Should not show affected row count
+INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+
+SET NOCOUNT OFF
+GO
+
+-- Should show rows affected
+INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+~~ROW COUNT: 2~~
+
+
+-- Scenario: Check transactional behaviour, the value should be rolled back in case
+-- of an error/rollback
+SELECT dbo.babel_nocount_getval()
+GO
+~~START~~
+varchar
+OFF
+~~END~~
+
+
+BEGIN TRAN t1
+SET NOCOUNT ON
+ROLLBACK TRAN t1
+GO
+
+-- Scenario: Check procedural context
+CREATE PROCEDURE babel_nocount_setval
+AS
+	INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+	SET NOCOUNT ON
+	INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+
+SET NOCOUNT OFF
+GO
+
+-- procedure should output rowcount only for the first insert
+EXEC babel_nocount_setval
+GO
+~~ROW COUNT: 4~~
+
+
+-- previous value should be restored after procedure execution and print the
+-- rowcount for the next insert
+SELECT dbo.babel_nocount_getval()
+INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+~~START~~
+varchar
+OFF
+~~END~~
+
+~~ROW COUNT: 16~~
+
+
+DROP FUNCTION dbo.babel_nocount_getval
+DROP TABLE babel_nocount_t1
+DROP PROCEDURE babel_nocount_setval
+GO
+
+
+

--- a/test/JDBC/input/BABEL_NOCOUNT.sql
+++ b/test/JDBC/input/BABEL_NOCOUNT.sql
@@ -1,0 +1,73 @@
+-- Helper function to retrieve the value of NOCOUNT
+CREATE FUNCTION dbo.babel_nocount_getval()
+	RETURNS VARCHAR(3)
+AS
+BEGIN
+	DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
+	IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
+	RETURN @NOCOUNT;
+END
+GO
+
+-- table to check the rowcount
+CREATE TABLE babel_nocount_t1(a int);
+INSERT INTO babel_nocount_t1 VALUES(0)
+GO
+
+-- Scenario: Check the default value
+SELECT dbo.babel_nocount_getval()
+GO
+
+-- Scenario: Check number of rows affected with nocount=on/off
+SET NOCOUNT ON
+GO
+
+-- Should not show affected row count
+INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+
+SET NOCOUNT OFF
+GO
+
+-- Should show rows affected
+INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+
+-- Scenario: Check transactional behaviour, the value should be rolled back in case
+-- of an error/rollback
+SELECT dbo.babel_nocount_getval()
+GO
+
+BEGIN TRAN t1
+SET NOCOUNT ON
+ROLLBACK TRAN t1
+GO
+
+-- Scenario: Check procedural context
+CREATE PROCEDURE babel_nocount_setval
+AS
+	INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+	SET NOCOUNT ON
+	INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+
+SET NOCOUNT OFF
+GO
+
+-- procedure should output rowcount only for the first insert
+EXEC babel_nocount_setval
+GO
+
+-- previous value should be restored after procedure execution and print the
+-- rowcount for the next insert
+SELECT dbo.babel_nocount_getval()
+INSERT INTO babel_nocount_t1 SELECT * FROM babel_nocount_t1
+GO
+
+DROP FUNCTION dbo.babel_nocount_getval
+DROP TABLE babel_nocount_t1
+DROP PROCEDURE babel_nocount_setval
+GO
+
+
+


### PR DESCRIPTION
### Description

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”

There's no functional change in the user experience. However, it improves the performance of DONE/DONEINPROC token generation in the TDS response.

>2. *Why* was the change made? What drove our desire to put effort into the change?

Perf report shows huge contention on TDSSendDone->GetConfigOption() function call while executing a test procedure.
```
...
      WHILE @f <= 10000000 
      BEGIN
            SET @n = @n % 999999 + sqrt(@f)
            SET @f = @f + 1
      END
...
``` 
A DONEINPROC token is sent after each statement execution in the procedure. Each iteration in the while loop will send the same token. While sending the DONE/DONEINPROC token, we need to check NOCOUNT GUC to take certain decisions. We're calling GetConfigOption for fetching the value of the GUC. This function does the following two things:

- Provides a generic API to search and fetch the value of a GUC. It accepts the GUC name as string value and does bunch of string string comparison to find a match.
- Once found, it also does some privilege checks to figure out whether the caller can see the value.
We don't need these two features at all as we already know the GUC name and the server is actually fetching the value to take some internal decisions.

So, we can remove the function call and access the GUC value directly. The changes shows 40% performance improvement for the above case. This will also improve the performance of any OLTP benchmark by improving the response time of a single statement.

>3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.

We've not changed the existing implementation of the GUC. We just declared a volatile pointer in the rendezvous struct variable and stored the address of the GUC. The GUC value can be accessed in other extension directly through this pointer. 

>4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.

```
Remove GetCOnfigOption call from TDSSendDone function

A DONEINPROC token is sent after each statement execution in the
procedure. Each iteration in the while loop will send the same token.
While sending the DONE/DONEINPROC token, we need to check
NOCOUNT GUC to take certain decisions. We're calling GetConfigOption
for fetching the value of the GUC.

This function does the following two things:
- Provides a generic API to search and fetch the value of a GUC. It accepts
the GUC name as string value and does bunch of string string comparison
to find a match.
- Once found, it also does some privilege checks to figure out whether the
caller can see the value. We don't need these two features at all as we
already know the GUC name and the server is actually fetching the value
to take some internal decisions.

So, we can remove the function call and access the GUC value directly.
This will improve the query response time. For some queries, this
improvement will be significant if the queries have to send multiple
DONE/DONEINPROC tokens.

Task: BABEL-2995
Signed-off-by: Kuntal Ghosh <kuntalgh@amazon.com>
```

### Issues Resolved

BABEL-2995

### Test Scenarios Covered ###
* **Use case based **
* **Boundary conditions **
* **Arbitrary inputs **
* **Negative test cases **
This change doesn't affect SET/GET functionalities of NOCOUNT. Still I've added test cases for different SET/GET scenarios as there were no test cases for NOCOUNT earlier.

* **Minor version upgrade tests -**
* **Major version upgrade tests -**
Since this is only affects runtime performance, upgrade tests are not needed.

* **Performance tests -**
For the above scenario, it shows 40% improvement.
For HammerDB, it shows 7-8% improvement.

* **Tooling impact -**
No functional changes

* **Client tests -**
JDBC, ODBC, .NET, Python drivers