### PR TITLE
Convert extracted user name from GSS token to canonical form always for TDS client

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -51,6 +51,7 @@
 #include "parser/scansup.h"
 #include "utils/guc.h"
 #include "utils/acl.h"
+#include "utils/formatting.h"
 #include "utils/lsyscache.h"
 #include "utils/memdebug.h"
 #include "utils/memutils.h"
@@ -1383,6 +1384,20 @@ SendGSSAuthResponse(Port *port, char *extradata, uint16_t extralen)
 	TDSInstrumentation(INSTR_TDS_TOKEN_SSPI);
 }
 
+static char *
+convertUsernameToCanonicalform(char *user_name)
+{
+	char *canonicalUsername = "";
+	char *chr;
+	if ((chr = strchr(user_name, '@')) != NULL)
+	{
+		canonicalUsername = psprintf("%s%s",
+									 str_tolower(user_name, (chr - user_name), C_COLLATION_OID),
+									 str_toupper(chr, strlen(chr), C_COLLATION_OID));
+		return canonicalUsername;
+	}
+	return user_name;
+}
 /*
  * This function is similar to pg_GSS_recvauth() but to authenticate a TDS
  * client.
@@ -1398,6 +1413,7 @@ CheckGSSAuth(Port *port)
 	int			ret;
 	gss_buffer_desc gbuf;
 	MemoryContext	oldContext;
+	char 		*at_pos = NULL;
 
 	if (pg_krb_server_keyfile && strlen(pg_krb_server_keyfile) > 0)
 	{
@@ -1532,13 +1548,12 @@ CheckGSSAuth(Port *port)
 
 	oldContext = MemoryContextSwitchTo(TopMemoryContext);
 	pfree(port->user_name);
-	port->user_name = pstrdup(gbuf.value);
-	if (strchr(gbuf.value, '@'))
+	port->user_name = convertUsernameToCanonicalform(gbuf.value);
+	if ((at_pos = strchr(gbuf.value, '@')) != NULL && loginInfo)
 	{
-		char       *cp = strchr(gbuf.value, '@');
-		cp++;
-		if (loginInfo)
-			loginInfo->domainname = pstrdup(cp);
+		/* skip '@' */
+		at_pos++;
+		loginInfo->domainname = pstrdup(at_pos);
 	}
 	MemoryContextSwitchTo(oldContext);
 


### PR DESCRIPTION
### Description

To support windows login with Babelfish, we are converting user provided NT formatted login (domain\logon) to canonical form (logon@DOMAIN) internally and store it in different catalog. So to facilitate the login to work with login in any letter case, we need to convert extracted user name from GSS token to canonical form for TDS client.

### Issues Resolved

Task: BABEL-3926, BABEL-3947
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Experiment

```
ubuntu@EC2AMAZ-SeJVNf:~/postgres15/share/extension$ sqlcmd -S EC2AMAZ-SeJVNf.BABEL.INTERNAL -U jdbc_user -P 12345678
1> exec babelfish_add_domain_mapping_entry 'babel', 'babel.internal'
2> go
1> create login [babel\KuntalGh] from windows;
2> go
1> exit
ubuntu@EC2AMAZ-SeJVNf:~/postgres15/share/extension$ sqlcmd -S EC2AMAZ-SeJVNf.BABEL.INTERNAL
1> select system_user;
2> go
system_user
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
babel\KuntalGh

(1 rows affected)
1> exit
```

### Test Scenarios Covered ###
* **Use case based -** 


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).