### PR TITLE
Support for DROP LOGIN for windows login

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1773,36 +1773,22 @@ TdsClientAuthentication(Port *port)
 			 */
 			if (!loginInfo->password)
 			{
-				/*
-				* If pg_hba.conf specifies that the entry should be authenticated using
-				* password and the request doesn't contain a password, we should
-				* throw an error.
-				*/
-				if (!loginInfo->password)
-				{
-					char		hostinfo[NI_MAXHOST];
+				char		hostinfo[NI_MAXHOST];
 
-					pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
-									hostinfo, sizeof(hostinfo),
-									NULL, 0,
-									NI_NUMERICHOST);
+				pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
+								   hostinfo, sizeof(hostinfo),
+								   NULL, 0,
+								   NI_NUMERICHOST);
 
-					ereport(FATAL,
-							(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-							errmsg("invalid TDS authentication request for host \"%s\", user \"%s\", database \"%s\"",
-									hostinfo, port->user_name, port->database_name),
-							errhint("Expected authentication request: md5 or password")));
-				}
-
-				/* we've a password, let's verify it */
-				status = CheckAuthPassword(port, &logdetail);
+				ereport(FATAL,
+						(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+						 errmsg("invalid TDS authentication request for host \"%s\", user \"%s\", database \"%s\"",
+								hostinfo, port->user_name, port->database_name),
+						 errhint("Expected authentication request: md5 or password")));
 			}
-			else if (loginInfo->sspiLen > 0 && loginInfo->sspi)
-			{
-				/* Cleanup sspi data. */
-				pfree(loginInfo->sspi);
-				loginInfo->sspiLen = 0;
-			}
+
+			/* we've a password, let's verify it */
+			status = CheckAuthPassword(port, &logdetail);
 			break;
 		case uaTrust:
 			status = STATUS_OK;

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -107,6 +107,8 @@ extern int16 get_dbid_from_physical_schema_name(const char *physical_schema_name
 #define BBF_AUTHID_LOGIN_EXT_TABLE_NAME "babelfish_authid_login_ext"
 #define BBF_AUTHID_LOGIN_EXT_IDX_NAME "babelfish_authid_login_ext_pkey"
 #define Anum_bbf_authid_login_ext_rolname 1
+#define Anum_bbf_authid_login_ext_type 3
+#define Anum_bbf_authid_login_ext_orig_loginname 9
 extern Oid			bbf_authid_login_ext_oid;
 extern Oid			bbf_authid_login_ext_idx_oid;
 

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -43,6 +43,7 @@
 #include "utils/catcache.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/formatting.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 #include "utils/timestamp.h"
@@ -1730,4 +1731,91 @@ has_user_in_db(const char *login, char **db_name)
 	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
 
 	return false;
+}
+
+/* 
+ * convertToUPN - This function is called to convert 
+ * domain\user to user@DOMAIN.
+ */
+char *
+convertToUPN(char* input)
+{
+	char *output = "";
+	char *pos_slash = NULL;
+
+	if ((pos_slash = strchr(input, '\\')) != NULL)
+	{
+		output = psprintf("%s@%s", 
+				 str_tolower(pos_slash + 1, strlen(pos_slash + 1), C_COLLATION_OID),
+				 str_toupper(input, (pos_slash - input), C_COLLATION_OID));
+	}
+	return output;
+}
+
+/*
+ * get_roleform_ext - Useful when someone tries to drop login and that login is in
+ * the form of windows format i.e, domain\user
+ */
+HeapTuple 
+get_roleform_ext(char *login)
+{
+	Relation	bbf_authid_login_ext_rel;
+	HeapTuple	tuple;
+	ScanKeyData	scanKey;
+	SysScanDesc	scan;
+	char		*upn_login;
+	TupleDesc	dsc;
+
+	if (!strchr(login, '\\'))
+		return NULL;
+
+	upn_login = convertToUPN(login);
+
+	/*
+	 * Trying to lookup provided windows user in babelfish_authid_login_ext catalog
+	 * using UPN form.
+	 */
+
+	/* Fetch the relation sys.babelfish_authid_login_ext */
+	bbf_authid_login_ext_rel = table_open(get_authid_login_ext_oid(),
+										  RowExclusiveLock);
+	dsc = RelationGetDescr(bbf_authid_login_ext_rel);
+
+	/* Search and drop on the role */
+	ScanKeyInit(&scanKey,
+				Anum_bbf_authid_login_ext_rolname,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(upn_login));
+
+	scan = systable_beginscan(bbf_authid_login_ext_rel,
+							  get_authid_login_ext_idx_oid(),
+							  true, NULL, 1, &scanKey);
+
+	tuple = systable_getnext(scan);
+
+	if (HeapTupleIsValid(tuple))
+	{
+		char *type;
+		bool isnull = true;
+		Datum datum = heap_getattr(tuple, Anum_bbf_authid_login_ext_type, dsc, &isnull);
+		if (isnull)
+			tuple = NULL;
+		type = pstrdup(TextDatumGetCString(datum));
+		/* Not a windows login */
+		if (strcasecmp(type, "U") != 0)
+			tuple = NULL;
+		pfree(type);
+	}
+
+	systable_endscan(scan);
+	table_close(bbf_authid_login_ext_rel, AccessShareLock);
+
+	if (!HeapTupleIsValid(tuple))
+		return tuple;
+
+	/* It is proven that this rolename is indeed windows login */
+	tuple = SearchSysCache1(AUTHNAME, PointerGetDatum(upn_login));
+
+	/* Return tuple even if it is invalid tuple */
+	return tuple;
 }

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -61,5 +61,7 @@ extern void add_to_bbf_authid_user_ext(const char *user_name,
 extern void drop_related_bbf_users(List *db_users);
 extern void alter_bbf_authid_user_ext(AlterRoleStmt *stmt);
 extern bool is_active_login(Oid role_oid);
+extern char *convertToUPN(char* input);
+extern HeapTuple get_roleform_ext(char *login);
 
 #endif


### PR DESCRIPTION
### Description

Adding support for DROP LOGIN [domain\login].

This commit adds support to drop logins for windows login. It first checks in pg_authid catalog whether supplied login is present or not. If it is not present and if login is in windows format e.g., [domain\login] then it would internally converts this supplied login to UPN form, [domain\login] to login@DOMAIN and then it will again retry to lookup pg_authid catalog using UPN form. 

### Issues Resolved

Task: BABEL-3847
Sub-task: BABEL-3854

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).