### PR TITLE
Add SLL parser mode

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -580,9 +580,9 @@ define_custom_variables(void)
 				 gettext_noop("disable SLL parser mode for ANTLR parser"),
 				 NULL,
 				 &pltsql_disable_sll_parse_mode,
-				 false,
-				 PGC_SUSET,
-				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+				 true,
+				 PGC_USERSET,
+				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);
 
 	/* temporary GUC until test is refactored properly */

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -21,6 +21,7 @@ bool enable_metadata_inconsistency_check = true;
 
 bool pltsql_dump_antlr_query_graph = false;
 bool pltsql_enable_antlr_detailed_log = false;
+bool pltsql_disable_sll_parse_mode = false;
 bool pltsql_allow_antlr_to_unsupported_grammar_for_testing = false;
 bool  pltsql_ansi_defaults = true;
 bool  pltsql_quoted_identifier = true;
@@ -570,6 +571,15 @@ define_custom_variables(void)
 				 gettext_noop("enable detailed ATNLR parser logging"),
 				 NULL,
 				 &pltsql_enable_antlr_detailed_log,
+				 false,
+				 PGC_SUSET,
+				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+				 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("babelfishpg_tsql.disable_sll_parse_mode",
+				 gettext_noop("disable SLL parser mode for ANTLR parser"),
+				 NULL,
+				 &pltsql_disable_sll_parse_mode,
 				 false,
 				 PGC_SUSET,
 				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -21,7 +21,7 @@ bool enable_metadata_inconsistency_check = true;
 
 bool pltsql_dump_antlr_query_graph = false;
 bool pltsql_enable_antlr_detailed_log = false;
-bool pltsql_disable_sll_parse_mode = false;
+bool pltsql_enable_sll_parse_mode = false;
 bool pltsql_allow_antlr_to_unsupported_grammar_for_testing = false;
 bool  pltsql_ansi_defaults = true;
 bool  pltsql_quoted_identifier = true;
@@ -576,11 +576,11 @@ define_custom_variables(void)
 				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);
 
-	DefineCustomBoolVariable("babelfishpg_tsql.disable_sll_parse_mode",
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_sll_parse_mode",
 				 gettext_noop("disable SLL parser mode for ANTLR parser"),
 				 NULL,
-				 &pltsql_disable_sll_parse_mode,
-				 true,
+				 &pltsql_enable_sll_parse_mode,
+				 false,
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -577,7 +577,7 @@ define_custom_variables(void)
 				 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("babelfishpg_tsql.enable_sll_parse_mode",
-				 gettext_noop("disable SLL parser mode for ANTLR parser"),
+				 gettext_noop("enable SLL parser mode for ANTLR parser"),
 				 NULL,
 				 &pltsql_enable_sll_parse_mode,
 				 false,

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1979,6 +1979,7 @@ extern void init_and_check_common_utility(void);
 typedef struct
 {
 	bool success;
+	bool parseTreeCreated; /* used to determine if on error should retry with a different parse mode */
 	size_t errpos;
 	int errcod;
 	const char *errfmt;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -69,7 +69,7 @@ extern "C"
 
 	extern bool pltsql_dump_antlr_query_graph;
 	extern bool pltsql_enable_antlr_detailed_log;
-	extern bool pltsql_disable_sll_parse_mode;
+	extern bool pltsql_enable_sll_parse_mode;
 
 	extern bool pltsql_enable_tsql_information_schema;
 
@@ -2455,10 +2455,10 @@ antlr_parser_cpp(const char *sourceText)
 		std::cout << sep << std::endl;
 	}
 
-	result = antlr_parse_query(sourceText, !pltsql_disable_sll_parse_mode);
+	result = antlr_parse_query(sourceText, pltsql_enable_sll_parse_mode);
 
 	// If parsing failed in SLL mode, reparse in LL mode
-	if (!result.success && result.errcod == ERRCODE_SYNTAX_ERROR && !pltsql_disable_sll_parse_mode)
+	if (!result.success && result.errcod == ERRCODE_SYNTAX_ERROR && pltsql_enable_sll_parse_mode)
 	{
 		elog(WARNING, "Query failed using SLL parser mode, retrying with LL parser mode query_text: %s", sourceText);
 		result = antlr_parse_query(sourceText, false);
@@ -2471,7 +2471,7 @@ antlr_parser_cpp(const char *sourceText)
 }
 
 ANTLR_result
-antlr_parse_query(const char *sourceText, bool useSSLParsing) {
+antlr_parse_query(const char *sourceText, bool useSLLParsing) {
 	ANTLR_result result;
 	MyInputStream sourceStream(sourceText);
 
@@ -2482,7 +2482,7 @@ antlr_parse_query(const char *sourceText, bool useSSLParsing) {
 
 	TSqlParser parser(&tokens);
 
-	if (useSSLParsing)
+	if (useSLLParsing)
 		parser.getInterpreter<atn::ParserATNSimulator>()->setPredictionMode(atn::PredictionMode::SLL);
 	parser.removeErrorListeners();
 	parser.addErrorListener(&errorListner);

--- a/test/JDBC/input/BABEL_2858-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL_2858-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS babel_2858_t1
+GO
+
+DROP TABLE IF EXISTS babel_2858_t1_deleted
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO

--- a/test/JDBC/input/BABEL_2858-vu-prepare.sql
+++ b/test/JDBC/input/BABEL_2858-vu-prepare.sql
@@ -1,0 +1,5 @@
+create table babel_2858_t1(num integer, word varchar(10));
+go
+
+create table babel_2858_t1_deleted(num integer, nextnum integer);
+go

--- a/test/JDBC/input/BABEL_2858-vu-verify.sql
+++ b/test/JDBC/input/BABEL_2858-vu-verify.sql
@@ -1,0 +1,25 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false)
+GO
+-- valid sll parsing and ll parsing
+SELECT * FROM babel_2858_t1
+GO
+
+-- fails both sll parsing and ll parsing
+SELECT FROM WHERE GROUP BY
+GO
+
+-- fails sll parsing passes ll parsing passes, valid query
+delete babel_2858_t1
+output babel_2858_t1.word
+from babel_2858_t1
+inner join babel_2858_t1_deleted
+ on babel_2858_t1.num=babel_2858_t1_deleted.num
+where babel_2858_t1.num=14;
+go
+
+-- fails sll parsing ll parsing passes, invalid query
+DECLARE @x xml (dbo.f);
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO

--- a/test/JDBC/sql_expected/BABEL_2858-vu-cleanup.out
+++ b/test/JDBC/sql_expected/BABEL_2858-vu-cleanup.out
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS babel_2858_t1
+GO
+
+DROP TABLE IF EXISTS babel_2858_t1_deleted
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/sql_expected/BABEL_2858-vu-prepare.out
+++ b/test/JDBC/sql_expected/BABEL_2858-vu-prepare.out
@@ -1,0 +1,5 @@
+create table babel_2858_t1(num integer, word varchar(10));
+go
+
+create table babel_2858_t1_deleted(num integer, nextnum integer);
+go

--- a/test/JDBC/sql_expected/BABEL_2858-vu-verify.out
+++ b/test/JDBC/sql_expected/BABEL_2858-vu-verify.out
@@ -1,0 +1,51 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+-- valid sll parsing and ll parsing
+SELECT * FROM babel_2858_t1
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- fails both sll parsing and ll parsing
+SELECT FROM WHERE GROUP BY
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'FROM' at line 2 and character position 7)~~
+
+
+-- fails sll parsing passes ll parsing passes, valid query
+delete babel_2858_t1
+output babel_2858_t1.word
+from babel_2858_t1
+inner join babel_2858_t1_deleted
+ on babel_2858_t1.num=babel_2858_t1_deleted.num
+where babel_2858_t1.num=14;
+go
+~~START~~
+varchar
+~~END~~
+
+
+-- fails sll parsing ll parsing passes, invalid query
+DECLARE @x xml (dbo.f);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: type modifier is not allowed for type "xml")~~
+
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+


### PR DESCRIPTION
### Description
This code enables SLL parsing in babelfish with the guc `enable_sll_parse_mode`. If SLL parsing fails to create a parse tree, parsing will be reattempted with LL parsing.

Task: BABEL-3759
Signed-off-by: Justin Jossick [jusjosj@amazon.com](mailto:jusjosj@amazon.com)

### Issues Resolved

BABEL-2858

### Test Scenarios Covered ###
* **Use case based -**
Several large stored procs where tested for parsing time with very large speed-ups, up to 35x, in parsing times.

* **Boundary conditions -**
See added tests, testing covered failures in both LL and SLL, failure in SLL but success in LL, failure in SLL success in LL at parse time but mutator rejects query, and success in both LL and SLL

* **Arbitrary inputs -**
Regression tests will cover this

* **Negative test cases -**
See added test files

* **Minor version upgrade tests -**
N/A

* **Major version upgrade tests -**
N/A

* **Performance tests -**
Several large stored procs where tested for parsing time with very large speed-ups, up to 35x, in parsing times.

* **Tooling impact -**


* **Client tests -**
JDBC


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).