### PR TITLE
Add SEQUENCE and detailed message for unsupported type for sp_rename

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2957,6 +2957,22 @@ BEGIN
 		BEGIN
 			THROW 33557097, N'Please provide @objtype that is supported in Babelfish', 1;
 		END
+	IF @objtype = 'COLUMN'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type Column', 1;
+		END
+	IF @objtype = 'INDEX'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type Index', 1;
+		END
+	IF @objtype = 'STATISTICS'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type Statistics', 1;
+		END
+	IF @objtype = 'USERDATATYPE'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type User-defined Data Type alias', 1;
+		END
 	IF @objtype IS NOT NULL AND (@objtype != 'OBJECT')
 		BEGIN
 			THROW 33557097, N'Provided @objtype is not currently supported in Babelfish', 1;
@@ -2976,8 +2992,6 @@ BEGIN
 				SELECT (ROW_NUMBER() OVER (ORDER BY NULL)) as row,*
 				FROM STRING_SPLIT(@objname, '.'))
 			SELECT @dbname = value FROM myTableWithRows WHERE row = 1;
-			PRINT 'db_name:  ';
-			PRINT sys.db_name();
 			IF @dbname != sys.db_name()
 				BEGIN
 					THROW 33557097, N'No item by the given @objname could be found in the current database', 1;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1501,6 +1501,22 @@ BEGIN
 		BEGIN
 			THROW 33557097, N'Please provide @objtype that is supported in Babelfish', 1;
 		END
+	IF @objtype = 'COLUMN'
+		BEGIN
+			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for Column yet.', 1;
+		END
+	IF @objtype = 'INDEX'
+		BEGIN
+			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for Index yet.', 1;
+		END
+	IF @objtype = 'STATISTICS'
+		BEGIN
+			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for Statistics yet.', 1;
+		END
+	IF @objtype = 'USERDATATYPE'
+		BEGIN
+			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for User-defined Data Type alias yet.', 1;
+		END
 	IF @objtype IS NOT NULL AND (@objtype != 'OBJECT')
 		BEGIN
 			THROW 33557097, N'Provided @objtype is not currently supported in Babelfish', 1;
@@ -1520,8 +1536,6 @@ BEGIN
 				SELECT (ROW_NUMBER() OVER (ORDER BY NULL)) as row,*
 				FROM STRING_SPLIT(@objname, '.'))
 			SELECT @dbname = value FROM myTableWithRows WHERE row = 1;
-			PRINT 'db_name:  ';
-			PRINT sys.db_name();
 			IF @dbname != sys.db_name()
 				BEGIN
 					THROW 33557097, N'No item by the given @objname could be found in the current database', 1;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1503,19 +1503,19 @@ BEGIN
 		END
 	IF @objtype = 'COLUMN'
 		BEGIN
-			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for Column yet.', 1;
+			THROW 33557097, N'Feature not supported: renaming object type Column', 1;
 		END
 	IF @objtype = 'INDEX'
 		BEGIN
-			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for Index yet.', 1;
+			THROW 33557097, N'Feature not supported: renaming object type Index', 1;
 		END
 	IF @objtype = 'STATISTICS'
 		BEGIN
-			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for Statistics yet.', 1;
+			THROW 33557097, N'Feature not supported: renaming object type Statistics', 1;
 		END
 	IF @objtype = 'USERDATATYPE'
 		BEGIN
-			THROW 33557097, N'Procedure or function ''sp_rename'' is not supported for User-defined Data Type alias yet.', 1;
+			THROW 33557097, N'Feature not supported: renaming object type User-defined Data Type alias', 1;
 		END
 	IF @objtype IS NOT NULL AND (@objtype != 'OBJECT')
 		BEGIN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -1852,6 +1852,22 @@ BEGIN
 		BEGIN
 			THROW 33557097, N'Please provide @objtype that is supported in Babelfish', 1;
 		END
+	IF @objtype = 'COLUMN'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type Column', 1;
+		END
+	IF @objtype = 'INDEX'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type Index', 1;
+		END
+	IF @objtype = 'STATISTICS'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type Statistics', 1;
+		END
+	IF @objtype = 'USERDATATYPE'
+		BEGIN
+			THROW 33557097, N'Feature not supported: renaming object type User-defined Data Type alias', 1;
+		END
 	IF @objtype IS NOT NULL AND (@objtype != 'OBJECT')
 		BEGIN
 			THROW 33557097, N'Provided @objtype is not currently supported in Babelfish', 1;
@@ -1871,8 +1887,6 @@ BEGIN
 				SELECT (ROW_NUMBER() OVER (ORDER BY NULL)) as row,*
 				FROM STRING_SPLIT(@objname, '.'))
 			SELECT @dbname = value FROM myTableWithRows WHERE row = 1;
-			PRINT 'db_name:  ';
-			PRINT sys.db_name();
 			IF @dbname != sys.db_name()
 				BEGIN
 					THROW 33557097, N'No item by the given @objname could be found in the current database', 1;

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2363,6 +2363,8 @@ rename_update_bbf_catalog(RenameStmt *stmt)
 		case OBJECT_FUNCTION:
 			rename_procfunc_update_bbf_catalog(stmt);
 			break;
+		case OBJECT_SEQUENCE:
+			break;
 		default:
 			break;	
 	}

--- a/test/JDBC/expected/Test-sp_rename-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_rename-vu-cleanup.out
@@ -35,5 +35,14 @@ GO
 DROP FUNCTION sp_rename_vu_schema1.sp_rename_vu_func3_new;
 GO
 
+DROP SEQUENCE sp_rename_vu_seq1_new;
+GO
+
+DROP SEQUENCE sp_rename_vu_seq2;
+GO
+
+DROP SEQUENCE sp_rename_vu_schema1.sp_rename_vu_seq1_new2;
+GO
+
 DROP SCHEMA sp_rename_vu_schema1;
 GO

--- a/test/JDBC/expected/Test-sp_rename-vu-prepare.out
+++ b/test/JDBC/expected/Test-sp_rename-vu-prepare.out
@@ -56,3 +56,23 @@ BEGIN
     RETURN 1;
 END
 GO
+
+CREATE SEQUENCE sp_rename_vu_seq1 
+START WITH 1  
+INCREMENT BY 1;  
+GO
+
+CREATE SEQUENCE sp_rename_vu_schema1.sp_rename_vu_seq1 
+START WITH 1  
+INCREMENT BY 1;  
+GO
+
+CREATE SEQUENCE sp_rename_vu_seq2
+START WITH 1  
+INCREMENT BY 1;  
+GO
+
+CREATE TRIGGER sp_rename_vu_trig1 ON sp_rename_vu_table2
+AFTER INSERT, UPDATE AS 
+RAISERROR ('Testing sp_rename', 16, 10);
+GO

--- a/test/JDBC/expected/Test-sp_rename-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_rename-vu-verify.out
@@ -117,6 +117,7 @@ varchar#!#varchar#!#nvarchar#!#text
 master_dbo#!#sp_rename_vu_func1#!#sp_rename_vu_func1#!#sp_rename_vu_func1()
 master_dbo#!#sp_rename_vu_func2#!#sp_rename_vu_func2#!#sp_rename_vu_func2(integer)
 master_dbo#!#sp_rename_vu_proc1#!#sp_rename_vu_proc1#!#sp_rename_vu_proc1()
+master_dbo#!#sp_rename_vu_trig1#!#<NULL>#!#sp_rename_vu_trig1()
 master_sp_rename_vu_schema1#!#sp_rename_vu_func3#!#sp_rename_vu_func3#!#sp_rename_vu_func3(integer)
 master_sp_rename_vu_schema1#!#sp_rename_vu_proc2#!#sp_rename_vu_proc2#!#sp_rename_vu_proc2()
 ~~END~~
@@ -157,6 +158,7 @@ varchar#!#varchar#!#nvarchar#!#text
 master_dbo#!#sp_rename_vu_func1_new#!#sp_rename_vu_func1_new#!#sp_rename_vu_func1_new()
 master_dbo#!#sp_rename_vu_func2#!#sp_rename_vu_func2#!#sp_rename_vu_func2(integer)
 master_dbo#!#sp_rename_vu_proc1_new#!#sp_rename_vu_proc1_new#!#sp_rename_vu_proc1_new()
+master_dbo#!#sp_rename_vu_trig1#!#<NULL>#!#sp_rename_vu_trig1()
 master_sp_rename_vu_schema1#!#sp_rename_vu_func3_new#!#sp_rename_vu_func3_new#!#sp_rename_vu_func3_new(integer)
 master_sp_rename_vu_schema1#!#sp_rename_vu_proc2_new#!#sp_rename_vu_proc2_new#!#sp_rename_vu_proc2_new()
 ~~END~~
@@ -389,7 +391,80 @@ varchar#!#varchar#!#nvarchar#!#text
 master_dbo#!#sp_rename_vu_func1_new#!#sp_rename_vu_func1_new#!#sp_rename_vu_func1_new()
 master_dbo#!#sp_rename_vu_func2_new#!#sp_rename_vu_FUNC2_neW#!#sp_rename_vu_func2_new(integer)
 master_dbo#!#sp_rename_vu_proc1_new2#!#sp_rename_vu_PRoc1_new2#!#sp_rename_vu_proc1_new2()
+master_dbo#!#sp_rename_vu_trig1#!#<NULL>#!#sp_rename_vu_trig1()
 master_sp_rename_vu_schema1#!#sp_rename_vu_func3_new#!#sp_rename_vu_func3_new#!#sp_rename_vu_func3_new(integer)
 master_sp_rename_vu_schema1#!#sp_rename_vu_proc2_new#!#sp_rename_vu_proc2_new#!#sp_rename_vu_proc2_new()
 ~~END~~
+
+
+-- SEQUENCE
+SELECT SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME 
+FROM information_schema.sequences WHERE SEQUENCE_NAME LIKE '%sp_rename_vu%' 
+ORDER BY SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+master#!#dbo#!#sp_rename_vu_seq1
+master#!#dbo#!#sp_rename_vu_seq2
+master#!#sp_rename_vu_schema1#!#sp_rename_vu_seq1
+~~END~~
+
+
+EXEC sp_rename 'sp_rename_vu_seq1', 'sp_rename_vu_seq1_new', 'OBJECT';
+GO
+
+EXEC sp_rename 'sp_rename_vu_schema1.sp_rename_vu_seq1', 'sp_rename_vu_seq1_new2', 'OBJECT';
+GO
+
+SELECT SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME 
+FROM information_schema.sequences WHERE SEQUENCE_NAME LIKE '%sp_rename_vu%' 
+ORDER BY SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+master#!#dbo#!#sp_rename_vu_seq1_new
+master#!#dbo#!#sp_rename_vu_seq2
+master#!#sp_rename_vu_schema1#!#sp_rename_vu_seq1_new2
+~~END~~
+
+
+-- ****Given objtype is valid but not supported yet****
+-- Column
+EXEC sp_rename 'sp_rename_vu_table2.sp_rename_vu_t2_col1', 'sp_rename_vu_t2_col1_new', 'COLUMN';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Feature not supported: renaming object type Column)~~
+
+
+-- Index
+EXEC sp_rename N'sp_rename_vu_index1', N'sp_rename_vu_index2', N'INDEX';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Feature not supported: renaming object type Index)~~
+
+
+-- Statistics
+EXEC sp_rename 'sp_rename_vu_stat1', 'sp_rename_vu_stat2', 'STATISTICS';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Feature not supported: renaming object type Statistics)~~
+
+
+-- USERDATATYPE
+EXEC sp_rename 'sp_rename_vu_alias1', 'sp_rename_vu_alias2', 'USERDATATYPE';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Feature not supported: renaming object type User-defined Data Type alias)~~
+
+
+-- Trigger
+EXEC sp_rename 'sp_rename_vu_trig1', 'sp_rename_vu_trig2', 'OBJECT';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Feature not supported: renaming object type Trigger)~~
 

--- a/test/JDBC/expected/babel_621.out
+++ b/test/JDBC/expected/babel_621.out
@@ -55,7 +55,7 @@ exec sp_rename N'table_4.uniq_table_4', N'uniq_table_4_a', N'INDEX';
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Procedure or function 'sp_rename' is not supported for Index yet.)~~
+~~ERROR (Message: Feature not supported: renaming object type Index)~~
 
 
 -- Very long index name

--- a/test/JDBC/expected/babel_621.out
+++ b/test/JDBC/expected/babel_621.out
@@ -55,7 +55,7 @@ exec sp_rename N'table_4.uniq_table_4', N'uniq_table_4_a', N'INDEX';
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Provided @objtype is not currently supported in Babelfish)~~
+~~ERROR (Message: Procedure or function 'sp_rename' is not supported for Index yet.)~~
 
 
 -- Very long index name

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-dep-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-dep-vu-verify.sql
@@ -1,4 +1,4 @@
--- sla 30000
+-- sla 40000
 
 -- tsql
 USE master

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-vu-cleanup.sql
@@ -35,5 +35,14 @@ GO
 DROP FUNCTION sp_rename_vu_schema1.sp_rename_vu_func3_new;
 GO
 
+DROP SEQUENCE sp_rename_vu_seq1_new;
+GO
+
+DROP SEQUENCE sp_rename_vu_seq2;
+GO
+
+DROP SEQUENCE sp_rename_vu_schema1.sp_rename_vu_seq1_new2;
+GO
+
 DROP SCHEMA sp_rename_vu_schema1;
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-vu-prepare.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-vu-prepare.sql
@@ -56,3 +56,23 @@ BEGIN
     RETURN 1;
 END
 GO
+
+CREATE SEQUENCE sp_rename_vu_seq1 
+START WITH 1  
+INCREMENT BY 1;  
+GO
+
+CREATE SEQUENCE sp_rename_vu_schema1.sp_rename_vu_seq1 
+START WITH 1  
+INCREMENT BY 1;  
+GO
+
+CREATE SEQUENCE sp_rename_vu_seq2
+START WITH 1  
+INCREMENT BY 1;  
+GO
+
+CREATE TRIGGER sp_rename_vu_trig1 ON sp_rename_vu_table2
+AFTER INSERT, UPDATE AS 
+RAISERROR ('Testing sp_rename', 16, 10);
+GO

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-vu-verify.sql
@@ -189,3 +189,41 @@ SELECT nspname, funcname, orig_name, funcsignature
 FROM sys.babelfish_function_ext WHERE funcname LIKE '%sp_rename_vu%' 
 ORDER BY nspname, funcname, orig_name, funcsignature
 GO
+
+-- SEQUENCE
+SELECT SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME 
+FROM information_schema.sequences WHERE SEQUENCE_NAME LIKE '%sp_rename_vu%' 
+ORDER BY SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME
+GO
+
+EXEC sp_rename 'sp_rename_vu_seq1', 'sp_rename_vu_seq1_new', 'OBJECT';
+GO
+
+EXEC sp_rename 'sp_rename_vu_schema1.sp_rename_vu_seq1', 'sp_rename_vu_seq1_new2', 'OBJECT';
+GO
+
+SELECT SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME 
+FROM information_schema.sequences WHERE SEQUENCE_NAME LIKE '%sp_rename_vu%' 
+ORDER BY SEQUENCE_CATALOG, SEQUENCE_SCHEMA, SEQUENCE_NAME
+GO
+
+-- ****Given objtype is valid but not supported yet****
+-- Column
+EXEC sp_rename 'sp_rename_vu_table2.sp_rename_vu_t2_col1', 'sp_rename_vu_t2_col1_new', 'COLUMN';
+GO
+
+-- Index
+EXEC sp_rename N'sp_rename_vu_index1', N'sp_rename_vu_index2', N'INDEX';
+GO
+
+-- Statistics
+EXEC sp_rename 'sp_rename_vu_stat1', 'sp_rename_vu_stat2', 'STATISTICS';
+GO
+
+-- USERDATATYPE
+EXEC sp_rename 'sp_rename_vu_alias1', 'sp_rename_vu_alias2', 'USERDATATYPE';
+GO
+
+-- Trigger
+EXEC sp_rename 'sp_rename_vu_trig1', 'sp_rename_vu_trig2', 'OBJECT';
+GO


### PR DESCRIPTION
Previously, subtype SEQUENCE was not supported for sp_rename. Also the
raised messages, when unsupported types were provided, were not
detailed. Now, SEQUENCE is supported for sp_rename and the messages are
more detailed for users.

Task: BABEL-3888

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).