### PR TITLE
Set local vars used in try to volatile

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1251,8 +1251,8 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	LocalTransactionId after_lxid;
 	SimpleEcontextStackEntry *topEntry;
 	volatile int save_nestlevel;
-	volatile char *old_db_name = get_cur_db_name();
-	volatile char *cur_db_name = NULL;
+	char *old_db_name = get_cur_db_name();
+	char *cur_db_name = NULL;
 	LOCAL_FCINFO(fcinfo,1);
 
 	PG_TRY();

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1250,9 +1250,9 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	volatile LocalTransactionId before_lxid;
 	LocalTransactionId after_lxid;
 	SimpleEcontextStackEntry *topEntry;
-	int save_nestlevel;
-	char *old_db_name = get_cur_db_name();
-	char *cur_db_name = NULL;
+	volatile int save_nestlevel;
+	volatile char *old_db_name = get_cur_db_name();
+	volatile char *cur_db_name = NULL;
 	LOCAL_FCINFO(fcinfo,1);
 
 	PG_TRY();


### PR DESCRIPTION
### Description

In changes for BABEL-3092, a try block was added to ensure the GUC stack is always popped after errors. Some locals were not declared as volatile, which this fixes.

### Issues Resolved

BABEL-3092

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).