### PR TITLE
Enable TAP tests for Babelfish

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Engine install directory'
     required: no
     default: postgres
+  tap_tests:
+    description: 'Tap Tests Enabled'
+    required: no
+    default: no
 
 runs:
   using: "composite"
@@ -35,7 +39,11 @@ runs:
 
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
         cd postgresql_modified_for_babelfish
-        ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+        if [[ ${{inputs.tap_tests}} == "yes" ]]; then
+          ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
+        else
+          ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+        fi
         make -j 4 2>error.txt
         make install
         make check

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -1,0 +1,69 @@
+name: TAP Tests
+on: [push, pull_request]
+
+jobs:
+  run-babelfish-tap-tests:
+    env:
+      INSTALL_DIR: postgres
+
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        uses: ./.github/composite-actions/install-dependencies
+
+      - name: Install Tap Tests Dependencies
+        id: install-tap-dependencies
+        if: always() && steps.install-dependencies.outcome == 'success'
+        run: |
+          export PERL_MM_USE_DEFAULT=1
+          sudo perl -MCPAN -e 'install IPC::Run'
+        shell: bash
+
+      - name: Install Kerberos Dependencies
+        id: install-kerberos-dependencies
+        if: always() && steps.install-tap-dependencies.outcome == 'success'
+        run: |
+          cd ~
+          export DEBIAN_FRONTEND=noninteractive
+          sudo -E apt-get install krb5-admin-server krb5-kdc krb5-user libkrb5-dev -y -qq
+        shell: bash
+
+      - name: Build Modified Postgres
+        id: build-modified-postgres
+        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        with:
+          tap_tests: 'yes'
+        uses: ./.github/composite-actions/build-modified-postgres
+
+      - name: Compile ANTLR
+        id: compile-antlr
+        if: always() && steps.build-modified-postgres.outcome == 'success'
+        uses: ./.github/composite-actions/compile-antlr
+
+      - name: Build Extensions
+        id: build-extensions
+        if: always() && steps.compile-antlr.outcome == 'success'
+        uses: ./.github/composite-actions/build-extensions
+
+      - name: Run TAP Tests
+        id: tap
+        if: always() && steps.build-extensions.outcome == 'success'
+        timeout-minutes: 5
+        run: |
+          export PG_CONFIG=~/${{env.INSTALL_DIR}}/bin/pg_config
+          export PATH=/opt/mssql-tools/bin:$PATH
+
+          cd contrib/babelfishpg_tds
+          make installcheck
+
+      - name: Upload Logs
+        if: always() && steps.tap.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: tap_tests_logs
+          path: contrib/babelfishpg_tds/test/tmp_check/log

--- a/contrib/babelfishpg_tds/Makefile
+++ b/contrib/babelfishpg_tds/Makefile
@@ -3,7 +3,6 @@ MODULE_big = babelfishpg_tds
 EXTENSION = babelfishpg_tds
 DATA = babelfishpg_tds--1.0.0.sql
 PGFILEDESC = "babelfishpg_tds - TDS Listener Extension"
-#REGRESS = babelfishpg_tds
 
 tds_top_dir = .
 tds_backend = $(tds_top_dir)/src/backend
@@ -36,6 +35,14 @@ $(tds_backend)/tds/err_handler.o: $(tds_include)/error_mapping.h
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
+# Only execute TAP tests if sqlcmd is installed in the path
+ifneq (, $(shell which sqlcmd))
+SUBDIRS = test
+endif
+
 #include ../Makefile.common
 
 .DEFAULT_GOAL := all
+
+$(recurse)
+$(recurs_always)

--- a/contrib/babelfishpg_tds/test/.gitignore
+++ b/contrib/babelfishpg_tds/test/.gitignore
@@ -1,0 +1,1 @@
+/tmp_check/

--- a/contrib/babelfishpg_tds/test/Makefile
+++ b/contrib/babelfishpg_tds/test/Makefile
@@ -1,0 +1,6 @@
+TAP_TESTS=1
+
+export with_gssapi with_krb_srvnam
+
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)

--- a/contrib/babelfishpg_tds/test/README.test
+++ b/contrib/babelfishpg_tds/test/README.test
@@ -1,0 +1,111 @@
+This folder contains TAP tests written for TDS endpoint. 
+
+In PG, TAP test framework is used to drive tests for backup and restore,
+replication, etc - anything that can't really be expressed using pg_regress
+or the isolation test framework.
+https://github.com/postgres/postgres/blob/master/src/test/perl/README
+
+Basically, it can be used if we want something more than just comparing the
+expected outputs. It may include:
+
+- Some engine/os configuration changes
+- Start or stop the server
+- grep log messages from log file and match with expected log file output
+- system calls
+
+In Babelfish, we can utilize the same test framework for the following
+scenarios:
+
+- pg_hba.conf changes with password authentication
+- Kerberos authentication by setting up MIT kerberos 
+- SSL setup and test encrypted connection
+- Provisioning
+
+We've added an additional library, called TDSNode.pm, that provides APIs to
+provision a babelfish node, execute T-SQL statements through a TDS endpoint
+and test TDS connections.
+
+Installing dependencies
+--------------------------
+
+For TAP tests, you need to install a few perl modules.
+IPC::Run
+Test::More
+
+In Amazon Linux, you can use the following command to install the same:
+sudo yum install 'perl(IPC::Run)'
+sudo yum install 'perl(Test::More)'
+
+You also need to install sqlcmd and add it to PATH.
+
+For GSSAPI tests, you need to install the kerberos packages.
+In Amazon Linux, you can use the following command to install the same:
+sudo yum install krb5-server krb5-workstation -y
+
+Running the tests
+----------------------
+
+To enable the TAP tests, the server needs to be configured with --enable-tap-tests 
+flag.  Additionally, to run the Kerberos test, the server needs to be configured
+with --with-gssapi flag.
+
+1. Configure engine with --enable-tap-tests and --with-gssapi flag
+2. Build engine and extension
+3. Execute the following command:
+export PG_CONFIG=<engine installation directory>/pg_config
+cd babelfish_extensions/contrib/babelfishpg_tds/
+make installcheck
+
+Individual test(s) can be run instead by passing
+something like PROVE_TESTS="t/001_testname.pl t/002_othertestname.pl" to make.
+
+Writing test cases
+----------------------
+Test scripts in the t/ subdirectory of a suite are executed in alphabetical
+order.
+
+Each test script should begin with:
+
+    use strict;
+    use warnings;
+    use PostgreSQL::Test::Cluster;
+    use PostgreSQL::Test::Utils;
+    use Test::More;
+    use TDSNode;
+
+then it will generally need to set up one or more nodes, run commands
+against them and evaluate the results. For example:
+
+    my $node = PostgreSQL::Test::Cluster->new('primary');
+    $node->init;
+	$node->append_conf(
+	'postgresql.conf', qq{
+log_connections = on
+listen_addresses='127.0.0.1'
+shared_preload_libraries = 'babelfishpg_tds'
+});
+    $node->start;
+
+	my $tsql_node = new TDSNode($node);
+	$tsql_node->init_tsql('test_master', 'testdb');
+
+    my $ret = $node->safe_tsql('master', 'SELECT 1');
+    is($ret, '1', 'SELECT 1 returns 1');
+
+	$node->stop('fast');
+
+Each test script should end with:
+
+	done_testing();
+
+All the APIs defined in [1] can be used. Additionally, we have a new module for
+TDS connections,
+Module: TDSNode
+APIs:
+TDSNode->init_tsql
+TDSNode->tsql_connstr
+TDSNode->safe_tsql
+TDSNode->connect_ok
+TDSNode->connect_fails
+
+[1] https://github.com/postgres/postgres/tree/master/src/test/perl/PostgreSQL

--- a/contrib/babelfishpg_tds/test/TDSNode.pm
+++ b/contrib/babelfishpg_tds/test/TDSNode.pm
@@ -1,0 +1,427 @@
+package TDSNode;
+use strict;
+use warnings;
+use Exporter 'import';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+use Scalar::Util qw(blessed);
+
+our @EXPORT = qw(
+  init_tsql
+  safe_tsql
+);
+
+#constructor
+sub new {
+	my $class = shift;
+
+	my ($node, %params) = @_;
+
+	my $self = {
+		_node => $node,
+		_tsql_port => 1433,
+		_tsql_master_role => '',
+		_tsql_master_db => ''
+	};
+
+	bless $self, $class;
+
+	return $self;
+}
+
+sub tsql_port {
+	my $self = shift;
+
+	return $self->{_tsql_port};
+}
+
+sub tsql_master_role {
+	my $self = shift;
+
+	return $self->{_tsql_master_role};
+}
+
+sub tsql_master_db {
+	my $self = shift;
+
+	return $self->{_tsql_master_db};
+}
+
+sub init_tsql {
+	my ($self, $role, $testdb) = @_;
+	my $node = $self->{_node};
+
+	if (!defined($role) or ($role eq ""))
+	{
+		die "cannot initialize babelfish, master role is empty";
+	}
+
+	if (!defined($testdb) or ($testdb eq ""))
+	{
+		die "cannot initialize babelfish, master database is empty";
+	}
+
+	$self->{_tsql_master_role} = $role;
+	$self->{_tsql_master_db} = $testdb;
+
+	$node->safe_psql('postgres', qq{CREATE USER $role WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT});
+	$node->safe_psql('postgres', qq{CREATE DATABASE $testdb OWNER $role});
+	$node->safe_psql($testdb, qq{CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE});
+	$node->safe_psql($testdb, qq{GRANT ALL ON SCHEMA sys to $role});
+	$node->safe_psql($testdb, qq{ALTER USER $role CREATEDB});
+	$node->safe_psql($testdb, qq{ALTER SYSTEM SET babelfishpg_tsql.database_name = '$testdb'});
+	$node->safe_psql($testdb, qq{SELECT pg_reload_conf()});
+	$node->safe_psql($testdb, qq{CALL sys.initialize_babelfish('$role')});
+}
+
+sub tsql {
+	my ($self, $dbname, $sql, %params) = @_;
+	my $node = $self->{_node};
+
+	my $stdout            = $params{stdout};
+	my $stderr            = $params{stderr};
+	my $timeout           = undef;
+	my $timeout_exception = 'tsql timed out';
+
+	my @connarray;
+	if (defined $params{connstr})
+	{
+		@connarray = @{$params{connstr}};
+	}
+	else
+	{
+		my $role = $self->{_tsql_master_role};
+		@connarray = $self->tsql_connstr_with_role($dbname, $role, '');
+	}
+
+	# Build connection string with database, query and warning level
+	my @tsql_params = (
+		$node->installed_command('sqlcmd'),
+		'-Q', $sql,
+		'-r1');
+
+	# Now append reset of the options
+	foreach(@connarray)
+	{
+		push @tsql_params, $_;
+	}
+
+	# If the caller wants an array and hasn't passed stdout/stderr
+	# references, allocate temporary ones to capture them so we
+	# can return them. Otherwise we won't redirect them at all.
+	if (wantarray)
+	{
+		if (!defined($stdout))
+		{
+			my $temp_stdout = "";
+			$stdout = \$temp_stdout;
+		}
+		if (!defined($stderr))
+		{
+			my $temp_stderr = "";
+			$stderr = \$temp_stderr;
+		}
+	}
+
+	$timeout =
+	  IPC::Run::timeout($params{timeout}, exception => $timeout_exception)
+	  if (defined($params{timeout}));
+
+	${ $params{timed_out} } = 0 if defined $params{timed_out};
+
+	# IPC::Run would otherwise append to existing contents:
+	$$stdout = "" if ref($stdout);
+	$$stderr = "" if ref($stderr);
+
+	my $ret;
+
+	do {
+		local $@;
+		eval {
+			my @ipcrun_opts = (\@tsql_params);
+			push @ipcrun_opts, '1>',  $stdout if defined $stdout;
+			push @ipcrun_opts, '2>', $stderr if defined $stderr;
+			push @ipcrun_opts, $timeout if defined $timeout;
+
+			IPC::Run::run @ipcrun_opts;
+			$ret = $?;
+		};
+		my $exc_save = $@;
+		if ($exc_save)
+		{
+
+			# IPC::Run::run threw an exception. re-throw unless it's a
+			# timeout, which we'll handle by testing is_expired
+			die $exc_save
+			  if (blessed($exc_save)
+				|| $exc_save !~ /^\Q$timeout_exception\E/);
+
+			$ret = undef;
+
+			die "Got timeout exception '$exc_save' but timer not expired?!"
+			  unless $timeout->is_expired;
+
+			if (defined($params{timed_out}))
+			{
+				${ $params{timed_out} } = 1;
+			}
+			else
+			{
+				die "sqlcmd timed out: stderr: '$$stderr'\n"
+				  . "while running '@tsql_params'";
+			}
+		}
+	};
+
+	if (defined $$stdout)
+	{
+		chomp $$stdout;
+	}
+
+	if (defined $$stderr)
+	{
+		chomp $$stderr;
+	}
+
+	# See http://perldoc.perl.org/perlvar.html#%24CHILD_ERROR
+	# We don't use IPC::Run::Simple to limit dependencies.
+	#
+	# We always die on signal.
+	my $core = $ret & 128 ? " (core dumped)" : "";
+	die "sqlcmd exited with signal "
+	  . ($ret & 127)
+	  . "$core: '$$stderr' while running '@tsql_params'"
+	  if $ret & 127;
+	$ret = $ret >> 8;
+
+	if ($ret && $params{on_error_die})
+	{
+		die "sqlcmd error: stderr: '$$stderr'\nwhile running '@tsql_params'"
+		  if $ret == 1;
+		die "connection error: '$$stderr'\nwhile running '@tsql_params'"
+		  if $ret == 2;
+		die
+		  "error running SQL: '$$stderr'\nwhile running '@tsql_params' with sql '$sql'"
+		  if $ret == 3;
+		die "sqlcmd returns $ret: '$$stderr'\nwhile running '@tsql_params'";
+	}
+
+	if (wantarray)
+	{
+		return ($ret, $$stdout, $$stderr);
+	}
+	else
+	{
+		return $ret;
+	}
+
+}
+
+sub safe_tsql {
+	my ($node, $dbname, $sql, %params) = @_;
+
+	my ($stdout, $stderr);
+
+	my $ret = tsql(
+		$node, $dbname, $sql,
+		%params,
+		stdout        => \$stdout,
+		stderr        => \$stderr,
+		on_error_die  => 1,
+		on_error_stop => 1);
+
+	# tsql can emit stderr from NOTICEs etc
+	if ($stderr ne "")
+	{
+		print "#### Begin standard error\n";
+		print $stderr;
+		print "\n#### End standard error\n";
+	}
+
+	return $stdout;
+}
+
+# prepares a sqlcmd string with -S and -d option. It also appends extra options
+# if provided.
+sub tsql_connstr
+{
+	my ($self, $dbname, %params) = @_;
+
+	my $node = $self->{_node};
+	my @connarray;
+
+	my $dbhost;
+	if (!defined $params{dbhost})
+	{
+		$dbhost = '127.0.0.1,'.$self->{_tsql_port};
+	}
+	else
+	{
+		$dbhost = $params{dbhost};
+	}
+	push @connarray, '-S', $dbhost;
+
+	# Escape properly the database string before using it, only
+	# single quotes and backslashes need to be treated this way.
+	$dbname =~ s#\\#\\\\#g;
+	$dbname =~ s#\'#\\\'#g;
+	push @connarray, '-d', $dbname;
+
+	push @connarray, @{ $params{extra_params} }
+	  if defined $params{extra_params};
+
+	return @connarray;
+}
+
+# same as tsql_connstr but also appends a login id and password
+sub tsql_connstr_with_role
+{
+	my ($self, $dbname, $dbrole, $dbpass, %params) = @_;
+
+	my $node = $self->{_node};
+	my @connarray = $self->tsql_connstr($dbname, %params);
+
+	$dbrole =~ s#\\#\\\\#g;
+	$dbrole =~ s#\'#\\\'#g;
+	push @connarray, '-U', $dbrole;
+	push @connarray, '-P', $dbpass;
+
+	return @connarray;
+}
+
+sub connect_ok
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+	my ($self, $test_name, %params) = @_;
+	my $node = $self->{_node};
+
+	my @connstr;
+	if (!defined($params{connstr}))
+	{
+		die "missing connection string";
+	}
+	else
+	{
+		@connstr = @{$params{connstr}};
+	}
+
+	my $sql;
+	if (defined($params{sql}))
+	{
+		$sql = $params{sql};
+	}
+	else
+	{
+		$sql = "SELECT \"connected with @connstr\"";
+	}
+
+	my (@log_like, @log_unlike);
+	if (defined($params{log_like}))
+	{
+		@log_like = @{ $params{log_like} };
+	}
+	if (defined($params{log_unlike}))
+	{
+		@log_unlike = @{ $params{log_unlike} };
+	}
+
+	my $log_location = -s $node->logfile();
+
+	# Never prompt for a password, any callers of this routine should
+	# have set up things properly, and this should not block.
+	my ($ret, $stdout, $stderr) = $self->tsql(
+		'master',
+		$sql,
+		connstr       => \@connstr,
+		on_error_stop => 0);
+
+	is($ret, 0, $test_name);
+
+	if (defined($params{expected_stdout}))
+	{
+		like($stdout, $params{expected_stdout}, "$test_name: matches");
+	}
+	if (@log_like or @log_unlike)
+	{
+		my $log_contents = slurp_file($node->logfile(), $log_location);
+
+		while (my $regex = shift @log_like)
+		{
+			like($log_contents, $regex, "$test_name: log matches");
+		}
+		while (my $regex = shift @log_unlike)
+		{
+			unlike($log_contents, $regex, "$test_name: log does not match");
+		}
+	}
+}
+
+sub connect_fails
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+	my ($self, $test_name, %params) = @_;
+	my $node = $self->{_node};
+
+	my @connstr;
+	if (!defined($params{connstr}))
+	{
+		die "missing connection string";
+	}
+	else
+	{
+		@connstr = @{$params{connstr}};
+	}
+
+	my $sql;
+	if (defined($params{sql}))
+	{
+		$sql = $params{sql};
+	}
+	else
+	{
+		$sql = "SELECT \"connected with @connstr\"";
+	}
+
+	my (@log_like, @log_unlike);
+	if (defined($params{log_like}))
+	{
+		@log_like = @{ $params{log_like} };
+	}
+	if (defined($params{log_unlike}))
+	{
+		@log_unlike = @{ $params{log_unlike} };
+	}
+
+	my $log_location = -s $node->logfile();
+
+	# Never prompt for a password, any callers of this routine should
+	# have set up things properly, and this should not block.
+	my ($ret, $stdout, $stderr) = $self->tsql(
+		'master',
+		$sql,
+		connstr       => \@connstr,
+		on_error_stop => 0);
+
+	isnt($ret, 0, $test_name);
+
+	if (defined($params{expected_stdout}))
+	{
+		like($stdout, $params{expected_stdout}, "$test_name: matches");
+	}
+	if (@log_like or @log_unlike)
+	{
+		my $log_contents = slurp_file($node->logfile(), $log_location);
+
+		while (my $regex = shift @log_like)
+		{
+			like($log_contents, $regex, "$test_name: log matches");
+		}
+		while (my $regex = shift @log_unlike)
+		{
+			unlike($log_contents, $regex, "$test_name: log does not match");
+		}
+	}
+}
+
+1;

--- a/contrib/babelfishpg_tds/test/t/001_tdspasswd.pl
+++ b/contrib/babelfishpg_tds/test/t/001_tdspasswd.pl
@@ -1,0 +1,69 @@
+# Copyright (c) 2021, Amazon Web Services, Inc. or its affiliates. All Rights Reserved
+
+# Verify that work items work correctly
+
+use strict;
+use warnings;
+
+
+use Test::More tests => 6;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use TDSNode;
+
+# Delete pg_hba.conf from the given node, add a new entry to it
+# and then execute a reload to refresh it.
+sub reset_pg_hba
+{
+	my $node       = shift;
+	my $hba_method = shift;
+
+	unlink($node->data_dir . '/pg_hba.conf');
+	# just for testing purposes, use a continuation line
+	$node->append_conf('pg_hba.conf', "host all all 127.0.0.1/32 \\\n $hba_method");
+	$node->reload;
+	return;
+}
+
+# Initialize primary node
+my $node = PostgreSQL::Test::Cluster->new('primary');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq{
+log_connections = on
+listen_addresses='127.0.0.1'
+shared_preload_libraries = 'babelfishpg_tds'
+lc_messages = 'C'
+});
+$node->start;
+
+# Initialize Babelfish
+my $tsql_node = new TDSNode($node);
+$tsql_node->init_tsql('test_master', 'testdb');
+
+# Create a login with password
+$tsql_node->safe_tsql("master","CREATE LOGIN test_login WITH PASSWORD='12345678'");
+
+my @connstr1 = $tsql_node->tsql_connstr_with_role('master', 'test_master', '');
+$tsql_node->connect_ok('Test 1', (connstr => \@connstr1));
+
+# Test password and md5 methods
+reset_pg_hba($node, 'password');
+my @connstr2 = $tsql_node->tsql_connstr_with_role('master', 'test_login', '12345678');
+$tsql_node->connect_ok('Test 2', (connstr => \@connstr2));
+reset_pg_hba($node, 'md5');
+my @connstr3 = $tsql_node->tsql_connstr_with_role('master', 'test_login', '12345678');
+$tsql_node->connect_ok('Test 3', (connstr => \@connstr3));
+
+# Test invalid password
+my @connstr4 = $tsql_node->tsql_connstr_with_role('master', 'test_login', '123');
+$tsql_node->connect_fails('Test 4', (connstr => \@connstr4));
+
+# Test reject method
+reset_pg_hba($node, 'reject');
+my @connstr5 = $tsql_node->tsql_connstr_with_role('master', 'test_login', '12345678');
+$tsql_node->connect_fails('Test 5', (connstr => \@connstr5),
+					   log_like =>
+					   [qr/pg_hba.conf rejects connection for host "127.0.0.1", user "test_login", database "testdb"/]);
+
+$node->stop;

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -1,0 +1,412 @@
+
+# Copyright (c) 2021-2022, PostgreSQL Global Development Group
+
+# Sets up a KDC and then runs a variety of tests to make sure that the
+# GSSAPI/Kerberos authentication and encryption are working properly,
+# that the options in pg_hba.conf and pg_ident.conf are handled correctly,
+# and that the server-side pg_stat_gssapi view reports what we expect to
+# see for each test.
+#
+# Since this requires setting up a full KDC, it doesn't make much sense
+# to have multiple test scripts (since they'd have to also create their
+# own KDC and that could cause race conditions or other problems)- so
+# just add whatever other tests are needed to here.
+#
+# See the README for additional information.
+
+use strict;
+use warnings;
+use PostgreSQL::Test::Utils;
+use PostgreSQL::Test::Cluster;
+use Test::More;
+use Time::HiRes qw(usleep);
+use TDSNode;
+
+if ($ENV{with_gssapi} ne 'yes')
+{
+	plan skip_all => 'GSSAPI/Kerberos not supported by this build';
+}
+
+my ($krb5_bin_dir, $krb5_sbin_dir);
+
+if ($^O eq 'darwin')
+{
+	$krb5_bin_dir  = '/usr/local/opt/krb5/bin';
+	$krb5_sbin_dir = '/usr/local/opt/krb5/sbin';
+}
+elsif ($^O eq 'freebsd')
+{
+	$krb5_bin_dir  = '/usr/local/bin';
+	$krb5_sbin_dir = '/usr/local/sbin';
+}
+elsif ($^O eq 'linux')
+{
+	$krb5_sbin_dir = '/usr/sbin';
+}
+
+my $krb5_config  = 'krb5-config';
+my $kinit        = 'kinit';
+my $kdb5_util    = 'kdb5_util';
+my $kadmin_local = 'kadmin.local';
+my $krb5kdc      = 'krb5kdc';
+
+if ($krb5_bin_dir && -d $krb5_bin_dir)
+{
+	$krb5_config = $krb5_bin_dir . '/' . $krb5_config;
+	$kinit       = $krb5_bin_dir . '/' . $kinit;
+}
+if ($krb5_sbin_dir && -d $krb5_sbin_dir)
+{
+	$kdb5_util    = $krb5_sbin_dir . '/' . $kdb5_util;
+	$kadmin_local = $krb5_sbin_dir . '/' . $kadmin_local;
+	$krb5kdc      = $krb5_sbin_dir . '/' . $krb5kdc;
+}
+
+my $host     = 'auth-test-localhost.postgresql.example.com';
+my $hostaddr = '127.0.0.1';
+my $realm    = 'EXAMPLE.COM';
+
+my $krb5_conf   = "${PostgreSQL::Test::Utils::tmp_check}/krb5.conf";
+my $kdc_conf    = "${PostgreSQL::Test::Utils::tmp_check}/kdc.conf";
+my $krb5_cache  = "${PostgreSQL::Test::Utils::tmp_check}/krb5cc";
+my $krb5_log    = "${PostgreSQL::Test::Utils::log_path}/krb5libs.log";
+my $kdc_log     = "${PostgreSQL::Test::Utils::log_path}/krb5kdc.log";
+my $kdc_port    = PostgreSQL::Test::Cluster::get_free_port();
+my $kdc_datadir = "${PostgreSQL::Test::Utils::tmp_check}/krb5kdc";
+my $kdc_pidfile = "${PostgreSQL::Test::Utils::tmp_check}/krb5kdc.pid";
+my $keytab      = "${PostgreSQL::Test::Utils::tmp_check}/krb5.keytab";
+
+my $dbname      = 'postgres';
+my $username    = 'test1';
+my $application = '002_tdskerberos.pl';
+
+note "setting up Kerberos";
+
+my ($stdout, $krb5_version);
+run_log [ $krb5_config, '--version' ], '>', \$stdout
+  or BAIL_OUT("could not execute krb5-config");
+BAIL_OUT("Heimdal is not supported") if $stdout =~ m/heimdal/;
+$stdout =~ m/Kerberos 5 release ([0-9]+\.[0-9]+)/
+  or BAIL_OUT("could not get Kerberos version");
+$krb5_version = $1;
+
+append_to_file(
+	$krb5_conf,
+	qq![logging]
+default = FILE:$krb5_log
+kdc = FILE:$kdc_log
+
+[libdefaults]
+default_realm = $realm
+
+[realms]
+$realm = {
+    kdc = $hostaddr:$kdc_port
+}!);
+
+append_to_file(
+	$kdc_conf,
+	qq![kdcdefaults]
+!);
+
+# For new-enough versions of krb5, use the _listen settings rather
+# than the _ports settings so that we can bind to localhost only.
+if ($krb5_version >= 1.15)
+{
+	append_to_file(
+		$kdc_conf,
+		qq!kdc_listen = $hostaddr:$kdc_port
+kdc_tcp_listen = $hostaddr:$kdc_port
+!);
+}
+else
+{
+	append_to_file(
+		$kdc_conf,
+		qq!kdc_ports = $kdc_port
+kdc_tcp_ports = $kdc_port
+!);
+}
+append_to_file(
+	$kdc_conf,
+	qq!
+[realms]
+$realm = {
+    database_name = $kdc_datadir/principal
+    admin_keytab = FILE:$kdc_datadir/kadm5.keytab
+    acl_file = $kdc_datadir/kadm5.acl
+    key_stash_file = $kdc_datadir/_k5.$realm
+}!);
+
+mkdir $kdc_datadir or die;
+
+# Ensure that we use test's config and cache files, not global ones.
+$ENV{'KRB5_CONFIG'}      = $krb5_conf;
+$ENV{'KRB5_KDC_PROFILE'} = $kdc_conf;
+$ENV{'KRB5CCNAME'}       = $krb5_cache;
+
+my $service_principal = "$ENV{with_krb_srvnam}/$host";
+my $tsql_service_principal = "MSSQLSvc/$hostaddr:1433";
+
+system_or_bail $kdb5_util, 'create', '-s', '-P', 'secret0';
+
+my $test1_password = 'secret1';
+system_or_bail $kadmin_local, '-q', "addprinc -pw $test1_password test1";
+
+system_or_bail $kadmin_local, '-q', "addprinc -randkey $service_principal";
+system_or_bail $kadmin_local, '-q', "addprinc -randkey $tsql_service_principal";
+system_or_bail $kadmin_local, '-q', "ktadd -k $keytab $service_principal $tsql_service_principal";
+
+system_or_bail $krb5kdc, '-P', $kdc_pidfile;
+
+END
+{
+	kill 'INT', `cat $kdc_pidfile` if -f $kdc_pidfile;
+}
+
+note "setting up PostgreSQL instance";
+
+my $node = PostgreSQL::Test::Cluster->new('node');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq{
+listen_addresses = '$hostaddr'
+krb_server_keyfile = '$keytab'
+log_connections = on
+shared_preload_libraries = 'babelfishpg_tds'
+lc_messages = 'C'
+});
+$node->start;
+
+# Initialize Babelfish
+my $tsql_node = new TDSNode($node);
+$tsql_node->init_tsql('test_master', 'testdb');
+
+$node->safe_psql('postgres', 'CREATE USER test1;');
+$node->safe_psql('postgres', 'CREATE ROLE "test1@EXAMPLE.COM";');
+
+note "running tests";
+
+# Test connection success or failure, and if success, that query returns true.
+sub test_access
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	my ($node, $role, $query, $expected_res, $gssencmode, $test_name,
+		@expect_log_msgs)
+	  = @_;
+
+	# need to connect over TCP/IP for Kerberos
+	my $connstr = $node->connstr('postgres')
+	  . " user=$role host=$host hostaddr=$hostaddr $gssencmode";
+
+	my %params = (sql => $query,);
+
+	if (@expect_log_msgs)
+	{
+		# Match every message literally.
+		my @regexes = map { qr/\Q$_\E/ } @expect_log_msgs;
+
+		$params{log_like} = \@regexes;
+	}
+
+	if ($expected_res eq 0)
+	{
+		# The result is assumed to match "true", or "t", here.
+		$params{expected_stdout} = qr/^t$/;
+
+		$node->connect_ok($connstr, $test_name, %params);
+	}
+	else
+	{
+		$node->connect_fails($connstr, $test_name, %params);
+	}
+}
+
+# As above, but test for an arbitrary query result.
+sub test_query
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	my ($node, $role, $query, $expected, $gssencmode, $test_name) = @_;
+
+	# need to connect over TCP/IP for Kerberos
+	my $connstr = $node->connstr('postgres')
+	  . " user=$role host=$host hostaddr=$hostaddr $gssencmode";
+
+	$node->connect_ok(
+		$connstr, $test_name,
+		sql             => $query,
+		expected_stdout => $expected);
+	return;
+}
+
+unlink($node->data_dir . '/pg_hba.conf');
+$node->append_conf('pg_hba.conf',
+	qq{host all all $hostaddr/32 gss map=mymap});
+$node->restart;
+
+test_access($node, 'test1', 'SELECT true', 2, '', 'fails without ticket');
+
+run_log [ $kinit, 'test1' ], \$test1_password or BAIL_OUT($?);
+
+test_access(
+	$node,
+	'test1',
+	'SELECT true',
+	2,
+	'',
+	'fails without mapping',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"no match in usermap \"mymap\" for user \"test1\"");
+
+$node->append_conf('pg_ident.conf', qq{mymap  /^(.*)\@$realm\$  \\1});
+$node->restart;
+
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated AND encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'',
+	'succeeds with mapping with default gssencmode and host hba',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=yes, principal=test1\@$realm)"
+);
+
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated AND encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'gssencmode=prefer',
+	'succeeds with GSS-encrypted access preferred with host hba',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=yes, principal=test1\@$realm)"
+);
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated AND encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'gssencmode=require',
+	'succeeds with GSS-encrypted access required with host hba',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=yes, principal=test1\@$realm)"
+);
+
+# Test that we can transport a reasonable amount of data.
+test_query(
+	$node,
+	'test1',
+	'SELECT * FROM generate_series(1, 100000);',
+	qr/^1\n.*\n1024\n.*\n9999\n.*\n100000$/s,
+	'gssencmode=require',
+	'receiving 100K lines works');
+
+test_query(
+	$node,
+	'test1',
+	"CREATE TEMP TABLE mytab (f1 int primary key);\n"
+	  . "COPY mytab FROM STDIN;\n"
+	  . join("\n", (1 .. 100000))
+	  . "\n\\.\n"
+	  . "SELECT COUNT(*) FROM mytab;",
+	qr/^100000$/s,
+	'gssencmode=require',
+	'sending 100K lines works');
+
+unlink($node->data_dir . '/pg_hba.conf');
+$node->append_conf('pg_hba.conf',
+	qq{hostgssenc all all $hostaddr/32 gss map=mymap});
+$node->restart;
+
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated AND encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'gssencmode=prefer',
+	'succeeds with GSS-encrypted access preferred and hostgssenc hba',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=yes, principal=test1\@$realm)"
+);
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated AND encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'gssencmode=require',
+	'succeeds with GSS-encrypted access required and hostgssenc hba',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=yes, principal=test1\@$realm)"
+);
+test_access($node, 'test1', 'SELECT true', 2, 'gssencmode=disable',
+	'fails with GSS encryption disabled and hostgssenc hba');
+
+unlink($node->data_dir . '/pg_hba.conf');
+$node->append_conf('pg_hba.conf',
+	qq{hostnogssenc all all $hostaddr/32 gss map=mymap});
+$node->restart;
+
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated and not encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'gssencmode=prefer',
+	'succeeds with GSS-encrypted access preferred and hostnogssenc hba, but no encryption',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=no, principal=test1\@$realm)"
+);
+test_access($node, 'test1', 'SELECT true', 2, 'gssencmode=require',
+	'fails with GSS-encrypted access required and hostnogssenc hba');
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated and not encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'gssencmode=disable',
+	'succeeds with GSS encryption disabled and hostnogssenc hba',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=no, principal=test1\@$realm)"
+);
+
+truncate($node->data_dir . '/pg_ident.conf', 0);
+unlink($node->data_dir . '/pg_hba.conf');
+$node->append_conf('pg_hba.conf',
+	qq{host all all $hostaddr/32 gss include_realm=0});
+$node->restart;
+
+test_access(
+	$node,
+	'test1',
+	'SELECT gss_authenticated AND encrypted from pg_stat_gssapi where pid = pg_backend_pid();',
+	0,
+	'',
+	'succeeds with include_realm=0 and defaults',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss",
+	"connection authorized: user=$username database=$dbname application_name=$application GSS (authenticated=yes, encrypted=yes, principal=test1\@$realm)"
+);
+
+# Reset pg_hba.conf, and cause a usermap failure with an authentication
+# that has passed.
+unlink($node->data_dir . '/pg_hba.conf');
+$node->append_conf('pg_hba.conf',
+	qq{host all all $hostaddr/32 gss include_realm=0 krb_realm=EXAMPLE.ORG});
+$node->restart;
+
+test_access(
+	$node,
+	'test1',
+	'SELECT true',
+	2,
+	'',
+	'fails with wrong krb_realm, but still authenticates',
+	"connection authenticated: identity=\"test1\@$realm\" method=gss");
+
+# Babelfish Tests start here
+my @connstr1 = $tsql_node->tsql_connstr('master');
+$tsql_node->connect_fails('Test 1', (connstr => \@connstr1, log_like => [qr/role "test1\@EXAMPLE.COM" is not permitted to log in/]));
+
+done_testing();


### PR DESCRIPTION
In PG, TAP test framework is used to drive tests for backup and restore, replication, etc - anything that can't really be expressed using pg_regress or the isolation test framework.

Basically, it can be used if we want something more than just comparing the expected outputs. It may include:
1. Some engine/os configuration changes
2. Start or stop the server
3. grep log messages from log file and match with expected log file output
4. system calls

In Babelfish, we can utilize the same test framework for the following scenarios:
1. pg_hba.conf changes with password authentication
2. Kerberos authentication by setting up MIT kerberos
3. SSL setup and test encrypted connection
4. Different Provisioning scenarios

Authored-by: Kuntal Ghosh <kuntalgh@amazon.com>
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).