### PR TITLE
OBJECT_ID should lookup in guest schema for guest user by default

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1063,7 +1063,7 @@ object_id(PG_FUNCTION_ARGS)
 		}
 		else if ((guest_role_name && strcmp(user, guest_role_name) == 0))
 		{
-			physical_schema_name = pstrdup(get_dbo_schema_name(db_name));
+			physical_schema_name = pstrdup(get_guest_schema_name(db_name));
 		}
 		else
 		{	

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-cleanup.out
@@ -21,6 +21,9 @@ GO
 USE master;
 GO
 
+DROP LOGIN babel_object_id_login2;
+GO
+
 DROP USER babel_object_id_master_user1
 GO
 

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-prepare.out
@@ -91,3 +91,13 @@ GO
 
 GRANT ALL ON babel_object_id_schema2.babel_object_id_db_t2 TO babel_object_id_user2;
 GO
+
+-- to test that it is looking in guest schema by default for guest user
+USE master
+GO
+
+CREATE LOGIN babel_object_id_login2 WITH PASSWORD = '12345678';
+GO
+
+USE babel_object_id_db;
+GO

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-verify.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-verify.out
@@ -625,5 +625,65 @@ babel_object_id_db_t2
 
 
 -- tsql
+-- to test that it is looking in guest schema by default for guest user
+USE babel_object_id_db
+GO
+
+CREATE TABLE dbo.babel_object_id_table_in_dbo_schema (a int);
+GO
+
+grant connect to guest
+GO
+
+-- tsql      user=babel_object_id_login2 password=12345678
+USE babel_object_id_db
+GO
+
+-- guest user
+SELECT current_user;
+GO
+~~START~~
+varchar
+guest
+~~END~~
+
+
+CREATE TABLE babel_object_id_table_in_guest_schema (a int);
+GO
+
+
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_id_table_in_guest_schema'))
+GO
+~~START~~
+varchar
+babel_object_id_table_in_guest_schema
+~~END~~
+
+
+SELECT OBJECT_NAME(OBJECT_ID('guest.babel_object_id_table_in_guest_schema'))
+GO
+~~START~~
+varchar
+babel_object_id_table_in_guest_schema
+~~END~~
+
+
+-- should return null
+SELECT OBJECT_NAME(OBJECT_ID('dbo.babel_object_id_table_in_dbo_schema'))
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- cleanup guest schema
+DROP TABLE babel_object_id_table_in_guest_schema
+GO
+
+-- tsql
 USE babel_object_id_db;
+GO
+
+DROP TABLE dbo.babel_object_id_table_in_dbo_schema;
 GO

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-cleanup.mix
@@ -21,6 +21,9 @@ GO
 USE master;
 GO
 
+DROP LOGIN babel_object_id_login2;
+GO
+
 DROP USER babel_object_id_master_user1
 GO
 

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-prepare.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-prepare.mix
@@ -91,3 +91,13 @@ GO
 
 GRANT ALL ON babel_object_id_schema2.babel_object_id_db_t2 TO babel_object_id_user2;
 GO
+
+-- to test that it is looking in guest schema by default for guest user
+USE master
+GO
+
+CREATE LOGIN babel_object_id_login2 WITH PASSWORD = '12345678';
+GO
+
+USE babel_object_id_db;
+GO

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-verify.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-verify.mix
@@ -308,6 +308,46 @@ GO
 SELECT OBJECT_NAME(OBJECT_ID('babel_object_id_db_t2'))
 GO
 
+-- to test that it is looking in guest schema by default for guest user
+-- tsql
+USE babel_object_id_db
+GO
+
+CREATE TABLE dbo.babel_object_id_table_in_dbo_schema (a int);
+GO
+
+grant connect to guest
+GO
+
+-- tsql      user=babel_object_id_login2 password=12345678
+USE babel_object_id_db
+GO
+
+-- guest user
+SELECT current_user;
+GO
+
+CREATE TABLE babel_object_id_table_in_guest_schema (a int);
+GO
+
+
+SELECT OBJECT_NAME(OBJECT_ID('babel_object_id_table_in_guest_schema'))
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('guest.babel_object_id_table_in_guest_schema'))
+GO
+
+-- should return null
+SELECT OBJECT_NAME(OBJECT_ID('dbo.babel_object_id_table_in_dbo_schema'))
+GO
+
+-- cleanup guest schema
+DROP TABLE babel_object_id_table_in_guest_schema
+GO
+
 -- tsql
 USE babel_object_id_db;
+GO
+
+DROP TABLE dbo.babel_object_id_table_in_dbo_schema;
 GO


### PR DESCRIPTION
### Description
Earlier OBJECT_ID function for guest user was looking the for object in "dbo" schema by default. Recently we have added guest schema for guest user, So by default OBJECT_ID function should lookup in guest schema for guest user.

This commit made changes so that OBJECT_ID should lookup in guest schema for guest user by default.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Issues Resolved

Task: BABEL-3961

3X PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1237
### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).