### PR TITLE
CREATE PROCEDURE with morethan 1 parameter and WITH-clause is not working as expected

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2750,9 +2750,9 @@ rewriteBatchLevelStatement(
 	else if (ctx->create_or_alter_procedure())
 	{
 		auto cctx = ctx->create_or_alter_procedure();
-		size_t num_commas_in_procedure_param = cctx->COMMA().size();
 		if (cctx->WITH())
 		{
+			size_t num_commas_in_procedure_param = cctx->COMMA().size();
 			auto options = cctx->procedure_option();
 			/* COMMA is shared between procedure-param and WITH-clause. calculate the number of COMMA so that it can be removed properly */
 			num_commas_in_procedure_param -= (cctx->procedure_option().size() - 1);
@@ -2779,14 +2779,19 @@ rewriteBatchLevelStatement(
 		/* DML trigger can have two WITH. one for trigger options and the other for WITH APPEND */
 		if (cctx->WITH().size() > 1 || (cctx->WITH().size() == 1 && !cctx->APPEND()))
 		{
+			size_t num_commas_in_dml_trigger_operaion = cctx->COMMA().size();
 			auto options = cctx->trigger_option();
+			/* COMMA is shared between dml_trigger_operation and WITH-clause. calculate the number of COMMA so that it can be removed properly */
+			num_commas_in_dml_trigger_operaion -= (cctx->trigger_option().size() - 1);
 			auto commas = cctx->COMMA();
+			std::vector<antlr4::tree::TerminalNode *> commas_in_with_clause;
+			commas_in_with_clause.insert(commas_in_with_clause.begin(), commas.begin() , commas.end() - num_commas_in_dml_trigger_operaion);
 			GetTokenFunc<TSqlParser::Trigger_optionContext*> getToken = [](TSqlParser::Trigger_optionContext* o) {
 				if (o->execute_as_clause())
 					return o->execute_as_clause()->CALLER();
 				return o->SCHEMABINDING();
 			};
-			bool all_removed = removeTokenFromOptionList(expr, options, commas, ctx, getToken);
+			bool all_removed = removeTokenFromOptionList(expr, options, commas_in_with_clause, ctx, getToken);
 			if (all_removed)
 				removeTokenStringFromQuery(expr, cctx->WITH(0), ctx);
 		}
@@ -2796,14 +2801,19 @@ rewriteBatchLevelStatement(
 		auto cctx = ctx->create_or_alter_trigger()->create_or_alter_ddl_trigger();
 		if (cctx->WITH())
 		{
+			size_t num_commas_in_ddl_trigger_operaion = cctx->COMMA().size();
 			auto options = cctx->trigger_option();
+			/* COMMA is shared between ddl_trigger_operation and WITH-clause. calculate the number of COMMA so that it can be removed properly */
+			num_commas_in_ddl_trigger_operaion -= (cctx->trigger_option().size() - 1);
 			auto commas = cctx->COMMA();
+			std::vector<antlr4::tree::TerminalNode *> commas_in_with_clause;
+			commas_in_with_clause.insert(commas_in_with_clause.begin(), commas.begin() , commas.end() - num_commas_in_ddl_trigger_operaion);
 			GetTokenFunc<TSqlParser::Trigger_optionContext*> getToken = [](TSqlParser::Trigger_optionContext* o) {
 				if (o->execute_as_clause())
 					return o->execute_as_clause()->CALLER();
 				return o->SCHEMABINDING();
 			};
-			bool all_removed = removeTokenFromOptionList(expr, options, commas, ctx, getToken);
+			bool all_removed = removeTokenFromOptionList(expr, options, commas_in_with_clause, ctx, getToken);
 			if (all_removed)
 				removeTokenStringFromQuery(expr, cctx->WITH(), ctx);
 		}

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-cleanup.out
@@ -1,4 +1,7 @@
 DROP TRIGGER babel_execute_as_caller_trigger1;
+DROP PROCEDURE babel_execute_as_caller_procedure_6;
+DROP PROCEDURE babel_execute_as_caller_procedure_5;
+DROP PROCEDURE babel_execute_as_caller_procedure_4;
 DROP PROCEDURE babel_execute_as_caller_procedure_3;
 DROP PROCEDURE babel_execute_as_caller_procedure_2;
 DROP PROCEDURE babel_execute_as_caller_procedure_1;

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-cleanup.out
@@ -1,3 +1,4 @@
+DROP TRIGGER babel_execute_as_caller_trigger4;
 DROP TRIGGER babel_execute_as_caller_trigger3;
 DROP TRIGGER babel_execute_as_caller_trigger2;
 DROP TRIGGER babel_execute_as_caller_trigger1;

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-cleanup.out
@@ -1,3 +1,5 @@
+DROP TRIGGER babel_execute_as_caller_trigger3;
+DROP TRIGGER babel_execute_as_caller_trigger2;
 DROP TRIGGER babel_execute_as_caller_trigger1;
 DROP PROCEDURE babel_execute_as_caller_procedure_6;
 DROP PROCEDURE babel_execute_as_caller_procedure_5;
@@ -5,6 +7,7 @@ DROP PROCEDURE babel_execute_as_caller_procedure_4;
 DROP PROCEDURE babel_execute_as_caller_procedure_3;
 DROP PROCEDURE babel_execute_as_caller_procedure_2;
 DROP PROCEDURE babel_execute_as_caller_procedure_1;
+DROP FUNCTION babel_execute_as_caller_function_return_int_7;
 DROP FUNCTION babel_execute_as_caller_function_return_int_6;
 DROP FUNCTION babel_execute_as_caller_function_return_int_5;
 DROP FUNCTION babel_execute_as_caller_function_return_int_4;

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-prepare.out
@@ -148,6 +148,21 @@ GO
 ~~ERROR (Message: 'EXECUTE AS SELF|OWNER|<user>|<login>' is not currently supported in Babelfish)~~
 
 
+-- triggers with more than 1 trigger option and with-clause
+CREATE TRIGGER babel_execute_as_caller_trigger2 on babel_execute_as_caller_table WITH EXECUTE AS CALLER AFTER INSERT, DELETE
+AS
+BEGIN
+  SELECT 'babel_execute_as_caller_trigger2 invoked'
+END
+GO
+
+CREATE TRIGGER babel_execute_as_caller_trigger3 on babel_execute_as_caller_table WITH EXECUTE AS CALLER, SCHEMABINDING AFTER INSERT, DELETE
+AS
+BEGIN
+  SELECT 'babel_execute_as_caller_trigger3 invoked'
+END
+GO
+
 -- create function with duplicate execute as caller
 CREATE FUNCTION babel_execute_as_caller_function_return_int_3 (@v int) RETURNS INT WITH EXECUTE AS CALLER, EXECUTE AS CALLER AS BEGIN RETURN @v+1 END;
 GO
@@ -160,6 +175,9 @@ CREATE FUNCTION babel_execute_as_caller_function_return_int_5 (@v int) RETURNS I
 GO
 
 CREATE FUNCTION babel_execute_as_caller_function_return_int_6 (@v int) RETURNS INT WITH RETURNS NULL ON NULL INPUT, EXECUTE AS CALLER, SCHEMABINDING AS BEGIN RETURN @v+1 END;
+GO
+
+CREATE FUNCTION babel_execute_as_caller_function_return_int_7 (@v int, @a varchar, @i int) RETURNS INT WITH RETURNS NULL ON NULL INPUT, EXECUTE AS CALLER, SCHEMABINDING AS BEGIN RETURN @v+1 END;
 GO
 
 CREATE FUNCTION babel_execute_as_caller_function_return_table_1(@i int) returns @tableVar table(a text not null) WITH schemabinding, execute as caller as begin return end

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-prepare.out
@@ -121,6 +121,19 @@ CREATE PROCEDURE babel_execute_as_caller_procedure_3 (@v int) WITH EXECUTE AS CA
 BEGIN PRINT CAST(@v AS VARCHAR(10)) END;
 GO
 
+-- procedures with more than 1 argument and with-clause
+CREATE PROCEDURE babel_execute_as_caller_procedure_4 (@arg1 int, @arg2 varchar(10)) WITH EXECUTE AS CALLER AS
+BEGIN SELECT @arg1,@arg2 END;
+GO
+
+CREATE PROCEDURE babel_execute_as_caller_procedure_5 (@arg1 int, @arg2 varchar(10), @arg3 int) WITH EXECUTE AS CALLER, SCHEMABINDING AS
+BEGIN SELECT @arg1, @arg2, @arg3 END;
+GO
+
+CREATE PROCEDURE babel_execute_as_caller_procedure_6 @arg1 int, @arg2 varchar(10), @arg3 int WITH EXECUTE AS CALLER, SCHEMABINDING AS
+BEGIN SELECT @arg1, @arg2, @arg3 END;
+GO
+
 -- trigger
 CREATE TABLE babel_execute_as_caller_table_1 (c varchar(20));
 GO

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-prepare.out
@@ -163,6 +163,22 @@ BEGIN
 END
 GO
 
+CREATE TRIGGER babel_execute_as_caller_trigger4 on babel_execute_as_caller_table WITH EXECUTE AS CALLER, SCHEMABINDING AFTER UPDATE, INSERT, DELETE
+AS
+BEGIN
+  SELECT 'babel_execute_as_caller_trigger4 invoked'
+END
+GO
+
+-- DML triggers aren't supported yet
+-- When supported the corner case of having more terigger_options and has WITH-clause should succeed
+CREATE TRIGGER trg_index_changes ON DATABASE WITH EXECUTE AS CALLER, SCHEMABINDING FOR  CREATE_INDEX, DROP_INDEX as begin insert into index_logs(a,b) values (1,2); end
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DDL trigger' is not currently supported in Babelfish)~~
+
+
 -- create function with duplicate execute as caller
 CREATE FUNCTION babel_execute_as_caller_function_return_int_3 (@v int) RETURNS INT WITH EXECUTE AS CALLER, EXECUTE AS CALLER AS BEGIN RETURN @v+1 END;
 GO

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-verify.out
@@ -78,6 +78,16 @@ INSERT INTO babel_execute_as_caller_table values (2);
 GO
 ~~ROW COUNT: 1~~
 
+~~START~~
+varchar
+babel_execute_as_caller_trigger2 invoked
+~~END~~
+
+~~START~~
+varchar
+babel_execute_as_caller_trigger3 invoked
+~~END~~
+
 ~~ROW COUNT: 1~~
 
 SELECT * FROM babel_execute_as_caller_table_1;
@@ -118,5 +128,13 @@ GO
 ~~START~~
 int
 7
+~~END~~
+
+
+SELECT babel_execute_as_caller_function_return_int_7(7, 'test', 5)
+GO
+~~START~~
+int
+8
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-verify.out
@@ -88,6 +88,11 @@ varchar
 babel_execute_as_caller_trigger3 invoked
 ~~END~~
 
+~~START~~
+varchar
+babel_execute_as_caller_trigger4 invoked
+~~END~~
+
 ~~ROW COUNT: 1~~
 
 SELECT * FROM babel_execute_as_caller_table_1;

--- a/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXECUTE_AS_CALLER-vu-verify.out
@@ -48,6 +48,31 @@ int
 ~~END~~
 
 
+-- procedures with more than 1 argument and with-clause
+EXEC babel_execute_as_caller_procedure_4 4, 'test'
+GO
+~~START~~
+int#!#varchar
+4#!#test
+~~END~~
+
+
+EXEC babel_execute_as_caller_procedure_5 5, 'test', 0
+GO
+~~START~~
+int#!#varchar#!#int
+5#!#test#!#0
+~~END~~
+
+
+EXEC babel_execute_as_caller_procedure_6 6, 'test', 0
+GO
+~~START~~
+int#!#varchar#!#int
+6#!#test#!#0
+~~END~~
+
+
 -- triggers
 INSERT INTO babel_execute_as_caller_table values (2);
 GO

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-cleanup.sql
@@ -1,4 +1,7 @@
 DROP TRIGGER babel_execute_as_caller_trigger1;
+DROP PROCEDURE babel_execute_as_caller_procedure_6;
+DROP PROCEDURE babel_execute_as_caller_procedure_5;
+DROP PROCEDURE babel_execute_as_caller_procedure_4;
 DROP PROCEDURE babel_execute_as_caller_procedure_3;
 DROP PROCEDURE babel_execute_as_caller_procedure_2;
 DROP PROCEDURE babel_execute_as_caller_procedure_1;

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-cleanup.sql
@@ -1,3 +1,4 @@
+DROP TRIGGER babel_execute_as_caller_trigger4;
 DROP TRIGGER babel_execute_as_caller_trigger3;
 DROP TRIGGER babel_execute_as_caller_trigger2;
 DROP TRIGGER babel_execute_as_caller_trigger1;

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-cleanup.sql
@@ -1,3 +1,5 @@
+DROP TRIGGER babel_execute_as_caller_trigger3;
+DROP TRIGGER babel_execute_as_caller_trigger2;
 DROP TRIGGER babel_execute_as_caller_trigger1;
 DROP PROCEDURE babel_execute_as_caller_procedure_6;
 DROP PROCEDURE babel_execute_as_caller_procedure_5;
@@ -5,6 +7,7 @@ DROP PROCEDURE babel_execute_as_caller_procedure_4;
 DROP PROCEDURE babel_execute_as_caller_procedure_3;
 DROP PROCEDURE babel_execute_as_caller_procedure_2;
 DROP PROCEDURE babel_execute_as_caller_procedure_1;
+DROP FUNCTION babel_execute_as_caller_function_return_int_7;
 DROP FUNCTION babel_execute_as_caller_function_return_int_6;
 DROP FUNCTION babel_execute_as_caller_function_return_int_5;
 DROP FUNCTION babel_execute_as_caller_function_return_int_4;

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-prepare.sql
@@ -114,6 +114,21 @@ CREATE TRIGGER babel_execute_as_caller_trigger1 ON babel_execute_as_caller_table
 FOR INSERT AS BEGIN UPDATE babel_execute_as_caller_table SET c1 =10 END
 GO
 
+-- triggers with more than 1 trigger option and with-clause
+CREATE TRIGGER babel_execute_as_caller_trigger2 on babel_execute_as_caller_table WITH EXECUTE AS CALLER AFTER INSERT, DELETE
+AS
+BEGIN
+  SELECT 'babel_execute_as_caller_trigger2 invoked'
+END
+GO
+
+CREATE TRIGGER babel_execute_as_caller_trigger3 on babel_execute_as_caller_table WITH EXECUTE AS CALLER, SCHEMABINDING AFTER INSERT, DELETE
+AS
+BEGIN
+  SELECT 'babel_execute_as_caller_trigger3 invoked'
+END
+GO
+
 -- create function with duplicate execute as caller
 CREATE FUNCTION babel_execute_as_caller_function_return_int_3 (@v int) RETURNS INT WITH EXECUTE AS CALLER, EXECUTE AS CALLER AS BEGIN RETURN @v+1 END;
 GO
@@ -126,6 +141,9 @@ CREATE FUNCTION babel_execute_as_caller_function_return_int_5 (@v int) RETURNS I
 GO
 
 CREATE FUNCTION babel_execute_as_caller_function_return_int_6 (@v int) RETURNS INT WITH RETURNS NULL ON NULL INPUT, EXECUTE AS CALLER, SCHEMABINDING AS BEGIN RETURN @v+1 END;
+GO
+
+CREATE FUNCTION babel_execute_as_caller_function_return_int_7 (@v int, @a varchar, @i int) RETURNS INT WITH RETURNS NULL ON NULL INPUT, EXECUTE AS CALLER, SCHEMABINDING AS BEGIN RETURN @v+1 END;
 GO
 
 CREATE FUNCTION babel_execute_as_caller_function_return_table_1(@i int) returns @tableVar table(a text not null) WITH schemabinding, execute as caller as begin return end

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-prepare.sql
@@ -91,6 +91,19 @@ CREATE PROCEDURE babel_execute_as_caller_procedure_3 (@v int) WITH EXECUTE AS CA
 BEGIN PRINT CAST(@v AS VARCHAR(10)) END;
 GO
 
+-- procedures with more than 1 argument and with-clause
+CREATE PROCEDURE babel_execute_as_caller_procedure_4 (@arg1 int, @arg2 varchar(10)) WITH EXECUTE AS CALLER AS
+BEGIN SELECT @arg1,@arg2 END;
+GO
+
+CREATE PROCEDURE babel_execute_as_caller_procedure_5 (@arg1 int, @arg2 varchar(10), @arg3 int) WITH EXECUTE AS CALLER, SCHEMABINDING AS
+BEGIN SELECT @arg1, @arg2, @arg3 END;
+GO
+
+CREATE PROCEDURE babel_execute_as_caller_procedure_6 @arg1 int, @arg2 varchar(10), @arg3 int WITH EXECUTE AS CALLER, SCHEMABINDING AS
+BEGIN SELECT @arg1, @arg2, @arg3 END;
+GO
+
 -- trigger
 CREATE TABLE babel_execute_as_caller_table_1 (c varchar(20));
 GO

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-prepare.sql
@@ -129,6 +129,18 @@ BEGIN
 END
 GO
 
+CREATE TRIGGER babel_execute_as_caller_trigger4 on babel_execute_as_caller_table WITH EXECUTE AS CALLER, SCHEMABINDING AFTER UPDATE, INSERT, DELETE
+AS
+BEGIN
+  SELECT 'babel_execute_as_caller_trigger4 invoked'
+END
+GO
+
+-- DML triggers aren't supported yet
+-- When supported the corner case of having more terigger_options and has WITH-clause should succeed
+CREATE TRIGGER trg_index_changes ON DATABASE WITH EXECUTE AS CALLER, SCHEMABINDING FOR  CREATE_INDEX, DROP_INDEX as begin insert into index_logs(a,b) values (1,2); end
+GO
+
 -- create function with duplicate execute as caller
 CREATE FUNCTION babel_execute_as_caller_function_return_int_3 (@v int) RETURNS INT WITH EXECUTE AS CALLER, EXECUTE AS CALLER AS BEGIN RETURN @v+1 END;
 GO

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-verify.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-verify.sql
@@ -46,3 +46,6 @@ GO
 
 SELECT babel_execute_as_caller_function_return_int_6(6)
 GO
+
+SELECT babel_execute_as_caller_function_return_int_7(7, 'test', 5)
+GO

--- a/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-verify.sql
+++ b/test/JDBC/input/BABEL-EXECUTE_AS_CALLER-vu-verify.sql
@@ -18,6 +18,16 @@ GO
 EXEC babel_execute_as_caller_procedure_2 2
 GO
 
+-- procedures with more than 1 argument and with-clause
+EXEC babel_execute_as_caller_procedure_4 4, 'test'
+GO
+
+EXEC babel_execute_as_caller_procedure_5 5, 'test', 0
+GO
+
+EXEC babel_execute_as_caller_procedure_6 6, 'test', 0
+GO
+
 -- triggers
 INSERT INTO babel_execute_as_caller_table values (2);
 GO


### PR DESCRIPTION
### Description
Earlier syntax error is being raised when tried to create a procedure which contains more than 1 parameter and WITH-clause in it. This was happened because the remove of COMMA is not handled properly in case of create or alter procedure.

This commit fixes the above issue by removing the COMMA in WITH-clause but not in the parameters.
### Issues Resolved

[List any issues this PR will resolve]
BABEL-3843
### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** Tested whether the create procedure accepts more than 1 parameters and WITH-clause in it.


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA


Signed-off-by: vasavi suthapalli <svasusri@amazon.com>
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).