### PR TITLE
Fix syntax error if query with single quotes is passed to OPENQUERY

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -16,8 +16,8 @@
 		 errmsg("Could not establish connection with remote server as use of TDS client library has been disabled. " \
 			"Please recompile source with 'ENABLE_TDS_LIB' flag to enable client library.")));
 
-#define LINKED_SERVER_DEBUG(...)	elog(LOG, __VA_ARGS__)
-#define LINKED_SERVER_DEBUG_FINER(...)	elog(LOG, __VA_ARGS__)
+#define LINKED_SERVER_DEBUG(...)	elog(DEBUG1, __VA_ARGS__)
+#define LINKED_SERVER_DEBUG_FINER(...)	elog(DEBUG2, __VA_ARGS__)
 
 PG_FUNCTION_INFO_V1(openquery_internal);
 

--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -772,14 +772,27 @@ getOpenqueryTupdescFromMetadata(char* linked_server, char* query, TupleDesc *tup
 		LINKED_SERVER_RETCODE erc;
 
 		StringInfoData buf;
-		int colcount;
+		int colcount, i;
 
 		linked_server_establish_connection(linked_server, &lsproc);
 
 		/* prepare the query that will executed on remote server to get column medata of result set*/
 		initStringInfo(&buf);
 		appendStringInfoString(&buf, "EXEC sp_describe_first_result_set N'");
-		appendStringInfoString(&buf, query);
+
+		for (i = 0; i < strlen(query); i++)
+		{
+			appendStringInfoChar(&buf, query[i]);
+
+			/*
+			 * If character is a single quote, we append another single quote
+			 * because we want to escape it when we feed the query as a parameter
+			 * to sp_describe_first_result_set stored procedure.
+			 */
+			if (query[i] == '\'')
+				appendStringInfoChar(&buf, '\'');
+		}
+
 		appendStringInfoString(&buf, "', NULL, 0");
 
 		LINKED_SERVER_DEBUG("LINKED SERVER: (Metadata) - Writing the following query to LinkedServerProcess struct: %s", buf.data);

--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -16,8 +16,8 @@
 		 errmsg("Could not establish connection with remote server as use of TDS client library has been disabled. " \
 			"Please recompile source with 'ENABLE_TDS_LIB' flag to enable client library.")));
 
-#define LINKED_SERVER_DEBUG(...)	elog(DEBUG1, __VA_ARGS__)
-#define LINKED_SERVER_DEBUG_FINER(...)	elog(DEBUG2, __VA_ARGS__)
+#define LINKED_SERVER_DEBUG(...)	elog(LOG, __VA_ARGS__)
+#define LINKED_SERVER_DEBUG_FINER(...)	elog(LOG, __VA_ARGS__)
 
 PG_FUNCTION_INFO_V1(openquery_internal);
 
@@ -772,7 +772,7 @@ getOpenqueryTupdescFromMetadata(char* linked_server, char* query, TupleDesc *tup
 		LINKED_SERVER_RETCODE erc;
 
 		StringInfoData buf;
-		int colcount, i;
+		int colcount;
 
 		linked_server_establish_connection(linked_server, &lsproc);
 
@@ -780,7 +780,7 @@ getOpenqueryTupdescFromMetadata(char* linked_server, char* query, TupleDesc *tup
 		initStringInfo(&buf);
 		appendStringInfoString(&buf, "EXEC sp_describe_first_result_set N'");
 
-		for (i = 0; i < strlen(query); i++)
+		for (int i = 0; i < strlen(query); i++)
 		{
 			appendStringInfoChar(&buf, query[i]);
 

--- a/test/JDBC/expected/openquery-vu-verify.out
+++ b/test/JDBC/expected/openquery-vu-verify.out
@@ -3484,3 +3484,11 @@ SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
 
 ~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: Server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
 
+
+#Test OPENQUERY where argument has quotes
+SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')
+~~START~~
+varchar
+Query having both 'single' and "double" quotes
+~~END~~
+

--- a/test/JDBC/expected/openquery-vu-verify.out
+++ b/test/JDBC/expected/openquery-vu-verify.out
@@ -3478,17 +3478,17 @@ int
 ~~END~~
 
 
-# Test OPENQUERY with an unreachable server
-SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: Server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
-
-
 #Test OPENQUERY where argument has quotes
 SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')
 ~~START~~
 varchar
 Query having both 'single' and "double" quotes
 ~~END~~
+
+
+# Test OPENQUERY with an unreachable server
+SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: Server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
 

--- a/test/JDBC/input/openquery-vu-verify.txt
+++ b/test/JDBC/input/openquery-vu-verify.txt
@@ -243,3 +243,6 @@ SELECT * FROM openquery_vu_prepare__openquery_view
 
 # Test OPENQUERY with an unreachable server
 SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
+
+#Test OPENQUERY where argument has quotes
+SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')

--- a/test/JDBC/input/openquery-vu-verify.txt
+++ b/test/JDBC/input/openquery-vu-verify.txt
@@ -241,8 +241,8 @@ SELECT * FROM OPENQUERY(bbf_server, 'select 123; select 456')
 # Test view dependent on OPENQUERY
 SELECT * FROM openquery_vu_prepare__openquery_view
 
-# Test OPENQUERY with an unreachable server
-SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
-
 #Test OPENQUERY where argument has quotes
 SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')
+
+# Test OPENQUERY with an unreachable server
+SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,9 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+openquery-vu-prepare
+openquery-vu-verify
+openquery-vu-cleanup
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,9 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-openquery-vu-prepare
-openquery-vu-verify
-openquery-vu-cleanup
+all
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 


### PR DESCRIPTION
Previously, we were not escaping the quotes when preparing the query to
fetch column metadata. So the query would look something like: "EXEC
sp_describe_result_set N'SELECT 'Lorem ipsum'', NULL, 0" which will
throw syntax error.

To fix this, for every single quote we see in the query, we will escape
by appending another quote to the column metadata query string.

Task: BABEL-3975
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** No


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).