### PR TITLE
Update identity_insert tests check for valid range

### DIFF
--- a/test/JDBC/input/BABEL-IDENTITY.sql
+++ b/test/JDBC/input/BABEL-IDENTITY.sql
@@ -362,5 +362,6 @@ dbo.test_table3,
 dbo.employees,
 dbo.t_neg_inc_1,
 dbo.t1_identity_1,
-dbo.t1_identity_2
+dbo.t1_identity_2,
+dbo.test_identity_range
 go

--- a/test/JDBC/input/BABEL-IDENTITY.sql
+++ b/test/JDBC/input/BABEL-IDENTITY.sql
@@ -317,6 +317,37 @@ go
 SET IDENTITY_INSERT dbo.t1_identity_2 OFF;
 go
 
+-- Test that the correct range of values can be inserted into an identity column
+CREATE TABLE dbo.test_identity_range (a INT IDENTITY, b INT);
+go
+
+SET IDENTITY_INSERT dbo.test_identity_range ON;
+go
+
+-- Check nonpositive values
+INSERT INTO dbo.test_identity_range (a, b) VALUES (0, 10);
+go
+
+INSERT INTO dbo.test_identity_range (a, b) VALUES (-5, 10);
+go
+
+-- Check max / min
+INSERT INTO dbo.test_identity_range (a, b) VALUES (-2147483648, 10);
+go
+
+INSERT INTO dbo.test_identity_range (a, b) VALUES (2147483647, 10);
+go
+
+-- Expect overflow
+INSERT INTO dbo.test_identity_range (a, b) VALUES (-2147483649, 10);
+go
+
+INSERT INTO dbo.test_identity_range (a, b) VALUES (2147483648, 10);
+go
+
+SELECT * from dbo.test_identity_range;
+go
+
 -- Clean up
 DROP PROCEDURE insert_test_table1,
 insert_employees,

--- a/test/JDBC/sql_expected/BABEL-IDENTITY.out
+++ b/test/JDBC/sql_expected/BABEL-IDENTITY.out
@@ -654,6 +654,61 @@ numeric
 SET IDENTITY_INSERT dbo.t1_identity_2 OFF;
 go
 
+-- Test that the correct range of values can be inserted into an identity column
+CREATE TABLE dbo.test_identity_range (a INT IDENTITY, b INT);
+go
+
+SET IDENTITY_INSERT dbo.test_identity_range ON;
+go
+
+-- Check nonpositive values
+INSERT INTO dbo.test_identity_range (a, b) VALUES (0, 10);
+go
+~~ROW COUNT: 1~~
+
+
+INSERT INTO dbo.test_identity_range (a, b) VALUES (-5, 10);
+go
+~~ROW COUNT: 1~~
+
+
+-- Check max / min
+INSERT INTO dbo.test_identity_range (a, b) VALUES (-2147483648, 10);
+go
+~~ROW COUNT: 1~~
+
+
+INSERT INTO dbo.test_identity_range (a, b) VALUES (2147483647, 10);
+go
+~~ROW COUNT: 1~~
+
+
+-- Expect overflow
+INSERT INTO dbo.test_identity_range (a, b) VALUES (-2147483649, 10);
+go
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+INSERT INTO dbo.test_identity_range (a, b) VALUES (2147483648, 10);
+go
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+SELECT * from dbo.test_identity_range;
+go
+~~START~~
+int#!#int
+0#!#10
+-5#!#10
+-2147483648#!#10
+2147483647#!#10
+~~END~~
+
+
 -- Clean up
 DROP PROCEDURE insert_test_table1,
 insert_employees,

--- a/test/JDBC/sql_expected/BABEL-IDENTITY.out
+++ b/test/JDBC/sql_expected/BABEL-IDENTITY.out
@@ -723,5 +723,6 @@ dbo.test_table3,
 dbo.employees,
 dbo.t_neg_inc_1,
 dbo.t1_identity_1,
-dbo.t1_identity_2
+dbo.t1_identity_2,
+dbo.test_identity_range
 go


### PR DESCRIPTION
A previous issue where nonpositive identity values could not be inserted has since been fixed by BABEL-3506. This commit adds regression tests that check for this issue, ensuring nonpositive and min/max int values can be added to identity columns.

Task: BABEL-3536, BABEL-3093

Signed-off-by: Walt Boettge <wboettge@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).