### PR TITLE
Added test for Keep Nulls Insert Bulk

### DIFF
--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -358,6 +358,9 @@ bcp -w#!#in#!#bcp_source#!#destinationTable
 #Q#Insert into sourceTable values (NULL, 1);
 #Q#Insert into sourceTable values (NULL, NULL);
 #Q#Insert into sourceTable(a) values (2);
+#Q#Insert into sourceTable(b) values (2);
+#Q#Insert into sourceTable(a) values (3);
+#Q#Insert into sourceTable values (4, NULL);
 bcp -k#!#out#!#bcp_source#!#sourceTable
 bcp -k#!#in#!#bcp_source#!#destinationTable1
 bcp#!#in#!#bcp_source#!#destinationTable2
@@ -368,6 +371,9 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #!#1
 #!#
 2#!#
+#!#2
+3#!#
+4#!#
 #Q#Select * from destinationTable1
 #D#int#!#int
 1#!#1
@@ -375,6 +381,9 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #!#1
 #!#
 2#!#
+#!#2
+3#!#
+4#!#
 #Q#Select * from destinationTable2
 #D#int#!#int
 1#!#1
@@ -382,6 +391,15 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #!#1
 #!#4
 2#!#4
+#!#2
+3#!#4
+4#!#4
+#Q#select count(*) from destinationTable1 where b is NULL
+#D#int
+5
+#Q#select count(*) from destinationTable2 where b is NULL
+#D#int
+0
 #Q#drop table sourceTable
 #Q#drop table destinationTable1
 #Q#drop table destinationTable2
@@ -393,6 +411,9 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #Q#Insert into sourceTable values (NULL, 1);
 #Q#Insert into sourceTable values (NULL, NULL);
 #Q#Insert into sourceTable(a) values (2);
+#Q#Insert into sourceTable(b) values (2);
+#Q#Insert into sourceTable(a) values (3);
+#Q#Insert into sourceTable values (4, NULL);
 bcp -k#!#out#!#bcp_source#!#sourceTable
 bcp -k#!#in#!#bcp_source#!#destinationTable1
 bcp#!#in#!#bcp_source#!#destinationTable2
@@ -403,6 +424,9 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #!#1
 #!#
 2#!#4
+#!#2
+3#!#4
+4#!#
 #Q#Select * from destinationTable1
 #D#int#!#int
 1#!#1
@@ -410,6 +434,9 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #!#1
 #!#
 2#!#4
+#!#2
+3#!#4
+4#!#
 #Q#Select * from destinationTable2
 #D#int#!#int
 1#!#1
@@ -417,6 +444,15 @@ bcp#!#in#!#bcp_source#!#destinationTable2
 #!#1
 #!#4
 2#!#4
+#!#2
+3#!#4
+4#!#4
+#Q#select count(*) from destinationTable1 where b is NULL
+#D#int
+3
+#Q#select count(*) from destinationTable2 where b is NULL
+#D#int
+0
 #Q#drop table sourceTable
 #Q#drop table destinationTable1
 #Q#drop table destinationTable2

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -275,12 +275,17 @@ Insert into sourceTable values (1, NULL);
 Insert into sourceTable values (NULL, 1);
 Insert into sourceTable values (NULL, NULL);
 Insert into sourceTable(a) values (2);
+Insert into sourceTable(b) values (2);
+Insert into sourceTable(a) values (3);
+Insert into sourceTable values (4, NULL);
 bcp -k#!#out#!#bcp_source#!#sourceTable
 bcp -k#!#in#!#bcp_source#!#destinationTable1
 bcp#!#in#!#bcp_source#!#destinationTable2
 Select * from sourceTable
 Select * from destinationTable1
 Select * from destinationTable2
+select count(*) from destinationTable1 where b is NULL
+select count(*) from destinationTable2 where b is NULL
 drop table sourceTable
 drop table destinationTable1
 drop table destinationTable2
@@ -293,12 +298,17 @@ Insert into sourceTable values (1, NULL);
 Insert into sourceTable values (NULL, 1);
 Insert into sourceTable values (NULL, NULL);
 Insert into sourceTable(a) values (2);
+Insert into sourceTable(b) values (2);
+Insert into sourceTable(a) values (3);
+Insert into sourceTable values (4, NULL);
 bcp -k#!#out#!#bcp_source#!#sourceTable
 bcp -k#!#in#!#bcp_source#!#destinationTable1
 bcp#!#in#!#bcp_source#!#destinationTable2
 Select * from sourceTable
 Select * from destinationTable1
 Select * from destinationTable2
+select count(*) from destinationTable1 where b is NULL
+select count(*) from destinationTable2 where b is NULL
 drop table sourceTable
 drop table destinationTable1
 drop table destinationTable2


### PR DESCRIPTION
2_X PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1200
Signed-off-by: Shlok Kumar Kyal (skkyal@amazon.com)

### Description
Added some test case for Keep Nulls option in Insert Bulk

### Issues Resolved
BABEL-3245

### Test Scenarios Covered ###
* **Use case based -**
Added testcase to check NULLs count

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).