### PR TITLE
Do not free the intermediate string if the address is being pointed by other pointer

### DIFF
--- a/contrib/babelfishpg_common/src/varchar.c
+++ b/contrib/babelfishpg_common/src/varchar.c
@@ -584,7 +584,7 @@ varchar(PG_FUNCTION_ARGS)
 	/* Encode the input string encoding to UTF8(server) encoding */
 	resStr = encoding_conv_util(tmp, maxmblen, collInfo.enc, PG_UTF8, &encodedByteLen);
 
-	if (tmp && s_data != tmp)
+	if (tmp && s_data != tmp && tmp != resStr)
 		pfree(tmp);
 
 	/* Output of encoding_conv_util() would always be NULL terminated So we can use cstring_to_text directly. */


### PR DESCRIPTION
### Description

Previously, Inside data type input function VARCHAR, we were free'ing intermediate even if the address is being pointed by other pointer which was causing segmentation fault at later point of execution. So this commit fixes this issue by avoiding freeing memory if it is pointed by other pointer. 


### Issues Resolved

Task: BABEL-3900
Authored-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).