### PR TITLE
Avoid password check if sspi data is present in login request

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1767,10 +1767,10 @@ TdsClientAuthentication(Port *port)
 			}
 
 			/*
-			* If pg_hba.conf specifies that the entry should be authenticated using
-			* password and the request doesn't contain a password, we should
-			* throw an error.
-			*/
+			 * If pg_hba.conf specifies that the entry should be authenticated using
+			 * password and the request doesn't contain a password, we should
+			 * throw an error.
+			 */
 			if (!loginInfo->password)
 			{
 				char		hostinfo[NI_MAXHOST];

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1423,10 +1423,6 @@ CheckGSSAuth(Port *port)
 										  NULL,
 										  NULL);
 
-		/* gbuf no longer used */
-		pfree(request->sspi);
-		request->sspiLen = 0;
-
 		elog(DEBUG4, "gss_accept_sec_context major: %d, "
 			 "minor: %d, outlen: %u, outflags: %x",
 			 maj_stat, min_stat,
@@ -1759,29 +1755,39 @@ TdsClientAuthentication(Port *port)
 			break;
 		case uaMD5:
 		case uaPassword:
-			/*
-			 * If pg_hba.conf specifies that the entry should be authenticated using
-			 * password and the request doesn't contain a password, we should
-			 * throw an error.
-			 */
-			if (!loginInfo->password)
+			/* if sspiLen > 0 then GSS auth is already done at this point */
+			if (loginInfo->sspiLen == 0)
 			{
-				char		hostinfo[NI_MAXHOST];
+				/*
+				* If pg_hba.conf specifies that the entry should be authenticated using
+				* password and the request doesn't contain a password, we should
+				* throw an error.
+				*/
+				if (!loginInfo->password)
+				{
+					char		hostinfo[NI_MAXHOST];
 
-				pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
-								   hostinfo, sizeof(hostinfo),
-								   NULL, 0,
-								   NI_NUMERICHOST);
+					pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
+									hostinfo, sizeof(hostinfo),
+									NULL, 0,
+									NI_NUMERICHOST);
 
-				ereport(FATAL,
-						(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-						 errmsg("invalid TDS authentication request for host \"%s\", user \"%s\", database \"%s\"",
-								hostinfo, port->user_name, port->database_name),
-						 errhint("Expected authentication request: md5 or password")));
+					ereport(FATAL,
+							(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+							errmsg("invalid TDS authentication request for host \"%s\", user \"%s\", database \"%s\"",
+									hostinfo, port->user_name, port->database_name),
+							errhint("Expected authentication request: md5 or password")));
+				}
+
+				/* we've a password, let's verify it */
+				status = CheckAuthPassword(port, &logdetail);
 			}
-
-			/* we've a password, let's verify it */
-			status = CheckAuthPassword(port, &logdetail);
+			else if (loginInfo->sspiLen > 0 && loginInfo->sspi)
+			{
+				/* Cleanup sspi data. */
+				pfree(loginInfo->sspi);
+				loginInfo->sspiLen = 0;
+			}
 			break;
 		case uaTrust:
 			status = STATUS_OK;

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1776,15 +1776,15 @@ TdsClientAuthentication(Port *port)
 				char		hostinfo[NI_MAXHOST];
 
 				pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
-								hostinfo, sizeof(hostinfo),
-								NULL, 0,
-								NI_NUMERICHOST);
+									hostinfo, sizeof(hostinfo),
+									NULL, 0,
+									NI_NUMERICHOST);
 
 				ereport(FATAL,
 						(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-						errmsg("invalid TDS authentication request for host \"%s\", user \"%s\", database \"%s\"",
+						 errmsg("invalid TDS authentication request for host \"%s\", user \"%s\", database \"%s\"",
 								hostinfo, port->user_name, port->database_name),
-						errhint("Expected authentication request: md5 or password")));
+						 errhint("Expected authentication request: md5 or password")));
 			}
 
 			/* we've a password, let's verify it */

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1776,9 +1776,9 @@ TdsClientAuthentication(Port *port)
 				char		hostinfo[NI_MAXHOST];
 
 				pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
-									hostinfo, sizeof(hostinfo),
-									NULL, 0,
-									NI_NUMERICHOST);
+								   hostinfo, sizeof(hostinfo),
+								   NULL, 0,
+								   NI_NUMERICHOST);
 
 				ereport(FATAL,
 						(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),


### PR DESCRIPTION
### Description

In T-SQL world, Authentication mechanism would be chosen by the client as opposed to Postgres where authentication method selection would be controlled through pg_hba.conf file on server side.

For example, TDS client such as sqlcmd would not specify any username in login packet when it wants to use Kerberos/NTLM authentication.

So in order to support Kerberos authentication, This commit avoids consulting pg_hba.conf file if sspi data is present in login request during authentication. 

### Issues Resolved
Task: BABEL-3847
Sub-task: BABEL-3849

Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**

- Tested these changes manually. We will add more test case in future PRs for AD authentication support. 

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).