### PR TITLE
Disable Savepoints for statements inside a function

### DIFF
--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1139,7 +1139,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		 * rollback will cleanup portal data which can lead to
 		 * problems when control returns back to portal level
 		 */
-		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt))
+		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive())
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1139,7 +1139,7 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		 * rollback will cleanup portal data which can lead to
 		 * problems when control returns back to portal level
 		 */
-		if (!pltsql_disable_internal_savepoint && !is_batch_command(stmt) && (IsTransactionBlockActive() || ro_func))
+		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt))
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);
@@ -1184,6 +1184,13 @@ int dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		ErrorData *edata;
 		int last_error;
 		bool error_mapped;
+
+		if (ro_func)
+		{
+			MemoryContextSwitchTo(cur_ctxt);
+			PG_RE_THROW();
+		}
+
 		support_tsql_trans = pltsql_support_tsql_transactions();
 
 		/* Close trigger nesting in engine */

--- a/test/JDBC/expected/TestErrorFunctions.out
+++ b/test/JDBC/expected/TestErrorFunctions.out
@@ -370,6 +370,199 @@ int#!#nvarchar#!#int#!#nvarchar#!#int#!#int
 ~~END~~
 
 
+-- stmt terminating
+create function f_with_error()returns int as begin	declare @i int = 0 set @i = 1 / 0 return 1 end
+go
+
+-- -1 should be returned
+select 1;
+select dbo.f_with_error();
+select -1;
+go
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+~~START~~
+int
+-1
+~~END~~
+
+
+begin transaction
+go
+
+-- second @@trancount should be executed
+select @@trancount
+select dbo.f_with_error();
+select @@trancount
+go
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- @@trancount should be 1
+select @@trancount
+go
+~~START~~
+int
+1
+~~END~~
+
+
+commit
+go
+
+-- batch and transaction aborting
+create function f_batch_tran_abort() returns smallmoney as begin declare @i smallmoney = 1; SELECT @i = CAST('ABC' AS SMALLMONEY); return @i end
+go
+
+-- -1 should not be returned
+select 1;
+select dbo.f_batch_tran_abort();
+select -1;
+go
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+smallmoney
+~~ERROR (Code: 293)~~
+
+~~ERROR (Message: invalid characters found: cannot cast value "ABC" to money)~~
+
+
+begin transaction
+go
+
+-- second @@trancount should not be executed and transaction should rollback
+select @@trancount
+select dbo.f_batch_tran_abort();
+select @@trancount
+go
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+smallmoney
+~~ERROR (Code: 293)~~
+
+~~ERROR (Message: invalid characters found: cannot cast value "ABC" to money)~~
+
+
+-- @@trancount should be 0
+select @@trancount
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- tests for xact_abort
+set xact_abort on
+go
+
+begin transaction
+go
+
+-- transaction rollback for simple stmt termination error.
+-- we cant have any function execution throwing an error that ignores xact abort
+-- since most of the errors are at DDL phase.
+select dbo.f_with_error();
+select @@trancount
+go
+~~START~~
+int
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+
+select @@trancount
+go
+~~START~~
+int
+0
+~~END~~
+
+
+set xact_abort off
+go
+
+-- try catch testing
+BEGIN TRY
+	SELECT 'TRY';
+	select dbo.f_with_error();
+	SELECT 'TRY AFTER ERROR'
+END TRY
+BEGIN CATCH
+    SELECT 'CATCH';
+END CATCH
+go
+~~START~~
+varchar
+TRY
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+varchar
+CATCH
+~~END~~
+
+
+BEGIN TRY
+	SELECT 'TRY';
+	select dbo.f_batch_tran_abort();
+	SELECT 'TRY AFTER ERROR'
+END TRY
+BEGIN CATCH
+    SELECT 'CATCH';
+END CATCH
+go
+~~START~~
+varchar
+TRY
+~~END~~
+
+~~START~~
+smallmoney
+~~END~~
+
+~~START~~
+varchar
+CATCH
+~~END~~
+
+
 /* Clean up */
 DROP PROC errorFuncProc1
 go
@@ -396,4 +589,8 @@ DROP PROC errorFuncProcInner
 go
 
 DROP TABLE errorFuncTable
+go
+
+drop function dbo.f_with_error
+drop function dbo.f_batch_tran_abort
 go

--- a/test/JDBC/input/errorHandling/TestErrorFunctions.sql
+++ b/test/JDBC/input/errorHandling/TestErrorFunctions.sql
@@ -258,6 +258,96 @@ go
 EXEC errorFuncProcOuter4
 go
 
+-- stmt terminating
+create function f_with_error()returns int as begin	declare @i int = 0 set @i = 1 / 0 return 1 end
+go
+
+-- -1 should be returned
+select 1;
+select dbo.f_with_error();
+select -1;
+go
+
+begin transaction
+go
+
+-- second @@trancount should be executed
+select @@trancount
+select dbo.f_with_error();
+select @@trancount
+go
+
+-- @@trancount should be 1
+select @@trancount
+go
+
+commit
+go
+
+-- batch and transaction aborting
+create function f_batch_tran_abort() returns smallmoney as begin declare @i smallmoney = 1; SELECT @i = CAST('ABC' AS SMALLMONEY); return @i end
+go
+
+-- -1 should not be returned
+select 1;
+select dbo.f_batch_tran_abort();
+select -1;
+go
+
+begin transaction
+go
+
+-- second @@trancount should not be executed and transaction should rollback
+select @@trancount
+select dbo.f_batch_tran_abort();
+select @@trancount
+go
+
+-- @@trancount should be 0
+select @@trancount
+go
+
+-- tests for xact_abort
+set xact_abort on
+go
+
+begin transaction
+go
+
+-- transaction rollback for simple stmt termination error.
+-- we cant have any function execution throwing an error that ignores xact abort
+-- since most of the errors are at DDL phase.
+select dbo.f_with_error();
+select @@trancount
+go
+
+select @@trancount
+go
+
+set xact_abort off
+go
+
+-- try catch testing
+BEGIN TRY
+	SELECT 'TRY';
+	select dbo.f_with_error();
+	SELECT 'TRY AFTER ERROR'
+END TRY
+BEGIN CATCH
+    SELECT 'CATCH';
+END CATCH
+go
+
+BEGIN TRY
+	SELECT 'TRY';
+	select dbo.f_batch_tran_abort();
+	SELECT 'TRY AFTER ERROR'
+END TRY
+BEGIN CATCH
+    SELECT 'CATCH';
+END CATCH
+go
+
 /* Clean up */
 DROP PROC errorFuncProc1
 go
@@ -284,4 +374,8 @@ DROP PROC errorFuncProcInner
 go
 
 DROP TABLE errorFuncTable
+go
+
+drop function dbo.f_with_error
+drop function dbo.f_batch_tran_abort
 go


### PR DESCRIPTION
Currently we have savepoints for every statement inside a function in order to rollback safely in case of any errors. This was done to not destroy portals amidst function execution. These Savepoints added around 40% perfomance overhead to function execution.
We have verified that any errors that occur inside a function shall rollback the entire function execution, so we can safely disable Savepoints for statements inside a function and let the function call(exec stmt) handle the error.

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>

### Description

### Issues Resolved
BABEL-3925

### Test Scenarios Covered ###
**Performance Testing**
For the following query:
```
create table numbers (a int primary key)
go
insert into numbers select * from generate_series(1,100000)
go
drop function if exists f_per_row
go
create function f_per_row (@num int)
returns int
AS
begin
    declare @i int
    select @i = 1
    select @i = 2
    select @i = 3
    select @i = 4
    select @i = 5
    select @i = 6
    select @i = 7
    select @i = 8
    select @i = 9
    select @i = 10
    return @i
end
go
select count(*) from (
    select dbo.f_per_row(a) as c
    from numbers
) as t
go
```

Before the Changes: Flamegraph ![perf-tsql-sp-orig-func](https://user-images.githubusercontent.com/51415286/215989886-f0b87e49-1632-4cee-b099-377950a25a62.svg)
```
select count(*) from (    select dbo.f_per_row(a) as c    from numbers ) as t
go
count
-----
100000



(1 rows affected)
4096:1: 21504:21504.0:0.1
```
After the changes: Flamegraph ![perf-tsql-sp-func1](https://user-images.githubusercontent.com/51415286/215990217-52bd05f2-cc2f-4d29-88a1-aea0720cb385.svg)

```
select count(*) from (    select dbo.f_per_row(a) as c    from numbers ) as t
go
count
-----
100000

(1 rows affected)
4096:1:12471:12471.0:0.1
```
Thus we see a speedup of 40%


* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).