### PR TITLE
Correct text of TIMESTAMP/ROWVERSION/@@DBTS messages

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1652,7 +1652,7 @@ DECLARE
 BEGIN
     eh_setting = (select s.setting FROM pg_catalog.pg_settings s where name = 'babelfishpg_tsql.escape_hatch_rowversion');
     IF eh_setting = 'strict' THEN
-        RAISE EXCEPTION 'DBTS is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore';
+        RAISE EXCEPTION 'To use @@DBTS, set ''babelfishpg_tsql.escape_hatch_rowversion'' to ''ignore''';
     ELSE
         RETURN sys.get_current_full_xact_id()::sys.ROWVERSION;
     END IF;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -779,6 +779,23 @@ RETURNS INTEGER AS
 'babelfishpg_tsql', 'object_id'
 LANGUAGE C STABLE;
 
+CREATE OR REPLACE FUNCTION sys.DBTS()
+RETURNS sys.ROWVERSION AS
+$$
+DECLARE
+    eh_setting text;
+BEGIN
+    eh_setting = (select s.setting FROM pg_catalog.pg_settings s where name = 'babelfishpg_tsql.escape_hatch_rowversion');
+    IF eh_setting = 'strict' THEN
+        RAISE EXCEPTION 'To use @@DBTS, set ''babelfishpg_tsql.escape_hatch_rowversion'' to ''ignore''';
+    ELSE
+        RETURN sys.get_current_full_xact_id()::sys.ROWVERSION;
+    END IF;
+END;
+$$
+STRICT
+LANGUAGE plpgsql;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -1106,6 +1106,23 @@ RETURNS INTEGER AS
 'babelfishpg_tsql', 'object_id'
 LANGUAGE C STABLE;
 
+CREATE OR REPLACE FUNCTION sys.DBTS()
+RETURNS sys.ROWVERSION AS
+$$
+DECLARE
+    eh_setting text;
+BEGIN
+    eh_setting = (select s.setting FROM pg_catalog.pg_settings s where name = 'babelfishpg_tsql.escape_hatch_rowversion');
+    IF eh_setting = 'strict' THEN
+        RAISE EXCEPTION 'To use @@DBTS, set ''babelfishpg_tsql.escape_hatch_rowversion'' to ''ignore''';
+    ELSE
+        RETURN sys.get_current_full_xact_id()::sys.ROWVERSION;
+    END IF;
+END;
+$$
+STRICT
+LANGUAGE plpgsql;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -587,8 +587,10 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitColumn_definition(TSqlPars
 	// ctx->special_column_option() will be handled by visitSpecial_column_option(). do nothing here.
 
 	if (ctx->TIMESTAMP())
-		handle(INSTR_TSQL_TIMESTAMP_DATATYPE, "TIMESTAMP datatype", &st_escape_hatch_rowversion, getLineAndPos(ctx->TIMESTAMP()));
-
+	{
+		if (*st_escape_hatch_rowversion.val != EH_IGNORE)
+			throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, "To use the TIMESTAMP datatype, set \'babelfishpg_tsql.escape_hatch_rowversion\' to \'ignore\'", getLineAndPos(ctx));
+	}
 	if (ctx->for_replication())
 		handle_for_replication(ctx->for_replication());
 
@@ -1417,9 +1419,15 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitData_type(TSqlParser::Data
 		{
 			std::string name = stripQuoteFromId(ctx->simple_name()->id().back());
 			if (pg_strcasecmp("timestamp", name.c_str()) == 0)
-				handle(INSTR_TSQL_TIMESTAMP_DATATYPE, "TIMESTAMP datatype", &st_escape_hatch_rowversion, getLineAndPos(ctx));
+			{
+				if (*st_escape_hatch_rowversion.val != EH_IGNORE)
+					throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, "To use the TIMESTAMP datatype, set \'babelfishpg_tsql.escape_hatch_rowversion\' to \'ignore\'", getLineAndPos(ctx));
+			}
 			else if (pg_strcasecmp("rowversion", name.c_str()) == 0)
-				handle(INSTR_TSQL_ROWVERSION_DATATYPE, "ROWVERSION datatype", &st_escape_hatch_rowversion, getLineAndPos(ctx));
+			{
+				if (*st_escape_hatch_rowversion.val != EH_IGNORE)
+					throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, "To use the ROWVERSION datatype, set \'babelfishpg_tsql.escape_hatch_rowversion\' to \'ignore\'", getLineAndPos(ctx));
+			}
 			else if (pg_strcasecmp("hierarchyid", name.c_str()) == 0)
 				handle(INSTR_TSQL_HIERARCHYID_DATATYPE, "HIERARCHYID datatype", getLineAndPos(ctx));
 			else if (pg_strcasecmp("geography", name.c_str()) == 0)

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2621,7 +2621,7 @@ CREATE TABLE t_ts(a timestamp);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'TIMESTAMP datatype' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore)~~
+~~ERROR (Message: To use the TIMESTAMP datatype, set 'babelfishpg_tsql.escape_hatch_rowversion' to 'ignore')~~
 
 CREATE TABLE t_ts2(a pg_catalog.timestamp); -- it's fine
 GO
@@ -2631,13 +2631,13 @@ CREATE TABLE t_rv(a ROWVERSION);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ROWVERSION datatype' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore)~~
+~~ERROR (Message: To use the ROWVERSION datatype, set 'babelfishpg_tsql.escape_hatch_rowversion' to 'ignore')~~
 
 CREATE PROCEDURE p_t2 (@v timestamp) AS BEGIN PRINT CAST(@v AS VARCHAR(10)) END;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'TIMESTAMP datatype' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore)~~
+~~ERROR (Message: To use the TIMESTAMP datatype, set 'babelfishpg_tsql.escape_hatch_rowversion' to 'ignore')~~
 
 SELECT @@DBTS;
 GO
@@ -2645,7 +2645,7 @@ GO
 binary
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: DBTS is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore)~~
+~~ERROR (Message: To use @@DBTS, set 'babelfishpg_tsql.escape_hatch_rowversion' to 'ignore')~~
 
 
 -- CREATE TYPE WITH (10788)
@@ -2963,13 +2963,13 @@ DECLARE @var_rowversion ROWVERSION;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ROWVERSION datatype' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore)~~
+~~ERROR (Message: To use the ROWVERSION datatype, set 'babelfishpg_tsql.escape_hatch_rowversion' to 'ignore')~~
 
 DECLARE @var_timestamp TIMESTAMP;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'TIMESTAMP datatype' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_rowversion to ignore)~~
+~~ERROR (Message: To use the TIMESTAMP datatype, set 'babelfishpg_tsql.escape_hatch_rowversion' to 'ignore')~~
 
 DECLARE @var_hierarchyid HIERARCHYID;
 GO


### PR DESCRIPTION
### Description

The TIMESTAMP/ROWVERSION feature is off by default, and the corresponding escape hatch must be set to 'ignore' in order to switch on the feature. However, the error messages that are raised need to be updated to be more correct and clear. Especially the mention of 'currently' is raising incorrect impressions.

Changed the error messages for TIMESTAMP/ROWVERSION/@@DBTS

### Issues Resolved
Task: BABEL-3896
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
Updated the expected error message
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests - **
JDBC tests