### PR TITLE
Fixes to support gcc 9.5

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -1351,21 +1351,21 @@ void BabelfishPreCreateCollation_hook(
 		 */
 		if (collcollate[0] == '@')
 		{
-			char *catcollcollate = palloc0(strlen(default_locale) +
-										   strlen(collcollate) + 1);
+			size_t totallen = strlen(default_locale) + strlen(collcollate) + 1;
+			char *catcollcollate = palloc0(totallen);
 
 			memcpy(catcollcollate, default_locale, strlen(default_locale));
-			strncat(catcollcollate, collcollate, strlen(collcollate));
+			strncat(catcollcollate, collcollate, totallen);
 			*pCollcollate = catcollcollate;
 		}
 
 		if (collctype[0] == '@')
 		{
-			char *catcollctype = palloc0(strlen(default_locale) +
-										 strlen(collctype) + 1);
+			size_t totallen = strlen(default_locale) + strlen(collctype) + 1;
+			char *catcollctype = palloc0(totallen);
 
 			memcpy(catcollctype, default_locale, strlen(default_locale));
-			strncat(catcollctype, collcollate, strlen(collcollate));
+			strncat(catcollctype, collcollate, totallen);
 			*pCollctype = catcollctype;
 		}
 	}

--- a/contrib/babelfishpg_tds/src/backend/fault_injection/fault_injection_tests.c
+++ b/contrib/babelfishpg_tds/src/backend/fault_injection/fault_injection_tests.c
@@ -236,13 +236,18 @@ static void
 throw_error_buffer(void *arg ,int *num_occurrences)
 {
 	char buffer[3] = {'\0'};
-	int can = 0;
-	char tem[10]="aaaaaaaaaa";
+	int  can = 0;
+	char tem[10] = "aaaaaaaaaa";
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 	memcpy(buffer,tem,10);
+#pragma GCC diagnostic pop
 	if (can !=0)
-	elog(LOG,"Buffer overflowed \n");
+		elog(LOG,"Buffer overflowed \n");
 	else
-	elog(LOG,"Did not Overflow \n");
+		elog(LOG,"Did not Overflow \n");
 }
 /*
  * Type declarations

--- a/contrib/babelfishpg_tds/src/backend/tds/guc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/guc.c
@@ -118,13 +118,15 @@ check_version_number(char **newval, void **extra, GucSource source)
 {
 	char 		*copy_version_number;
 	char		*token;
-	int		part = 0;
+	int 		part = 0,
+	    		len = 0;
 
 	Assert(*newval != NULL);
 	if(pg_strcasecmp(*newval,"default") == 0)
 		return true;
-	copy_version_number = palloc(sizeof(char) * strlen(*newval) + 1);
-	strncpy(copy_version_number,*newval,strlen(*newval) + 1);
+	len = strlen(*newval);
+	copy_version_number = palloc0(len + 1);
+	memcpy(copy_version_number, *newval, len);
 	for (token = strtok(copy_version_number, "."); token; token = strtok(NULL, "."))
 	{	
 		/* check each token contains only digits */

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -392,12 +392,15 @@ static int *
 ProcessVersionNumber(const char* inputString)
 {
 	static int 	version_arr[4];
-	int 		part = 0;
-	char		*copy_version_number = palloc0(sizeof(char) * strlen(inputString) + 1);
+	int 		part = 0,
+	    		len = 0;
+	char		*copy_version_number;
 	char 		*token;
 
 	Assert(inputString != NULL);
-	strncpy(copy_version_number,inputString,strlen(inputString) + 1);
+	len = strlen(inputString);
+	copy_version_number = palloc0(len + 1);
+	memcpy(copy_version_number, inputString, len);
 	for (token = strtok(copy_version_number, "."); token; token = strtok(NULL, "."))
 	{ 
 		version_arr[part] = atoi(token);

--- a/contrib/babelfishpg_tsql/src/applock.c
+++ b/contrib/babelfishpg_tsql/src/applock.c
@@ -55,7 +55,7 @@ static HTAB * appLockCacheGlobal = NULL;
 typedef struct applockcacheent
 {
     int64       key;			/* (hashed) key integer of the lock */
-    char        resource[APPLOCK_MAX_RESOURCE_LENGTH];	/* Resource name string of the lock */
+    char        resource[APPLOCK_MAX_RESOURCE_LENGTH + 1];	/* Resource name string of the lock */
     uint32_t    refcount;		/* Currently how many times this lock is being held. 
 	                               Note the count may be different locally/globally.*/
     slist_head  mode_head;		/* lock mode list, keeping track of all lock modes 
@@ -502,7 +502,7 @@ static int64 ApplockGetUsableKey(char *resource)
 		entry->key = usable_key;
 		entry->refcount = 1;
 		entry->resource[0] = '\0';
-		strncat(entry->resource, resource, strlen(resource));
+		strncat(entry->resource, resource, APPLOCK_MAX_RESOURCE_LENGTH);
 	}
 
 	LWLockRelease(TsqlApplockSyncLock);
@@ -647,7 +647,7 @@ static int _sp_getapplock_internal (char *resource, char *lockmode,
 	/* lock aquired, we can insert or update the local cache entry now. */
 	AppLockCacheInsert(key, entry);
 	entry->resource[0] = '\0';
-	strncat(entry->resource, resource, strlen(resource));
+	strncat(entry->resource, resource, APPLOCK_MAX_RESOURCE_LENGTH);
 	entry->refcount++;
 	node = malloc(sizeof(AppLockModeNode));
 	node->mode = mode;

--- a/contrib/babelfishpg_tsql/src/cursor.c
+++ b/contrib/babelfishpg_tsql/src/cursor.c
@@ -51,7 +51,7 @@ void reset_sp_cursor_params(void);
 /* cursor information hashtab */
 typedef struct cursorhashent
 {
-	char curname[NAMEDATALEN];
+	char curname[NAMEDATALEN + 1];
 	PLtsql_expr *explicit_expr;
 	uint32 cursor_options;
 	int16 fetch_status;
@@ -93,7 +93,7 @@ static Oid tsql_cursor_oid = InvalidOid;
 static Oid lookup_tsql_cursor_oid(void);
 
 /* keep the name of last opened cursor name for @@cursor_rows */
-static char last_opened_cursor[NAMEDATALEN];
+static char last_opened_cursor[NAMEDATALEN + 1];
 
 /* implementation function shared between cursor functions and procedures */
 static int cursor_status_impl(PLtsql_var *var);
@@ -458,7 +458,7 @@ CursorHashEnt *pltsql_insert_cursor_entry(char *curname, PLtsql_expr *explicit_e
 		elog(ERROR, "duplicate cursor name");
 
 	curname[0] = '\0';
-	strncat(hentry->curname, curname, strlen(curname));
+	strncat(hentry->curname, curname, NAMEDATALEN);
 	hentry->explicit_expr = explicit_expr;
 	hentry->cursor_options = cursor_options;
 	hentry->fetch_status = -9;
@@ -551,7 +551,7 @@ void pltsql_update_cursor_last_operation(char *curname, int last_operation)
 	if (last_operation == 1) /* open */
 	{
 		last_opened_cursor[0] = '\0';
-		strncat(last_opened_cursor, curname, strlen(curname));
+		strncat(last_opened_cursor, curname, NAMEDATALEN);
 	}
 }
 

--- a/contrib/babelfishpg_tsql/src/format.c
+++ b/contrib/babelfishpg_tsql/src/format.c
@@ -405,23 +405,23 @@ format_validate_and_culture(const char *culture, const char *config_name)
 	if (culture_len > 0)
 	{
 		culture_temp = palloc(sizeof(char) * culture_len + 1);
-		strncpy(culture_temp, culture, culture_len);
+		memcpy(culture_temp, culture, culture_len);
 		culture_temp[culture_len] = '\0';
 
-		temp_res = palloc(sizeof(char) * culture_len + 10);
+		temp_res = palloc0(sizeof(char) * culture_len + 10);
 
 		if (strchr(culture_temp, '-') != NULL)
 		{
 			token = strtok(culture_temp, "-");
 			for (char *c = token; *c; ++c) *c = tolower(*c);
-			strncpy(temp_res, token, strlen(token) + 1);
+			memcpy(temp_res, token, strlen(token));
 			strncat(temp_res, "_", 2);
 
 			if (token != NULL)
 			{
 				token = strtok(NULL, "-");
 				for (char *c = token; *c; ++c) *c = toupper(*c);
-				strncat(temp_res, token, strlen(token) + 1);
+				strncat(temp_res, token, culture_len);
 				temp_res[culture_len] = '\0';
 			}
 			else
@@ -1510,7 +1510,7 @@ regexp_replace(char *format_res, char *match_with, const char *replace_with, cha
 
 	result = text_to_cstring(replace_text_regexp(s, (void *) re, r, false));
 
-	strncpy(format_res, result, strlen(result) + 1);
+	strncpy(format_res, result, strlen(format_res));
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -945,8 +945,9 @@ get_physical_schema_name(char *db_name, const char *schema_name)
 		return NULL;
 
 	/* always return a new copy */
-	name = palloc0(len > MAX_BBF_NAMEDATALEND ? len : MAX_BBF_NAMEDATALEND);
-	strncpy(name, schema_name, strlen(schema_name));
+	len = len > MAX_BBF_NAMEDATALEND ? len : MAX_BBF_NAMEDATALEND;
+	name = palloc0(len + 1);
+	strncpy(name, schema_name, len);
 
 	if (is_shared_schema(name))
 		return name;
@@ -1018,7 +1019,8 @@ get_physical_user_name(char *db_name, char *user_name)
 				 errmsg("database \"%s\" does not exist.", db_name)));
 
 	/* Get a new copy */
-	new_user_name = palloc0(len > MAX_BBF_NAMEDATALEND ? len : MAX_BBF_NAMEDATALEND);
+	len = len > MAX_BBF_NAMEDATALEND ? len : MAX_BBF_NAMEDATALEND;
+	new_user_name = palloc0(len + 1);
 	strncpy(new_user_name, user_name, len);
 
 	/* Truncate to 64 bytes */

--- a/contrib/babelfishpg_tsql/src/pl_funcs.c
+++ b/contrib/babelfishpg_tsql/src/pl_funcs.c
@@ -101,12 +101,11 @@ pltsql_ns_additem(PLtsql_nsitem_type itemtype, int itemno, const char *name)
 	/* first item added must be a label */
 	Assert(ns_top != NULL || itemtype == PLTSQL_NSTYPE_LABEL);
 
-	nse = palloc(offsetof(PLtsql_nsitem, name) + strlen(name) + 1);
+	nse = palloc0(offsetof(PLtsql_nsitem, name) + strlen(name) + 1);
 	nse->itemtype = itemtype;
 	nse->itemno = itemno;
 	nse->prev = ns_top;
-	nse->name[0] = '\0';
-	strncat(nse->name, name, strlen(name));
+	memcpy(nse->name, name, strlen(name));
 	ns_top = nse;
 }
 

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1010,9 +1010,9 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 				break;
 		}
 
-		undeclaredparams->tablename = (char *) palloc(sizeof(char) * 64);
+		undeclaredparams->tablename = (char *) palloc(NAMEDATALEN);
 		relname_len = strlen(relation->relname);
-		strncpy(undeclaredparams->tablename, relation->relname, relname_len);
+		strncpy(undeclaredparams->tablename, relation->relname, NAMEDATALEN);
 		undeclaredparams->tablename[relname_len] = '\0';
 		undeclaredparams->schemaoid = RelationGetNamespace(r);
 		undeclaredparams->targetattnums = (int *) palloc(sizeof(int) * list_length(target_attnums));
@@ -1032,8 +1032,8 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 
 			col = (ResTarget *)list_nth(cols, target_attnum_i);
 			colname_len = strlen(col->name);
-			undeclaredparams->targetcolnames[num_target_attnums] = (char *) palloc(sizeof(char) * 64);
-			strncpy(undeclaredparams->targetcolnames[num_target_attnums], col->name, colname_len);
+			undeclaredparams->targetcolnames[num_target_attnums] = (char *) palloc(NAMEDATALEN);
+			strncpy(undeclaredparams->targetcolnames[num_target_attnums], col->name, NAMEDATALEN);
 			undeclaredparams->targetcolnames[num_target_attnums][colname_len] = '\0';
 
 			target_attnum_i += 1;
@@ -1143,8 +1143,8 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 						if (undeclared)
 						{
 							int paramname_len = strlen(field->val.str);
-							undeclaredparams->paramnames[numresults] = (char *) palloc(64 * sizeof(char));
-							strncpy(undeclaredparams->paramnames[numresults], field->val.str, paramname_len);
+							undeclaredparams->paramnames[numresults] = (char *) palloc(NAMEDATALEN);
+							strncpy(undeclaredparams->paramnames[numresults], field->val.str, NAMEDATALEN);
 							undeclaredparams->paramnames[numresults][paramname_len] = '\0';
 							undeclaredparams->paramindexes[numresults] = numvalues;
 							numresults += 1;

--- a/contrib/babelfishpg_tsql/src/properties.c
+++ b/contrib/babelfishpg_tsql/src/properties.c
@@ -156,15 +156,18 @@ void* get_servername_helper()
 static char *
 get_version_number(const char* version_string, int idx)
 {
-	int		part = 0;
+	int 		part = 0,
+	    		len = 0;
 	char		*token;
-	char 		*copy_version_number = palloc(sizeof(char) * strlen(version_string) + 1);
+	char 		*copy_version_number;
 
 	Assert(version_string != NULL);
 	if(idx == -1) 
 		return (char *)version_string;
 
-	strncpy(copy_version_number,version_string,strlen(version_string) + 1);
+	len = strlen(version_string);
+	copy_version_number = palloc0(len + 1);
+	memcpy(copy_version_number, version_string, len);
 	for (token = strtok(copy_version_number, "."); token; token = strtok(NULL, "."))
 	{ 
 		if(part == idx)

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -41,7 +41,7 @@ set_cur_db(int16 id, const char *name)
 	Assert(len <= MAX_BBF_NAMEDATALEND);
 
 	current_db_id = id;
-	strncpy(current_db_name, name, len);
+	strncpy(current_db_name, name, MAX_BBF_NAMEDATALEND);
 	current_db_name[len] = '\0';
 
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->set_db_stat_var)
@@ -211,17 +211,17 @@ Datum babelfish_db_name(PG_FUNCTION_ARGS)
 	if (dbid == 1)
 	{
 		dbname = palloc((strlen("master") + 1) * sizeof(char));
-		strncpy(dbname, "master", strlen("master") + 1);
+		strncpy(dbname, "master", MAX_BBF_NAMEDATALEND);
 	}
 	else if (dbid == 2)
 	{
 		dbname = palloc((strlen("tempdb") + 1) * sizeof(char));
-		strncpy(dbname, "tempdb", strlen("tempdb") + 1);
+		strncpy(dbname, "tempdb", MAX_BBF_NAMEDATALEND);
 	}
 	else if (dbid == 4)
 	{
 		dbname = palloc((strlen("msdb") + 1) * sizeof(char));
-		strncpy(dbname, "msdb", strlen("msdb") + 1);
+		strncpy(dbname, "msdb", MAX_BBF_NAMEDATALEND);
 	}
 	else
 		dbname = get_db_name(dbid);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -26,6 +26,9 @@
 
 #define RAISE_ERROR_PARAMS_LIMIT 20
 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wregister"
 extern "C" {
 #if 0
 #include "tsqlNodes.h"
@@ -47,6 +50,7 @@ extern "C" {
 #undef LOG
 #endif
 }
+#pragma GCC diagnostic pop
 
 using namespace std;
 using namespace antlr4;

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -12,11 +12,14 @@
 #include "../antlr/antlr4cpp_generated_src/TSqlParser/TSqlParser.h"
 #include "tsqlIface.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wregister"
 extern "C" {
 #include "pltsql_instr.h"
 #include "pltsql.h"
 #include "guc.h"
 }
+#pragma GCC diagnostic pop
 
 extern bool pltsql_allow_antlr_to_unsupported_grammar_for_testing;
 


### PR DESCRIPTION
### Description
Following fixes have been done:
1. Fixed bounds of `strncpy` and `strncat` functions to not depend
upon source string, it is fix `stringop-overflow` compiler errors. ([Ref](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88059))
3. Replaced `strncpy` with `memcpy` at some places where use of
`strncpy` was not needed.
4. Added `pragma` to ignore some intentional GCC errors.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).