### PR TITLE
Improve performance for prepared query execution

### DIFF
--- a/contrib/babelfishpg_tsql/src/plan_inval.c
+++ b/contrib/babelfishpg_tsql/src/plan_inval.c
@@ -63,11 +63,11 @@ pltsql_check_guc_plan(CachedPlanSource *plansource)
 	if (sql_dialect != SQL_DIALECT_TSQL || !valid)
 		return valid;
 
-	/* Identify each GUC by name and revalidate accordingly */
+	/* Identify each GUC by plan_info_enum_list and revalidate accordingly */
 	foreach (lc, plansource->pltsql_plan_info)
 	{
 		List *info_sublist = (List *) lfirst(lc);
-		plan_info_enum_list enum_list = (plan_info_enum_list) lthird(info_sublist);
+		plan_info_enum_list enum_list = (plan_info_enum_list) linitial(info_sublist);
 
 		/* Execute revalidate function only if it is an insert query. */
 		if (plansource->commandTag == CMDTAG_INSERT){
@@ -91,12 +91,8 @@ pltsql_initialize_identity_insert_plan(CachedPlanSource *plansource)
 {
 	List *id_insert_info_sublist = NIL;
 	plan_info_enum_list* id_insert_enum;
-	char *id_insert_name;
 
 	tsql_identity_insert_fields *id_insert_state;
-
-	/* Initialize name */
-	id_insert_name = pstrdup(pltsql_identity_insert_name);
 	
 	/* Initialize enum */
 	id_insert_enum = IDENTITY_INSERT;
@@ -109,9 +105,8 @@ pltsql_initialize_identity_insert_plan(CachedPlanSource *plansource)
 	id_insert_state->schema_oid = tsql_identity_insert.schema_oid;
 
 	/* Create info sublist */
-	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_name);
-	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_state);
 	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_enum);
+	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_state);
 
 	/* Append to plan info list */
 	plansource->pltsql_plan_info = lappend(plansource->pltsql_plan_info,

--- a/contrib/babelfishpg_tsql/src/plan_inval.c
+++ b/contrib/babelfishpg_tsql/src/plan_inval.c
@@ -17,6 +17,13 @@
 
 const char *pltsql_identity_insert_name = "tsql_identity_insert";
 
+/*
+ * Defining enum to avoid string comparision in pltsql_check_guc_plan.
+ */
+typedef enum {
+IDENTITY_INSERT
+} plan_info_enum_list;
+
 void pltsql_add_guc_plan(CachedPlanSource *plansource);
 bool pltsql_check_guc_plan(CachedPlanSource *plansource);
 
@@ -60,10 +67,13 @@ pltsql_check_guc_plan(CachedPlanSource *plansource)
 	foreach (lc, plansource->pltsql_plan_info)
 	{
 		List *info_sublist = (List *) lfirst(lc);
-		char *name = (char *) linitial(info_sublist);
+		plan_info_enum_list enum_list = (plan_info_enum_list) lthird(info_sublist);
 
-		if (valid && strcmp(name, pltsql_identity_insert_name) == 0)
-			valid = pltsql_revalidate_identity_insert_plan(plansource, info_sublist);
+		/* Execute revalidate function only if it is an insert query. */
+		if (plansource->commandTag == CMDTAG_INSERT){
+			if (valid && enum_list == IDENTITY_INSERT)
+				valid = pltsql_revalidate_identity_insert_plan(plansource, info_sublist);
+		}
 
 		/* Return if invalidated */
 		if (!valid)
@@ -80,12 +90,17 @@ static void
 pltsql_initialize_identity_insert_plan(CachedPlanSource *plansource)
 {
 	List *id_insert_info_sublist = NIL;
+	plan_info_enum_list* id_insert_enum;
 	char *id_insert_name;
+
 	tsql_identity_insert_fields *id_insert_state;
 
 	/* Initialize name */
 	id_insert_name = pstrdup(pltsql_identity_insert_name);
-
+	
+	/* Initialize enum */
+	id_insert_enum = IDENTITY_INSERT;
+	
 	/* Copy state */
 	id_insert_state = (tsql_identity_insert_fields *)
 												palloc(sizeof *id_insert_state);
@@ -96,6 +111,7 @@ pltsql_initialize_identity_insert_plan(CachedPlanSource *plansource)
 	/* Create info sublist */
 	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_name);
 	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_state);
+	id_insert_info_sublist = lappend(id_insert_info_sublist, id_insert_enum);
 
 	/* Append to plan info list */
 	plansource->pltsql_plan_info = lappend(plansource->pltsql_plan_info,


### PR DESCRIPTION
### Description
- added condition to execute pltsql_revalidate_identity_insert_plan function only if they query is an insert operation
- defined an enum to be used for instead of the string comparison of pltsql_identity_insert GUC to remove avoid the string comparison overhead
- the string comparison to check pltsql_identity_insert GUC value was identified as a performance overhead, the changes mentioned above are optimisations to address this issue. 

### Issues Resolved
BABEL-3788

Signed-off-by: Aditya Verma <adiityav@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** N/A since the change does not alter any existing functionality


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** 
JDBC, ODBC, .NET, Python drivers

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).