### PR TITLE
[BABEL-2858] Enable SLL parsing guc by default (#1182)

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -21,7 +21,7 @@ bool enable_metadata_inconsistency_check = true;
 
 bool pltsql_dump_antlr_query_graph = false;
 bool pltsql_enable_antlr_detailed_log = false;
-bool pltsql_enable_sll_parse_mode = false;
+bool pltsql_enable_sll_parse_mode = true;
 bool pltsql_allow_antlr_to_unsupported_grammar_for_testing = false;
 bool  pltsql_ansi_defaults = true;
 bool  pltsql_quoted_identifier = true;
@@ -589,7 +589,7 @@ define_custom_variables(void)
 				 gettext_noop("enable SLL parser mode for ANTLR parser"),
 				 NULL,
 				 &pltsql_enable_sll_parse_mode,
-				 false,
+				 true,
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2464,7 +2464,7 @@ antlr_parser_cpp(const char *sourceText)
 	 * Generally the mutator steps are non-reentrant, if parsetree is created and mutators are run, subsequent parsing may produce
 	 * incorrect error messages
 	*/
-	if (!result.success && !result.parseTreeCreated)
+	if (!result.success && !result.parseTreeCreated && pltsql_enable_sll_parse_mode)
 	{
 		elog(DEBUG1, "Query failed using SLL parser mode, retrying with LL parser mode query_text: %s", sourceText);
 		result = antlr_parse_query(sourceText, false);


### PR DESCRIPTION
Description

[BABEL-2858] Enable SLL parsing guc by default

After testing showed across the board performance gains and little downside, it was decided to enable SLL parsing by default. This commit also ensures we only retry parsing with LL mode if SLL mode was initially used

Task: BABEL-2858
Signed-off-by: Justin Jossick [jusjosj@amazon.com](mailto:jusjosj@amazon.com)
Test Scenarios Covered

    Use case based -
    See jira

    Boundary conditions -
    See unit tests

    Arbitrary inputs -
    covered by regression

    Negative test cases -
    n/a

    Minor version upgrade tests -
    see unit tests

    Major version upgrade tests -
    see unit tests

    Performance tests -
    see jira

    Tooling impact -
    n/a

    Client tests -
    sqlcmd/jdbc

Check List

    Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).