### PR TITLE
Fix: Additional check if login is a DB user when adding member to sysadmin

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1394,12 +1394,18 @@ check_alter_server_stmt(GrantRoleStmt *stmt)
 {
 	Oid grantee;
 	const char 	*grantee_name;
+	const char 	*granted_name;
 	RoleSpec 	*spec;
+	AccessPriv 	*granted;
 	CatCList   	*memlist;
 	Oid         sysadmin;
+	char		*db_name;
 
 	spec = (RoleSpec *) linitial(stmt->grantee_roles);		
 	sysadmin = get_role_oid("sysadmin", false);
+
+	granted = (AccessPriv *) linitial(stmt->granted_roles);
+	granted_name = granted->priv_name;
 
 	/* grantee MUST be a login */
 	grantee_name = spec->rolename;
@@ -1416,6 +1422,12 @@ check_alter_server_stmt(GrantRoleStmt *stmt)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("Current login %s does not have permission to alter server role",
 					 GetUserNameFromId(GetSessionUserId(), true))));
+
+	/* sysadmin role is not granted if grantee login has a user in one of the databases, as Babelfish only supports one dbo currently*/
+	if (stmt->is_grant && (strcmp(granted_name, "sysadmin") == 0) && has_user_in_db(grantee_name, &db_name))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("'sysadmin' role cannot be granted to login: a user is already created in database '%s'", db_name)));
 
 	/* could not drop the last member of sysadmin */
 	memlist = SearchSysCacheList1(AUTHMEMROLEMEM,
@@ -1665,3 +1677,48 @@ is_active_login(Oid role_oid)
 	return true;
 }
 
+/*
+ * To check if given login is already a user in one of the databases
+ */
+bool
+has_user_in_db(const char *login, char **db_name)
+{
+	Relation		bbf_authid_user_ext_rel;
+	HeapTuple		tuple_user_ext;
+	ScanKeyData		key[3];
+	TableScanDesc	scan;
+	NameData		*login_name;
+	bool			is_null;
+
+	// open the table to scane
+	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
+										 RowExclusiveLock);
+
+	// change the target name to NameData for search
+	login_name = (NameData *) palloc0(NAMEDATALEN);
+	snprintf(login_name->data, NAMEDATALEN, "%s", login);
+
+	// operate scanning
+	ScanKeyInit(&key[0],
+				Anum_bbf_authid_user_ext_login_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				NameGetDatum(login_name));
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 1, key);
+
+	// match stored, if there is a match
+	tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
+	if (HeapTupleIsValid(tuple_user_ext))
+	{
+
+		Datum name = heap_getattr(tuple_user_ext, Anum_bbf_authid_user_ext_database_name,
+								  bbf_authid_user_ext_rel->rd_att, &is_null);
+
+		*db_name = pstrdup(TextDatumGetCString(name));
+
+		return true;
+	}
+	table_endscan(scan);
+	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+
+	return false;
+}

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -60,5 +60,6 @@ extern void add_to_bbf_authid_user_ext(const char *user_name,
 extern void drop_related_bbf_users(List *db_users);
 extern void alter_bbf_authid_user_ext(AlterRoleStmt *stmt);
 extern bool is_active_login(Oid role_oid);
+extern bool has_user_in_db(const char *login, char **db_name);
 
 #endif

--- a/test/JDBC/expected/BABEL-3637.out
+++ b/test/JDBC/expected/BABEL-3637.out
@@ -1,0 +1,322 @@
+-- tsql
+USE master
+GO
+
+CREATE PROC test_babel_3637_proc1 @rolename AS sys.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(ServerRole sys.SYSNAME,
+									MemberName sys.SYSNAME,
+									MemberSID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637 (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember @rolename;
+	SELECT ServerRole, MemberName FROM @tmp_babel_3637;
+END
+GO
+
+CREATE PROC test_babel_3637_proc2 @rolename AS SYS.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(UserName sys.SYSNAME, RoleName sys.SYSNAME, LoginName sys.SYSNAME NULL, DefDBName sys.SYSNAME NULL, DefSchemaName sys.SYSNAME, UserID INT, SID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637(UserName, RoleName, LoginName, DefDBName, DefSchemaName, UserID, SID) EXEC sp_helpuser @rolename;
+	SELECT UserName, RoleName, LoginName, DefDBName, DefSchemaName from @tmp_babel_3637;
+END
+GO
+
+CREATE LOGIN babel_3637_login1 WITH PASSWORD='12345678';
+GO
+CREATE LOGIN babel_3637_login2 WITH PASSWORD='12345678';
+GO
+
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+CREATE DATABASE babel_3637_db
+GO
+USE babel_3637_db
+GO
+
+CREATE PROC test_babel_3637_proc1 @rolename AS sys.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(ServerRole sys.SYSNAME,
+									MemberName sys.SYSNAME,
+									MemberSID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637 (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember @rolename;
+	SELECT ServerRole, MemberName FROM @tmp_babel_3637;
+END
+GO
+
+CREATE PROC test_babel_3637_proc2 @rolename AS SYS.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(UserName sys.SYSNAME, RoleName sys.SYSNAME, LoginName sys.SYSNAME NULL, DefDBName sys.SYSNAME NULL, DefSchemaName sys.SYSNAME, UserID INT, SID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637(UserName, RoleName, LoginName, DefDBName, DefSchemaName, UserID, SID) EXEC sp_helpuser @rolename;
+	SELECT UserName, RoleName, LoginName, DefDBName, DefSchemaName from @tmp_babel_3637;
+END
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login1;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#babel_3637_login1
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login2;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#babel_3637_login1
+sysadmin#!#babel_3637_login2
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login2;
+GO
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#babel_3637_login1
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login1;
+GO
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+CREATE USER babel_3637_login2
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login1;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#babel_3637_login1
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'sysadmin' role cannot be granted to login: a user is already created in database 'babel_3637_db')~~
+
+
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#babel_3637_login1
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login2;
+GO
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#babel_3637_login1
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login1;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#varchar
+sysadmin#!#jdbc_user
+~~END~~
+
+EXEC test_babel_3637_proc2
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
+dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
+guest#!#public#!#<NULL>#!#<NULL>#!#
+~~END~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3637_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP LOGIN babel_3637_login1
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3637_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP LOGIN babel_3637_login2
+GO
+
+-- tsql
+USE master
+GO
+DROP DATABASE babel_3637_db;
+GO

--- a/test/JDBC/input/BABEL-3637.mix
+++ b/test/JDBC/input/BABEL-3637.mix
@@ -1,0 +1,154 @@
+-- tsql
+USE master
+GO
+
+CREATE PROC test_babel_3637_proc1 @rolename AS sys.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(ServerRole sys.SYSNAME,
+									MemberName sys.SYSNAME,
+									MemberSID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637 (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember @rolename;
+	SELECT ServerRole, MemberName FROM @tmp_babel_3637;
+END
+GO
+
+CREATE PROC test_babel_3637_proc2 @rolename AS SYS.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(UserName sys.SYSNAME, RoleName sys.SYSNAME, LoginName sys.SYSNAME NULL, DefDBName sys.SYSNAME NULL, DefSchemaName sys.SYSNAME, UserID INT, SID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637(UserName, RoleName, LoginName, DefDBName, DefSchemaName, UserID, SID) EXEC sp_helpuser @rolename;
+	SELECT UserName, RoleName, LoginName, DefDBName, DefSchemaName from @tmp_babel_3637;
+END
+GO
+
+CREATE LOGIN babel_3637_login1 WITH PASSWORD='12345678';
+GO
+CREATE LOGIN babel_3637_login2 WITH PASSWORD='12345678';
+GO
+
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+CREATE DATABASE babel_3637_db
+GO
+USE babel_3637_db
+GO
+
+CREATE PROC test_babel_3637_proc1 @rolename AS sys.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(ServerRole sys.SYSNAME,
+									MemberName sys.SYSNAME,
+									MemberSID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637 (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember @rolename;
+	SELECT ServerRole, MemberName FROM @tmp_babel_3637;
+END
+GO
+
+CREATE PROC test_babel_3637_proc2 @rolename AS SYS.SYSNAME = NULL
+AS
+BEGIN
+	DECLARE @tmp_babel_3637 TABLE(UserName sys.SYSNAME, RoleName sys.SYSNAME, LoginName sys.SYSNAME NULL, DefDBName sys.SYSNAME NULL, DefSchemaName sys.SYSNAME, UserID INT, SID sys.VARBINARY(85));
+	INSERT INTO @tmp_babel_3637(UserName, RoleName, LoginName, DefDBName, DefSchemaName, UserID, SID) EXEC sp_helpuser @rolename;
+	SELECT UserName, RoleName, LoginName, DefDBName, DefSchemaName from @tmp_babel_3637;
+END
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login1;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login2;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login2;
+GO
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login1;
+GO
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+CREATE USER babel_3637_login2
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login1;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_3637_login2;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login2;
+GO
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_3637_login1;
+GO
+
+EXEC test_babel_3637_proc1
+GO
+EXEC test_babel_3637_proc2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3637_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+DROP LOGIN babel_3637_login1
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_3637_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+DROP LOGIN babel_3637_login2
+GO
+
+-- tsql
+USE master
+GO
+DROP DATABASE babel_3637_db;
+GO


### PR DESCRIPTION
Previously, when adding a member to sysadmin role, there was no check on whether current login has DB user in one of the databases. As Babelfish does not support >1 dbo, every login has to be checked if it is a user already when being added to sysadmin. Now, logins that already have a user in one of the databases are blocked, when users try to add the login to sysadmin role.

Taask: BABEL-3637

Signed-off-by: Ray Kim <raydhkim@amazon.com>

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based - Added


* **Boundary conditions - N/A


* **Arbitrary inputs - N/A


* **Negative test cases - Added


* **Minor version upgrade tests - N/A


* **Major version upgrade tests - N/A


* **Performance tests - N/A


* **Tooling impact - N/A


* **Client tests - N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).