### PR TITLE
Re-implement object_name() sql function to C type function to improve performance

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -40,6 +40,13 @@
 #include "../src/catalog.h"
 #include "../src/collation.h"
 #include "../src/rolecmds.h"
+#include "utils/fmgroids.h"
+#include "utils/acl.h"
+#include "access/table.h"
+#include "access/genam.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_trigger.h"
+#include "catalog/pg_constraint.h"
 
 #define TSQL_STAT_GET_ACTIVITY_COLS 25
 #define SP_DATATYPE_INFO_HELPER_COLS 23
@@ -72,6 +79,7 @@ PG_FUNCTION_INFO_V1(get_current_full_xact_id);
 PG_FUNCTION_INFO_V1(checksum);
 PG_FUNCTION_INFO_V1(has_dbaccess);
 PG_FUNCTION_INFO_V1(object_id);
+PG_FUNCTION_INFO_V1(object_name);
 PG_FUNCTION_INFO_V1(sp_datatype_info_helper);
 PG_FUNCTION_INFO_V1(language);
 PG_FUNCTION_INFO_V1(host_name);
@@ -1161,20 +1169,14 @@ object_id(PG_FUNCTION_ARGS)
 		}
 		else
 		{
-			/* search in pg_constraint by name and schema oid */
-			result = tsql_get_constraint_oid(object_name, schema_oid, user_id);
-
-			if (!OidIsValid(result)) /* search only if not found earlier */
+			/* search in pg_class by name and schema oid */
+			Oid relid = get_relname_relid((const char *) object_name, schema_oid);
+			if (OidIsValid(relid) && pg_class_aclcheck(relid, user_id, ACL_SELECT) == ACLCHECK_OK)
 			{
-				/* search in pg_class by name and schema oid */
-				Oid relid = get_relname_relid((const char *) object_name, schema_oid);
-				if (OidIsValid(relid) && pg_class_aclcheck(relid, user_id, ACL_SELECT) == ACLCHECK_OK)
-				{
-					result = relid;
-				} 
+				result = relid;
 			}
-
-			if (!OidIsValid(result))
+								
+			if (!OidIsValid(result))  /* search only if not found earlier */
 			{
 				/* search in pg_trigger by name and schema oid */
 				result = tsql_get_trigger_oid(object_name, schema_oid, user_id);
@@ -1184,6 +1186,12 @@ object_id(PG_FUNCTION_ARGS)
 			{
 				/* search in pg_proc by name and schema oid */
 				result = tsql_get_proc_oid(object_name, schema_oid, user_id);
+			}
+
+			if (!OidIsValid(result))
+			{
+				 /* search in pg_constraint by name and schema oid */
+				result = tsql_get_constraint_oid(object_name, schema_oid, user_id);
 			}
 		}
 	}
@@ -1197,6 +1205,163 @@ object_id(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 }
 
+/*
+ * object_name
+ * 		returns the object name with object id and database id as input where database id is optional
+ * Returns NULL
+ * 		if there is no such object in specified database, if database id is not provided it will lookup in current database
+ * 		if user don't have right permission
+ */
+Datum
+object_name(PG_FUNCTION_ARGS)
+{
+	int32 				input1 = PG_GETARG_INT32(0);
+	Oid 				object_id;
+	Oid 				database_id;
+	Oid 				user_id = GetUserId();
+	Oid				schema_id = InvalidOid;
+	HeapTuple 			tuple;
+	Relation			tgrel;
+	ScanKeyData 			key;
+	SysScanDesc 			tgscan;
+	EphemeralNamedRelation 		enr;
+	bool 				found = false;
+	char 				*result = NULL;
+
+	if(input1 < 0)
+		PG_RETURN_NULL();
+	object_id = (Oid) input1;
+	if (!PG_ARGISNULL(1)) /* if database id is provided */
+	{
+		int32  input2 = PG_GETARG_INT32(1);
+		if(input2 < 0)
+			PG_RETURN_NULL();
+		database_id = (Oid) input2;
+		if (database_id != get_cur_db_id()) /* cross-db lookup */
+		{	
+			char *db_name = get_db_name(database_id);
+			if (db_name == NULL) /* database doesn't exist with given oid */
+				PG_RETURN_NULL();
+			user_id = GetSessionUserId();
+			pfree(db_name);
+		}
+	}
+	else	/* by default lookup in current database */
+		database_id = get_cur_db_id();
+
+	/* search in list of ENRs registered in the current query environment by object_id */
+	enr = get_ENR_withoid(currentQueryEnv, object_id);
+	if(enr != NULL && enr->md.enrtype == ENR_TSQL_TEMP)
+	{
+		result = enr->md.name;
+		PG_RETURN_VARCHAR_P((VarChar *) cstring_to_text(result));
+	}
+
+	/* search in pg_class by object_id */
+	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(object_id));
+	if (HeapTupleIsValid(tuple))
+	{
+		/* check if user have right permission on object */
+		if (pg_class_aclcheck(object_id, user_id, ACL_SELECT) == ACLCHECK_OK)
+		{	
+			Form_pg_class pg_class = (Form_pg_class) GETSTRUCT(tuple);
+			result = NameStr(pg_class->relname);
+			schema_id = pg_class->relnamespace;
+		}
+		ReleaseSysCache(tuple);
+		found = true;
+	}
+
+	if (!found)
+	{
+		/* search in pg_proc by object_id */
+		tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(object_id));
+		if (HeapTupleIsValid(tuple))
+		{
+			/* check if user have right permission on object */
+			if (pg_proc_aclcheck(object_id, user_id, ACL_EXECUTE) == ACLCHECK_OK)
+			{
+				Form_pg_proc procform = (Form_pg_proc) GETSTRUCT(tuple);
+				result = NameStr(procform->proname);
+				schema_id = procform->pronamespace;
+			}
+			ReleaseSysCache(tuple);
+			found = true;
+		}
+	}
+
+	if (!found)
+	{
+		/* search in pg_type by object_id */
+		tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(object_id));
+		if (HeapTupleIsValid(tuple))
+		{
+			/* check if user have right permission on object */
+			if (pg_type_aclcheck(object_id, user_id, ACL_USAGE) == ACLCHECK_OK)
+			{	
+				Form_pg_type pg_type = (Form_pg_type) GETSTRUCT(tuple);
+				result = NameStr(pg_type->typname);
+			}
+			ReleaseSysCache(tuple);
+			found = true;
+		}
+	}
+	
+	if(!found)
+	{
+		/* search in pg_trigger by object_id */
+		tgrel = table_open(TriggerRelationId, AccessShareLock);
+		ScanKeyInit(&key,
+				Anum_pg_trigger_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(object_id));
+
+		tgscan = systable_beginscan(tgrel, TriggerOidIndexId, true,
+						NULL, 1, &key);
+
+		tuple = systable_getnext(tgscan);
+		if (HeapTupleIsValid(tuple))
+		{
+			Form_pg_trigger pg_trigger = (Form_pg_trigger) GETSTRUCT(tuple);
+			/* check if user have right permission on object */
+			if(OidIsValid(pg_trigger->tgrelid) && 
+				pg_class_aclcheck(pg_trigger->tgrelid, user_id, ACL_SELECT) == ACLCHECK_OK)
+			{
+				result = NameStr(pg_trigger->tgname);
+				schema_id = get_rel_namespace(pg_trigger->tgrelid);
+			}
+			found = true;
+		}
+		systable_endscan(tgscan);
+		table_close(tgrel, AccessShareLock);
+	}
+
+	if(!found)
+	{
+		/* search in pg_constraint by object_id */
+		tuple = SearchSysCache1(CONSTROID, ObjectIdGetDatum(object_id));
+		if (HeapTupleIsValid(tuple))
+		{	
+			Form_pg_constraint con = (Form_pg_constraint) GETSTRUCT(tuple);
+			/* check if user have right permission on object */
+			if (OidIsValid(con->conrelid) && (pg_class_aclcheck(con->conrelid, user_id, ACL_SELECT) == ACLCHECK_OK))
+			{	
+				result = NameStr(con->conname);
+				schema_id = con->connamespace;
+			}
+			ReleaseSysCache(tuple);
+			found = true;
+		}
+	}
+
+	if(result)
+	{	
+		/* check if schema corresponding to found object belongs to specified database */
+		if(!OidIsValid(schema_id) || is_schema_from_db(schema_id, database_id)) /* in case of pg_type schema_id will be invalid */
+			PG_RETURN_VARCHAR_P((VarChar *) cstring_to_text(result));
+	}
+	PG_RETURN_NULL();
+}
 
 Datum
 has_dbaccess(PG_FUNCTION_ARGS)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1340,6 +1340,11 @@ ALTER FUNCTION sys.system_user() STABLE;
 ALTER FUNCTION sys.session_user() STABLE;
 ALTER FUNCTION UPDATE (TEXT) STABLE;
 
+CREATE OR REPLACE FUNCTION sys.OBJECT_NAME(IN object_id INT, IN database_id INT DEFAULT NULL)
+RETURNS sys.SYSNAME AS
+'babelfishpg_tsql', 'object_name'
+LANGUAGE C STABLE;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1994,6 +1994,7 @@ extern Oid tsql_get_trigger_oid(char *tgname, Oid tgnamespace, Oid user_id);
 extern Oid tsql_get_constraint_oid(char *conname, Oid connamespace, Oid user_id);
 extern Oid tsql_get_proc_oid(char *proname, Oid pronamespace, Oid user_id);
 extern char** split_object_name(char *name);
+extern bool is_schema_from_db(Oid schema_oid, Oid db_id);
 
 typedef struct
 {

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -21,6 +21,7 @@
 #include "utils/acl.h"
 #include "access/table.h"
 #include "access/genam.h"
+#include "catalog.h"
 
 #include "multidb.h"
 
@@ -1137,3 +1138,19 @@ split_object_name(char *name)
 }
 
 
+
+/*
+ * is_schema_from_db
+ *		Given schema_oid and db_id, check if schema belongs to provided database id.
+ */
+bool is_schema_from_db(Oid schema_oid, Oid db_id)
+{
+	Oid db_id_from_schema;
+	char *schema_name = get_namespace_name(schema_oid);
+	if(!schema_name)
+		return false;
+
+	db_id_from_schema = get_dbid_from_physical_schema_name(schema_name, true);
+	pfree(schema_name);
+	return (db_id_from_schema == db_id);
+}

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-verify.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-verify.out
@@ -519,8 +519,8 @@ babel_object_id_user2
 ~~END~~
 
 
--- Now we can access
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_t1'))
+-- Now we can access, to verify name using object_name we have to provide db_id for cross-db lookup 
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_t1'), DB_ID('master'))
 GO
 ~~START~~
 varchar
@@ -528,7 +528,7 @@ babel_object_id_t1
 ~~END~~
 
 
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_proc1'))
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_proc1'), DB_ID('master'))
 GO
 ~~START~~
 varchar
@@ -536,7 +536,7 @@ babel_object_id_proc1
 ~~END~~
 
 
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_func1'))
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_func1'), DB_ID('master'))
 GO
 ~~START~~
 varchar
@@ -544,7 +544,7 @@ babel_object_id_func1
 ~~END~~
 
 
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_v1'))
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_v1'), DB_ID('master'))
 GO
 ~~START~~
 varchar

--- a/test/JDBC/expected/BABEL_OBJECT_NAME-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_OBJECT_NAME-vu-cleanup.out
@@ -1,0 +1,67 @@
+-- tsql
+USE babel_object_name_db;
+GO
+
+DROP USER babel_object_name_user2
+GO
+
+DROP TABLE babel_object_name_db_t1;
+GO
+
+USE master;
+GO
+
+
+DROP USER babel_object_name_master_user1;
+GO
+
+DROP TABLE babel_object_name_store_OID
+GO
+
+DROP LOGIN babel_object_name_login1;
+GO
+
+DROP DATABASE babel_object_name_db;
+GO
+
+DROP VIEW babel_object_name_constraint_view
+GO
+
+DROP TABLE babel_object_name_t_pk
+GO
+
+DROP VIEW babel_object_name_v1_view
+GO
+
+DROP VIEW babel_object_name_func1_view
+GO
+
+DROP VIEW babel_object_name_trg_view 
+GO
+
+DROP VIEW babel_object_name_t1_view
+GO
+
+DROP VIEW babel_object_name_proc1_view
+GO
+
+DROP VIEW babel_object_name_type_view
+GO
+
+DROP TYPE babel_object_name_type_int
+GO
+
+DROP VIEW babel_object_name_v1
+GO
+
+DROP FUNCTION BABEL_OBJECT_NAME_func1
+GO
+
+DROP PROCEDURE BABEL_OBJECT_NAME_PROC1
+GO
+
+DROP TRIGGER babel_object_name_trg
+GO
+
+DROP TABLE babel_object_name_t1
+GO

--- a/test/JDBC/expected/BABEL_OBJECT_NAME-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_OBJECT_NAME-vu-prepare.out
@@ -1,0 +1,90 @@
+-- tsql
+-- To test table, trigger, procedure, function
+CREATE TABLE babel_object_name_t1 (a int);
+GO
+
+CREATE TRIGGER babel_object_name_trg ON babel_object_name_t1 AFTER INSERT AS SELECT 1;
+GO
+
+CREATE PROCEDURE BABEL_OBJECT_NAME_PROC1 AS SELECT 1;
+GO
+
+CREATE FUNCTION BABEL_OBJECT_NAME_func1() returns int BEGIN RETURN 1; END
+GO
+
+CREATE VIEW babel_object_name_v1 AS SELECT 1;
+GO
+
+-- to test type
+CREATE TYPE babel_object_name_type_int FROM INT NOT NULL
+GO
+
+CREATE VIEW babel_object_name_type_view AS
+SELECT OBJECT_NAME(user_type_id) FROM  sys.types where name = 'babel_object_name_type_int'
+GO
+
+CREATE VIEW babel_object_name_proc1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('BABEL_OBJECT_NAME_PROC1'))
+GO
+
+CREATE VIEW babel_object_name_t1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_t1'))
+GO
+
+CREATE VIEW babel_object_name_trg_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_trg'));
+GO
+
+CREATE VIEW babel_object_name_func1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('BABEL_OBJECT_NAME_func1'))
+GO
+
+CREATE VIEW babel_object_name_v1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_v1'))
+GO
+
+
+-- To test constraint
+CREATE TABLE babel_object_name_t_pk ( a int, b int constraint babel_object_name_constraint check ( b > 0 ))
+go
+
+CREATE VIEW babel_object_name_constraint_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_constraint'))
+go
+
+-- To test cross-db lookup
+CREATE DATABASE babel_object_name_db;
+GO
+
+USE babel_object_name_db;
+GO
+
+CREATE TABLE babel_object_name_db_t1 (a int);
+GO
+
+
+-- to test dependency of user's permission on object
+USE master;
+GO
+
+CREATE LOGIN babel_object_name_login1 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_name_master_user1 FOR LOGIN babel_object_name_login1;
+GO
+
+USE babel_object_name_db;
+GO
+
+CREATE USER babel_object_name_user2 FOR LOGIN babel_object_name_login1;
+GO
+
+USE master;
+GO
+
+CREATE TABLE babel_object_name_store_OID (a int);
+GO
+
+
+
+

--- a/test/JDBC/expected/BABEL_OBJECT_NAME-vu-verify.out
+++ b/test/JDBC/expected/BABEL_OBJECT_NAME-vu-verify.out
@@ -1,0 +1,300 @@
+-- tsql
+-- test table, trigger, procedure, function
+SELECT * FROM babel_object_name_t1_view
+GO
+~~START~~
+varchar
+babel_object_name_t1
+~~END~~
+
+
+SELECT * FROM babel_object_name_proc1_view
+GO
+~~START~~
+varchar
+babel_object_name_proc1
+~~END~~
+
+
+SELECT * FROM babel_object_name_func1_view
+GO
+~~START~~
+varchar
+babel_object_name_func1
+~~END~~
+
+
+SELECT * FROM babel_object_name_v1_view
+GO
+~~START~~
+varchar
+babel_object_name_v1
+~~END~~
+
+
+SELECT * FROM babel_object_name_trg_view
+GO
+~~START~~
+varchar
+babel_object_name_trg
+~~END~~
+
+
+-- test types
+SELECT * FROM babel_object_name_type_view
+GO
+~~START~~
+varchar
+babel_object_name_type_int
+~~END~~
+
+
+-- test constraint
+SELECT * FROM babel_object_name_constraint_view
+GO
+~~START~~
+varchar
+babel_object_name_constraint
+~~END~~
+
+
+-- Negative values/ out of range values
+SELECT OBJECT_NAME(-123)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_trg_view'), -123)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- max value
+SELECT OBJECT_NAME(2147483647)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- greater than max allowed value
+SELECT OBJECT_NAME(2147483648)
+GO
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+-- To test temp object
+CREATE TABLE #babel_object_name_temp_t1 (a int);
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('#babel_object_name_temp_t1'))
+GO
+~~START~~
+varchar
+#babel_object_name_temp_t1
+~~END~~
+
+
+SELECT OBJECT_NAME(OBJECT_ID('#babel_object_name_temp_t1'), db_id('tempdb'))
+GO
+~~START~~
+varchar
+#babel_object_name_temp_t1
+~~END~~
+
+
+DROP TABLE #babel_object_name_temp_t1;
+GO
+
+-- test cross database lookup
+USE master;
+GO
+
+-- should work
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_db..babel_object_name_db_t1'), db_id('babel_object_name_db'))
+GO
+~~START~~
+varchar
+babel_object_name_db_t1
+~~END~~
+
+
+-- should fail
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_db..babel_object_name_db_t1'))
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- to test dependency of user's permission on object
+USE master;
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_t1'));
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_trg'));
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('BABEL_OBJECT_NAME_PROC1'));
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('BABEL_OBJECT_NAME_func1'));
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_v1'));
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_constraint'));
+GO
+~~ROW COUNT: 1~~
+
+
+-- give access
+GRANT ALL ON babel_object_name_store_OID TO babel_object_name_master_user1;
+GO
+
+GRANT SELECT ON babel_object_name_t1 TO babel_object_name_master_user1;
+GO
+
+GRANT EXECUTE ON BABEL_OBJECT_NAME_PROC1 TO babel_object_name_master_user1;
+GO
+
+GRANT EXECUTE ON BABEL_OBJECT_NAME_func1 TO babel_object_name_master_user1;
+GO
+
+GRANT SELECT ON babel_object_name_v1 TO babel_object_name_master_user1;
+GO
+
+GRANT SELECT ON babel_object_name_t_pk TO babel_object_name_master_user1;
+GO
+
+-- tsql      user=babel_object_name_login1 password=12345678
+USE master
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+babel_object_name_master_user1
+~~END~~
+
+
+-- should work as we have grant access in prepare
+SELECT OBJECT_NAME(a) FROM babel_object_name_store_OID
+GO
+~~START~~
+varchar
+babel_object_name_t1
+babel_object_name_trg
+babel_object_name_proc1
+babel_object_name_func1
+babel_object_name_v1
+babel_object_name_constraint
+~~END~~
+
+
+
+-- cross-db will also work 
+USE babel_object_name_db
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+babel_object_name_user2
+~~END~~
+
+
+SELECT OBJECT_NAME(a, DB_ID('master')) FROM master..babel_object_name_store_OID
+GO
+~~START~~
+varchar
+babel_object_name_t1
+babel_object_name_trg
+babel_object_name_proc1
+babel_object_name_func1
+babel_object_name_v1
+babel_object_name_constraint
+~~END~~
+
+
+
+-- tsql
+-- lets revoke access
+USE master;
+GO
+
+
+REVOKE SELECT ON babel_object_name_t1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE EXECUTE ON BABEL_OBJECT_NAME_PROC1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE EXECUTE ON BABEL_OBJECT_NAME_func1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE SELECT ON babel_object_name_v1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE SELECT ON babel_object_name_t_pk FROM babel_object_name_master_user1;
+GO
+
+-- tsql      user=babel_object_name_login1 password=12345678
+-- should return null
+SELECT OBJECT_NAME(a) FROM master..babel_object_name_store_OID
+GO
+~~START~~
+varchar
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+~~END~~
+
+
+SELECT OBJECT_NAME(a, DB_ID('master')) FROM master..babel_object_name_store_OID
+GO
+~~START~~
+varchar
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+REVOKE ALL ON babel_object_name_store_OID FROM babel_object_name_master_user1;
+GO

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-verify.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-verify.mix
@@ -248,17 +248,17 @@ GO
 SELECT current_user;
 GO
 
--- Now we can access
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_t1'))
+-- Now we can access, to verify name using object_name we have to provide db_id for cross-db lookup 
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_t1'), DB_ID('master'))
 GO
 
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_proc1'))
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_proc1'), DB_ID('master'))
 GO
 
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_func1'))
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_func1'), DB_ID('master'))
 GO
 
-SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_v1'))
+SELECT OBJECT_NAME(OBJECT_ID('master..babel_object_id_v1'), DB_ID('master'))
 GO
 
 SELECT (CASE WHEN OBJECT_ID('master..babel_object_id_trg') = NULL THEN 'false' ELSE 'true' END) result;

--- a/test/JDBC/input/BABEL_OBJECT_NAME-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL_OBJECT_NAME-vu-cleanup.mix
@@ -1,0 +1,67 @@
+-- tsql
+USE babel_object_name_db;
+GO
+
+DROP USER babel_object_name_user2
+GO
+
+DROP TABLE babel_object_name_db_t1;
+GO
+
+USE master;
+GO
+
+
+DROP USER babel_object_name_master_user1;
+GO
+
+DROP TABLE babel_object_name_store_OID
+GO
+
+DROP LOGIN babel_object_name_login1;
+GO
+
+DROP DATABASE babel_object_name_db;
+GO
+
+DROP VIEW babel_object_name_constraint_view
+GO
+
+DROP TABLE babel_object_name_t_pk
+GO
+
+DROP VIEW babel_object_name_v1_view
+GO
+
+DROP VIEW babel_object_name_func1_view
+GO
+
+DROP VIEW babel_object_name_trg_view 
+GO
+
+DROP VIEW babel_object_name_t1_view
+GO
+
+DROP VIEW babel_object_name_proc1_view
+GO
+
+DROP VIEW babel_object_name_type_view
+GO
+
+DROP TYPE babel_object_name_type_int
+GO
+
+DROP VIEW babel_object_name_v1
+GO
+
+DROP FUNCTION BABEL_OBJECT_NAME_func1
+GO
+
+DROP PROCEDURE BABEL_OBJECT_NAME_PROC1
+GO
+
+DROP TRIGGER babel_object_name_trg
+GO
+
+DROP TABLE babel_object_name_t1
+GO

--- a/test/JDBC/input/BABEL_OBJECT_NAME-vu-prepare.mix
+++ b/test/JDBC/input/BABEL_OBJECT_NAME-vu-prepare.mix
@@ -1,0 +1,90 @@
+-- To test table, trigger, procedure, function
+-- tsql
+CREATE TABLE babel_object_name_t1 (a int);
+GO
+
+CREATE TRIGGER babel_object_name_trg ON babel_object_name_t1 AFTER INSERT AS SELECT 1;
+GO
+
+CREATE PROCEDURE BABEL_OBJECT_NAME_PROC1 AS SELECT 1;
+GO
+
+CREATE FUNCTION BABEL_OBJECT_NAME_func1() returns int BEGIN RETURN 1; END
+GO
+
+CREATE VIEW babel_object_name_v1 AS SELECT 1;
+GO
+
+-- to test type
+CREATE TYPE babel_object_name_type_int FROM INT NOT NULL
+GO
+
+CREATE VIEW babel_object_name_type_view AS
+SELECT OBJECT_NAME(user_type_id) FROM  sys.types where name = 'babel_object_name_type_int'
+GO
+
+CREATE VIEW babel_object_name_proc1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('BABEL_OBJECT_NAME_PROC1'))
+GO
+
+CREATE VIEW babel_object_name_t1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_t1'))
+GO
+
+CREATE VIEW babel_object_name_trg_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_trg'));
+GO
+
+CREATE VIEW babel_object_name_func1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('BABEL_OBJECT_NAME_func1'))
+GO
+
+CREATE VIEW babel_object_name_v1_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_v1'))
+GO
+
+
+-- To test constraint
+CREATE TABLE babel_object_name_t_pk ( a int, b int constraint babel_object_name_constraint check ( b > 0 ))
+go
+
+CREATE VIEW babel_object_name_constraint_view AS
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_constraint'))
+go
+
+-- To test cross-db lookup
+CREATE DATABASE babel_object_name_db;
+GO
+
+USE babel_object_name_db;
+GO
+
+CREATE TABLE babel_object_name_db_t1 (a int);
+GO
+
+
+-- to test dependency of user's permission on object
+USE master;
+GO
+
+CREATE LOGIN babel_object_name_login1 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_name_master_user1 FOR LOGIN babel_object_name_login1;
+GO
+
+USE babel_object_name_db;
+GO
+
+CREATE USER babel_object_name_user2 FOR LOGIN babel_object_name_login1;
+GO
+
+USE master;
+GO
+
+CREATE TABLE babel_object_name_store_OID (a int);
+GO
+
+
+
+

--- a/test/JDBC/input/BABEL_OBJECT_NAME-vu-verify.mix
+++ b/test/JDBC/input/BABEL_OBJECT_NAME-vu-verify.mix
@@ -1,0 +1,164 @@
+-- test table, trigger, procedure, function
+-- tsql
+SELECT * FROM babel_object_name_t1_view
+GO
+
+SELECT * FROM babel_object_name_proc1_view
+GO
+
+SELECT * FROM babel_object_name_func1_view
+GO
+
+SELECT * FROM babel_object_name_v1_view
+GO
+
+SELECT * FROM babel_object_name_trg_view
+GO
+
+-- test types
+SELECT * FROM babel_object_name_type_view
+GO
+
+-- test constraint
+SELECT * FROM babel_object_name_constraint_view
+GO
+
+-- Negative values/ out of range values
+SELECT OBJECT_NAME(-123)
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_trg_view'), -123)
+GO
+
+-- max value
+SELECT OBJECT_NAME(2147483647)
+GO
+
+-- greater than max allowed value
+SELECT OBJECT_NAME(2147483648)
+GO
+
+-- To test temp object
+CREATE TABLE #babel_object_name_temp_t1 (a int);
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('#babel_object_name_temp_t1'))
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('#babel_object_name_temp_t1'), db_id('tempdb'))
+GO
+
+DROP TABLE #babel_object_name_temp_t1;
+GO
+
+-- test cross database lookup
+USE master;
+GO
+
+-- should work
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_db..babel_object_name_db_t1'), db_id('babel_object_name_db'))
+GO
+
+-- should fail
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_db..babel_object_name_db_t1'))
+GO
+
+-- to test dependency of user's permission on object
+USE master;
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_t1'));
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_trg'));
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('BABEL_OBJECT_NAME_PROC1'));
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('BABEL_OBJECT_NAME_func1'));
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_v1'));
+GO
+
+INSERT INTO babel_object_name_store_OID VALUES(OBJECT_ID('babel_object_name_constraint'));
+GO
+
+-- give access
+GRANT ALL ON babel_object_name_store_OID TO babel_object_name_master_user1;
+GO
+
+GRANT SELECT ON babel_object_name_t1 TO babel_object_name_master_user1;
+GO
+
+GRANT EXECUTE ON BABEL_OBJECT_NAME_PROC1 TO babel_object_name_master_user1;
+GO
+
+GRANT EXECUTE ON BABEL_OBJECT_NAME_func1 TO babel_object_name_master_user1;
+GO
+
+GRANT SELECT ON babel_object_name_v1 TO babel_object_name_master_user1;
+GO
+
+GRANT SELECT ON babel_object_name_t_pk TO babel_object_name_master_user1;
+GO
+
+-- tsql      user=babel_object_name_login1 password=12345678
+USE master
+GO
+
+SELECT current_user;
+GO
+
+-- should work as we have grant access in prepare
+SELECT OBJECT_NAME(a) FROM babel_object_name_store_OID
+GO
+
+
+-- cross-db will also work 
+USE babel_object_name_db
+GO
+
+SELECT current_user;
+GO
+
+SELECT OBJECT_NAME(a, DB_ID('master')) FROM master..babel_object_name_store_OID
+GO
+
+
+-- lets revoke access
+-- tsql
+USE master;
+GO
+
+
+REVOKE SELECT ON babel_object_name_t1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE EXECUTE ON BABEL_OBJECT_NAME_PROC1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE EXECUTE ON BABEL_OBJECT_NAME_func1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE SELECT ON babel_object_name_v1 FROM babel_object_name_master_user1;
+GO
+
+REVOKE SELECT ON babel_object_name_t_pk FROM babel_object_name_master_user1;
+GO
+
+-- tsql      user=babel_object_name_login1 password=12345678
+-- should return null
+SELECT OBJECT_NAME(a) FROM master..babel_object_name_store_OID
+GO
+
+SELECT OBJECT_NAME(a, DB_ID('master')) FROM master..babel_object_name_store_OID
+GO
+
+-- tsql
+USE master;
+GO
+
+REVOKE ALL ON babel_object_name_store_OID FROM babel_object_name_master_user1;
+GO

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -300,3 +300,4 @@ BABEL_OBJECT_ID
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
 bbf_view_def-before-14_5
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -299,3 +299,4 @@ BABEL_OBJECT_ID
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
 bbf_view_def-before-14_5
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -299,3 +299,4 @@ BABEL_OBJECT_ID
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
 bbf_view_def-before-14_5
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -298,3 +298,4 @@ BABEL_OBJECT_ID
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
 bbf_view_def-before-14_5
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -309,3 +309,4 @@ BABEL_OBJECT_ID
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
 bbf_view_def-before-14_5
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -321,3 +321,4 @@ bbf_view_def-before-14_7-or-15_2
 BABEL_OBJECT_ID
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -344,3 +344,4 @@ sys-all_sql_modules_before-14_7
 sys-sql_modules_before-14_7
 AVG-Aggregate-common
 AVG-Aggregate-Dep-before-15-2-or-14-7
+BABEL_OBJECT_NAME

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -371,3 +371,4 @@ AVG-Aggregate-common
 AVG-Aggregate-Dep
 bbf_view_def
 BABEL-3802
+BABEL_OBJECT_NAME

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -109,7 +109,6 @@ Could not find upgrade tests for function sys.datediff_internal
 Could not find upgrade tests for function sys.datediff_internal_df
 Could not find upgrade tests for function sys.datepart_internal
 Could not find upgrade tests for function sys.datetime2fromparts
-Could not find upgrade tests for function sys.db_id
 Could not find upgrade tests for function sys.default_domain
 Could not find upgrade tests for function sys.error_line
 Could not find upgrade tests for function sys.error_number


### PR DESCRIPTION
To improve the performance, this commit contains the re-implementation of OBJECT_NAME sql function to C type function. This commit also add checks on user's permission of object, support cross database lookup and also lookup in pg_triggers for triggers. This commit also changes volatility of OBJECT_NAME function from IMMUTABLE to STABLE.


### Issues Resolved

[BABEL-3873]

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

3X PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1065
This PR also includes the fix in upgrade script of previous commit: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1132 
### Test Scenarios Covered ###
* **Use case based -** Yes

* **Boundary conditions -** NA

* **Arbitrary inputs -** NA


* **Negative test cases -** YES

* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes

* **Performance tests -** N/A

* **Tooling impact -** N/A


* **Client tests -** N/A