### PR TITLE
Fix table variable usage with sp_executesql

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -80,6 +80,16 @@ CREATE OR REPLACE VIEW information_schema_tsql.schemata AS
 GRANT SELECT ON information_schema_tsql.schemata TO PUBLIC;
 
 -- please add your SQL here
+
+-- 2.4 changes table types to explicitly be stored as pass-by-value in pg_type. While MVU forces the catalog
+-- to be regenerated, mVU (minor version upgrade) does not, so we need to manually fix it here.
+UPDATE pg_catalog.pg_type AS t SET typbyval = 't' 
+FROM sys.babelfish_namespace_ext AS b,
+    pg_catalog.pg_namespace AS n
+WHERE b.nspname = n.nspname AND t.typnamespace = n.oid -- only update types in babelfish namespaces
+    AND typtype = 'c' -- only update composite types
+    AND typacl IS NOT NULL; -- table types have non-NULL typacl, while normal tables have it as NULL
+
 create or replace view sys.views as 
 select 
   t.relname as name

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -6859,6 +6859,7 @@ exec_eval_datum(PLtsql_execstate *estate,
 				*typeid = tbl->tbltypeid;
 				*typetypmod = -1;
 				*value = CStringGetDatum(tbl->tblname);
+				*isnull = false;
 				break;
 			}
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -118,6 +118,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		QueryEnvironment *queryEnv,
 		DestReceiver *dest,
 		QueryCompletion *qc);
+static void set_pgtype_byval(List *name, bool byval);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -3109,6 +3110,8 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		case T_CreateStmt:
 			{
 				CreateStmt *create_stmt = (CreateStmt *) parsetree;
+				RangeVar *rel = create_stmt->relation;
+				bool isTableVariable = (rel->relname[0] == '@');
 
 				if(restore_tsql_tabletype)
 					create_stmt->tsql_tabletype = true;
@@ -3120,16 +3123,20 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 					standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 							queryEnv, dest, qc);
 
-				if (create_stmt->tsql_tabletype)
+				if (create_stmt->tsql_tabletype || isTableVariable)
 				{
 					RangeVar *rel = create_stmt->relation;
 					List *name;
+
 					if (rel->schemaname)
 						name = list_make2(makeString(rel->schemaname), makeString(rel->relname));
 					else
 						name = list_make1(makeString(rel->relname));
 
-					revoke_type_permission_from_public(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc, name);
+					set_pgtype_byval(name, true);
+
+					if (create_stmt->tsql_tabletype)
+						revoke_type_permission_from_public(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc, name);
 				}
 
 				return;
@@ -3158,6 +3165,45 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 	else
 		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 				queryEnv, dest, qc);
+}
+
+/*
+ * Update the pg_type catalog entry for the given name to have
+ * typbyval set to the given value.
+ */
+static void set_pgtype_byval(List *name, bool byval)
+{
+	Relation	catalog;
+	TypeName   *typename;
+	HeapTuple	tup;
+
+	Datum		values[Natts_pg_type];
+	bool		nulls[Natts_pg_type];
+	bool		replaces[Natts_pg_type];
+	HeapTuple	newtup;
+
+	/*
+	* Table types need to set the typbyval column in pg_type to 't'
+	*/
+	catalog = table_open(TypeRelationId, RowExclusiveLock);
+	typename = makeTypeNameFromNameList(name);
+	tup = typenameType(NULL, typename, NULL);
+
+	/* Update the current type's tuple */
+	memset(values, 0, sizeof(values));
+	memset(nulls, 0, sizeof(nulls));
+	memset(replaces, 0, sizeof(replaces));
+	replaces[Anum_pg_type_typbyval - 1] = true;
+	values[Anum_pg_type_typbyval - 1] = BoolGetDatum(byval);
+
+	newtup = heap_modify_tuple(tup, RelationGetDescr(catalog), values, nulls, replaces);
+	CatalogTupleUpdate(catalog, &newtup->t_self, newtup);
+
+	/* Clean up */
+	ReleaseSysCache(tup);
+
+	table_close(catalog, RowExclusiveLock);
+
 }
 
 /*

--- a/test/JDBC/expected/table-variable-vu-cleanup.out
+++ b/test/JDBC/expected/table-variable-vu-cleanup.out
@@ -46,10 +46,14 @@ go
 drop function table_variable_vu_preparemstvf_conditional
 go
 
--- BABEL-3967 - table variable in sp_executesql is null error
+-- BABEL-3967 - table variable in sp_executesql
 drop procedure table_variable_vu_proc1
 go
 drop function table_variable_vu_tvp_function
 go
 drop type table_variable_vu_type
+go
+drop type table_variable_vu_schema.table_variable_vu_type
+go
+drop schema table_variable_vu_schema
 go

--- a/test/JDBC/expected/table-variable-vu-cleanup.out
+++ b/test/JDBC/expected/table-variable-vu-cleanup.out
@@ -57,3 +57,5 @@ drop type table_variable_vu_schema.table_variable_vu_type
 go
 drop schema table_variable_vu_schema
 go
+drop function table_variable_vu_func2
+go

--- a/test/JDBC/expected/table-variable-vu-prepare.out
+++ b/test/JDBC/expected/table-variable-vu-prepare.out
@@ -208,7 +208,7 @@ begin
 end
 go
 
--- BABEL-3967 - table variable in sp_executesql is null error
+-- BABEL-3967 - table variable in sp_executesql
 create type table_variable_vu_type as table (a text not null, b int primary key, c int, d int)
 go
 
@@ -224,4 +224,10 @@ begin
 	select @result = count(*) from @tvp 
 	return @result 
 end;
+go
+
+create schema table_variable_vu_schema
+go
+
+create type table_variable_vu_schema.table_variable_vu_type as table (a nvarchar, b ntext)
 go

--- a/test/JDBC/expected/table-variable-vu-prepare.out
+++ b/test/JDBC/expected/table-variable-vu-prepare.out
@@ -231,3 +231,11 @@ go
 
 create type table_variable_vu_schema.table_variable_vu_type as table (a nvarchar, b ntext)
 go
+
+create function table_variable_vu_func2 () returns @SomeTable table (col1 int, col2 varchar(16))
+AS
+BEGIN
+    INSERT @SomeTable SELECT 1234, 'abcd'
+    RETURN
+END
+go

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -178,7 +178,7 @@ hello1
 ~~END~~
 
 
--- BABEL-3967 - table variable in sp_executesql is null error
+-- BABEL-3967 - table variable in sp_executesql
 declare @var1 table_variable_vu_type
 insert into @var1 values ('1', 2, 3, 4)
 exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
@@ -201,6 +201,52 @@ go
 
 ~~START~~
 int
+1
+~~END~~
+
+
+-- double-check that the underlying type for table_variable_vu_type is pass-by-val
+select typbyval from pg_type where typname = 'table_variable_vu_type';
+go
+~~START~~
+bit
+1
+1
+~~END~~
+
+
+declare @tableVar table_variable_vu_schema.table_variable_vu_type
+insert into @tableVar values ('a', 'b'), ('c', 'd')
+select * from @tableVar
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+nvarchar#!#ntext
+a#!#b
+c#!#d
+~~END~~
+
+
+declare @tableVar as table (x int)
+insert into @tableVar values (1),(2),(3)
+select * from @tableVar
+select typbyval from pg_catalog.pg_type where typname like '@tablevar%';
+go
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+~~START~~
+bit
+1
+1
+1
 1
 ~~END~~
 

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -250,3 +250,17 @@ bit
 1
 ~~END~~
 
+
+select * from table_variable_vu_func2()
+select typbyval from pg_catalog.pg_type where typname like '@sometable_table_variable_vu_func2%';
+go
+~~START~~
+int#!#varchar
+1234#!#abcd
+~~END~~
+
+~~START~~
+bit
+1
+~~END~~
+

--- a/test/JDBC/input/table-variable-vu-cleanup.sql
+++ b/test/JDBC/input/table-variable-vu-cleanup.sql
@@ -46,10 +46,14 @@ go
 drop function table_variable_vu_preparemstvf_conditional
 go
 
--- BABEL-3967 - table variable in sp_executesql is null error
+-- BABEL-3967 - table variable in sp_executesql
 drop procedure table_variable_vu_proc1
 go
 drop function table_variable_vu_tvp_function
 go
 drop type table_variable_vu_type
+go
+drop type table_variable_vu_schema.table_variable_vu_type
+go
+drop schema table_variable_vu_schema
 go

--- a/test/JDBC/input/table-variable-vu-cleanup.sql
+++ b/test/JDBC/input/table-variable-vu-cleanup.sql
@@ -57,3 +57,5 @@ drop type table_variable_vu_schema.table_variable_vu_type
 go
 drop schema table_variable_vu_schema
 go
+drop function table_variable_vu_func2
+go

--- a/test/JDBC/input/table-variable-vu-prepare.sql
+++ b/test/JDBC/input/table-variable-vu-prepare.sql
@@ -194,7 +194,7 @@ begin
 end
 go
 
--- BABEL-3967 - table variable in sp_executesql is null error
+-- BABEL-3967 - table variable in sp_executesql
 create type table_variable_vu_type as table (a text not null, b int primary key, c int, d int)
 go
 
@@ -210,4 +210,10 @@ begin
 	select @result = count(*) from @tvp 
 	return @result 
 end;
+go
+
+create schema table_variable_vu_schema
+go
+
+create type table_variable_vu_schema.table_variable_vu_type as table (a nvarchar, b ntext)
 go

--- a/test/JDBC/input/table-variable-vu-prepare.sql
+++ b/test/JDBC/input/table-variable-vu-prepare.sql
@@ -217,3 +217,11 @@ go
 
 create type table_variable_vu_schema.table_variable_vu_type as table (a nvarchar, b ntext)
 go
+
+create function table_variable_vu_func2 () returns @SomeTable table (col1 int, col2 varchar(16))
+AS
+BEGIN
+    INSERT @SomeTable SELECT 1234, 'abcd'
+    RETURN
+END
+go

--- a/test/JDBC/input/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table-variable-vu-verify.sql
@@ -67,7 +67,7 @@ go
 select * from table_variable_vu_preparemstvf_conditional(1)
 go
 
--- BABEL-3967 - table variable in sp_executesql is null error
+-- BABEL-3967 - table variable in sp_executesql
 declare @var1 table_variable_vu_type
 insert into @var1 values ('1', 2, 3, 4)
 exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
@@ -78,4 +78,19 @@ insert into @tableVar values('1', 2, 3, 4);
 declare @ret int;
 select @ret = table_variable_vu_tvp_function(@tableVar);
 select @ret 
+go
+
+-- double-check that the underlying type for table_variable_vu_type is pass-by-val
+select typbyval from pg_type where typname = 'table_variable_vu_type';
+go
+
+declare @tableVar table_variable_vu_schema.table_variable_vu_type
+insert into @tableVar values ('a', 'b'), ('c', 'd')
+select * from @tableVar
+go
+
+declare @tableVar as table (x int)
+insert into @tableVar values (1),(2),(3)
+select * from @tableVar
+select typbyval from pg_catalog.pg_type where typname like '@tablevar%';
 go

--- a/test/JDBC/input/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table-variable-vu-verify.sql
@@ -94,3 +94,7 @@ insert into @tableVar values (1),(2),(3)
 select * from @tableVar
 select typbyval from pg_catalog.pg_type where typname like '@tablevar%';
 go
+
+select * from table_variable_vu_func2()
+select typbyval from pg_catalog.pg_type where typname like '@sometable_table_variable_vu_func2%';
+go


### PR DESCRIPTION
Signed-off-by: Jason Teng <jasonten@amazon.com>

### Description

In Babelfish, table variables are always passed by value. Postgres, however, will default to passing table variables by reference, leading to server crashes due to invalid memory accesses. This was previously worked around by setting the `isnull` flag to true when setting up a table variable. However, this leads to an error if a table variable is used with `sp_executesql`, as the PG executor will then use the `isnull` flag to fill in null values for the parameter. 

This commit resolves the issue in 2 steps: 
1. We properly set the `isnull` flag to false (since the datum is not empty) 
2. We add additional code in `bbf_ProcessUtility()` to detect when a TSQL table type is created and modify the pg_type entry to set the column `typbyval` to true. With this, future accesses to the table variable will properly see that the type is pass-by-value.


### Issues Resolved

BABEL-3967

### Engine PR

https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/104

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).