### PR TITLE
Correct BABEL-VERSION output file

### DIFF
--- a/test/JDBC/expected/BABEL-VERSION.out
+++ b/test/JDBC/expected/BABEL-VERSION.out
@@ -1,25 +1,33 @@
 -- psql
 Alter system set babelfishpg_tds.product_version = "9.4.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
 
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
 
 ~~START~~
 bool
 t
 ~~END~~
 
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
+
+~~START~~
+void
+
+~~END~~
+
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 ~~START~~
@@ -31,25 +39,32 @@ Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.400.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~
 
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~
 
 ~~START~~
 bool
 t
 ~~END~~
 
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~
+
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 ~~START~~
@@ -61,25 +76,32 @@ Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.-1.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
 
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
 
 ~~START~~
 bool
 t
 ~~END~~
 
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 ~~START~~
@@ -91,25 +113,32 @@ Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.4.66000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~
 
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~
 
 ~~START~~
 bool
 t
 ~~END~~
 
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~
+
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 ~~START~~
@@ -121,25 +150,32 @@ Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
 -- psql
 Alter system set babelfishpg_tds.product_version = ".4.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
 
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
 
 ~~START~~
 bool
 t
 ~~END~~
 
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~
+
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 ~~START~~
@@ -151,25 +187,32 @@ Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.4e.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
 
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16  Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
 
 ~~START~~
 bool
 t
 ~~END~~
 
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 ~~START~~
@@ -183,7 +226,7 @@ Alter system set babelfishpg_tds.product_version = "15.4.-1.6";
 GO
 ~~WARNING (Code: 0)~~
 
-~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
+~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
 
 
 Alter system set babelfishpg_tds.product_version = "e.4.3000.6";
@@ -198,7 +241,6 @@ GO
 ~~WARNING (Code: 0)~~
 
 ~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
-
 
 
 Alter system set babelfishpg_tds.product_version = "11..3000.6";

--- a/test/JDBC/input/BABEL-VERSION.mix
+++ b/test/JDBC/input/BABEL-VERSION.mix
@@ -1,72 +1,61 @@
 -- psql
 Alter system set babelfishpg_tds.product_version = "9.4.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
+
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.400.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.-1.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.4.66000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 
 -- psql
 Alter system set babelfishpg_tds.product_version = ".4.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 
 -- psql
 Alter system set babelfishpg_tds.product_version = "15.4e.3000.6";
 SELECT pg_reload_conf();
+SELECT pg_sleep(1);
 GO
 
 -- tsql
-exec pg_sleep 1
-GO
-
 SELECT SUBSTRING(@@VERSION, 1, CHARINDEX(CHAR(10), @@VERSION) - 1);
 GO
 
@@ -79,7 +68,6 @@ GO
 
 Alter system set babelfishpg_tds.product_version = "11.4.3000";
 GO
-
 
 Alter system set babelfishpg_tds.product_version = "11..3000.6";
 GO


### PR DESCRIPTION
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description
Before this PR, the BABEL-VERSION test is failed because psql is not fully synced after using ALTER SYSTEM set the babelfishpg_tds.product_version GUC. In this PR, we added 1s pg_sleep before reloading pg config to wait PG to sync.
### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).