### PR TITLE
Adding support to close existing connection for .mix test file execution inside JDBC test framework

### DIFF
--- a/test/JDBC/expected/test_conn_terminate.out
+++ b/test/JDBC/expected/test_conn_terminate.out
@@ -1,0 +1,27 @@
+-- tsql
+create login [test_conn] with password = '12345678';
+GO
+
+-- tsql user=test_conn password=12345678
+select 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- terminate-tsql-conn user=test_conn password=12345678
+
+-- tsql
+DROP LOGIN [test_conn];
+GO

--- a/test/JDBC/input/test_conn_terminate.mix
+++ b/test/JDBC/input/test_conn_terminate.mix
@@ -1,0 +1,17 @@
+-- tsql
+create login [test_conn] with password = '12345678';
+GO
+
+-- tsql user=test_conn password=12345678
+select 1
+GO
+
+-- tsql
+select 1;
+GO
+
+-- terminate-tsql-conn user=test_conn password=12345678
+
+-- tsql
+DROP LOGIN [test_conn];
+GO

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCCrossDialect.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCCrossDialect.java
@@ -168,4 +168,41 @@ public class JDBCCrossDialect {
         closeConnectionsUtil(tsqlConnectionMap, bw, logger);
         closeConnectionsUtil(psqlConnectionMap, bw, logger);
     }
+
+    void terminateTsqlConnection (String strLine, BufferedWriter bw, Logger logger) {
+        getConnectionAttributes(strLine);
+
+        if (tsqlConnectionMap.containsKey(newUser + newPassword + newDatabase)) {
+            Connection connection = tsqlConnectionMap.get(newUser + newPassword + newDatabase);
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                    handleSQLExceptionWithFile(e, bw, logger);
+                }
+            }
+
+            tsqlConnectionMap.remove(newUser + newPassword + newDatabase);
+            resetConnectionAttributes();
+        }
+    }
+
+
+    void terminatePsqlConnection (String strLine, BufferedWriter bw, Logger logger) {
+        getConnectionAttributes(strLine);
+
+        if (psqlConnectionMap.containsKey(newUser + newPassword + newPhysicalDatabase + searchPath)) {
+            Connection connection = psqlConnectionMap.get(newUser + newPassword + newPhysicalDatabase + searchPath);
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                    handleSQLExceptionWithFile(e, bw, logger);
+                }
+            }
+
+            psqlConnectionMap.remove(newUser + newPassword + newDatabase);
+            resetConnectionAttributes();
+        }
+    }
 }

--- a/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
@@ -251,6 +251,17 @@ public class batch_run {
                     // Ensure con_bbl is never null
                     if (connection != null) con_bbl = connection;
 
+                } else if (isCrossDialectFile && ( (tsqlDialect = strLine.toLowerCase().startsWith("-- terminate-tsql-conn")) ||
+                                                    (psqlDialect = strLine.toLowerCase().startsWith("-- terminate-psql-conn")))) {
+
+                    bw.write(strLine);
+                    bw.newLine();
+
+                    if (tsqlDialect) {
+                        jdbcCrossDialect.terminateTsqlConnection(strLine, bw, logger);
+                    } else if (psqlDialect) {
+                        jdbcCrossDialect.terminatePsqlConnection(strLine, bw, logger);
+                    }
                 } else {
                     // execute statement as a normal SQL statement
                     if (isSQLFile) {


### PR DESCRIPTION
### Description

Previously, All the newly opened connections were being persisted throughout the execution of .mix test file execution inside JDBC test framework. Which might not be expected in some cases of cleanup, for example, we can not cleanup newly created login if any open connection is holding that username. So, this commit adds support to terminate any existing connection based on connection attributes. 

Example usage: we can terminate tsql connection opened by supplied user and password.  
-- terminate-tsql-conn user=<login> password=<password> 

Similarly, -- terminate-psql-conn user=<login> password=<password> can be used. 

### Issues Resolved

No-jira

Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** 
Added new test file

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).