### PR TITLE
Fix indentation in minor version upgrade workflow

### DIFF
--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -39,19 +39,19 @@ jobs:
         if: always() && steps.compile-antlr.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions
 
-    - name: Build tds_fdw Extension
-      id: build-tds_fdw-extension
-      if: always() && steps.build-extensions-older.outcome == 'success'
-      run: |
-        cd ..
-        export TDS_FDW_VERSION="2.0.3"
-        sudo apt-get install wget
-        wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
-        tar -xvzf v${TDS_FDW_VERSION}.tar.gz
-        cd tds_fdw-${TDS_FDW_VERSION}/
-        make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config
-        sudo make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config install
-      shell: bash
+      - name: Build tds_fdw Extension
+        id: build-tds_fdw-extension
+        if: always() && steps.build-extensions-older.outcome == 'success'
+        run: |
+          cd ..
+          export TDS_FDW_VERSION="2.0.3"
+          sudo apt-get install wget
+          wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
+          tar -xvzf v${TDS_FDW_VERSION}.tar.gz
+          cd tds_fdw-${TDS_FDW_VERSION}/
+          make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config
+          sudo make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config install
+        shell: bash
 
       - name: Install extensions
         id: install-extensions-older


### PR DESCRIPTION
### Description

Due to incorrect indentation of one of the steps in the minor version upgrade workflow, the action was not running as part of checks. Fixed the same.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).