### PR TITLE
Better error message when client library throws error in OPENQUERY

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -94,6 +94,7 @@ linked_server_msg_handler(LinkedServerProcess lsproc, int error_code, int state,
 	return 0;
 }
 
+/* Copied from babelfishRemoveSubstr() defined in PG engine */
 static char *
 remove_substr(char *src, const char *substr)
 {

--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -149,7 +149,7 @@ linked_server_err_handler(LinkedServerProcess lsproc, int severity, int db_error
 	 * We remove "Adaptive" from error message since we are only
 	 * supporting remote servers that use T-SQL and communicate over TDS
 	 */
-	err_msg = remove_substr(db_err_str, "Adaptive ");
+	err_msg = remove_substr(pstrdup(db_err_str), "Adaptive ");
 
 	/* "Server" --> "server" */
 	pos = strstr(err_msg, "Server");

--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -151,23 +151,26 @@ linked_server_err_handler(LinkedServerProcess lsproc, int severity, int db_error
 
 	initStringInfo(&buf);
 
-	/*
-	 * We remove "Adaptive" from error message since we are only
-	 * supporting remote servers that use T-SQL and communicate over TDS
-	 */
-	err_msg = remove_substr(pnstrdup(db_err_str, strlen(db_err_str)), "Adaptive ");
-	str = err_msg;
-
-	/* We convert the 'S' in "Server" to lowercase */
-	while((pos = strstr(str, "Server")) != NULL)
+	if (db_err_str)
 	{
-		*pos = 's';
+		/*
+		 * We remove "Adaptive" from error message since we are only
+		 * supporting remote servers that use T-SQL and communicate over TDS
+		 */
+		err_msg = remove_substr(pnstrdup(db_err_str, strlen(db_err_str) + 1), "Adaptive ");
+		str = err_msg;
 
-		/* skip length of "Server" */
-		str = pos + 6;
+		/* We convert the 'S' in "Server" to lowercase */
+		while((pos = strstr(str, "Server")) != NULL)
+		{
+			*pos = 's';
 
-		if (!str)
-			break;
+			/* skip length of "Server" */
+			str = pos + 6;
+
+			if (!str)
+				break;
+		}
 	}
 
 	appendStringInfo(&buf, "TDS client library error: DB #: %i, ", db_error);

--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -155,10 +155,10 @@ linked_server_err_handler(LinkedServerProcess lsproc, int severity, int db_error
 	 * We remove "Adaptive" from error message since we are only
 	 * supporting remote servers that use T-SQL and communicate over TDS
 	 */
-	err_msg = remove_substr(pstrdup(db_err_str), "Adaptive ");
+	err_msg = remove_substr(pnstrdup(db_err_str, strlen(db_err_str)), "Adaptive ");
 	str = err_msg;
 
-	/* "Server" --> "server" */
+	/* We convert the 'S' in "Server" to lowercase */
 	while((pos = strstr(str, "Server")) != NULL)
 	{
 		*pos = 's';

--- a/test/JDBC/expected/openquery-vu-verify.out
+++ b/test/JDBC/expected/openquery-vu-verify.out
@@ -3482,7 +3482,7 @@ int
 SELECT * FROM OPENQUERY(bbf_server_unreachable, 'select 1')
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: Server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
+~~ERROR (Message: TDS client library error: DB #: 20012, DB Msg: server name not found in configuration files, OS #: 0, OS Msg: Success, Level: 2)~~
 
 
 #Test OPENQUERY where argument has quotes


### PR DESCRIPTION
In this commit, we improve the error message that is prepared by the TDS client library used to communicate with remote T-SQL servers.

Task: BABEL-3974
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A (Client library generated messages are the only possible input)


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).