### PR TITLE
Updated JDBC test framework to have the ability to set custom SLA for .txt files

### DIFF
--- a/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
@@ -252,16 +252,16 @@ public class batch_run {
                     if (connection != null) con_bbl = connection;
 
                 } else {
+                    customSLA = strLine.toLowerCase().startsWith("-- sla");
+                    if (customSLA){
+                        String[] tokens=strLine.split(" ");  
+                        sla = Long.parseLong(tokens[2]);
+                        sla = sla*(1000000L);
+                        continue;
+                    }
                     // execute statement as a normal SQL statement
                     if (isSQLFile) {
-                        customSLA = strLine.toLowerCase().startsWith("-- sla");
-                        if (customSLA){
-                            String[] tokens=strLine.split(" ");  
-                            sla = Long.parseLong(tokens[2]);
-                            sla = sla*(1000000L);
-                            continue;
-                        }
-                        else if (!strLine.equalsIgnoreCase("GO")) {
+                        if (!strLine.equalsIgnoreCase("GO")) {
                             sqlBatch.append(strLine).append(System.lineSeparator());
                             continue;
                         } else {


### PR DESCRIPTION
### Description

Currently in JDBC test framework, we cannot add custom SLAs for .txt test files. This changes adds the ability to set custom SLA for txt files.

This commit cherry-picks [735b805c59af0687ee3cdc8315582a70f6566ef1](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/735b805c59af0687ee3cdc8315582a70f6566ef1) from BABEL_3_X_DEV

Signed-off-by: Sai Rohan Basa <bsrohan@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).