### PR TITLE
Add support to use sys-apt2 to avoid mirror issues while fetching dependencies

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -5,14 +5,17 @@ runs:
     - name: Install Dependencies
       run: |
         cd ~
-        echo 'Acquire::Retries "10";
-        Acquire::https::Timeout "240";
-        Acquire::http::Timeout "240";
-        APT::Get::Assume-Yes "true";
-        APT::Install-Recommends "false";
-        APT::Install-Suggests "false";
-        Debug::Acquire::https "true";
-        ' | sudo tee -a /etc/apt/apt.conf.d/99custom
+        # echo 'Acquire::Retries "10";
+        # Acquire::https::Timeout "240";
+        # Acquire::http::Timeout "240";
+        # APT::Get::Assume-Yes "true";
+        # APT::Install-Recommends "false";
+        # APT::Install-Suggests "false";
+        # Debug::Acquire::https "true";
+        # ' | sudo tee -a /etc/apt/apt.conf.d/99custom
+        sudo gem install apt-spy2
+        sudo apt-spy2 check
+        sudo apt-spy2 fix --commit
         sudo apt clean && sudo apt-get update --fix-missing -y
         curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list

--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -4,15 +4,6 @@ runs:
   steps:
     - name: Install Dependencies
       run: |
-        cd ~
-        # echo 'Acquire::Retries "10";
-        # Acquire::https::Timeout "240";
-        # Acquire::http::Timeout "240";
-        # APT::Get::Assume-Yes "true";
-        # APT::Install-Recommends "false";
-        # APT::Install-Suggests "false";
-        # Debug::Acquire::https "true";
-        # ' | sudo tee -a /etc/apt/apt.conf.d/99custom
         sudo gem install apt-spy2
         sudo apt-spy2 check
         sudo apt-spy2 fix --commit


### PR DESCRIPTION
### Description
Add support to use sys-apt2 to avoid mirror issues while fetching dependencies

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>
### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).