### PR TITLE
Fix OBJECT_NAME when input object_id belongs to shared schema

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1359,8 +1359,13 @@ object_name(PG_FUNCTION_ARGS)
 
 	if(result)
 	{	
-		/* check if schema corresponding to found object belongs to specified database */
-		if(!OidIsValid(schema_id) || is_schema_from_db(schema_id, database_id)) /* in case of pg_type schema_id will be invalid */
+		/* 
+		 * Check if schema corresponding to found object belongs to specified database,
+		 * schema also can be shared schema like "sys" or "information_schema_tsql".
+		 * In case of pg_type schema_id will be invalid.
+		 */
+		if(!OidIsValid(schema_id) || is_schema_from_db(schema_id, database_id) 
+				|| (schema_id == get_namespace_oid("sys", true)) || (schema_id == get_namespace_oid("information_schema_tsql", true)))
 			PG_RETURN_VARCHAR_P((VarChar *) cstring_to_text(result));
 	}
 	PG_RETURN_NULL();

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -970,6 +970,7 @@ get_physical_schema_name_by_mode(char *db_name, const char *schema_name, Migrati
 		{
 			result = palloc0(MAX_BBF_NAMEDATALEND);
 			snprintf(result, (MAX_BBF_NAMEDATALEND), "%s_%s", name, "tsql");
+			pfree(name);
 			return result;
 		}
 		else

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -964,7 +964,17 @@ get_physical_schema_name_by_mode(char *db_name, const char *schema_name, Migrati
 	strncpy(name, schema_name, len);
 
 	if (is_shared_schema(name))
-		return name;
+	{	
+		/* in case of "information_schema" it will return "information_schema_tsql" */
+		if (strcmp(schema_name, "information_schema") == 0)
+		{
+			result = palloc0(MAX_BBF_NAMEDATALEND);
+			snprintf(result, (MAX_BBF_NAMEDATALEND), "%s_%s", name, "tsql");
+			return result;
+		}
+		else
+			return name;
+	}
 
 	/* Parser guarantees identifier will alsways be truncated to 64B.
 	 * Schema name that comes from other source (e.g scheam_id function)
@@ -1000,6 +1010,7 @@ get_physical_schema_name_by_mode(char *db_name, const char *schema_name, Migrati
 	}
 
 	truncate_tsql_identifier(result);
+	pfree(name);
 
 	return result;
 }

--- a/test/JDBC/expected/BABEL_OBJECT_NAME-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_OBJECT_NAME-vu-cleanup.out
@@ -65,3 +65,12 @@ GO
 
 DROP TABLE babel_object_name_t1
 GO
+
+DROP VIEW babel_object_name_shared_schema_v1
+GO
+
+DROP VIEW babel_object_name_shared_schema_v2
+GO
+
+DROP VIEW babel_object_name_shared_schema_v3
+GO

--- a/test/JDBC/expected/BABEL_OBJECT_NAME-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_OBJECT_NAME-vu-prepare.out
@@ -52,6 +52,19 @@ CREATE VIEW babel_object_name_constraint_view AS
 SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_constraint'))
 go
 
+-- To test shared schema
+CREATE VIEW babel_object_name_shared_schema_v1 AS
+SELECT OBJECT_NAME(OBJECT_ID('sys.objects'))
+go
+
+CREATE VIEW babel_object_name_shared_schema_v2 AS
+SELECT OBJECT_NAME(OBJECT_ID('information_schema_tsql.columns'))
+go
+
+CREATE VIEW babel_object_name_shared_schema_v3 AS
+SELECT OBJECT_NAME(OBJECT_ID('information_schema.columns'))
+go
+
 -- To test cross-db lookup
 CREATE DATABASE babel_object_name_db;
 GO

--- a/test/JDBC/expected/BABEL_OBJECT_NAME-vu-verify.out
+++ b/test/JDBC/expected/BABEL_OBJECT_NAME-vu-verify.out
@@ -58,6 +58,31 @@ babel_object_name_constraint
 ~~END~~
 
 
+-- test shared schema
+SELECT * FROM babel_object_name_shared_schema_v1
+GO
+~~START~~
+varchar
+objects
+~~END~~
+
+
+SELECT * FROM babel_object_name_shared_schema_v2
+GO
+~~START~~
+varchar
+columns
+~~END~~
+
+
+SELECT * FROM babel_object_name_shared_schema_v3
+GO
+~~START~~
+varchar
+columns
+~~END~~
+
+
 -- Negative values/ out of range values
 SELECT OBJECT_NAME(-123)
 GO

--- a/test/JDBC/input/BABEL_OBJECT_NAME-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL_OBJECT_NAME-vu-cleanup.mix
@@ -65,3 +65,12 @@ GO
 
 DROP TABLE babel_object_name_t1
 GO
+
+DROP VIEW babel_object_name_shared_schema_v1
+GO
+
+DROP VIEW babel_object_name_shared_schema_v2
+GO
+
+DROP VIEW babel_object_name_shared_schema_v3
+GO

--- a/test/JDBC/input/BABEL_OBJECT_NAME-vu-prepare.mix
+++ b/test/JDBC/input/BABEL_OBJECT_NAME-vu-prepare.mix
@@ -52,6 +52,19 @@ CREATE VIEW babel_object_name_constraint_view AS
 SELECT OBJECT_NAME(OBJECT_ID('babel_object_name_constraint'))
 go
 
+-- To test shared schema
+CREATE VIEW babel_object_name_shared_schema_v1 AS
+SELECT OBJECT_NAME(OBJECT_ID('sys.objects'))
+go
+
+CREATE VIEW babel_object_name_shared_schema_v2 AS
+SELECT OBJECT_NAME(OBJECT_ID('information_schema_tsql.columns'))
+go
+
+CREATE VIEW babel_object_name_shared_schema_v3 AS
+SELECT OBJECT_NAME(OBJECT_ID('information_schema.columns'))
+go
+
 -- To test cross-db lookup
 CREATE DATABASE babel_object_name_db;
 GO

--- a/test/JDBC/input/BABEL_OBJECT_NAME-vu-verify.mix
+++ b/test/JDBC/input/BABEL_OBJECT_NAME-vu-verify.mix
@@ -23,6 +23,16 @@ GO
 SELECT * FROM babel_object_name_constraint_view
 GO
 
+-- test shared schema
+SELECT * FROM babel_object_name_shared_schema_v1
+GO
+
+SELECT * FROM babel_object_name_shared_schema_v2
+GO
+
+SELECT * FROM babel_object_name_shared_schema_v3
+GO
+
 -- Negative values/ out of range values
 SELECT OBJECT_NAME(-123)
 GO


### PR DESCRIPTION
### Description
Earlier we were checking that schema corresponding to provided object_id belongs to specified database/current database due to which OBJECT_NAME was not working for object that belongs to shared schema. 

This commit fix the OBJECT_NAME when input object_id belongs to shared schema. This commit also make changes in get_physical_schema_name_by_mode function so that it will  return "information_schema_tsql" when the input schema name is "information_schema".

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Issues Resolved

[BABEL-3873]

3X PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1226
### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).