### PR TITLE
Added SSMS Scripting Support for Identity Columns (#955)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -380,7 +380,7 @@ select CAST(c.oid as int) as object_id
   , case when a.attnotnull then CAST(0 as sys.bit) else CAST(1 as sys.bit) end as is_nullable
   , CAST(0 as sys.bit) as is_ansi_padded
   , CAST(0 as sys.bit) as is_rowguidcol
-  , CAST(0 as sys.bit) as is_identity
+  , CAST(case when a.attidentity <> ''::"char" then 1 else 0 end AS sys.bit) as is_identity
   , CAST(0 as sys.bit) as is_computed
   , CAST(0 as sys.bit) as is_filestream
   , CAST(0 as sys.bit) as is_replicated

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -87,6 +87,61 @@ $$
 $$
 LANGUAGE sql PARALLEL SAFE STABLE;
 
+create or replace view sys.all_columns as
+select CAST(c.oid as int) as object_id
+  , CAST(a.attname as sys.sysname) as name
+  , CAST(a.attnum as int) as column_id
+  , CAST(t.oid as int) as system_type_id
+  , CAST(t.oid as int) as user_type_id
+  , CAST(sys.tsql_type_max_length_helper(coalesce(tsql_type_name, tsql_base_type_name), a.attlen, a.atttypmod) as smallint) as max_length
+  , CAST(case
+      when a.atttypmod != -1 then
+        sys.tsql_type_precision_helper(coalesce(tsql_type_name, tsql_base_type_name), a.atttypmod)
+      else
+        sys.tsql_type_precision_helper(coalesce(tsql_type_name, tsql_base_type_name), t.typtypmod)
+    end as sys.tinyint) as precision
+  , CAST(case
+      when a.atttypmod != -1 THEN
+        sys.tsql_type_scale_helper(coalesce(tsql_type_name, tsql_base_type_name), a.atttypmod, false)
+      else
+        sys.tsql_type_scale_helper(coalesce(tsql_type_name, tsql_base_type_name), t.typtypmod, false)
+    end as sys.tinyint) as scale
+  , CAST(coll.collname as sys.sysname) as collation_name
+  , case when a.attnotnull then CAST(0 as sys.bit) else CAST(1 as sys.bit) end as is_nullable
+  , CAST(0 as sys.bit) as is_ansi_padded
+  , CAST(0 as sys.bit) as is_rowguidcol
+  , CAST(case when a.attidentity <> ''::"char" then 1 else 0 end AS sys.bit) as is_identity
+  , CAST(0 as sys.bit) as is_computed
+  , CAST(0 as sys.bit) as is_filestream
+  , CAST(0 as sys.bit) as is_replicated
+  , CAST(0 as sys.bit) as is_non_sql_subscribed
+  , CAST(0 as sys.bit) as is_merge_published
+  , CAST(0 as sys.bit) as is_dts_replicated
+  , CAST(0 as sys.bit) as is_xml_document
+  , CAST(0 as int) as xml_collection_id
+  , CAST(coalesce(d.oid, 0) as int) as default_object_id
+  , CAST(coalesce((select oid from pg_constraint where conrelid = t.oid and contype = 'c' and a.attnum = any(conkey) limit 1), 0) as int) as rule_object_id
+  , CAST(0 as sys.bit) as is_sparse
+  , CAST(0 as sys.bit) as is_column_set
+  , CAST(0 as sys.tinyint) as generated_always_type
+  , CAST('NOT_APPLICABLE' as sys.nvarchar(60)) as generated_always_type_desc
+from pg_attribute a
+inner join pg_class c on c.oid = a.attrelid
+inner join pg_type t on t.oid = a.atttypid
+inner join pg_namespace s on s.oid = c.relnamespace
+left join pg_attrdef d on c.oid = d.adrelid and a.attnum = d.adnum
+left join pg_collation coll on coll.oid = a.attcollation
+, sys.translate_pg_type_to_tsql(a.atttypid) AS tsql_type_name
+, sys.translate_pg_type_to_tsql(t.typbasetype) AS tsql_base_type_name
+where not a.attisdropped
+and (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+-- r = ordinary table, i = index, S = sequence, t = TOAST table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table
+and c.relkind in ('r', 'v', 'm', 'f', 'p')
+and has_schema_privilege(s.oid, 'USAGE')
+and has_column_privilege(quote_ident(s.nspname) ||'.'||quote_ident(c.relname), a.attname, 'SELECT,INSERT,UPDATE,REFERENCES')
+and a.attnum > 0;
+GRANT SELECT ON sys.all_columns TO PUBLIC;
+
 CREATE or replace VIEW sys.check_constraints AS
 SELECT CAST(c.conname as sys.sysname) as name
   , CAST(oid as integer) as object_id

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -168,6 +168,61 @@ $$
 $$
 LANGUAGE sql PARALLEL SAFE STABLE;
 
+create or replace view sys.all_columns as
+select CAST(c.oid as int) as object_id
+  , CAST(a.attname as sys.sysname) as name
+  , CAST(a.attnum as int) as column_id
+  , CAST(t.oid as int) as system_type_id
+  , CAST(t.oid as int) as user_type_id
+  , CAST(sys.tsql_type_max_length_helper(coalesce(tsql_type_name, tsql_base_type_name), a.attlen, a.atttypmod) as smallint) as max_length
+  , CAST(case
+      when a.atttypmod != -1 then
+        sys.tsql_type_precision_helper(coalesce(tsql_type_name, tsql_base_type_name), a.atttypmod)
+      else
+        sys.tsql_type_precision_helper(coalesce(tsql_type_name, tsql_base_type_name), t.typtypmod)
+    end as sys.tinyint) as precision
+  , CAST(case
+      when a.atttypmod != -1 THEN
+        sys.tsql_type_scale_helper(coalesce(tsql_type_name, tsql_base_type_name), a.atttypmod, false)
+      else
+        sys.tsql_type_scale_helper(coalesce(tsql_type_name, tsql_base_type_name), t.typtypmod, false)
+    end as sys.tinyint) as scale
+  , CAST(coll.collname as sys.sysname) as collation_name
+  , case when a.attnotnull then CAST(0 as sys.bit) else CAST(1 as sys.bit) end as is_nullable
+  , CAST(0 as sys.bit) as is_ansi_padded
+  , CAST(0 as sys.bit) as is_rowguidcol
+  , CAST(case when a.attidentity <> ''::"char" then 1 else 0 end AS sys.bit) as is_identity
+  , CAST(0 as sys.bit) as is_computed
+  , CAST(0 as sys.bit) as is_filestream
+  , CAST(0 as sys.bit) as is_replicated
+  , CAST(0 as sys.bit) as is_non_sql_subscribed
+  , CAST(0 as sys.bit) as is_merge_published
+  , CAST(0 as sys.bit) as is_dts_replicated
+  , CAST(0 as sys.bit) as is_xml_document
+  , CAST(0 as int) as xml_collection_id
+  , CAST(coalesce(d.oid, 0) as int) as default_object_id
+  , CAST(coalesce((select oid from pg_constraint where conrelid = t.oid and contype = 'c' and a.attnum = any(conkey) limit 1), 0) as int) as rule_object_id
+  , CAST(0 as sys.bit) as is_sparse
+  , CAST(0 as sys.bit) as is_column_set
+  , CAST(0 as sys.tinyint) as generated_always_type
+  , CAST('NOT_APPLICABLE' as sys.nvarchar(60)) as generated_always_type_desc
+from pg_attribute a
+inner join pg_class c on c.oid = a.attrelid
+inner join pg_type t on t.oid = a.atttypid
+inner join pg_namespace s on s.oid = c.relnamespace
+left join pg_attrdef d on c.oid = d.adrelid and a.attnum = d.adnum
+left join pg_collation coll on coll.oid = a.attcollation
+, sys.translate_pg_type_to_tsql(a.atttypid) AS tsql_type_name
+, sys.translate_pg_type_to_tsql(t.typbasetype) AS tsql_base_type_name
+where not a.attisdropped
+and (s.oid in (select schema_id from sys.schemas) or s.nspname = 'sys')
+-- r = ordinary table, i = index, S = sequence, t = TOAST table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table
+and c.relkind in ('r', 'v', 'm', 'f', 'p')
+and has_schema_privilege(s.oid, 'USAGE')
+and has_column_privilege(quote_ident(s.nspname) ||'.'||quote_ident(c.relname), a.attname, 'SELECT,INSERT,UPDATE,REFERENCES')
+and a.attnum > 0;
+GRANT SELECT ON sys.all_columns TO PUBLIC;
+
 CREATE or replace VIEW sys.check_constraints AS
 SELECT CAST(c.conname as sys.sysname) as name
   , CAST(oid as integer) as object_id

--- a/test/JDBC/expected/sys-all_columns-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-all_columns-dep-vu-prepare.out
@@ -2,8 +2,8 @@ DROP TABLE IF EXISTS sys_all_columns_dep_vu_prepare_table
 GO
 
 CREATE TABLE sys_all_columns_dep_vu_prepare_table (
-	sac_int_col INT PRIMARY KEY,
-	sac_text_col_not_null VARCHAR(50) NOT NULL
+	sac_int_col1 INT PRIMARY KEY,
+	sac_text_col_not_null1 VARCHAR(50) NOT NULL
 )
 GO
 
@@ -11,7 +11,7 @@ CREATE PROCEDURE sys_all_columns_dep_vu_prepare_proc1
 AS
     SELECT name, is_nullable, column_id 
     FROM sys.all_columns 
-    WHERE name in ('sac_int_col', 'sac_text_col_not_null');
+    WHERE name in ('sac_int_col1', 'sac_text_col_not_null1');
 GO
 
 CREATE FUNCTION sys_all_columns_dep_vu_prepare_func1() 
@@ -25,5 +25,5 @@ CREATE VIEW sys_all_columns_dep_vu_prepare_view1
 AS
     SELECT name, max_length, precision
     FROM sys.all_columns
-    WHERE name in ('sac_int_col', 'sac_text_col_not_null');
+    WHERE name in ('sac_int_col1', 'sac_text_col_not_null1');
 GO

--- a/test/JDBC/expected/sys-all_columns-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-all_columns-dep-vu-verify.out
@@ -2,8 +2,8 @@ EXEC sys_all_columns_dep_vu_prepare_proc1;
 GO
 ~~START~~
 varchar#!#bit#!#int
-sac_int_col#!#0#!#1
-sac_text_col_not_null#!#0#!#2
+sac_int_col1#!#0#!#1
+sac_text_col_not_null1#!#0#!#2
 ~~END~~
 
 
@@ -19,8 +19,8 @@ SELECT * FROM sys_all_columns_dep_vu_prepare_view1;
 GO
 ~~START~~
 varchar#!#smallint#!#tinyint
-sac_int_col#!#4#!#10
-sac_text_col_not_null#!#50#!#0
+sac_int_col1#!#4#!#10
+sac_text_col_not_null1#!#50#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-all_columns-vu-cleanup.out
+++ b/test/JDBC/expected/sys-all_columns-vu-cleanup.out
@@ -1,3 +1,4 @@
 DROP TABLE IF EXISTS sys_all_columns_vu_prepare_table
 DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t1
+DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t2
 GO

--- a/test/JDBC/expected/sys-all_columns-vu-prepare.out
+++ b/test/JDBC/expected/sys-all_columns-vu-prepare.out
@@ -1,4 +1,6 @@
 DROP TABLE IF EXISTS sys_all_columns_vu_prepare_table
+DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t1
+DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t2
 GO
 
 CREATE TABLE sys_all_columns_vu_prepare_table (
@@ -15,5 +17,13 @@ CREATE TABLE sys_all_columns_vu_prepare_t1 (
 	datecol date,
 	moneycol money,
 	datetimecol datetime,
+)
+GO
+
+CREATE TABLE sys_all_columns_vu_prepare_t2 (
+	col_one INT PRIMARY KEY,
+	col_two INT,
+	col_three INT IDENTITY(1,1),
+	col_computed AS col_one * col_two
 )
 GO

--- a/test/JDBC/expected/sys-all_columns-vu-verify.out
+++ b/test/JDBC/expected/sys-all_columns-vu-verify.out
@@ -34,3 +34,17 @@ intcol#!#1#!#4#!#10#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
 moneycol#!#5#!#8#!#19#!#4#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE
 ~~END~~
 
+
+SELECT name, is_identity, is_computed
+FROM sys.all_columns
+WHERE name in ('col_computed', 'col_one', 'col_two', 'col_three')
+ORDER BY name
+GO
+~~START~~
+varchar#!#bit#!#bit
+col_computed#!#0#!#0
+col_one#!#0#!#0
+col_three#!#1#!#0
+col_two#!#0#!#0
+~~END~~
+

--- a/test/JDBC/input/views/sys-all_columns-dep-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-all_columns-dep-vu-prepare.sql
@@ -2,8 +2,8 @@ DROP TABLE IF EXISTS sys_all_columns_dep_vu_prepare_table
 GO
 
 CREATE TABLE sys_all_columns_dep_vu_prepare_table (
-	sac_int_col INT PRIMARY KEY,
-	sac_text_col_not_null VARCHAR(50) NOT NULL
+	sac_int_col1 INT PRIMARY KEY,
+	sac_text_col_not_null1 VARCHAR(50) NOT NULL
 )
 GO
 
@@ -11,7 +11,7 @@ CREATE PROCEDURE sys_all_columns_dep_vu_prepare_proc1
 AS
     SELECT name, is_nullable, column_id 
     FROM sys.all_columns 
-    WHERE name in ('sac_int_col', 'sac_text_col_not_null');
+    WHERE name in ('sac_int_col1', 'sac_text_col_not_null1');
 GO
 
 CREATE FUNCTION sys_all_columns_dep_vu_prepare_func1() 
@@ -25,5 +25,5 @@ CREATE VIEW sys_all_columns_dep_vu_prepare_view1
 AS
     SELECT name, max_length, precision
     FROM sys.all_columns
-    WHERE name in ('sac_int_col', 'sac_text_col_not_null');
+    WHERE name in ('sac_int_col1', 'sac_text_col_not_null1');
 GO

--- a/test/JDBC/input/views/sys-all_columns-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys-all_columns-vu-cleanup.sql
@@ -1,3 +1,4 @@
 DROP TABLE IF EXISTS sys_all_columns_vu_prepare_table
 DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t1
+DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t2
 GO

--- a/test/JDBC/input/views/sys-all_columns-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-all_columns-vu-prepare.sql
@@ -1,4 +1,6 @@
 DROP TABLE IF EXISTS sys_all_columns_vu_prepare_table
+DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t1
+DROP TABLE IF EXISTS sys_all_columns_vu_prepare_t2
 GO
 
 CREATE TABLE sys_all_columns_vu_prepare_table (
@@ -15,5 +17,13 @@ CREATE TABLE sys_all_columns_vu_prepare_t1 (
 	datecol date,
 	moneycol money,
 	datetimecol datetime,
+)
+GO
+
+CREATE TABLE sys_all_columns_vu_prepare_t2 (
+	col_one INT PRIMARY KEY,
+	col_two INT,
+	col_three INT IDENTITY(1,1),
+	col_computed AS col_one * col_two
 )
 GO

--- a/test/JDBC/input/views/sys-all_columns-vu-verify.sql
+++ b/test/JDBC/input/views/sys-all_columns-vu-verify.sql
@@ -12,3 +12,9 @@ FROM sys.all_columns
 WHERE name='intcol' OR name='char128col' OR name='bitcol' OR name='datecol' OR name='moneycol' OR name='datetimecol'
 ORDER BY name
 GO
+
+SELECT name, is_identity, is_computed
+FROM sys.all_columns
+WHERE name in ('col_computed', 'col_one', 'col_two', 'col_three')
+ORDER BY name
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -268,6 +268,7 @@ format
 msdb-dbo-syspolicy_system_health_state
 dateadd_internal_df
 sys-all_columns
+sys-all_columns-dep
 sys-all_sql_modules
 sys-assembly_modules
 sys-change_tracking_databases

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -956,7 +956,6 @@ View information_schema_tsql.constraint_column_usage
 View information_schema_tsql.domains
 View information_schema_tsql.routines
 View information_schema_tsql.views
-View sys.all_columns
 View sys.all_sql_modules_internal
 View sys.assembly_modules
 View sys.babelfish_has_perms_by_name_permissions


### PR DESCRIPTION
### Description

Initially the value of is_identity is marked as 0 by default.Have added conditions in order to select between 0 and 1 in order to support SSMS scripting.

Task : BABEL-3805

Signed-off-by: Ashish Prasad <pashisht@amazon.com>


### Issues Resolved

BABEL-3805

Testing
Added JDBC Testcases

### Test Scenarios Covered

- Use case based -  Yes
- Boundary conditions - N/A
- Arbitrary inputs - N/A
- Negative test cases - N/A
- Minor version upgrade tests - N/A
- Major version upgrade tests - N/A
- Performance tests - N/A
- Tooling impact - N/A
- Client tests - N/A

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).