### PR TITLE
Choose install mirror based on download speed

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -4,9 +4,7 @@ runs:
   steps:
     - name: Install Dependencies
       run: |
-        sudo gem install apt-spy2
-        sudo apt-spy2 check
-        sudo apt-spy2 fix --commit
+        $GITHUB_WORKSPACE/.github/scripts/choose_install_mirror
         sudo apt clean && sudo apt-get update --fix-missing -y
         curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list

--- a/.github/scripts/choose_install_mirror
+++ b/.github/scripts/choose_install_mirror
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Choosing fastest up-to-date ubuntu mirror based on download speed..."
+UBUNTU_MIRROR=$({
+# choose mirrors that are up-to-date by checking the Last-Modified header for
+{
+    # consider Azure's Ubuntu mirror
+    echo http://azure.archive.ubuntu.com/ubuntu/
+    # also consider AWS's Ubuntu mirror
+    echo http://us-east-1.ec2.archive.ubuntu.com/ubuntu/
+    echo http://us-east-2.ec2.archive.ubuntu.com/ubuntu/
+    echo http://us-west-1.ec2.archive.ubuntu.com/ubuntu/
+    echo http://us-west-2.ec2.archive.ubuntu.com/ubuntu/
+    echo http://ap-southeast-1.ec2.archive.ubuntu.com/ubuntu/
+    echo http://ap-south-1.ec2.archive.ubuntu.com/ubuntu/
+    echo http://ap-south-2.ec2.archive.ubuntu.com/ubuntu/
+    echo http://eu-central-1.ec2.archive.ubuntu.com/ubuntu/
+    echo http://eu-west-2.ec2.archive.ubuntu.com/ubuntu/
+
+} | xargs -I {} sh -c 'echo "$(curl -m 5 -sI {}dists/$(lsb_release -c | cut -f2)-security/Contents-$(dpkg --print-architecture).gz|sed s/\\r\$//|grep Last-Modified|awk -F": " "{ print \$2 }" | LANG=C date -f- -u +%s)" "{}"' | sort -rg | awk '{ if (NR==1) TS=$1; if ($1 == TS) print $2 }'
+} | xargs -I {} sh -c 'echo `curl -r 0-102400 -m 5 -s -w %{speed_download} -o /dev/null {}ls-lR.gz` {}' \
+|sort -g -r |head -1| awk '{ print $2  }')
+if [ -z "$UBUNTU_MIRROR" ]; then
+    # fallback to full mirrors list
+    UBUNTU_MIRROR="mirror://mirrors.ubuntu.com/mirrors.txt"
+fi
+OLD_MIRROR=$(cat /etc/apt/sources.list | grep '^deb ' | head -1 | awk '{ print $2 }')
+
+#add retries and timeout for apt
+echo 'Acquire::Retries "10";
+Acquire::https::Timeout "240";
+Acquire::http::Timeout "240";
+APT::Get::Assume-Yes "true";
+APT::Install-Recommends "false";
+APT::Install-Suggests "false";
+Debug::Acquire::https "true";
+' | sudo tee -a /etc/apt/apt.conf.d/99custom
+
+sudo cat /etc/apt/apt.conf.d/99custom
+
+echo "Picked '$UBUNTU_MIRROR'. Current mirror is '$OLD_MIRROR'."
+if [[ "$OLD_MIRROR" != "$UBUNTU_MIRROR" ]]; then
+    sudo sed -i "s|$OLD_MIRROR|$UBUNTU_MIRROR|g" /etc/apt/sources.list
+    sudo apt-get update
+fi


### PR DESCRIPTION
### Description

Due to unstable/flaky  behaviour apt-spy2 and longer install dependency times ,
The new approach downloads a package from 10-20 mirrors , sort them by download speed and picks the fastest mirror for download , also has logic for retries set 10 . 

example run :- [link](https://github.com/babelfish-for-postgresql/babelfish_extensions/actions/runs/4004774987/jobs/6874333996#step:3:37)

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).