### PR TITLE
Fix crash when calling procedure with more than allowed parameters

### DIFF
--- a/contrib/babelfishpg_tsql/src/prepare.c
+++ b/contrib/babelfishpg_tsql/src/prepare.c
@@ -192,6 +192,12 @@ is_exec_stmt_on_scalar_func(const char *stmt, int *first_arg_location, const cha
 	if (!funcname)
 		return false;
 
+	/* safety check */
+	if (nargs > FUNC_MAX_ARGS)
+		ereport(ERROR, (errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+				errmsg("cannot pass more than %d arguments to a procedure",
+						FUNC_MAX_ARGS)));
+	
 	for (i = 0; i < nargs; ++i)
 	{
 		/* We really don't care of the exact argument datatypes */

--- a/test/JDBC/expected/BABEL-3984.out
+++ b/test/JDBC/expected/BABEL-3984.out
@@ -1,0 +1,241 @@
+EXEC NoSuchProcedure  
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a procedure)~~
+
+
+EXEC NoSuchProcedure 
+0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a procedure)~~
+
+
+
+DECLARE @a0 int = 0, @a1 int = 1, @a2 int = 2, @a3 int = 3, @a4 int = 4, @a5 int = 5, @a6 int = 6, @a7 int = 7, @a8 int = 8, @a9 int = 9, @a10 int = 10, @a11 int = 11, @a12 int = 12, @a13 int = 13,
+@a14 int = 14, @a15 int = 15, @a16 int = 16, @a17 int = 17, @a18 int = 18, @a19 int = 19, @a20 int = 20, @a21 int = 21, @a22 int = 22, @a23 int = 23, @a24 int = 24, @a25 int = 25, @a26 int = 26,
+@a27 int = 27, @a28 int = 28, @a29 int = 29, @a30 int = 30, @a31 int = 31, @a32 int = 32, @a33 int = 33, @a34 int = 34, @a35 int = 35, @a36 int = 36, @a37 int = 37, @a38 int = 38, @a39 int = 39,
+@a40 int = 40, @a41 int = 41, @a42 int = 42, @a43 int = 43, @a44 int = 44, @a45 int = 45, @a46 int = 46, @a47 int = 47, @a48 int = 48, @a49 int = 49, @a50 int = 50, @a51 int = 51, @a52 int = 52,
+@a53 int = 53, @a54 int = 54, @a55 int = 55, @a56 int = 56, @a57 int = 57, @a58 int = 58, @a59 int = 59, @a60 int = 60, @a61 int = 61, @a62 int = 62, @a63 int = 63, @a64 int = 64, @a65 int = 65,
+@a66 int = 66, @a67 int = 67, @a68 int = 68, @a69 int = 69, @a70 int = 70, @a71 int = 71, @a72 int = 72, @a73 int = 73, @a74 int = 74, @a75 int = 75, @a76 int = 76, @a77 int = 77, @a78 int = 78,
+@a79 int = 79, @a80 int = 80, @a81 int = 81, @a82 int = 82, @a83 int = 83, @a84 int = 84, @a85 int = 85, @a86 int = 86, @a87 int = 87, @a88 int = 88, @a89 int = 89, @a90 int = 90, @a91 int = 91,
+@a92 int = 92, @a93 int = 93, @a94 int = 94, @a95 int = 95, @a96 int = 96, @a97 int = 97, @a98 int = 98, @a99 int = 99, @a100 int = 100, @a101 int = 101, @a102 int = 102, @a103 int = 103, 
+@a104 int = 104;
+EXEC NoSuchProcedure @a0, @a1, @a2, @a3, @a4, @a5, @a6, @a7, @a8, @a9, @a10, @a11, @a12, @a13, @a14, @a15, @a16, @a17, @a18, @a19, @a20, @a21,
+@a22, @a23, @a24, @a25, @a26, @a27, @a28, @a29, @a30, @a31, @a32, @a33, @a34, @a35, @a36, @a37, @a38, @a39, @a40, @a41, @a42, @a43, @a44, @a45,
+@a46, @a47, @a48, @a49, @a50, @a51, @a52, @a53, @a54, @a55, @a56, @a57, @a58, @a59, @a60, @a61, @a62, @a63, @a64, @a65, @a66, @a67, @a68, @a69,
+@a70, @a71, @a72, @a73, @a74, @a75, @a76, @a77, @a78, @a79, @a80, @a81, @a82, @a83, @a84, @a85, @a86, @a87, @a88, @a89, @a90, @a91, @a92, @a93,
+@a94, @a95, @a96, @a97, @a98, @a99, @a100, @a101, @a102, @a103, @a104;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a procedure)~~
+
+
+
+SELECT * FROM NoSuchFunction
+(
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a function)~~
+
+
+SELECT * FROM NoSuchFunction
+(
+0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a function)~~
+
+
+
+DECLARE @a0 int = 0, @a1 int = 1, @a2 int = 2, @a3 int = 3, @a4 int = 4, @a5 int = 5, @a6 int = 6, @a7 int = 7, @a8 int = 8, @a9 int = 9, @a10 int = 10, @a11 int = 11, @a12 int = 12, @a13 int = 13,
+@a14 int = 14, @a15 int = 15, @a16 int = 16, @a17 int = 17, @a18 int = 18, @a19 int = 19, @a20 int = 20, @a21 int = 21, @a22 int = 22, @a23 int = 23, @a24 int = 24, @a25 int = 25, @a26 int = 26,
+@a27 int = 27, @a28 int = 28, @a29 int = 29, @a30 int = 30, @a31 int = 31, @a32 int = 32, @a33 int = 33, @a34 int = 34, @a35 int = 35, @a36 int = 36, @a37 int = 37, @a38 int = 38, @a39 int = 39,
+@a40 int = 40, @a41 int = 41, @a42 int = 42, @a43 int = 43, @a44 int = 44, @a45 int = 45, @a46 int = 46, @a47 int = 47, @a48 int = 48, @a49 int = 49, @a50 int = 50, @a51 int = 51, @a52 int = 52,
+@a53 int = 53, @a54 int = 54, @a55 int = 55, @a56 int = 56, @a57 int = 57, @a58 int = 58, @a59 int = 59, @a60 int = 60, @a61 int = 61, @a62 int = 62, @a63 int = 63, @a64 int = 64, @a65 int = 65,
+@a66 int = 66, @a67 int = 67, @a68 int = 68, @a69 int = 69, @a70 int = 70, @a71 int = 71, @a72 int = 72, @a73 int = 73, @a74 int = 74, @a75 int = 75, @a76 int = 76, @a77 int = 77, @a78 int = 78,
+@a79 int = 79, @a80 int = 80, @a81 int = 81, @a82 int = 82, @a83 int = 83, @a84 int = 84, @a85 int = 85, @a86 int = 86, @a87 int = 87, @a88 int = 88, @a89 int = 89, @a90 int = 90, @a91 int = 91,
+@a92 int = 92, @a93 int = 93, @a94 int = 94, @a95 int = 95, @a96 int = 96, @a97 int = 97, @a98 int = 98, @a99 int = 99, @a100 int = 100, @a101 int = 101, @a102 int = 102, @a103 int = 103, 
+@a104 int = 104;
+SELECT * FROM NoSuchFunction
+(
+@a0, @a1, @a2, @a3, @a4, @a5, @a6, @a7, @a8, @a9, @a10, @a11, @a12, @a13, @a14, @a15, @a16, @a17, @a18, @a19, @a20, @a21,
+@a22, @a23, @a24, @a25, @a26, @a27, @a28, @a29, @a30, @a31, @a32, @a33, @a34, @a35, @a36, @a37, @a38, @a39, @a40, @a41, @a42, @a43, @a44, @a45,
+@a46, @a47, @a48, @a49, @a50, @a51, @a52, @a53, @a54, @a55, @a56, @a57, @a58, @a59, @a60, @a61, @a62, @a63, @a64, @a65, @a66, @a67, @a68, @a69,
+@a70, @a71, @a72, @a73, @a74, @a75, @a76, @a77, @a78, @a79, @a80, @a81, @a82, @a83, @a84, @a85, @a86, @a87, @a88, @a89, @a90, @a91, @a92, @a93,
+@a94, @a95, @a96, @a97, @a98, @a99, @a100, @a101, @a102, @a103, @a104
+);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a function)~~
+
+
+-- max allowed
+CREATE PROCEDURE babel_3984_procedure
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int
+)
+AS
+SELECT
+@a0 + @a1 + @a2 + @a3 + @a4 + @a5 + @a6 + @a7 + @a8 + @a9 + @a10 + @a11 + @a12 + @a13 + @a14 + @a15 + @a16 + @a17 + @a18 + @a19 + @a20 + @a21 + @a22 + 
+@a23 + @a24 + @a25 + @a26 + @a27 + @a28 + @a29 + @a30 + @a31 + @a32 + @a33 + @a34 + @a35 + @a36 + @a37 + @a38 + @a39 + @a40 + @a41 + @a42 + @a43 + @a44 + 
+@a45 + @a46 + @a47 + @a48 + @a49 + @a50 + @a51 + @a52 + @a53 + @a54 + @a55 + @a56 + @a57 + @a58 + @a59 + @a60 + @a61 + @a62 + @a63 + @a64 + @a65 + @a66 + 
+@a67 + @a68 + @a69 + @a70 + @a71 + @a72 + @a73 + @a74 + @a75 + @a76 + @a77 + @a78 + @a79 + @a80 + @a81 + @a82 + @a83 + @a84 + @a85 + @a86 + @a87 + @a88 + 
+@a89 + @a90 + @a91 + @a92 + @a93 + @a94 + @a95 + @a96 + @a97 + @a98 + @a99
+GO
+
+EXEC babel_3984_procedure
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+-- call for more than max should throw error
+EXEC babel_3984_procedure
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a procedure)~~
+
+
+-- create for more than allowed should also throw error
+CREATE PROCEDURE babel_3984_procedure2
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int, @a100 int, @a101 int
+)
+AS
+SELECT 1
+GO
+~~ERROR (Code: 180)~~
+
+~~ERROR (Message: functions cannot have more than 100 arguments)~~
+
+
+-- max allowed
+CREATE FUNCTION babel_3984_function
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int
+)
+RETURNS int 
+AS
+BEGIN
+RETURN
+(
+@a0 + @a1 + @a2 + @a3 + @a4 + @a5 + @a6 + @a7 + @a8 + @a9 + @a10 + @a11 + @a12 + @a13 + @a14 + @a15 + @a16 + @a17 + @a18 + @a19 + @a20 + @a21 + @a22 + 
+@a23 + @a24 + @a25 + @a26 + @a27 + @a28 + @a29 + @a30 + @a31 + @a32 + @a33 + @a34 + @a35 + @a36 + @a37 + @a38 + @a39 + @a40 + @a41 + @a42 + @a43 + @a44 + 
+@a45 + @a46 + @a47 + @a48 + @a49 + @a50 + @a51 + @a52 + @a53 + @a54 + @a55 + @a56 + @a57 + @a58 + @a59 + @a60 + @a61 + @a62 + @a63 + @a64 + @a65 + @a66 + 
+@a67 + @a68 + @a69 + @a70 + @a71 + @a72 + @a73 + @a74 + @a75 + @a76 + @a77 + @a78 + @a79 + @a80 + @a81 + @a82 + @a83 + @a84 + @a85 + @a86 + @a87 + @a88 + 
+@a89 + @a90 + @a91 + @a92 + @a93 + @a94 + @a95 + @a96 + @a97 + @a98 + @a99  
+)
+END 
+GO
+
+SELECT * FROM babel_3984_function
+(
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+)
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+-- call for more than allowed should throw error
+SELECT * FROM babel_3984_function
+(
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot pass more than 100 arguments to a function)~~
+
+
+-- create for more than allowed should also throw error
+CREATE FUNCTION babel_3984_function2
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int, @a100 int, @a101 int
+)
+RETURNS int
+AS 
+BEGIN
+RETURN
+(
+@a0 + @a1 + @a2 + @a3 + @a4 + @a5 + @a6 + @a7 + @a8 + @a9 + @a10 + @a11 + @a12 + @a13 + @a14 + @a15 + @a16 + @a17 + @a18 + @a19 + @a20 + @a21 + @a22 + 
+@a23 + @a24 + @a25 + @a26 + @a27 + @a28 + @a29 + @a30 + @a31 + @a32 + @a33 + @a34 + @a35 + @a36 + @a37 + @a38 + @a39 + @a40 + @a41 + @a42 + @a43 + @a44 + 
+@a45 + @a46 + @a47 + @a48 + @a49 + @a50 + @a51 + @a52 + @a53 + @a54 + @a55 + @a56 + @a57 + @a58 + @a59 + @a60 + @a61 + @a62 + @a63 + @a64 + @a65 + @a66 + 
+@a67 + @a68 + @a69 + @a70 + @a71 + @a72 + @a73 + @a74 + @a75 + @a76 + @a77 + @a78 + @a79 + @a80 + @a81 + @a82 + @a83 + @a84 + @a85 + @a86 + @a87 + @a88 + 
+@a89 + @a90 + @a91 + @a92 + @a93 + @a94 + @a95 + @a96 + @a97 + @a98 + @a99 + @a100 + @a101
+)
+END
+GO
+~~ERROR (Code: 180)~~
+
+~~ERROR (Message: functions cannot have more than 100 arguments)~~
+
+
+
+
+DROP PROCEDURE babel_3984_procedure
+GO
+
+DROP FUNCTION babel_3984_function
+GO
+

--- a/test/JDBC/input/BABEL-3984.sql
+++ b/test/JDBC/input/BABEL-3984.sql
@@ -1,0 +1,191 @@
+EXEC NoSuchProcedure  
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL
+GO
+
+EXEC NoSuchProcedure 
+0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104
+GO
+
+DECLARE @a0 int = 0, @a1 int = 1, @a2 int = 2, @a3 int = 3, @a4 int = 4, @a5 int = 5, @a6 int = 6, @a7 int = 7, @a8 int = 8, @a9 int = 9, @a10 int = 10, @a11 int = 11, @a12 int = 12, @a13 int = 13,
+@a14 int = 14, @a15 int = 15, @a16 int = 16, @a17 int = 17, @a18 int = 18, @a19 int = 19, @a20 int = 20, @a21 int = 21, @a22 int = 22, @a23 int = 23, @a24 int = 24, @a25 int = 25, @a26 int = 26,
+@a27 int = 27, @a28 int = 28, @a29 int = 29, @a30 int = 30, @a31 int = 31, @a32 int = 32, @a33 int = 33, @a34 int = 34, @a35 int = 35, @a36 int = 36, @a37 int = 37, @a38 int = 38, @a39 int = 39,
+@a40 int = 40, @a41 int = 41, @a42 int = 42, @a43 int = 43, @a44 int = 44, @a45 int = 45, @a46 int = 46, @a47 int = 47, @a48 int = 48, @a49 int = 49, @a50 int = 50, @a51 int = 51, @a52 int = 52,
+@a53 int = 53, @a54 int = 54, @a55 int = 55, @a56 int = 56, @a57 int = 57, @a58 int = 58, @a59 int = 59, @a60 int = 60, @a61 int = 61, @a62 int = 62, @a63 int = 63, @a64 int = 64, @a65 int = 65,
+@a66 int = 66, @a67 int = 67, @a68 int = 68, @a69 int = 69, @a70 int = 70, @a71 int = 71, @a72 int = 72, @a73 int = 73, @a74 int = 74, @a75 int = 75, @a76 int = 76, @a77 int = 77, @a78 int = 78,
+@a79 int = 79, @a80 int = 80, @a81 int = 81, @a82 int = 82, @a83 int = 83, @a84 int = 84, @a85 int = 85, @a86 int = 86, @a87 int = 87, @a88 int = 88, @a89 int = 89, @a90 int = 90, @a91 int = 91,
+@a92 int = 92, @a93 int = 93, @a94 int = 94, @a95 int = 95, @a96 int = 96, @a97 int = 97, @a98 int = 98, @a99 int = 99, @a100 int = 100, @a101 int = 101, @a102 int = 102, @a103 int = 103, 
+@a104 int = 104;
+
+EXEC NoSuchProcedure @a0, @a1, @a2, @a3, @a4, @a5, @a6, @a7, @a8, @a9, @a10, @a11, @a12, @a13, @a14, @a15, @a16, @a17, @a18, @a19, @a20, @a21,
+@a22, @a23, @a24, @a25, @a26, @a27, @a28, @a29, @a30, @a31, @a32, @a33, @a34, @a35, @a36, @a37, @a38, @a39, @a40, @a41, @a42, @a43, @a44, @a45,
+@a46, @a47, @a48, @a49, @a50, @a51, @a52, @a53, @a54, @a55, @a56, @a57, @a58, @a59, @a60, @a61, @a62, @a63, @a64, @a65, @a66, @a67, @a68, @a69,
+@a70, @a71, @a72, @a73, @a74, @a75, @a76, @a77, @a78, @a79, @a80, @a81, @a82, @a83, @a84, @a85, @a86, @a87, @a88, @a89, @a90, @a91, @a92, @a93,
+@a94, @a95, @a96, @a97, @a98, @a99, @a100, @a101, @a102, @a103, @a104;
+GO
+
+
+SELECT * FROM NoSuchFunction
+(
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,
+NULL,  NULL,  NULL,  NULL,  NULL
+)
+GO
+
+SELECT * FROM NoSuchFunction
+(
+0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104
+)
+GO
+
+DECLARE @a0 int = 0, @a1 int = 1, @a2 int = 2, @a3 int = 3, @a4 int = 4, @a5 int = 5, @a6 int = 6, @a7 int = 7, @a8 int = 8, @a9 int = 9, @a10 int = 10, @a11 int = 11, @a12 int = 12, @a13 int = 13,
+@a14 int = 14, @a15 int = 15, @a16 int = 16, @a17 int = 17, @a18 int = 18, @a19 int = 19, @a20 int = 20, @a21 int = 21, @a22 int = 22, @a23 int = 23, @a24 int = 24, @a25 int = 25, @a26 int = 26,
+@a27 int = 27, @a28 int = 28, @a29 int = 29, @a30 int = 30, @a31 int = 31, @a32 int = 32, @a33 int = 33, @a34 int = 34, @a35 int = 35, @a36 int = 36, @a37 int = 37, @a38 int = 38, @a39 int = 39,
+@a40 int = 40, @a41 int = 41, @a42 int = 42, @a43 int = 43, @a44 int = 44, @a45 int = 45, @a46 int = 46, @a47 int = 47, @a48 int = 48, @a49 int = 49, @a50 int = 50, @a51 int = 51, @a52 int = 52,
+@a53 int = 53, @a54 int = 54, @a55 int = 55, @a56 int = 56, @a57 int = 57, @a58 int = 58, @a59 int = 59, @a60 int = 60, @a61 int = 61, @a62 int = 62, @a63 int = 63, @a64 int = 64, @a65 int = 65,
+@a66 int = 66, @a67 int = 67, @a68 int = 68, @a69 int = 69, @a70 int = 70, @a71 int = 71, @a72 int = 72, @a73 int = 73, @a74 int = 74, @a75 int = 75, @a76 int = 76, @a77 int = 77, @a78 int = 78,
+@a79 int = 79, @a80 int = 80, @a81 int = 81, @a82 int = 82, @a83 int = 83, @a84 int = 84, @a85 int = 85, @a86 int = 86, @a87 int = 87, @a88 int = 88, @a89 int = 89, @a90 int = 90, @a91 int = 91,
+@a92 int = 92, @a93 int = 93, @a94 int = 94, @a95 int = 95, @a96 int = 96, @a97 int = 97, @a98 int = 98, @a99 int = 99, @a100 int = 100, @a101 int = 101, @a102 int = 102, @a103 int = 103, 
+@a104 int = 104;
+
+SELECT * FROM NoSuchFunction
+(
+@a0, @a1, @a2, @a3, @a4, @a5, @a6, @a7, @a8, @a9, @a10, @a11, @a12, @a13, @a14, @a15, @a16, @a17, @a18, @a19, @a20, @a21,
+@a22, @a23, @a24, @a25, @a26, @a27, @a28, @a29, @a30, @a31, @a32, @a33, @a34, @a35, @a36, @a37, @a38, @a39, @a40, @a41, @a42, @a43, @a44, @a45,
+@a46, @a47, @a48, @a49, @a50, @a51, @a52, @a53, @a54, @a55, @a56, @a57, @a58, @a59, @a60, @a61, @a62, @a63, @a64, @a65, @a66, @a67, @a68, @a69,
+@a70, @a71, @a72, @a73, @a74, @a75, @a76, @a77, @a78, @a79, @a80, @a81, @a82, @a83, @a84, @a85, @a86, @a87, @a88, @a89, @a90, @a91, @a92, @a93,
+@a94, @a95, @a96, @a97, @a98, @a99, @a100, @a101, @a102, @a103, @a104
+);
+GO
+
+-- max allowed
+CREATE PROCEDURE babel_3984_procedure
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int
+)
+AS
+SELECT
+@a0 + @a1 + @a2 + @a3 + @a4 + @a5 + @a6 + @a7 + @a8 + @a9 + @a10 + @a11 + @a12 + @a13 + @a14 + @a15 + @a16 + @a17 + @a18 + @a19 + @a20 + @a21 + @a22 + 
+@a23 + @a24 + @a25 + @a26 + @a27 + @a28 + @a29 + @a30 + @a31 + @a32 + @a33 + @a34 + @a35 + @a36 + @a37 + @a38 + @a39 + @a40 + @a41 + @a42 + @a43 + @a44 + 
+@a45 + @a46 + @a47 + @a48 + @a49 + @a50 + @a51 + @a52 + @a53 + @a54 + @a55 + @a56 + @a57 + @a58 + @a59 + @a60 + @a61 + @a62 + @a63 + @a64 + @a65 + @a66 + 
+@a67 + @a68 + @a69 + @a70 + @a71 + @a72 + @a73 + @a74 + @a75 + @a76 + @a77 + @a78 + @a79 + @a80 + @a81 + @a82 + @a83 + @a84 + @a85 + @a86 + @a87 + @a88 + 
+@a89 + @a90 + @a91 + @a92 + @a93 + @a94 + @a95 + @a96 + @a97 + @a98 + @a99
+GO
+
+EXEC babel_3984_procedure
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+GO
+
+-- call for more than max should throw error
+EXEC babel_3984_procedure
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+GO
+
+-- create for more than allowed should also throw error
+CREATE PROCEDURE babel_3984_procedure2
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int, @a100 int, @a101 int
+)
+AS
+SELECT 1
+GO
+
+-- max allowed
+CREATE FUNCTION babel_3984_function
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int
+)
+RETURNS int 
+AS
+BEGIN
+RETURN
+(
+@a0 + @a1 + @a2 + @a3 + @a4 + @a5 + @a6 + @a7 + @a8 + @a9 + @a10 + @a11 + @a12 + @a13 + @a14 + @a15 + @a16 + @a17 + @a18 + @a19 + @a20 + @a21 + @a22 + 
+@a23 + @a24 + @a25 + @a26 + @a27 + @a28 + @a29 + @a30 + @a31 + @a32 + @a33 + @a34 + @a35 + @a36 + @a37 + @a38 + @a39 + @a40 + @a41 + @a42 + @a43 + @a44 + 
+@a45 + @a46 + @a47 + @a48 + @a49 + @a50 + @a51 + @a52 + @a53 + @a54 + @a55 + @a56 + @a57 + @a58 + @a59 + @a60 + @a61 + @a62 + @a63 + @a64 + @a65 + @a66 + 
+@a67 + @a68 + @a69 + @a70 + @a71 + @a72 + @a73 + @a74 + @a75 + @a76 + @a77 + @a78 + @a79 + @a80 + @a81 + @a82 + @a83 + @a84 + @a85 + @a86 + @a87 + @a88 + 
+@a89 + @a90 + @a91 + @a92 + @a93 + @a94 + @a95 + @a96 + @a97 + @a98 + @a99  
+)
+END 
+GO
+
+SELECT * FROM babel_3984_function
+(
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+)
+GO
+
+-- call for more than allowed should throw error
+SELECT * FROM babel_3984_function
+(
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+)
+GO
+
+-- create for more than allowed should also throw error
+CREATE FUNCTION babel_3984_function2
+(
+@a0 int, @a1 int, @a2 int, @a3 int, @a4 int, @a5 int, @a6 int, @a7 int, @a8 int, @a9 int, @a10 int, @a11 int, @a12 int, @a13 int, @a14 int, @a15 int,
+@a16 int, @a17 int, @a18 int, @a19 int, @a20 int, @a21 int, @a22 int, @a23 int, @a24 int, @a25 int, @a26 int, @a27 int, @a28 int, @a29 int, @a30 int,
+@a31 int, @a32 int, @a33 int, @a34 int, @a35 int, @a36 int, @a37 int, @a38 int, @a39 int, @a40 int, @a41 int, @a42 int, @a43 int, @a44 int, @a45 int,
+@a46 int, @a47 int, @a48 int, @a49 int, @a50 int, @a51 int, @a52 int, @a53 int, @a54 int, @a55 int, @a56 int, @a57 int, @a58 int, @a59 int, @a60 int,
+@a61 int, @a62 int, @a63 int, @a64 int, @a65 int, @a66 int, @a67 int, @a68 int, @a69 int, @a70 int, @a71 int, @a72 int, @a73 int, @a74 int, @a75 int,
+@a76 int, @a77 int, @a78 int, @a79 int, @a80 int, @a81 int, @a82 int, @a83 int, @a84 int, @a85 int, @a86 int, @a87 int, @a88 int, @a89 int, @a90 int,
+@a91 int, @a92 int, @a93 int, @a94 int, @a95 int, @a96 int, @a97 int, @a98 int, @a99 int, @a100 int, @a101 int
+)
+RETURNS int
+AS 
+BEGIN
+RETURN
+(
+@a0 + @a1 + @a2 + @a3 + @a4 + @a5 + @a6 + @a7 + @a8 + @a9 + @a10 + @a11 + @a12 + @a13 + @a14 + @a15 + @a16 + @a17 + @a18 + @a19 + @a20 + @a21 + @a22 + 
+@a23 + @a24 + @a25 + @a26 + @a27 + @a28 + @a29 + @a30 + @a31 + @a32 + @a33 + @a34 + @a35 + @a36 + @a37 + @a38 + @a39 + @a40 + @a41 + @a42 + @a43 + @a44 + 
+@a45 + @a46 + @a47 + @a48 + @a49 + @a50 + @a51 + @a52 + @a53 + @a54 + @a55 + @a56 + @a57 + @a58 + @a59 + @a60 + @a61 + @a62 + @a63 + @a64 + @a65 + @a66 + 
+@a67 + @a68 + @a69 + @a70 + @a71 + @a72 + @a73 + @a74 + @a75 + @a76 + @a77 + @a78 + @a79 + @a80 + @a81 + @a82 + @a83 + @a84 + @a85 + @a86 + @a87 + @a88 + 
+@a89 + @a90 + @a91 + @a92 + @a93 + @a94 + @a95 + @a96 + @a97 + @a98 + @a99 + @a100 + @a101
+)
+END
+GO
+
+
+
+DROP PROCEDURE babel_3984_procedure
+GO
+
+DROP FUNCTION babel_3984_function
+GO
+


### PR DESCRIPTION


### Description

Earlier, Inside is_exec_stmt_on_scalar_func function,  we were accessing the unallocated memory when number of args are greater than FUNC_MAX_ARGS due to which PG crashes with message 'stack smashing detected'  in the PG log. This commit adds a safety check to throw error in case of more than allowed arguments.


Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Issues Resolved

Task : BABEL-3984

BABEL_2_3_STABLE PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1270
### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** NA


* **Negative test cases -** Yes


* **Minor version upgrade tests -**  NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).