### PR TITLE
Error in SqlMembershipProvider class in .Net when fully qualified function name is used

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -22,6 +22,8 @@
 #include "access/table.h"
 #include "access/genam.h"
 
+#include "multidb.h"
+
 common_utility_plugin *common_utility_plugin_ptr = NULL;
 
 bool suppress_string_truncation_error = false;
@@ -288,6 +290,10 @@ void pltsql_read_procedure_info(StringInfo inout_str,
 	appendStringInfoString(&proc_stmt, inout_str->data);
 	parsetree = raw_parser(proc_stmt.data, RAW_PARSE_DEFAULT);
 	cstmt  = (CallStmt *) ((RawStmt *) linitial(parsetree))->stmt;
+	Assert(cstmt);
+
+	if (enable_schema_mapping())
+		rewrite_object_refs((Node *) cstmt);
 
 	funccall = cstmt->funccall;
 

--- a/test/dotnet/ExpectedOutput/TestStoredProcedure.out
+++ b/test/dotnet/ExpectedOutput/TestStoredProcedure.out
@@ -385,3 +385,37 @@ hello#!#1
 #D#varchar#!#int
 hello#!#200
 #Q#DROP PROCEDURE sp_test21
+#Q#CREATE PROCEDURE dbo.sp_test22 ( @one int, @two int ) AS BEGIN SELECT @one, @two; END;
+#Q#DECLARE @one int = 100; DECLARE @two int = 200; EXECUTE sp_test22 @one = @one, @two = @two;
+#D#int#!#int
+100#!#200
+#Q#sp_test22
+#D#int#!#int
+100#!#200
+#Q#dbo.sp_test22
+#D#int#!#int
+100#!#200
+#Q#DROP PROCEDURE dbo.sp_test22
+#Q#CREATE SCHEMA testschema
+#Q#CREATE PROCEDURE testschema.sp_test23 ( @one int, @two int ) AS BEGIN SELECT @one, @two; END;
+#Q#DECLARE @one int = 100; DECLARE @two int = 200; EXECUTE testschema.sp_test23 @one = @one, @two = @two;
+#D#int#!#int
+100#!#200
+#Q#testschema.sp_test23
+#D#int#!#int
+100#!#200
+#Q#sp_test23
+#E#procedure sp_test23(@one => integer, @two => integer) does not exist
+#Q#CREATE PROCEDURE dbo.sp_test23 ( @one varchar(30), @two int ) AS BEGIN SELECT @one, @two; END;
+#Q#EXECUTE sp_test23 @one = "hello", @two = 1;
+#D#varchar#!#int
+hello#!#1
+#Q#sp_test23
+#D#varchar#!#int
+hello#!#200
+#Q#dbo.sp_test23
+#D#varchar#!#int
+hello#!#200
+#Q#DROP PROCEDURE testschema.sp_test23
+#Q#DROP PROCEDURE dbo.sp_test23
+#Q#DROP SCHEMA testschema

--- a/test/dotnet/input/Storedproc/TestStoredProcedure.txt
+++ b/test/dotnet/input/Storedproc/TestStoredProcedure.txt
@@ -211,3 +211,30 @@ EXECUTE sp_test21 @one = "hello", @two = 1;
 #EXECUTE sp_test21 @two = 1, @one = "hello"; ##### Babel 2392
 storedproc#!#prep#!#sp_test21#!#varchar|-|one|-|hello|-|input#!#int|-|two|-|200|-|input
 DROP PROCEDURE sp_test21
+
+CREATE PROCEDURE dbo.sp_test22 ( @one int, @two int ) AS BEGIN SELECT @one, @two; END;
+DECLARE @one int = 100; DECLARE @two int = 200; EXECUTE sp_test22 @one = @one, @two = @two;
+storedproc#!#prep#!#sp_test22#!#int|-|one|-|100|-|input#!#int|-|two|-|200|-|input
+storedproc#!#prep#!#dbo.sp_test22#!#int|-|one|-|100|-|input#!#int|-|two|-|200|-|input
+DROP PROCEDURE dbo.sp_test22
+
+# Test (23): Stored Procedure on a non-default schema
+CREATE SCHEMA testschema
+
+CREATE PROCEDURE testschema.sp_test23 ( @one int, @two int ) AS BEGIN SELECT @one, @two; END;
+DECLARE @one int = 100; DECLARE @two int = 200; EXECUTE testschema.sp_test23 @one = @one, @two = @two;
+storedproc#!#prep#!#testschema.sp_test23#!#int|-|one|-|100|-|input#!#int|-|two|-|200|-|input
+
+# Should fail because sp_test23 does not exist in default schema
+storedproc#!#prep#!#sp_test23#!#int|-|one|-|100|-|input#!#int|-|two|-|200|-|input
+
+# create one with the same name as previous one but different schema
+CREATE PROCEDURE dbo.sp_test23 ( @one varchar(30), @two int ) AS BEGIN SELECT @one, @two; END;
+EXECUTE sp_test23 @one = "hello", @two = 1;
+storedproc#!#prep#!#sp_test23#!#varchar|-|one|-|hello|-|input#!#int|-|two|-|200|-|input
+storedproc#!#prep#!#dbo.sp_test23#!#varchar|-|one|-|hello|-|input#!#int|-|two|-|200|-|input
+
+DROP PROCEDURE testschema.sp_test23
+DROP PROCEDURE dbo.sp_test23
+DROP SCHEMA testschema
+# Test (23): End


### PR DESCRIPTION
Error in SqlMembershipProvider class in .Net when fully qualified function name is used

While executing something like "SqlCommand("dbo.aspnet_CheckSchemaVersion", connection);", pltsql_read_procedure_info() is called internally and it ignores any schema mapping before calling FuncnameGetCandidates(). The code change ensures to rewrite_object_refs() when necessary.

Task: BABEL-3530
Signed-off-by: Kristian Lejao <klejao@amazon.com>

3X PR [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1080)

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).