### PR TITLE
The guest schema must exist by default

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1750,6 +1750,14 @@ CREATE OR REPLACE FUNCTION sys.session_context ("@key" sys.sysname)
 	RETURNS sys.SQL_VARIANT AS 'babelfishpg_tsql', 'session_context' LANGUAGE C;
 GRANT EXECUTE ON FUNCTION sys.session_context TO PUBLIC;
 
+CREATE OR REPLACE PROCEDURE sys.babel_create_guest_schemas()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'create_guest_schema_for_all_dbs';
+
+CALL sys.babel_create_guest_schemas();
+
+DROP PROCEDURE sys.babel_create_guest_schemas();
+
 CREATE OR REPLACE PROCEDURE sys.babelfish_sp_rename_internal(
 	IN "@objname" sys.nvarchar(776),
 	IN "@newname" sys.SYSNAME,

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -10,9 +10,9 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
+#include "utils/syscache.h"
 
 #include "catalog.h"
-#include "guc.h"
 #include "multidb.h"
 #include "session.h"
 
@@ -940,11 +940,12 @@ get_current_physical_schema_name(PG_FUNCTION_ARGS)
 	PG_RETURN_TEXT_P(CStringGetTextDatum(ret));
 }
 
+
 /* db_name is the logical db that user want to query against
  * retrieve the physical mapped schema for the query
  */
 char *
-get_physical_schema_name(char *db_name, const char *schema_name)
+get_physical_schema_name_by_mode(char *db_name, const char *schema_name, MigrationMode mode)
 {
 	char *name;
 	char *result;
@@ -971,7 +972,7 @@ get_physical_schema_name(char *db_name, const char *schema_name)
 	 */
 	truncate_tsql_identifier(name);
 
-	if (SINGLE_DB == get_migration_mode())
+	if (SINGLE_DB == mode)
 	{
 		if ((strlen(db_name) == 6 && (strncmp(db_name, "master", 6) == 0)) ||
 			(strlen(db_name) == 6 && (strncmp(db_name, "tempdb", 6) == 0)) ||
@@ -988,10 +989,7 @@ get_physical_schema_name(char *db_name, const char *schema_name)
 		}
 		else 
 		{
-			/* db_name is valid. 
-			 * under SINGLE_DB this is only possible 
-			 * when target db is the customer db.
-			 * in such case we only return the schema_name name */
+			/* all schema names are not prepended with db name on single-db */
 			return name;
 		}
 	}
@@ -1004,6 +1002,12 @@ get_physical_schema_name(char *db_name, const char *schema_name)
 	truncate_tsql_identifier(result);
 
 	return result;
+}
+
+char *
+get_physical_schema_name(char *db_name, const char *schema_name)
+{
+	return get_physical_schema_name_by_mode(db_name, schema_name, get_migration_mode());
 }
 
 /*
@@ -1135,6 +1139,11 @@ const char *get_guest_role_name(const char *dbname)
 		return "tempdb_guest";
 	if (0 == strcmp(dbname , "msdb"))
 		return "msdb_guest";
+
+	/*
+	* Always prefix with dbname regardless if single or multidb.
+	* Note that dbo is an exception.
+	*/
 	else
 	{
 		char *name = palloc0(MAX_BBF_NAMEDATALEND);
@@ -1143,6 +1152,48 @@ const char *get_guest_role_name(const char *dbname)
 		return name;
 	}
 }
+
+const char *get_guest_schema_name(const char *dbname)
+{
+	if (0 == strcmp(dbname , "master"))
+		return "master_guest";
+	if (0 == strcmp(dbname , "tempdb"))
+		return "tempdb_guest";
+	if (0 == strcmp(dbname , "msdb"))
+		return "msdb_guest";
+
+	if (SINGLE_DB == get_migration_mode())
+		return "guest";
+	else
+	{
+		char *name = palloc0(MAX_BBF_NAMEDATALEND);
+		snprintf(name, MAX_BBF_NAMEDATALEND, "%s_guest", dbname);
+		truncate_identifier(name, strlen(name), false);
+		return name;
+	}
+}
+
+bool is_builtin_database(const char *dbname)
+{
+	return ((strlen(dbname) == 6 && (strncmp(dbname, "master", 6) == 0)) ||
+            (strlen(dbname) == 6 && (strncmp(dbname, "tempdb", 6) == 0)) ||
+            (strlen(dbname) == 4 && (strncmp(dbname, "msdb", 4) == 0)));
+}
+
+bool physical_schema_name_exists(char *phys_schema_name)
+{
+	return SearchSysCacheExists1(NAMESPACENAME, PointerGetDatum(phys_schema_name));
+}
+
+/*
+* Assume the database already exists and it is not a built in database
+*/
+bool is_user_database_singledb(const char *dbname)
+{
+	Assert(DbidIsValid(get_db_id(dbname)));
+	return !is_builtin_database(dbname) && physical_schema_name_exists("dbo");
+}
+
 
 /*************************************************************
  * 					Helper Functions	

--- a/contrib/babelfishpg_tsql/src/multidb.h
+++ b/contrib/babelfishpg_tsql/src/multidb.h
@@ -2,7 +2,7 @@
 #define PLTSQL_MULTIDB_H
 
 #include "postgres.h"
-
+#include "guc.h"
 #include "nodes/parsenodes.h"
 
 #define MAX_BBF_NAMEDATALEND (2*NAMEDATALEN + 2)  /* two identifiers + 1 '_' + 1 terminator */
@@ -18,11 +18,16 @@ extern void rewrite_plain_name(List *name);  /* Value Strings */
 /* helper functions */
 extern char *get_physical_user_name(char *db_name, char *user_name);
 extern char *get_physical_schema_name(char *db_name, const char *schema_name);
+extern char *get_physical_schema_name_by_mode(char *db_name, const char *schema_name, MigrationMode mode);
 extern const char *get_dbo_schema_name(const char *dbname);
 extern const char *get_dbo_role_name(const char *dbname);
 extern const char *get_db_owner_name(const char *dbname);
 extern const char *get_guest_role_name(const char *dbname);
+extern const char *get_guest_schema_name(const char *dbname);
 extern bool is_shared_schema(const char *name);
 extern void truncate_tsql_identifier(char *ident);
+extern bool physical_schema_name_exists(char *phys_schema_name);
+extern bool is_builtin_database(const char *dbname);
+extern bool is_user_database_singledb(const char *dbname);
 
 #endif

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -137,10 +137,16 @@ set_search_path_for_user_schema(const char* db_name, const char* user)
 	const char		*dbo_role_name = get_dbo_role_name(db_name);
 	const char		*guest_role_name = get_guest_role_name(db_name);
 
-	if ((dbo_role_name && strcmp(user, dbo_role_name) == 0) ||
-		(guest_role_name && strcmp(user, guest_role_name) == 0))
+	if ((dbo_role_name && strcmp(user, dbo_role_name) == 0))
 	{
 		physical_schema = get_dbo_schema_name(db_name);
+	}
+	else if (guest_role_name && strcmp(user, guest_role_name) == 0)
+	{
+		const char *guest_schema = get_authid_user_ext_schema_name(db_name, "guest");
+		if (!guest_schema)
+			guest_schema = "guest";
+		physical_schema = get_physical_schema_name(pstrdup(db_name), guest_schema);
 	}
 	else
 	{

--- a/test/JDBC/expected/14_6__preparation__BABEL-guest-before-14_7-or-15_2-vu-prepare.out
+++ b/test/JDBC/expected/14_6__preparation__BABEL-guest-before-14_7-or-15_2-vu-prepare.out
@@ -1,0 +1,28 @@
+-- tsql
+-- create two databases one with guest schema and one without
+create database babel_2571_db_guest;
+go
+
+create database babel_2571_db_no_guest;
+go
+
+-- no guest schema created 
+select name from sys.schemas where name like '%guest%';
+go
+~~START~~
+varchar
+~~END~~
+
+
+use babel_2571_db_guest;
+go
+
+-- this should succeed prior to 14_7 or 15_2
+create schema guest;
+go
+
+create table guest.babel_2571_table_t1(a int, b int);
+go
+
+create login babel_2571_login1 with password='123456789';
+go

--- a/test/JDBC/expected/BABEL-2403.out
+++ b/test/JDBC/expected/BABEL-2403.out
@@ -70,6 +70,9 @@ name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext mus
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
+name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
+name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
+name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_login_ext must also exist in pg_authid"}
 text#!#sys#!#name#!#{"Rule": "<default_database_name> in babelfish_authid_login_ext must also exist in babelfish_sysdatabases"}
 name#!#pg_catalog#!#rolname#!#{"Rule": "<rolname> in babelfish_authid_login_ext must also exist in pg_authid"}
@@ -160,6 +163,9 @@ name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in bab
 name#!#pg_catalog#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in pg_authid"}
 name#!#sys#!#nspname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_dbo must also exist in babelfish_namespace_ext"}
 name#!#sys#!#rolname#!#{"Rule": "In multi-db mode, for each <name> in babelfish_sysdatabases, <name>_guest must also exist in babelfish_authid_user_ext"}
+name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
+name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
+name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}
 name#!#pg_catalog#!#nspname#!#{"Rule": "<nspname> in babelfish_namespace_ext must also exist in pg_namespace"}

--- a/test/JDBC/expected/BABEL-2418.out
+++ b/test/JDBC/expected/BABEL-2418.out
@@ -13,16 +13,20 @@ go
 CREATE SCHEMA babel_2418_schema2
 go
 
-SELECT nspname FROM sys.babelfish_namespace_ext;
+SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname;
 go
 ~~START~~
 varchar
-master_dbo
-tempdb_dbo
-msdb_dbo
-dbo
 babel_2418_schema1
 babel_2418_schema2
+dbo
+guest
+master_dbo
+master_guest
+msdb_dbo
+msdb_guest
+tempdb_dbo
+tempdb_guest
 ~~END~~
 
 
@@ -32,12 +36,15 @@ go
 DROP DATABASE babel_2418_db
 go
 
-SELECT nspname FROM sys.babelfish_namespace_ext;
+SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname;
 go
 ~~START~~
 varchar
 master_dbo
-tempdb_dbo
+master_guest
 msdb_dbo
+msdb_guest
+tempdb_dbo
+tempdb_guest
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-guest.out
+++ b/test/JDBC/expected/BABEL-guest.out
@@ -1,0 +1,149 @@
+
+-- tsql
+-- Test for JIRA BABEL-2571. The 'guest' schema should exist by default.
+-- Furthermore, the default schema of guest users should be guest instead of dbo
+-- in order to match the behaviour in SQL Server.
+-- This test creates a guest login in order to verify the guest schema.
+USE master
+GO
+
+CREATE TABLE babel_2571_table1(a int, b int)
+GO
+
+CREATE LOGIN babel_2571_login1 WITH password='123'
+GO
+
+CREATE DATABASE babel_2571_db1
+GO
+
+USE babel_2571_db1
+GO
+
+GRANT CONNECT TO guest
+GO
+
+
+-- This should show two schemas under master
+USE master
+GO
+
+SELECT name, USER_NAME(principal_id) FROM sys.schemas ORDER BY name
+GO
+~~START~~
+varchar#!#nvarchar
+dbo#!#db_owner
+guest#!#guest
+~~END~~
+
+
+-- But also show all databases created have the guest schema
+SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname
+GO
+~~START~~
+varchar
+dbo
+guest
+master_dbo
+master_guest
+msdb_dbo
+msdb_guest
+tempdb_dbo
+tempdb_guest
+~~END~~
+
+
+-- tsql         user=babel_2571_login1 password=12345678
+-- Login as guest to show default schema is guest
+SELECT schema_name()
+GO
+~~START~~
+varchar
+guest
+~~END~~
+
+
+USE babel_2571_db1
+GO
+
+CREATE TABLE babel_2571_table2(a int, b int)
+GO
+
+-- Dropping guest schema should not be allowed regardless of the user
+SELECT user_name()
+GO
+~~START~~
+nvarchar
+guest
+~~END~~
+
+
+DROP SCHEMA guest
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the schema 'guest')~~
+
+
+-- this should fail
+SELECT * FROM dbo.babel_2571_table2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.babel_2571_table2" does not exist)~~
+
+
+-- This should not
+SELECT * FROM guest.babel_2571_table2
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+-- tsql
+SELECT user_name()
+GO
+~~START~~
+nvarchar
+dbo
+~~END~~
+
+
+DROP SCHEMA guest
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the schema 'master_guest')~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_2571_login1'
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP TABLE babel_2571_table1
+GO
+
+DROP DATABASE babel_2571_db1
+GO
+
+DROP LOGIN babel_2571_login1
+GO

--- a/test/JDBC/expected/BABEL_SCHEMATA-vu-verify.out
+++ b/test/JDBC/expected/BABEL_SCHEMATA-vu-verify.out
@@ -7,6 +7,7 @@ go
 ~~START~~
 varchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar
 db_schemata_10#!#dbo#!#dbo#!#<NULL>#!#<NULL>#!#<NULL>
+db_schemata_10#!#guest#!#guest#!#<NULL>#!#<NULL>#!#<NULL>
 db_schemata_10#!#information_schema_tsql#!#information_schema_tsql#!#<NULL>#!#<NULL>#!#<NULL>
 db_schemata_10#!#schema_schemata_11#!#dbo#!#<NULL>#!#<NULL>#!#<NULL>
 db_schemata_10#!#schema_schemata_12#!#schemata_user1#!#<NULL>#!#<NULL>#!#<NULL>

--- a/test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-cleanup.out
@@ -1,0 +1,9 @@
+-- tsql
+drop login babel_2571_login1
+go
+
+drop database babel_2571_db_guest;
+go
+
+drop database babel_2571_db_no_guest;
+go

--- a/test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-verify.out
@@ -1,0 +1,57 @@
+-- tsql
+use babel_2571_db_guest;
+go
+
+grant connect to guest;
+go
+
+grant select on guest.babel_2571_table_t1 to guest;
+go
+
+use babel_2571_db_no_guest;
+go
+
+grant connect to guest;
+go
+
+-- tsql user=babel_2571_login1 password=123456789
+use babel_2571_db_guest;
+go
+
+-- the table we created prior to upgrade should be there
+select user_name()
+go
+~~START~~
+nvarchar
+guest
+~~END~~
+
+
+select schema_name()
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+
+select * from guest.babel_2571_table_t1
+go
+~~START~~
+int#!#int
+~~END~~
+
+
+use babel_2571_db_no_guest;
+go
+
+-- guest schema must be created as part of upgrade
+select schema_name()
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+
+

--- a/test/JDBC/expected/sys-dm_exec_connections-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-dm_exec_connections-dep-vu-verify.out
@@ -1,6 +1,23 @@
 -- tsql user=sys_dm_exec_connections_dep_vu_prepare_login password=password
+
 -- if we query the view not as sysadmin, then we will get an error
-exec sys_dm_exec_connections_dep_vu_prepare_p1
+select user_name()
+GO
+~~START~~
+nvarchar
+guest
+~~END~~
+
+
+select schema_name()
+GO
+~~START~~
+varchar
+guest
+~~END~~
+
+
+exec dbo.sys_dm_exec_connections_dep_vu_prepare_p1
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/sys-dm_exec_sessions-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-dm_exec_sessions-dep-vu-verify.out
@@ -1,6 +1,6 @@
 -- tsql user=sys_dm_exec_sessions_dep_vu_prepare_login password=password
 -- if we query the view not as sysadmin, we will only see info of this session only
-exec sys_dm_exec_sessions_dep_vu_prepare_p1
+exec dbo.sys_dm_exec_sessions_dep_vu_prepare_p1
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/input/BABEL-2418.sql
+++ b/test/JDBC/input/BABEL-2418.sql
@@ -13,7 +13,7 @@ go
 CREATE SCHEMA babel_2418_schema2
 go
 
-SELECT nspname FROM sys.babelfish_namespace_ext;
+SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname;
 go
 
 USE master
@@ -22,5 +22,5 @@ go
 DROP DATABASE babel_2418_db
 go
 
-SELECT nspname FROM sys.babelfish_namespace_ext;
+SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname;
 go

--- a/test/JDBC/input/ownership/BABEL-guest.mix
+++ b/test/JDBC/input/ownership/BABEL-guest.mix
@@ -1,0 +1,90 @@
+-- Test for JIRA BABEL-2571. The 'guest' schema should exist by default.
+-- Furthermore, the default schema of guest users should be guest instead of dbo
+-- in order to match the behaviour in SQL Server.
+-- This test creates a guest login in order to verify the guest schema.
+
+-- tsql
+USE master
+GO
+
+CREATE TABLE babel_2571_table1(a int, b int)
+GO
+
+CREATE LOGIN babel_2571_login1 WITH password='123'
+GO
+
+CREATE DATABASE babel_2571_db1
+GO
+
+USE babel_2571_db1
+GO
+
+GRANT CONNECT TO guest
+GO
+
+
+-- This should show two schemas under master
+USE master
+GO
+
+SELECT name, USER_NAME(principal_id) FROM sys.schemas ORDER BY name
+GO
+
+-- But also show all databases created have the guest schema
+SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname
+GO
+
+-- Login as guest to show default schema is guest
+-- tsql         user=babel_2571_login1 password=12345678
+SELECT schema_name()
+GO
+
+USE babel_2571_db1
+GO
+
+CREATE TABLE babel_2571_table2(a int, b int)
+GO
+
+-- Dropping guest schema should not be allowed regardless of the user
+SELECT user_name()
+GO
+
+DROP SCHEMA guest
+GO
+
+-- this should fail
+SELECT * FROM dbo.babel_2571_table2
+GO
+
+-- This should not
+SELECT * FROM guest.babel_2571_table2
+GO
+
+-- tsql
+SELECT user_name()
+GO
+
+DROP SCHEMA guest
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_2571_login1'
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+
+-- tsql
+DROP TABLE babel_2571_table1
+GO
+
+DROP DATABASE babel_2571_db1
+GO
+
+DROP LOGIN babel_2571_login1
+GO

--- a/test/JDBC/input/views/sys-dm_exec_connections-dep-vu-verify.mix
+++ b/test/JDBC/input/views/sys-dm_exec_connections-dep-vu-verify.mix
@@ -1,6 +1,13 @@
 -- tsql user=sys_dm_exec_connections_dep_vu_prepare_login password=password
 -- if we query the view not as sysadmin, then we will get an error
-exec sys_dm_exec_connections_dep_vu_prepare_p1
+
+select user_name()
+GO
+
+select schema_name()
+GO
+
+exec dbo.sys_dm_exec_connections_dep_vu_prepare_p1
 GO
 
 -- tsql

--- a/test/JDBC/input/views/sys-dm_exec_sessions-dep-vu-verify.mix
+++ b/test/JDBC/input/views/sys-dm_exec_sessions-dep-vu-verify.mix
@@ -1,6 +1,6 @@
 -- tsql user=sys_dm_exec_sessions_dep_vu_prepare_login password=password
 -- if we query the view not as sysadmin, we will only see info of this session only
-exec sys_dm_exec_sessions_dep_vu_prepare_p1
+exec dbo.sys_dm_exec_sessions_dep_vu_prepare_p1
 GO
 
 -- tsql

--- a/test/JDBC/upgrade/14_6/preparation/BABEL-guest-before-14_7-or-15_2-vu-prepare.mix
+++ b/test/JDBC/upgrade/14_6/preparation/BABEL-guest-before-14_7-or-15_2-vu-prepare.mix
@@ -1,0 +1,24 @@
+-- tsql
+-- create two databases one with guest schema and one without
+create database babel_2571_db_guest;
+go
+
+create database babel_2571_db_no_guest;
+go
+
+-- no guest schema created 
+select name from sys.schemas where name like '%guest%';
+go
+
+use babel_2571_db_guest;
+go
+
+-- this should succeed prior to 14_7 or 15_2
+create schema guest;
+go
+
+create table guest.babel_2571_table_t1(a int, b int);
+go
+
+create login babel_2571_login1 with password='123456789';
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_6/BABEL-guest-before-14_7-or-15_2-vu-cleanup.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_6/BABEL-guest-before-14_7-or-15_2-vu-cleanup.mix
@@ -1,0 +1,9 @@
+-- tsql
+drop login babel_2571_login1
+go
+
+drop database babel_2571_db_guest;
+go
+
+drop database babel_2571_db_no_guest;
+go

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_6/BABEL-guest-before-14_7-or-15_2-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_6/BABEL-guest-before-14_7-or-15_2-vu-verify.mix
@@ -1,0 +1,38 @@
+-- tsql
+use babel_2571_db_guest;
+go
+
+grant connect to guest;
+go
+
+grant select on guest.babel_2571_table_t1 to guest;
+go
+
+use babel_2571_db_no_guest;
+go
+
+grant connect to guest;
+go
+
+-- tsql user=babel_2571_login1 password=123456789
+use babel_2571_db_guest;
+go
+
+-- the table we created prior to upgrade should be there
+select user_name()
+go
+
+select schema_name()
+go
+
+select * from guest.babel_2571_table_t1
+go
+
+use babel_2571_db_no_guest;
+go
+
+-- guest schema must be created as part of upgrade
+select schema_name()
+go
+
+

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -10,6 +10,7 @@ Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for procedure babelfish_drop_deprecated_opclass in file babelfishpg_common--1.0.0--1.1.0.sql
+Unexpected drop found for procedure sys.babel_create_guest_schemas in file babelfishpg_tsql--2.3.0--2.4.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_function in file babelfishpg_tsql--1.2.1--2.0.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_function in file babelfishpg_tsql--1.3.0--2.0.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_function in file babelfishpg_tsql--2.1.0--2.2.0.sql


### PR DESCRIPTION
When a SQL Server database is created,
it contains schemas dbo, guest, sys and INFORMATION SCHEMA. In Babelfish, we only show the dbo schema,
and for all intents and purposes,
we have effectively disabled the guest schema as well as most of the guest user for GA.

However, it appears possible to create a schema named guest, and this should not be allowed given that it has a special status in SQL Server.
This should be blocked (and not overridden by any escape hatches).

Dropping the guest schema should also not be allowed.

Task: BABEL-2571
Signed-off-by: Kristian Lejao <klejao@amazon.com>

### Description
single-db JDBC is added here : test/JDBC/input/ownership/BABEL-guest.mix
It covers the following scenario as being hit in Jira 2571 and 2461
Scenarios:
	- guest schema must be created by default as part of create db
	- guest login uses guest schema as default schema
	- dropping guest schema is not allowed unless it is part of drop db

multi-db test is added in MVU
14.6 -> latest
I have to pick 14.6 because it is a baseline level where create guest schema is allowed.
We cannot use a more generic baseline because once baseline moves to 14.7 or 15.2, then test would not behave as expected anymore.

prepare:
	test/JDBC/expected/14_6__preparation__BABEL-guest-before-14_7-or-15_2-vu-prepare.out
verify and cleanup
	test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-verify.out
	test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-cleanup.out

Similar framework used as this one https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/347/files
	Test scenario covers both cases where database before upgrade does not have guest schema and second db with guest schema

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).