### PR TITLE
Fix install-dependencies github action

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -5,8 +5,17 @@ runs:
     - name: Install Dependencies
       run: |
         cd ~
-        sudo apt-get update
+        echo 'Acquire::Retries "10";
+        Acquire::https::Timeout "240";
+        Acquire::http::Timeout "240";
+        APT::Get::Assume-Yes "true";
+        APT::Install-Recommends "false";
+        APT::Install-Suggests "false";
+        Debug::Acquire::https "true";
+        ' | sudo tee -a /etc/apt/apt.conf.d/99custom
+        sudo apt clean && sudo apt-get update --fix-missing -y
         curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+        sudo apt-get update --fix-missing -y
         sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison mssql-tools unixodbc-dev
       shell: bash

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/sys-all_views-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/sys-all_views-vu-verify.sql
@@ -1,4 +1,3 @@
--- sla 10000
 SELECT * FROM sys_all_views_dep_view_vu_prepare
 GO
 

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_8/sys-all_views-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_8/sys-all_views-vu-verify.sql
@@ -1,4 +1,3 @@
--- sla 10000
 SELECT * FROM sys_all_views_dep_view_vu_prepare
 GO
 

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_9/sys-all_views-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_9/sys-all_views-vu-verify.sql
@@ -1,4 +1,3 @@
--- sla 10000
 SELECT * FROM sys_all_views_dep_view_vu_prepare
 GO
 

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/sys-all_views-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/sys-all_views-vu-verify.sql
@@ -1,4 +1,3 @@
--- sla 10000
 SELECT * FROM sys_all_views_dep_view_vu_prepare
 GO
 


### PR DESCRIPTION
### Description

- Modified install-dependencies composite action to retry 10 times before failing.

Task: BABEL-OSS
Signed-off-by: Rishabh Tanwar ritanwar@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).