### PR TITLE
Do not free the intermediate string if the address is being pointed by other pointer

### DIFF
--- a/contrib/babelfishpg_common/src/varchar.c
+++ b/contrib/babelfishpg_common/src/varchar.c
@@ -585,7 +585,7 @@ varchar(PG_FUNCTION_ARGS)
 	/* Encode the input string encoding to UTF8(server) encoding */
 	resStr = encoding_conv_util(tmp, maxmblen, collInfo.enc, PG_UTF8, &encodedByteLen);
 
-	if (tmp && s_data != tmp)
+	if (tmp && s_data != tmp && tmp != resStr)
 		pfree(tmp);
 
 	/* Output of encoding_conv_util() would always be NULL terminated So we can use cstring_to_text directly. */


### PR DESCRIPTION


### Description

Previously, Inside data type input function VARCHAR, we were free'ing intermediate even if the address is being pointed by other pointer which was causing segmentation fault at later point of execution. So this commit fixes this issue by avoiding freeing memory if it is pointed by other pointer. 


### Issues Resolved

Task: BABEL-3900
Authored-by: Dipesh Dhameliya <dddhamel@amazon.com>

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).