### PR TITLE
Fix crash in LINKED_SERVER_OPEN() when calling OPENQUERY()

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -750,8 +750,7 @@ linked_server_establish_connection(char* servername, LinkedServerProcess *lsproc
 	}
 	PG_CATCH();
 	{
-		LINKED_SERVER_DEBUG("LINKED SERVER: Closing connections to remote server due to error");
-		LINKED_SERVER_EXIT();
+		LINKED_SERVER_DEBUG("LINKED SERVER: Failed to establish connection to remote server due to error");
 
 		PG_RE_THROW();
 	}

--- a/test/JDBC/expected/openquery-vu-verify.out
+++ b/test/JDBC/expected/openquery-vu-verify.out
@@ -3478,17 +3478,17 @@ int
 ~~END~~
 
 
+# Test OPENQUERY with an unreachable server
+SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: Server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
+
+
 #Test OPENQUERY where argument has quotes
 SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')
 ~~START~~
 varchar
 Query having both 'single' and "double" quotes
 ~~END~~
-
-
-# Test OPENQUERY with an unreachable server
-SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: Server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
 

--- a/test/JDBC/input/openquery-vu-verify.txt
+++ b/test/JDBC/input/openquery-vu-verify.txt
@@ -241,8 +241,8 @@ SELECT * FROM OPENQUERY(bbf_server, 'select 123; select 456')
 # Test view dependent on OPENQUERY
 SELECT * FROM openquery_vu_prepare__openquery_view
 
-#Test OPENQUERY where argument has quotes
-SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')
-
 # Test OPENQUERY with an unreachable server
 SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
+
+#Test OPENQUERY where argument has quotes
+SELECT * FROM OPENQUERY(bbf_server, 'SELECT ''Query having both ''''single'''' and "double" quotes''')


### PR DESCRIPTION
Previously, if an error occurred during establishing connection to
remote server, we were calling LINKED_SERVER_EXIT() twice which caused
some inconsistency in the underlying client library since we only call
LINKED_SERVER_INIT() once for every connection to remote server.

In this commit, if we encounter an error during login, we will only
call LINKED_SERVER_EXIT() once, either in the function body of metadata
query execution or the actual query execution that was passed to
OPENQUERY.

Task: BABEL-3989
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###

Earlier if there was an error during login time, we would decrement the underlying ref_count twice causing the lib structure used for communication in an incorrect state. Thus any further attempts to establish connection would have an unknown behaviour. So to test the fix we try a correct OPENQUERY() call after an unsuccessful one.

* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).