### PR TITLE
Trigger function should be created in schema the of trigger

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2747,7 +2747,7 @@ tsql_CreateTrigStmt:
 					 * trigger will be created as part of
 					 * this create trigger command.
 					 */
-					n1->funcname = list_make1(makeString(n1->trigname));
+					n1->funcname = $3;
  					if (list_length($3) > 1){
 	 					n1->trigname = ((String *)list_nth($3,1))->sval;
 						/*
@@ -2788,7 +2788,7 @@ tsql_CreateTrigStmt:
 
 					n2->is_procedure = false;
 					n2->replace = true;
-					n2->funcname = list_make1(makeString(n1->trigname));;
+					n2->funcname = $3;
 					n2->parameters = NIL;
 					n2->returnType = makeTypeName("trigger");
 					n2->options = list_make3(lang, body, trigStmt);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -445,10 +445,11 @@ pltsql_pre_parse_analyze(ParseState *pstate, RawStmt *parseTree)
 				}
 				else
 				{
+					Assert(list_length(funcStmt->funcname) == 1);
 					/*
 					 * Add schemaname to trigger's function name.
 					 */
-					if (list_length(funcStmt->funcname) == 1 && trigStmt->relation->schemaname != NULL)
+					if (trigStmt->relation->schemaname != NULL)
 					{
 						funcStmt->funcname = lcons(makeString(trigStmt->relation->schemaname), funcStmt->funcname);
 					}

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -425,6 +425,7 @@ pltsql_pre_parse_analyze(ParseState *pstate, RawStmt *parseTree)
 	if (parseTree->stmt->type == T_CreateFunctionStmt ){
 		ListCell 		*option;
 		CreateTrigStmt *trigStmt;
+		CreateFunctionStmt *funcStmt = (CreateFunctionStmt *) parseTree->stmt;
 		char* trig_schema;
 		foreach (option, ((CreateFunctionStmt *) parseTree->stmt)->options){
 			DefElem *defel = (DefElem *) lfirst(option);
@@ -441,6 +442,16 @@ pltsql_pre_parse_analyze(ParseState *pstate, RawStmt *parseTree)
 						   trig_schema , trigStmt->trigname)));
 					}
 					trigStmt->args = NIL;
+				}
+				else
+				{
+					/*
+					 * Add schemaname to trigger's function name.
+					 */
+					if (list_length(funcStmt->funcname) == 1 && trigStmt->relation->schemaname != NULL)
+					{
+						funcStmt->funcname = lcons(makeString(trigStmt->relation->schemaname), funcStmt->funcname);
+					}
 				}
 			}
 		}

--- a/test/JDBC/expected/babel_trigger-vu-cleanup.out
+++ b/test/JDBC/expected/babel_trigger-vu-cleanup.out
@@ -1,4 +1,13 @@
 -- clean up
+drop trigger babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_trig3
+GO
+
+drop table babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1
+GO
+
+drop schema babel_trigger_vu_prepare_sch1
+GO
+
 drop table babel_trigger_vu_prepare_t1
 GO
 

--- a/test/JDBC/expected/babel_trigger-vu-prepare.out
+++ b/test/JDBC/expected/babel_trigger-vu-prepare.out
@@ -191,3 +191,17 @@ begin
 end
 GO
 
+-- to test trigger created inside schema
+create schema babel_trigger_vu_prepare_sch1
+GO
+
+create table babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1(col nvarchar(60))
+GO
+
+create trigger babel_trigger_vu_prepare_trig3 on babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1 after insert
+as
+begin
+	SELECT 'trigger3 from sch1 invoked'
+end
+GO
+

--- a/test/JDBC/expected/babel_trigger-vu-verify.out
+++ b/test/JDBC/expected/babel_trigger-vu-verify.out
@@ -218,4 +218,14 @@ GO
 ~~ROW COUNT: 1~~
 
 
+-- Test for trigger inside schema
+insert into babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1(col) select N'Muffler'
+GO
+~~START~~
+varchar
+trigger3 from sch1 invoked
+~~END~~
+
+~~ROW COUNT: 1~~
+
 

--- a/test/JDBC/expected/babel_trigger.out
+++ b/test/JDBC/expected/babel_trigger.out
@@ -398,7 +398,38 @@ GO
 ~~ERROR (Message: trigger "notify" does not exist)~~
 
 
+-- test trigger function's schema
+create schema babel_trigger_sch1;
+GO
+
+create table babel_trigger_sch1.babel_trigger_t1(a int, b int);
+GO
+
+create trigger babel_trigger_sch1.babel_trigger_trig1 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
+GO
+
+-- if we don't specify the schema name of trigger
+create trigger babel_trigger_trig2 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
+GO
+
+select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2');
+GO
+~~START~~
+varchar#!#varchar
+babel_trigger_trig2#!#babel_trigger_sch1
+babel_trigger_trig1#!#babel_trigger_sch1
+~~END~~
+
+
 -- clean up
+drop trigger babel_trigger_sch1.babel_trigger_trig1
+GO
+drop trigger babel_trigger_sch1.babel_trigger_trig2
+GO
+drop table babel_trigger_sch1.babel_trigger_t1
+GO
+drop schema babel_trigger_sch1
+GO
 drop table testing1
 GO
 drop table product_audits

--- a/test/JDBC/expected/babel_trigger.out
+++ b/test/JDBC/expected/babel_trigger.out
@@ -412,12 +412,12 @@ GO
 create trigger babel_trigger_trig2 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
 GO
 
-select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2');
+select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2') order by name;
 GO
 ~~START~~
 varchar#!#varchar
-babel_trigger_trig2#!#babel_trigger_sch1
 babel_trigger_trig1#!#babel_trigger_sch1
+babel_trigger_trig2#!#babel_trigger_sch1
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_trigger.out
+++ b/test/JDBC/expected/babel_trigger.out
@@ -412,7 +412,21 @@ GO
 create trigger babel_trigger_trig2 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
 GO
 
-select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2') order by name;
+create trigger babel_trigger_trig3 on babel_trigger_t1 after insert as select 1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_trigger_t1" does not exist)~~
+
+
+create trigger babel_trigger_sch1.babel_trigger_trig4 on babel_trigger_t1 after insert as select 1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create trigger 'babel_trigger_sch1.babel_trigger_trig4' because its schema is different from the schema of the target table or view.)~~
+
+
+select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2','babel_trigger_trig3','babel_trigger_trig4') order by name;
 GO
 ~~START~~
 varchar#!#varchar

--- a/test/JDBC/input/babel_trigger.sql
+++ b/test/JDBC/input/babel_trigger.sql
@@ -320,7 +320,32 @@ GO
 drop trigger notify
 GO
 
+-- test trigger function's schema
+create schema babel_trigger_sch1;
+GO
+
+create table babel_trigger_sch1.babel_trigger_t1(a int, b int);
+GO
+
+create trigger babel_trigger_sch1.babel_trigger_trig1 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
+GO
+
+-- if we don't specify the schema name of trigger
+create trigger babel_trigger_trig2 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
+GO
+
+select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2');
+GO
+
 -- clean up
+drop trigger babel_trigger_sch1.babel_trigger_trig1
+GO
+drop trigger babel_trigger_sch1.babel_trigger_trig2
+GO
+drop table babel_trigger_sch1.babel_trigger_t1
+GO
+drop schema babel_trigger_sch1
+GO
 drop table testing1
 GO
 drop table product_audits

--- a/test/JDBC/input/babel_trigger.sql
+++ b/test/JDBC/input/babel_trigger.sql
@@ -334,7 +334,7 @@ GO
 create trigger babel_trigger_trig2 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
 GO
 
-select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2');
+select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2') order by name;
 GO
 
 -- clean up

--- a/test/JDBC/input/babel_trigger.sql
+++ b/test/JDBC/input/babel_trigger.sql
@@ -334,7 +334,13 @@ GO
 create trigger babel_trigger_trig2 on babel_trigger_sch1.babel_trigger_t1 after insert as select 1;
 GO
 
-select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2') order by name;
+create trigger babel_trigger_trig3 on babel_trigger_t1 after insert as select 1;
+GO
+
+create trigger babel_trigger_sch1.babel_trigger_trig4 on babel_trigger_t1 after insert as select 1;
+GO
+
+select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2','babel_trigger_trig3','babel_trigger_trig4') order by name;
 GO
 
 -- clean up

--- a/test/JDBC/input/triggers/babel_trigger-vu-cleanup.sql
+++ b/test/JDBC/input/triggers/babel_trigger-vu-cleanup.sql
@@ -1,4 +1,13 @@
 -- clean up
+drop trigger babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_trig3
+GO
+
+drop table babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1
+GO
+
+drop schema babel_trigger_vu_prepare_sch1
+GO
+
 drop table babel_trigger_vu_prepare_t1
 GO
 

--- a/test/JDBC/input/triggers/babel_trigger-vu-prepare.sql
+++ b/test/JDBC/input/triggers/babel_trigger-vu-prepare.sql
@@ -187,3 +187,17 @@ begin
 end
 GO
 
+-- to test trigger created inside schema
+create schema babel_trigger_vu_prepare_sch1
+GO
+
+create table babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1(col nvarchar(60))
+GO
+
+create trigger babel_trigger_vu_prepare_trig3 on babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1 after insert
+as
+begin
+	SELECT 'trigger3 from sch1 invoked'
+end
+GO
+

--- a/test/JDBC/input/triggers/babel_trigger-vu-verify.sql
+++ b/test/JDBC/input/triggers/babel_trigger-vu-verify.sql
@@ -144,4 +144,7 @@ GO
 insert into babel_trigger_vu_prepare_t5 (col) select N'Muffler'
 GO
 
+-- Test for trigger inside schema
+insert into babel_trigger_vu_prepare_sch1.babel_trigger_vu_prepare_t1(col) select N'Muffler'
+GO
 


### PR DESCRIPTION
### Description

Previously, Trigger function was always created in the dbo schema, no matter whether we specify schema while creating a trigger or not.

This commit fixes above issue by providing parent trigger's schema while creating implicit trigger function.

Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved

BABEL-3629

### Test Scenarios Covered ###
* **Use case based -**
Added test for verifying the schemas

* **Boundary conditions -**
NA

* **Arbitrary inputs -**
NA

* **Negative test cases -**
NA

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
Added

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).