### PR TITLE
Rewrite sys.all_views to improve performance

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1836,6 +1836,44 @@ END;
 $$;
 GRANT EXECUTE on PROCEDURE sys.sp_rename(IN sys.nvarchar(776), IN sys.SYSNAME, IN sys.varchar(13)) TO PUBLIC;
 
+create or replace view sys.all_views as
+SELECT
+    CAST(c.relname AS sys.SYSNAME) as name
+  , CAST(c.oid AS INT) as object_id
+  , CAST(null AS INT) as principal_id
+  , CAST(c.relnamespace as INT) as schema_id
+  , CAST(0 as INT) as parent_object_id
+  , CAST('V' as sys.bpchar(2)) as type
+  , CAST('VIEW'as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+  , CAST(0 as sys.BIT) AS is_replicated
+  , CAST(0 as sys.BIT) AS has_replication_filter
+  , CAST(0 as sys.BIT) AS has_opaque_metadata
+  , CAST(0 as sys.BIT) AS has_unchecked_assembly_data
+  , CAST(
+      CASE 
+        WHEN (v.check_option = 'NONE') 
+          THEN 0
+        ELSE 1
+      END
+    AS sys.BIT) AS with_check_option
+  , CAST(0 as sys.BIT) AS is_date_correlation_view
+FROM pg_catalog.pg_namespace AS ns
+INNER JOIN pg_class c ON ns.oid = c.relnamespace
+INNER JOIN information_schema.views v ON c.relname = v.table_name AND ns.nspname = v.table_schema
+WHERE c.relkind = 'v' AND ns.nspname in 
+  (SELECT nspname from sys.babelfish_namespace_ext where dbid = sys.db_id() UNION ALL SELECT CAST('sys' AS NAME))
+AND pg_is_other_temp_schema(ns.oid) = false
+AND (pg_has_role(c.relowner, 'USAGE') = true
+OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') = true
+OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') = true);
+GRANT SELECT ON sys.all_views TO PUBLIC;
+
+
 /* set sys functions as STABLE */
 ALTER FUNCTION sys.schema_id() STABLE;
 ALTER FUNCTION sys.schema_name() STABLE;


### PR DESCRIPTION
3x PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1127

Earlier sys.all_views was dependent on sys.all_objects rather than directly relying on pg_class because of which we saw perfomance degradation due to inefficient plans. The optimizer was somehow rewriting it efficiently for larger rows, but perfomance was terrible for fewer rows. With this commit we have rewritten sys.all_views in a cleaner and efficient way to rely on pg_class directly.
Signed-off-by: Shlok Kumar Kyal ([skkyal@amazon.com](mailto:skkyal@amazon.com))

### Description
Rewritten the sys.all_views view to improve the performance


### Issues Resolved
BABEL-3903

### Test Scenarios Covered ###
JDBC Tests for sys.all_views are already present
* **Use case based -**
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Tooling impact -**
* **Client tests -**


* **Performance tests -**
Tried testing on 'db.r5.large' instance 
query ran : `select * from from sys.all_views`
count of object:
```
select count(*) from sys.all_views
2> go
count      
-----------
        351
```
Time Taken
Old view : 2147 ms (avg of 5 times)
New view: 361 ms (avg of 5 times)

Improvement of 6 times


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).