### PR TITLE
Add TAP tests to check for Babelfish extensions

### DIFF
--- a/contrib/babelfishpg_tds/test/t/003_bbfextnotloaded.pl
+++ b/contrib/babelfishpg_tds/test/t/003_bbfextnotloaded.pl
@@ -1,0 +1,39 @@
+# Copyright (c) 2021, Amazon Web Services, Inc. or its affiliates. All Rights Reserved
+
+# Verify that we throw appropriate error in case
+# Babelfish extensions are not installed
+
+use strict;
+use warnings;
+use Test::More;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use TDSNode;
+
+# Initialize primary node
+my $node = PostgreSQL::Test::Cluster->new('primary');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq{
+log_connections = on
+listen_addresses='127.0.0.1'
+shared_preload_libraries = 'babelfishpg_tds'
+lc_messages = 'C'
+babelfishpg_tsql.database_name = 'testdb'
+});
+$node->start;
+
+# Create user and a babelfish database but don't create babelfish extensions
+my $tsql_node = new TDSNode($node);
+$node->safe_psql('postgres', qq{CREATE USER test_master WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT});
+$node->safe_psql('postgres', qq{CREATE DATABASE testdb OWNER test_master});
+
+# Connection should fail with a FATAL error in log
+my @connstr1 = $tsql_node->tsql_connstr_with_role('master', 'test_master', '12345678');
+$tsql_node->connect_fails('Test 1', (connstr => \@connstr1),
+					   log_like =>
+					   [qr/babelfishpg_tsql extension is not installed/]);
+
+$node->stop;
+
+done_testing();


### PR DESCRIPTION
### Description

This commit adds TAP tests to check that we throw a fatal error in case installation of babelfish extensions fails.

Task: BABEL-3357
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).