### PR TITLE
Safe Gaurd the stack using (-fstack-protector-strong) compiler flag 

### DIFF
--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -13,7 +13,7 @@ MODULEPATH = $$libdir/$(EXTENSION)-$(BBFPGCMN_MAJOR_VERSION)
 MODULE_big = $(EXTENSION)
 
 PG_CFLAGS += -g -Werror
-
+PG_CFLAGS += -fstack-protector-strong
 ifdef PREV_EXTVERSION
 DATA = sql/$(EXTENSION)--$(PREV_EXTVERSION).sql
 endif

--- a/contrib/babelfishpg_money/Makefile
+++ b/contrib/babelfishpg_money/Makefile
@@ -12,7 +12,7 @@ DATA_built = babelfishpg_money--1.1.0.sql
 
 CFLAGS = `$(PG_CONFIG) --includedir-server`
 PG_CFLAGS += -Werror
-
+PG_CFLAGS += -fstack-protector-strong
 TESTS = $(wildcard test/sql/*.sql)
 
 REGRESS_BRIN := $(shell LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(PG_CONFIG) --version | grep -qE "XL 9\.[5-9]| 10\.0| 11\.[0-9]| 12\.[0-9]" && echo brin-xl)

--- a/contrib/babelfishpg_tds/Makefile
+++ b/contrib/babelfishpg_tds/Makefile
@@ -10,6 +10,7 @@ tds_include = $(tds_top_dir)/src/include
 TSQL_SRC = ../babelfishpg_tsql
 
 PG_CFLAGS += -Werror
+PG_CFLAGS += -fstack-protector-strong
 PG_CPPFLAGS += -I$(TSQL_SRC) -I$(PG_SRC) -I$(tds_top_dir) -DFAULT_INJECTOR
 
 # Exclude the following files from the build (sometimes these

--- a/contrib/babelfishpg_tds/src/backend/fault_injection/fault_injection_tests.c
+++ b/contrib/babelfishpg_tds/src/backend/fault_injection/fault_injection_tests.c
@@ -22,6 +22,9 @@
 #include "src/include/tds_request.h"
 #include "src/include/faultinjection.h"
 
+#include <stdio.h>
+#include <string.h>
+
 /* test cases */
 static void
 test_fault1(void *arg, int *num_occurrences)
@@ -229,6 +232,18 @@ throw_error_comm(void *arg, int *num_occurrences)
 	elog(FATAL, "FATAL error triggered from fault injection");
 }
 
+static void
+throw_error_buffer(void *arg ,int *num_occurrences)
+{
+	char buffer[3] = {'\0'};
+	int can = 0;
+	char tem[10]="aaaaaaaaaa";
+	memcpy(buffer,tem,10);
+	if (can !=0)
+	elog(LOG,"Buffer overflowed \n");
+	else
+	elog(LOG,"Did not Overflow \n");
+}
 /*
  * Type declarations
  *
@@ -264,5 +279,6 @@ TEST_LIST = {
 	{"parsing_tamper_rpc_parameter_datatype", ParseRpcType, 0, &parsing_tamper_rpc_parameter_datatype},
 	{"pre_parsing_throw_error", PreParsingType, 0, &throw_error},
 	{"post_parsing_throw_error", PostParsingType, 0, &throw_error},
+	{"buffer_overflow_test",PreParsingType,0, &throw_error_buffer},
 	{"", InvalidType, 0, NULL} /* keep this as last */
 };

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -80,6 +80,7 @@ PG_CXXFLAGS += -Wno-undef -Wall -Wcpp
 PG_CXXFLAGS += -Wno-register # otherwise C++17 gags on PostgreSQL headers
 PG_CXXFLAGS += -I$(ANTLR4_RUNTIME_INCLUDE_DIR)
 PG_CFLAGS += -g -Werror
+PG_CFLAGS += -fstack-protector-strong
 PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -DFAULT_INJECTOR
 
 SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto

--- a/test/JDBC/expected/babel_tds_fault_injection.out
+++ b/test/JDBC/expected/babel_tds_fault_injection.out
@@ -166,8 +166,14 @@ select inject_fault('pre_parsing_tamper_request');
 select inject_fault('pre_parsing_tamper_rpc_request_sptype');
 select inject_fault('parsing_tamper_rpc_parameter_datatype');
 select inject_fault('pre_parsing_throw_error');
+select inject_fault('buffer_overflow_test');
 select inject_fault('post_parsing_throw_error');
 GO
+~~START~~
+text
+enabled, pending occurrences: 1
+~~END~~
+
 ~~START~~
 text
 enabled, pending occurrences: 1
@@ -322,6 +328,15 @@ disabled, Type: TDS post-parsing
 
 -- should be disabled
 select inject_fault_status('pre_parsing_throw_error');
+go
+~~START~~
+text
+disabled, Type: TDS pre-parsing
+~~END~~
+
+
+-- should be disabled
+select inject_fault_status('buffer_overflow_test');
 go
 ~~START~~
 text

--- a/test/JDBC/input/babel_tds_fault_injection.sql
+++ b/test/JDBC/input/babel_tds_fault_injection.sql
@@ -71,6 +71,7 @@ select inject_fault('pre_parsing_tamper_request');
 select inject_fault('pre_parsing_tamper_rpc_request_sptype');
 select inject_fault('parsing_tamper_rpc_parameter_datatype');
 select inject_fault('pre_parsing_throw_error');
+select inject_fault('buffer_overflow_test');
 select inject_fault('post_parsing_throw_error');
 GO
 
@@ -129,6 +130,10 @@ go
 
 -- should be disabled
 select inject_fault_status('pre_parsing_throw_error');
+go
+
+-- should be disabled
+select inject_fault_status('buffer_overflow_test');
 go
 
 -- should be disabled


### PR DESCRIPTION
### Description

Previously there was no compiler flags related to safegaurding of stack which may lead to buffer overflow . It is resolved by adding -fstack-protector-strong flag to each makefile of babelfish extension.

Task: BABEL-3581

Signed-off-by: Ashish Prasad <pashisht@amazon.com>

### Issues Resolved
BABEL-3581

### Testing  ###
Added testcase in fault injection framework.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).