### PR TITLE
Fix warnings corresponding to maybe-uninitialized flag

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -433,7 +433,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 		case T_OpExpr:
 		{
 			OpExpr *op = (OpExpr *) expr;
-			Node *arg1, *arg2;
+			Node *arg1, *arg2 = NULL;
 			int32 typmod1 = -1, typmod2 = -1;
 			uint8_t scale1, scale2, precision1, precision2;
 			uint8_t scale, precision;
@@ -456,8 +456,6 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				precision1 = ((typmod1 - VARHDRSZ) >> 16) & 0xffff;
 				scale2 = (typmod2 - VARHDRSZ) & 0xffff;
 				precision2 = ((typmod2 - VARHDRSZ) >> 16) & 0xffff;
-				if(arg2->type == T_Aggref)
-					has_aggregate_operand = true;
 			}
 			else if (list_length(op->args) == 1)
 			{
@@ -509,8 +507,8 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			 * Refer to details of precision and scale calculation in the following link:
 			 * https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/data-types/precision-scale-and-length-transact-sql.md
 			 */
-			if(arg1->type == T_Aggref)
-				has_aggregate_operand = true;
+			has_aggregate_operand = arg1->type == T_Aggref ||
+						(list_length(op->args) == 2 && arg2->type == T_Aggref);
 
 			switch (op->opfuncid)
 			{

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -456,6 +456,8 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				precision1 = ((typmod1 - VARHDRSZ) >> 16) & 0xffff;
 				scale2 = (typmod2 - VARHDRSZ) & 0xffff;
 				precision2 = ((typmod2 - VARHDRSZ) >> 16) & 0xffff;
+				if(arg2->type == T_Aggref)
+					has_aggregate_operand = true;
 			}
 			else if (list_length(op->args) == 1)
 			{
@@ -507,8 +509,8 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			 * Refer to details of precision and scale calculation in the following link:
 			 * https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/data-types/precision-scale-and-length-transact-sql.md
 			 */
-			has_aggregate_operand = arg1->type == T_Aggref ||
-						(list_length(op->args) == 2 && arg2->type == T_Aggref);
+			if(arg1->type == T_Aggref)
+				has_aggregate_operand = true;
 
 			switch (op->opfuncid)
 			{

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -721,7 +721,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.SEQUENCES AS
             CAST(extc.orig_name AS sys.nvarchar(128)) AS "SEQUENCE_SCHEMA",
             CAST(r.relname AS sys.nvarchar(128)) AS "SEQUENCE_NAME",
             CAST(CASE WHEN tsql_type_name = 'sysname' THEN sys.translate_pg_type_to_tsql(t.typbasetype) ELSE tsql_type_name END
-                    AS sys.nvarchar(128))AS "DATA_TYPE",  -- numeric and decimal data types are converted into bigint which is due to Postgres' inherent implementation
+                    AS sys.nvarchar(128))AS "DATA_TYPE",  -- numeric and decimal data types are converted into bigint which is due to Postgres inherent implementation
             CAST(information_schema_tsql._pgtsql_numeric_precision(tsql_type_name, t.oid, -1)
                         AS smallint) AS "NUMERIC_PRECISION",
             CAST(information_schema_tsql._pgtsql_numeric_precision_radix(tsql_type_name, case when t.typtype = 'd' THEN t.typbasetype ELSE t.oid END, -1)

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2941,8 +2941,7 @@ static PlannedStmt *
 pltsql_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt * plan;
-	//PLtsql_execstate *estate = NULL;
-	PLtsql_execstate *estate;
+	PLtsql_execstate *estate = NULL;
 
 	if (pltsql_explain_analyze)
 	{

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2941,6 +2941,7 @@ static PlannedStmt *
 pltsql_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt * plan;
+	//PLtsql_execstate *estate = NULL;
 	PLtsql_execstate *estate;
 
 	if (pltsql_explain_analyze)

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1537,7 +1537,7 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 	Oid restype;
 	int32 restypmod;
 	char *querystr;
-	int ret;
+	int ret = 0;
 
 	switch(stmt->sp_type_code)
 	{

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -609,8 +609,8 @@ pltsql_pre_parse_analyze(ParseState *pstate, RawStmt *parseTree)
 			/* detect object type */
 			GrantStmt	*grant = (GrantStmt *) parseTree->stmt;
 			ListCell	*cell;
-			List	*plan_name;
-			ObjectWithArgs *func;
+			List	*plan_name = NIL;
+			ObjectWithArgs *func = NULL;
 
 			Assert(list_length(grant->objects) == 1);
 			foreach(cell, grant->objects)
@@ -1743,7 +1743,7 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 	Oid tsqlSeqTypOid;
 	TypeName *type_def;
 	List* type_names;
-	List* new_type_names;
+	List* new_type_names = NULL;
 	AclResult aclresult;
 	Oid base_type;
 	int list_len;
@@ -1783,7 +1783,7 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 	typname = typeTypeName(typ);
 	type_def->names = type_names;
 
-	if(list_len > 1)
+	if(new_type_names)
 		list_free(new_type_names);
 
 	aclresult = pg_type_aclcheck(*newtypid, GetUserId(), ACL_USAGE);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1783,7 +1783,7 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 	typname = typeTypeName(typ);
 	type_def->names = type_names;
 
-	if(new_type_names)
+	if(list_len > 1)
 		list_free(new_type_names);
 
 	aclresult = pg_type_aclcheck(*newtypid, GetUserId(), ACL_USAGE);

--- a/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
@@ -732,7 +732,7 @@ tsql_print_function_arguments(StringInfo buf, HeapTuple proctup,
 						 bool print_table_args, bool print_defaults, int** typmod_arr_arg, bool* has_tvp)
 {
 	Form_pg_proc proc = (Form_pg_proc) GETSTRUCT(proctup);
-	HeapTuple	bbffunctuple;
+	HeapTuple	bbffunctuple = NULL;
 	int			numargs;
 	Oid		   *argtypes;
 	char	  **argnames;

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -851,9 +851,9 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 		int numresults = 0;
 		int num_target_attnums = 0;
 		RawStmt    *parsetree;
-		InsertStmt *insert_stmt;
-		UpdateStmt *update_stmt;
-		DeleteStmt *delete_stmt;
+		InsertStmt *insert_stmt = NULL;
+		UpdateStmt *update_stmt = NULL;
+		DeleteStmt *delete_stmt = NULL;
 		RangeVar *relation;
 		Oid relid;
 		Relation r;
@@ -1087,7 +1087,7 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 			}
 			foreach(sublc, sublist)
 			{
-				ColumnRef *columnref;
+				ColumnRef *columnref = NULL;
 				ResTarget *res;
 				List *fields;
 				ListCell *fieldcell;

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1575,7 +1575,7 @@ is_rolemember(PG_FUNCTION_ARGS)
 	Oid		dbo_role_oid;
 	char	*role;
 	char 	*dc_role;
-	char 	*dc_principal;
+	char 	*dc_principal = NULL;
 	char	*physical_role_name;
 	char	*physical_principal_name;
 	char	*cur_db_name;


### PR DESCRIPTION
### Description
Fix warning corresponding to `-Wmaybe-uninitialized` flag, this flag will get turned on with `-Wall` if any of the optimization modes enabled. This commit fix those warnings.

### Issues Resolved

[BABEL-3666]

### Test Scenarios Covered ###
We don't need to add more tests as we already have test coverage for functions which are getting modified in this commit to fix the warnings in them. 
* **Use case based -**
 NA

* **Boundary conditions -**
  NA

* **Arbitrary inputs -**
  NA

* **Negative test cases -**
  NA

* **Minor version upgrade tests -**
 NA

* **Major version upgrade tests -**
 NA

* **Performance tests -**
  NA

* **Tooling impact -**
   NA

* **Client tests -**
  JDBC, ODBC, .NET, Python drivers

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).