### PR TITLE
Optimize LookupEncodingByLCID for Insert Bulk 

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -104,7 +104,7 @@ int TdsUTF16toUTF8XmlResult(StringInfo buf, void **resultPtr);
 Datum TdsTypeBitToDatum(StringInfo buf);
 Datum TdsTypeIntegerToDatum(StringInfo buf, int maxLen);
 Datum TdsTypeFloatToDatum(StringInfo buf, int maxLen);
-Datum TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType);
+Datum TdsTypeVarcharToDatum(StringInfo buf, pg_enc encoding, uint8_t tdsColDataType);
 Datum TdsTypeNCharToDatum(StringInfo buf);
 Datum TdsTypeNumericToDatum(StringInfo buf, int scale);
 Datum TdsTypeVarbinaryToDatum(StringInfo buf);
@@ -900,17 +900,13 @@ TdsTypeFloatToDatum(StringInfo buf, int maxLen)
 
 /* Helper Function to convert Varchar,Char and Text values into Datum. */
 Datum
-TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType)
+TdsTypeVarcharToDatum(StringInfo buf, pg_enc encoding, uint8_t tdsColDataType)
 {
 	char 		csave;
 	Datum 		pval;
-	pg_enc 		encoding;
 
 	csave = buf->data[buf->len];
 	buf->data[buf->len] = '\0';
-
-	/* If we recieve 0 value for LCID then we should treat it as a default LCID.*/
-	encoding = TdsGetEncoding(collation);
 
 	pval = TdsAnyToServerEncodingConversion(encoding,
 									buf->data, buf->len,
@@ -2080,7 +2076,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 					{
 						case TDS_TYPE_CHAR:
 						case TDS_TYPE_VARCHAR:
-							values[i] = TdsTypeVarcharToDatum(temp, colMetaData[currentColumn].collation, colMetaData[currentColumn].columnTdsType);
+							values[i] = TdsTypeVarcharToDatum(temp, colMetaData[currentColumn].encoding, colMetaData[currentColumn].columnTdsType);
 						break;
 						case TDS_TYPE_NCHAR:
 							values[i] = TdsTypeNCharToDatum(temp);

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -480,6 +480,7 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
 	char *physical_schema = NULL;
 	StringInfo tempStringInfo = palloc( sizeof(StringInfoData));
+	uint32_t collation;
 
 	/* Database-Name.Schema-Name.TableType-Name */
 	for(; i < 3; i++)
@@ -589,18 +590,11 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 				{
 					memcpy(&colmetadata[i].maxLen, &messageData[*offset], sizeof(uint16));
 					*offset += sizeof(uint16);
-					if (colmetadata[i].maxLen == 0xffff)
-					{
-						memcpy(&colmetadata[i].collation, &messageData[*offset], sizeof(uint32_t));
-						*offset += sizeof(uint32_t);
-						colmetadata[i].sortId = messageData[(*offset)++];
-					}
-					else
-					{
-						memcpy(&colmetadata[i].collation, &messageData[*offset], sizeof(uint32_t));
-						*offset += sizeof(uint32_t);
-						colmetadata[i].sortId = messageData[(*offset)++];
-					}
+
+					memcpy(&collation, &messageData[*offset], sizeof(uint32_t));
+					*offset += sizeof(uint32_t);
+					colmetadata[i].sortId = messageData[(*offset)++];
+					colmetadata[i].encoding = TdsGetEncoding(collation);
 				}
 				break;
 				case TDS_TYPE_XML:

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -204,8 +204,8 @@ typedef struct TvpColMetaData
 	uint8_t scale;
 	uint8_t precision;
 
-	uint32_t collation;
 	uint8_t sortId;
+	pg_enc	encoding;
 
 	uint32_t maxLen;
 } TvpColMetaData;
@@ -241,8 +241,8 @@ typedef struct BulkLoadColMetaData
 	uint8_t 	precision;
 
 	/* For String Datatpes. */
-	uint32_t 	collation;
 	uint8_t 	sortId;
+	pg_enc		encoding;
 
 	uint32_t 	maxLen;
 
@@ -457,7 +457,7 @@ extern Datum TdsRecvTypeDatetimeoffset(const char *message, const ParameterToken
 extern Datum TdsTypeBitToDatum(StringInfo buf);
 extern Datum TdsTypeIntegerToDatum(StringInfo buf, int maxLen);
 extern Datum TdsTypeFloatToDatum(StringInfo buf, int maxLen);
-extern Datum TdsTypeVarcharToDatum(StringInfo buf, uint32_t collation, uint8_t tdsColDataType);
+extern Datum TdsTypeVarcharToDatum(StringInfo buf, pg_enc encoding, uint8_t tdsColDataType);
 extern Datum TdsTypeNCharToDatum(StringInfo buf);
 extern Datum TdsTypeNumericToDatum(StringInfo buf, int scale);
 extern Datum TdsTypeVarbinaryToDatum(StringInfo buf);


### PR DESCRIPTION
Cherry Pick Commit https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/4f7df9813e57d15f421f807793bc7caaa975e34d from 2_X_DEV to 3_X_DEV

### Description
Previously every call to the function VarCharToDatum() previously used TDSGetEncoding() function which internally called  LookupEncodingByLCID().For bulk insert scenario for every row in a table for a varchar,char,text column we called VarCharToDatum function which lead to extra calls to LookupEncodingByLCID function causing an overhead .

The current solution implemented is to at the start of request set the encoding of the column as a part of  columnMetadata for both bulk insert as well as Tvp(Table valued Parameters). This would remove the redundant calls to LookupEncodingByLCID.




### Issues Resolved
BABEL-3623
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>
[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
Already existing tests are sufficient

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).