### PR TITLE
Fixed test case after solution for BABEL-3895

### DIFF
--- a/test/JDBC/expected/latest__verification_cleanup__14_5__ISC-Check-Constraints-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_5__ISC-Check-Constraints-vu-verify.out
@@ -44,7 +44,7 @@ isc_check_constraints_db1#!#dbo#!#test_tsql_cast_c_float_check#!#(((c_float < CA
 isc_check_constraints_db1#!#dbo#!#test_tsql_cast_c_numeric_check#!#(((c_numeric < CAST(133.230182309832423 AS numeric(18,0))) AND (c_numeric < CAST(133.230182309832423 AS numeric(5,3)))))
 isc_check_constraints_db1#!#dbo#!#test_tsql_cast_c_real_check#!#((c_real < CAST((133.230182309832423) AS real)))
 isc_check_constraints_db1#!#dbo#!#test_tsql_collate_c_char_check#!#((c_char <> (CAST('sflkjasdlkfjf' AS char(7)) COLLATE japanese_ci_as)))
-isc_check_constraints_db1#!#dbo#!#test_tsql_collate_c_char_check1#!#((c_char <> CAST('abcd' AS char(7))))
+isc_check_constraints_db1#!#dbo#!#test_tsql_collate_c_char_check1#!#((c_char <> (CAST('abcd' AS char(7)) COLLATE "default")))
 isc_check_constraints_db1#!#dbo#!#test_tsql_collate_c_nchar_check#!#((CAST((c_nchar) AS nchar(7)) <> (CAST(('sflkjasdlkfjf') AS nchar(7)) COLLATE latin1_general_ci_as)))
 isc_check_constraints_db1#!#dbo#!#test_tsql_collate_c_varchar_check#!#((c_varchar <> (CAST('sflkjasdlkfjf' AS varchar(12)) COLLATE latin1_general_ci_as)))
 isc_check_constraints_db1#!#dbo#!#test_tsql_const_c_binary_check#!#((c_binary > CAST(('0xfe') AS binary(8))))


### PR DESCRIPTION
### Description

This commit fixes the expected output file latest__verification_cleanup__14_5__ISC-Check-Constraints-vu-verify.out after the fix of BABEL-3895. Relevant long term fix is merged through [2180e27](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/2180e27991be9f9b0f4a515d23f7ee53225a1309),  [2ae9c9d](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/2ae9c9d2153a865d5bfdabcc3c8998beb271fa36) and faa73e12b7c9e39da24e539e3b33cd7d3f4a8c45


### Issues Resolved

Task: BABEL-3895
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).