### PR TITLE
Lowercase index and table names during hint extraction

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -645,6 +645,8 @@ validate_and_stringify_hints()
 	if (!leading_hint.empty())
 		hint += leading_hint;
 	hint += "*/";
+	transform(hint.begin(), hint.end(), hint.begin(), ::tolower);
+
 	return hint;
 }
 
@@ -3528,6 +3530,10 @@ std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> ind
 {
 	if (alias_to_table_mapping.find(table_name) != alias_to_table_mapping.end())
 		table_name = alias_to_table_mapping[table_name];
+
+	//lowercase table names and later index names since they are lowercase in pg when hashed
+	transform(table_name.begin(), table_name.end(), table_name.begin(), ::tolower);
+
 	std::string index_values;
 	for (auto ictx: index_valuesCtx)
 	{
@@ -3535,7 +3541,10 @@ std::string extractIndexValues(std::vector<TSqlParser::Index_valueContext *> ind
 		{
 			if (index_values.size())
 				index_values += " ";
-			char * index_value = construct_unique_index_name(const_cast <char *>(::getFullText(ictx->id()).c_str()), const_cast <char *>(table_name.c_str()));
+			std::string indexName = ::getFullText(ictx->id());
+
+			transform(indexName.begin(), indexName.end(), indexName.begin(), ::tolower);
+			char * index_value = construct_unique_index_name(const_cast <char *>(indexName.c_str()), const_cast <char *>(table_name.c_str()));
 			index_values += std::string(index_value);
 		}
 	}

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -10,7 +10,7 @@ go
 create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
 go
 
-create index index_babel_3292_t1_c1 on babel_3292_t1(c1)
+create index inDex_BABEL_3292_T1_c1 on babel_3292_t1(c1)
 go
 
 create table babel_3292_t2(a2 int PRIMARY KEY, b2 int, c2 int)
@@ -65,7 +65,7 @@ select * from babel_3292_t1 (index(index_babel_3292_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                 where b1 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                 where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -75,7 +75,7 @@ select * from babel_3292_t1 (index=index_babel_3292_t1_b1) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                where b1 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -85,7 +85,7 @@ select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                     where b1 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                     where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -95,7 +95,7 @@ select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                    where b1 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1                                    where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -105,7 +105,7 @@ select * from babel_3292_t1 t1 with(index=index_babel_3292_t1_b1) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 t1                                    where b1 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 t1                                    where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -115,7 +115,7 @@ select * from babel_3292_t1 as t1 with(index=index_babel_3292_t1_b1) where b1 = 
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 as t1                                    where b1 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 as t1                                    where b1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -125,7 +125,7 @@ select * from babel_3292_t1 where b1=1 option(table hint(babel_3292_t1, index(in
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 where b1=1                                                                 
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 where b1=1                                                                 
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -135,7 +135,7 @@ select * from babel_3292_t1 t1 where b1=1 option(table hint(t1, index(index_babe
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 t1 where b1=1                                                      
+Query Text: select/*+ indexscan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 t1 where b1=1                                                      
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -161,7 +161,7 @@ select * from babel_3292_t1 with(index(index_babel_3292_t1_b1), index(index_babe
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ * from babel_3292_t1                                                                    where b1 = 1 and c1 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ * from babel_3292_t1                                                                    where b1 = 1 and c1 = 1
 Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
@@ -172,7 +172,18 @@ select * from babel_3292_t1 where b1 = 1 and c1 = 1 option(table hint(babel_3292
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ * from babel_3292_t1 where b1 = 1 and c1 = 1                                                                                                
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ * from babel_3292_t1 where b1 = 1 and c1 = 1                                                                                                
+Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1
+  Index Cond: (c1 = 1)
+  Filter: (b1 = 1)
+~~END~~
+
+
+select * from BABEL_3292_t1 where b1 = 1 and c1 = 1 option(table hint(Babel_3292_t1, index(IndeX_BABEL_3292_t1_b1), index(Index_baBel_3292_t1_C1)))
+go
+~~START~~
+text
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t1 index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c) */ * from BABEL_3292_t1 where b1 = 1 and c1 = 1                                                                                                
 Index Scan using index_babel_3292_t1_c1babel_329c7d18660bd3d9742036705bdc0da925c on babel_3292_t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
@@ -202,7 +213,7 @@ select * from babel_3292_t1 with(index(index_babel_3292_t1_b1)), babel_3292_t2 w
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                    , babel_3292_t2                                     where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                    , babel_3292_t2                                     where b1 = 1 and b2 = 1
 Nested Loop
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -216,7 +227,7 @@ select * from babel_3292_t1 with(index=index_babel_3292_t1_b1), babel_3292_t2 wi
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                   , babel_3292_t2                                    where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                   , babel_3292_t2                                    where b1 = 1 and b2 = 1
 Nested Loop
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -230,7 +241,7 @@ select * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1 option(table 
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                           
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1, babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                           
 Nested Loop
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -244,7 +255,7 @@ select * from babel_3292_t1 t1 with(index=index_babel_3292_t1_b1), babel_3292_t2
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 t1                                   , babel_3292_t2 t2                                    where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 t1                                   , babel_3292_t2 t2                                    where b1 = 1 and b2 = 1
 Nested Loop
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
         Index Cond: (b1 = 1)
@@ -258,7 +269,7 @@ select * from babel_3292_t1 t1, babel_3292_t2 t2 where b1 = 1 and b2 = 1 option(
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 t1, babel_3292_t2 t2 where b1 = 1 and b2 = 1                                                                                                     
+Query Text: select/*+ indexscan(t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 t1, babel_3292_t2 t2 where b1 = 1 and b2 = 1                                                                                                     
 Nested Loop
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1 t1
         Index Cond: (b1 = 1)
@@ -286,7 +297,7 @@ insert into babel_3292_t2 select * from babel_3292_t1 with(index(index_babel_329
 go
 ~~START~~
 text
-Query Text: insert/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ into babel_3292_t2 select * from babel_3292_t1                                     where b1 = 1
+Query Text: insert/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ into babel_3292_t2 select * from babel_3292_t1                                     where b1 = 1
 Insert on babel_3292_t2
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -297,7 +308,7 @@ insert into babel_3292_t2 select * from babel_3292_t1 where b1 = 1 option(table 
 go
 ~~START~~
 text
-Query Text: insert/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ into babel_3292_t2 select * from babel_3292_t1 where b1 = 1                                                                 
+Query Text: insert/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ into babel_3292_t2 select * from babel_3292_t1 where b1 = 1                                                                 
 Insert on babel_3292_t2
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -322,7 +333,7 @@ update babel_3292_t1 with(index(index_babel_3292_t1_b1)) set a1 = 1 where b1 = 1
 go
 ~~START~~
 text
-Query Text: update/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1                                     set a1 = 1 where b1 = 1
+Query Text: update/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1                                     set a1 = 1 where b1 = 1
 Update on babel_3292_t1
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -333,7 +344,7 @@ update babel_3292_t1 set a1 = 1 where b1 = 1 option(table hint(babel_3292_t1, in
 go
 ~~START~~
 text
-Query Text: update/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1 set a1 = 1 where b1 = 1                                                                 
+Query Text: update/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1 set a1 = 1 where b1 = 1                                                                 
 Update on babel_3292_t1
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -358,7 +369,7 @@ delete from babel_3292_t1 with(index(index_babel_3292_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: delete/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ from babel_3292_t1                                     where b1 = 1
+Query Text: delete/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ from babel_3292_t1                                     where b1 = 1
 Delete on babel_3292_t1
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -369,7 +380,7 @@ delete from babel_3292_t1 where b1 = 1 option(table hint(babel_3292_t1, index(in
 go
 ~~START~~
 text
-Query Text: delete/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ from babel_3292_t1 where b1 = 1                                                                 
+Query Text: delete/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ from babel_3292_t1 where b1 = 1                                                                 
 Delete on babel_3292_t1
   ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
         Index Cond: (b1 = 1)
@@ -400,7 +411,7 @@ select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 with(
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
+Query Text: select/*+ indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
 HashAggregate
   Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
   ->  Append
@@ -417,7 +428,7 @@ select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                 
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                 
 HashAggregate
   Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
   ->  Append
@@ -434,7 +445,7 @@ select * from babel_3292_t1 with(index=index_babel_3292_t1_b1) where b1 = 1 UNIO
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                    where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                    where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
 HashAggregate
   Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
   ->  Append
@@ -449,7 +460,7 @@ select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                                                                           
+Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                                                                           
 HashAggregate
   Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
   ->  Append
@@ -480,7 +491,7 @@ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=i
 go
 ~~START~~
 text
-Query Text: with/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+Query Text: with/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
   Filter: (c1 = 1)
@@ -491,7 +502,18 @@ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1
 go
 ~~START~~
 text
-Query Text: with/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1                                                                 
+Query Text: with/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1                                                                 
+Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+  Index Cond: (b1 = 1)
+  Filter: (c1 = 1)
+~~END~~
+
+
+with BaBeL_3292_T1_CTE (a1, b1, c1) as (select * from BABEL_3292_t1 with(index=INDEX_BABEL_3292_T1_B1) where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
+go
+~~START~~
+text
+Query Text: with/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ BaBeL_3292_T1_CTE (a1, b1, c1) as (select * from BABEL_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
   Filter: (c1 = 1)
@@ -503,7 +525,7 @@ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1
 go
 ~~START~~
 text
-Query Text: with/*+ IndexScan(babel_3292_t1_cte index_babel_3292_t1_c1babel_32961b5cc4ed008f5c7776c7f58f0abe80b) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte                                    where c1 = 1
+Query Text: with/*+ indexscan(babel_3292_t1_cte index_babel_3292_t1_c1babel_32961b5cc4ed008f5c7776c7f58f0abe80b) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte                                    where c1 = 1
 Bitmap Heap Scan on babel_3292_t1
   Recheck Cond: ((c1 = 1) AND (b1 = 1))
   ->  BitmapAnd
@@ -519,7 +541,7 @@ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=i
 go
 ~~START~~
 text
-Query Text: with/*+ IndexScan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) IndexScan(babel_3292_t1_cte index_babel_3292_t1_c1babel_32961b5cc4ed008f5c7776c7f58f0abe80b) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte                                    where c1 = 1
+Query Text: with/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t1_cte index_babel_3292_t1_c1babel_32961b5cc4ed008f5c7776c7f58f0abe80b) */ babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1                                    where b1 = 1) select * from babel_3292_t1_cte                                    where c1 = 1
 Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
   Index Cond: (b1 = 1)
   Filter: (c1 = 1)
@@ -575,7 +597,7 @@ select * from tempdb.babel_3292_schema.t1 (index(index_babel_3292_schema_t1_b1))
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1                                        where b1 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1                                        where b1 = 1
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -585,7 +607,7 @@ select * from tempdb.babel_3292_schema.t1 t1 (index(index_babel_3292_schema_t1_b
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1 t1                                        where b1 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1 t1                                        where b1 = 1
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -595,7 +617,7 @@ select * from tempdb.babel_3292_schema.t1 where b1=1 option(table hint(tempdb.ba
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1 where b1=1                                                                                      
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1 where b1=1                                                                                      
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -605,7 +627,7 @@ select * from tempdb.babel_3292_schema.t1 t1 where b1=1 option(table hint(t1, in
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1 t1 where b1=1                                                             
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ * from tempdb.babel_3292_schema.t1 t1 where b1=1                                                             
 Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -615,7 +637,7 @@ select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ * from tempdb.babel_3292_schema.t1                                                                                  where b1 = 1 and c1 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ * from tempdb.babel_3292_schema.t1                                                                                  where b1 = 1 and c1 = 1
 Index Scan using index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0 on t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
@@ -626,7 +648,7 @@ select * from tempdb.babel_3292_schema.t1 where b1 = 1 and c1 = 1 option(table h
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ * from tempdb.babel_3292_schema.t1 where b1 = 1 and c1 = 1                                                                                                                            
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t1 index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0) */ * from tempdb.babel_3292_schema.t1 where b1 = 1 and c1 = 1                                                                                                                            
 Index Scan using index_babel_3292_schema_t1_c1t1185ec046d5c38219c998001d0ae030d0 on t1
   Index Cond: (c1 = 1)
   Filter: (b1 = 1)
@@ -637,7 +659,7 @@ select * from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1                                           , tempdb.dbo.babel_3292_t2                                     where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1                                           , tempdb.dbo.babel_3292_t2                                     where b1 = 1 and b2 = 1
 Nested Loop
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -651,7 +673,7 @@ select * from tempdb.babel_3292_schema.t1 t1 with(index(index_babel_3292_schema_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1                                           , tempdb.dbo.babel_3292_t2 t2                                     where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1                                           , tempdb.dbo.babel_3292_t2 t2                                     where b1 = 1 and b2 = 1
 Nested Loop
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -665,7 +687,7 @@ select * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                                                           
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1, tempdb.dbo.babel_3292_t2 where b1 = 1 and b2 = 1                                                                                                                                                           
 Nested Loop
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -679,7 +701,7 @@ select * from tempdb.babel_3292_schema.t1 t1, tempdb.dbo.babel_3292_t2 t2 where 
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1, tempdb.dbo.babel_3292_t2 t2 where b1 = 1 and b2 = 1                                                                                                            
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1, tempdb.dbo.babel_3292_t2 t2 where b1 = 1 and b2 = 1                                                                                                            
 Nested Loop
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -693,7 +715,7 @@ insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 w
 go
 ~~START~~
 text
-Query Text: insert/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1                                            where b1 = 1
+Query Text: insert/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1                                            where b1 = 1
 Insert on babel_3292_t2
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -704,7 +726,7 @@ insert into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 w
 go
 ~~START~~
 text
-Query Text: insert/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 where b1 = 1                                                                                      
+Query Text: insert/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ into tempdb.dbo.babel_3292_t2 select * from tempdb.babel_3292_schema.t1 where b1 = 1                                                                                      
 Insert on babel_3292_t2
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -715,7 +737,7 @@ update tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1)) se
 go
 ~~START~~
 text
-Query Text: update/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ tempdb.babel_3292_schema.t1                                            set a1 = 1 where b1 = 1
+Query Text: update/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ tempdb.babel_3292_schema.t1                                            set a1 = 1 where b1 = 1
 Update on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -726,7 +748,7 @@ update tempdb.babel_3292_schema.t1 set a1 = 1 where b1 = 1 option(table hint(tem
 go
 ~~START~~
 text
-Query Text: update/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ tempdb.babel_3292_schema.t1 set a1 = 1 where b1 = 1                                                                                      
+Query Text: update/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ tempdb.babel_3292_schema.t1 set a1 = 1 where b1 = 1                                                                                      
 Update on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -737,7 +759,7 @@ delete from tempdb.babel_3292_schema.t1 with(index(index_babel_3292_schema_t1_b1
 go
 ~~START~~
 text
-Query Text: delete/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ from tempdb.babel_3292_schema.t1                                            where b1 = 1
+Query Text: delete/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ from tempdb.babel_3292_schema.t1                                            where b1 = 1
 Delete on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -748,7 +770,7 @@ delete from tempdb.babel_3292_schema.t1 where b1 = 1 option(table hint(tempdb.ba
 go
 ~~START~~
 text
-Query Text: delete/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ from tempdb.babel_3292_schema.t1 where b1 = 1                                                                                      
+Query Text: delete/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) */ from tempdb.babel_3292_schema.t1 where b1 = 1                                                                                      
 Delete on t1
   ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
         Index Cond: (b1 = 1)
@@ -759,7 +781,7 @@ select * from tempdb.babel_3292_schema.t1 with(index=index_babel_3292_schema_t1_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2                                    where b2 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2                                    where b2 = 1
 HashAggregate
   Group Key: t1.a1, t1.b1, t1.c1
   ->  Append
@@ -774,7 +796,7 @@ select * from tempdb.babel_3292_schema.t1 t1 with(index=index_babel_3292_schema_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2                                    where b2 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2                                    where b2 = 1
 HashAggregate
   Group Key: t1.a1, t1.b1, t1.c1
   ->  Append
@@ -789,7 +811,7 @@ select * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempd
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                           
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                           
 HashAggregate
   Group Key: t1.a1, t1.b1, t1.c1
   ->  Append
@@ -804,7 +826,7 @@ select * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from te
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) IndexScan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1                                                                                                            
+Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1                                                                                                            
 HashAggregate
   Group Key: t1.a1, t1.b1, t1.c1
   ->  Append

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -73,7 +73,7 @@ select * from babel_3293_t1 inner merge join babel_3293_t2 on babel_3293_t1.a1 =
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -95,7 +95,7 @@ select * from babel_3293_t1 t1 inner merge join babel_3293_t2 t2 on t1.a1 = t2.a
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(t1 t2) Leading(t1 t2)*/ * from babel_3293_t1 t1 inner       join babel_3293_t2 t2 on t1.a1 = t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ mergejoin(t1 t2) leading(t1 t2)*/ * from babel_3293_t1 t1 inner       join babel_3293_t2 t2 on t1.a1 = t2.a2 where b1 = 1 and b2 = 1
 Merge Join
   Merge Cond: (t1.a1 = t2.a2)
   ->  Sort
@@ -117,7 +117,26 @@ select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.
 go
 ~~START~~
 text
-Query Text: select/*+ NestLoop(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ nestloop(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Nested Loop
+  Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
+  ->  Bitmap Heap Scan on babel_3293_t1
+        Recheck Cond: (b1 = 1)
+        ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+              Index Cond: (b1 = 1)
+  ->  Materialize
+        ->  Bitmap Heap Scan on babel_3293_t2
+              Recheck Cond: (b2 = 1)
+              ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                    Index Cond: (b2 = 1)
+~~END~~
+
+
+select * from BABEL_3293_t1 LeFt ouTer LOOP join Babel_3293_T2 on BABEL_3293_t1.a1 = BABEL_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+~~START~~
+text
+Query Text: select/*+ nestloop(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from BABEL_3293_t1 LeFt ouTer      join Babel_3293_T2 on BABEL_3293_t1.a1 = BABEL_3293_t2.a2 where b1 = 1 and b2 = 1
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Bitmap Heap Scan on babel_3293_t1
@@ -136,7 +155,7 @@ select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) join babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ * from babel_3293_t1                                     join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) indexscan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ * from babel_3293_t1                                     join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
@@ -176,7 +195,7 @@ select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.a1 = babel_3293_t3.a3
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.a1 = babel_3293_t3.a3
 Nested Loop
   ->  Merge Left Join
         Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
@@ -191,7 +210,7 @@ select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3  where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3  where b1 = 1 and b2 = 1 and b3 = 1
 Nested Loop
   ->  Merge Join
         Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
@@ -217,7 +236,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
   ->  Sort
@@ -244,7 +263,7 @@ select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.
 go
 ~~START~~
 text
-Query Text: select/*+ NestLoop(babel_3293_t1 babel_3293_t2) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: select/*+ nestloop(babel_3293_t1 babel_3293_t2) nestloop(babel_3293_t1 babel_3293_t2 babel_3293_t3) leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 left outer      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
   ->  Nested Loop
@@ -268,7 +287,7 @@ select * from babel_3293_t1 left outer merge join babel_3293_t2 on babel_3293_t1
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2) NestLoop(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2) nestloop(babel_3293_t1 babel_3293_t2 babel_3293_t3) leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner      join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t3.a3)
   ->  Merge Join
@@ -295,7 +314,7 @@ select * from babel_3293_t1 t1 left outer merge join babel_3293_t2 t2 on t1.a1 =
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(t1 t2) NestLoop(t1 t2 t3) Leading(t1 t2 t3)*/ * from babel_3293_t1 t1 left outer       join babel_3293_t2 t2 on t1.a1 = t2.a2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Query Text: select/*+ mergejoin(t1 t2) nestloop(t1 t2 t3) leading(t1 t2 t3)*/ * from babel_3293_t1 t1 left outer       join babel_3293_t2 t2 on t1.a1 = t2.a2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
 Nested Loop
   Join Filter: (t1.a1 = t3.a3)
   ->  Merge Join
@@ -322,7 +341,7 @@ select * from babel_3293_t1, babel_3293_t2 inner merge join babel_3293_t3 on bab
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1, babel_3293_t2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1, babel_3293_t2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where babel_3293_t1.a1=babel_3293_t3.a3
 Merge Join
   Merge Cond: (babel_3293_t2.a2 = babel_3293_t3.a3)
   ->  Merge Join
@@ -337,7 +356,7 @@ select * from babel_3293_t1 t1, babel_3293_t2 t2 inner merge join babel_3293_t3 
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(t1 t2 t3) Leading(t1 t2 t3)*/ * from babel_3293_t1 t1, babel_3293_t2 t2 inner       join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
+Query Text: select/*+ mergejoin(t1 t2 t3) leading(t1 t2 t3)*/ * from babel_3293_t1 t1, babel_3293_t2 t2 inner       join babel_3293_t3 t3 on t2.a2 = t3.a3 where t1.a1 = t3.a3
 Merge Join
   Merge Cond: (t2.a2 = t3.a3)
   ->  Merge Join
@@ -352,7 +371,7 @@ select * from babel_3293_t1 t1, babel_3293_t2 t2 inner hash join babel_3293_t3 t
 go
 ~~START~~
 text
-Query Text: select/*+ HashJoin(t1 t2 t3) Leading(t1 t2 t3)*/ * from babel_3293_t1 t1, babel_3293_t2 t2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3
+Query Text: select/*+ hashjoin(t1 t2 t3) leading(t1 t2 t3)*/ * from babel_3293_t1 t1, babel_3293_t2 t2 inner      join babel_3293_t3 t3 on t2.a2 = t3.a3
 Hash Join
   Hash Cond: (t2.a2 = t3.a3)
   ->  Nested Loop
@@ -364,12 +383,39 @@ Hash Join
 ~~END~~
 
 
+select * from BABEL_3293_t1 t1 left outer MERGE join BaBeL_3293_T2 t2 on t1.a1 = t2.a2 InNeR LOOP JOIN bABEL_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+~~START~~
+text
+Query Text: select/*+ mergejoin(t1 t2) nestloop(t1 t2 t3) leading(t1 t2 t3)*/ * from BABEL_3293_t1 t1 left outer       join BaBeL_3293_T2 t2 on t1.a1 = t2.a2 InNeR      JOIN bABEL_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+Nested Loop
+  Join Filter: (t1.a1 = t3.a3)
+  ->  Merge Join
+        Merge Cond: (t1.a1 = t2.a2)
+        ->  Sort
+              Sort Key: t1.a1
+              ->  Bitmap Heap Scan on babel_3293_t1 t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+        ->  Sort
+              Sort Key: t2.a2
+              ->  Bitmap Heap Scan on babel_3293_t2 t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Index Scan using babel_3293_t3_pkey on babel_3293_t3 t3
+        Index Cond: (a3 = t2.a2)
+        Filter: (b3 = 1)
+~~END~~
+
+
 -- Join hints through option clause
 select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_nestloop off) Set(enable_mergejoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Query Text: select/*+ set(enable_nestloop off) set(enable_mergejoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Bitmap Heap Scan on babel_3293_t1
@@ -388,7 +434,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                   
+Query Text: select/*+ set(enable_nestloop off) set(enable_hashjoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                   
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -410,7 +456,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_hashjoin off) Set(enable_mergejoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
+Query Text: select/*+ set(enable_hashjoin off) set(enable_mergejoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                  
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Bitmap Heap Scan on babel_3293_t1
@@ -429,7 +475,35 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                   
+Query Text: select/*+ set(enable_nestloop off) set(enable_hashjoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                   
+Merge Join
+  Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
+  ->  Merge Join
+        Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
+        ->  Sort
+              Sort Key: babel_3293_t1.a1
+              ->  Bitmap Heap Scan on babel_3293_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210
+                          Index Cond: (b1 = 1)
+        ->  Sort
+              Sort Key: babel_3293_t2.a2
+              ->  Bitmap Heap Scan on babel_3293_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e
+                          Index Cond: (b2 = 1)
+  ->  Sort
+        Sort Key: babel_3293_t3.a3
+        ->  Seq Scan on babel_3293_t3
+              Filter: (b3 = 1)
+~~END~~
+
+
+select * from babeL_3293_T1 join BABEL_3293_T2 on babeL_3293_T1.a1 = BABEL_3293_T2.a2 join babEl_3293_t3 on babel_3293_T2.a2 = BABEL_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+~~START~~
+text
+Query Text: select/*+ set(enable_nestloop off) set(enable_hashjoin off) */ * from babeL_3293_T1 join BABEL_3293_T2 on babeL_3293_T1.a1 = BABEL_3293_T2.a2 join babEl_3293_t3 on babel_3293_T2.a2 = BABEL_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                   
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
   ->  Merge Join
@@ -465,7 +539,7 @@ select * from babel_3293_t1 inner hash join babel_3293_t2 on babel_3293_t1.a1 = 
 go
 ~~START~~
 text
-Query Text: select/*+ HashJoin(babel_3293_t1 babel_3293_t2) Set(enable_nestloop off) Set(enable_mergejoin off) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                  
+Query Text: select/*+ hashjoin(babel_3293_t1 babel_3293_t2) set(enable_nestloop off) set(enable_mergejoin off) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                  
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Seq Scan on babel_3293_t1
@@ -478,7 +552,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_hashjoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                              
+Query Text: select/*+ set(enable_hashjoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2                              
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using babel_3293_t1_pkey on babel_3293_t1
@@ -504,7 +578,7 @@ select * from babel_3293_t1 inner loop join babel_3293_t2 on babel_3293_t1.a1 = 
 go
 ~~START~~
 text
-Query Text: select/*+ NestLoop(babel_3293_t1 babel_3293_t2) MergeJoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) Set(enable_hashjoin off) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                              
+Query Text: select/*+ nestloop(babel_3293_t1 babel_3293_t2) mergejoin(babel_3293_t1 babel_3293_t2 babel_3293_t3) set(enable_hashjoin off) leading(babel_3293_t1 babel_3293_t2 babel_3293_t3)*/ * from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 inner       join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1                              
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t3.a3)
   ->  Sort
@@ -532,7 +606,7 @@ select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) inner loop join 
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) NestLoop(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1                                     inner      join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) indexscan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) nestloop(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1                                     inner      join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
@@ -547,7 +621,7 @@ select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) right outer merg
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1                                     right outer       join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) indexscan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from babel_3293_t1                                     right outer       join babel_3293_t2                                 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Merge Join
   Merge Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -565,7 +639,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) Set(enable_hashjoin off) Set(enable_mergejoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                      
+Query Text: select/*+ indexscan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) indexscan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) set(enable_hashjoin off) set(enable_mergejoin off) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                      
 Nested Loop
   Join Filter: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
@@ -581,7 +655,7 @@ select * from (select distinct a1 as a1 from babel_3293_t1) s1 inner merge join 
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ * from (select distinct a1 as a1 from babel_3293_t1) s1 inner       join babel_3293_t2 on s1.a1 = babel_3293_t2.a2
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ * from (select distinct a1 as a1 from babel_3293_t1) s1 inner       join babel_3293_t2 on s1.a1 = babel_3293_t2.a2
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2.a2)
   ->  HashAggregate
@@ -596,7 +670,7 @@ select * from (select babel_3293_t1.* from babel_3293_t1 inner merge join babel_
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3293_t1 babel_3293_t2) HashJoin(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2)*/ * from (select babel_3293_t1.* from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s1 inner join (select babel_3293_t1.* from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s2 on s1.a1 = s2.a1
+Query Text: select/*+ mergejoin(babel_3293_t1 babel_3293_t2) hashjoin(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2 babel_3293_t1 babel_3293_t2)*/ * from (select babel_3293_t1.* from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s1 inner join (select babel_3293_t1.* from babel_3293_t1 inner      join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2) s2 on s1.a1 = s2.a1
 Hash Join
   Hash Cond: (babel_3293_t1.a1 = babel_3293_t2_1.a2)
   ->  Hash Join
@@ -644,7 +718,7 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(join_collapse_limit 1) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3                    
+Query Text: select/*+ set(join_collapse_limit 1) */ * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t1.b1 = babel_3293_t3.b3                    
 Merge Join
   Merge Cond: (babel_3293_t1.b1 = babel_3293_t3.b3)
   ->  Sort
@@ -691,7 +765,7 @@ update babel_3293_t1 set a1 = 1 from babel_3293_t1 inner merge join babel_3293_t
 go
 ~~START~~
 text
-Query Text: update/*+ MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 set a1 = 1 from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: update/*+ mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 set a1 = 1 from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Update on babel_3293_t1
   ->  Nested Loop
         ->  HashAggregate
@@ -716,7 +790,7 @@ update babel_3293_t1 set a1 = 1 from babel_3293_t1 with(index(index_babel_3293_t
 go
 ~~START~~
 text
-Query Text: update/*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 set a1 = 1 from babel_3293_t1                                     full outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: update/*+ indexscan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 set a1 = 1 from babel_3293_t1                                     full outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Update on babel_3293_t1
   ->  Nested Loop
         ->  HashAggregate
@@ -765,7 +839,7 @@ delete babel_3293_t1 from babel_3293_t1 inner merge join babel_3293_t2 on babel_
 go
 ~~START~~
 text
-Query Text: delete/*+ MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: delete/*+ mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 from babel_3293_t1 inner       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Delete on babel_3293_t1
   ->  Nested Loop
         ->  HashAggregate
@@ -790,7 +864,7 @@ delete babel_3293_t1 from babel_3293_t1 with(index(index_babel_3293_t1_b1)) left
 go
 ~~START~~
 text
-Query Text: delete/*+ IndexScan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) MergeJoin(babel_3293_t1 babel_3293_t2) Leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 from babel_3293_t1                                     left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: delete/*+ indexscan(babel_3293_t1 index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210) mergejoin(babel_3293_t1 babel_3293_t2) leading(babel_3293_t1 babel_3293_t2)*/ babel_3293_t1 from babel_3293_t1                                     left outer       join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Delete on babel_3293_t1
   ->  Nested Loop
         ->  HashAggregate
@@ -863,7 +937,7 @@ select * from tempdb.babel_3293_schema.t1 inner merge join tempdb.dbo.babel_3293
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(t1 babel_3293_t2) Leading(t1 babel_3293_t2)*/ * from tempdb.babel_3293_schema.t1 inner       join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ mergejoin(t1 babel_3293_t2) leading(t1 babel_3293_t2)*/ * from tempdb.babel_3293_schema.t1 inner       join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Merge Join
   Merge Cond: (t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -885,7 +959,7 @@ select * from tempdb.babel_3293_schema.t1 with(index(index_babel_3293_schema_t1_
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ * from tempdb.babel_3293_schema.t1                                            join tempdb.dbo.babel_3293_t2                                 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
+Query Text: select/*+ indexscan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) indexscan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) */ * from tempdb.babel_3293_schema.t1                                            join tempdb.dbo.babel_3293_t2                                 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1
 Hash Join
   Hash Cond: (t1.a1 = babel_3293_t2.a2)
   ->  Index Scan using index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9 on t1
@@ -900,7 +974,7 @@ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempd
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) IndexScan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) Set(enable_nestloop off) Set(enable_hashjoin off) */ * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
+Query Text: select/*+ indexscan(t1 index_babel_3293_schema_t1_b1t1baa4a261b22c51c48cc060f8d390c3e9) indexscan(babel_3293_t2 index_babel_3293_t2_b2babel_329ea1aa3a9e72f8fece1b90ee8c2a8f24e) set(enable_nestloop off) set(enable_hashjoin off) */ * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 where b1 = 1 and b2 = 1                                                                                                                                                                       
 Merge Join
   Merge Cond: (t1.a1 = babel_3293_t2.a2)
   ->  Sort
@@ -918,7 +992,7 @@ select * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempd
 go
 ~~START~~
 text
-Query Text: select/*+ Set(join_collapse_limit 1) */ * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3                    
+Query Text: select/*+ set(join_collapse_limit 1) */ * from tempdb.babel_3293_schema.t1 join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3                    
 Merge Join
   Merge Cond: (t1.b1 = babel_3293_t3.b3)
   ->  Sort
@@ -938,7 +1012,7 @@ select * from tempdb.babel_3293_schema.t1 inner loop join tempdb.dbo.babel_3293_
 go
 ~~START~~
 text
-Query Text: select/*+ NestLoop(t1 babel_3293_t2) MergeJoin(t1 babel_3293_t2 babel_3293_t3) Leading(t1 babel_3293_t2 babel_3293_t3)*/ * from tempdb.babel_3293_schema.t1 inner      join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 left outer       join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3
+Query Text: select/*+ nestloop(t1 babel_3293_t2) mergejoin(t1 babel_3293_t2 babel_3293_t3) leading(t1 babel_3293_t2 babel_3293_t3)*/ * from tempdb.babel_3293_schema.t1 inner      join tempdb.dbo.babel_3293_t2 on tempdb.babel_3293_schema.t1.a1 = tempdb.dbo.babel_3293_t2.a2 left outer       join tempdb.dbo.babel_3293_t3 on tempdb.babel_3293_schema.t1.b1 = tempdb.dbo.babel_3293_t3.b3
 Merge Left Join
   Merge Cond: (t1.b1 = babel_3293_t3.b3)
   ->  Nested Loop

--- a/test/JDBC/expected/BABEL-3294.out
+++ b/test/JDBC/expected/BABEL-3294.out
@@ -77,7 +77,7 @@ select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 0)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(max_parallel_workers_per_gather 64) */ * from babel_3294_t1 t1 where a1 = 1                 
+Query Text: select/*+ set(max_parallel_workers_per_gather 64) */ * from babel_3294_t1 t1 where a1 = 1                 
 Gather
   Workers Planned: 16
   ->  Parallel Seq Scan on babel_3294_t1 t1
@@ -92,7 +92,7 @@ select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 1)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(max_parallel_workers_per_gather 1) */ * from babel_3294_t1 t1 where a1 = 1                 
+Query Text: select/*+ set(max_parallel_workers_per_gather 1) */ * from babel_3294_t1 t1 where a1 = 1                 
 Gather
   Workers Planned: 1
   ->  Parallel Seq Scan on babel_3294_t1 t1
@@ -104,7 +104,7 @@ select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 2)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(max_parallel_workers_per_gather 2) */ * from babel_3294_t1 t1 where a1 = 1                 
+Query Text: select/*+ set(max_parallel_workers_per_gather 2) */ * from babel_3294_t1 t1 where a1 = 1                 
 Gather
   Workers Planned: 2
   ->  Parallel Seq Scan on babel_3294_t1 t1
@@ -116,7 +116,7 @@ select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 4)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(max_parallel_workers_per_gather 4) */ * from babel_3294_t1 t1 where a1 = 1                 
+Query Text: select/*+ set(max_parallel_workers_per_gather 4) */ * from babel_3294_t1 t1 where a1 = 1                 
 Gather
   Workers Planned: 4
   ->  Parallel Seq Scan on babel_3294_t1 t1
@@ -128,7 +128,7 @@ select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 8)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(max_parallel_workers_per_gather 8) */ * from babel_3294_t1 t1 where a1 = 1                 
+Query Text: select/*+ set(max_parallel_workers_per_gather 8) */ * from babel_3294_t1 t1 where a1 = 1                 
 Gather
   Workers Planned: 8
   ->  Parallel Seq Scan on babel_3294_t1 t1
@@ -140,7 +140,7 @@ select * from babel_3294_t1 t1 where a1 = 1 option(maxdop 16)
 go
 ~~START~~
 text
-Query Text: select/*+ Set(max_parallel_workers_per_gather 16) */ * from babel_3294_t1 t1 where a1 = 1                  
+Query Text: select/*+ set(max_parallel_workers_per_gather 16) */ * from babel_3294_t1 t1 where a1 = 1                  
 Gather
   Workers Planned: 16
   ->  Parallel Seq Scan on babel_3294_t1 t1

--- a/test/JDBC/expected/BABEL-3295.out
+++ b/test/JDBC/expected/BABEL-3295.out
@@ -32,7 +32,7 @@ select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1                                 where b1 = 1
+Query Text: select/*+ indexscan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1                                 where b1 = 1
 Bitmap Heap Scan on babel_3295_t1
   Recheck Cond: (b1 = 1)
   ->  Bitmap Index Scan on index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7
@@ -44,7 +44,7 @@ select * from babel_3295_t1 where b1 = 1 option(table hint(babel_3295_t1, index(
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1 where b1 = 1                                                                 
+Query Text: select/*+ indexscan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1 where b1 = 1                                                                 
 Bitmap Heap Scan on babel_3295_t1
   Recheck Cond: (b1 = 1)
   ->  Bitmap Index Scan on index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7
@@ -56,7 +56,7 @@ select * from babel_3295_t1 inner merge join babel_3295_t2 on babel_3295_t1.a1 =
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3295_t1 babel_3295_t2) Leading(babel_3295_t1 babel_3295_t2)*/ * from babel_3295_t1 inner       join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+Query Text: select/*+ mergejoin(babel_3295_t1 babel_3295_t2) leading(babel_3295_t1 babel_3295_t2)*/ * from babel_3295_t1 inner       join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
 Hash Join
   Hash Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
   ->  Seq Scan on babel_3295_t1
@@ -69,7 +69,7 @@ select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2                   
+Query Text: select/*+ set(enable_nestloop off) set(enable_hashjoin off) */ * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2                   
 Hash Join
   Hash Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
   ->  Seq Scan on babel_3295_t1
@@ -100,7 +100,7 @@ select * from babel_3295_t1 (index(index_babel_3295_t1_b1)) where b1 = 1
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1                                 where b1 = 1
+Query Text: select/*+ indexscan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1                                 where b1 = 1
 Index Scan using index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7 on babel_3295_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -110,7 +110,7 @@ select * from babel_3295_t1 where b1 = 1 option(table hint(babel_3295_t1, index(
 go
 ~~START~~
 text
-Query Text: select/*+ IndexScan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1 where b1 = 1                                                                 
+Query Text: select/*+ indexscan(babel_3295_t1 index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7) */ * from babel_3295_t1 where b1 = 1                                                                 
 Index Scan using index_babel_3295_t1_b1babel_329f054c0439acbb57ada93af5f2888cbf7 on babel_3295_t1
   Index Cond: (b1 = 1)
 ~~END~~
@@ -120,7 +120,7 @@ select * from babel_3295_t1 inner merge join babel_3295_t2 on babel_3295_t1.a1 =
 go
 ~~START~~
 text
-Query Text: select/*+ MergeJoin(babel_3295_t1 babel_3295_t2) Leading(babel_3295_t1 babel_3295_t2)*/ * from babel_3295_t1 inner       join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
+Query Text: select/*+ mergejoin(babel_3295_t1 babel_3295_t2) leading(babel_3295_t1 babel_3295_t2)*/ * from babel_3295_t1 inner       join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2
 Merge Join
   Merge Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
   ->  Index Scan using babel_3295_t1_pkey on babel_3295_t1
@@ -132,7 +132,7 @@ select * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_
 go
 ~~START~~
 text
-Query Text: select/*+ Set(enable_nestloop off) Set(enable_hashjoin off) */ * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2                   
+Query Text: select/*+ set(enable_nestloop off) set(enable_hashjoin off) */ * from babel_3295_t1 join babel_3295_t2 on babel_3295_t1.a1 = babel_3295_t2.a2                   
 Merge Join
   Merge Cond: (babel_3295_t1.a1 = babel_3295_t2.a2)
   ->  Index Scan using babel_3295_t1_pkey on babel_3295_t1

--- a/test/JDBC/expected/BABEL-3512.out
+++ b/test/JDBC/expected/BABEL-3512.out
@@ -97,7 +97,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_1';
 GO
 ~~START~~
 text
-SELECT/*+ HashJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ babel_3512_t1.a1 FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2
+SELECT/*+ hashjoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ babel_3512_t1.a1 FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2
 ~~END~~
 
 
@@ -109,7 +109,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_1
-  Query Text: SELECT/*+ HashJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ babel_3512_t1.a1 FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2
+  Query Text: SELECT/*+ hashjoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ babel_3512_t1.a1 FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2
   ->  Hash Join
         Hash Cond: (babel_3512_t2.b2 = babel_3512_t1.a1)
         ->  Seq Scan on babel_3512_t2
@@ -131,7 +131,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_2';
 GO
 ~~START~~
 text
-SELECT/*+ HashJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2<newline>SELECT/*+ NestLoop(babel_3512_t2 babel_3512_t1) Leading(babel_3512_t2 babel_3512_t1)*/ * FROM babel_3512_t2 inner      join babel_3512_t1 ON babel_3512_t1.c1 = babel_3512_t2.c2
+SELECT/*+ hashjoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2<newline>SELECT/*+ nestloop(babel_3512_t2 babel_3512_t1) leading(babel_3512_t2 babel_3512_t1)*/ * FROM babel_3512_t2 inner      join babel_3512_t1 ON babel_3512_t1.c1 = babel_3512_t2.c2
 ~~END~~
 
 
@@ -143,13 +143,13 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_2
-  Query Text: SELECT/*+ HashJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2
+  Query Text: SELECT/*+ hashjoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON a1 = b2
   ->  Hash Join
         Hash Cond: (babel_3512_t2.b2 = babel_3512_t1.a1)
         ->  Seq Scan on babel_3512_t2
         ->  Hash
               ->  Seq Scan on babel_3512_t1
-  Query Text: SELECT/*+ NestLoop(babel_3512_t2 babel_3512_t1) Leading(babel_3512_t2 babel_3512_t1)*/ * FROM babel_3512_t2 inner      join babel_3512_t1 ON babel_3512_t1.c1 = babel_3512_t2.c2
+  Query Text: SELECT/*+ nestloop(babel_3512_t2 babel_3512_t1) leading(babel_3512_t2 babel_3512_t1)*/ * FROM babel_3512_t2 inner      join babel_3512_t1 ON babel_3512_t1.c1 = babel_3512_t2.c2
   ->  Nested Loop
         ->  Seq Scan on babel_3512_t2
         ->  Index Scan using index_babel_3512_t1_c1babel_35191aab574110138d8b9ec599810282a81 on babel_3512_t1
@@ -169,7 +169,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_3';
 GO
 ~~START~~
 text
-SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1
+SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1
 ~~END~~
 
 
@@ -181,7 +181,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_3
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 1)
 ~~END~~
@@ -202,7 +202,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_4';
 GO
 ~~START~~
 text
-SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1<newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                     WHERE b1 = 1<newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1 WHERE b1 = 3                                                                 <newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1                                    WHERE b1 = 1 UNION SELECT * FROM babel_3512_t2                                    WHERE b2 = 1
+SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1<newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                     WHERE b1 = 1<newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1 WHERE b1 = 3                                                                 <newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1                                    WHERE b1 = 1 UNION SELECT * FROM babel_3512_t2                                    WHERE b2 = 1
 ~~END~~
 
 
@@ -214,16 +214,16 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_4
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                 WHERE b1 = 1
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 1)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                     WHERE b1 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1                                     WHERE b1 = 1
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 1)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1 WHERE b1 = 3
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ * FROM babel_3512_t1 WHERE b1 = 3
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 3)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1                                    WHERE b1 = 1 UNION SELECT * FROM babel_3512_t2                                    WHERE b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1                                    WHERE b1 = 1 UNION SELECT * FROM babel_3512_t2                                    WHERE b2 = 1
   ->  HashAggregate
         Group Key: babel_3512_t1.a1, babel_3512_t1.b1, babel_3512_t1.c1
         ->  Append
@@ -246,7 +246,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_5';
 GO
 ~~START~~
 text
-WITH/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1
+WITH/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1
 ~~END~~
 
 
@@ -258,7 +258,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_5
-  Query Text: WITH/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1
+  Query Text: WITH/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 1)
         Filter: (c1 = 1)
@@ -278,7 +278,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_6';
 GO
 ~~START~~
 text
-WITH/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1<newline>WITH/*+ IndexScan(babel_3512_t2 index_babel_3512_t2_b1babel_351ed65eb34ef55dec01b20e7fff9c5ca06) */ babel_3512_t2_cte (a1, b2, c2) as (SELECT * FROM babel_3512_t2                                    WHERE b2 = 1) SELECT * FROM babel_3512_t2_cte WHERE c2 = 1
+WITH/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1<newline>WITH/*+ indexscan(babel_3512_t2 index_babel_3512_t2_b1babel_351ed65eb34ef55dec01b20e7fff9c5ca06) */ babel_3512_t2_cte (a1, b2, c2) as (SELECT * FROM babel_3512_t2                                    WHERE b2 = 1) SELECT * FROM babel_3512_t2_cte WHERE c2 = 1
 ~~END~~
 
 
@@ -290,11 +290,11 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_6
-  Query Text: WITH/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1
+  Query Text: WITH/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) */ babel_3512_t1_cte (a1, b1, c1) as (SELECT * FROM babel_3512_t1                                    WHERE b1 = 1) SELECT * FROM babel_3512_t1_cte WHERE c1 = 1
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 1)
         Filter: (c1 = 1)
-  Query Text: WITH/*+ IndexScan(babel_3512_t2 index_babel_3512_t2_b1babel_351ed65eb34ef55dec01b20e7fff9c5ca06) */ babel_3512_t2_cte (a1, b2, c2) as (SELECT * FROM babel_3512_t2                                    WHERE b2 = 1) SELECT * FROM babel_3512_t2_cte WHERE c2 = 1
+  Query Text: WITH/*+ indexscan(babel_3512_t2 index_babel_3512_t2_b1babel_351ed65eb34ef55dec01b20e7fff9c5ca06) */ babel_3512_t2_cte (a1, b2, c2) as (SELECT * FROM babel_3512_t2                                    WHERE b2 = 1) SELECT * FROM babel_3512_t2_cte WHERE c2 = 1
   ->  Seq Scan on babel_3512_t2
         Filter: ((b2 = 1) AND (c2 = 1))
 ~~END~~
@@ -312,7 +312,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_7';
 GO
 ~~START~~
 text
-SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1                                                                                                                           
+SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1                                                                                                                           
 ~~END~~
 
 
@@ -324,7 +324,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_7
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1
   ->  Nested Loop
         ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
               Index Cond: (b1 = 1)
@@ -348,7 +348,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_8';
 GO
 ~~START~~
 text
-SELECT * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1<newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1                                                                                                                           <newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1 babel_3512_t1                                   , babel_3512_t2 babel_3512_t2                                    WHERE b1 = 1 AND b2 = 1
+SELECT * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1<newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1                                                                                                                           <newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1 babel_3512_t1                                   , babel_3512_t2 babel_3512_t2                                    WHERE b1 = 1 AND b2 = 1
 ~~END~~
 
 
@@ -371,14 +371,14 @@ Query Text: EXEC babel_3512_proc_8
                     Recheck Cond: (b2 = 1)
                     ->  Bitmap Index Scan on index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9
                           Index Cond: (b2 = 1)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1, babel_3512_t2 WHERE b1 = 1 AND b2 = 1
   ->  Nested Loop
         ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
               Index Cond: (b1 = 1)
         ->  Materialize
               ->  Index Scan using index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9 on babel_3512_t2
                     Index Cond: (b2 = 1)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1 babel_3512_t1                                   , babel_3512_t2 babel_3512_t2                                    WHERE b1 = 1 AND b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1 babel_3512_t1                                   , babel_3512_t2 babel_3512_t2                                    WHERE b1 = 1 AND b2 = 1
   ->  Nested Loop
         ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
               Index Cond: (b1 = 1)
@@ -399,7 +399,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_9';
 GO
 ~~START~~
 text
-SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     inner      join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
+SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     inner      join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
 ~~END~~
 
 
@@ -411,7 +411,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_proc_9
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     inner      join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     inner      join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
   ->  Nested Loop
         Join Filter: (babel_3512_t1.a1 = babel_3512_t2.a2)
         ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
@@ -435,7 +435,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_proc_10';
 GO
 ~~START~~
 text
-SELECT * FROM babel_3512_t1 join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1<newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) Set(enable_hashjoin off) Set(enable_mergejoin off) */ * FROM babel_3512_t1 join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1                                                                                                                                      <newline>SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) MergeJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     right outer       join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
+SELECT * FROM babel_3512_t1 join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1<newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) set(enable_hashjoin off) set(enable_mergejoin off) */ * FROM babel_3512_t1 join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1                                                                                                                                      <newline>SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) mergejoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     right outer       join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
 ~~END~~
 
 
@@ -459,7 +459,7 @@ Query Text: EXEC babel_3512_proc_10
                     Recheck Cond: (b2 = 1)
                     ->  Bitmap Index Scan on index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9
                           Index Cond: (b2 = 1)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) Set(enable_hashjoin off) Set(enable_mergejoin off) */ * FROM babel_3512_t1 join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) set(enable_hashjoin off) set(enable_mergejoin off) */ * FROM babel_3512_t1 join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
   ->  Nested Loop
         Join Filter: (babel_3512_t1.a1 = babel_3512_t2.a2)
         ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
@@ -467,7 +467,7 @@ Query Text: EXEC babel_3512_proc_10
         ->  Materialize
               ->  Index Scan using index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9 on babel_3512_t2
                     Index Cond: (b2 = 1)
-  Query Text: SELECT/*+ IndexScan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) IndexScan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) MergeJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     right outer       join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
+  Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) mergejoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ * FROM babel_3512_t1                                     right outer       join babel_3512_t2                                 ON babel_3512_t1.a1 = babel_3512_t2.a2 WHERE b1 = 1 AND b2 = 1
   ->  Merge Join
         Merge Cond: (babel_3512_t1.a1 = babel_3512_t2.a2)
         ->  Sort
@@ -538,7 +538,7 @@ SELECT/* this is a comment block */ * FROM babel_3512_t1 inner loop join babel_3
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -550,7 +550,7 @@ SELECT /* this is a comment block */ * FROM babel_3512_t1 inner loop join babel_
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ /* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ /* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -562,7 +562,7 @@ SELECT	/* this is a comment block */ * FROM babel_3512_t1 inner loop join babel_
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/	/* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/	/* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -585,7 +585,7 @@ babel_3512_t2.a2
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ HashJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/
+Query Text: SELECT/*+ hashjoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/
 *
 FROM
 babel_3512_t1
@@ -619,7 +619,7 @@ SELECT/*this is a comment block*/*FROM babel_3512_t1 inner loop join babel_3512_
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/*FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/*FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -631,7 +631,7 @@ Nested Loop
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/* FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/* FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -643,7 +643,7 @@ Nested Loop
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -655,7 +655,7 @@ Nested Loop
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block1234*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block1234*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
   ->  Seq Scan on babel_3512_t1
   ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -668,7 +668,7 @@ SELECT/*this is a comment
 GO
 ~~START~~
 text
-Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment
+Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment
  multi line block */
  /*this is a comment block*/	* FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 Nested Loop
@@ -695,7 +695,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_comment_test_1';
 GO
 ~~START~~
 text
-SELECT/* this is a comment block */ * FROM babel_3512_t1 inner join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ MergeJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ /* this is a comment block */ * FROM<newline> babel_3512_t1 inner       join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/*FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>/* this is another comment block */SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+SELECT/* this is a comment block */ * FROM babel_3512_t1 inner join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ mergejoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ /* this is a comment block */ * FROM<newline> babel_3512_t1 inner       join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/*FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>/* this is another comment block */SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 ~~END~~
 
 
@@ -711,7 +711,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3512_comment_test_2';
 GO
 ~~START~~
 text
-SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>/* this is another comment block *//* this is another comment block */SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block1234*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment<newline> multi line block */<newline> /*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>/* this is another comment block *//* this is another comment block */SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block1234*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2<newline>SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment<newline> multi line block */<newline> /*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
 ~~END~~
 
 
@@ -729,23 +729,23 @@ Query Text: EXEC babel_3512_comment_test_1
         ->  Seq Scan on babel_3512_t1
         ->  Hash
               ->  Seq Scan on babel_3512_t2
-  Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+  Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//* this is a comment block */ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Nested Loop
         ->  Seq Scan on babel_3512_t1
         ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
               Index Cond: (a2 = babel_3512_t1.a1)
-  Query Text: SELECT/*+ MergeJoin(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*/ /* this is a comment block */ * FROM
+  Query Text: SELECT/*+ mergejoin(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*/ /* this is a comment block */ * FROM
  babel_3512_t1 inner       join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Merge Join
         Merge Cond: (babel_3512_t1.a1 = babel_3512_t2.a2)
         ->  Index Scan using babel_3512_t1_pkey on babel_3512_t1
         ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
-  Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/*FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+  Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/*FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Nested Loop
         ->  Seq Scan on babel_3512_t1
         ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
               Index Cond: (a2 = babel_3512_t1.a1)
-  Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+  Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Nested Loop
         ->  Seq Scan on babel_3512_t1
         ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
@@ -758,17 +758,17 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3512_comment_test_2
-  Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+  Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Nested Loop
         ->  Seq Scan on babel_3512_t1
         ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
               Index Cond: (a2 = babel_3512_t1.a1)
-  Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block1234*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
+  Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment block1234*//*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Nested Loop
         ->  Seq Scan on babel_3512_t1
         ->  Index Scan using babel_3512_t2_pkey on babel_3512_t2
               Index Cond: (a2 = babel_3512_t1.a1)
-  Query Text: SELECT/*+ NestLoop(babel_3512_t1 babel_3512_t2) Leading(babel_3512_t1 babel_3512_t2)*//*this is a comment
+  Query Text: SELECT/*+ nestloop(babel_3512_t1 babel_3512_t2) leading(babel_3512_t1 babel_3512_t2)*//*this is a comment
  multi line block */
  /*this is a comment block*/ * FROM babel_3512_t1 inner      join babel_3512_t2 ON babel_3512_t1.a1 = babel_3512_t2.a2
   ->  Nested Loop

--- a/test/JDBC/expected/BABEL-3513-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3513-vu-prepare.out
@@ -34,7 +34,7 @@ go
 ~~START~~
 text
 Query Text: EXEC babel_3513_proc_1
-  Query Text: SELECT/*+ MergeJoin(babel_3513_t1 babel_3513_t2) Leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
+  Query Text: SELECT/*+ mergejoin(babel_3513_t1 babel_3513_t2) leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
   ->  Nested Loop
         Join Filter: (babel_3513_t1.a1 = babel_3513_t2.b2)
         ->  Seq Scan on babel_3513_t1
@@ -56,7 +56,7 @@ go
 ~~START~~
 text
 Query Text: EXEC babel_3513_proc_1
-  Query Text: SELECT/*+ MergeJoin(babel_3513_t1 babel_3513_t2) Leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
+  Query Text: SELECT/*+ mergejoin(babel_3513_t1 babel_3513_t2) leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
   ->  Nested Loop
         Join Filter: (babel_3513_t1.a1 = babel_3513_t2.b2)
         ->  Seq Scan on babel_3513_t1
@@ -69,7 +69,7 @@ SELECT babel_3513_t1.a1 FROM babel_3513_t1 inner merge join babel_3513_t2 ON a1 
 go
 ~~START~~
 text
-Query Text: SELECT/*+ MergeJoin(babel_3513_t1 babel_3513_t2) Leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
+Query Text: SELECT/*+ mergejoin(babel_3513_t1 babel_3513_t2) leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
 Merge Join
   Merge Cond: (babel_3513_t1.a1 = babel_3513_t2.b2)
   ->  Sort

--- a/test/JDBC/expected/BABEL-3513-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3513-vu-verify.out
@@ -23,7 +23,7 @@ go
 ~~START~~
 text
 Query Text: EXEC babel_3513_proc_1
-  Query Text: SELECT/*+ MergeJoin(babel_3513_t1 babel_3513_t2) Leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
+  Query Text: SELECT/*+ mergejoin(babel_3513_t1 babel_3513_t2) leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
   ->  Merge Join
         Merge Cond: (babel_3513_t1.a1 = babel_3513_t2.b2)
         ->  Sort
@@ -55,7 +55,7 @@ go
 ~~START~~
 text
 Query Text: EXEC babel_3513_proc_1
-  Query Text: SELECT/*+ MergeJoin(babel_3513_t1 babel_3513_t2) Leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
+  Query Text: SELECT/*+ mergejoin(babel_3513_t1 babel_3513_t2) leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
   ->  Merge Join
         Merge Cond: (babel_3513_t1.a1 = babel_3513_t2.b2)
         ->  Sort
@@ -72,7 +72,7 @@ SELECT babel_3513_t1.a1 FROM babel_3513_t1 inner merge join babel_3513_t2 ON a1 
 go
 ~~START~~
 text
-Query Text: SELECT/*+ MergeJoin(babel_3513_t1 babel_3513_t2) Leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
+Query Text: SELECT/*+ mergejoin(babel_3513_t1 babel_3513_t2) leading(babel_3513_t1 babel_3513_t2)*/ babel_3513_t1.a1 FROM babel_3513_t1 inner       join babel_3513_t2 ON a1 = b2
 Nested Loop
   Join Filter: (babel_3513_t1.a1 = babel_3513_t2.b2)
   ->  Seq Scan on babel_3513_t1

--- a/test/JDBC/expected/BABEL-3592.out
+++ b/test/JDBC/expected/BABEL-3592.out
@@ -55,7 +55,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_insert_multiline';
 GO
 ~~START~~
 text
-insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2<newline>    select *<newline>    from babel_3592_t1                                    <newline>    where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1                                                                 
+insert into babel_3592_t2 select * from babel_3592_t1 where b1 = 1<newline>insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2<newline>    select *<newline>    from babel_3592_t1                                    <newline>    where b1 = 1<newline>insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1                                                                 
 ~~END~~
 
 
@@ -82,14 +82,14 @@ Query Text: EXEC babel_3592_insert_multiline
               Recheck Cond: (b1 = 1)
               ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
                     Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
     select *
     from babel_3592_t1                                    
     where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -101,7 +101,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3592_insert_singleline
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -128,7 +128,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_updates_multiline';
 GO
 ~~START~~
 text
-update babel_3592_t1 <newline>    set a1 = 1 where b1 = 1<newline>update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 <newline>                                        <newline>    set a1 = 1 where b1 = 1<newline>update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 
+update babel_3592_t1 <newline>    set a1 = 1 where b1 = 1<newline>update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 <newline>                                        <newline>    set a1 = 1 where b1 = 1<newline>update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 
 ~~END~~
 
 
@@ -136,7 +136,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_updates_singleline';
 GO
 ~~START~~
 text
-update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 
+update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 
 ~~END~~
 
 
@@ -160,14 +160,14 @@ Query Text: EXEC babel_3592_insert_multiline
               Recheck Cond: (b1 = 1)
               ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
                     Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
     select *
     from babel_3592_t1                                    
     where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -179,7 +179,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3592_updates_singleline
-  Query Text: update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1
+  Query Text: update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1
   ->  Update on babel_3592_t1
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -207,7 +207,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_delete_multiline';
 GO
 ~~START~~
 text
-delete from babel_3592_t1 where b1 = 1<newline>delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1                                                       <newline>    where b1 = 1<newline>delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1                                                                 
+delete from babel_3592_t1 where b1 = 1<newline>delete/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1                                                       <newline>    where b1 = 1<newline>delete/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1                                                                 
 ~~END~~
 
 
@@ -215,7 +215,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_delete_singleline';
 GO
 ~~START~~
 text
-delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1                                                                 
+delete/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1                                                                 
 ~~END~~
 
 
@@ -239,14 +239,14 @@ Query Text: EXEC babel_3592_insert_multiline
               Recheck Cond: (b1 = 1)
               ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
                     Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2
     select *
     from babel_3592_t1                                    
     where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -258,7 +258,7 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3592_delete_singleline
-  Query Text: delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1
+  Query Text: delete/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ from babel_3592_t1 where b1 = 1
   ->  Delete on babel_3592_t1
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -299,7 +299,7 @@ SELECT prosrc FROM pg_proc WHERE proname = 'babel_3592_proc_mixed_statements';
 GO
 ~~START~~
 text
-update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1                                     set a1 = 1 where b1 = 1<newline>        select/*+ NestLoop(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2<newline>    select/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      <newline>     join babel_3592_t2<newline>      on babel_3592_t1.a1 = babel_3592_t2.a2<newline>    update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 <newline>    delete/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1 inner       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1<newline>delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1                                     left outer       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1<newline>insert<newline>into<newline>babel_3592_t2 select * from babel_3592_t1 where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1                                     where b1 = 1<newline>insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1                                                                 <newline>-- comments inside the stored proc<newline>update babel_3592_t1 set a1 = 1 where b1 = 1<newline>/*<newline> *multiline comment<newline> */<newline> select/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) IndexScan(babel_3592_t2 index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d) */ * from babel_3592_t1                                    , babel_3592_t2                                     where b1 = 1 and b2 = 1
+update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1                                     set a1 = 1 where b1 = 1<newline>        select/*+ nestloop(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2<newline>    select/*+ mergejoin(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      <newline>     join babel_3592_t2<newline>      on babel_3592_t1.a1 = babel_3592_t2.a2<newline>    update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1                                                                 <newline>    delete/*+ mergejoin(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1 inner       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1<newline>delete/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) mergejoin(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1                                     left outer       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1<newline>insert<newline>into<newline>babel_3592_t2 select * from babel_3592_t1 where b1 = 1<newline>insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1                                     where b1 = 1<newline>insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1                                                                 <newline>-- comments inside the stored proc<newline>update babel_3592_t1 set a1 = 1 where b1 = 1<newline>/*<newline> *multiline comment<newline> */<newline> select/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) indexscan(babel_3592_t2 index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d) */ * from babel_3592_t1                                    , babel_3592_t2                                     where b1 = 1 and b2 = 1
 ~~END~~
 
 
@@ -326,27 +326,27 @@ GO
 ~~START~~
 text
 Query Text: EXEC babel_3592_proc_mixed_statements
-  Query Text: update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1                                     set a1 = 1 where b1 = 1
+  Query Text: update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1                                     set a1 = 1 where b1 = 1
   ->  Update on babel_3592_t1
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
-  Query Text: select/*+ NestLoop(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2
+  Query Text: select/*+ nestloop(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2
   ->  Nested Loop
         ->  Seq Scan on babel_3592_t1
         ->  Index Scan using babel_3592_t2_pkey on babel_3592_t2
               Index Cond: (a2 = babel_3592_t1.a1)
-  Query Text: select/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      
+  Query Text: select/*+ mergejoin(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ * from babel_3592_t1 inner      
      join babel_3592_t2
       on babel_3592_t1.a1 = babel_3592_t2.a2
   ->  Merge Join
         Merge Cond: (babel_3592_t1.a1 = babel_3592_t2.a2)
         ->  Index Scan using babel_3592_t1_pkey on babel_3592_t1
         ->  Index Scan using babel_3592_t2_pkey on babel_3592_t2
-  Query Text: update/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1
+  Query Text: update/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ babel_3592_t1 set a1 = 1 where b1 = 1
   ->  Update on babel_3592_t1
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
-  Query Text: delete/*+ MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1 inner       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+  Query Text: delete/*+ mergejoin(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1 inner       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
   ->  Delete on babel_3592_t1
         ->  Nested Loop
               ->  HashAggregate
@@ -364,7 +364,7 @@ Query Text: EXEC babel_3592_proc_mixed_statements
                                             Index Cond: (b2 = 1)
               ->  Tid Scan on babel_3592_t1
                     TID Cond: (ctid = babel_3592_t1_1.ctid)
-  Query Text: delete/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) MergeJoin(babel_3592_t1 babel_3592_t2) Leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1                                     left outer       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
+  Query Text: delete/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) mergejoin(babel_3592_t1 babel_3592_t2) leading(babel_3592_t1 babel_3592_t2)*/ babel_3592_t1 from babel_3592_t1                                     left outer       join babel_3592_t2 on babel_3592_t1.a1 = babel_3592_t2.a2 where b1 = 1 and b2 = 1
   ->  Delete on babel_3592_t1
         ->  Nested Loop
               ->  HashAggregate
@@ -388,11 +388,11 @@ babel_3592_t2 select * from babel_3592_t1 where b1 = 1
               Recheck Cond: (b1 = 1)
               ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
                     Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1                                     where b1 = 1
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1                                     where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
-  Query Text: insert/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
+  Query Text: insert/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) */ into babel_3592_t2 select * from babel_3592_t1 where b1 = 1
   ->  Insert on babel_3592_t2
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)
@@ -402,7 +402,7 @@ babel_3592_t2 select * from babel_3592_t1 where b1 = 1
               Recheck Cond: (b1 = 1)
               ->  Bitmap Index Scan on index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836
                     Index Cond: (b1 = 1)
-  Query Text: select/*+ IndexScan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) IndexScan(babel_3592_t2 index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d) */ * from babel_3592_t1                                    , babel_3592_t2                                     where b1 = 1 and b2 = 1
+  Query Text: select/*+ indexscan(babel_3592_t1 index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836) indexscan(babel_3592_t2 index_babel_3592_t2_b2babel_359155b730148d8fcf0167f32edb84e3f7d) */ * from babel_3592_t1                                    , babel_3592_t2                                     where b1 = 1 and b2 = 1
   ->  Nested Loop
         ->  Index Scan using index_babel_3592_t1_b1babel_35976c64b612d1f74e2768783beca3bf836 on babel_3592_t1
               Index Cond: (b1 = 1)

--- a/test/JDBC/input/pg_hint_plan/BABEL-3292.sql
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3292.sql
@@ -10,7 +10,7 @@ go
 create index index_babel_3292_t1_b1 on babel_3292_t1(b1)
 go
 
-create index index_babel_3292_t1_c1 on babel_3292_t1(c1)
+create index inDex_BABEL_3292_T1_c1 on babel_3292_t1(c1)
 go
 
 create table babel_3292_t2(a2 int PRIMARY KEY, b2 int, c2 int)
@@ -74,6 +74,9 @@ select * from babel_3292_t1 with(index(index_babel_3292_t1_b1), index(index_babe
 go
 
 select * from babel_3292_t1 where b1 = 1 and c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1), index(index_babel_3292_t1_c1)))
+go
+
+select * from BABEL_3292_t1 where b1 = 1 and c1 = 1 option(table hint(Babel_3292_t1, index(IndeX_BABEL_3292_t1_b1), index(Index_baBel_3292_t1_C1)))
 go
 
 -- Test with multiple tables
@@ -149,6 +152,9 @@ with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 with(index=i
 go
 
 with babel_3292_t1_cte (a1, b1, c1) as (select * from babel_3292_t1 where b1 = 1) select * from babel_3292_t1_cte where c1 = 1 option(table hint(babel_3292_t1, index(index_babel_3292_t1_b1)))
+go
+
+with BaBeL_3292_T1_CTE (a1, b1, c1) as (select * from BABEL_3292_t1 with(index=INDEX_BABEL_3292_T1_B1) where b1 = 1) select * from babel_3292_t1_cte where c1 = 1
 go
 
 -- Limitation: Hint given on a CTE is not applied

--- a/test/JDBC/input/pg_hint_plan/BABEL-3293.sql
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3293.sql
@@ -52,6 +52,9 @@ go
 select * from babel_3293_t1 left outer loop join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1
 go
 
+select * from BABEL_3293_t1 LeFt ouTer LOOP join Babel_3293_T2 on BABEL_3293_t1.a1 = BABEL_3293_t2.a2 where b1 = 1 and b2 = 1
+go
+
 select * from babel_3293_t1 with(index(index_babel_3293_t1_b1)) join babel_3293_t2 (index(index_babel_3293_t2_b2)) on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 -- Join query with just table hints
 go
 
@@ -86,6 +89,9 @@ go
 select * from babel_3293_t1 t1, babel_3293_t2 t2 inner hash join babel_3293_t3 t3 on t2.a2 = t3.a3
 go
 
+select * from BABEL_3293_t1 t1 left outer MERGE join BaBeL_3293_T2 t2 on t1.a1 = t2.a2 InNeR LOOP JOIN bABEL_3293_t3 t3 on t2.a2 = t3.a3 where b1 = 1 and b2 = 1 and b3 = 1
+go
+
 -- Join hints through option clause
 select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 where b1 = 1 and b2 = 1 option(hash join)
 go
@@ -97,6 +103,9 @@ select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_
 go
 
 select * from babel_3293_t1 join babel_3293_t2 on babel_3293_t1.a1 = babel_3293_t2.a2 join babel_3293_t3 on babel_3293_t2.a2 = babel_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
+go
+
+select * from babeL_3293_T1 join BABEL_3293_T2 on babeL_3293_T1.a1 = BABEL_3293_T2.a2 join babEl_3293_t3 on babel_3293_T2.a2 = BABEL_3293_t3.a3 where b1 = 1 and b2 = 1 and b3 = 1 option(merge join)
 go
 
 -- Conflicting join hints


### PR DESCRIPTION
### Description
Without this change there will be a mismatch between the index name used at query time and query creation since index and table are lowercase when the index is being created.

In addition to lowercasing the table and index name before hashing, we also need to lower case the table name in the hints themselves.  Without this change hints would not be applied when tables with uppercase letters are in present in the FROM clause.  Lowercase the whole hint has ensures that tables are always lowercase.

Task: BABEL-3759
Signed-off-by: Justin Jossick jusjosj@amazon.com

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).