### PR TITLE
Fix the hardcoded version number in login ack

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/guc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/guc.c
@@ -137,12 +137,12 @@ check_version_number(char **newval, void **extra, GucSource source)
 				errmsg("Please enter 4 valid numbers separated by \'.\' ")));
 		}
 		
-		/* check Major Version is between 11 and 15 */
-		if(part == 0 && (11 > atoi(token) || atoi(token) > 15))
+		/* check Major Version is between 11 and 16 */
+		if(part == 0 && (11 > atoi(token) || atoi(token) > 16))
 		{
 			ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("Please enter a valid major version number between 11 and 15")));
+				errmsg("Please enter a valid major version number between 11 and 16")));
 		}
 		/*
 		 * Minor Version takes 1 byte in PreLogin message when doing handshake, 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1991,11 +1991,6 @@ TdsSendLoginAck(Port *port)
 	int	MicroVersion;
 	char	srvVersionBytes[4];
 
-	/* TODO: should these version numbers be hardcoded? */
-	char srvVersionBytes[] = {
-		0x0C, 0x00, 0x07, 0xd0
-	};
-
 	PG_TRY();
 	{
 

--- a/test/JDBC/expected/BABEL-VERSION.out
+++ b/test/JDBC/expected/BABEL-VERSION.out
@@ -3,17 +3,12 @@ Alter system set babelfishpg_tds.product_version = "9.4.3000.6";
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Please enter a valid major version number between 11 and 15
+~~ERROR (Message: ERROR: Please enter a valid major version number between 11 and 16
     Server SQLState: 22023)~~
 
 
 Alter system set babelfishpg_tds.product_version = "16.4.3000.6";
 GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Please enter a valid major version number between 11 and 15
-    Server SQLState: 22023)~~
-
 
 Alter system set babelfishpg_tds.product_version = "15.400.3000.6";
 GO
@@ -67,7 +62,7 @@ Alter system set babelfishpg_tds.product_version = ".4.3000.6";
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Please enter a valid major version number between 11 and 15
+~~ERROR (Message: ERROR: Please enter a valid major version number between 11 and 16
     Server SQLState: 22023)~~
 
 


### PR DESCRIPTION
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description

In this PR, we fixed the hardcoded version number in login ack, and updated the error throwing method and also make the maximum allowed version to 16.

### Issues Resolved

BABEL-3545

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).