### PR TITLE
[BABEL-3888] Add print message for sp_rename

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3000,6 +3000,7 @@ BEGIN
 	SELECT @currtype = type FROM sys.objects o1 INNER JOIN sys.schemas s1 ON o1.schema_id = s1.schema_id 
 	WHERE s1.name = @schemaname AND o1.name = @subname;
 	EXEC sys.babelfish_sp_rename_internal @subname, @newname, @schemaname, @currtype;
+	PRINT 'Caution: Changing any part of an object name could break scripts and stored procedures.';
 END;
 $$;
 GRANT EXECUTE on PROCEDURE sys.sp_rename(IN sys.nvarchar(776), IN sys.SYSNAME, IN sys.varchar(13)) TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1897,6 +1897,7 @@ BEGIN
 	SELECT @currtype = type FROM sys.objects o1 INNER JOIN sys.schemas s1 ON o1.schema_id = s1.schema_id 
 	WHERE s1.name = @schemaname AND o1.name = @subname;
 	EXEC sys.babelfish_sp_rename_internal @subname, @newname, @schemaname, @currtype;
+	PRINT 'Caution: Changing any part of an object name could break scripts and stored procedures.';
 END;
 $$;
 GRANT EXECUTE on PROCEDURE sys.sp_rename(IN sys.nvarchar(776), IN sys.SYSNAME, IN sys.varchar(13)) TO PUBLIC;

--- a/test/JDBC/expected/Test-sp_rename-dep-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_rename-dep-vu-verify.out
@@ -5,6 +5,10 @@ GO
 
 EXEC sp_rename_dep_proc1 
 GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Caution: Changing any part of an object name could break scripts and stored procedures.  Server SQLState: S0001)~~
+
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
 master#!#sp_rename_dep_schema1#!#sp_rename_dep_dummy_table1_new#!#BASE TABLE
@@ -13,6 +17,10 @@ master#!#sp_rename_dep_schema1#!#sp_rename_dep_dummy_table1_new#!#BASE TABLE
 
 EXEC sp_rename_dep_proc2
 GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Caution: Changing any part of an object name could break scripts and stored procedures.  Server SQLState: S0001)~~
+
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 master#!#dbo#!#sp_rename_dep_dummy_func1_new#!#FUNCTION


### PR DESCRIPTION
Adding a caution message to sp_rename babelfish, mimicing the behavior of sp_rename in sql server.

Signed-off-by: Ray Kim <raydhkim@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).