### PR TITLE
Avoid dumping COLLATE default for const clause

### DIFF
--- a/contrib/babelfishpg_common/src/babelfishpg_common.c
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.c
@@ -10,6 +10,7 @@
 #include "parser/parse_target.h"
 #include "parser/scansup.h"  /* downcase_identifier */
 #include "utils/guc.h"
+#include "utils/ruleutils.h"
 
 #include "collation.h"
 #include "encoding/encoding.h"
@@ -122,6 +123,8 @@ _PG_init(void)
 
 	prev_PreCreateCollation_hook = PreCreateCollation_hook;
 	PreCreateCollation_hook = BabelfishPreCreateCollation_hook;
+
+	get_tsql_const_collation_hook = get_tsql_const_collation;
 }
 void
 _PG_fini(void)
@@ -132,4 +135,5 @@ _PG_fini(void)
 	CLUSTER_COLLATION_OID_hook = prev_CLUSTER_COLLATION_OID_hook;
 	TranslateCollation_hook = prev_TranslateCollation_hook;
 	PreCreateCollation_hook = prev_PreCreateCollation_hook;
+	get_tsql_const_collation_hook = NULL;
 }

--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -1475,3 +1475,31 @@ babelfish_update_server_collation_name(PG_FUNCTION_ARGS)
 	MemoryContextSwitchTo(oldContext);
 	PG_RETURN_VOID();
 }
+
+
+/*
+ * get_tsql_const_collation - determines whether collation needs to be dumped or not
+ * for collatable data types such as varchar, char, nvarchar, nchar, etc for Const clause.
+ * 
+ * This would be required to handle clause such as default clause, check constraints during Major Version 
+ * Upgrade from version 14.6 (Babelfish v2.3.0 or later) to 15.1 (Babelfish v3.0.0 or later) because 
+ * the default collation of mentioned data types would be same as the T-SQL collation which was 
+ * DEFAULT_COLLATION_OID previously (Babelfish version prior to v2.3.0). And all the existing const clause 
+ * like default clause and check constraint clause might still be DEFAULT_COLLATION_OID. So this function 
+ * will help detecting such cases and will avoid dumping COLLATE clause for such cases.
+ */
+bool
+get_tsql_const_collation(Const *constval) {
+	Oid typid = constval->consttype;
+
+	if (constval->constcollid == DEFAULT_COLLATION_OID &&
+		(is_tsql_nvarchar_datatype(typid) ||
+		 is_tsql_varchar_datatype(typid) ||
+		 is_tsql_bpchar_datatype(typid) ||
+		 is_tsql_nchar_datatype(typid)))
+	{
+		return false;
+	}
+
+	return true;
+}

--- a/contrib/babelfishpg_common/src/collation.h
+++ b/contrib/babelfishpg_common/src/collation.h
@@ -152,3 +152,5 @@ BabelfishPreCreateCollation_hook(
 
 extern TranslateCollation_hook_type prev_TranslateCollation_hook;
 extern PreCreateCollation_hook_type prev_PreCreateCollation_hook;
+
+extern bool get_tsql_const_collation(Const *constval);


### PR DESCRIPTION
Previously, During v2.3.0 release, we fixed the most of collatable data types such as varchar to have the correct default collation same as server_collation_name. This fix may lead to dump extra COLLATE "default" clause for const clause during upgrade from 14.x to 15.1 if server is upgrade to 14.6 via minor version upgrade first.

To fix this, we have introduced new hook handle_const_collation_hook on engine side and it would be initialised to print_const_collation inside babelfishpg_common extension which would determine if COLLATE needs to be dumped or not for given const clause.

Task: BABEL-3895
Engine PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/96
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).