### PR TITLE
Support cross-db column permission check in has_perms_by_name

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -2442,13 +2442,19 @@ BEGIN
         SELECT CASE
             WHEN cs_as_sub_securable_class = 'column'
                 THEN CASE 
-                    WHEN (SELECT count(name) 
-                        FROM sys.all_columns 
-                        WHERE name = cs_as_sub_securable COLLATE sys.database_default
-                            -- Use V as the object type to specify that the securable is table-like.
-                            -- We do not know that the securable is a view, but object_id behaves the 
-                            -- same for differint table-like types, so V can be arbitrarily chosen.
-                            AND object_id = sys.object_id(cs_as_securable, 'V')) = 1
+                    WHEN (SELECT count(a.attname)
+                        FROM pg_attribute a
+                        INNER JOIN pg_class c ON c.oid = a.attrelid
+                        INNER JOIN pg_namespace s ON s.oid = c.relnamespace
+                        WHERE
+                        a.attname = cs_as_sub_securable COLLATE sys.database_default
+                        AND c.relname = object_name COLLATE sys.database_default
+                        AND s.nspname = pg_schema COLLATE sys.database_default
+                        AND NOT a.attisdropped
+                        AND (s.nspname IN (SELECT nspname FROM sys.babelfish_namespace_ext) OR s.nspname = 'sys')
+                        -- r = ordinary table, i = index, S = sequence, t = TOAST table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table
+                        AND c.relkind IN ('r', 'v', 'm', 'f', 'p')
+                        AND a.attnum > 0) = 1
                                 THEN 'column'
                     ELSE NULL
                 END

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -488,13 +488,19 @@ BEGIN
         SELECT CASE
             WHEN cs_as_sub_securable_class = 'column'
                 THEN CASE 
-                    WHEN (SELECT count(name) 
-                        FROM sys.all_columns 
-                        WHERE name = cs_as_sub_securable COLLATE sys.database_default
-                            -- Use V as the object type to specify that the securable is table-like.
-                            -- We do not know that the securable is a view, but object_id behaves the 
-                            -- same for differint table-like types, so V can be arbitrarily chosen.
-                            AND object_id = sys.object_id(cs_as_securable, 'V')) = 1
+                    WHEN (SELECT count(a.attname)
+                        FROM pg_attribute a
+                        INNER JOIN pg_class c ON c.oid = a.attrelid
+                        INNER JOIN pg_namespace s ON s.oid = c.relnamespace
+                        WHERE
+                        a.attname = cs_as_sub_securable COLLATE sys.database_default
+                        AND c.relname = object_name COLLATE sys.database_default
+                        AND s.nspname = pg_schema COLLATE sys.database_default
+                        AND NOT a.attisdropped
+                        AND (s.nspname IN (SELECT nspname FROM sys.babelfish_namespace_ext) OR s.nspname = 'sys')
+                        -- r = ordinary table, i = index, S = sequence, t = TOAST table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table
+                        AND c.relkind IN ('r', 'v', 'm', 'f', 'p')
+                        AND a.attnum > 0) = 1
                                 THEN 'column'
                     ELSE NULL
                 END

--- a/test/JDBC/expected/sys-has_perms_by_name-vu-verify.out
+++ b/test/JDBC/expected/sys-has_perms_by_name-vu-verify.out
@@ -656,7 +656,6 @@ int
 ~~END~~
 
 
--- Currently, using tsql we are not able access cross-db entries in sys.all_columns due to which column permissions check are not working for has_perms_by_name
 USE master;
 GO
 
@@ -664,7 +663,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'SELECT',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -672,7 +671,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'UPDATE',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -680,7 +679,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'INSERT',
 GO
 ~~START~~
 int
-0
+<NULL>
 ~~END~~
 
 
@@ -688,7 +687,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'DELETE',
 GO
 ~~START~~
 int
-0
+<NULL>
 ~~END~~
 
 
@@ -696,7 +695,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'REFERENC
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -704,7 +703,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'EXECUTE'
 GO
 ~~START~~
 int
-0
+<NULL>
 ~~END~~
 
 
@@ -712,7 +711,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..v_perms_by_name','OBJECT', 'SELECT',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -745,7 +744,7 @@ SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'SELECT', 'col2', 'COLUMN')
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -753,7 +752,7 @@ SELECT HAS_PERMS_BY_NAME('t_perms_by_name','OBJECT', 'UPDATE', 'col1', 'COLUMN')
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -781,7 +780,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..v_perms_by_name','OBJECT', 'SELECT',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -789,7 +788,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'SELECT',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -797,7 +796,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'UPDATE',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -841,7 +840,7 @@ SELECT HAS_PERMS_BY_NAME('db_perms_by_name..t_perms_by_name','OBJECT', 'SELECT',
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 

--- a/test/JDBC/input/functions/sys-has_perms_by_name-vu-verify.mix
+++ b/test/JDBC/input/functions/sys-has_perms_by_name-vu-verify.mix
@@ -321,7 +321,6 @@ GO
 SELECT HAS_PERMS_BY_NAME('v_perms_by_name','OBJECT', 'SELECT', 'col1', 'COLUMN');
 GO
 
--- Currently, using tsql we are not able access cross-db entries in sys.all_columns due to which column permissions check are not working for has_perms_by_name
 USE master;
 GO
 


### PR DESCRIPTION
### Description

Earlier, Implementation of sys.has_perms_by_name() function using TSQL view sys.all_columns due to which it was returning NULL for column permissions because system objects only shows current database's metadata.

This commit fixes above issue by using relevant PG catalogs in sys.has_perms_by_name()'s implementation instead of sys.all_columns for checking whether column exists or not.

Task: BABEL-3636
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved
BABEL-3636

### Test Scenarios Covered ###
* **Use case based -**
Already added in previous efforts, just updated the output

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).