### PR TITLE
fix user privilege for sp_babelfish_volatility

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2182,7 +2182,7 @@ Datum sp_babelfish_volatility(PG_FUNCTION_ARGS)
 			pfree(logical_schema_name);
 			if ((guest_role_name && strcmp(user, guest_role_name) == 0))
 			{	
-				physical_schema_name = pstrdup(get_dbo_schema_name(db_name));
+				physical_schema_name = pstrdup(get_guest_schema_name(db_name));
 			}
 			else
 			{
@@ -2245,10 +2245,12 @@ Datum sp_babelfish_volatility(PG_FUNCTION_ARGS)
 						"WHEN t1.provolatile = 's' THEN 'stable' "
 						"ELSE 'immutable' "
 					"END AS Volatility "
-					"from (SELECT (aclexplode(proacl)).*, proname, provolatile, pronamespace from pg_proc WHERE prokind = 'f') t1 "
+					"from pg_proc t1 "
 					"JOIN pg_namespace t2 ON t1.pronamespace = t2.oid "
 					"JOIN sys.babelfish_namespace_ext t3 ON t3.nspname = t2.nspname "
-					"where t1.grantee = %d AND t3.dbid = sys.db_id() ORDER BY t3.orig_name, t1.proname", user_id
+					"where has_function_privilege(t1.oid, CAST('EXECUTE' as text)) "
+					"AND t3.dbid = sys.db_id() AND prokind = 'f' "
+					"ORDER BY t3.orig_name, t1.proname"
 				);
 		}
 		else

--- a/test/JDBC/expected/Test-sp_babelfish_volatility-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_babelfish_volatility-vu-cleanup.out
@@ -43,6 +43,9 @@ go
 drop user test_sp_babelfish_volatility_user
 go
 
+drop login test_sp_babelfish_volatility_login_2
+go
+
 use master
 go
 

--- a/test/JDBC/expected/Test-sp_babelfish_volatility-vu-prepare.out
+++ b/test/JDBC/expected/Test-sp_babelfish_volatility-vu-prepare.out
@@ -62,3 +62,9 @@ go
 
 create function [test_bbf_vol_f1;drop table test_bbf_vol_t1;]() returns int begin declare @a int; set @a = 1; return @a; end
 go
+
+use test_sp_babelfish_volatility_db1
+go
+
+CREATE LOGIN test_sp_babelfish_volatility_login_2 WITH PASSWORD = 'abc'
+GO

--- a/test/JDBC/expected/Test-sp_babelfish_volatility-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_babelfish_volatility-vu-verify.out
@@ -49,6 +49,53 @@ nvarchar#!#varchar#!#text
 dbo#!#test_sp_babelfish_volatility_f1#!#volatile
 ~~END~~
 
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'stable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f1#!#stable
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'immutable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f1#!#immutable
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'volatile'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'random'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: "random" is not a valid volatility)~~
+
+sp_babelfish_volatility '.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
 
 /* test with schema name */
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
@@ -92,6 +139,53 @@ go
 ~~ERROR (Message: "random" is not a valid volatility)~~
 
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+test_sp_babelfish_volatility_schema1#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+test_sp_babelfish_volatility_schema1#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1', 'stable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+test_sp_babelfish_volatility_schema1#!#test_sp_babelfish_volatility_f1#!#stable
+~~END~~
+
+sp_babelfish_volatility '"test_sp_babelfish_volatility_schema1".test_sp_babelfish_volatility_f1', 'immutable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+test_sp_babelfish_volatility_schema1#!#test_sp_babelfish_volatility_f1#!#immutable
+~~END~~
+
+sp_babelfish_volatility '[test_sp_babelfish_volatility_schema1].test_sp_babelfish_volatility_f1', 'volatile'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+test_sp_babelfish_volatility_schema1#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1', 'random'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: "random" is not a valid volatility)~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
 go
 ~~START~~
 nvarchar#!#varchar#!#text
@@ -429,6 +523,24 @@ go
 nvarchar#!#varchar#!#text
 ~~END~~
 
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function does not exist)~~
+
+sp_babelfish_volatility 'dbo.test_sp_babelfish_volatility_f2'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: current user does not have priviledges on the function)~~
+
+sp_babelfish_volatility
+go
+~~START~~
+nvarchar#!#varchar#!#text
+~~END~~
+
 
 -- tsql
 /* grant access to current user */
@@ -457,6 +569,28 @@ dbo#!#test_sp_babelfish_volatility_f2#!#stable
 ~~END~~
 
 exec sys.sp_babelfish_volatility
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f2#!#stable
+test_sp_babelfish_volatility_schema2#!#test_sp_babelfish_volatility_f1#!#stable
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema2.test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+test_sp_babelfish_volatility_schema2#!#test_sp_babelfish_volatility_f1#!#stable
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f2'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+dbo#!#test_sp_babelfish_volatility_f2#!#stable
+~~END~~
+
+sp_babelfish_volatility
 go
 ~~START~~
 nvarchar#!#varchar#!#text
@@ -525,6 +659,63 @@ go
 revoke execute on test_sp_babelfish_volatility_schema2.test_sp_babelfish_volatility_f1 from test_sp_babelfish_volatility_user
 go
 revoke execute on test_sp_babelfish_volatility_f2 from test_sp_babelfish_volatility_user
+go
+
+-- tsql
+/* test default schema in guest user */
+use test_sp_babelfish_volatility_db1
+go
+grant connect to guest
+go
+
+-- tsql     user=test_sp_babelfish_volatility_login_2 password='abc'
+use test_sp_babelfish_volatility_db1
+go
+SELECT current_user
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+create function test_sp_babelfish_volatility_f1() returns int begin declare @a int; set @a = 1; return @a; end
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+guest#!#test_sp_babelfish_volatility_f1#!#volatile
+~~END~~
+
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'stable';
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+~~START~~
+nvarchar#!#varchar#!#text
+guest#!#test_sp_babelfish_volatility_f1#!#stable
+~~END~~
+
+sp_babelfish_volatility 'dbo.test_sp_babelfish_volatility_f2'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: current user does not have priviledges on the function)~~
+
+sp_babelfish_volatility
+go
+~~START~~
+nvarchar#!#varchar#!#text
+guest#!#test_sp_babelfish_volatility_f1#!#stable
+~~END~~
+
+drop function test_sp_babelfish_volatility_f1
+go
+
+-- tsql
+use test_sp_babelfish_volatility_db1
+go
+revoke connect from guest
 go
 
 -- psql

--- a/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-cleanup.sql
@@ -43,6 +43,9 @@ go
 drop user test_sp_babelfish_volatility_user
 go
 
+drop login test_sp_babelfish_volatility_login_2
+go
+
 use master
 go
 

--- a/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-prepare.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-prepare.sql
@@ -62,3 +62,9 @@ go
 
 create function [test_bbf_vol_f1;drop table test_bbf_vol_t1;]() returns int begin declare @a int; set @a = 1; return @a; end
 go
+
+use test_sp_babelfish_volatility_db1
+go
+
+CREATE LOGIN test_sp_babelfish_volatility_login_2 WITH PASSWORD = 'abc'
+GO

--- a/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-verify.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-verify.mix
@@ -20,6 +20,24 @@ exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'random'
 go
 exec sys.sp_babelfish_volatility '.test_sp_babelfish_volatility_f1'
 go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'stable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'immutable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'volatile'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'random'
+go
+sp_babelfish_volatility '.test_sp_babelfish_volatility_f1'
+go
 
 /* test with schema name */
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
@@ -39,6 +57,24 @@ go
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1', 'random'
 go
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1', 'stable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility '"test_sp_babelfish_volatility_schema1".test_sp_babelfish_volatility_f1', 'immutable'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility '[test_sp_babelfish_volatility_schema1].test_sp_babelfish_volatility_f1', 'volatile'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1', 'random'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema1.test_sp_babelfish_volatility_f1'
 go
 
 /* testing for trailing spaces */
@@ -171,6 +207,12 @@ exec sys.sp_babelfish_volatility 'dbo.test_sp_babelfish_volatility_f2'
 go
 exec sys.sp_babelfish_volatility
 go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'dbo.test_sp_babelfish_volatility_f2'
+go
+sp_babelfish_volatility
+go
 
 /* grant access to current user */
 -- tsql
@@ -189,6 +231,12 @@ go
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_f2'
 go
 exec sys.sp_babelfish_volatility
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_schema2.test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f2'
+go
+sp_babelfish_volatility
 go
 
 /* test for default schema */
@@ -221,6 +269,39 @@ go
 revoke execute on test_sp_babelfish_volatility_schema2.test_sp_babelfish_volatility_f1 from test_sp_babelfish_volatility_user
 go
 revoke execute on test_sp_babelfish_volatility_f2 from test_sp_babelfish_volatility_user
+go
+
+/* test default schema in guest user */
+-- tsql
+use test_sp_babelfish_volatility_db1
+go
+grant connect to guest
+go
+
+-- tsql     user=test_sp_babelfish_volatility_login_2 password='abc'
+use test_sp_babelfish_volatility_db1
+go
+SELECT current_user
+go
+create function test_sp_babelfish_volatility_f1() returns int begin declare @a int; set @a = 1; return @a; end
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1', 'stable';
+go
+sp_babelfish_volatility 'test_sp_babelfish_volatility_f1'
+go
+sp_babelfish_volatility 'dbo.test_sp_babelfish_volatility_f2'
+go
+sp_babelfish_volatility
+go
+drop function test_sp_babelfish_volatility_f1
+go
+
+-- tsql
+use test_sp_babelfish_volatility_db1
+go
+revoke connect from guest
 go
 
 -- psql


### PR DESCRIPTION
3_X_PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1240
Signed-off-by: Shlok Kumar Kyal ([skkyal@amazon.com](mailto:skkyal@amazon.com))

### Description

Previously when the procedure is called as `sp_babelfish_volatility` without any arguement is not giving expected result. But `sys.sp_babelfish_volatility`  without any arguement was giving expected result. So, previously we were using `aclexplode(proacl)` to check the user priviledge which donot cover all cases. Instead used `has_function_privilege` function with this PR, which take care for that cases.

Also earlier, the default schema for guest user was set to `dbo` schema. Recently we have added guest schema for guest user. So we need to set default schema for guest user as guest schema. With this changes the guest schema is looked up for guest user by default.


### Issues Resolved
BABEL - 3699

### Test Scenarios Covered ###
* **Use case based - yes**


* **Boundary conditions - yes**


* **Arbitrary inputs - yes**


* **Negative test cases - yes**


* **Minor version upgrade tests - yes**


* **Major version upgrade tests - yes**


* **Performance tests - NA**


* **Tooling impact - NA**


* **Client tests - NA**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).