### PR TITLE
Incorrect permission handling of scope_identity

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -282,12 +282,6 @@ last_identity_value(void)
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("last identity not valid")));
 
-	if (pg_class_aclcheck(last_used_seq_identity->relid, GetUserId(),
-						  ACL_SELECT | ACL_USAGE) != ACLCHECK_OK)
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("permission denied for sequence")));
-
 	return last_used_seq_identity->last_identity;
 }
 

--- a/test/JDBC/expected/BABEL-3853.out
+++ b/test/JDBC/expected/BABEL-3853.out
@@ -1,0 +1,122 @@
+
+-- tsql
+-- Create table with scope identity and Two logins and two users.
+-- One login granted with INSERT authority should be able to see SCOPE_IDENTITY value.
+-- Other login should not.
+USE master;
+GO
+
+CREATE TABLE babel_object_id_t1 (a int identity, b int);
+GO
+
+CREATE LOGIN babel_object_id_login1 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user1 FOR LOGIN babel_object_id_login1;
+GO
+
+CREATE LOGIN babel_object_id_login2 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user2 FOR LOGIN babel_object_id_login2;
+GO
+
+-- Grant INSERT to user1 but not user2
+GRANT INSERT on babel_object_id_t1 to babel_object_id_master_user1;
+GO
+
+-- tsql      user=babel_object_id_login1 password=12345678
+USE master
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+babel_object_id_master_user1
+~~END~~
+
+
+INSERT INTO babel_object_id_t1(b) VALUES(1);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT SCOPE_IDENTITY()
+GO
+~~START~~
+numeric
+1
+~~END~~
+
+
+-- tsql      user=babel_object_id_login2 password=12345678
+-- A login without INSERT authority on table should not see SCOPE_IDENTITY() value
+USE master
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+babel_object_id_master_user2
+~~END~~
+
+
+INSERT INTO babel_object_id_t1(b) VALUES(2);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_object_id_t1)~~
+
+
+SELECT SCOPE_IDENTITY()
+GO
+~~START~~
+numeric
+<NULL>
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+DROP TABLE babel_object_id_t1
+GO
+
+DROP USER babel_object_id_master_user1
+GO
+
+DROP USER babel_object_id_master_user2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) IN ('babel_object_id_login1', 'babel_object_id_login2')
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+t
+~~END~~
+
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP LOGIN babel_object_id_login1;
+GO
+
+DROP LOGIN babel_object_id_login2;
+GO

--- a/test/JDBC/input/BABEL-3853.mix
+++ b/test/JDBC/input/BABEL-3853.mix
@@ -1,0 +1,85 @@
+-- Create table with scope identity and Two logins and two users.
+-- One login granted with INSERT authority should be able to see SCOPE_IDENTITY value.
+-- Other login should not.
+
+-- tsql
+USE master;
+GO
+
+CREATE TABLE babel_object_id_t1 (a int identity, b int);
+GO
+
+CREATE LOGIN babel_object_id_login1 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user1 FOR LOGIN babel_object_id_login1;
+GO
+
+CREATE LOGIN babel_object_id_login2 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user2 FOR LOGIN babel_object_id_login2;
+GO
+
+-- Grant INSERT to user1 but not user2
+GRANT INSERT on babel_object_id_t1 to babel_object_id_master_user1;
+GO
+
+-- tsql      user=babel_object_id_login1 password=12345678
+USE master
+GO
+
+SELECT current_user;
+GO
+
+INSERT INTO babel_object_id_t1(b) VALUES(1);
+GO
+
+SELECT SCOPE_IDENTITY()
+GO
+
+-- A login without INSERT authority on table should not see SCOPE_IDENTITY() value
+-- tsql      user=babel_object_id_login2 password=12345678
+USE master
+GO
+
+SELECT current_user;
+GO
+
+INSERT INTO babel_object_id_t1(b) VALUES(2);
+GO
+
+SELECT SCOPE_IDENTITY()
+GO
+
+-- tsql
+USE master;
+GO
+
+DROP TABLE babel_object_id_t1
+GO
+
+DROP USER babel_object_id_master_user1
+GO
+
+DROP USER babel_object_id_master_user2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) IN ('babel_object_id_login1', 'babel_object_id_login2')
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+
+-- tsql
+DROP LOGIN babel_object_id_login1;
+GO
+
+DROP LOGIN babel_object_id_login2;
+GO


### PR DESCRIPTION
BBF creates a hidden sequence behind the identity column. SCOPE_IDENTITY() should return the latest inserted value for this sequence in current session.
Its implementation: last_identity_value function is checking SELECT/USAGE permission against the sequence.
Since the sequence is hidden, it should not need any additional permission from customer to retrieve value from it through scope_idenity. Logically, if current user has INSERT permission to the target table, scope_identity should return value.

Task: BABEL-3853
Signed-off-by: Kristian Lejao <klejao@amazon.com>

### Description


- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).