### PR TITLE
Fix systypes changes in upgrade scripts

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1131,8 +1131,8 @@ DECLARE
 BEGIN
 	CASE
 	WHEN v_type in ('text', 'ntext', 'image') THEN precision = CAST(NULL AS SMALLINT);
-  WHEN v_type in ('nchar', 'nvarchar', 'sysname') THEN precision = max_length/2;
-  WHEN v_type = 'sql_variant' THEN precision = 0;
+	WHEN v_type in ('nchar', 'nvarchar', 'sysname') THEN precision = max_length/2;
+	WHEN v_type = 'sql_variant' THEN precision = 0;
 	ELSE
 		precision = max_length;
 	END CASE;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1430,8 +1430,8 @@ DECLARE
 BEGIN
 	CASE
 	WHEN v_type in ('text', 'ntext', 'image') THEN precision = CAST(NULL AS SMALLINT);
-  WHEN v_type in ('nchar', 'nvarchar', 'sysname') THEN precision = max_length/2;
-  WHEN v_type = 'sql_variant' THEN precision = 0;
+	WHEN v_type in ('nchar', 'nvarchar', 'sysname') THEN precision = max_length/2;
+	WHEN v_type = 'sql_variant' THEN precision = 0;
 	ELSE
 		precision = max_length;
 	END CASE;
@@ -1453,15 +1453,17 @@ SELECT CAST(name as sys.sysname) as name
   , CAST(0 as smallint) as reserved
   , CAST(sys.CollationProperty(collation_name, 'CollationId') as int) as collationid
   , CAST((case when user_type_id < 32767 then user_type_id::int else null end) as smallint) as usertype
-  , CAST((case when (tsql_base_type_name in ('nvarchar', 'varchar', 'sysname', 'varbinary')) then 1 else 0 end) as sys.bit) as variable
+  , CAST((case when (coalesce(sys.translate_pg_type_to_tsql(system_type_id), sys.translate_pg_type_to_tsql(user_type_id)) 
+            in ('nvarchar', 'varchar', 'sysname', 'varbinary')) then 1 
+          else 0 end) as sys.bit) as variable
   , CAST(is_nullable as sys.bit) as allownulls
   , CAST(system_type_id as int) as type
   , CAST(null as sys.varchar(255)) as printfmt
-  , (case when precision <> 0::smallint then precision else sys.systypes_precision_helper(tsql_base_type_name, max_length) end) as prec
+  , (case when precision <> 0::smallint then precision 
+      else sys.systypes_precision_helper(sys.translate_pg_type_to_tsql(system_type_id), max_length) end) as prec
   , CAST(scale as sys.tinyint) as scale
   , CAST(collation_name as sys.sysname) as collation
-FROM sys.types
-, coalesce(sys.translate_pg_type_to_tsql(system_type_id), sys.translate_pg_type_to_tsql(user_type_id)) AS tsql_base_type_name;
+FROM sys.types;
 GRANT SELECT ON sys.systypes TO PUBLIC;
 
 -- Drops the temporary procedure used by the upgrade script.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -1858,8 +1858,8 @@ DECLARE
 BEGIN
 	CASE
 	WHEN v_type in ('text', 'ntext', 'image') THEN precision = CAST(NULL AS SMALLINT);
-  WHEN v_type in ('nchar', 'nvarchar', 'sysname') THEN precision = max_length/2;
-  WHEN v_type = 'sql_variant' THEN precision = 0;
+	WHEN v_type in ('nchar', 'nvarchar', 'sysname') THEN precision = max_length/2;
+	WHEN v_type = 'sql_variant' THEN precision = 0;
 	ELSE
 		precision = max_length;
 	END CASE;
@@ -1881,15 +1881,17 @@ SELECT CAST(name as sys.sysname) as name
   , CAST(0 as smallint) as reserved
   , CAST(sys.CollationProperty(collation_name, 'CollationId') as int) as collationid
   , CAST((case when user_type_id < 32767 then user_type_id::int else null end) as smallint) as usertype
-  , CAST((case when (tsql_base_type_name in ('nvarchar', 'varchar', 'sysname', 'varbinary')) then 1 else 0 end) as sys.bit) as variable
+  , CAST((case when (coalesce(sys.translate_pg_type_to_tsql(system_type_id), sys.translate_pg_type_to_tsql(user_type_id)) 
+            in ('nvarchar', 'varchar', 'sysname', 'varbinary')) then 1 
+          else 0 end) as sys.bit) as variable
   , CAST(is_nullable as sys.bit) as allownulls
   , CAST(system_type_id as int) as type
   , CAST(null as sys.varchar(255)) as printfmt
-  , (case when precision <> 0::smallint then precision else sys.systypes_precision_helper(tsql_base_type_name, max_length) end) as prec
+  , (case when precision <> 0::smallint then precision 
+      else sys.systypes_precision_helper(sys.translate_pg_type_to_tsql(system_type_id), max_length) end) as prec
   , CAST(scale as sys.tinyint) as scale
   , CAST(collation_name as sys.sysname) as collation
-FROM sys.types
-, coalesce(sys.translate_pg_type_to_tsql(system_type_id), sys.translate_pg_type_to_tsql(user_type_id)) AS tsql_base_type_name;
+FROM sys.types;
 GRANT SELECT ON sys.systypes TO PUBLIC;
 
 -- Drops the temporary procedure used by the upgrade script.


### PR DESCRIPTION

### Description
This commit fix the sys.systypes changes in upgrade scripts which occurred in https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1117

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).