### PR TITLE
Fix crash during restore

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -685,7 +685,6 @@ is_user(Oid role_oid)
 	HeapTuple	tuple;
 	HeapTuple	authtuple;
 	NameData	rolname;
-	BpChar		type;
 	char		*type_str = "";
 
 	authtuple = SearchSysCache1(AUTHOID, ObjectIdGetDatum(role_oid));
@@ -710,9 +709,17 @@ is_user(Oid role_oid)
 
 	if (!HeapTupleIsValid(tuple))
 		is_user = false;
+	else
+	{
+		Datum		datum;
+		bool		isnull;
+		TupleDesc	dsc;
 
-	type = ((Form_authid_user_ext) GETSTRUCT(tuple))->type;
-	type_str = bpchar_to_cstring(&type);
+		dsc = RelationGetDescr(relation);
+		datum = heap_getattr(tuple, USER_EXT_TYPE + 1, dsc, &isnull);
+		if (!isnull)
+			type_str = pstrdup(TextDatumGetCString(datum));
+	}
 
 	if (strcmp(type_str, "S") != 0)
 		is_user = false;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2312,11 +2312,14 @@ pltsql_store_func_default_positions(ObjectAddress address, List *parameters, con
 	uint64		flag_values = 0, flag_validity = 0;
 	char *original_query = get_original_query_string();
 
+	/* Disallow extended catalog lookup during restore */
+	if (babelfish_dump_restore)
+		return;
 	/* Fetch the object details from function */
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
-	/* Disallow extended catalog lookup during restore */
-	if (!HeapTupleIsValid(proctup) || babelfish_dump_restore)
+	if (!HeapTupleIsValid(proctup))
 		return;
+
 	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
 
 	if (!is_pltsql_language_oid(form_proctup->prolang))


### PR DESCRIPTION
### Description
* Previously, we were accessing a heap tuple even if it is invalid (in `is_user` function).
Fixed this by adding checks.
* Currently, there is no known reproducible test case scenario but goal of this commit is
fix the problematic code.

Task: BABEL-3827
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

3.x PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1223
### Test Scenarios Covered ###
* **Use case based -**
Currently existing test cases are enough to test this change.

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).