### PR TITLE
SCOPE_IDENTITY should return identity value in correct scope.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -6,6 +6,11 @@ RETURNS INT8
 AS 'babelfishpg_tsql', 'get_last_identity'
 LANGUAGE C STABLE;
 
+CREATE OR REPLACE FUNCTION sys.babelfish_get_scope_identity()
+RETURNS INT8
+AS 'babelfishpg_tsql', 'get_scope_identity'
+LANGUAGE C STABLE;
+
 CREATE OR REPLACE FUNCTION sys.bbf_get_current_physical_schema_name(IN schemaname TEXT)
 RETURNS TEXT
 AS 'babelfishpg_tsql', 'get_current_physical_schema_name'

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -236,7 +236,7 @@ LANGUAGE C STABLE;
 CREATE OR REPLACE FUNCTION sys.scope_identity()
 RETURNS numeric(38,0) AS
 $BODY$
-	SELECT sys.babelfish_get_last_identity_numeric()::numeric(38,0);
+	SELECT sys.babelfish_get_scope_identity()::numeric(38,0);
 $BODY$
 LANGUAGE SQL STABLE;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -31,6 +31,20 @@ end
 $$
 LANGUAGE plpgsql;
 
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_scope_identity()
+RETURNS INT8
+AS 'babelfishpg_tsql', 'get_scope_identity'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION sys.scope_identity()
+RETURNS numeric(38,0) AS
+$BODY$
+ SELECT sys.babelfish_get_scope_identity()::numeric(38,0);
+$BODY$
+LANGUAGE SQL STABLE;
+
+
 /*
  * SCHEMATA view
  */

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -56,6 +56,18 @@ LANGUAGE plpgsql;
  * final behaviour.
  */
 
+CREATE OR REPLACE FUNCTION sys.babelfish_get_scope_identity()
+RETURNS INT8
+AS 'babelfishpg_tsql', 'get_scope_identity'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION sys.scope_identity()
+RETURNS numeric(38,0) AS
+$BODY$
+ SELECT sys.babelfish_get_scope_identity()::numeric(38,0);
+$BODY$
+LANGUAGE SQL STABLE;
+
 create or replace view sys.views as 
 select 
   t.relname as name

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -22,4 +22,6 @@ extern bool metadata_inconsistency_check_enabled(void);
 int pltsql_new_guc_nest_level(void);
 void pltsql_revert_guc(int nest_level);
 
+extern int pltsql_new_scope_identity_nest_level(void);
+extern void pltsql_revert_last_scope_identity(int nest_level);
 #endif

--- a/contrib/babelfishpg_tsql/src/pl_funcs-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_funcs-2.c
@@ -10,6 +10,7 @@
 #include "pltsql-2.h"
 #include "pltsql_instr.h"
 #include "utils/builtins.h"
+#include "utils/numeric.h"
 #include "utils/syscache.h"
 
 static int cmpfunc(const void *a, const void *b)
@@ -121,6 +122,23 @@ get_last_identity(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	}
 	PG_END_TRY();
+}
+
+PG_FUNCTION_INFO_V1(get_scope_identity);
+
+Datum
+get_scope_identity(PG_FUNCTION_ARGS)
+{
+    PG_TRY();
+    {
+        PG_RETURN_INT64(last_scope_identity_value());
+    }
+    PG_CATCH();
+    {
+        FlushErrorState();
+        PG_RETURN_NULL();
+    }
+    PG_END_TRY();
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3902,6 +3902,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	Datum		retval;
 	int			rc;
 	int                     save_nestlevel;
+	int			scope_level;
 	MemoryContext	savedPortalCxt;
 	bool support_tsql_trans = pltsql_support_tsql_transactions();
 	Oid prev_procid = InvalidOid;
@@ -3956,6 +3957,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 		func->use_count++;
 
 		save_nestlevel = pltsql_new_guc_nest_level();
+		scope_level = pltsql_new_scope_identity_nest_level();
 
 		prev_procid = procid_var;
 		PG_TRY();
@@ -3997,6 +3999,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 			ENRDropTempTables(currentQueryEnv);
 			remove_queryEnv();
 			pltsql_revert_guc(save_nestlevel);
+			pltsql_revert_last_scope_identity(scope_level);
 			terminate_batch(true /* send_error */, false /* compile_error */);
 			sql_dialect = saved_dialect;
 			return retval;
@@ -4016,6 +4019,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	ENRDropTempTables(currentQueryEnv);
 	remove_queryEnv();
 	pltsql_revert_guc(save_nestlevel);
+	pltsql_revert_last_scope_identity(scope_level);
 
 	terminate_batch(false /* send_error */, false /* compile_error */);
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2073,6 +2073,7 @@ extern int64 last_identity_value(void);
 extern void pltsql_nextval_identity(Oid seqid, int64 val);
 extern void pltsql_resetcache_identity(void);
 extern int64 pltsql_setval_identity(Oid seqid, int64 val, int64 last_val);
+extern int64 last_scope_identity_value(void);
 
 /*
  * Functions in linked_servers.c

--- a/test/JDBC/expected/Test-Identity-before-14_7-or-15_2-vu-cleanup.out
+++ b/test/JDBC/expected/Test-Identity-before-14_7-or-15_2-vu-cleanup.out
@@ -1,0 +1,47 @@
+DROP PROCEDURE test_identity_vu_prepare_p1
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func1
+GO
+
+DROP TRIGGER test_indentity_vu_prepare_trig1
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func2
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func3
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func4
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p2
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p3
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p4
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p5
+GO
+
+DROP TABLE test_identity_vu_prepare_t1
+GO
+
+DROP TABLE test_identity_vu_prepare_t2
+GO
+
+DROP TABLE test_identity_vu_prepare_t3
+GO
+
+DROP TABLE test_identity_vu_prepare_t4
+GO
+
+DROP TABLE test_identity_vu_prepare_t5
+GO
+
+DROP TABLE test_identity_vu_prepare_t6
+GO

--- a/test/JDBC/expected/Test-Identity-before-14_7-or-15_2-vu-prepare.out
+++ b/test/JDBC/expected/Test-Identity-before-14_7-or-15_2-vu-prepare.out
@@ -37,13 +37,12 @@ numeric
 ~~END~~
 
 
--- should succeed on atleast 14_7 or 15_2, should still succeed after upgrade
+-- should fail before 14_7 or 15_2, should succeed after upgrade to 14_7 or 15_2
 SELECT sys.babelfish_get_scope_identity()
 GO
-~~START~~
-bigint
-1
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function sys.babelfish_get_scope_identity() does not exist)~~
 
 
 CREATE PROCEDURE test_identity_vu_prepare_p1
@@ -53,7 +52,6 @@ SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE FUNCTION test_identity_vu_prepare_func1()
@@ -82,7 +80,6 @@ SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t2
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t2')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE TABLE test_identity_vu_prepare_t3
@@ -98,7 +95,6 @@ SELECT MAX(DepartmentID) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t3
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t3')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 INSERT test_identity_vu_prepare_t3 VALUES ('Babelfish6'),('Babelfish7'),('Babelfish8')
@@ -121,18 +117,11 @@ GO
 ~~ROW COUNT: 1~~
 
 
--- IDENTITY vs SCOPE_IDENTITY vs IDENT_CURRENT
--- The value of IDENTITY should not be the same as SCOPE_IDENTITY
--- IDENTITY should return value of identity from trigger (t3)
--- SCOPE_IDENTITY should return value of identity in scope of last INSERT (t2)
--- IDENT_CURRENT(t2) should return value of identity of t2 regardless of scope
--- The output in expected files are verified against SQL Server
 SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t2
 SELECT MAX(DepartmentID) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t3
 SELECT @@IDENTITY
 SELECT SCOPE_IDENTITY()
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t2')
-SELECT sys.babelfish_get_scope_identity()
 GO
 ~~START~~
 smallint
@@ -151,16 +140,11 @@ numeric
 
 ~~START~~
 numeric
-4
+115
 ~~END~~
 
 ~~START~~
 numeric
-4
-~~END~~
-
-~~START~~
-bigint
 4
 ~~END~~
 
@@ -226,6 +210,7 @@ CREATE TABLE test_identity_vu_prepare_t6
 )
 GO
 
+
 CREATE PROCEDURE test_identity_vu_prepare_p5
 AS
 INSERT INTO test_identity_vu_prepare_t6 
@@ -236,3 +221,7 @@ GO
 CREATE VIEW scope_identity_view AS
 SELECT sys.babelfish_get_scope_identity()
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function sys.babelfish_get_scope_identity() does not exist)~~
+

--- a/test/JDBC/expected/Test-Identity-before-14_7-or-15_2-vu-verify.out
+++ b/test/JDBC/expected/Test-Identity-before-14_7-or-15_2-vu-verify.out
@@ -1,5 +1,31 @@
 EXEC test_identity_vu_prepare_p1
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+
+CREATE VIEW scope_identity_view AS
+SELECT sys.babelfish_get_scope_identity()
+GO
 
 -- SCOPE_IDENTITY should return NULL because insert into t1 happened inside a function
 -- Validated the same behaviour in SQLServer
@@ -7,15 +33,68 @@ SELECT MAX(id) as MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
-SELECT sys.babelfish_get_scope_identity()
 SELECT * FROM scope_identity_view
 GO
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+numeric
+<NULL>
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+~~START~~
+bigint
+<NULL>
+~~END~~
+
 
 EXEC test_identity_vu_prepare_p1
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
 
 SELECT * FROM test_identity_vu_prepare_t1 ORDER BY id
 GO
+~~START~~
+int#!#nvarchar
+1#!#Nirmit_Shah
+2#!#Nirmit_Shah
+3#!#Nirmit_Shah
+~~END~~
+
 
 -- SCOPE_IDENTITY should not be the same as IDENTITY
 -- SCOPE_IDENTITY matches max(id) in t2
@@ -23,67 +102,223 @@ GO
 -- validated same behaviour in SQLServer
 EXEC test_identity_vu_prepare_p2
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+5
+~~END~~
+
+~~START~~
+numeric
+5
+~~END~~
+
+~~START~~
+numeric
+120
+~~END~~
+
+~~START~~
+numeric
+5
+~~END~~
+
 
 -- insert into t3, no triggers during insert into t3
 -- all identities should be the same
 -- validated in SQL Server
 EXEC test_identity_vu_prepare_p3
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+125
+~~END~~
+
+~~START~~
+numeric
+125
+~~END~~
+
+~~START~~
+numeric
+125
+~~END~~
+
+~~START~~
+numeric
+125
+~~END~~
+
 
 SELECT * FROM test_identity_vu_prepare_t2 ORDER BY id
 GO
+~~START~~
+smallint#!#nvarchar
+1#!#Babelfish1
+2#!#Babelfish2
+3#!#Babelfish3
+4#!#Babelfish12
+5#!#Babelfish4
+~~END~~
+
 SELECT * FROM test_identity_vu_prepare_t3 ORDER BY DepartmentID
 GO
+~~START~~
+int#!#varchar
+100#!#Babelfish6
+105#!#Babelfish7
+110#!#Babelfish8
+115#!#Babelfish11
+120#!#Babelfish11
+125#!#Babelfish5
+~~END~~
+
 
 SELECT test_identity_vu_prepare_func1()
 GO
+~~START~~
+tinyint
+3
+~~END~~
+
 
 SELECT test_identity_vu_prepare_func2()
 GO
+~~START~~
+tinyint
+5
+~~END~~
+
 
 SELECT test_identity_vu_prepare_func3()
 GO
+~~START~~
+tinyint
+125
+~~END~~
+
 
 SELECT * FROM test_identity_vu_prepare_t4 ORDER BY Name
 GO
+~~START~~
+varchar#!#int
+Babelfish13#!#21
+Babelfish14#!#20
+Babelfish15#!#23
+~~END~~
+
 
 -- SCOPE_IDENTITY is NULL because all INSERTs so far happened inside a function
 -- Similarly, this was validated against SQL Server
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t4')
-SELECT sys.babelfish_get_scope_identity()
 GO
+~~START~~
+numeric
+<NULL>
+~~END~~
+
+~~START~~
+numeric
+125
+~~END~~
+
+~~START~~
+numeric
+<NULL>
+~~END~~
+
 
 ALTER TABLE test_identity_vu_prepare_t4 ADD id INT IDENTITY(1,1) NOT NULL
 GO
 
 SELECT * FROM test_identity_vu_prepare_t4 ORDER BY Name
 GO
+~~START~~
+varchar#!#int#!#int
+Babelfish13#!#21#!#1
+Babelfish14#!#20#!#2
+Babelfish15#!#23#!#3
+~~END~~
+
 
 SELECT MAX(id) as MaximumUsedIdentity FROM test_identity_vu_prepare_t4
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t4')
-SELECT sys.babelfish_get_scope_identity()
 GO
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
 
 SELECT * FROM test_identity_vu_prepare_t5 ORDER BY Name
 GO
+~~START~~
+varchar#!#int
+Babelfish16#!#21
+Babelfish17#!#20
+Babelfish18#!#23
+~~END~~
+
 
 SELECT test_identity_vu_prepare_func4()
 GO
+~~START~~
+tinyint
+<NULL>
+~~END~~
+
 
 EXEC test_identity_vu_prepare_p4
 GO
 
 SELECT test_identity_vu_prepare_func4()
 GO
+~~START~~
+tinyint
+3
+~~END~~
+
 
 INSERT test_identity_vu_prepare_t6 
 OUTPUT INSERTED.ID
 VALUES ('Babelfish5'),('Babelfish6'),('Babelfish7')
 GO
+~~START~~
+int
+1
+2
+3
+~~END~~
+
 
 EXEC test_identity_vu_prepare_p5
 GO
+~~START~~
+int
+4
+~~END~~
+

--- a/test/JDBC/expected/Test-Identity-vu-verify.out
+++ b/test/JDBC/expected/Test-Identity-vu-verify.out
@@ -22,11 +22,20 @@ numeric
 2
 ~~END~~
 
+~~START~~
+bigint
+2
+~~END~~
 
+
+-- SCOPE_IDENTITY should return NULL because insert into t1 happened inside a function
+-- Validated the same behaviour in SQLServer
 SELECT MAX(id) as MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
+SELECT sys.babelfish_get_scope_identity()
+SELECT * FROM scope_identity_view
 GO
 ~~START~~
 int
@@ -35,7 +44,7 @@ int
 
 ~~START~~
 numeric
-2
+<NULL>
 ~~END~~
 
 ~~START~~
@@ -46,6 +55,16 @@ numeric
 ~~START~~
 numeric
 2
+~~END~~
+
+~~START~~
+bigint
+<NULL>
+~~END~~
+
+~~START~~
+bigint
+<NULL>
 ~~END~~
 
 
@@ -73,8 +92,13 @@ numeric
 3
 ~~END~~
 
+~~START~~
+bigint
+3
+~~END~~
 
-SELECT * FROM test_identity_vu_prepare_t1
+
+SELECT * FROM test_identity_vu_prepare_t1 ORDER BY id
 GO
 ~~START~~
 int#!#nvarchar
@@ -84,6 +108,10 @@ int#!#nvarchar
 ~~END~~
 
 
+-- SCOPE_IDENTITY should not be the same as IDENTITY
+-- SCOPE_IDENTITY matches max(id) in t2
+-- IDENTITY is the value from trigger
+-- validated same behaviour in SQLServer
 EXEC test_identity_vu_prepare_p2
 GO
 ~~ROW COUNT: 1~~
@@ -97,7 +125,7 @@ smallint
 
 ~~START~~
 numeric
-120
+5
 ~~END~~
 
 ~~START~~
@@ -110,7 +138,15 @@ numeric
 5
 ~~END~~
 
+~~START~~
+bigint
+5
+~~END~~
 
+
+-- insert into t3, no triggers during insert into t3
+-- all identities should be the same
+-- validated in SQL Server
 EXEC test_identity_vu_prepare_p3
 GO
 ~~ROW COUNT: 1~~
@@ -135,8 +171,13 @@ numeric
 125
 ~~END~~
 
+~~START~~
+bigint
+125
+~~END~~
 
-SELECT * FROM test_identity_vu_prepare_t2
+
+SELECT * FROM test_identity_vu_prepare_t2 ORDER BY id
 GO
 ~~START~~
 smallint#!#nvarchar
@@ -147,7 +188,7 @@ smallint#!#nvarchar
 5#!#Babelfish4
 ~~END~~
 
-SELECT * FROM test_identity_vu_prepare_t3
+SELECT * FROM test_identity_vu_prepare_t3 ORDER BY DepartmentID
 GO
 ~~START~~
 int#!#varchar
@@ -184,7 +225,7 @@ tinyint
 ~~END~~
 
 
-SELECT * FROM test_identity_vu_prepare_t4
+SELECT * FROM test_identity_vu_prepare_t4 ORDER BY Name
 GO
 ~~START~~
 varchar#!#int
@@ -194,13 +235,16 @@ Babelfish15#!#23
 ~~END~~
 
 
+-- SCOPE_IDENTITY is NULL because all INSERTs so far happened inside a function
+-- Similarly, this was validated against SQL Server
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t4')
+SELECT sys.babelfish_get_scope_identity()
 GO
 ~~START~~
 numeric
-125
+<NULL>
 ~~END~~
 
 ~~START~~
@@ -213,11 +257,16 @@ numeric
 <NULL>
 ~~END~~
 
+~~START~~
+bigint
+<NULL>
+~~END~~
+
 
 ALTER TABLE test_identity_vu_prepare_t4 ADD id INT IDENTITY(1,1) NOT NULL
 GO
 
-SELECT * FROM test_identity_vu_prepare_t4
+SELECT * FROM test_identity_vu_prepare_t4 ORDER BY Name
 GO
 ~~START~~
 varchar#!#int#!#int
@@ -231,6 +280,7 @@ SELECT MAX(id) as MaximumUsedIdentity FROM test_identity_vu_prepare_t4
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t4')
+SELECT sys.babelfish_get_scope_identity()
 GO
 ~~START~~
 int
@@ -252,8 +302,13 @@ numeric
 3
 ~~END~~
 
+~~START~~
+bigint
+3
+~~END~~
 
-SELECT * FROM test_identity_vu_prepare_t5
+
+SELECT * FROM test_identity_vu_prepare_t5 ORDER BY Name
 GO
 ~~START~~
 varchar#!#int

--- a/test/JDBC/expected/Test-scope-identity.out
+++ b/test/JDBC/expected/Test-scope-identity.out
@@ -1,0 +1,303 @@
+
+-- Testcases for BABEL-3907, BABEL-3413
+-- There exist some Identity testing already.
+-- see Test-Identity (MVU and standlone), identity_function (MVU and standalone)
+-- Test 1
+-- Two tables with identity column. First table has a trigger to insert into second table.
+-- SCOPE_IDENTITY should show identity value from first table because it is in the scope
+-- while IDENTITY should show value on second table
+-- This was validated against SQLServer
+CREATE TABLE ScopeIdentityMainTable (
+ ID int IDENTITY(1,1) NOT NULL,
+ FIRSTNAME varchar(255),
+ LASTNAME varchar(255),
+ PRIMARY KEY (ID)
+);
+GO
+
+CREATE TABLE ScopeIdentityTableUpdatedByKey (
+ ID int,
+ FIRSTNAME varchar(255),
+ LASTNAME varchar(255),
+ VALTYPE varchar(255),
+ SQLIDENTITYCOL [int] IDENTITY(1,1) NOT NULL,
+ FOREIGN KEY (ID) REFERENCES ScopeIdentityMainTable(ID)
+);
+GO
+
+CREATE TABLE ScopeIdentityTableUpdatedByTrigger (
+ ID int,
+ VALTYPE varchar(255),
+ SQLIDENTITYCOL [int] IDENTITY(1,1) NOT NULL
+)
+GO
+
+-- Insert a value to make sure this table has a different value than MainTable
+INSERT INTO ScopeIdentityTableUpdatedByTrigger (id, valtype) VALUES ( 5, 'Name');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TRIGGER UpdateTableByTrigger
+ON ScopeIdentityMainTable
+FOR INSERT 
+AS
+ INSERT INTO ScopeIdentityTableUpdatedByTrigger(Id, ValType)
+ SELECT Id ,'Name' FROM INSERTED;
+GO
+
+SELECT * FROM ScopeIdentityMainTable;
+GO
+~~START~~
+int#!#varchar#!#varchar
+~~END~~
+
+
+SELECT * FROM ScopeIdentityTableUpdatedByKey;
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#int
+~~END~~
+
+
+SELECT * FROM ScopeIdentityTableUpdatedByTrigger;
+GO
+~~START~~
+int#!#varchar#!#int
+5#!#Name#!#1
+~~END~~
+
+
+INSERT INTO ScopeIdentityMainTable (firstname, lastname) values ('Infor', 'HMS');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT @@IDENTITY as [Identity]
+ , SCOPE_IDENTITY() AS [Scope_Identity]
+ , IDENT_CURRENT('ScopeIdentityMainTable') AS IC_MainTable 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByKey') AS IC_TableUpdatedByKey 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByTrigger') AS IC_TableUpdatedByTrigger
+ , sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+~~START~~
+numeric#!#numeric#!#numeric#!#numeric#!#numeric#!#bigint
+2#!#1#!#1#!#1#!#2#!#1
+~~END~~
+
+
+-- Test 2
+-- Create a Stored Procedure (SP1) that calls SP2 which does an INSERT to MainTable
+-- The INSERT INTO MainTable does a trigger INSERT INTO TableUpdatedByTrigger
+-- This was validated against SQL Server
+CREATE PROCEDURE ScopeIdentitySP2
+AS
+    INSERT ScopeIdentityMainTable (firstname, lastname) values ('Infor2', 'HMS2');
+    SELECT MAX(id) AS MaximumUsedIdentity FROM ScopeIdentityMainTable
+    SELECT SCOPE_IDENTITY()
+    SELECT @@IDENTITY
+    SELECT IDENT_CURRENT('ScopeIdentityMainTable')
+GO
+
+-- SCOPE_IDENTITY should be NULL because INSERT happened outside scope
+CREATE PROCEDURE ScopeIdentitySP1
+AS
+    EXEC ScopeIdentitySP2
+    SELECT MAX(id) AS MaximumUsedIdentity FROM ScopeIdentityMainTable
+    SELECT SCOPE_IDENTITY()
+    SELECT @@IDENTITY
+    SELECT IDENT_CURRENT('ScopeIdentityMainTable')
+GO
+
+EXEC ScopeIdentitySP1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+numeric
+<NULL>
+~~END~~
+
+~~START~~
+numeric
+3
+~~END~~
+
+~~START~~
+numeric
+2
+~~END~~
+
+
+SELECT @@IDENTITY as [Identity]
+ , SCOPE_IDENTITY() AS [Scope_Identity]
+ , IDENT_CURRENT('ScopeIdentityMainTable') AS IC_MainTable 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByKey') AS IC_TableUpdatedByKey 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByTrigger') AS IC_TableUpdatedByTrigger
+ , sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+~~START~~
+numeric#!#numeric#!#numeric#!#numeric#!#numeric#!#bigint
+3#!#1#!#2#!#1#!#3#!#1
+~~END~~
+
+
+
+-- Test 3
+-- Verify scope_identity() inside sp_executesql
+-- Similarly as above, the output was validated against SQL Server
+CREATE FUNCTION ScopeIdentityFunc1()
+RETURNS TINYINT
+AS
+BEGIN
+RETURN SCOPE_IDENTITY()
+END
+GO
+
+-- ScopeIdentityFunc1 should return NULL because insert happened outside scope
+INSERT ScopeIdentityMainTable (firstname, lastname) values ('Infor3', 'HMS3');
+SELECT dbo.ScopeIdentityFunc1();
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+tinyint
+<NULL>
+~~END~~
+
+
+sp_executesql N'INSERT INTO ScopeIdentityMainTable (firstname, lastname) values (@var1, @var2);
+SELECT dbo.ScopeIdentityFunc1(), @@IDENTITY as [Identity], SCOPE_IDENTITY() AS [Scope_Identity]',
+N'@var1 varchar(20), @var2 varchar(20)', @var1='Infor4', @var2='HMS4';
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+tinyint#!#numeric#!#numeric
+<NULL>#!#5#!#4
+~~END~~
+
+
+
+-- Test 4
+-- Test SP -> sp_executesql -> trigger nesting
+CREATE PROCEDURE ScopeIdentitySP3
+AS
+    EXEC sp_executesql N'INSERT INTO ScopeIdentityMainTable (firstname, lastname) values (@var1, @var2);
+    SELECT dbo.ScopeIdentityFunc1(), @@IDENTITY as [Identity], SCOPE_IDENTITY() AS [Scope_Identity]',
+    N'@var1 varchar(20), @var2 varchar(20)', @var1='Infor5', @var2='HMS5';
+    SELECT MAX(id) AS MaximumUsedIdentity FROM ScopeIdentityMainTable
+    SELECT SCOPE_IDENTITY()
+    SELECT @@IDENTITY
+    SELECT IDENT_CURRENT('ScopeIdentityMainTable')
+    SELECT sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+
+EXEC ScopeIdentitySP3
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+tinyint#!#numeric#!#numeric
+<NULL>#!#6#!#5
+~~END~~
+
+~~START~~
+int
+5
+~~END~~
+
+~~START~~
+numeric
+<NULL>
+~~END~~
+
+~~START~~
+numeric
+6
+~~END~~
+
+~~START~~
+numeric
+5
+~~END~~
+
+~~START~~
+bigint
+<NULL>
+~~END~~
+
+
+SELECT @@IDENTITY as [Identity]
+ , SCOPE_IDENTITY() AS [Scope_Identity]
+ , IDENT_CURRENT('ScopeIdentityMainTable') AS IC_MainTable 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByKey') AS IC_TableUpdatedByKey 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByTrigger') AS IC_TableUpdatedByTrigger
+ , sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+~~START~~
+numeric#!#numeric#!#numeric#!#numeric#!#numeric#!#bigint
+6#!#3#!#5#!#1#!#6#!#3
+~~END~~
+
+
+
+DROP FUNCTION ScopeIdentityFunc1
+GO
+
+DROP PROCEDURE ScopeIdentitySP1
+GO
+
+DROP PROCEDURE ScopeIdentitySP2
+GO
+
+DROP PROCEDURE ScopeIdentitySP3
+GO
+
+DROP TRIGGER UpdateTableByTrigger
+GO
+
+DROP TABLE ScopeIdentityTableUpdatedByTrigger
+GO
+
+DROP TABLE ScopeIdentityTableUpdatedByKey
+GO
+
+DROP TABLE ScopeIdentityMainTable
+GO
+

--- a/test/JDBC/expected/identity_function-vu-verify.out
+++ b/test/JDBC/expected/identity_function-vu-verify.out
@@ -36,11 +36,13 @@ int
 ~~END~~
 
 
+-- scope_identity returns NULL because proc is runs in a different scope.
+-- This was validated against SQL Server
 exec indentity_function_tests_proc
 GO
 ~~START~~
 numeric#!#numeric#!#numeric#!#bigint
-1#!#1#!#1#!#1
+<NULL>#!#1#!#1#!#1
 ~~END~~
 
 

--- a/test/JDBC/input/Test-Identity-before-14_7-or-15_2-vu-cleanup.sql
+++ b/test/JDBC/input/Test-Identity-before-14_7-or-15_2-vu-cleanup.sql
@@ -1,0 +1,47 @@
+DROP PROCEDURE test_identity_vu_prepare_p1
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func1
+GO
+
+DROP TRIGGER test_indentity_vu_prepare_trig1
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func2
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func3
+GO
+
+DROP FUNCTION test_identity_vu_prepare_func4
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p2
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p3
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p4
+GO
+
+DROP PROCEDURE test_identity_vu_prepare_p5
+GO
+
+DROP TABLE test_identity_vu_prepare_t1
+GO
+
+DROP TABLE test_identity_vu_prepare_t2
+GO
+
+DROP TABLE test_identity_vu_prepare_t3
+GO
+
+DROP TABLE test_identity_vu_prepare_t4
+GO
+
+DROP TABLE test_identity_vu_prepare_t5
+GO
+
+DROP TABLE test_identity_vu_prepare_t6
+GO

--- a/test/JDBC/input/Test-Identity-before-14_7-or-15_2-vu-prepare.sql
+++ b/test/JDBC/input/Test-Identity-before-14_7-or-15_2-vu-prepare.sql
@@ -8,43 +8,16 @@ GO
 
 INSERT INTO test_identity_vu_prepare_t1 VALUES ('Nirmit_Shah')
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
 GO
-~~START~~
-int
-1
-~~END~~
 
-~~START~~
-numeric
-1
-~~END~~
-
-~~START~~
-numeric
-1
-~~END~~
-
-~~START~~
-numeric
-1
-~~END~~
-
-
--- should succeed on atleast 14_7 or 15_2, should still succeed after upgrade
+-- should fail before 14_7 or 15_2, should succeed after upgrade to 14_7 or 15_2
 SELECT sys.babelfish_get_scope_identity()
 GO
-~~START~~
-bigint
-1
-~~END~~
-
 
 CREATE PROCEDURE test_identity_vu_prepare_p1
 AS
@@ -53,7 +26,6 @@ SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE FUNCTION test_identity_vu_prepare_func1()
@@ -72,8 +44,6 @@ GO
 
 INSERT test_identity_vu_prepare_t2 VALUES ('Babelfish1'),('Babelfish2'),('Babelfish3')
 GO
-~~ROW COUNT: 3~~
-
 
 CREATE PROCEDURE test_identity_vu_prepare_p2
 AS
@@ -82,7 +52,6 @@ SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t2
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t2')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE TABLE test_identity_vu_prepare_t3
@@ -98,13 +67,10 @@ SELECT MAX(DepartmentID) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t3
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t3')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 INSERT test_identity_vu_prepare_t3 VALUES ('Babelfish6'),('Babelfish7'),('Babelfish8')
 GO
-~~ROW COUNT: 3~~
-
 
 CREATE TRIGGER test_indentity_vu_prepare_trig1  
 ON test_identity_vu_prepare_t2  
@@ -116,54 +82,13 @@ GO
 
 INSERT INTO test_identity_vu_prepare_t2 VALUES('Babelfish12')
 GO
-~~ROW COUNT: 1~~
 
-~~ROW COUNT: 1~~
-
-
--- IDENTITY vs SCOPE_IDENTITY vs IDENT_CURRENT
--- The value of IDENTITY should not be the same as SCOPE_IDENTITY
--- IDENTITY should return value of identity from trigger (t3)
--- SCOPE_IDENTITY should return value of identity in scope of last INSERT (t2)
--- IDENT_CURRENT(t2) should return value of identity of t2 regardless of scope
--- The output in expected files are verified against SQL Server
 SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t2
 SELECT MAX(DepartmentID) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t3
 SELECT @@IDENTITY
 SELECT SCOPE_IDENTITY()
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t2')
-SELECT sys.babelfish_get_scope_identity()
 GO
-~~START~~
-smallint
-4
-~~END~~
-
-~~START~~
-int
-115
-~~END~~
-
-~~START~~
-numeric
-115
-~~END~~
-
-~~START~~
-numeric
-4
-~~END~~
-
-~~START~~
-numeric
-4
-~~END~~
-
-~~START~~
-bigint
-4
-~~END~~
-
 
 CREATE FUNCTION test_identity_vu_prepare_func2()
 RETURNS TINYINT
@@ -190,8 +115,6 @@ GO
 
 INSERT test_identity_vu_prepare_t4 VALUES ('Babelfish13',21),('Babelfish14',20),('Babelfish15',23)
 GO
-~~ROW COUNT: 3~~
-
 
 CREATE TABLE test_identity_vu_prepare_t5
 (
@@ -202,8 +125,6 @@ GO
 
 INSERT test_identity_vu_prepare_t5 VALUES ('Babelfish16',21),('Babelfish17',20),('Babelfish18',23)
 GO
-~~ROW COUNT: 3~~
-
 
 CREATE PROCEDURE test_identity_vu_prepare_p4
 AS
@@ -225,6 +146,7 @@ CREATE TABLE test_identity_vu_prepare_t6
    Name VARCHAR(20)
 )
 GO
+
 
 CREATE PROCEDURE test_identity_vu_prepare_p5
 AS

--- a/test/JDBC/input/Test-Identity-before-14_7-or-15_2-vu-verify.sql
+++ b/test/JDBC/input/Test-Identity-before-14_7-or-15_2-vu-verify.sql
@@ -1,13 +1,16 @@
 EXEC test_identity_vu_prepare_p1
 GO
 
+CREATE VIEW scope_identity_view AS
+SELECT sys.babelfish_get_scope_identity()
+GO
+
 -- SCOPE_IDENTITY should return NULL because insert into t1 happened inside a function
 -- Validated the same behaviour in SQLServer
 SELECT MAX(id) as MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
-SELECT sys.babelfish_get_scope_identity()
 SELECT * FROM scope_identity_view
 GO
 
@@ -52,7 +55,6 @@ GO
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t4')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 ALTER TABLE test_identity_vu_prepare_t4 ADD id INT IDENTITY(1,1) NOT NULL
@@ -65,7 +67,6 @@ SELECT MAX(id) as MaximumUsedIdentity FROM test_identity_vu_prepare_t4
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t4')
-SELECT sys.babelfish_get_scope_identity()
 GO
 
 SELECT * FROM test_identity_vu_prepare_t5 ORDER BY Name

--- a/test/JDBC/input/Test-Identity-vu-prepare.sql
+++ b/test/JDBC/input/Test-Identity-vu-prepare.sql
@@ -15,6 +15,10 @@ SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
 GO
 
+-- should succeed on atleast 14_7 or 15_2, should still succeed after upgrade
+SELECT sys.babelfish_get_scope_identity()
+GO
+
 CREATE PROCEDURE test_identity_vu_prepare_p1
 AS
 INSERT INTO test_identity_vu_prepare_t1 VALUES ('Nirmit_Shah')
@@ -22,6 +26,7 @@ SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t1
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t1')
+SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE FUNCTION test_identity_vu_prepare_func1()
@@ -48,6 +53,7 @@ SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t2
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t2')
+SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE TABLE test_identity_vu_prepare_t3
@@ -63,6 +69,7 @@ SELECT MAX(DepartmentID) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t3
 SELECT SCOPE_IDENTITY()
 SELECT @@IDENTITY
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t3')
+SELECT sys.babelfish_get_scope_identity()
 GO
 
 INSERT test_identity_vu_prepare_t3 VALUES ('Babelfish6'),('Babelfish7'),('Babelfish8')
@@ -79,11 +86,18 @@ GO
 INSERT INTO test_identity_vu_prepare_t2 VALUES('Babelfish12')
 GO
 
+-- IDENTITY vs SCOPE_IDENTITY vs IDENT_CURRENT
+-- The value of IDENTITY should not be the same as SCOPE_IDENTITY
+-- IDENTITY should return value of identity from trigger (t3)
+-- SCOPE_IDENTITY should return value of identity in scope of last INSERT (t2)
+-- IDENT_CURRENT(t2) should return value of identity of t2 regardless of scope
+-- The output in expected files are verified against SQL Server
 SELECT MAX(id) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t2
 SELECT MAX(DepartmentID) AS MaximumUsedIdentity FROM test_identity_vu_prepare_t3
 SELECT @@IDENTITY
 SELECT SCOPE_IDENTITY()
 SELECT IDENT_CURRENT('test_identity_vu_prepare_t2')
+SELECT sys.babelfish_get_scope_identity()
 GO
 
 CREATE FUNCTION test_identity_vu_prepare_func2()
@@ -143,10 +157,13 @@ CREATE TABLE test_identity_vu_prepare_t6
 )
 GO
 
-
 CREATE PROCEDURE test_identity_vu_prepare_p5
 AS
 INSERT INTO test_identity_vu_prepare_t6 
 OUTPUT INSERTED.ID
 VALUES ('Babelfish19')
+GO
+
+CREATE VIEW scope_identity_view AS
+SELECT sys.babelfish_get_scope_identity()
 GO

--- a/test/JDBC/input/Test-scope-identity.sql
+++ b/test/JDBC/input/Test-scope-identity.sql
@@ -1,0 +1,173 @@
+-- Testcases for BABEL-3907, BABEL-3413
+-- There exist some Identity testing already.
+-- see Test-Identity (MVU and standlone), identity_function (MVU and standalone)
+
+-- Test 1
+-- Two tables with identity column. First table has a trigger to insert into second table.
+-- SCOPE_IDENTITY should show identity value from first table because it is in the scope
+-- while IDENTITY should show value on second table
+-- This was validated against SQLServer
+CREATE TABLE ScopeIdentityMainTable (
+ ID int IDENTITY(1,1) NOT NULL,
+ FIRSTNAME varchar(255),
+ LASTNAME varchar(255),
+ PRIMARY KEY (ID)
+);
+GO
+
+CREATE TABLE ScopeIdentityTableUpdatedByKey (
+ ID int,
+ FIRSTNAME varchar(255),
+ LASTNAME varchar(255),
+ VALTYPE varchar(255),
+ SQLIDENTITYCOL [int] IDENTITY(1,1) NOT NULL,
+ FOREIGN KEY (ID) REFERENCES ScopeIdentityMainTable(ID)
+);
+GO
+
+CREATE TABLE ScopeIdentityTableUpdatedByTrigger (
+ ID int,
+ VALTYPE varchar(255),
+ SQLIDENTITYCOL [int] IDENTITY(1,1) NOT NULL
+)
+GO
+
+-- Insert a value to make sure this table has a different value than MainTable
+INSERT INTO ScopeIdentityTableUpdatedByTrigger (id, valtype) VALUES ( 5, 'Name');
+GO
+
+CREATE TRIGGER UpdateTableByTrigger
+ON ScopeIdentityMainTable
+FOR INSERT 
+AS
+ INSERT INTO ScopeIdentityTableUpdatedByTrigger(Id, ValType)
+ SELECT Id ,'Name' FROM INSERTED;
+GO
+
+SELECT * FROM ScopeIdentityMainTable;
+GO
+
+SELECT * FROM ScopeIdentityTableUpdatedByKey;
+GO
+
+SELECT * FROM ScopeIdentityTableUpdatedByTrigger;
+GO
+
+INSERT INTO ScopeIdentityMainTable (firstname, lastname) values ('Infor', 'HMS');
+GO
+
+SELECT @@IDENTITY as [Identity]
+ , SCOPE_IDENTITY() AS [Scope_Identity]
+ , IDENT_CURRENT('ScopeIdentityMainTable') AS IC_MainTable 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByKey') AS IC_TableUpdatedByKey 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByTrigger') AS IC_TableUpdatedByTrigger
+ , sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+
+-- Test 2
+-- Create a Stored Procedure (SP1) that calls SP2 which does an INSERT to MainTable
+-- The INSERT INTO MainTable does a trigger INSERT INTO TableUpdatedByTrigger
+-- This was validated against SQL Server
+CREATE PROCEDURE ScopeIdentitySP2
+AS
+    INSERT ScopeIdentityMainTable (firstname, lastname) values ('Infor2', 'HMS2');
+    SELECT MAX(id) AS MaximumUsedIdentity FROM ScopeIdentityMainTable
+    SELECT SCOPE_IDENTITY()
+    SELECT @@IDENTITY
+    SELECT IDENT_CURRENT('ScopeIdentityMainTable')
+GO
+
+-- SCOPE_IDENTITY should be NULL because INSERT happened outside scope
+CREATE PROCEDURE ScopeIdentitySP1
+AS
+    EXEC ScopeIdentitySP2
+    SELECT MAX(id) AS MaximumUsedIdentity FROM ScopeIdentityMainTable
+    SELECT SCOPE_IDENTITY()
+    SELECT @@IDENTITY
+    SELECT IDENT_CURRENT('ScopeIdentityMainTable')
+GO
+
+EXEC ScopeIdentitySP1
+GO
+
+SELECT @@IDENTITY as [Identity]
+ , SCOPE_IDENTITY() AS [Scope_Identity]
+ , IDENT_CURRENT('ScopeIdentityMainTable') AS IC_MainTable 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByKey') AS IC_TableUpdatedByKey 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByTrigger') AS IC_TableUpdatedByTrigger
+ , sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+
+
+-- Test 3
+-- Verify scope_identity() inside sp_executesql
+-- Similarly as above, the output was validated against SQL Server
+CREATE FUNCTION ScopeIdentityFunc1()
+RETURNS TINYINT
+AS
+BEGIN
+RETURN SCOPE_IDENTITY()
+END
+GO
+
+-- ScopeIdentityFunc1 should return NULL because insert happened outside scope
+INSERT ScopeIdentityMainTable (firstname, lastname) values ('Infor3', 'HMS3');
+SELECT dbo.ScopeIdentityFunc1();
+GO
+
+sp_executesql N'INSERT INTO ScopeIdentityMainTable (firstname, lastname) values (@var1, @var2);
+SELECT dbo.ScopeIdentityFunc1(), @@IDENTITY as [Identity], SCOPE_IDENTITY() AS [Scope_Identity]',
+N'@var1 varchar(20), @var2 varchar(20)', @var1='Infor4', @var2='HMS4';
+GO
+
+-- Test 4
+-- Test SP -> sp_executesql -> trigger nesting
+CREATE PROCEDURE ScopeIdentitySP3
+AS
+    EXEC sp_executesql N'INSERT INTO ScopeIdentityMainTable (firstname, lastname) values (@var1, @var2);
+    SELECT dbo.ScopeIdentityFunc1(), @@IDENTITY as [Identity], SCOPE_IDENTITY() AS [Scope_Identity]',
+    N'@var1 varchar(20), @var2 varchar(20)', @var1='Infor5', @var2='HMS5';
+
+    SELECT MAX(id) AS MaximumUsedIdentity FROM ScopeIdentityMainTable
+    SELECT SCOPE_IDENTITY()
+    SELECT @@IDENTITY
+    SELECT IDENT_CURRENT('ScopeIdentityMainTable')
+    SELECT sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+
+EXEC ScopeIdentitySP3
+GO
+
+SELECT @@IDENTITY as [Identity]
+ , SCOPE_IDENTITY() AS [Scope_Identity]
+ , IDENT_CURRENT('ScopeIdentityMainTable') AS IC_MainTable 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByKey') AS IC_TableUpdatedByKey 
+ , IDENT_CURRENT('ScopeIdentityTableUpdatedByTrigger') AS IC_TableUpdatedByTrigger
+ , sys.babelfish_get_scope_identity() AS [BB_Scope_Identity]
+GO
+
+
+DROP FUNCTION ScopeIdentityFunc1
+GO
+
+DROP PROCEDURE ScopeIdentitySP1
+GO
+
+DROP PROCEDURE ScopeIdentitySP2
+GO
+
+DROP PROCEDURE ScopeIdentitySP3
+GO
+
+DROP TRIGGER UpdateTableByTrigger
+GO
+
+DROP TABLE ScopeIdentityTableUpdatedByTrigger
+GO
+
+DROP TABLE ScopeIdentityTableUpdatedByKey
+GO
+
+DROP TABLE ScopeIdentityMainTable
+GO
+

--- a/test/JDBC/input/identity_function-vu-verify.mix
+++ b/test/JDBC/input/identity_function-vu-verify.mix
@@ -14,6 +14,8 @@ GO
 select id from indentity_function_tests_t1 WHERE id = sys.babelfish_get_last_identity();
 GO
 
+-- scope_identity returns NULL because proc is runs in a different scope.
+-- This was validated against SQL Server
 exec indentity_function_tests_proc
 GO
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -113,3 +113,6 @@ ignore#!#datediff_internal_date-before-14_7-or-15_2-vu-cleanup
 ignore#!#openquery_upgrd-vu-prepare
 ignore#!#openquery_upgrd-vu-verify
 ignore#!#openquery_upgrd-vu-cleanup
+ignore#!#Test-Identity-before-14_7-or-15_2-vu-prepare
+ignore#!#Test-Identity-before-14_7-or-15_2-vu-verify
+ignore#!#Test-Identity-before-14_7-or-15_2-vu-cleanup

--- a/test/JDBC/sql_expected/BABEL-IDENTITY.out
+++ b/test/JDBC/sql_expected/BABEL-IDENTITY.out
@@ -904,7 +904,7 @@ go
 text
 Query Text: SELECT num_index, mycol FROM dbo.test_numeric_index_no_id WHERE num_index = scope_identity()
 Index Scan using test_numeric_index_no_id_pkey on test_numeric_index_no_id
-  Index Cond: (num_index = (((babelfish_get_last_identity())::numeric(38,0))::numeric(38,0))::numeric)
+  Index Cond: (num_index = ((babelfish_get_scope_identity())::numeric(38,0))::numeric)
 ~~END~~
 
 

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -115,7 +115,7 @@ BABEL-3314
 BABEL-TABLEOPTIONS
 temp-tables
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -164,7 +164,7 @@ BABEL-TABLEOPTIONS
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 babel_char
 BABEL-SQUARE

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -187,7 +187,7 @@ BABEL-3748-before-14_7
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 babel_char
 BABEL-SQUARE

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -186,7 +186,7 @@ BABEL-3748-before-14_7
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 babel_char
 BABEL-SQUARE

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -186,7 +186,7 @@ BABEL-3748-before-14_7
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 babel_char
 BABEL-SQUARE

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -182,7 +182,7 @@ BABEL-2955
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 babel_char
 BABEL-SQUARE

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -186,7 +186,7 @@ BABEL-3748-before-14_7
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 babel_char
 BABEL-SQUARE

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -105,7 +105,7 @@ BABEL-2955
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 BABEL-1189
 BABEL-1243

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -105,7 +105,7 @@ BABEL-3358
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 BABEL-1189
 BABEL-1062

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -107,7 +107,7 @@ BABEL-3358
 temp-tables
 table-variable
 TestNotNull
-Test-Identity
+Test-Identity-before-14_7-or-15_2
 Test-Computed-Columns
 BABEL-1189
 BABEL-1062


### PR DESCRIPTION
IDENTITY and SCOPE_IDENTITY are the same today because they have the same implementation. This is wrong. In order to fix this, we introduce a stack of identity value which should contain the correct identity value for a particular scope and return that when a user calls select scope_identity().

On the other hand, select @@identity remains the same.

The stack implementation is similar to the GucStack.

Task: [BABEL-3907]
Signed-off-by: Kristian Lejao <klejao@amazon.com>

### Description
-- Test scenarios
(1) Fixed existing SCOPE_IDENTITY testcases: (Test-Identity and identity_function)
(2) Introduced new testcase Test-scope-identity to test out exact scenario in BABEL-3907
and additional coverage

Overall, the three testcases cover the following:

(1) Multiple tables with triggers
(2) Stored procedures calling INSERT statement with TRIGGER
(3) Stored procedures calling another SP calling INSERT with TRIGGER
(4) SCOPE_IDENTITY inside a View
(5) SCOPE_IDENTITY inside a Function
(6) SCOPE_IDENTITY inside sp_executesql
(7) MVU testcase before 14_6/15_2 and newer

Outputs were validated against SQL Server


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).