### PR TITLE
Support storing and retrieving TSQL trigger definition in Babelfish

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1739,7 +1739,7 @@ SELECT
   , CAST(0 as sys.bit)  AS uses_database_collation
   , CAST(0 as sys.bit)  AS is_recompiled
   , CAST(
-      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF', 'TR') THEN
+      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF') THEN
         CASE WHEN p.proisstrict THEN 1
         ELSE 0 
         END

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1728,9 +1728,8 @@ CREATE OR REPLACE VIEW sys.all_sql_modules_internal AS
 SELECT
   ao.object_id AS object_id
   , CAST(
-      CASE WHEN ao.type in ('P', 'FN', 'IN', 'TF', 'RF', 'IF') THEN COALESCE(f.definition, '')
+      CASE WHEN ao.type in ('P', 'FN', 'IN', 'TF', 'RF', 'IF', 'TR') THEN COALESCE(f.definition, '')
       WHEN ao.type = 'V' THEN COALESCE(bvd.definition, '')
-      WHEN ao.type = 'TR' THEN NULL
       ELSE NULL
       END
     AS sys.nvarchar(4000)) AS definition  -- Object definition work in progress, will update definition with BABEL-3127 Jira.
@@ -1740,7 +1739,7 @@ SELECT
   , CAST(0 as sys.bit)  AS uses_database_collation
   , CAST(0 as sys.bit)  AS is_recompiled
   , CAST(
-      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF') THEN
+      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF', 'TR') THEN
         CASE WHEN p.proisstrict THEN 1
         ELSE 0 
         END

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -947,7 +947,7 @@ SELECT
   , CAST(0 as sys.bit)  AS uses_database_collation
   , CAST(0 as sys.bit)  AS is_recompiled
   , CAST(
-      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF', 'TR') THEN
+      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF') THEN
         CASE WHEN p.proisstrict THEN 1
         ELSE 0 
         END

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -936,9 +936,8 @@ CREATE OR REPLACE VIEW sys.all_sql_modules_internal AS
 SELECT
   ao.object_id AS object_id
   , CAST(
-      CASE WHEN ao.type in ('P', 'FN', 'IN', 'TF', 'RF', 'IF') THEN COALESCE(f.definition, '')
+      CASE WHEN ao.type in ('P', 'FN', 'IN', 'TF', 'RF', 'IF', 'TR') THEN COALESCE(f.definition, '')
       WHEN ao.type = 'V' THEN COALESCE(bvd.definition, '')
-      WHEN ao.type = 'TR' THEN NULL
       ELSE NULL
       END
     AS sys.nvarchar(4000)) AS definition  -- Object definition work in progress, will update definition with BABEL-3127 Jira.
@@ -948,7 +947,7 @@ SELECT
   , CAST(0 as sys.bit)  AS uses_database_collation
   , CAST(0 as sys.bit)  AS is_recompiled
   , CAST(
-      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF') THEN
+      CASE WHEN ao.type IN ('P', 'FN', 'IN', 'TF', 'RF', 'IF', 'TR') THEN
         CASE WHEN p.proisstrict THEN 1
         ELSE 0 
         END

--- a/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules-vu-verify.out
@@ -57,7 +57,7 @@ WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sy
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+CREATE TRIGGER sys_all_sql_modules_vu_prepare_tr1 ON sys_all_sql_modules_vu_prepare_t2 INSTEAD OF INSERT<newline>AS<newline>BEGIN<newline>SELECT * FROM sys_all_sql_modules_vu_prepare_t1;<newline>END#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-all_sql_modules_before-14_5-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules_before-14_5-vu-verify.out
@@ -55,7 +55,7 @@ WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sy
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-all_sql_modules_before-14_7-vu-verify.out
+++ b/test/JDBC/expected/sys-all_sql_modules_before-14_7-vu-verify.out
@@ -56,7 +56,7 @@ WHERE object_id = (SELECT TOP(1) object_id FROM sys.all_objects WHERE name = 'sy
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-sql_modules-vu-verify.out
+++ b/test/JDBC/expected/sys-sql_modules-vu-verify.out
@@ -56,7 +56,7 @@ WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sq
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+CREATE TRIGGER sys_sql_modules_vu_prepare_tr1 ON sys_sql_modules_vu_prepare_t2 INSTEAD OF INSERT<newline>AS<newline>BEGIN<newline>SELECT * FROM sys_sql_modules_vu_prepare_t1;<newline>END#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-sql_modules_before-14_7-vu-verify.out
+++ b/test/JDBC/expected/sys-sql_modules_before-14_7-vu-verify.out
@@ -55,7 +55,7 @@ WHERE object_id = (SELECT TOP(1) object_id FROM sys.objects WHERE name = 'sys_sq
 GO
 ~~START~~
 nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#bit
-<NULL>#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
+#!#1#!#1#!#0#!#0#!#0#!#0#!#<NULL>#!#0
 ~~END~~
 
 


### PR DESCRIPTION
### Description

SSMS uses the views sys.sql_modules and sys.all_sql_modules to show the object definitions. This change is needed for the SSMS scripting so that users have a way to script the trigger definition in TSQL syntax which helps in DDL Export.

### Issues Resolved

Task: BABEL-3681
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
The views sys.sql_modules and sys.all_sql_modules should show the trigger definition instead of NULL.

* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests -**
JDBC Tests
