### PR TITLE
Add NULL checks for GUCs in tdsstat_bestart()

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -423,7 +423,6 @@ tdsstat_bestart(void)
 	char *library_name = NULL;
 	char *host_name = NULL;
 	const char *language = NULL;
-	const char *guc_val = NULL;
 
 	/*
 	 * To minimize the time spent modifying the TdsStatus entry, and
@@ -440,7 +439,6 @@ tdsstat_bestart(void)
 		   unvolatize(TdsStatus *, vtdsentry),
 		   sizeof(TdsStatus));
 
-
 	ltdsentry.st_procpid = MyProcPid;
 	ltdsentry.client_version = MyTdsClientVersion;
 	ltdsentry.client_pid = MyTdsClientPid;
@@ -448,42 +446,31 @@ tdsstat_bestart(void)
 	ltdsentry.packet_size = MyTdsPacketSize;
 
 	/* Set the boot GUC values */
-	guc_val = GetConfigOption("babelfishpg_tsql.quoted_identifier", true, true);
-	ltdsentry.quoted_identifier = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.quoted_identifier = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->quoted_identifier) ? pltsql_plugin_handler_ptr->quoted_identifier : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.arithabort", true, true);
-	ltdsentry.arithabort = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.arithabort = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->arithabort) ? pltsql_plugin_handler_ptr->arithabort : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.ansi_null_dflt_on", true, true);
-	ltdsentry.ansi_null_dflt_on = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.ansi_null_dflt_on = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->ansi_null_dflt_on) ? pltsql_plugin_handler_ptr->ansi_null_dflt_on : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.ansi_defaults", true, true);
-	ltdsentry.ansi_defaults = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.ansi_defaults = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->ansi_defaults) ? pltsql_plugin_handler_ptr->ansi_defaults : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.ansi_warnings", true, true);
-	ltdsentry.ansi_warnings = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.ansi_warnings = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->ansi_warnings) ? pltsql_plugin_handler_ptr->ansi_warnings : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.ansi_padding", true, true);
-	ltdsentry.ansi_padding = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.ansi_padding = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->ansi_padding) ? pltsql_plugin_handler_ptr->ansi_padding : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.ansi_nulls", true, true);
-	ltdsentry.ansi_nulls = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.ansi_nulls = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->ansi_nulls) ? pltsql_plugin_handler_ptr->ansi_nulls : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.concat_null_yields_null", true, true);
-	ltdsentry.concat_null_yields_null = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+	ltdsentry.concat_null_yields_null = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->concat_null_yields_null) ? pltsql_plugin_handler_ptr->concat_null_yields_null : true;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.textsize", true, true);
-	ltdsentry.textsize = guc_val != NULL ? atoi(guc_val) : 0;
+	ltdsentry.textsize = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->textsize) ? pltsql_plugin_handler_ptr->textsize : 0;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.datefirst", true, true);
-	ltdsentry.datefirst = guc_val != NULL ? atoi(guc_val) : 7;
+	ltdsentry.datefirst = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->datefirst) ? pltsql_plugin_handler_ptr->datefirst : 7;
 
-	guc_val = GetConfigOption("babelfishpg_tsql.lock_timeout", true, true);
-	ltdsentry.lock_timeout = guc_val != NULL ? atoi(guc_val) : -1;
+	ltdsentry.lock_timeout = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->lock_timeout) ? pltsql_plugin_handler_ptr->lock_timeout : -1;
 
 	ltdsentry.transaction_isolation = DefaultXactIsoLevel;
 
-	language = GetConfigOption("babelfishpg_tsql.language", true, true);
+	language = (pltsql_plugin_handler_ptr && pltsql_plugin_handler_ptr->language) ? pltsql_plugin_handler_ptr->language : NULL;
 
 	if (language != NULL)
 	{

--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -423,6 +423,7 @@ tdsstat_bestart(void)
 	char *library_name = NULL;
 	char *host_name = NULL;
 	const char *language = NULL;
+	const char *guc_val = NULL;
 
 	/*
 	 * To minimize the time spent modifying the TdsStatus entry, and
@@ -447,17 +448,39 @@ tdsstat_bestart(void)
 	ltdsentry.packet_size = MyTdsPacketSize;
 
 	/* Set the boot GUC values */
-	ltdsentry.quoted_identifier = strcmp(GetConfigOption("babelfishpg_tsql.quoted_identifier", true, true), "on") == 0 ? true : false;
-	ltdsentry.arithabort = strcmp(GetConfigOption("babelfishpg_tsql.arithabort", true, true), "on") == 0 ? true : false;
-	ltdsentry.ansi_null_dflt_on = strcmp(GetConfigOption("babelfishpg_tsql.ansi_null_dflt_on", true, true), "on") == 0 ? true : false;
-	ltdsentry.ansi_defaults = strcmp(GetConfigOption("babelfishpg_tsql.ansi_defaults", true, true), "on") == 0 ? true : false;
-	ltdsentry.ansi_warnings = strcmp(GetConfigOption("babelfishpg_tsql.ansi_warnings", true, true), "on") == 0 ? true : false;
-	ltdsentry.ansi_padding = strcmp(GetConfigOption("babelfishpg_tsql.ansi_padding", true, true), "on") == 0 ? true : false;
-	ltdsentry.ansi_nulls = strcmp(GetConfigOption("babelfishpg_tsql.ansi_nulls", true, true), "on") == 0 ? true : false;
-	ltdsentry.concat_null_yields_null = strcmp(GetConfigOption("babelfishpg_tsql.concat_null_yields_null", true, true), "on") == 0 ? true : false;
-	ltdsentry.textsize = atoi(GetConfigOption("babelfishpg_tsql.textsize", true, true));
-	ltdsentry.datefirst = atoi(GetConfigOption("babelfishpg_tsql.datefirst", true, true));
-	ltdsentry.lock_timeout = atoi(GetConfigOption("lock_timeout", true, true));
+	guc_val = GetConfigOption("babelfishpg_tsql.quoted_identifier", true, true);
+	ltdsentry.quoted_identifier = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.arithabort", true, true);
+	ltdsentry.arithabort = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.ansi_null_dflt_on", true, true);
+	ltdsentry.ansi_null_dflt_on = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.ansi_defaults", true, true);
+	ltdsentry.ansi_defaults = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.ansi_warnings", true, true);
+	ltdsentry.ansi_warnings = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.ansi_padding", true, true);
+	ltdsentry.ansi_padding = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.ansi_nulls", true, true);
+	ltdsentry.ansi_nulls = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.concat_null_yields_null", true, true);
+	ltdsentry.concat_null_yields_null = ((guc_val == NULL) || (strcmp(guc_val, "on") == 0)) ? true : false;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.textsize", true, true);
+	ltdsentry.textsize = guc_val != NULL ? atoi(guc_val) : 0;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.datefirst", true, true);
+	ltdsentry.datefirst = guc_val != NULL ? atoi(guc_val) : 7;
+
+	guc_val = GetConfigOption("babelfishpg_tsql.lock_timeout", true, true);
+	ltdsentry.lock_timeout = guc_val != NULL ? atoi(guc_val) : -1;
+
 	ltdsentry.transaction_isolation = DefaultXactIsoLevel;
 
 	language = GetConfigOption("babelfishpg_tsql.language", true, true);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -151,6 +151,18 @@ static void revoke_type_permission_from_public(PlannedStmt *pstmt, const char *q
 		ProcessUtilityContext context, ParamListInfo params, QueryEnvironment *queryEnv, DestReceiver *dest, QueryCompletion *qc, List *type_name);
 static void set_current_query_is_create_tbl_check_constraint(Node *expr);
 
+extern bool  pltsql_ansi_defaults;
+extern bool  pltsql_quoted_identifier;
+extern bool  pltsql_concat_null_yields_null;
+extern bool  pltsql_ansi_nulls;
+extern bool  pltsql_ansi_null_dflt_on;
+extern bool  pltsql_ansi_padding;
+extern bool  pltsql_ansi_warnings;
+extern bool  pltsql_arithabort;
+extern int   pltsql_datefirst;
+extern char* pltsql_language;
+extern int pltsql_lock_timeout;
+
 PG_FUNCTION_INFO_V1(pltsql_inline_handler);
 
 static Oid lang_handler_oid = InvalidOid;     /* Oid of language handler function */
@@ -3565,6 +3577,19 @@ _PG_init(void)
 		(*pltsql_protocol_plugin_ptr)->tsql_char_input = &tsql_bpchar_input;
 		(*pltsql_protocol_plugin_ptr)->get_cur_db_name = &get_cur_db_name;
 		(*pltsql_protocol_plugin_ptr)->get_physical_schema_name = &get_physical_schema_name;
+
+		(*pltsql_protocol_plugin_ptr)->quoted_identifier = pltsql_quoted_identifier;
+		(*pltsql_protocol_plugin_ptr)->arithabort = pltsql_arithabort;
+		(*pltsql_protocol_plugin_ptr)->ansi_null_dflt_on = pltsql_ansi_null_dflt_on;
+		(*pltsql_protocol_plugin_ptr)->ansi_defaults = pltsql_ansi_defaults;
+		(*pltsql_protocol_plugin_ptr)->ansi_warnings = pltsql_ansi_warnings;
+		(*pltsql_protocol_plugin_ptr)->ansi_padding = pltsql_ansi_padding;
+		(*pltsql_protocol_plugin_ptr)->ansi_nulls = pltsql_ansi_nulls;
+		(*pltsql_protocol_plugin_ptr)->concat_null_yields_null = pltsql_concat_null_yields_null;
+		(*pltsql_protocol_plugin_ptr)->textsize = text_size;
+		(*pltsql_protocol_plugin_ptr)->datefirst = pltsql_datefirst;
+		(*pltsql_protocol_plugin_ptr)->lock_timeout = pltsql_lock_timeout;
+		(*pltsql_protocol_plugin_ptr)->language = pltsql_language;
 	}
 
 	get_language_procs("pltsql", &lang_handler_oid, &lang_validator_oid);

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1644,6 +1644,20 @@ typedef struct PLtsql_protocol_plugin
 	char* (*get_cur_db_name) ();
 
 	char* (*get_physical_schema_name) (char *db_name, const char *schema_name);
+
+	/* Session level GUCs */
+	bool		quoted_identifier;
+	bool		arithabort;
+	bool		ansi_null_dflt_on;
+	bool		ansi_defaults;
+	bool		ansi_warnings;
+	bool		ansi_padding;
+	bool		ansi_nulls;
+	bool		concat_null_yields_null;
+	int		textsize;
+	int		datefirst;
+	int		lock_timeout;
+	const char*	language;
 	
 } PLtsql_protocol_plugin;
 


### PR DESCRIPTION
### Description

In this commit we add NULL checks for various GUCs that are relevant for the TDS statistics collector. Before comparing the GUC values, we first check whether they are NULL or not. If GUC value is NULL, we set its respective entry equal to the boot value explicitly.

Task: BABEL-3357
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###

Currently the only way this crash can be reproduced is if the babelfishpg_tsql extension compilation is successful but the extension creation fails. This fix has been manually tested since such a case cannot be automated in our actions.

* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).