### PR TITLE
Enhance BABEL-LOGIN-USER-EXT test

### DIFF
--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -900,19 +900,19 @@ GO
 -- psql
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 GO
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
 -- Wait to sync with another session
 SELECT pg_sleep(1);
 GO
 ~~START~~
 void
 
-~~END~~
-
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-LOGIN-USER-EXT.mix
+++ b/test/JDBC/input/BABEL-LOGIN-USER-EXT.mix
@@ -458,10 +458,10 @@ GO
 -- psql
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 GO
+SELECT pg_reload_conf();
+GO
 -- Wait to sync with another session
 SELECT pg_sleep(1);
-GO
-SELECT pg_reload_conf();
 GO
 
 -- tsql


### PR DESCRIPTION
### Description

Previously, USER & ROLE related test cases were failing occasionally due to flakiness caused by change of migration-mode GUC. Enhanced BABEL-LOGIN-USER-EXT test by adding sleep after setting migration-mode GUC to make if more reliable.

Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved
BABEL-3811

### Test Scenarios Covered ###
Just a test change.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).