### PR TITLE
Refactor flatten_search_path logic to improve perfomance

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -663,8 +663,7 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	char *cur_dbname = get_cur_db_name();
 
 	/* fetch current search_path */
-	List *path_oids = fetch_search_path(false);
-	char *old_search_path = flatten_search_path(path_oids);
+	char *old_search_path = NULL;
 	char *new_search_path;
 	estate->db_name = NULL;
 	if (stmt->proc_name == NULL)
@@ -696,6 +695,12 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 		if (strncmp(stmt->proc_name, "sp_", 3) == 0 && strcmp(cur_dbname, "master") != 0
 			&& ((stmt->schema_name == NULL || stmt->schema_name[0] == (char)'\0') || strcmp(stmt->schema_name, "dbo") == 0))
 			{
+				if (!old_search_path)
+				{
+					List 		*path_oids = fetch_search_path(false);
+					old_search_path = flatten_search_path(path_oids);
+					list_free(path_oids);
+				}
 				new_search_path = psprintf("%s, master_dbo", old_search_path);
 
 				/* Add master_dbo to the new search path */
@@ -1086,7 +1091,6 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 							GUC_ACTION_SAVE, true, 0, false);
 		SetCurrentRoleId(current_user_id, false);
 	}
-	list_free(path_oids);
 
 	if (expr->plan && !expr->plan->saved)
 	{


### PR DESCRIPTION
Earlier fetch/flatten_search_path were being called for every execute function, procedure and exec_sql statements. This was blindly adding a bottleneck to use cases where it wasn't even required. With this change we refactor the calls to these functions appropriately so that they only get called for specific use cases.

Note: This is the first pass for optimisation and we are thinking of ways to mitigate this bottleneck altogether.

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>


### Issues Resolved
BABEL-3754

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).