### PR TITLE
Fix scale and precision for numeric type when typmod -1 for aggregates

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -707,6 +707,16 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			precision = ((typmod - VARHDRSZ) >> 16) & 0xffff;
 
 			/*
+			 * If we recieve typmod as -1 we should fallback to default scale and precision
+			 * Rather than using -1 typmod to calculate scale and precision which leads to 
+			 * TDS protocol error.
+			 */
+			if (typmod == -1)
+			{
+				scale = tds_default_numeric_scale;
+				precision = tds_default_numeric_precision;
+			}
+			/*
 			 * [BABEL-3074] NUMERIC overflow causes TDS error for aggregate
 			 * function sum(); resultant precision should be tds_default_numeric_precision 
 			 */

--- a/test/JDBC/expected/BABEL-3943.out
+++ b/test/JDBC/expected/BABEL-3943.out
@@ -1,0 +1,38 @@
+-- psql
+CREATE TABLE master_dbo.owner_amounts ( 
+"tax" DECIMAL(26, 6) NULL , 
+"active" smallint NULL DEFAULT ((1)), 
+"moment_id" INT NOT NULL DEFAULT ((0)) 
+) ; 
+GO
+
+grant select on master_dbo.owner_amounts to public; 
+GO
+
+insert into master_dbo.owner_amounts 
+select 0,1,862 from generate_series(1,200000);
+GO
+~~ROW COUNT: 200000~~
+
+
+-- tsql
+SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
+GO
+~~START~~
+numeric
+0E-8
+~~END~~
+
+
+SELECT sum([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
+GO
+~~START~~
+numeric
+0E-8
+~~END~~
+
+
+
+--cleanup
+drop table owner_amounts
+GO

--- a/test/JDBC/input/BABEL-3943.mix
+++ b/test/JDBC/input/BABEL-3943.mix
@@ -1,0 +1,26 @@
+-- psql
+CREATE TABLE master_dbo.owner_amounts ( 
+"tax" DECIMAL(26, 6) NULL , 
+"active" smallint NULL DEFAULT ((1)), 
+"moment_id" INT NOT NULL DEFAULT ((0)) 
+) ; 
+GO
+
+grant select on master_dbo.owner_amounts to public; 
+GO
+
+insert into master_dbo.owner_amounts 
+select 0,1,862 from generate_series(1,200000);
+GO
+
+-- tsql
+SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
+GO
+
+SELECT sum([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
+GO
+
+
+--cleanup
+drop table owner_amounts
+GO


### PR DESCRIPTION
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Description
When using Aggregate Functions (SUM,AVG) ,we are able to resolve typmod of numeric column (`resolve_numeric_typmod_from_expr`) when there are no predicates but when there are predicates (Where clauses )

the sum aggregate serialises(`AGGSPLIT_FINAL_DESERIAL`) the data into `bytea` type for partial aggregation for performance improvement reasons so  we should fallback to default precision and scale cause when we are  not able to extract the typmod for the column(now being `bytea` type for this specific case) used for partial aggregation.


### Issues Resolved
BABEL-3943

### Test Scenarios Covered ###
* **Use case based -**
   - Added test cases for aggregates(SUM,AVG) with predicates (Where clauses) which leads to typmod resolved to be -1

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).