### PR TITLE
Fix the os version and failures due to new version of pyodbc for github action in BABEL_2_2_STABLE

### DIFF
--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -143,6 +143,7 @@ runs:
         fileGenerator_databaseName=jdbc_testdb \
         fileGenerator_user=jdbc_user \
         fileGenerator_password=12345678 \
+        LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/odbc/ \
         python3 upgrade_validation.py
       shell: bash
 

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-dotnet-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   isolation-tests:
     name: Isolation-Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -9,7 +9,7 @@ jobs:
       ENGINE_BRANCH_FROM: BABEL_1_2_STABLE__PG_13_6
       EXTENSION_BRANCH_FROM: BABEL_1_2_STABLE
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
       # the extension code, because that's what we're actually testing.
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-odbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-pg-hint-plan-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-babelfish-python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -10,7 +10,7 @@ jobs:
       ENGINE_BRANCH_FROM: BABEL_1_2_STABLE__PG_13_6
       EXTENSION_BRANCH_FROM: BABEL_1_2_STABLE
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   run-sql-validation-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         id: checkout

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   generate-version-upgrade-tests:
     name: Generate Version Upgrade Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       upgrade-path-list: ${{ steps.generate-upgrade-path.outputs.upgrade-path-list }}
     steps:
@@ -25,7 +25,7 @@ jobs:
       matrix:
         upgrade-path: ${{ fromJson(needs.generate-version-upgrade-tests.outputs.upgrade-path-list) }}
     name: Run Version Upgrade Test for ${{ matrix.upgrade-path.title }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/test/python/expected/pyodbc/TestAuth.out
+++ b/test/python/expected/pyodbc/TestAuth.out
@@ -1,26 +1,26 @@
 #database name, username and password should not exceed 128 characters
 py_auth#!#database|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 911)~~
-~~ERROR (Message: [08004] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (911) (SQLDriverConnect))~~
+~~ERROR (Message: [08004] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" does not exist (911) (SQLDriverConnect))~~
 
 py_auth#!#database|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'DATABASE' (0) (SQLDriverConnect))~~
 
 py_auth#!#user|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]role "111111111111111111111111111111111111111111111111111111111111111" does not exist (33557097) (SQLDriverConnect))~~
 
 py_auth#!#user|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'UID' (0) (SQLDriverConnect))~~
 
 #not sure why any password is accepted during authentication through cloud desktop
 #This test should throw error but from cloud desktop a connection is successfully established
 #py_auth#!#password|-|11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 py_auth#!#password|-|111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112
 ~~ERROR (Code: 0)~~
-~~ERROR (Message: [08001] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
+~~ERROR (Message: [08001] [Microsoft][ODBC Driver 17 for SQL Server]Invalid value specified for connection string attribute 'PWD' (0) (SQLDriverConnect))~~
 
 py_auth#!#others|-|packetSize=0
 ~~SUCCESS~~
@@ -30,5 +30,5 @@ py_auth#!#others|-|packetSize=4096
 ~~SUCCESS~~
 py_auth#!#database|-|test1 SELECT 1
 ~~ERROR (Code: 911)~~
-~~ERROR (Message: [08004] [unixODBC][Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (911) (SQLDriverConnect))~~
+~~ERROR (Message: [08004] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (911) (SQLDriverConnect))~~
 


### PR DESCRIPTION
We're running the github actions on ubuntu-latest. Previously, it was ubuntu-20.04, but in any recently created fork, it's pointing to ubuntu-22.04. This is causing dependency/build failure in the github actions running in the fork. So, let's fix the os version.

Task: BABEL-OSS
Signed-off by: Kuntal Ghosh kuntalgh@amazon.com