### PR TITLE
Fix bugs for SP_* Prepare procedures

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -2269,6 +2269,14 @@ read_param_def(InlineCodeBlockArgs *args, const char *paramdefstr)
 		p = (FunctionParameter *) lfirst(lc);
 		args->argnames[i] = p->name;
 		args->argmodes[i] = p->mode;
+
+		/*
+		 * Handle User defined types with schema qualifiers. Convert logical Schema Name to
+		 * Physical Schema Name. Note: The list length can not be more than 2 since db name
+		 * can not be a qualifier for a UDT and error will be thrown in the parser itself.
+		 */
+		rewrite_plain_name(p->argType->names);
+
 		typenameTypeIdAndMod(NULL, p->argType, &(args->argtypes[i]), &(args->argtypmods[i]));
 		i++;
 	}
@@ -2386,7 +2394,8 @@ read_param_val(PLtsql_execstate *estate, List *params, InlineCodeBlockArgs *args
 		{
 			for (j = i; j < args->numargs; j++)
 			{
-				if (strcmp(p->name, args->argnames[j]) == 0)
+				/* Case insensitive param names can be used. */
+				if (pg_strcasecmp(p->name, args->argnames[j]) == 0)
 				{
 					/* Check if the param's declared mode matches called mode */
 					if (!check_spexecutesql_param(&(args->argmodes[j]), p))

--- a/test/JDBC/expected/TestSPPrepare.out
+++ b/test/JDBC/expected/TestSPPrepare.out
@@ -810,3 +810,139 @@ GO
 
 DROP Table sp_prepare_table
 GO
+
+-- testing with Schema.User_Defined_Types
+Create schema udt_schema
+GO
+create type udt_schema.int_udt from int
+GO
+
+
+CREATE PROCEDURE udt_schema.udt_proc
+(
+    @TypeId udt_schema.int_udt,
+	@createdBy VARCHAR(100)
+)
+AS
+BEGIN
+		SET NOCOUNT ON;
+	IF @TypeId IS NULL
+	BEGIN
+		RAISERROR('mandatory field TypeId missing', 16, 1);
+		RETURN
+	END
+	IF 1=1
+	BEGIN
+		SELECT 1
+	END
+END
+GO
+
+declare @p0 udt_schema.int_udt
+set @p0 = 1
+exec sp_executesql N'EXEC udt_schema.udt_proc @TypeId = @P0, @CreatedBy = @p1',
+N'@P0 udt_schema.int_udt, @P1 VARCHAR(100)',
+@p0=@p0,@p1=N'abc@xyz1.com'
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- testing with Table varaibles
+CREATE TYPE udt_schema.tvp_type AS TABLE (TypeId bigINT, createdBy VARCHAR(100))
+GO
+
+
+CREATE PROCEDURE udt_schema.tvp_proc
+(
+    @TypeId BIGINT,
+	@createdBy VARCHAR(100),
+	@TVPTypeData udt_schema.tvp_type READONLY -- tvp with schema.type_name
+)
+AS
+BEGIN 
+		SET NOCOUNT ON;
+	IF @TypeId IS NULL
+	BEGIN
+		RAISERROR('mandatory field TypeId missing', 16, 1);
+		RETURN
+	END
+	IF 1=1
+	BEGIN
+		SELECT 1
+	END
+END
+GO
+
+
+declare @p2 udt_schema.tvp_type
+insert into @p2 values(307,N'abc@xyz.com ')
+exec sp_executesql N'EXEC udt_schema.tvp_proc @TypeId = @P0, @CreatedBy = @p1, @TVPTypeData = @P2',
+N'@P0 bigint, @P1 VARCHAR(100), @P2 [udt_schema].[tvp_type] READONLY',
+8,N'abc@xyz1.com ', @P2=@p2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+DROP PROCEDURE udt_schema.udt_proc;
+DROP PROCEDURE udt_schema.tvp_proc;
+DROP TYPE udt_schema.tvp_type;
+DROP TYPE udt_schema.int_udt;
+DROP SCHEMA udt_schema;
+GO
+
+
+CREATE TABLE [tblEmployees](
+      [fldEmployeeID] [int] NULL,
+      [fldResource] [bit] NOT NULL)
+GO
+
+insert into tblEmployees values (1, 0)
+insert into tblEmployees values (1, 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+declare  @DSICoreSpecificationEqualsAndOperator1EmpMapIsResource bit
+EXECUTE sp_executesql N'
+SELECT DISTINCT _EmpMap.fldEmployeeID
+FROM tblEmployees AS _EmpMap
+WHERE  ( _EmpMap.fldResource = @DSICoreSpecificationEqualsAndOperator1EmpMapIsResource );'
+,N'@DSICoreSpecificationEqualsAndOperator1EmpMapIsResource Bit'
+,@DSICoreSpecificationEqualsAndOperator1EmpMapIsResource = 0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+declare  @dsicorespecificationequalsandoperator1empmapisresource  bit
+EXECUTE sp_executesql N'
+SELECT DISTINCT _EmpMap.fldEmployeeID
+FROM tblEmployees AS _EmpMap
+WHERE  ( _EmpMap.fldResource = @dsicorespecificationequalsandoperator1empmapisresource  );'
+,N'@dsicorespecificationequalsandoperator1empmapisresource  Bit'
+,@dsicorespecificationequalsandoperator1empmapisresource  = 0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Drop table tblEmployees
+GO

--- a/test/JDBC/input/storedProcedures/TestSPPrepare.sql
+++ b/test/JDBC/input/storedProcedures/TestSPPrepare.sql
@@ -438,3 +438,113 @@ GO
 
 DROP Table sp_prepare_table
 GO
+
+-- testing with Schema.User_Defined_Types
+Create schema udt_schema
+GO
+create type udt_schema.int_udt from int
+GO
+
+CREATE PROCEDURE udt_schema.udt_proc
+(
+    @TypeId udt_schema.int_udt,
+	@createdBy VARCHAR(100)
+)
+AS
+BEGIN
+		SET NOCOUNT ON;
+	IF @TypeId IS NULL
+	BEGIN
+		RAISERROR('mandatory field TypeId missing', 16, 1);
+		RETURN
+	END
+
+	IF 1=1
+	BEGIN
+		SELECT 1
+	END
+END
+GO
+
+declare @p0 udt_schema.int_udt
+set @p0 = 1
+exec sp_executesql N'EXEC udt_schema.udt_proc @TypeId = @P0, @CreatedBy = @p1',
+N'@P0 udt_schema.int_udt, @P1 VARCHAR(100)',
+@p0=@p0,@p1=N'abc@xyz1.com'
+GO
+
+-- testing with Table varaibles
+CREATE TYPE udt_schema.tvp_type AS TABLE (TypeId bigINT, createdBy VARCHAR(100))
+GO
+
+CREATE PROCEDURE udt_schema.tvp_proc
+(
+    @TypeId BIGINT,
+	@createdBy VARCHAR(100),
+	@TVPTypeData udt_schema.tvp_type READONLY -- tvp with schema.type_name
+)
+AS
+BEGIN 
+		SET NOCOUNT ON;
+	IF @TypeId IS NULL
+	BEGIN
+		RAISERROR('mandatory field TypeId missing', 16, 1);
+		RETURN
+	END
+
+	IF 1=1
+	BEGIN
+		SELECT 1
+	END
+END
+GO
+
+declare @p2 udt_schema.tvp_type
+insert into @p2 values(307,N'abc@xyz.com ')
+
+exec sp_executesql N'EXEC udt_schema.tvp_proc @TypeId = @P0, @CreatedBy = @p1, @TVPTypeData = @P2',
+N'@P0 bigint, @P1 VARCHAR(100), @P2 [udt_schema].[tvp_type] READONLY',
+8,N'abc@xyz1.com ', @P2=@p2
+GO
+
+
+
+DROP PROCEDURE udt_schema.udt_proc;
+DROP PROCEDURE udt_schema.tvp_proc;
+DROP TYPE udt_schema.tvp_type;
+DROP TYPE udt_schema.int_udt;
+DROP SCHEMA udt_schema;
+GO
+
+
+CREATE TABLE [tblEmployees](
+      [fldEmployeeID] [int] NULL,
+      [fldResource] [bit] NOT NULL)
+GO
+
+insert into tblEmployees values (1, 0)
+insert into tblEmployees values (1, 1)
+GO
+
+declare  @DSICoreSpecificationEqualsAndOperator1EmpMapIsResource bit
+
+EXECUTE sp_executesql N'
+SELECT DISTINCT _EmpMap.fldEmployeeID
+FROM tblEmployees AS _EmpMap
+WHERE  ( _EmpMap.fldResource = @DSICoreSpecificationEqualsAndOperator1EmpMapIsResource );'
+,N'@DSICoreSpecificationEqualsAndOperator1EmpMapIsResource Bit'
+,@DSICoreSpecificationEqualsAndOperator1EmpMapIsResource = 0;
+GO
+
+declare  @dsicorespecificationequalsandoperator1empmapisresource  bit
+
+EXECUTE sp_executesql N'
+SELECT DISTINCT _EmpMap.fldEmployeeID
+FROM tblEmployees AS _EmpMap
+WHERE  ( _EmpMap.fldResource = @dsicorespecificationequalsandoperator1empmapisresource  );'
+,N'@dsicorespecificationequalsandoperator1empmapisresource  Bit'
+,@dsicorespecificationequalsandoperator1empmapisresource  = 0;
+GO
+
+Drop table tblEmployees
+GO


### PR DESCRIPTION
1. Fixed schema name resolution for user defined types (Convert logical Schema Name to Physical Schema Name) in particular to the param types in SP_* procedures
2. Allowed using case insensitive param names for SP_* procedures

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>

### Issues Resolved
BABEL-3738
BABEL-3114

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
Added test cases based on used case.

* **Boundary conditions -**
SP_* elaborate test cases already present.

* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).