### PR TITLE
Changed a misleading error message to more comprehensible form

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -349,10 +349,9 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 		if (user_dbname)
 		 	ereport(ERROR,
  				 (errcode(ERRCODE_DUPLICATE_DATABASE),
-                	errmsg("Only one user database allowed under single-db mode. User database \"%s\" already exists",
-							user_dbname)));
+                	errmsg("Only one user database allowed under single-db mode. You cannot create user database \'%s\',  because user database \'%s\' already exists",
+							dbname, user_dbname)));
 	}
-
 	if (!have_createdb_privilege())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/test/JDBC/expected/BABEL-1435.out
+++ b/test/JDBC/expected/BABEL-1435.out
@@ -124,7 +124,7 @@ CREATE DATABASE db2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Only one user database allowed under single-db mode. User database "db1" already exists)~~
+~~ERROR (Message: Only one user database allowed under single-db mode. You cannot create user database 'db2',  because user database 'db1' already exists)~~
 
 
 USE db1;


### PR DESCRIPTION
Signed-off-by: Kritika <kritikaq@amazon.com>

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]


The error message raised when trying to create a second DB was "Only one user database allowed under single-db mode. User database "x" already exists". 
Now the error message is "Only one user database allowed under single-db mode. You cannot create user database 'y',  because user database 'x' already exists".

The user finds this message misleading since he does not understand where 'x' comes from, as he was in fact trying to create 'y'. 
 
Changed a misleading error message to more comprehensible form.
### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).