### PR TITLE
Fix babel_datatype test output

### DIFF
--- a/contrib/babelfishpg_tsql/expected/test/babel_datatype.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_datatype.out
@@ -825,9 +825,7 @@ select CAST('2020-03-15 09:00:00.123456' AS datetime2(0));
 (1 row)
 
 select CAST('2020-03-15 09:00:00.123456' AS datetime2(-1));
-ERROR:  TIMESTAMP(-1) precision must not be negative
-LINE 1: select CAST('2020-03-15 09:00:00.123456' AS datetime2(-1));
-                                                    ^
+ERROR:  Specified scale -1 is invalid. 'datetime2' datatype must have scale between 0 and 7
 create table testing1(ts DATETIME, tstz DATETIME2(7));
 WARNING:  TIMESTAMP(7) precision reduced to maximum allowed, 6
 LINE 1: create table testing1(ts DATETIME, tstz DATETIME2(7));

--- a/test/JDBC/input/BABEL-SP_SPECIAL_COLUMNS_100-dep-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_SPECIAL_COLUMNS_100-dep-vu-verify.sql
@@ -1,4 +1,4 @@
--- sla 400000
+-- sla 600000
 exec babel_sp_special_columns_100_dep_vu_prepare_p1
 go
 


### PR DESCRIPTION
### Description
Commit fc345ac missed to update the expected error message in babel_datatype test, so fixing it here.

Task: BABEL-3720
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).