### PR TITLE
Properly ending scan and closing table for additional check if login is DB user when adding to sysadmin

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1723,7 +1723,9 @@ has_user_in_db(const char *login, char **db_name)
 								  bbf_authid_user_ext_rel->rd_att, &is_null);
 
 		*db_name = pstrdup(TextDatumGetCString(name));
-
+		
+		table_endscan(scan);
+		table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
 		return true;
 	}
 	table_endscan(scan);


### PR DESCRIPTION
Previously, the opened table and scan were not terminated properly on one condition, which have a risk of handle leak. Now those issues are properly managed.

Signed-off-by: Ray Kim <raydhkim@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).