### PR TITLE
Make DATETIME accepted DATETIME2(7) parameter

### DIFF
--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -154,7 +154,7 @@ datetime2_in(PG_FUNCTION_ARGS)
 static void
 AdjustDatetime2ForTypmod(Timestamp *time, int32 typmod)
 {
-	static const int64 TimestampScales[MAX_TIMESTAMP_PRECISION_TSQL + 1] = {
+	static const int64 TimestampScales[MAX_DATETIME2_PRECISION + 1] = {
 		INT64CONST(1000000),
 		INT64CONST(100000),
 		INT64CONST(10000),
@@ -165,7 +165,7 @@ AdjustDatetime2ForTypmod(Timestamp *time, int32 typmod)
 		INT64CONST(1)
 	};
 
-	static const int64 TimestampOffsets[MAX_TIMESTAMP_PRECISION_TSQL + 1] = {
+	static const int64 TimestampOffsets[MAX_DATETIME2_PRECISION + 1] = {
 		INT64CONST(500000),
 		INT64CONST(50000),
 		INT64CONST(5000),
@@ -177,7 +177,7 @@ AdjustDatetime2ForTypmod(Timestamp *time, int32 typmod)
 	};
 
 	/* new offset for negative timestamp value */
-	static const int64 TimestampOffsetsNegative[MAX_TIMESTAMP_PRECISION_TSQL + 1] = {
+	static const int64 TimestampOffsetsNegative[MAX_DATETIME2_PRECISION + 1] = {
 		INT64CONST(499999),
 		INT64CONST(49999),
 		INT64CONST(4999),
@@ -193,11 +193,11 @@ AdjustDatetime2ForTypmod(Timestamp *time, int32 typmod)
 	if (!TIMESTAMP_NOT_FINITE(*time)
 		&& (typmod != -1))
 	{
-		if (typmod < 0 || typmod > MAX_TIMESTAMP_PRECISION_TSQL)
+		if (typmod < 0 || typmod > MAX_DATETIME2_PRECISION)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("datetime2(%d) precision must be between %d and %d",
-							typmod, 0, MAX_TIMESTAMP_PRECISION_TSQL)));
+							typmod, 0, MAX_DATETIME2_PRECISION)));
 
 		if (*time >= INT64CONST(0))
 		{	

--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -154,34 +154,37 @@ datetime2_in(PG_FUNCTION_ARGS)
 static void
 AdjustDatetime2ForTypmod(Timestamp *time, int32 typmod)
 {
-	static const int64 TimestampScales[MAX_TIMESTAMP_PRECISION + 1] = {
+	static const int64 TimestampScales[MAX_TIMESTAMP_PRECISION_TSQL + 1] = {
 		INT64CONST(1000000),
 		INT64CONST(100000),
 		INT64CONST(10000),
 		INT64CONST(1000),
 		INT64CONST(100),
 		INT64CONST(10),
+		INT64CONST(1),
 		INT64CONST(1)
 	};
 
-	static const int64 TimestampOffsets[MAX_TIMESTAMP_PRECISION + 1] = {
+	static const int64 TimestampOffsets[MAX_TIMESTAMP_PRECISION_TSQL + 1] = {
 		INT64CONST(500000),
 		INT64CONST(50000),
 		INT64CONST(5000),
 		INT64CONST(500),
 		INT64CONST(50),
 		INT64CONST(5),
+		INT64CONST(0),
 		INT64CONST(0)
 	};
 
 	/* new offset for negative timestamp value */
-	static const int64 TimestampOffsetsNegative[MAX_TIMESTAMP_PRECISION + 1] = {
+	static const int64 TimestampOffsetsNegative[MAX_TIMESTAMP_PRECISION_TSQL + 1] = {
 		INT64CONST(499999),
 		INT64CONST(49999),
 		INT64CONST(4999),
 		INT64CONST(499),
 		INT64CONST(49),
 		INT64CONST(4),
+		INT64CONST(0),
 		INT64CONST(0)
 	};
 
@@ -190,11 +193,11 @@ AdjustDatetime2ForTypmod(Timestamp *time, int32 typmod)
 	if (!TIMESTAMP_NOT_FINITE(*time)
 		&& (typmod != -1))
 	{
-		if (typmod < 0 || typmod > MAX_TIMESTAMP_PRECISION)
+		if (typmod < 0 || typmod > MAX_TIMESTAMP_PRECISION_TSQL)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("datetime2(%d) precision must be between %d and %d",
-							typmod, 0, MAX_TIMESTAMP_PRECISION)));
+							typmod, 0, MAX_TIMESTAMP_PRECISION_TSQL)));
 
 		if (*time >= INT64CONST(0))
 		{	

--- a/contrib/babelfishpg_common/src/datetime2.h
+++ b/contrib/babelfishpg_common/src/datetime2.h
@@ -10,8 +10,6 @@
 
 /* Maximum precision for datetime2 */
 #define MAX_DATETIME2_PRECISION 7
-/* Maximum precision for round off datetime2 */
-#define MAX_TIMESTAMP_PRECISION_TSQL 7
 
 /* Datetime2 limits */
 /* lower bound: 0001-01-01 00:00:00.000 */

--- a/contrib/babelfishpg_common/src/datetime2.h
+++ b/contrib/babelfishpg_common/src/datetime2.h
@@ -10,6 +10,8 @@
 
 /* Maximum precision for datetime2 */
 #define MAX_DATETIME2_PRECISION 7
+/* Maximum precision for round off datetime2 */
+#define MAX_TIMESTAMP_PRECISION_TSQL 7
 
 /* Datetime2 limits */
 /* lower bound: 0001-01-01 00:00:00.000 */

--- a/test/JDBC/expected/BABEL-2934.out
+++ b/test/JDBC/expected/BABEL-2934.out
@@ -89,3 +89,39 @@ time
 12:15:04.123457
 ~~END~~
 
+
+-- BABEL-3570
+CREATE FUNCTION BABEL_3570_function (@p datetime2(7)) RETURNS INT 
+AS
+BEGIN
+RETURN 0
+END
+GO
+
+SELECT BABEL_3570_function(getdate())
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DECLARE @BABEL_3570_dt datetime = getdate()
+SELECT BABEL_3570_function(@BABEL_3570_dt)
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+CREATE PROC BABEL_3570_proc @p datetime2(7) as print 'pass'
+GO
+
+DECLARE @BABEL_3570_dt datetime = getdate()
+EXEC BABEL_3570_proc @BABEL_3570_dt
+GO
+
+DROP FUNCTION BABEL_3570_function
+DROP PROC BABEL_3570_proc
+GO

--- a/test/JDBC/input/BABEL-2934.sql
+++ b/test/JDBC/input/BABEL-2934.sql
@@ -48,3 +48,29 @@ go
 
 select cast('12:15:04.1234567' as TIME(7))
 go
+
+-- BABEL-3570
+CREATE FUNCTION BABEL_3570_function (@p datetime2(7)) RETURNS INT 
+AS
+BEGIN
+RETURN 0
+END
+GO
+
+SELECT BABEL_3570_function(getdate())
+GO
+
+DECLARE @BABEL_3570_dt datetime = getdate()
+SELECT BABEL_3570_function(@BABEL_3570_dt)
+GO
+
+CREATE PROC BABEL_3570_proc @p datetime2(7) as print 'pass'
+GO
+
+DECLARE @BABEL_3570_dt datetime = getdate()
+EXEC BABEL_3570_proc @BABEL_3570_dt
+GO
+
+DROP FUNCTION BABEL_3570_function
+DROP PROC BABEL_3570_proc
+GO


### PR DESCRIPTION
### Description

Before this PR, DATETIME not accepted for DATETIME2(7) parameter and BABELFISH throws error ``datetime2(7) precision must be between 0 and 6``. In our code, we use ``MAX_TIMESTAMP_PRECISION`` as 6 as the same as engine side, but DATETIME2 should accept 7 when doing scale. In this PR, we reuse constant value ``MAX_DATETIME2_PRECISION`` as 7 in order to let DATETIME accepted DATETIME2(7) parameter.

### Issues Resolved

BABEL-3570

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).