### PR TITLE
Re-enable pg_hint_plan

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -49,6 +49,14 @@ runs:
           export PATH=$HOME/${{ inputs.install_dir }}/bin:$PATH
           make
           make install
+        elif [[ ${{inputs.engine_branch}} != *"__PG_13_"* ]]; then
+          cd ../..
+          rm -rf pg_hint_plan
+          git clone --depth 1 --branch PG15 https://github.com/ossc-db/pg_hint_plan.git
+          cd pg_hint_plan
+          export PATH=$HOME/${{ inputs.install_dir }}/bin:$PATH
+          make
+          make install
         fi
       env:
         HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}

--- a/test/JDBC/input/BABEL-SP_FKEYS-dep-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_FKEYS-dep-vu-verify.sql
@@ -1,3 +1,3 @@
--- sla 45000
+-- sla 50000
 exec babel_sp_fkeys_dep_vu_prepare_p1
 go

--- a/test/JDBC/input/BABEL-SP_FKEYS-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_FKEYS-vu-verify.sql
@@ -1,4 +1,4 @@
--- sla 1200000
+-- sla 1300000
 use babel_sp_fkeys_vu_prepare_db1
 go
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -18,17 +18,6 @@ ignore#!#BABEL-ROLE-vu-cleanup
 ignore#!#BABEL-ROLE
 ignore#!#BABEL-USER
 
-# TO-DO: re-enable these tests when pg_hint_plan extension gets supported in PG15
-ignore#!#BABEL-3291
-ignore#!#BABEL-3292
-ignore#!#BABEL-3293
-ignore#!#BABEL-3294
-ignore#!#BABEL-3295
-ignore#!#BABEL-3512
-ignore#!#BABEL-3592
-ignore#!#BABEL-3513-vu-prepare
-ignore#!#BABEL-3513-vu-verify
-
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 ignore#!#BABEL-SP_FKEYS
 ignore#!#BABEL-SP_FKEYS-vu-prepare

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -328,8 +328,7 @@ sys-all_parameters-dep
 BABEL-3556
 BABEL-3588
 BABEL-3268
-# TO-DO: Uncomment following test when pg_hint_plan extension gets supported in PG15
-# BABEL-3513
+BABEL-3513
 BABEL_GRANT_CONNECT
 BABEL-sp_helpdb
 BABEL-2795

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -334,8 +334,7 @@ sys-all_parameters-dep
 BABEL-3556
 BABEL-3588
 BABEL-3268
-# TO-DO: Uncomment following test when pg_hint_plan extension gets supported in PG15
-# BABEL-3513
+BABEL-3513
 BABEL_GRANT_CONNECT
 BABEL-sp_helpdb
 BABEL-2795


### PR DESCRIPTION
### Description
* Modified github action to clone/build PG15 branch of pg_hint_plan extension.
* Re-enabled all the tests related to TSQL hints (pg_hint_plan).

Note: This change is only need in BABEL_3_X_DEV branch.

Signed-off-by: Rishabh Tanwar ritanwar@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).