### PR TITLE
Throw an error if locallogin is not NULL in sp_addlinkedsrvlogin stored procedure

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2254,6 +2254,7 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 {
 	char *servername = PG_ARGISNULL(0) ? NULL : lowerstr(text_to_cstring(PG_GETARG_VARCHAR_PP(0)));
 	char *useself = PG_ARGISNULL(1) ? NULL : lowerstr(text_to_cstring(PG_GETARG_VARCHAR_PP(1)));
+	char *locallogin = PG_ARGISNULL(2) ? NULL : text_to_cstring(PG_GETARG_VARCHAR_PP(2));
 	char *username = PG_ARGISNULL(3) ? NULL : text_to_cstring(PG_GETARG_VARCHAR_PP(3));
 	char *password = PG_ARGISNULL(4) ? NULL : text_to_cstring(PG_GETARG_VARCHAR_PP(4));
 
@@ -2270,6 +2271,11 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_FDW_ERROR),
 					errmsg("Only @useself = FALSE is supported. Remote login using user's self credentials is not supported.")));
 
+	if (locallogin != NULL)
+		ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("Only @locallogin = NULL is supported")));
+							
 	initStringInfo(&query);
 
 	/*

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2274,7 +2274,7 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	if (locallogin != NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("Only @locallogin = NULL is supported")));
+					errmsg("Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported")));
 							
 	initStringInfo(&query);
 
@@ -2348,7 +2348,7 @@ sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	if (locallogin != NULL)
 		ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("Only @locallogin = NULL is supported")));
+							errmsg("Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported")));
 	
 	initStringInfo(&query);
 

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2273,8 +2273,8 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 
 	if (locallogin != NULL)
 		ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("Only @locallogin = NULL is supported")));
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("Only @locallogin = NULL is supported")));
 							
 	initStringInfo(&query);
 

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2274,7 +2274,7 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	if (locallogin != NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported")));
+					errmsg("Only @locallogin = NULL is supported. Configuring remote server access specific to local login is not yet supported")));
 							
 	initStringInfo(&query);
 
@@ -2348,7 +2348,7 @@ sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	if (locallogin != NULL)
 		ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported")));
+							errmsg("Only @locallogin = NULL is supported. Configuring remote server access specific to local login is not yet supported")));
 	
 	initStringInfo(&query);
 

--- a/test/JDBC/expected/linked_servers-vu-prepare.out
+++ b/test/JDBC/expected/linked_servers-vu-prepare.out
@@ -94,7 +94,7 @@ EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = 'FALSE', @loc
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Only @locallogin = NULL is supported)~~
+~~ERROR (Message: Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported)~~
 
 
 -- Create a linked server login with @useself = FALSE. Also call sp_addlinkedsrvlogin from master.dbo schema

--- a/test/JDBC/expected/linked_servers-vu-prepare.out
+++ b/test/JDBC/expected/linked_servers-vu-prepare.out
@@ -89,6 +89,14 @@ GO
 ~~ERROR (Message: Only @useself = FALSE is supported. Remote login using user's self credentials is not supported.)~~
 
 
+-- Create a linked server login with @locallogin != NULL (Should throw error as locallogin is not yet supported)
+EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = 'FALSE', @locallogin = 'login1', @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only @locallogin = NULL is supported)~~
+
+
 -- Create a linked server login with @useself = FALSE. Also call sp_addlinkedsrvlogin from master.dbo schema
 EXEC master.dbo.sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = 'FALSE', @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
 GO

--- a/test/JDBC/expected/linked_servers-vu-prepare.out
+++ b/test/JDBC/expected/linked_servers-vu-prepare.out
@@ -94,7 +94,7 @@ EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = 'FALSE', @loc
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported)~~
+~~ERROR (Message: Only @locallogin = NULL is supported. Configuring remote server access specific to local login is not yet supported)~~
 
 
 -- Create a linked server login with @useself = FALSE. Also call sp_addlinkedsrvlogin from master.dbo schema

--- a/test/JDBC/expected/linked_servers-vu-verify.out
+++ b/test/JDBC/expected/linked_servers-vu-verify.out
@@ -149,7 +149,7 @@ EXEC sp_droplinkedsrvlogin @rmtsrvname = "mssql_server", @locallogin = "login_1"
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported)~~
+~~ERROR (Message: Only @locallogin = NULL is supported. Configuring remote server access specific to local login is not yet supported)~~
 
 
 -- drop all the linked server logins that have been created (case insensitive)

--- a/test/JDBC/expected/linked_servers-vu-verify.out
+++ b/test/JDBC/expected/linked_servers-vu-verify.out
@@ -149,7 +149,7 @@ EXEC sp_droplinkedsrvlogin @rmtsrvname = "mssql_server", @locallogin = "login_1"
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Only @locallogin = NULL is supported)~~
+~~ERROR (Message: Only @locallogin = NULL is supported. Configuring Remote server access specific to local login is not yet supported)~~
 
 
 -- drop all the linked server logins that have been created (case insensitive)

--- a/test/JDBC/input/linked_servers-vu-prepare.mix
+++ b/test/JDBC/input/linked_servers-vu-prepare.mix
@@ -57,6 +57,10 @@ GO
 EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = NULL, @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
 GO
 
+-- Create a linked server login with @locallogin != NULL (Should throw error as locallogin is not yet supported)
+EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = 'FALSE', @locallogin = 'login1', @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
+GO
+
 -- Create a linked server login with @useself = FALSE. Also call sp_addlinkedsrvlogin from master.dbo schema
 EXEC master.dbo.sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server', @useself = 'FALSE', @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
 GO


### PR DESCRIPTION
### Description

Currently, in sp_addlinkedsrvlogin stored procedure, if locallogin parameter is not NULL, we are ignoring it and creating a mapping for CURRENT_USER. With this commit we will be throwing an error if locallogin is not NULL.

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Issues Resolved

BABEL-861

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** Yes


* **Negative test cases -** N/A


* **Minor version upgrade tests -** None


* **Major version upgrade tests -** None


* **Performance tests -** None


* **Tooling impact -** None


* **Client tests -** None



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).