### PR TITLE
Avoid dropping rds_ad role after cleanup script

### DIFF
--- a/test/JDBC/expected/BABEL-3828-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3828-vu-cleanup.out
@@ -14,11 +14,4 @@ GO
 ~~ERROR (Message: Cannot drop the login 'babeluser@BABEL', because it does not exist or you do not have permission.)~~
 
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO
+

--- a/test/JDBC/expected/BABEL-3844-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3844-vu-cleanup.out
@@ -54,11 +54,3 @@ GO
 drop database testdb;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/expected/Babel_domain_mapping_test-vu-verify.out
+++ b/test/JDBC/expected/Babel_domain_mapping_test-vu-verify.out
@@ -196,11 +196,3 @@ int
 ~~END~~
 
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/expected/Test_user_from_win_login-vu-verify.out
+++ b/test/JDBC/expected/Test_user_from_win_login-vu-verify.out
@@ -16,11 +16,4 @@ GO
 drop login [pnq\admin];
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO
+

--- a/test/JDBC/expected/test_windows_alter_login-vu-cleanup.out
+++ b/test/JDBC/expected/test_windows_alter_login-vu-cleanup.out
@@ -11,11 +11,3 @@ GO
 DROP DATABASE alter_db;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/expected/test_windows_alter_user-vu-cleanup.out
+++ b/test/JDBC/expected/test_windows_alter_user-vu-cleanup.out
@@ -11,11 +11,3 @@ GO
 drop schema ad_schema;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/expected/test_windows_login-vu-cleanup.out
+++ b/test/JDBC/expected/test_windows_login-vu-cleanup.out
@@ -85,11 +85,4 @@ GO
 DROP DATABASE ad_db;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO
+

--- a/test/JDBC/expected/test_windows_sp_helpuser-vu-cleanup.out
+++ b/test/JDBC/expected/test_windows_sp_helpuser-vu-cleanup.out
@@ -14,11 +14,3 @@ GO
 drop table temp_sp_helpuser;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/expected/test_windows_sp_helpuser-vu-verify.out
+++ b/test/JDBC/expected/test_windows_sp_helpuser-vu-verify.out
@@ -1,5 +1,5 @@
 -- tsql
-select rolname, login_name from babelfish_authid_user_ext where rolname in ('master_bbf\ad_sp_helpuser','master_pass_sp_helpuser');
+select rolname, login_name from babelfish_authid_user_ext where rolname in ('master_bbf\ad_sp_helpuser','master_pass_sp_helpuser') order by rolname;
 GO
 ~~START~~
 varchar#!#varchar

--- a/test/JDBC/input/BABEL-3828-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-3828-vu-cleanup.mix
@@ -10,11 +10,4 @@ GO
 DROP LOGIN [babel\babeluser];
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO
+

--- a/test/JDBC/input/BABEL-3844-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-3844-vu-cleanup.mix
@@ -50,11 +50,3 @@ GO
 drop database testdb;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/input/Babel_domain_mapping_test-vu-verify.mix
+++ b/test/JDBC/input/Babel_domain_mapping_test-vu-verify.mix
@@ -123,11 +123,3 @@ GO
 select count(*) from sys.babelfish_domain_mapping;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/input/Test_user_from_win_login-vu-verify.mix
+++ b/test/JDBC/input/Test_user_from_win_login-vu-verify.mix
@@ -11,11 +11,4 @@ GO
 drop login [pnq\admin];
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO
+

--- a/test/JDBC/input/test_windows_alter_login-vu-cleanup.mix
+++ b/test/JDBC/input/test_windows_alter_login-vu-cleanup.mix
@@ -11,11 +11,3 @@ GO
 DROP DATABASE alter_db;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/input/test_windows_alter_user-vu-cleanup.mix
+++ b/test/JDBC/input/test_windows_alter_user-vu-cleanup.mix
@@ -11,11 +11,3 @@ GO
 drop schema ad_schema;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/input/test_windows_login-vu-cleanup.mix
+++ b/test/JDBC/input/test_windows_login-vu-cleanup.mix
@@ -61,11 +61,4 @@ GO
 DROP DATABASE ad_db;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO
+

--- a/test/JDBC/input/test_windows_sp_helpuser-vu-cleanup.mix
+++ b/test/JDBC/input/test_windows_sp_helpuser-vu-cleanup.mix
@@ -14,11 +14,3 @@ GO
 drop table temp_sp_helpuser;
 GO
 
--- psql
-do 
-$$ begin 
-    if exists (select * from pg_catalog.pg_roles where rolname = 'rds_ad') 
-        then DROP ROLE rds_ad; 
-    end if; 
-end $$;
-GO

--- a/test/JDBC/input/test_windows_sp_helpuser-vu-verify.mix
+++ b/test/JDBC/input/test_windows_sp_helpuser-vu-verify.mix
@@ -1,5 +1,5 @@
 -- tsql
-select rolname, login_name from babelfish_authid_user_ext where rolname in ('master_bbf\ad_sp_helpuser','master_pass_sp_helpuser');
+select rolname, login_name from babelfish_authid_user_ext where rolname in ('master_bbf\ad_sp_helpuser','master_pass_sp_helpuser') order by rolname;
 GO
 
 CREATE TABLE temp_sp_helpuser(UserName sys.sysname, RoleName sys.sysname, LoginName sys.sysname, 


### PR DESCRIPTION
### Description

Removing dropping rds_ad role after cleanup script.

### Issues Resolved

Related Task: BABEL-3847
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)



### Check List
- [] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).