### PR TITLE
Put CATALOG_COLLATION and COLLATE clause under escape_hatch_database_misc_options

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5703,6 +5703,8 @@ getCreateDatabaseOptionTobeRemoved(TSqlParser::Create_database_optionContext* o)
 		return o->DB_CHAINING();
 	if (o->TRUSTWORTHY())
 		return o->TRUSTWORTHY();
+	if (o->CATALOG_COLLATION())
+		return o->CATALOG_COLLATION();
 	if (o->PERSISTENT_LOG_BUFFER())
 		return o->PERSISTENT_LOG_BUFFER();
 	return nullptr;

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -801,7 +801,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_database(TSqlParser
 		handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_ON, "CREATE DATABASE ON <database-file-spec>", &st_escape_hatch_storage_options, getLineAndPos(ctx->ON()[0]));
 
 	if (ctx->collation())
-		handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_COLLATE, "COLLATE", getLineAndPos(ctx->collation()));
+		handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_COLLATE, "COLLATE", &st_escape_hatch_database_misc_options, getLineAndPos(ctx->collation()));
 
 	if (ctx->WITH())
 	{
@@ -832,7 +832,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_database(TSqlParser
 			if (cdoctx->TRUSTWORTHY())
 				handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_WITH_TRUSTWORTHY, cdoctx->TRUSTWORTHY(), &st_escape_hatch_database_misc_options);
 			if (cdoctx->CATALOG_COLLATION())
-				handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_WITH_CATALOG_COLLATION, cdoctx->CATALOG_COLLATION());
+				handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_WITH_CATALOG_COLLATION, cdoctx->CATALOG_COLLATION(), &st_escape_hatch_database_misc_options);
 			if (cdoctx->PERSISTENT_LOG_BUFFER())
 				handle(INSTR_UNSUPPORTED_TSQL_CREATE_DATABASE_WITH_PERSISTENT_LOG_BUFFER, cdoctx->PERSISTENT_LOG_BUFFER(), &st_escape_hatch_database_misc_options);
 		}

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -520,6 +520,23 @@ GO
 DROP DATABASE db_unsupported6;
 GO
 
+CREATE DATABASE db_unsupported7 WITH CATALOG_COLLATION = DATABASE_DEFAULT;
+GO
+DROP DATABASE db_unsupported7;
+GO
+
+CREATE DATABASE db_unsupported8 COLLATE SQL_Latin1_General_CP1_CI_AS;
+GO
+DROP DATABASE db_unsupported8;
+GO
+
+CREATE DATABASE db_unsupported9 COLLATE Arabic_CI_AS;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: only "sql_latin1_general_cp1_ci_as" supported for default collation)~~
+
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_database_misc_options', 'strict', 'false')
 GO
 ~~START~~
@@ -574,6 +591,27 @@ GO
 ~~ERROR (Code: 911)~~
 
 ~~ERROR (Message: database "db_unsupported6" does not exist)~~
+
+
+CREATE DATABASE db_unsupported7 WITH CATALOG_COLLATION = DATABASE_DEFAULT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'CATALOG_COLLATION' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_database_misc_options to ignore)~~
+
+
+CREATE DATABASE db_unsupported8 COLLATE SQL_Latin1_General_CP1_CI_AS;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'COLLATE' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_database_misc_options to ignore)~~
+
+
+CREATE DATABASE db_unsupported9 COLLATE Arabic_CI_AS;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'COLLATE' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_database_misc_options to ignore)~~
 
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_database_misc_options', 'ignore', 'false')
@@ -2446,7 +2484,7 @@ CREATE DATABASE t448 COLLATE NOT_VALID_COLLATION;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'COLLATE' is not currently supported in Babelfish)~~
+~~ERROR (Message: only "sql_latin1_general_cp1_ci_as" supported for default collation)~~
 
 
 

--- a/test/JDBC/input/BABEL-UNSUPPORTED.sql
+++ b/test/JDBC/input/BABEL-UNSUPPORTED.sql
@@ -311,6 +311,19 @@ GO
 DROP DATABASE db_unsupported6;
 GO
 
+CREATE DATABASE db_unsupported7 WITH CATALOG_COLLATION = DATABASE_DEFAULT;
+GO
+DROP DATABASE db_unsupported7;
+GO
+
+CREATE DATABASE db_unsupported8 COLLATE SQL_Latin1_General_CP1_CI_AS;
+GO
+DROP DATABASE db_unsupported8;
+GO
+
+CREATE DATABASE db_unsupported9 COLLATE Arabic_CI_AS;
+GO
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_database_misc_options', 'strict', 'false')
 GO
 
@@ -332,6 +345,15 @@ GO
 CREATE DATABASE db_unsupported6 WITH PERSISTENT_LOG_BUFFER = ON (DIRECTORY_NAME = '/tmp');
 GO
 DROP DATABASE db_unsupported6;
+GO
+
+CREATE DATABASE db_unsupported7 WITH CATALOG_COLLATION = DATABASE_DEFAULT
+GO
+
+CREATE DATABASE db_unsupported8 COLLATE SQL_Latin1_General_CP1_CI_AS;
+GO
+
+CREATE DATABASE db_unsupported9 COLLATE Arabic_CI_AS;
 GO
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_database_misc_options', 'ignore', 'false')


### PR DESCRIPTION
Cherry-pick commit 71d892705c342f2846f19758d0d72cb2ebe08bb4  to BABEL3_0_STABLE from BABEL3_X_DEV

- Added escape hatch ( `escape_hatch_database_misc_options`) to CATALOG_COLLATION database option as this clause is mostly meaningless is Babelfish, it makes sense to treat it the same way as similar options, and put it under the escape hatch
- Added escape hatch ( `escape_hatch_database_misc_options`) to COLLATE clause as currently we don't allow to create database with collation different than cluster default collation

Issues Resolved: BABEL-3706
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).