### PR TITLE
Fixed index_id columns for index_columns to match sys.indexes

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1951,7 +1951,7 @@ GRANT SELECT ON sys.endpoints TO PUBLIC;
 create or replace view sys.index_columns
 as
 select i.indrelid::integer as object_id
-  , i.indexrelid::integer as index_id
+  , CAST(CASE WHEN i.indisclustered THEN 1 ELSE 1+row_number() OVER(PARTITION BY c.oid) END AS INTEGER) AS index_id
   , a.attrelid::integer as index_column_id
   , a.attnum::integer as column_id
   , a.attnum::sys.tinyint as key_ordinal

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -2648,6 +2648,24 @@ $BODY$
 LANGUAGE plpgsql
 STABLE;
 
+create or replace view sys.index_columns
+as
+select i.indrelid::integer as object_id
+  , CAST(CASE WHEN i.indisclustered THEN 1 ELSE 1+row_number() OVER(PARTITION BY c.oid) END AS INTEGER) AS index_id
+  , a.attrelid::integer as index_column_id
+  , a.attnum::integer as column_id
+  , a.attnum::sys.tinyint as key_ordinal
+  , 0::sys.tinyint as partition_ordinal
+  , 0::sys.bit as is_descending_key
+  , 1::sys.bit as is_included_column
+from pg_index as i
+inner join pg_catalog.pg_attribute a on i.indexrelid = a.attrelid
+inner join pg_class c on i.indrelid = c.oid
+inner join sys.schemas sch on sch.schema_id = c.relnamespace
+where has_schema_privilege(sch.schema_id, 'USAGE')
+and has_table_privilege(c.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
+GRANT SELECT ON sys.index_columns TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/sys-index_columns-vu-verify.out
+++ b/test/JDBC/expected/sys-index_columns-vu-verify.out
@@ -28,6 +28,14 @@ int
 ~~END~~
 
 
+SELECT count(*) from sys.index_columns ic, sys.indexes i where ic.object_id = i.object_id and ic.index_id = i.index_id and i.name like 'sys_index_columns_vu_prepare_i3%'
+GO
+~~START~~
+int
+1
+~~END~~
+
+
 SELECT count(*) FROM  sys.index_columns idx JOIN sys.tables tab ON idx.object_id = tab.object_id WHERE tab.name = 'sys_index_columns_vu_prepare_t3';
 GO
 ~~START~~

--- a/test/JDBC/input/views/sys-index_columns-vu-verify.sql
+++ b/test/JDBC/input/views/sys-index_columns-vu-verify.sql
@@ -13,5 +13,8 @@ GO
 SELECT count(*) FROM  sys.index_columns idx JOIN sys.tables tab ON idx.object_id = tab.object_id WHERE tab.name = 'sys_index_columns_vu_prepare_t2';
 GO
 
+SELECT count(*) from sys.index_columns ic, sys.indexes i where ic.object_id = i.object_id and ic.index_id = i.index_id and i.name like 'sys_index_columns_vu_prepare_i3%'
+GO
+
 SELECT count(*) FROM  sys.index_columns idx JOIN sys.tables tab ON idx.object_id = tab.object_id WHERE tab.name = 'sys_index_columns_vu_prepare_t3';
 GO


### PR DESCRIPTION
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Description
The mismatch in index_id columns for views sys.indexes and sys.index_columns was leading to failures in DDL export.
This change makes sure that both columns return same metadata

### Issues Resolved
BABEL-3964

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
  - Added tests to verify index_id for sys.indexes and sys.index_columns are in sync
  - Already Existing test cases
  - Already existing Dependency tests

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).