### PR TITLE
Fix crash in heap_fill_tuple when executing T-SQL OPENQUERY

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -1123,7 +1123,7 @@ openquery_imp(PG_FUNCTION_ARGS)
 				while (LINKED_SERVER_NEXT_ROW(lsproc) != NO_MORE_ROWS)
 				{
 					/* for each row */
-					Datum	*values = palloc0(sizeof(SIZEOF_DATUM) * colcount);
+					Datum	*values = palloc0(sizeof(Datum) * colcount);
 					bool	*nulls = palloc0(sizeof(bool) * colcount);
 
 					for (i = 0; i < colcount; i++)


### PR DESCRIPTION
There was a sporadic crash occurring in heap_fill_tuple() due to
incorrect memory allocation for values array that stores the Datum for
every row of a result set. In this commit, we fix this by allocating
space as the product of sizeof(Datum) times the number of columns
expected in the result set.

Task: BABEL-3986
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).