### PR TITLE
Add Tiberius tests to GitHub actions

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -35,7 +35,7 @@ runs:
 
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
         cd postgresql_modified_for_babelfish
-        ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+        ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --with-openssl
         make -j 4 2>error.txt
         make install
         make check

--- a/.github/composite-actions/enable-ssl/action.yml
+++ b/.github/composite-actions/enable-ssl/action.yml
@@ -1,0 +1,18 @@
+name: 'Enable SSL'
+
+inputs:
+  install_dir:
+    description: 'Engine install directory'
+    required: no
+    default: postgres
+
+runs:
+  using: "composite"
+  steps:
+    - name: Enable SSL
+      run: |
+        cd ~/${{inputs.install_dir}}/data
+        openssl req -new -x509 -days 3650 -nodes -text -out server.crt -keyout server.key -subj "/CN=localhost"
+        sudo sed -i "s/#ssl = off/ssl = on /g" postgresql.conf
+        ~/${{inputs.install_dir}}/bin/pg_ctl -D ~/${{inputs.install_dir}}/data/ -l logfile restart
+      shell: bash

--- a/.github/workflows/tiberius-tests.yml
+++ b/.github/workflows/tiberius-tests.yml
@@ -1,0 +1,101 @@
+name: Tiberius Tests
+on: [push, pull_request]
+
+jobs:
+  run-babelfish-tiberius-tests:
+    runs-on: ubuntu-20.04
+
+    env:
+      TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=jdbc_user;password=12345678;TrustServerCertificate=true"
+
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        uses: ./.github/composite-actions/install-dependencies
+
+      - name: Build Modified Postgres
+        id: build-modified-postgres
+        if: always() && steps.install-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+      
+      - name: Compile ANTLR
+        id: compile-antlr
+        if: always() && steps.build-modified-postgres.outcome == 'success'
+        uses: ./.github/composite-actions/compile-antlr
+      
+      - name: Build Extensions
+        id: build-extensions
+        if: always() && steps.compile-antlr.outcome == 'success'
+        uses: ./.github/composite-actions/build-extensions
+      
+      - name: Install Extensions
+        id: install-extensions
+        if: always() && steps.build-extensions.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
+
+      - name: Enable SSL
+        id: enable-ssl
+        if: always() && steps.install-extensions.outcome == 'success'
+        uses: ./.github/composite-actions/enable-ssl
+
+      - name: Run Tiberius Tests
+        id: tiberius
+        if: always() && steps.enable-ssl.outcome == 'success'
+        timeout-minutes: 60
+        run: |
+          git clone --depth 1 --branch v0.11.3 https://github.com/prisma/tiberius.git
+          cd tiberius
+          export RUST_BACKTRACE=1
+          export RUSTFLAGS=-Awarnings
+          export TIBTEST="cargo test --features chrono,time,rust_decimal,bigdecimal --test query"
+          export TIBLOG=~/tiberius.log
+          $TIBTEST connect >> $TIBLOG 2>&1
+          $TIBTEST transactions >> $TIBLOG 2>&1
+          $TIBTEST correct_row_handling_when_not_enough_data >> $TIBLOG 2>&1
+          $TIBTEST multiple_stored_procedure_functions >> $TIBLOG 2>&1
+          $TIBTEST multiple_queries >> $TIBLOG 2>&1
+          $TIBTEST i16_token >> $TIBLOG 2>&1
+          $TIBTEST i32_token >> $TIBLOG 2>&1
+          $TIBTEST i64_token >> $TIBLOG 2>&1
+          $TIBTEST f32_token >> $TIBLOG 2>&1
+          $TIBTEST f64_token >> $TIBLOG 2>&1
+          $TIBTEST short_strings >> $TIBLOG 2>&1
+          $TIBTEST long_strings >> $TIBLOG 2>&1
+          $TIBTEST drop_stream_before_handling_all_results_should_not_cause_weird_things >> $TIBLOG 2>&1
+          $TIBTEST nbc_rows_tokio -- --exact >> $TIBLOG 2>&1
+          $TIBTEST nbc_rows_async_std -- --exact >> $TIBLOG 2>&1
+          $TIBTEST guid_type >> $TIBLOG 2>&1
+          $TIBTEST numeric_type_u128 >> $TIBLOG 2>&1
+          $TIBTEST rust_decimal:: >> $TIBLOG 2>&1
+          $TIBTEST bigdecimal::bigdecimal_type_ >> $TIBLOG 2>&1
+          $TIBTEST with_time_crate >> $TIBLOG 2>&1
+          $TIBTEST xml_read_ >> $TIBLOG 2>&1
+          $TIBTEST mars_sp_routines_must_fetch_all_results >> $TIBLOG 2>&1
+          $TIBTEST warnings_should_not_affect_column_fetch >> $TIBLOG 2>&1
+          $TIBTEST columns_fetch_should_work >> $TIBLOG 2>&1
+          $TIBTEST into_row_stream_should_work >> $TIBLOG 2>&1
+          cat $TIBLOG
+
+      - name: Cleanup babelfish database
+        id: cleanup
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          sudo ~/postgres/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+
+      - name: Upload Log
+        if: always() && steps.tiberius.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: postgres-log
+          path: ~/postgres/data/logfile
+
+      - name: Upload Tiberius Log
+        if: always() && steps.tiberius.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: tiberius-log
+          path: ~/tiberius.log


### PR DESCRIPTION
Signed-off-by: Alex Kasko <alex@staticlibs.net>

### Description

[Tiberius](https://github.com/prisma/tiberius) is a standalone TDS client library. My employer plans to run an existing application on Babelfish on Amazon Aurora. Minor part of this app uses Tiberius to connect to DB. We didn't have any problem with Tiberius+Babelfish so far (our Tiberius usage is only a couple of simple queries). Still it may be a good idea to add Tiberius test suite to the Babelfish GitHub Actions runs.

The majority of the [Tiberius tests](https://github.com/prisma/tiberius/tree/v0.11.3/tests) relies on global temporary tables ([example](https://github.com/prisma/tiberius/blob/v0.11.3/tests/query.rs#L283)) that are not supported in Babelfish. I've cherry-picked the set of tests that run fine on `2.x` and added them to a separate GitHub workflow `tiberius-tests`.

Tiberius uses SSL for almost all of the tests, to support this I've added `--with-openssl` flag to `build-modified-postgres` action and also added a separate `enable-ssl` action.

### Issues Resolved

N/A.

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).