### PR TITLE
Optimize LookupEncodingByLCID for Insert Bulk

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -274,6 +274,7 @@ GetBulkLoadRequest(StringInfo message)
 				memcpy(&colmetadata[currentColumn].collation, &message->data[offset], sizeof(uint32_t));
 				offset += sizeof(uint32_t);
 				colmetadata[currentColumn].sortId = message->data[offset++];
+				colmetadata[currentColumn].encoding = TdsGetEncoding(colmetadata[currentColumn].collation);
 			}
 			break;
 			case TDS_TYPE_TEXT:
@@ -675,7 +676,7 @@ SetBulkLoadRowData(TDSRequestBulkLoad request, StringInfo message)
 					{
 						case TDS_TYPE_CHAR:
 						case TDS_TYPE_VARCHAR:
-							rowData->columnValues[i] = TdsTypeVarcharToDatum(temp, colmetadata[i].collation, colmetadata[i].columnTdsType);
+							rowData->columnValues[i] = TdsTypeVarcharToDatumCopy(temp, colmetadata[i].collation, colmetadata[i].columnTdsType, colmetadata[i].encoding);
 						break;
 						case TDS_TYPE_NCHAR:
 						case TDS_TYPE_NVARCHAR:
@@ -742,7 +743,7 @@ SetBulkLoadRowData(TDSRequestBulkLoad request, StringInfo message)
 					switch(colmetadata[i].columnTdsType)
 					{
 						case TDS_TYPE_TEXT:
-							rowData->columnValues[i] = TdsTypeVarcharToDatum(temp, colmetadata[i].collation, colmetadata[i].columnTdsType);
+							rowData->columnValues[i] = TdsTypeVarcharToDatumCopy(temp, colmetadata[i].collation, colmetadata[i].columnTdsType, colmetadata[i].encoding);
 						break;
 						case TDS_TYPE_NTEXT:
 							rowData->columnValues[i] = TdsTypeNCharToDatum(temp);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -676,7 +676,7 @@ SetBulkLoadRowData(TDSRequestBulkLoad request, StringInfo message)
 					{
 						case TDS_TYPE_CHAR:
 						case TDS_TYPE_VARCHAR:
-							rowData->columnValues[i] = TdsTypeVarcharToDatumCopy(temp, colmetadata[i].collation, colmetadata[i].columnTdsType, colmetadata[i].encoding);
+							rowData->columnValues[i] = TdsTypeVarcharToDatum(temp, colmetadata[i].encoding, colmetadata[i].columnTdsType);
 						break;
 						case TDS_TYPE_NCHAR:
 						case TDS_TYPE_NVARCHAR:
@@ -743,7 +743,7 @@ SetBulkLoadRowData(TDSRequestBulkLoad request, StringInfo message)
 					switch(colmetadata[i].columnTdsType)
 					{
 						case TDS_TYPE_TEXT:
-							rowData->columnValues[i] = TdsTypeVarcharToDatumCopy(temp, colmetadata[i].collation, colmetadata[i].columnTdsType, colmetadata[i].encoding);
+							rowData->columnValues[i] = TdsTypeVarcharToDatum(temp, colmetadata[i].encoding, colmetadata[i].columnTdsType);
 						break;
 						case TDS_TYPE_NTEXT:
 							rowData->columnValues[i] = TdsTypeNCharToDatum(temp);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -205,7 +205,8 @@ GetBulkLoadRequest(StringInfo message)
 {
 	TDSRequestBulkLoad		request;
 	uint16_t 				colCount;
-	BulkLoadColMetaData 			*colmetadata;
+	BulkLoadColMetaData		*colmetadata;
+	uint32_t				collation;
 
 	TdsErrorContext->err_text = "Fetching Bulk Load Request";
 
@@ -271,10 +272,10 @@ GetBulkLoadRequest(StringInfo message)
 				memcpy(&colmetadata[currentColumn].maxLen, &message->data[offset], sizeof(uint16));
 				offset += sizeof(uint16);
 
-				memcpy(&colmetadata[currentColumn].collation, &message->data[offset], sizeof(uint32_t));
+				memcpy(&collation, &message->data[offset], sizeof(uint32_t));
 				offset += sizeof(uint32_t);
 				colmetadata[currentColumn].sortId = message->data[offset++];
-				colmetadata[currentColumn].encoding = TdsGetEncoding(colmetadata[currentColumn].collation);
+				colmetadata[currentColumn].encoding = TdsGetEncoding(collation);
 			}
 			break;
 			case TDS_TYPE_TEXT:
@@ -291,9 +292,10 @@ GetBulkLoadRequest(StringInfo message)
 					colmetadata[currentColumn].columnTdsType == TDS_TYPE_NTEXT)
 				{
 					CheckMessageHasEnoughBytesToRead(&message, sizeof(uint32_t) + 1);
-					memcpy(&colmetadata[currentColumn].collation, &message->data[offset], sizeof(uint32_t));
+					memcpy(&collation, &message->data[offset], sizeof(uint32_t));
 					offset += sizeof(uint32_t);
 					colmetadata[currentColumn].sortId = message->data[offset++];
+					colmetadata[currentColumn].encoding = TdsGetEncoding(collation);
 				}
 
 				CheckMessageHasEnoughBytesToRead(&message, sizeof(uint16_t));

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -104,8 +104,7 @@ int TdsUTF16toUTF8XmlResult(StringInfo buf, void **resultPtr);
 Datum TdsTypeBitToDatum(StringInfo buf);
 Datum TdsTypeIntegerToDatum(StringInfo buf, int maxLen);
 Datum TdsTypeFloatToDatum(StringInfo buf, int maxLen);
-Datum TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType);
-Datum TdsTypeVarcharToDatumCopy(StringInfo buf, uint32_t collation, uint8_t tdsColDataType, pg_enc encoding);
+Datum TdsTypeVarcharToDatum(StringInfo buf, pg_enc encoding, uint8_t tdsColDataType);
 Datum TdsTypeNCharToDatum(StringInfo buf);
 Datum TdsTypeNumericToDatum(StringInfo buf, int scale);
 Datum TdsTypeVarbinaryToDatum(StringInfo buf);
@@ -901,27 +900,7 @@ TdsTypeFloatToDatum(StringInfo buf, int maxLen)
 
 /* Helper Function to convert Varchar,Char and Text values into Datum. */
 Datum
-TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType)
-{
-	char 		csave;
-	Datum 		pval;
-	pg_enc 		encoding;
-
-	csave = buf->data[buf->len];
-	buf->data[buf->len] = '\0';
-
-	/* If we recieve 0 value for LCID then we should treat it as a default LCID.*/
-	encoding = TdsGetEncoding(collation);
-
-	pval = TdsAnyToServerEncodingConversion(encoding,
-									buf->data, buf->len,
-									tdsColDataType);
-	buf->data[buf->len] = csave;
-	return pval;
-}
-
-Datum
-TdsTypeVarcharToDatumCopy(StringInfo buf, uint32_t collation, uint8_t tdsColDataType, pg_enc encoding)
+TdsTypeVarcharToDatum(StringInfo buf, pg_enc encoding, uint8_t tdsColDataType)
 {
 	char 		csave;
 	Datum 		pval;
@@ -2097,7 +2076,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 					{
 						case TDS_TYPE_CHAR:
 						case TDS_TYPE_VARCHAR:
-							values[i] = TdsTypeVarcharToDatumCopy(temp, colMetaData[currentColumn].collation, colMetaData[currentColumn].columnTdsType, colMetaData[currentColumn].encoding);
+							values[i] = TdsTypeVarcharToDatum(temp, colMetaData[currentColumn].encoding, colMetaData[currentColumn].columnTdsType);
 						break;
 						case TDS_TYPE_NCHAR:
 							values[i] = TdsTypeNCharToDatum(temp);

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -480,6 +480,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
 	char *physical_schema = NULL;
 	StringInfo tempStringInfo = palloc( sizeof(StringInfoData));
+	uint32_t collation;
 
 	/* Database-Name.Schema-Name.TableType-Name */
 	for(; i < 3; i++)
@@ -589,19 +590,11 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 				{
 					memcpy(&colmetadata[i].maxLen, &messageData[*offset], sizeof(uint16));
 					*offset += sizeof(uint16);
-					if (colmetadata[i].maxLen == 0xffff)
-					{
-						memcpy(&colmetadata[i].collation, &messageData[*offset], sizeof(uint32_t));
-						*offset += sizeof(uint32_t);
-						colmetadata[i].sortId = messageData[(*offset)++];
-					}
-					else
-					{
-						memcpy(&colmetadata[i].collation, &messageData[*offset], sizeof(uint32_t));
-						*offset += sizeof(uint32_t);
-						colmetadata[i].sortId = messageData[(*offset)++];
-						colmetadata[i].encoding = TdsGetEncoding(colmetadata[i].collation);
-					}
+
+					memcpy(&collation, &messageData[*offset], sizeof(uint32_t));
+					*offset += sizeof(uint32_t);
+					colmetadata[i].sortId = messageData[(*offset)++];
+					colmetadata[i].encoding = TdsGetEncoding(collation);
 				}
 				break;
 				case TDS_TYPE_XML:

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -600,6 +600,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 						memcpy(&colmetadata[i].collation, &messageData[*offset], sizeof(uint32_t));
 						*offset += sizeof(uint32_t);
 						colmetadata[i].sortId = messageData[(*offset)++];
+						colmetadata[i].encoding = TdsGetEncoding(colmetadata[i].collation);
 					}
 				}
 				break;

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -459,8 +459,7 @@ extern Datum TdsRecvTypeDatetimeoffset(const char *message, const ParameterToken
 extern Datum TdsTypeBitToDatum(StringInfo buf);
 extern Datum TdsTypeIntegerToDatum(StringInfo buf, int maxLen);
 extern Datum TdsTypeFloatToDatum(StringInfo buf, int maxLen);
-extern Datum TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType);
-extern Datum TdsTypeVarcharToDatumCopy(StringInfo buf, uint32_t collation, uint8_t tdsColDataType, pg_enc encoding);
+extern Datum TdsTypeVarcharToDatum(StringInfo buf, pg_enc encoding, uint8_t tdsColDataType);
 extern Datum TdsTypeNCharToDatum(StringInfo buf);
 extern Datum TdsTypeNumericToDatum(StringInfo buf, int scale);
 extern Datum TdsTypeVarbinaryToDatum(StringInfo buf);

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -206,6 +206,7 @@ typedef struct TvpColMetaData
 
 	uint32_t collation;
 	uint8_t sortId;
+	pg_enc	encoding;
 
 	uint32_t maxLen;
 } TvpColMetaData;
@@ -243,6 +244,7 @@ typedef struct BulkLoadColMetaData
 	/* For String Datatpes. */
 	uint32_t 	collation;
 	uint8_t 	sortId;
+	pg_enc		encoding;
 
 	uint32_t 	maxLen;
 
@@ -458,6 +460,7 @@ extern Datum TdsTypeBitToDatum(StringInfo buf);
 extern Datum TdsTypeIntegerToDatum(StringInfo buf, int maxLen);
 extern Datum TdsTypeFloatToDatum(StringInfo buf, int maxLen);
 extern Datum TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType);
+extern Datum TdsTypeVarcharToDatumCopy(StringInfo buf, uint32_t collation, uint8_t tdsColDataType, pg_enc encoding);
 extern Datum TdsTypeNCharToDatum(StringInfo buf);
 extern Datum TdsTypeNumericToDatum(StringInfo buf, int scale);
 extern Datum TdsTypeVarbinaryToDatum(StringInfo buf);

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -204,7 +204,6 @@ typedef struct TvpColMetaData
 	uint8_t scale;
 	uint8_t precision;
 
-	uint32_t collation;
 	uint8_t sortId;
 	pg_enc	encoding;
 
@@ -242,7 +241,6 @@ typedef struct BulkLoadColMetaData
 	uint8_t 	precision;
 
 	/* For String Datatpes. */
-	uint32_t 	collation;
 	uint8_t 	sortId;
 	pg_enc		encoding;
 


### PR DESCRIPTION
### Description
Previously every call to the function VarCharToDatum() previously used TDSGetEncoding() function which internally called  LookupEncodingByLCID().For bulk insert scenario for every row in a table for a varchar,char,text column we called VarCharToDatum function which lead to extra calls to LookupEncodingByLCID function causing an overhead .

The current solution implemented is to at the start of request set the encoding of the column as a part of  columnMetadata for both bulk insert as well as Tvp(Table valued Parameters). This would remove the redundant calls to LookupEncodingByLCID.




### Issues Resolved
BABEL-3623
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>
[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
Already existing tests are sufficient

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).