### PR TITLE
Rewrite sys.types

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1040,20 +1040,25 @@ left join pg_catalog.pg_locks         blocking_locks
 GRANT SELECT ON sys.sysprocesses TO PUBLIC;
 
 create or replace view sys.types As
-with tt_internal as MATERIALIZED
+with RECURSIVE type_code_list as
+(
+    select distinct  pg_typname as pg_type_name, tsql_typname as tsql_type_name
+    from sys.babelfish_typecode_list()
+),
+tt_internal as MATERIALIZED
 (
   Select * from sys.table_types_internal
 )
 -- For System types
 select 
-  tsql_type_name as name
+  ti.tsql_type_name as name
   , t.oid as system_type_id
   , t.oid as user_type_id
   , s.oid as schema_id
   , cast(NULL as INT) as principal_id
-  , sys.tsql_type_max_length_helper(tsql_type_name, t.typlen, t.typtypmod, true) as max_length
-  , cast(sys.tsql_type_precision_helper(tsql_type_name, t.typtypmod) as int) as precision
-  , cast(sys.tsql_type_scale_helper(tsql_type_name, t.typtypmod, false) as int) as scale
+  , sys.tsql_type_max_length_helper(ti.tsql_type_name, t.typlen, t.typtypmod, true) as max_length
+  , cast(sys.tsql_type_precision_helper(ti.tsql_type_name, t.typtypmod) as int) as precision
+  , cast(sys.tsql_type_scale_helper(ti.tsql_type_name, t.typtypmod, false) as int) as scale
   , CASE c.collname
     WHEN 'default' THEN default_collation_name
     ELSE  c.collname
@@ -1066,11 +1071,11 @@ select
   , 0 as is_table_type
 from pg_type t
 inner join pg_namespace s on s.oid = t.typnamespace
+inner join type_code_list ti on t.typname = ti.pg_type_name
 left join pg_collation c on c.oid = t.typcollation
-,sys.translate_pg_type_to_tsql(t.oid) AS tsql_type_name
 ,cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
 where
-tsql_type_name IS NOT NULL
+ti.tsql_type_name IS NOT NULL  
 and pg_type_is_visible(t.oid)
 and (s.nspname = 'pg_catalog' OR s.nspname = 'sys')
 union all 
@@ -1099,12 +1104,15 @@ select cast(t.typname as text) as name
   , case when tt.typrelid is not null then 1 else 0 end as is_table_type
 from pg_type t
 join sys.schemas sch on t.typnamespace = sch.schema_id
+left join type_code_list ti on t.typname = ti.pg_type_name
 left join pg_collation c on c.oid = t.typcollation
 left join tt_internal tt on t.typrelid = tt.typrelid
 , sys.translate_pg_type_to_tsql(t.typbasetype) AS tsql_base_type_name
 , cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
 -- we want to show details of user defined datatypes created under babelfish database
 where 
+ ti.tsql_type_name IS NULL
+and
   (
     -- show all user defined datatypes created under babelfish database except table types
     t.typtype = 'd'

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1,16 +1,19 @@
 /* Tsql system catalog views */
 
--- The sys.table_types_internal view mimics the logic used in sys.is_table_type function
+/*
+ * We do not need to join with pg_class since we can check the dependent class-id in
+ * pg_depend directly.
+ * Note: this view, although written efficiently might cause perfomance degradation when
+ * joined with other system objects. One should try to use them as part of a materialized CTE.
+ */
 create or replace view sys.table_types_internal as
 SELECT pt.typrelid
     FROM pg_catalog.pg_type pt
-    INNER JOIN pg_catalog.pg_depend dep
-    ON pt.typrelid = dep.objid
-    INNER JOIN pg_catalog.pg_class pc ON pc.oid = dep.objid
+    INNER JOIN pg_catalog.pg_depend dep ON pt.typrelid = dep.objid
+    INNER join sys.schemas sch on pt.typnamespace = sch.schema_id
     WHERE 
-    pt.typnamespace in (select schema_id from sys.schemas) 
-    and (pt.typtype = 'c' AND dep.deptype = 'i'  AND pc.relkind = 'r')
-;
+    (pt.typtype = 'c' AND dep.deptype = 'i' AND pt.oid = dep.refobjid AND dep.deptype = 'i'
+    AND dep.classid = 'pg_catalog.pg_class'::regclass AND dep.refclassid = 'pg_catalog.pg_type'::regclass);
 
 create or replace view sys.tables as
 select
@@ -1040,21 +1043,20 @@ left join pg_catalog.pg_locks         blocking_locks
 GRANT SELECT ON sys.sysprocesses TO PUBLIC;
 
 create or replace view sys.types As
-with type_code_list as
+with tt_internal as MATERIALIZED
 (
-    select distinct  pg_typname as pg_type_name, tsql_typname as tsql_type_name
-    from sys.babelfish_typecode_list()
+  Select * from sys.table_types_internal
 )
 -- For System types
 select 
-  ti.tsql_type_name as name
+  tsql_type_name as name
   , t.oid as system_type_id
   , t.oid as user_type_id
   , s.oid as schema_id
   , cast(NULL as INT) as principal_id
-  , sys.tsql_type_max_length_helper(ti.tsql_type_name, t.typlen, t.typtypmod, true) as max_length
-  , cast(sys.tsql_type_precision_helper(ti.tsql_type_name, t.typtypmod) as int) as precision
-  , cast(sys.tsql_type_scale_helper(ti.tsql_type_name, t.typtypmod, false) as int) as scale
+  , sys.tsql_type_max_length_helper(tsql_type_name, t.typlen, t.typtypmod, true) as max_length
+  , cast(sys.tsql_type_precision_helper(tsql_type_name, t.typtypmod) as int) as precision
+  , cast(sys.tsql_type_scale_helper(tsql_type_name, t.typtypmod, false) as int) as scale
   , CASE c.collname
     WHEN 'default' THEN default_collation_name
     ELSE  c.collname
@@ -1067,11 +1069,11 @@ select
   , 0 as is_table_type
 from pg_type t
 inner join pg_namespace s on s.oid = t.typnamespace
-inner join type_code_list ti on t.typname = ti.pg_type_name
 left join pg_collation c on c.oid = t.typcollation
+,sys.translate_pg_type_to_tsql(t.oid) AS tsql_type_name
 ,cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
 where
-ti.tsql_type_name IS NOT NULL  
+tsql_type_name IS NOT NULL
 and pg_type_is_visible(t.oid)
 and (s.nspname = 'pg_catalog' OR s.nspname = 'sys')
 union all 
@@ -1100,15 +1102,12 @@ select cast(t.typname as text) as name
   , case when tt.typrelid is not null then 1 else 0 end as is_table_type
 from pg_type t
 join sys.schemas sch on t.typnamespace = sch.schema_id
-left join type_code_list ti on t.typname = ti.pg_type_name
 left join pg_collation c on c.oid = t.typcollation
-left join sys.table_types_internal tt on t.typrelid = tt.typrelid
+left join tt_internal tt on t.typrelid = tt.typrelid
 , sys.translate_pg_type_to_tsql(t.typbasetype) AS tsql_base_type_name
 , cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
 -- we want to show details of user defined datatypes created under babelfish database
 where 
- ti.tsql_type_name IS NULL
-and
   (
     -- show all user defined datatypes created under babelfish database except table types
     t.typtype = 'd'

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1,19 +1,16 @@
 /* Tsql system catalog views */
 
 /*
- * We do not need to join with pg_class since we can check the dependent class-id in
- * pg_depend directly.
  * Note: this view, although written efficiently might cause perfomance degradation when
  * joined with other system objects. One should try to use them as part of a materialized CTE.
  */
 create or replace view sys.table_types_internal as
 SELECT pt.typrelid
     FROM pg_catalog.pg_type pt
-    INNER JOIN pg_catalog.pg_depend dep ON pt.typrelid = dep.objid
     INNER join sys.schemas sch on pt.typnamespace = sch.schema_id
-    WHERE 
-    (pt.typtype = 'c' AND dep.deptype = 'i' AND pt.oid = dep.refobjid AND dep.deptype = 'i'
-    AND dep.classid = 'pg_catalog.pg_class'::regclass AND dep.refclassid = 'pg_catalog.pg_type'::regclass);
+    INNER JOIN pg_catalog.pg_depend dep ON pt.typrelid = dep.objid
+    INNER JOIN pg_catalog.pg_class pc ON pc.oid = dep.objid
+    WHERE pt.typtype = 'c' AND dep.deptype = 'i'  AND pc.relkind = 'r';
 
 create or replace view sys.tables as
 select

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -560,7 +560,7 @@ where
     tt.typrelid is not null  
   );
 GRANT SELECT ON sys.types TO PUBLIC;
-=======
+
 CREATE OR REPLACE PROCEDURE sys.sp_addlinkedsrvlogin( IN "@rmtsrvname" sys.sysname,
                                                       IN "@useself" sys.varchar(8) DEFAULT 'TRUE',
                                                       IN "@locallogin" sys.sysname DEFAULT NULL,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -480,11 +480,10 @@ GRANT SELECT ON information_schema_tsql.SEQUENCES TO PUBLIC;
 create or replace view sys.table_types_internal as
 SELECT pt.typrelid
     FROM pg_catalog.pg_type pt
-    INNER JOIN pg_catalog.pg_depend dep ON pt.typrelid = dep.objid
     INNER join sys.schemas sch on pt.typnamespace = sch.schema_id
-    WHERE 
-    (pt.typtype = 'c' AND dep.deptype = 'i' AND pt.oid = dep.refobjid AND dep.deptype = 'i'
-    AND dep.classid = 'pg_catalog.pg_class'::regclass AND dep.refclassid = 'pg_catalog.pg_type'::regclass);
+    INNER JOIN pg_catalog.pg_depend dep ON pt.typrelid = dep.objid
+    INNER JOIN pg_catalog.pg_class pc ON pc.oid = dep.objid
+    WHERE pt.typtype = 'c' AND dep.deptype = 'i'  AND pc.relkind = 'r';
 
 create or replace view sys.types As
 with tt_internal as MATERIALIZED

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -477,6 +477,90 @@ CREATE OR REPLACE VIEW information_schema_tsql.SEQUENCES AS
 
 GRANT SELECT ON information_schema_tsql.SEQUENCES TO PUBLIC;
 
+create or replace view sys.table_types_internal as
+SELECT pt.typrelid
+    FROM pg_catalog.pg_type pt
+    INNER JOIN pg_catalog.pg_depend dep ON pt.typrelid = dep.objid
+    INNER join sys.schemas sch on pt.typnamespace = sch.schema_id
+    WHERE 
+    (pt.typtype = 'c' AND dep.deptype = 'i' AND pt.oid = dep.refobjid AND dep.deptype = 'i'
+    AND dep.classid = 'pg_catalog.pg_class'::regclass AND dep.refclassid = 'pg_catalog.pg_type'::regclass);
+
+create or replace view sys.types As
+with tt_internal as MATERIALIZED
+(
+  Select * from sys.table_types_internal
+)
+-- For System types
+select 
+  tsql_type_name as name
+  , t.oid as system_type_id
+  , t.oid as user_type_id
+  , s.oid as schema_id
+  , cast(NULL as INT) as principal_id
+  , sys.tsql_type_max_length_helper(tsql_type_name, t.typlen, t.typtypmod, true) as max_length
+  , cast(sys.tsql_type_precision_helper(tsql_type_name, t.typtypmod) as int) as precision
+  , cast(sys.tsql_type_scale_helper(tsql_type_name, t.typtypmod, false) as int) as scale
+  , CASE c.collname
+    WHEN 'default' THEN default_collation_name
+    ELSE  c.collname
+    END as collation_name
+  , case when typnotnull then 0 else 1 end as is_nullable
+  , 0 as is_user_defined
+  , 0 as is_assembly_type
+  , 0 as default_object_id
+  , 0 as rule_object_id
+  , 0 as is_table_type
+from pg_type t
+inner join pg_namespace s on s.oid = t.typnamespace
+left join pg_collation c on c.oid = t.typcollation
+,sys.translate_pg_type_to_tsql(t.oid) AS tsql_type_name
+,cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
+where
+tsql_type_name IS NOT NULL
+and pg_type_is_visible(t.oid)
+and (s.nspname = 'pg_catalog' OR s.nspname = 'sys')
+union all 
+-- For User Defined Types
+select cast(t.typname as text) as name
+  , t.typbasetype as system_type_id
+  , t.oid as user_type_id
+  , t.typnamespace as schema_id
+  , null::integer as principal_id
+  , case when tt.typrelid is not null then -1::smallint else sys.tsql_type_max_length_helper(tsql_base_type_name, t.typlen, t.typtypmod) end as max_length
+  , case when tt.typrelid is not null then 0::smallint else cast(sys.tsql_type_precision_helper(tsql_base_type_name, t.typtypmod) as int) end as precision
+  , case when tt.typrelid is not null then 0::smallint else cast(sys.tsql_type_scale_helper(tsql_base_type_name, t.typtypmod, false) as int) end as scale
+  , CASE c.collname
+    WHEN 'default' THEN default_collation_name
+    ELSE  c.collname 
+    END as collation_name
+  , case when tt.typrelid is not null then 0
+         else case when typnotnull then 0 else 1 end
+    end
+    as is_nullable
+  -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
+  , 1 as is_user_defined
+  , 0 as is_assembly_type
+  , 0 as default_object_id
+  , 0 as rule_object_id
+  , case when tt.typrelid is not null then 1 else 0 end as is_table_type
+from pg_type t
+join sys.schemas sch on t.typnamespace = sch.schema_id
+left join pg_collation c on c.oid = t.typcollation
+left join tt_internal tt on t.typrelid = tt.typrelid
+, sys.translate_pg_type_to_tsql(t.typbasetype) AS tsql_base_type_name
+, cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
+-- we want to show details of user defined datatypes created under babelfish database
+where 
+  (
+    -- show all user defined datatypes created under babelfish database except table types
+    t.typtype = 'd'
+    or
+    -- only for table types
+    tt.typrelid is not null  
+  );
+GRANT SELECT ON sys.types TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -486,20 +486,25 @@ SELECT pt.typrelid
     WHERE pt.typtype = 'c' AND dep.deptype = 'i'  AND pc.relkind = 'r';
 
 create or replace view sys.types As
-with tt_internal as MATERIALIZED
+with RECURSIVE type_code_list as
+(
+    select distinct  pg_typname as pg_type_name, tsql_typname as tsql_type_name
+    from sys.babelfish_typecode_list()
+),
+tt_internal as MATERIALIZED
 (
   Select * from sys.table_types_internal
 )
 -- For System types
 select 
-  tsql_type_name as name
+  ti.tsql_type_name as name
   , t.oid as system_type_id
   , t.oid as user_type_id
   , s.oid as schema_id
   , cast(NULL as INT) as principal_id
-  , sys.tsql_type_max_length_helper(tsql_type_name, t.typlen, t.typtypmod, true) as max_length
-  , cast(sys.tsql_type_precision_helper(tsql_type_name, t.typtypmod) as int) as precision
-  , cast(sys.tsql_type_scale_helper(tsql_type_name, t.typtypmod, false) as int) as scale
+  , sys.tsql_type_max_length_helper(ti.tsql_type_name, t.typlen, t.typtypmod, true) as max_length
+  , cast(sys.tsql_type_precision_helper(ti.tsql_type_name, t.typtypmod) as int) as precision
+  , cast(sys.tsql_type_scale_helper(ti.tsql_type_name, t.typtypmod, false) as int) as scale
   , CASE c.collname
     WHEN 'default' THEN default_collation_name
     ELSE  c.collname
@@ -512,11 +517,11 @@ select
   , 0 as is_table_type
 from pg_type t
 inner join pg_namespace s on s.oid = t.typnamespace
+inner join type_code_list ti on t.typname = ti.pg_type_name
 left join pg_collation c on c.oid = t.typcollation
-,sys.translate_pg_type_to_tsql(t.oid) AS tsql_type_name
 ,cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
 where
-tsql_type_name IS NOT NULL
+ti.tsql_type_name IS NOT NULL  
 and pg_type_is_visible(t.oid)
 and (s.nspname = 'pg_catalog' OR s.nspname = 'sys')
 union all 
@@ -545,12 +550,15 @@ select cast(t.typname as text) as name
   , case when tt.typrelid is not null then 1 else 0 end as is_table_type
 from pg_type t
 join sys.schemas sch on t.typnamespace = sch.schema_id
+left join type_code_list ti on t.typname = ti.pg_type_name
 left join pg_collation c on c.oid = t.typcollation
 left join tt_internal tt on t.typrelid = tt.typrelid
 , sys.translate_pg_type_to_tsql(t.typbasetype) AS tsql_base_type_name
 , cast(current_setting('babelfishpg_tsql.server_collation_name') as name) as default_collation_name
 -- we want to show details of user defined datatypes created under babelfish database
 where 
+ ti.tsql_type_name IS NULL
+and
   (
     -- show all user defined datatypes created under babelfish database except table types
     t.typtype = 'd'


### PR DESCRIPTION
### Description
Earlier sys.types was performing poorly and was one of the reasons why other system objects which depend on it performed really bad and made the objects practically unusable. So to fix we need to rewrite sys.types. There were 2 parts to this rewrite:
1. Naked Select on sys.types took 2 hours on a baseline database.
2. Client side query which joins with sys.types, sys.all_columns and sys.tables, which runs fast with current implementation should not be impacted.

To resolve (1), it would be simple to directly rewrite sys.types to have dependency on only pg_catalog and not on babelfish objects. We achieved sub-second results for naked select but the query mentioned in (2) seemed to have been impacted negatively. The reason behind the impact was that optimizer was rewriting queries inefficiently when it came to the new implementation. To force the optimizer to not rewrite I have used materialized CTE which addresses both the issues.

Authored-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)
Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)


### Issues Resolved
BABEL-3841

### Perfomance Testing:

With original sys.types:
```
select  tbl.name AS [Name] , clmns.name , usrt.name as tname from sys.tables AS tbl inner join sys.all_columns as clmns on clmns.object_id = tbl.object_id inner join sys.types as usrt on usrt.user_type_id = clmns.user_type_id
(24492 rows affected)

4096:1:57831:57831.0:0.0 
```

With Modified sys.types

```
select  tbl.name AS [Name] , clmns.name , usrt.name as tname from sys.tables AS tbl inner join sys.all_columns as clmns on clmns.object_id = tbl.object_id inner join sys.types as usrt on usrt.user_type_id = clmns.user_type_id
(24492 rows affected)

4096:1:7443:7443.0:0.1 
```

### Test Scenarios Covered ###
TESTS ALREADY PRESENT IN THESE UPGRADE FILES:
sys-types-dep
sys-table_types
sys-table_types-dep

* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).