### PR TITLE
Add Babelfish version number to @@Version for 2.2.stable

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -142,9 +142,9 @@ version(PG_FUNCTION_ARGS)
 
 		appendStringInfo(&temp,
 						 "Babelfish for PostgreSQL with SQL Server Compatibility - %s"
-						 "\n%s %s\nCopyright (c) Amazon Web Services\n%s",
+						 "\n%s %s\nCopyright (c) Amazon Web Services\n%s (Babelfish %s)",
 						 BABEL_COMPATIBILITY_VERSION,
-						 __DATE__, __TIME__, pg_version);
+						 __DATE__, __TIME__, pg_version, BABELFISH_VERSION_STR);
 	}
 	else
 		appendStringInfoString(&temp, pltsql_version);

--- a/test/JDBC/input/BABEL-2681.sql
+++ b/test/JDBC/input/BABEL-2681.sql
@@ -6,4 +6,6 @@ select cast(SERVERPROPERTY('ProductMajorVersion') as varchar) as ProductMajorVer
 -- only print till the server version i.e. first newline character
 select substring(@@version, 1, CHARINDEX(CHAR(10), @@version) - 1);
 select @@microsoftversion;
+-- check there is Bablefish version info
+select count(*) from (select @@version) a where version like '% (Babelfish %.%.%)';
 go

--- a/test/JDBC/sql_expected/BABEL-2681.out
+++ b/test/JDBC/sql_expected/BABEL-2681.out
@@ -6,6 +6,8 @@ select cast(SERVERPROPERTY('ProductMajorVersion') as varchar) as ProductMajorVer
 -- only print till the server version i.e. first newline character
 select substring(@@version, 1, CHARINDEX(CHAR(10), @@version) - 1);
 select @@microsoftversion;
+-- check there is Bablefish version info
+select count(*) from (select @@version) a where version like '% (Babelfish %.%.%)';
 go
 ~~START~~
 varchar
@@ -25,5 +27,10 @@ Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
 ~~START~~
 int
 201332885
+~~END~~
+
+~~START~~
+int
+1
 ~~END~~
 


### PR DESCRIPTION
Task: BABEL-3767
Signed-off-by: Yuhao Wei <yuhaowei@amazon.com>

### Description

Added the `BABELFISH_VERSION_STR` to the fourth line of `@@VERSION`.

### Issues Resolved

BABEL-3767

### Test Scenarios Covered ###
* **Use case based -**
Added test case in `BABEL-2681`.

* **Boundary conditions -**
N/A

* **Arbitrary inputs -**
N/A

* **Negative test cases -**
N/A

* **Minor version upgrade tests -**
N/A

* **Major version upgrade tests -**
N/A

* **Performance tests -**
N/A

* **Tooling impact -**
N/A

* **Client tests -**
N/A


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).