### PR TITLE
Optimise sys.indexes view and fix indid column for sys.sysindexes

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1612,51 +1612,58 @@ $$ LANGUAGE SQL IMMUTABLE;
 
 -- TODO: BABEL-2838
 CREATE OR REPLACE VIEW sys.sp_special_columns_view AS
-SELECT DISTINCT 
-CAST(1 as smallint) AS SCOPE,
-CAST(coalesce (split_part(pa.attoptions[1] collate "C", '=', 2) ,c1.name) AS sys.sysname) AS COLUMN_NAME, -- get original column name if exists
-CAST(t6.data_type AS smallint) AS DATA_TYPE,
+SELECT
+CAST(1 AS SMALLINT) AS SCOPE,
+CAST(coalesce (split_part(a.attoptions[1] COLLATE "C", '=', 2) ,a.attname) AS sys.sysname) AS COLUMN_NAME, -- get original column name if exists
+CAST(t6.data_type AS SMALLINT) AS DATA_TYPE,
 
 CASE -- cases for when they are of type identity. 
-	WHEN c1.is_identity = 1 AND (t8.name = 'decimal' or t8.name = 'numeric') 
-	THEN CAST(CONCAT(t8.name, '() identity') AS sys.sysname)
-	WHEN c1.is_identity = 1 AND (t8.name != 'decimal' AND t8.name != 'numeric')
-	THEN CAST(CONCAT(t8.name, ' identity') AS sys.sysname)
-	ELSE CAST(t8.name AS sys.sysname)
+	WHEN  a.attidentity <> ''::"char" AND (t1.name = 'decimal' OR t1.name = 'numeric')
+	THEN CAST(CONCAT(t1.name, '() identity') AS sys.sysname)
+	WHEN  a.attidentity <> ''::"char" AND (t1.name != 'decimal' AND t1.name != 'numeric')
+	THEN CAST(CONCAT(t1.name, ' identity') AS sys.sysname)
+	ELSE CAST(t1.name AS sys.sysname)
 END AS TYPE_NAME,
 
-CAST(sys.sp_special_columns_precision_helper(coalesce(tsql_type_name, tsql_base_type_name), c1.precision, c1.max_length, t6."PRECISION") AS int) AS PRECISION,
-CAST(sys.sp_special_columns_length_helper(coalesce(tsql_type_name, tsql_base_type_name), c1.precision, c1.max_length, t6."PRECISION") AS int) AS LENGTH,
-CAST(sys.sp_special_columns_scale_helper(coalesce(tsql_type_name, tsql_base_type_name), c1.scale) AS smallint) AS SCALE,
+CAST(sys.sp_special_columns_precision_helper(COALESCE(tsql_type_name, tsql_base_type_name), c1.precision, c1.max_length, t6."PRECISION") AS INT) AS PRECISION,
+CAST(sys.sp_special_columns_length_helper(coalesce(tsql_type_name, tsql_base_type_name), c1.precision, c1.max_length, t6."PRECISION") AS INT) AS LENGTH,
+CAST(sys.sp_special_columns_scale_helper(coalesce(tsql_type_name, tsql_base_type_name), c1.scale) AS SMALLINT) AS SCALE,
 CAST(1 AS smallint) AS PSEUDO_COLUMN,
-CAST(c1.is_nullable AS int) AS IS_NULLABLE,
-CAST(t2.dbname AS sys.sysname) AS TABLE_QUALIFIER,
+CASE
+	WHEN a.attnotnull
+	THEN CAST(0 AS INT)
+	ELSE CAST(1 AS INT) END
+AS IS_NULLABLE,
+CAST(nsp_ext.dbname AS sys.sysname) AS TABLE_QUALIFIER,
 CAST(s1.name AS sys.sysname) AS TABLE_OWNER,
-CAST(t1.relname AS sys.sysname) AS TABLE_NAME,
+CAST(C.relname AS sys.sysname) AS TABLE_NAME,
 
 CASE 
-	WHEN idx.is_primary_key != 1
-	THEN CAST('u' AS sys.sysname) -- if it is a unique index, then we should cast it as 'u' for filtering purposes
-	ELSE CAST('p' AS sys.sysname)
+	WHEN X.indisprimary
+	THEN CAST('p' AS sys.sysname)
+	ELSE CAST('u' AS sys.sysname) -- if it is a unique index, then we should cast it as 'u' for filtering purposes
 END AS CONSTRAINT_TYPE,
-CAST(idx.name AS sys.sysname) AS CONSTRAINT_NAME,
-CAST(idx.index_id AS int) AS INDEX_ID
-        
-FROM pg_catalog.pg_class t1 
-	JOIN sys.pg_namespace_ext t2 ON t1.relnamespace = t2.oid
-	JOIN sys.schemas s1 ON s1.schema_id = t1.relnamespace
-	LEFT JOIN sys.indexes idx ON idx.object_id = t1.oid
-	INNER JOIN pg_catalog.pg_attribute i2 ON idx.index_id = i2.attrelid
-	INNER JOIN sys.columns c1 ON c1.object_id = idx.object_id AND cast(i2.attname as sys.sysname) = c1.name collate sys.database_default
+CAST(I.relname AS sys.sysname) CONSTRAINT_NAME,
+CAST(X.indexrelid AS int) AS INDEX_ID
 
-	JOIN pg_catalog.pg_type AS t7 ON t7.oid = c1.system_type_id
-	JOIN sys.types AS t8 ON c1.user_type_id = t8.user_type_id 
-	LEFT JOIN sys.sp_datatype_info_helper(2::smallint, false) AS t6 ON t7.typname = t6.pg_type_name OR t7.typname = t6.type_name --need in order to get accurate DATA_TYPE value
-	LEFT JOIN pg_catalog.pg_attribute AS pa ON t1.oid = pa.attrelid AND c1.name = pa.attname collate sys.database_default
-	, sys.translate_pg_type_to_tsql(t8.user_type_id) AS tsql_type_name
-	, sys.translate_pg_type_to_tsql(t8.system_type_id) AS tsql_base_type_name
-	WHERE has_schema_privilege(s1.schema_id, 'USAGE');
-  
+FROM( pg_index X
+JOIN pg_class C ON X.indrelid = C.oid
+JOIN pg_class I ON I.oid = X.indexrelid
+CROSS JOIN LATERAL unnest(X.indkey) AS ak(k)
+        LEFT JOIN pg_attribute a
+                       ON (a.attrelid = X.indrelid AND a.attnum = ak.k)
+)
+LEFT JOIN sys.pg_namespace_ext nsp_ext ON C.relnamespace = nsp_ext.oid
+LEFT JOIN sys.schemas s1 ON s1.schema_id = C.relnamespace
+LEFT JOIN sys.columns c1 ON c1.object_id = X.indrelid AND cast(a.attname AS sys.sysname) = c1.name COLLATE sys.database_default
+LEFT JOIN pg_catalog.pg_type AS T ON T.oid = c1.system_type_id
+LEFT JOIN sys.types AS t1 ON a.atttypid = t1.user_type_id
+LEFT JOIN sys.sp_datatype_info_helper(2::smallint, false) AS t6 ON T.typname = t6.pg_type_name OR T.typname = t6.type_name --need in order to get accurate DATA_TYPE value
+, sys.translate_pg_type_to_tsql(t1.user_type_id) AS tsql_type_name
+, sys.translate_pg_type_to_tsql(t1.system_type_id) AS tsql_base_type_name
+WHERE has_schema_privilege(s1.schema_id, 'USAGE')
+AND X.indislive ;
+
 GRANT SELECT ON sys.sp_special_columns_view TO PUBLIC; 
 
 

--- a/test/JDBC/expected/sys-foreign_keys-vu-verify.out
+++ b/test/JDBC/expected/sys-foreign_keys-vu-verify.out
@@ -143,24 +143,6 @@ int
 ~~END~~
 
 
-SELECT key_index_id from sys.foreign_keys where name = 'fk1_pk1_id_fkey'
-EXCEPT
-SELECT index_id from sys.indexes where name = 'pk1_pkey'
-GO
-~~START~~
-int
-~~END~~
-
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk1_pk1_id_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk1_pkey');
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey';
 GO
@@ -170,24 +152,6 @@ int
 ~~END~~
 
 
-SELECT key_index_id from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey'
-EXCEPT 
-SELECT index_id from sys.indexes where name = 'pk2_pk2_unique_int_1_key'
-GO
-~~START~~
-int
-~~END~~
-
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk2_fk2_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk2_pk2_unique_int_1_key');
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk3_pk3_int_1_pk3_int_2_fkey';
 GO
@@ -196,22 +160,4 @@ int
 1
 ~~END~~
 
-
-SELECT key_index_id FROM sys.foreign_keys WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-EXCEPT
-SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey'
-GO
-~~START~~
-int
-~~END~~
-
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey');
-GO
-~~START~~
-int
-1
-~~END~~
 

--- a/test/JDBC/expected/sys-foreign_keys.out
+++ b/test/JDBC/expected/sys-foreign_keys.out
@@ -178,24 +178,6 @@ int
 ~~END~~
 
 
-SELECT key_index_id from sys.foreign_keys where name = 'fk1_pk1_id_fkey'
-EXCEPT
-SELECT index_id from sys.indexes where name = 'pk1_pkey'
-GO
-~~START~~
-int
-~~END~~
-
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk1_pk1_id_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk1_pkey');
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 DROP TABLE FK1;
 GO
@@ -218,25 +200,6 @@ CREATE TABLE FK2 (
 GO
 
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey';
-GO
-~~START~~
-int
-1
-~~END~~
-
-
-SELECT key_index_id from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey'
-EXCEPT 
-SELECT index_id from sys.indexes where name = 'pk2_pk2_unique_int_1_key'
-GO
-~~START~~
-int
-~~END~~
-
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk2_fk2_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk2_pk2_unique_int_1_key');
 GO
 ~~START~~
 int
@@ -271,24 +234,6 @@ int
 1
 ~~END~~
 
-
-SELECT key_index_id FROM sys.foreign_keys WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-EXCEPT
-SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey'
-GO
-~~START~~
-int
-~~END~~
-
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey');
-GO
-~~START~~
-int
-1
-~~END~~
 
 
 DROP TABLE FK3;

--- a/test/JDBC/expected/sys-sysindexes-vu-verify.out
+++ b/test/JDBC/expected/sys-sysindexes-vu-verify.out
@@ -19,6 +19,15 @@ int
 ~~END~~
 
 
+--check indid and index_id return same values
+select count(*) from sys.indexes v1 inner join sys.sysindexes v2 on v1.object_id = v2.id and indid=index_id where v1.name LIKE '%SYS_SYSINDEXES_VU_PREPARE_T1_I1%';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
 EXEC sys_sysindexes_vu_prepare_p1
 GO
 ~~START~~

--- a/test/JDBC/input/views/sys-foreign_keys-vu-verify.sql
+++ b/test/JDBC/input/views/sys-foreign_keys-vu-verify.sql
@@ -58,38 +58,11 @@ GO
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk1_pk1_id_fkey';
 GO
 
-SELECT key_index_id from sys.foreign_keys where name = 'fk1_pk1_id_fkey'
-EXCEPT
-SELECT index_id from sys.indexes where name = 'pk1_pkey'
-GO
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk1_pk1_id_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk1_pkey');
-GO
 
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey';
 GO
 
-SELECT key_index_id from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey'
-EXCEPT 
-SELECT index_id from sys.indexes where name = 'pk2_pk2_unique_int_1_key'
-GO
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk2_fk2_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk2_pk2_unique_int_1_key');
-GO
 
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk3_pk3_int_1_pk3_int_2_fkey';
 GO
 
-SELECT key_index_id FROM sys.foreign_keys WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-EXCEPT
-SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey'
-GO
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey');
-GO

--- a/test/JDBC/input/views/sys-foreign_keys.sql
+++ b/test/JDBC/input/views/sys-foreign_keys.sql
@@ -93,15 +93,6 @@ GO
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk1_pk1_id_fkey';
 GO
 
-SELECT key_index_id from sys.foreign_keys where name = 'fk1_pk1_id_fkey'
-EXCEPT
-SELECT index_id from sys.indexes where name = 'pk1_pkey'
-GO
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk1_pk1_id_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk1_pkey');
-GO
 
 DROP TABLE FK1;
 GO
@@ -124,16 +115,6 @@ CREATE TABLE FK2 (
 GO
 
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey';
-GO
-
-SELECT key_index_id from sys.foreign_keys where name = 'fk2_fk2_int_2_fkey'
-EXCEPT 
-SELECT index_id from sys.indexes where name = 'pk2_pk2_unique_int_1_key'
-GO
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk2_fk2_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk2_pk2_unique_int_1_key');
 GO
 
 DROP TABLE FK2;
@@ -159,15 +140,6 @@ GO
 SELECT COUNT(*) from sys.foreign_keys where name = 'fk3_pk3_int_1_pk3_int_2_fkey';
 GO
 
-SELECT key_index_id FROM sys.foreign_keys WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-EXCEPT
-SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey'
-GO
-
-SELECT count(DISTINCT key_index_id) FROM sys.foreign_keys 
-WHERE NAME = 'fk3_pk3_int_1_pk3_int_2_fkey'
-AND key_index_id IN (SELECT index_id FROM sys.indexes WHERE NAME = 'pk3_pkey');
-GO
 
 DROP TABLE FK3;
 GO

--- a/test/JDBC/input/views/sys-sysindexes-vu-verify.sql
+++ b/test/JDBC/input/views/sys-sysindexes-vu-verify.sql
@@ -9,6 +9,10 @@ GO
 SELECT COUNT(*) FROM sys.sysindexes WHERE name LIKE '%SYS_SYSINDEXES_VU_PREPARE_T1_I1%'
 GO
 
+--check indid and index_id return same values
+select count(*) from sys.indexes v1 inner join sys.sysindexes v2 on v1.object_id = v2.id and indid=index_id where v1.name LIKE '%SYS_SYSINDEXES_VU_PREPARE_T1_I1%';
+GO
+
 EXEC sys_sysindexes_vu_prepare_p1
 GO
 


### PR DESCRIPTION
### Description
1. According to the old definition of sys.indexes we were performing a separate select query on pg_constraint for each entry/row  in the view. This could be optimised by joining the view directly based on constraint Oid to get the necessary metadata needed  and we were also performing redundant select on sys.schemas view for each entry in the view, this could also be avoid by using a **left join** and a predicate to check for 'sys' indexes as well
2. Previously we where returning `type_desc`(from sys.indexes) as `indid` in sys.sysindexes view , fixed the view definition to use `index_id` column from indexes view for `indid` column
3. Removed Dependency on sys.indexes from sys.sp_special_columns view as now the index_id returned is unique only to the object

### Issues Resolved
BABEL-3898,BABEL-3897
[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
  - Added new checks to compare indid and index_id both should be equal

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**
On a database with large number of objects (~15k indexes)
Performing simple query on the view `SELECT count(*) from sys.indexes`

| View Def | Time |
| ------------- | ------------- |
|Old View| 35547 ms| 
|New View | 384 ms | 

* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).