### PR TITLE
Bump Babelfish internal version to 14.5.1.0 and Babelfish extension version to 2.2.1 for BABEL_2_2_STABLE

### DIFF
--- a/contrib/babelfishpg_tsql/src/babelfish_version.h
+++ b/contrib/babelfishpg_tsql/src/babelfish_version.h
@@ -8,8 +8,8 @@
  *-------------------------------------------------------------------------
  */
 
-#define BABELFISH_VERSION_STR "2.2.0"
-#define BABELFISH_INTERNAL_VERSION_STR "Babelfish 14.4.0.0"
+#define BABELFISH_VERSION_STR "2.2.1"
+#define BABELFISH_INTERNAL_VERSION_STR "Babelfish 14.5.1.0"
 #define BABEL_COMPATIBILITY_VERSION "12.0.2000.8"
 #define BABEL_COMPATIBILITY_MAJOR_VERSION "12"
 


### PR DESCRIPTION
Signed-off-by: Yuhao Wei <yuhaowei@amazon.com>

### Description
Bump Babelfish extensions version number and Babelfish internal version number.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).