### PR TITLE
Throw error for ALTER LOGIN ... WITH PASSWORD for windows login

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2654,6 +2654,8 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 				if (islogin)
 				{
 					Oid		datdba;
+					char*	alter_login_name = NULL;
+					bool	is_password = false;
 
 					datdba = get_role_oid("sysadmin", false);
 
@@ -2671,9 +2673,12 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 								ereport(ERROR,
 										(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 										 errmsg("Current login does not have privileges to alter password")));
+
+							is_password = true;	
 						}
 					}
 
+					alter_login_name = pnstrdup(stmt->role->rolename, strlen(stmt->role->rolename));
 					/*
 					 * Leveraging the fact that convertToUPN API returns the login name in UPN format
 					 * if login name contains '\' i,e,. windows login.
@@ -2682,6 +2687,17 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 					 * to UPN format or else it will be as it was
 					 */
 					stmt->role->rolename = convertToUPN(stmt->role->rolename);
+
+					/* If the previous rolname is same as current, then its password based login
+					 * else, it is windows based login. If, user is trying to alter password for
+					 * windows login, throw error
+					 */
+					if (strcmp(alter_login_name, stmt->role->rolename) != 0 && is_password)
+					{
+							ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), 
+									errmsg("Cannot use parameter PASSWORD for a windows login")));
+					}
+					pfree(alter_login_name);
 
 					if (get_role_oid(stmt->role->rolename, true) == InvalidOid)
 						  ereport(ERROR, (errcode(ERRCODE_DUPLICATE_OBJECT), 

--- a/test/JDBC/expected/test_windows_alter_login-vu-verify.out
+++ b/test/JDBC/expected/test_windows_alter_login-vu-verify.out
@@ -48,6 +48,20 @@ GO
 ~~ERROR (Message: Cannot drop the login 'aduser_alter@babel', because it does not exist or you do not have permission.)~~
 
 
+ALTER LOGIN [babel\aduser_alter] WITH PASSWORD='123'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use parameter PASSWORD for a windows login)~~
+
+
+ALTER LOGIN [babel\aduser_alter] WITH  PASSWORD  ='123'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use parameter PASSWORD for a windows login)~~
+
+
 ALTER LOGIN passWORduser_alter DISABLE;
 GO
 
@@ -86,6 +100,30 @@ GO
 ~~START~~
 name#!#int4#!#"sys"."varchar"#!#"sys"."varchar"#!#bpchar
 passworduser_alter#!#0#!#alter_db#!#English#!#S
+~~END~~
+
+
+-- tsql
+ALTER LOGIN passWORduser_alter with PASSWORD='12345678';
+GO
+
+-- tsql user=passWORduser_alter password=12345678;
+SELECT SUSER_NAME();
+GO
+~~START~~
+nvarchar
+passWORduser_alter
+~~END~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'passworduser_alter' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
 ~~END~~
 
 

--- a/test/JDBC/input/test_windows_alter_login-vu-verify.mix
+++ b/test/JDBC/input/test_windows_alter_login-vu-verify.mix
@@ -29,6 +29,12 @@ GO
 ALTER LOGIN [aduser_alter@BABEL] DISABLE;
 GO
 
+ALTER LOGIN [babel\aduser_alter] WITH PASSWORD='123'
+GO
+
+ALTER LOGIN [babel\aduser_alter] WITH  PASSWORD  ='123'
+GO
+
 ALTER LOGIN passWORduser_alter DISABLE;
 GO
 
@@ -53,6 +59,20 @@ GO
 -- psql
 select rolname, is_disabled, default_database_name, default_language_name, type from sys.babelfish_authid_login_ext
 where rolname = 'passworduser_alter';
+GO
+
+-- tsql
+ALTER LOGIN passWORduser_alter with PASSWORD='12345678';
+GO
+
+-- tsql user=passWORduser_alter password=12345678;
+SELECT SUSER_NAME();
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'passworduser_alter' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 
 -- tsql


### PR DESCRIPTION
Signed-off-by: Shameem Ahmed <shameemahmed20apr2000@gmail.com>

### Description
This commit throws error for ALTER LOGIN ... WITH PASSWORD for windows based login. Till now, if any user tries to alter the login with password for a windows login, then the query gets executed successfully. Even though the login won't be able to connect to the db with that password, it has to connect using AD authentication only, still that is not ideal behaviour. So, in this commit we are addressing this issue to throw error if someone is trying to ALTER LOGIN ... WITH PASSWORD for a windows login.


### Issues Resolved

BABEL-3931
Related to BABEL-3847

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).