### PR TITLE
Fix outer join ctid is null error in update/delete

### DIFF
--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -91,9 +91,9 @@ PG_CXXFLAGS += -Wno-register # otherwise C++17 gags on PostgreSQL headers
 PG_CXXFLAGS += -I$(ANTLR4_RUNTIME_INCLUDE_DIR)
 PG_CFLAGS += -g -Werror
 PG_CFLAGS += -fstack-protector-strong
-PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -I$(FREE_TDS_INCLUDE_DIR) -DFAULT_INJECTOR -DENABLE_TDS_LIB
+PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -I$(FREE_TDS_INCLUDE_DIR) -DFAULT_INJECTOR
 
-SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto $(FREE_TDS_LIB) -L$(FREE_TDS_LIB_DIR)
+SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto
 
 UPGRADES = $(patsubst sql/upgrades/%.sql,sql/%.sql,$(wildcard sql/upgrades/*.sql))
 

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -91,9 +91,9 @@ PG_CXXFLAGS += -Wno-register # otherwise C++17 gags on PostgreSQL headers
 PG_CXXFLAGS += -I$(ANTLR4_RUNTIME_INCLUDE_DIR)
 PG_CFLAGS += -g -Werror
 PG_CFLAGS += -fstack-protector-strong
-PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -I$(FREE_TDS_INCLUDE_DIR) -DFAULT_INJECTOR
+PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -I$(FREE_TDS_INCLUDE_DIR) -DFAULT_INJECTOR -DENABLE_TDS_LIB
 
-SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto
+SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto $(FREE_TDS_LIB) -L$(FREE_TDS_LIB_DIR)
 
 UPGRADES = $(patsubst sql/upgrades/%.sql,sql/%.sql,$(wildcard sql/upgrades/*.sql))
 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3392,6 +3392,9 @@ pltsql_set_target_table_alternative(ParseState *pstate, Node *stmt, CmdType comm
 	{
 		int res = setTargetTable(pstate, target, inh, false, requiredPerms);
 		pstate->p_rtable = NIL;
+
+		rewrite_update_outer_join(stmt, command, target);
+		
 		return res;
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsql_analyze.c
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.c
@@ -180,3 +180,98 @@ handle_rowversion_target_in_update_stmt(RangeVar *target_table, UpdateStmt *stmt
 
 	RelationClose(rel);
 }
+
+static bool
+target_in_outer_join(Node *expr, RangeVar *target, bool outside_outer)
+{
+	JoinExpr *join_expr;
+	RangeVar *arg;
+
+	if (!expr)
+		return false;
+	else if (IsA(expr, RangeVar)) // Base condition
+	{
+		arg = (RangeVar *)expr;
+		return outside_outer && strcmp(arg->relname, target->relname) == 0;
+	}
+	else if(!IsA(expr, JoinExpr))
+		return false;
+	join_expr = (JoinExpr *) expr;
+
+	// Check if 'target' is on the 'outside' of a join, i.e. right on a left join or left on a right join
+	switch(join_expr->jointype)
+	{
+		case JOIN_INNER:
+			return target_in_outer_join(join_expr->larg, target, outside_outer)
+				|| target_in_outer_join(join_expr->rarg, target, outside_outer);
+		case JOIN_LEFT:
+			return target_in_outer_join(join_expr->larg, target, outside_outer)
+				|| target_in_outer_join(join_expr->rarg, target, true);
+		case JOIN_RIGHT:
+			return target_in_outer_join(join_expr->larg, target, true)
+				|| target_in_outer_join(join_expr->rarg, target, outside_outer);
+		case JOIN_FULL:
+			return target_in_outer_join(join_expr->larg, target, true)
+				|| target_in_outer_join(join_expr->rarg, target, true);
+		default:
+			return false;
+	}
+}
+
+static void
+add_target_ctid_not_null_clause(Node **where_clause, RangeVar *target)
+{
+	NullTest  *new_clause;
+	ColumnRef *col_ref;
+	char      *rel_name = target->relname;
+
+	new_clause = makeNode(NullTest);
+	new_clause->nulltesttype = IS_NOT_NULL;
+	new_clause->argisrow = false;
+	new_clause->location = -1;
+
+	if (target->alias && target->alias->aliasname)
+		rel_name = target->alias->aliasname;
+	col_ref = makeNode(ColumnRef);
+	col_ref->location = -1;
+	col_ref->fields = list_make2(makeString(rel_name), makeString("ctid"));
+	new_clause->arg = (Expr*) col_ref;
+
+	if (!*where_clause)
+		*where_clause = (Node *)new_clause;
+	else
+	{
+		BoolExpr *bool_expr = makeNode(BoolExpr);;
+		bool_expr->boolop = AND_EXPR;
+		bool_expr->location = -1;
+		bool_expr->args = list_make2(*where_clause, new_clause);
+		*where_clause = (Node*) bool_expr;
+	}
+		
+}
+
+void
+rewrite_update_outer_join(Node *stmt, CmdType command, RangeVar *target)
+{
+	switch (command)
+	{
+		case CMD_UPDATE:
+		{
+			UpdateStmt *update_stmt = (UpdateStmt *) stmt;
+			List      *fromClause = update_stmt->fromClause;
+			if (fromClause && target_in_outer_join(linitial(fromClause), target, false))
+				add_target_ctid_not_null_clause(&update_stmt->whereClause, target);
+			break;
+		}
+		case CMD_DELETE:
+		{
+			DeleteStmt *delete_stmt = (DeleteStmt *) stmt;
+			List      *fromClause = delete_stmt->usingClause;
+			if (fromClause && target_in_outer_join(linitial(fromClause), target, false))
+				add_target_ctid_not_null_clause(&delete_stmt->whereClause, target);			
+			break;
+		}
+		default:
+			return;
+	}
+}

--- a/contrib/babelfishpg_tsql/src/tsql_analyze.h
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.h
@@ -1,6 +1,7 @@
 #ifndef TSQL_ANALYZE_H
 #define TSQL_ANALYZE_H
 
+#include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
@@ -11,5 +12,6 @@
 extern RangeVar *pltsql_get_target_table(RangeVar *orig_target, List *fromClause);
 extern void pltsql_update_query_result_relation(Query *qry, Relation target_rel, List *rtable);
 extern void handle_rowversion_target_in_update_stmt(RangeVar *target_table, UpdateStmt *stmt);
+extern void rewrite_update_outer_join(Node *stmt, CmdType command, RangeVar *target);
 
 #endif /* TSQL_ANALYZE_H */

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -791,6 +791,7 @@ Update on babel_3293_t1
               Sort Key: babel_3293_t1.a1
               ->  Index Scan using index_babel_3293_t1_b1babel_329dabb714f0f2c475b9c9e7d1d90cbd210 on babel_3293_t1
                     Index Cond: (b1 = 1)
+                    Filter: (ctid IS NOT NULL)
         ->  Sort
               Sort Key: babel_3293_t2.a2
               ->  Bitmap Heap Scan on babel_3293_t2

--- a/test/JDBC/expected/babel_delete.out
+++ b/test/JDBC/expected/babel_delete.out
@@ -201,11 +201,279 @@ go
 ~~ROW COUNT: 3~~
 
 
-
 -- will be tracked in BABEL-3910
---exec babel_2020_delete_ct;
---delete babel_2020_delete_t1 from babel_2020_delete_t2 left outer join babel_2020_delete_t1 x on babel_2020_delete_t2.a = x.a;
---go
+drop procedure if exists babel_3910_init_tables
+go
+
+create procedure babel_3910_init_tables as
+begin
+    drop table if exists t1_3910
+    create table t1_3910 (a int)
+    insert into t1_3910 values (1), (2), (3), (4), (NULL)
+    drop table if exists t2_3910
+    create table t2_3910 (a int)
+    insert into t2_3910 values (2), (3), (4), (5), (NULL)
+    drop table if exists t3_3910
+    create table t3_3910 (a int)
+    insert into t3_3910 values (3), (4), (5), (6), (NULL)
+    drop table if exists t4_3910
+    create table t4_3910 (a int)
+    insert into t4_3910 values (4), (5), (6), (7), (NULL)
+end
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 left outer join t1_3910 on t2_3910.a = t1_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1_3910 from t1_3910 right outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1_3910 from t1_3910 full outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+~~END~~
+
+
+exec babel_3910_init_tables
+delete t1_3910 
+from (t1_3910 right join t2_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 2~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables
+delete t1_3910 
+from (t2_3910 left join t1_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 2~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables
+delete t1_3910
+from    
+        (t3_3910 left join 
+            (t1_3910 join t2_3910 on t1_3910.a = t2_3910.a) 
+        on t3_3910.a = t2_3910.a) 
+    join t4_3910 on t3_3910.a = t4_3910.a
+GO
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+3
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 left outer join t1_3910 x on t2_3910.a = x.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t2.a = 2
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+3
+4
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where 0 < t1.a OR t1.a < 10;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+~~END~~
+
+
+drop procedure if exists babel_3910_init_tables;
+drop table if exists t1_3910;
+drop table if exists t2_3910;
+drop table if exists t3_3910;
+drop table if exists t4_3910;
+go
+
 -- null filters
 exec babel_2020_delete_ct;
 delete babel_2020_delete_t1 from babel_2020_delete_t1 x where x.a is null;

--- a/test/JDBC/expected/babel_delete.out
+++ b/test/JDBC/expected/babel_delete.out
@@ -467,6 +467,57 @@ int
 ~~END~~
 
 
+exec babel_3910_init_tables;
+delete t1 from t3_3910 t3, t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t3.a = t2.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 2~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+<NULL>
+~~END~~
+
+
+exec babel_3910_init_tables;
+delete t1 from t3_3910 t3, (t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a), t4_3910 t4
+where t3.a = t2.a and t4.a = t3.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+3
+<NULL>
+~~END~~
+
+
 drop procedure if exists babel_3910_init_tables;
 drop table if exists t1_3910;
 drop table if exists t2_3910;

--- a/test/JDBC/expected/babel_update.out
+++ b/test/JDBC/expected/babel_update.out
@@ -587,11 +587,305 @@ go
 ~~ROW COUNT: 3~~
 
 
-
 -- will be tracked in BABEL-3910
---exec babel_2020_update_ct;
---update babel_2020_update_t1 set a = 100 from babel_2020_update_t2 left outer join babel_2020_update_t1 x on babel_2020_update_t2.a = x.a;
---go
+drop procedure if exists babel_3910_init_tables
+go
+
+create procedure babel_3910_init_tables as
+begin
+    drop table if exists t1_3910
+    create table t1_3910 (a int)
+    insert into t1_3910 values (1), (2), (3), (4), (NULL)
+    drop table if exists t2_3910
+    create table t2_3910 (a int)
+    insert into t2_3910 values (2), (3), (4), (5), (NULL)
+    drop table if exists t3_3910
+    create table t3_3910 (a int)
+    insert into t3_3910 values (3), (4), (5), (6), (NULL)
+    drop table if exists t4_3910
+    create table t4_3910 (a int)
+    insert into t4_3910 values (4), (5), (6), (7), (NULL)
+end
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t2_3910 left outer join t1_3910 on t2_3910.a = t1_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+100
+100
+100
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t1_3910 right outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+100
+100
+100
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t1_3910 full outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+100
+100
+100
+100
+100
+~~END~~
+
+
+exec babel_3910_init_tables
+update t1_3910 set t1_3910.a = 1 
+from (t1_3910 right join t2_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 2~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+<NULL>
+1
+1
+~~END~~
+
+
+exec babel_3910_init_tables
+update t1_3910 set t1_3910.a = 1 
+from (t2_3910 left join t1_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 2~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+<NULL>
+1
+1
+~~END~~
+
+
+exec babel_3910_init_tables
+update t1_3910 set t1_3910.a = 1
+from    
+        (t3_3910 left join 
+            (t1_3910 join t2_3910 on t1_3910.a = t2_3910.a) 
+        on t3_3910.a = t2_3910.a) 
+    join t4_3910 on t3_3910.a = t4_3910.a
+GO
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+3
+<NULL>
+1
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1_3910 set t1_3910.a = 100 from t2_3910 left outer join t1_3910 x on t2_3910.a = x.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+100
+100
+100
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+100
+100
+100
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t2.a = 2
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+3
+4
+<NULL>
+100
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1 set a = 100 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where 0 < t1.a OR t1.a < 10;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+<NULL>
+100
+100
+100
+~~END~~
+
+
+drop procedure if exists babel_3910_init_tables;
+drop table if exists t1_3910;
+drop table if exists t2_3910;
+drop table if exists t3_3910;
+drop table if exists t4_3910;
+go
+
 -- null filters
 exec babel_2020_update_ct;
 update babel_2020_update_t1 set a = 100 from babel_2020_update_t1 x where x.a is null;

--- a/test/JDBC/expected/babel_update.out
+++ b/test/JDBC/expected/babel_update.out
@@ -879,6 +879,60 @@ int
 ~~END~~
 
 
+exec babel_3910_init_tables;
+update t1 set a = 100 from t3_3910 t3, t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t3.a = t2.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 2~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+<NULL>
+100
+100
+~~END~~
+
+
+exec babel_3910_init_tables;
+update t1 set a = 100 from t3_3910 t3, (t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a), t4_3910 t4
+where t3.a = t2.a and t4.a = t3.a;
+go
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
+
+
+select a from t1_3910;
+go
+~~START~~
+int
+1
+2
+3
+<NULL>
+100
+~~END~~
+
+
 drop procedure if exists babel_3910_init_tables;
 drop table if exists t1_3910;
 drop table if exists t2_3910;

--- a/test/JDBC/input/dml/babel_delete.sql
+++ b/test/JDBC/input/dml/babel_delete.sql
@@ -94,9 +94,113 @@ delete babel_2020_delete_t1 from babel_2020_delete_t1 x left outer join babel_20
 go
 
 -- will be tracked in BABEL-3910
---exec babel_2020_delete_ct;
---delete babel_2020_delete_t1 from babel_2020_delete_t2 left outer join babel_2020_delete_t1 x on babel_2020_delete_t2.a = x.a;
---go
+drop procedure if exists babel_3910_init_tables
+go
+
+create procedure babel_3910_init_tables as
+begin
+    drop table if exists t1_3910
+    create table t1_3910 (a int)
+    insert into t1_3910 values (1), (2), (3), (4), (NULL)
+    drop table if exists t2_3910
+    create table t2_3910 (a int)
+    insert into t2_3910 values (2), (3), (4), (5), (NULL)
+    drop table if exists t3_3910
+    create table t3_3910 (a int)
+    insert into t3_3910 values (3), (4), (5), (6), (NULL)
+    drop table if exists t4_3910
+    create table t4_3910 (a int)
+    insert into t4_3910 values (4), (5), (6), (7), (NULL)
+end
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 left outer join t1_3910 on t2_3910.a = t1_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t1_3910 right outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t1_3910 full outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables
+delete t1_3910 
+from (t1_3910 right join t2_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables
+delete t1_3910 
+from (t2_3910 left join t1_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables
+delete t1_3910
+from    
+        (t3_3910 left join 
+            (t1_3910 join t2_3910 on t1_3910.a = t2_3910.a) 
+        on t3_3910.a = t2_3910.a) 
+    join t4_3910 on t3_3910.a = t4_3910.a
+GO
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 left outer join t1_3910 x on t2_3910.a = x.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1_3910 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t2.a = 2
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where 0 < t1.a OR t1.a < 10;
+go
+
+select a from t1_3910;
+go
+
+drop procedure if exists babel_3910_init_tables;
+drop table if exists t1_3910;
+drop table if exists t2_3910;
+drop table if exists t3_3910;
+drop table if exists t4_3910;
+go
 
 -- null filters
 exec babel_2020_delete_ct;

--- a/test/JDBC/input/dml/babel_delete.sql
+++ b/test/JDBC/input/dml/babel_delete.sql
@@ -195,6 +195,22 @@ go
 select a from t1_3910;
 go
 
+exec babel_3910_init_tables;
+delete t1 from t3_3910 t3, t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t3.a = t2.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+delete t1 from t3_3910 t3, (t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a), t4_3910 t4
+where t3.a = t2.a and t4.a = t3.a;
+go
+
+select a from t1_3910;
+go
+
 drop procedure if exists babel_3910_init_tables;
 drop table if exists t1_3910;
 drop table if exists t2_3910;

--- a/test/JDBC/input/dml/babel_update.sql
+++ b/test/JDBC/input/dml/babel_update.sql
@@ -376,6 +376,22 @@ go
 select a from t1_3910;
 go
 
+exec babel_3910_init_tables;
+update t1 set a = 100 from t3_3910 t3, t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t3.a = t2.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1 set a = 100 from t3_3910 t3, (t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a), t4_3910 t4
+where t3.a = t2.a and t4.a = t3.a;
+go
+
+select a from t1_3910;
+go
+
 drop procedure if exists babel_3910_init_tables;
 drop table if exists t1_3910;
 drop table if exists t2_3910;

--- a/test/JDBC/input/dml/babel_update.sql
+++ b/test/JDBC/input/dml/babel_update.sql
@@ -275,9 +275,113 @@ update babel_2020_update_t1 set a = 100 from babel_2020_update_t1 x left outer j
 go
 
 -- will be tracked in BABEL-3910
---exec babel_2020_update_ct;
---update babel_2020_update_t1 set a = 100 from babel_2020_update_t2 left outer join babel_2020_update_t1 x on babel_2020_update_t2.a = x.a;
---go
+drop procedure if exists babel_3910_init_tables
+go
+
+create procedure babel_3910_init_tables as
+begin
+    drop table if exists t1_3910
+    create table t1_3910 (a int)
+    insert into t1_3910 values (1), (2), (3), (4), (NULL)
+    drop table if exists t2_3910
+    create table t2_3910 (a int)
+    insert into t2_3910 values (2), (3), (4), (5), (NULL)
+    drop table if exists t3_3910
+    create table t3_3910 (a int)
+    insert into t3_3910 values (3), (4), (5), (6), (NULL)
+    drop table if exists t4_3910
+    create table t4_3910 (a int)
+    insert into t4_3910 values (4), (5), (6), (7), (NULL)
+end
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t2_3910 left outer join t1_3910 on t2_3910.a = t1_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t1_3910 right outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t1_3910 full outer join t2_3910 on t2_3910.a = t1_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables
+update t1_3910 set t1_3910.a = 1 
+from (t1_3910 right join t2_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables
+update t1_3910 set t1_3910.a = 1 
+from (t2_3910 left join t1_3910 on t1_3910.a = t2_3910.a) 
+    join t3_3910 on t2_3910.a = t3_3910.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables
+update t1_3910 set t1_3910.a = 1
+from    
+        (t3_3910 left join 
+            (t1_3910 join t2_3910 on t1_3910.a = t2_3910.a) 
+        on t3_3910.a = t2_3910.a) 
+    join t4_3910 on t3_3910.a = t4_3910.a
+GO
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set t1_3910.a = 100 from t2_3910 left outer join t1_3910 x on t2_3910.a = x.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a;
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1_3910 set a = 100 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where t2.a = 2
+go
+
+select a from t1_3910;
+go
+
+exec babel_3910_init_tables;
+update t1 set a = 100 from t2_3910 t2 left outer join t1_3910 t1 on t2.a = t1.a
+where 0 < t1.a OR t1.a < 10;
+go
+
+select a from t1_3910;
+go
+
+drop procedure if exists babel_3910_init_tables;
+drop table if exists t1_3910;
+drop table if exists t2_3910;
+drop table if exists t3_3910;
+drop table if exists t4_3910;
+go
 
 -- null filters
 exec babel_2020_update_ct;


### PR DESCRIPTION
### Description
This fixes an issue with update and delete statements using outer joins in their from clauses. Previously, if the target table was on the 'other side' of an outer join (i.e. right side of a left outer join) an Babelfish would give a 'ctid is null' error while the statement would work in T-SQL.

To fix this issue, the queries is checked for update/delete targets present in from clauses on these particular sides of join statements. If so, the query is re-written by adding a WHERE clause that filters rows where the target's ctid is null. The offending queries now match the T-SQL behavior.

### Issues Resolved

Task: BABEL-3910

### Test Scenarios Covered ###
* **Use case based -**
Checks the scenario in the jira, as well as with other types of joins.

* **Boundary conditions -**
Checks with nested joins. Checks with aliasing tables

* **Arbitrary inputs -**
N/A

* **Negative test cases -**
Tests confirm other cases of update / delete with joins aren't affected.

* **Minor version upgrade tests -**
N/A

* **Major version upgrade tests -**
N/A

* **Performance tests -**
N/A

* **Tooling impact -**
N/A

* **Client tests -**
N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).