### PR TITLE
Allow FOR XML/JSON to be able to return zero rows

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -59,7 +59,7 @@ ELSE
 END IF;
 END;
 $$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.tsql_select_for_xml_text_result(res NTEXT)
 RETURNS setof NTEXT AS
@@ -72,7 +72,7 @@ ELSE
 END IF;
 END;
 $$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql IMMUTABLE;
 
 -- SELECT FOR JSON
 CREATE OR REPLACE FUNCTION sys.tsql_query_to_json_sfunc(
@@ -116,7 +116,7 @@ ELSE
 END IF;
 END;
 $$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql IMMUTABLE;
 
 -- User and Login Functions
 CREATE OR REPLACE FUNCTION sys.user_name(IN id OID DEFAULT NULL)

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -48,6 +48,32 @@ CREATE OR REPLACE AGGREGATE sys.tsql_select_for_xml_text_agg(
     FINALFUNC = tsql_query_to_xml_text_ffunc
 );
 
+CREATE OR REPLACE FUNCTION sys.tsql_select_for_xml_result(res XML)
+RETURNS setof XML AS
+$$
+BEGIN
+IF res IS NOT NULL THEN
+    return next res;
+ELSE
+    return;
+END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sys.tsql_select_for_xml_text_result(res NTEXT)
+RETURNS setof NTEXT AS
+$$
+BEGIN
+IF res IS NOT NULL THEN
+    return next res;
+ELSE
+    return;
+END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
 -- SELECT FOR JSON
 CREATE OR REPLACE FUNCTION sys.tsql_query_to_json_sfunc(
     state INTERNAL,
@@ -78,6 +104,19 @@ CREATE OR REPLACE AGGREGATE sys.tsql_select_for_json_agg(
     SFUNC = tsql_query_to_json_sfunc,
     FINALFUNC = tsql_query_to_json_ffunc
 );
+
+CREATE OR REPLACE FUNCTION sys.tsql_select_for_json_result(res sys.NVARCHAR)
+RETURNS setof sys.NVARCHAR AS
+$$
+BEGIN
+IF res IS NOT NULL THEN
+    return next res;
+ELSE
+    return;
+END IF;
+END;
+$$
+LANGUAGE plpgsql;
 
 -- User and Login Functions
 CREATE OR REPLACE FUNCTION sys.user_name(IN id OID DEFAULT NULL)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -228,7 +228,7 @@ ELSE
 END IF;
 END;
 $$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.tsql_select_for_xml_text_result(res NTEXT)
 RETURNS setof NTEXT AS
@@ -241,7 +241,7 @@ ELSE
 END IF;
 END;
 $$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql IMMUTABLE;
 
 -- SELECT FOR JSON
 CREATE OR REPLACE FUNCTION sys.tsql_query_to_json_sfunc(
@@ -285,7 +285,7 @@ ELSE
 END IF;
 END;
 $$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE PROCEDURE sys.sp_updatestats(IN "@resample" VARCHAR(8) DEFAULT 'NO')
 AS $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -217,6 +217,32 @@ CREATE OR REPLACE AGGREGATE sys.tsql_select_for_xml_text_agg(
     FINALFUNC = tsql_query_to_xml_text_ffunc
 );
 
+CREATE OR REPLACE FUNCTION sys.tsql_select_for_xml_result(res XML)
+RETURNS setof XML AS
+$$
+BEGIN
+IF res IS NOT NULL THEN
+    return next res;
+ELSE
+    return;
+END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sys.tsql_select_for_xml_text_result(res NTEXT)
+RETURNS setof NTEXT AS
+$$
+BEGIN
+IF res IS NOT NULL THEN
+    return next res;
+ELSE
+    return;
+END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
 -- SELECT FOR JSON
 CREATE OR REPLACE FUNCTION sys.tsql_query_to_json_sfunc(
     state INTERNAL,
@@ -247,6 +273,19 @@ CREATE OR REPLACE AGGREGATE sys.tsql_select_for_json_agg(
     SFUNC = tsql_query_to_json_sfunc,
     FINALFUNC = tsql_query_to_json_ffunc
 );
+
+CREATE OR REPLACE FUNCTION sys.tsql_select_for_json_result(res sys.NVARCHAR)
+RETURNS setof sys.NVARCHAR AS
+$$
+BEGIN
+IF res IS NOT NULL THEN
+    return next res;
+ELSE
+    return;
+END IF;
+END;
+$$
+LANGUAGE plpgsql;
 
 CREATE OR REPLACE PROCEDURE sys.sp_updatestats(IN "@resample" VARCHAR(8) DEFAULT 'NO')
 AS $$

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -1276,6 +1276,17 @@ TsqlForXMLMakeFuncCall(TSQL_ForClause* forclause)
 						   root_name ? makeStringConst(root_name, -1) : makeStringConst("", -1));
 	fc = makeFuncCall(func_name, func_args, COERCE_EXPLICIT_CALL, -1);
 
+	/* In SQL Server if the result is empty then 0 rows are returned. Unfortunately it is not
+	 * possible to mimic this behavior solely using an aggregate, so we use an additional SRF
+	 * and pass the result to that function so that returning 0 rows is possible.
+	 */
+	func_name= list_make2(makeString("sys"), 
+							makeString(return_xml_type ? 
+								"tsql_select_for_xml_result" : 
+								"tsql_select_for_xml_text_result"));
+	func_args = list_make1(fc);
+	fc = makeFuncCall(func_name, func_args, COERCE_EXPLICIT_CALL, -1);
+
 	rt->name = palloc0(4);
 	strncpy(rt->name, "xml", 3);
 	rt->indirection = NIL;
@@ -1335,7 +1346,7 @@ TsqlForJSONMakeFuncCall(TSQL_ForClause* forclause)
 	}
 	
 	/*
-	 * Finally make function call to tsql_select_for_json_agg
+	 * Make function call to tsql_select_for_json_agg
 	 */
 	func_name= list_make2(makeString("sys"), makeString("tsql_select_for_json_agg"));
 	func_args = list_make5(makeColumnRef(construct_unique_index_name("rows", "tsql_for"), NIL, -1, NULL),
@@ -1343,6 +1354,14 @@ TsqlForJSONMakeFuncCall(TSQL_ForClause* forclause)
 						   makeBoolAConst(include_null_values, -1),
 						   makeBoolAConst(without_array_wrapper, -1),
 						   root_name ? makeStringConst(root_name, -1) : makeNullAConst(-1));
+	fc = makeFuncCall(func_name, func_args, COERCE_EXPLICIT_CALL, -1);
+
+	/* In SQL Server if the result is empty then 0 rows are returned. Unfortunately it is not
+	 * possible to mimic this behavior solely using an aggregate, so we use an additional SRF
+	 * and pass the result to that function so that returning 0 rows is possible.
+	 */
+	func_name= list_make2(makeString("sys"), makeString("tsql_select_for_json_result"));
+	func_args = list_make1(fc);
 	fc = makeFuncCall(func_name, func_args, COERCE_EXPLICIT_CALL, -1);
 
 	rt->name = palloc0(5);

--- a/test/JDBC/expected/forjson-subquery-vu-cleanup.out
+++ b/test/JDBC/expected/forjson-subquery-vu-cleanup.out
@@ -16,12 +16,6 @@ GO
 DROP VIEW forjson_subquery_vu_v_with_order_by
 GO
 
-DROP TABLE forjson_subquery_vu_t_countries
-GO
-
-DROP TABLE forjson_subquery_vu_t1
-GO
-
 -- Binary strings
 DROP VIEW forjson_subquery_vu_v_binary_strings
 GO
@@ -34,6 +28,16 @@ DROP VIEW forjson_subquery_vu_v_rowversion
 GO
 
 DROP VIEW forjson_subquery_vu_v_timestamp
+GO
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+DROP PROCEDURE forjson_subquery_vu_p_empty
+GO
+
+DROP TABLE forjson_subquery_vu_t_countries
+GO
+
+DROP TABLE forjson_subquery_vu_t1
 GO
 
 -- Binary strings

--- a/test/JDBC/expected/forjson-subquery-vu-cleanup.out
+++ b/test/JDBC/expected/forjson-subquery-vu-cleanup.out
@@ -34,6 +34,10 @@ GO
 DROP PROCEDURE forjson_subquery_vu_p_empty
 GO
 
+-- exercise tsql_select_for_json_result internal function
+DROP VIEW forjson_subquery_vu_v_internal
+GO
+
 DROP TABLE forjson_subquery_vu_t_countries
 GO
 

--- a/test/JDBC/expected/forjson-subquery-vu-prepare.out
+++ b/test/JDBC/expected/forjson-subquery-vu-prepare.out
@@ -144,3 +144,8 @@ SELECT * FROM forjson_subquery_vu_t_countries
 	WHERE 1 = 0
 	FOR JSON PATH
 GO
+
+-- exercise tsql_select_for_json_result internal function
+CREATE VIEW forjson_subquery_vu_v_internal AS
+SELECT * FROM tsql_select_for_json_result('abcd')
+GO

--- a/test/JDBC/expected/forjson-subquery-vu-prepare.out
+++ b/test/JDBC/expected/forjson-subquery-vu-prepare.out
@@ -137,3 +137,10 @@ SELECT
     FOR JSON PATH
 ) as c1;
 GO
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+CREATE PROCEDURE forjson_subquery_vu_p_empty AS
+SELECT * FROM forjson_subquery_vu_t_countries
+	WHERE 1 = 0
+	FOR JSON PATH
+GO

--- a/test/JDBC/expected/forjson-subquery-vu-verify.out
+++ b/test/JDBC/expected/forjson-subquery-vu-verify.out
@@ -69,3 +69,19 @@ nvarchar
 
 ~~ERROR (Message: binary types are not supported with FOR JSON)~~
 
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+EXEC forjson_subquery_vu_p_empty
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT @@rowcount
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/forjson-subquery-vu-verify.out
+++ b/test/JDBC/expected/forjson-subquery-vu-verify.out
@@ -85,3 +85,12 @@ int
 0
 ~~END~~
 
+
+-- exercise tsql_select_for_json_result internal function
+SELECT * FROM forjson_subquery_vu_v_internal
+GO
+~~START~~
+nvarchar
+abcd
+~~END~~
+

--- a/test/JDBC/expected/forxml-subquery-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-subquery-vu-cleanup.out
@@ -19,6 +19,8 @@ go
 -- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
 DROP PROCEDURE forxml_subquery_vu_p_empty
 GO
+DROP PROCEDURE forxml_subquery_vu_p_empty_xml
+GO
 DROP VIEW forxml_subquery_vu_v_internal
 GO
 DROP VIEW forxml_subquery_vu_v_internal_text

--- a/test/JDBC/expected/forxml-subquery-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-subquery-vu-cleanup.out
@@ -16,6 +16,9 @@ drop view forxml_subquery_vu_v_cte4;
 go
 drop view forxml_subquery_vu_v_correlated_subquery;
 go
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+DROP PROCEDURE forxml_subquery_vu_p_empty
+GO
 drop table forxml_subquery_vu_t_t1;
 go
 drop table forxml_subquery_vu_t_t2;

--- a/test/JDBC/expected/forxml-subquery-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-subquery-vu-cleanup.out
@@ -19,6 +19,10 @@ go
 -- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
 DROP PROCEDURE forxml_subquery_vu_p_empty
 GO
+DROP VIEW forxml_subquery_vu_v_internal
+GO
+DROP VIEW forxml_subquery_vu_v_internal_text
+GO
 drop table forxml_subquery_vu_t_t1;
 go
 drop table forxml_subquery_vu_t_t2;

--- a/test/JDBC/expected/forxml-subquery-vu-prepare.out
+++ b/test/JDBC/expected/forxml-subquery-vu-prepare.out
@@ -64,3 +64,12 @@ SELECT * FROM forxml_subquery_vu_t_t1
 	WHERE 1 = 0
 	FOR XML RAW
 GO
+
+-- exercise result internal functions
+CREATE VIEW forxml_subquery_vu_v_internal AS
+SELECT * FROM tsql_select_for_xml_result('<abcd/>')
+GO
+
+CREATE VIEW forxml_subquery_vu_v_internal_text AS
+SELECT * FROM tsql_select_for_xml_text_result('<abcd/>')
+GO

--- a/test/JDBC/expected/forxml-subquery-vu-prepare.out
+++ b/test/JDBC/expected/forxml-subquery-vu-prepare.out
@@ -65,6 +65,12 @@ SELECT * FROM forxml_subquery_vu_t_t1
 	FOR XML RAW
 GO
 
+CREATE PROCEDURE forxml_subquery_vu_p_empty_xml AS
+SELECT * FROM forxml_subquery_vu_t_t1
+	WHERE 1 = 0
+	FOR XML RAW, TYPE
+GO
+
 -- exercise result internal functions
 CREATE VIEW forxml_subquery_vu_v_internal AS
 SELECT * FROM tsql_select_for_xml_result('<abcd/>')

--- a/test/JDBC/expected/forxml-subquery-vu-prepare.out
+++ b/test/JDBC/expected/forxml-subquery-vu-prepare.out
@@ -57,3 +57,10 @@ go
 create view forxml_subquery_vu_v_correlated_subquery as
 select a, (select * from forxml_subquery_vu_t_t2 where id = t.id for xml raw) as mycol from forxml_subquery_vu_t_t1 t
 go
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+CREATE PROCEDURE forxml_subquery_vu_p_empty AS
+SELECT * FROM forxml_subquery_vu_t_t1
+	WHERE 1 = 0
+	FOR XML RAW
+GO

--- a/test/JDBC/expected/forxml-subquery-vu-verify.out
+++ b/test/JDBC/expected/forxml-subquery-vu-verify.out
@@ -52,3 +52,19 @@ t1_a2#!#<row id="2" a="t2_a2"/>
 <NULL>#!#<row id="3"/>
 ~~END~~
 
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+EXEC forxml_subquery_vu_p_empty
+GO
+~~START~~
+ntext
+~~END~~
+
+
+SELECT @@rowcount
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/forxml-subquery-vu-verify.out
+++ b/test/JDBC/expected/forxml-subquery-vu-verify.out
@@ -69,6 +69,22 @@ int
 ~~END~~
 
 
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+EXEC forxml_subquery_vu_p_empty_xml
+GO
+~~START~~
+xml
+~~END~~
+
+
+SELECT @@rowcount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
 -- exercise result internal functions
 SELECT * FROM forxml_subquery_vu_v_internal
 GO

--- a/test/JDBC/expected/forxml-subquery-vu-verify.out
+++ b/test/JDBC/expected/forxml-subquery-vu-verify.out
@@ -68,3 +68,20 @@ int
 0
 ~~END~~
 
+
+-- exercise result internal functions
+SELECT * FROM forxml_subquery_vu_v_internal
+GO
+~~START~~
+xml
+<abcd/>
+~~END~~
+
+
+SELECT * FROM forxml_subquery_vu_v_internal_text
+GO
+~~START~~
+ntext
+<abcd/>
+~~END~~
+

--- a/test/JDBC/expected/forxml-subquery-vu-verify.out
+++ b/test/JDBC/expected/forxml-subquery-vu-verify.out
@@ -69,7 +69,6 @@ int
 ~~END~~
 
 
--- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
 EXEC forxml_subquery_vu_p_empty_xml
 GO
 ~~START~~

--- a/test/JDBC/expected/forxml-vu-verify.out
+++ b/test/JDBC/expected/forxml-vu-verify.out
@@ -87,11 +87,9 @@ ntext
 ~~END~~
 
 -- test NULL parameter
--- TODO fix BABEL-3569 so this returns 0 rows
 exec forxml_vu_p_strvar 1, NULL;
 go
 ~~START~~
 ntext
-<NULL>
 ~~END~~
 

--- a/test/JDBC/input/forjson/forjson-subquery-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjson-subquery-vu-cleanup.sql
@@ -30,6 +30,10 @@ GO
 DROP PROCEDURE forjson_subquery_vu_p_empty
 GO
 
+-- exercise tsql_select_for_json_result internal function
+DROP VIEW forjson_subquery_vu_v_internal
+GO
+
 DROP TABLE forjson_subquery_vu_t_countries
 GO
 

--- a/test/JDBC/input/forjson/forjson-subquery-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjson-subquery-vu-cleanup.sql
@@ -12,12 +12,6 @@ GO
 DROP VIEW forjson_subquery_vu_v_with_order_by
 GO
 
-DROP TABLE forjson_subquery_vu_t_countries
-GO
-
-DROP TABLE forjson_subquery_vu_t1
-GO
-
 -- Binary strings
 DROP VIEW forjson_subquery_vu_v_binary_strings
 GO
@@ -30,6 +24,16 @@ DROP VIEW forjson_subquery_vu_v_rowversion
 GO
 
 DROP VIEW forjson_subquery_vu_v_timestamp
+GO
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+DROP PROCEDURE forjson_subquery_vu_p_empty
+GO
+
+DROP TABLE forjson_subquery_vu_t_countries
+GO
+
+DROP TABLE forjson_subquery_vu_t1
 GO
 
 -- Binary strings

--- a/test/JDBC/input/forjson/forjson-subquery-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjson-subquery-vu-prepare.sql
@@ -123,3 +123,10 @@ SELECT
     FOR JSON PATH
 ) as c1;
 GO
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+CREATE PROCEDURE forjson_subquery_vu_p_empty AS
+SELECT * FROM forjson_subquery_vu_t_countries
+	WHERE 1 = 0
+	FOR JSON PATH
+GO

--- a/test/JDBC/input/forjson/forjson-subquery-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjson-subquery-vu-prepare.sql
@@ -130,3 +130,8 @@ SELECT * FROM forjson_subquery_vu_t_countries
 	WHERE 1 = 0
 	FOR JSON PATH
 GO
+
+-- exercise tsql_select_for_json_result internal function
+CREATE VIEW forjson_subquery_vu_v_internal AS
+SELECT * FROM tsql_select_for_json_result('abcd')
+GO

--- a/test/JDBC/input/forjson/forjson-subquery-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjson-subquery-vu-verify.sql
@@ -32,3 +32,7 @@ GO
 
 SELECT @@rowcount
 GO
+
+-- exercise tsql_select_for_json_result internal function
+SELECT * FROM forjson_subquery_vu_v_internal
+GO

--- a/test/JDBC/input/forjson/forjson-subquery-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjson-subquery-vu-verify.sql
@@ -25,3 +25,10 @@ GO
 
 SELECT * FROM forjson_subquery_vu_v_timestamp
 GO
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+EXEC forjson_subquery_vu_p_empty
+GO
+
+SELECT @@rowcount
+GO

--- a/test/JDBC/input/forxml/forxml-subquery-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-cleanup.sql
@@ -19,6 +19,8 @@ go
 -- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
 DROP PROCEDURE forxml_subquery_vu_p_empty
 GO
+DROP PROCEDURE forxml_subquery_vu_p_empty_xml
+GO
 DROP VIEW forxml_subquery_vu_v_internal
 GO
 DROP VIEW forxml_subquery_vu_v_internal_text

--- a/test/JDBC/input/forxml/forxml-subquery-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-cleanup.sql
@@ -16,6 +16,9 @@ drop view forxml_subquery_vu_v_cte4;
 go
 drop view forxml_subquery_vu_v_correlated_subquery;
 go
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+DROP PROCEDURE forxml_subquery_vu_p_empty
+GO
 drop table forxml_subquery_vu_t_t1;
 go
 drop table forxml_subquery_vu_t_t2;

--- a/test/JDBC/input/forxml/forxml-subquery-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-cleanup.sql
@@ -19,6 +19,10 @@ go
 -- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
 DROP PROCEDURE forxml_subquery_vu_p_empty
 GO
+DROP VIEW forxml_subquery_vu_v_internal
+GO
+DROP VIEW forxml_subquery_vu_v_internal_text
+GO
 drop table forxml_subquery_vu_t_t1;
 go
 drop table forxml_subquery_vu_t_t2;

--- a/test/JDBC/input/forxml/forxml-subquery-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-prepare.sql
@@ -51,6 +51,12 @@ SELECT * FROM forxml_subquery_vu_t_t1
 	FOR XML RAW
 GO
 
+CREATE PROCEDURE forxml_subquery_vu_p_empty_xml AS
+SELECT * FROM forxml_subquery_vu_t_t1
+	WHERE 1 = 0
+	FOR XML RAW, TYPE
+GO
+
 -- exercise result internal functions
 CREATE VIEW forxml_subquery_vu_v_internal AS
 SELECT * FROM tsql_select_for_xml_result('<abcd/>')

--- a/test/JDBC/input/forxml/forxml-subquery-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-prepare.sql
@@ -43,3 +43,10 @@ go
 create view forxml_subquery_vu_v_correlated_subquery as
 select a, (select * from forxml_subquery_vu_t_t2 where id = t.id for xml raw) as mycol from forxml_subquery_vu_t_t1 t
 go
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+CREATE PROCEDURE forxml_subquery_vu_p_empty AS
+SELECT * FROM forxml_subquery_vu_t_t1
+	WHERE 1 = 0
+	FOR XML RAW
+GO

--- a/test/JDBC/input/forxml/forxml-subquery-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-prepare.sql
@@ -50,3 +50,12 @@ SELECT * FROM forxml_subquery_vu_t_t1
 	WHERE 1 = 0
 	FOR XML RAW
 GO
+
+-- exercise result internal functions
+CREATE VIEW forxml_subquery_vu_v_internal AS
+SELECT * FROM tsql_select_for_xml_result('<abcd/>')
+GO
+
+CREATE VIEW forxml_subquery_vu_v_internal_text AS
+SELECT * FROM tsql_select_for_xml_text_result('<abcd/>')
+GO

--- a/test/JDBC/input/forxml/forxml-subquery-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-verify.sql
@@ -15,3 +15,10 @@ GO
 
 select * from forxml_subquery_vu_v_correlated_subquery;
 go
+
+-- BABEL-3569/BABEL-3690 return 0 rows for empty rowset
+EXEC forxml_subquery_vu_p_empty
+GO
+
+SELECT @@rowcount
+GO

--- a/test/JDBC/input/forxml/forxml-subquery-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-verify.sql
@@ -22,3 +22,10 @@ GO
 
 SELECT @@rowcount
 GO
+
+-- exercise result internal functions
+SELECT * FROM forxml_subquery_vu_v_internal
+GO
+
+SELECT * FROM forxml_subquery_vu_v_internal_text
+GO

--- a/test/JDBC/input/forxml/forxml-subquery-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-subquery-vu-verify.sql
@@ -23,6 +23,12 @@ GO
 SELECT @@rowcount
 GO
 
+EXEC forxml_subquery_vu_p_empty_xml
+GO
+
+SELECT @@rowcount
+GO
+
 -- exercise result internal functions
 SELECT * FROM forxml_subquery_vu_v_internal
 GO

--- a/test/JDBC/input/forxml/forxml-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-vu-verify.sql
@@ -31,6 +31,5 @@ go
 exec forxml_vu_p_strvar 1, 't1_a1';
 go
 -- test NULL parameter
--- TODO fix BABEL-3569 so this returns 0 rows
 exec forxml_vu_p_strvar 1, NULL;
 go


### PR DESCRIPTION
Signed-off-by: Jason Teng <jasonten@amazon.com>

### Description

If FOR XML/JSON are used on a query that returns 0 rows, the result is supposed to be an empty result with 0 rows.
In order to mimic this behavior, we need to use an additional set-returning function and pass the result of the aggregate
function call to that SRF so that returning 0 rows is possible.

### Issues Resolved

BABEL-3569, BABEL-3690

### Test Scenarios Covered ###
regression tests + new tests for empty rowsets

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).