### PR TITLE
[BABEL-2646]Updated error message for four part object names

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1346,7 +1346,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFunc_proc_name_database_sc
 antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFunc_proc_name_server_database_schema(TSqlParser::Func_proc_name_server_database_schemaContext *ctx)
 {
 	if (ctx->DOT().size() >= 3 && ctx->server) /* server.db.schema.funcname */
-		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, format_errmsg("%s is not currently supported in Babelfish", "Remote object reference with 4-part object name"), getLineAndPos(ctx));
+		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Remote object reference with 4-part object name is not currently supported in Babelfish", getLineAndPos(ctx));
 
 	if (ctx->DOT().empty())
 	{
@@ -1360,7 +1360,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFunc_proc_name_server_data
 antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFull_object_name(TSqlParser::Full_object_nameContext *ctx)
 {
 	if (ctx->DOT().size() >= 3 && ctx->server) /* server.db.schema.funcname */
-		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, format_errmsg("%s is not currently supported in Babelfish", "Remote object reference with 4-part object name"), getLineAndPos(ctx));
+		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Remote object reference with 4-part object name is not currently supported in Babelfish", getLineAndPos(ctx));
 
 	return visitChildren(ctx);
 }

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1346,7 +1346,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFunc_proc_name_database_sc
 antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFunc_proc_name_server_database_schema(TSqlParser::Func_proc_name_server_database_schemaContext *ctx)
 {
 	if (ctx->DOT().size() >= 3 && ctx->server) /* server.db.schema.funcname */
-		handle(INSTR_UNSUPPORTED_TSQL_SERVERNAME_IN_NAME, "Remote object reference with 4-part object name", getLineAndPos(ctx));
+		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, format_errmsg("%s is not currently supported in Babelfish", "Remote object reference with 4-part object name"), getLineAndPos(ctx));
 
 	if (ctx->DOT().empty())
 	{
@@ -1360,7 +1360,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFunc_proc_name_server_data
 antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitFull_object_name(TSqlParser::Full_object_nameContext *ctx)
 {
 	if (ctx->DOT().size() >= 3 && ctx->server) /* server.db.schema.funcname */
-		handle(INSTR_UNSUPPORTED_TSQL_SERVERNAME_IN_NAME, "Remote object reference with 4-part object name", getLineAndPos(ctx));
+		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, format_errmsg("%s is not currently supported in Babelfish", "Remote object reference with 4-part object name"), getLineAndPos(ctx));
 
 	return visitChildren(ctx);
 }

--- a/test/JDBC/expected/BABEL-2455.out
+++ b/test/JDBC/expected/BABEL-2455.out
@@ -320,14 +320,14 @@ insert into yourserver.master.dbo.t1 values (1);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'Remote object reference with 4-part object name' is not currently supported in Babelfish)~~
+~~ERROR (Message: Remote object reference with 4-part object name is not currently supported in Babelfish)~~
 
 
 select yourserver.master.dbo.f1(1);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'Remote object reference with 4-part object name' is not currently supported in Babelfish)~~
+~~ERROR (Message: Remote object reference with 4-part object name is not currently supported in Babelfish)~~
 
 
 -- cleanup


### PR DESCRIPTION
### Description

Currently, when referencing a remote object with a 4-part object name, the message **'Remote object reference with 4-part object name' is not currently supported in Babelfish** is raised. This commit removes the quotes around it. The error message is changed to **Remote object reference with 4-part object name is not currently supported by Babelfish**.

### Testing

- Use case based: Updated test `babel-2646` with new error message
- Boundary conditions: N/A
- Arbitrary inputs: N/A
- Negative test scenarios: N/A
- Minor version upgrade tests: N/A
- Major version upgrade tests: N/A
- Performance tests: Have not seen big impact on SLA.

 
### Issues Resolved

BABEL-2646

Authored-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)
Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).