### PR TITLE
Add SLL parser mode [cherrypick of #1025 to 3_x_dev]

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -22,6 +22,7 @@ bool enable_metadata_inconsistency_check = true;
 
 bool pltsql_dump_antlr_query_graph = false;
 bool pltsql_enable_antlr_detailed_log = false;
+bool pltsql_enable_sll_parse_mode = false;
 bool pltsql_allow_antlr_to_unsupported_grammar_for_testing = false;
 bool  pltsql_ansi_defaults = true;
 bool  pltsql_quoted_identifier = true;
@@ -583,6 +584,15 @@ define_custom_variables(void)
 				 false,
 				 PGC_SUSET,
 				 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+				 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_sll_parse_mode",
+				 gettext_noop("enable SLL parser mode for ANTLR parser"),
+				 NULL,
+				 &pltsql_enable_sll_parse_mode,
+				 false,
+				 PGC_USERSET,
+				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);
 
 	/* temporary GUC until test is refactored properly */

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2000,6 +2000,7 @@ extern bool is_schema_from_db(Oid schema_oid, Oid db_id);
 typedef struct
 {
 	bool success;
+	bool parseTreeCreated; /* used to determine if on error should retry with a different parse mode */
 	size_t errpos;
 	int errcod;
 	const char *errfmt;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -73,6 +73,7 @@ extern "C"
 
 	extern bool pltsql_dump_antlr_query_graph;
 	extern bool pltsql_enable_antlr_detailed_log;
+	extern bool pltsql_enable_sll_parse_mode;
 
 	extern bool pltsql_enable_tsql_information_schema;
 
@@ -169,6 +170,7 @@ static bool does_object_name_need_delimiter(TSqlParser::IdContext *id);
 static std::string delimit_identifier(TSqlParser::IdContext *id);
 static bool does_msg_exceeds_params_limit(const std::string& msg);
 static std::string getProcNameFromExecParam(TSqlParser::Execute_parameterContext *exParamCtx);
+static ANTLR_result antlr_parse_query(const char *sourceText, bool useSSLParsing);
 
 /*
  * Structure / Utility function for general purpose of query string modification
@@ -2435,7 +2437,9 @@ ANTLR_result
 antlr_parser_cpp(const char *sourceText)
 {
 	ANTLR_result result;
-
+	instr_time	parseStart;
+	instr_time	parseEnd;
+	INSTR_TIME_SET_CURRENT(parseStart);
 	// special handling for empty sourceText
 	if (strlen(sourceText) == 0)
 	{
@@ -2453,6 +2457,30 @@ antlr_parser_cpp(const char *sourceText)
 		std::cout << sep << std::endl;
 	}
 
+	result = antlr_parse_query(sourceText, pltsql_enable_sll_parse_mode);
+
+	/* 
+	 * Only try to reparse if creation of the parse tree failed.  If parse tree is created, parsing mode will make no difference
+	 * Generally the mutator steps are non-reentrant, if parsetree is created and mutators are run, subsequent parsing may produce
+	 * incorrect error messages
+	*/
+	if (!result.success && !result.parseTreeCreated)
+	{
+		elog(DEBUG1, "Query failed using SLL parser mode, retrying with LL parser mode query_text: %s", sourceText);
+		result = antlr_parse_query(sourceText, false);
+		if (result.parseTreeCreated)
+			elog(WARNING, "Query parsing failed using SLL parser mode but succeeded with LL mode: %s", sourceText);
+	}
+	INSTR_TIME_SET_CURRENT(parseEnd);
+	INSTR_TIME_SUBTRACT(parseEnd, parseStart);
+	elog(DEBUG1, "ANTLR Query Parse Time for query: %s | %f ms", sourceText, 1000.0 * INSTR_TIME_GET_DOUBLE(parseEnd));
+
+	return result;
+}
+
+ANTLR_result
+antlr_parse_query(const char *sourceText, bool useSLLParsing) {
+	ANTLR_result result;
 	MyInputStream sourceStream(sourceText);
 
 	TSqlLexer lexer(&sourceStream);
@@ -2460,8 +2488,11 @@ antlr_parser_cpp(const char *sourceText)
 
 	MyParserErrorListener errorListner;
 
-        TSqlParser parser(&tokens);
+	TSqlParser parser(&tokens);
+	volatile bool parseTreeCreated = false;
 
+	if (useSLLParsing)
+		parser.getInterpreter<atn::ParserATNSimulator>()->setPredictionMode(atn::PredictionMode::SLL);
 	parser.removeErrorListeners();
 	parser.addErrorListener(&errorListner);
 
@@ -2485,7 +2516,7 @@ antlr_parser_cpp(const char *sourceText)
 			tree = parser.func_body_return_select_body();
 		else /* normal path */
 			tree = parser.tsql_file();
-
+		parseTreeCreated = true;
 		if (pltsql_enable_antlr_detailed_log)
 			std::cout << tree->toStringTree(&parser, true) << std::endl;
 
@@ -2544,12 +2575,14 @@ antlr_parser_cpp(const char *sourceText)
 		if (pltsql_parseonly)
 			pltsql_parse_result = makeEmptyBlockStmt(0);
 
+		result.parseTreeCreated = parseTreeCreated;
 		result.success = true;
 		return result;
 	}
 	catch (PGErrorWrapperException &e)
 	{
 		result.success = false;
+		result.parseTreeCreated = parseTreeCreated;
 		result.errcod = e.get_errcode();
 		result.errpos = e.get_errpos();
 		result.errfmt = e.get_errmsg();
@@ -2564,6 +2597,7 @@ antlr_parser_cpp(const char *sourceText)
 	catch (std::exception &e) /* not to cause a crash just in case */
 	{
 		result.success = false;
+		result.parseTreeCreated = parseTreeCreated;
 		result.errcod = ERRCODE_SYNTAX_ERROR;
 		result.errpos = 0;
 		result.errfmt = pstrdup(e.what());
@@ -2574,6 +2608,7 @@ antlr_parser_cpp(const char *sourceText)
 	catch (...) /* not to cause a crash just in case. consume all exception before C-layer */
 	{
 		result.success = false;
+		result.parseTreeCreated = parseTreeCreated;
 		result.errcod = ERRCODE_SYNTAX_ERROR;
 		result.errpos = 0;
 		result.errfmt = "unknown error";

--- a/test/JDBC/input/BABEL_2858-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL_2858-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS babel_2858_t1
+GO
+
+DROP TABLE IF EXISTS babel_2858_t1_deleted
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO

--- a/test/JDBC/input/BABEL_2858-vu-prepare.sql
+++ b/test/JDBC/input/BABEL_2858-vu-prepare.sql
@@ -1,0 +1,5 @@
+create table babel_2858_t1(num integer, word varchar(10));
+go
+
+create table babel_2858_t1_deleted(num integer, nextnum integer);
+go

--- a/test/JDBC/input/BABEL_2858-vu-verify.sql
+++ b/test/JDBC/input/BABEL_2858-vu-verify.sql
@@ -1,0 +1,25 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false)
+GO
+-- valid sll parsing and ll parsing
+SELECT * FROM babel_2858_t1
+GO
+
+-- fails both sll parsing and ll parsing
+SELECT FROM WHERE GROUP BY
+GO
+
+-- fails sll parsing passes ll parsing passes, valid query
+delete babel_2858_t1
+output babel_2858_t1.word
+from babel_2858_t1
+inner join babel_2858_t1_deleted
+ on babel_2858_t1.num=babel_2858_t1_deleted.num
+where babel_2858_t1.num=14;
+go
+
+-- fails sll parsing ll parsing passes, invalid query
+DECLARE @x xml (dbo.f);
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO

--- a/test/JDBC/sql_expected/BABEL_2858-vu-cleanup.out
+++ b/test/JDBC/sql_expected/BABEL_2858-vu-cleanup.out
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS babel_2858_t1
+GO
+
+DROP TABLE IF EXISTS babel_2858_t1_deleted
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/sql_expected/BABEL_2858-vu-prepare.out
+++ b/test/JDBC/sql_expected/BABEL_2858-vu-prepare.out
@@ -1,0 +1,5 @@
+create table babel_2858_t1(num integer, word varchar(10));
+go
+
+create table babel_2858_t1_deleted(num integer, nextnum integer);
+go

--- a/test/JDBC/sql_expected/BABEL_2858-vu-verify.out
+++ b/test/JDBC/sql_expected/BABEL_2858-vu-verify.out
@@ -1,0 +1,51 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+-- valid sll parsing and ll parsing
+SELECT * FROM babel_2858_t1
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- fails both sll parsing and ll parsing
+SELECT FROM WHERE GROUP BY
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'FROM' at line 2 and character position 7)~~
+
+
+-- fails sll parsing passes ll parsing passes, valid query
+delete babel_2858_t1
+output babel_2858_t1.word
+from babel_2858_t1
+inner join babel_2858_t1_deleted
+ on babel_2858_t1.num=babel_2858_t1_deleted.num
+where babel_2858_t1.num=14;
+go
+~~START~~
+varchar
+~~END~~
+
+
+-- fails sll parsing ll parsing passes, invalid query
+DECLARE @x xml (dbo.f);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: type modifier is not allowed for type "xml")~~
+
+
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+


### PR DESCRIPTION
Description

This code enables SLL parsing in babelfish with the guc enable_sll_parse_mode. If SLL parsing fails to create a parse tree, parsing will be reattempted with LL parsing.

Task: BABEL-3759
Signed-off-by: Justin Jossick [jusjosj@amazon.com](mailto:jusjosj@amazon.com)
Issues Resolved

BABEL-2858
Test Scenarios Covered

    Use case based -
    Several large stored procs where tested for parsing time with very large speed-ups, up to 35x, in parsing times.

    Boundary conditions -
    See added tests, testing covered failures in both LL and SLL, failure in SLL but success in LL, failure in SLL success in LL at parse time but mutator rejects query, and success in both LL and SLL

    Arbitrary inputs -
    Regression tests will cover this

    Negative test cases -
    See added test files

    Minor version upgrade tests -
    N/A

    Major version upgrade tests -
    N/A

    Performance tests -
    Several large stored procs where tested for parsing time with very large speed-ups, up to 35x, in parsing times.

    Tooling impact -

    Client tests -
    JDBC

Check List

    Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).