### PR TITLE
Fix table variable bug with sp_executesql

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -6859,13 +6859,6 @@ exec_eval_datum(PLtsql_execstate *estate,
 				*typeid = tbl->tbltypeid;
 				*typetypmod = -1;
 				*value = CStringGetDatum(tbl->tblname);
-				/*
-				 * Set isnull to true because by default composite type is
-				 * pass-by-reference, which will cause problems since our usage
-				 * here is not. Setting isnull to true will bypass the problem.
-				 */
-				*isnull = true;
-
 				break;
 			}
 

--- a/test/JDBC/expected/table-variable-vu-cleanup.out
+++ b/test/JDBC/expected/table-variable-vu-cleanup.out
@@ -46,4 +46,10 @@ go
 drop function table_variable_vu_preparemstvf_conditional
 go
 
-
+-- BABEL-3967 - table variable in sp_executesql is null error
+drop procedure table_variable_vu_proc1
+go
+drop function table_variable_vu_tvp_function
+go
+drop type table_variable_vu_type
+go

--- a/test/JDBC/expected/table-variable-vu-prepare.out
+++ b/test/JDBC/expected/table-variable-vu-prepare.out
@@ -208,4 +208,20 @@ begin
 end
 go
 
+-- BABEL-3967 - table variable in sp_executesql is null error
+create type table_variable_vu_type as table (a text not null, b int primary key, c int, d int)
+go
 
+create proc table_variable_vu_proc1 (@x table_variable_vu_type readonly) as
+begin
+	select tvp.b from @x tvp
+end
+go
+
+create function table_variable_vu_tvp_function (@tvp table_variable_vu_type READONLY) returns int as 
+begin 
+	declare @result int 
+	select @result = count(*) from @tvp 
+	return @result 
+end;
+go

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -178,4 +178,29 @@ hello1
 ~~END~~
 
 
+-- BABEL-3967 - table variable in sp_executesql is null error
+declare @var1 table_variable_vu_type
+insert into @var1 values ('1', 2, 3, 4)
+exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+declare @tableVar table_variable_vu_type;
+insert into @tableVar values('1', 2, 3, 4);
+declare @ret int;
+select @ret = table_variable_vu_tvp_function(@tableVar);
+select @ret 
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
 

--- a/test/JDBC/input/table-variable-vu-cleanup.sql
+++ b/test/JDBC/input/table-variable-vu-cleanup.sql
@@ -46,4 +46,10 @@ go
 drop function table_variable_vu_preparemstvf_conditional
 go
 
-
+-- BABEL-3967 - table variable in sp_executesql is null error
+drop procedure table_variable_vu_proc1
+go
+drop function table_variable_vu_tvp_function
+go
+drop type table_variable_vu_type
+go

--- a/test/JDBC/input/table-variable-vu-prepare.sql
+++ b/test/JDBC/input/table-variable-vu-prepare.sql
@@ -194,4 +194,20 @@ begin
 end
 go
 
+-- BABEL-3967 - table variable in sp_executesql is null error
+create type table_variable_vu_type as table (a text not null, b int primary key, c int, d int)
+go
 
+create proc table_variable_vu_proc1 (@x table_variable_vu_type readonly) as
+begin
+	select tvp.b from @x tvp
+end
+go
+
+create function table_variable_vu_tvp_function (@tvp table_variable_vu_type READONLY) returns int as 
+begin 
+	declare @result int 
+	select @result = count(*) from @tvp 
+	return @result 
+end;
+go

--- a/test/JDBC/input/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table-variable-vu-verify.sql
@@ -67,4 +67,15 @@ go
 select * from table_variable_vu_preparemstvf_conditional(1)
 go
 
+-- BABEL-3967 - table variable in sp_executesql is null error
+declare @var1 table_variable_vu_type
+insert into @var1 values ('1', 2, 3, 4)
+exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
+go
 
+declare @tableVar table_variable_vu_type;
+insert into @tableVar values('1', 2, 3, 4);
+declare @ret int;
+select @ret = table_variable_vu_tvp_function(@tableVar);
+select @ret 
+go


### PR DESCRIPTION
### Description
When using `sp_executesql` and table valued parameter for a procedure, an issue was found that table-variable-parameter(TVP) wasn't getting the values assigned. The value to be assigned should be a table-name, but since we declare table-variables as NULL the table-name(value) wasn't getting assigned to the bind parameter. To resolve this we removed the code where we set Table variables as NULL.

### Issues Resolved

BABEL-3967

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).