### PR TITLE
fix tests for sp_babelfish_volatility

### DIFF
--- a/test/JDBC/expected/Test-sp_babelfish_volatility-vu-prepare.out
+++ b/test/JDBC/expected/Test-sp_babelfish_volatility-vu-prepare.out
@@ -13,7 +13,7 @@ go
 create function [test_sp_babelfish_volatility_schema1 with .dot and spaces].test_sp_babelfish_volatility_f1() returns int begin declare @a int; set @a = 1; return @a; end
 go
 
-CREATE LOGIN test_sp_babelfish_volatility_login WITH PASSWORD = 'abc';
+CREATE LOGIN test_sp_babelfish_volatility_login WITH PASSWORD = '12345678';
 GO
 
 CREATE DATABASE test_sp_babelfish_volatility_db1
@@ -66,5 +66,5 @@ go
 use test_sp_babelfish_volatility_db1
 go
 
-CREATE LOGIN test_sp_babelfish_volatility_login_2 WITH PASSWORD = 'abc'
+CREATE LOGIN test_sp_babelfish_volatility_login_2 WITH PASSWORD = '12345678'
 GO

--- a/test/JDBC/expected/Test-sp_babelfish_volatility-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_babelfish_volatility-vu-verify.out
@@ -494,7 +494,7 @@ dbo#!#test_sp_babelfish_volatility_f2#!#stable
 ~~END~~
 
 
--- tsql      user=test_sp_babelfish_volatility_login password='abc'
+-- tsql      user=test_sp_babelfish_volatility_login password=12345678
 /* function on which user has privilege is only visible */
 use test_sp_babelfish_volatility_db1
 go
@@ -551,7 +551,7 @@ go
 grant execute on test_sp_babelfish_volatility_f2 to test_sp_babelfish_volatility_user
 go
 
--- tsql      user=test_sp_babelfish_volatility_login password='abc'
+-- tsql      user=test_sp_babelfish_volatility_login password=12345678
 use test_sp_babelfish_volatility_db1
 go
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema2.test_sp_babelfish_volatility_f1'
@@ -606,7 +606,7 @@ go
 ALTER USER test_sp_babelfish_volatility_user WITH DEFAULT_SCHEMA=test_sp_babelfish_volatility_schema2
 GO
 
--- tsql      user=test_sp_babelfish_volatility_login password='abc'
+-- tsql      user=test_sp_babelfish_volatility_login password=12345678
 use test_sp_babelfish_volatility_db1
 go
 select current_user
@@ -668,7 +668,7 @@ go
 grant connect to guest
 go
 
--- tsql     user=test_sp_babelfish_volatility_login_2 password='abc'
+-- tsql     user=test_sp_babelfish_volatility_login_2 password=12345678
 use test_sp_babelfish_volatility_db1
 go
 SELECT current_user

--- a/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-prepare.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-prepare.sql
@@ -13,7 +13,7 @@ go
 create function [test_sp_babelfish_volatility_schema1 with .dot and spaces].test_sp_babelfish_volatility_f1() returns int begin declare @a int; set @a = 1; return @a; end
 go
 
-CREATE LOGIN test_sp_babelfish_volatility_login WITH PASSWORD = 'abc';
+CREATE LOGIN test_sp_babelfish_volatility_login WITH PASSWORD = '12345678';
 GO
 
 CREATE DATABASE test_sp_babelfish_volatility_db1
@@ -66,5 +66,5 @@ go
 use test_sp_babelfish_volatility_db1
 go
 
-CREATE LOGIN test_sp_babelfish_volatility_login_2 WITH PASSWORD = 'abc'
+CREATE LOGIN test_sp_babelfish_volatility_login_2 WITH PASSWORD = '12345678'
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-verify.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_babelfish_volatility-vu-verify.mix
@@ -196,7 +196,7 @@ exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_f2'
 go
 
 /* function on which user has privilege is only visible */
--- tsql      user=test_sp_babelfish_volatility_login password='abc'
+-- tsql      user=test_sp_babelfish_volatility_login password=12345678
 use test_sp_babelfish_volatility_db1
 go
 select current_user
@@ -223,7 +223,7 @@ go
 grant execute on test_sp_babelfish_volatility_f2 to test_sp_babelfish_volatility_user
 go
 
--- tsql      user=test_sp_babelfish_volatility_login password='abc'
+-- tsql      user=test_sp_babelfish_volatility_login password=12345678
 use test_sp_babelfish_volatility_db1
 go
 exec sys.sp_babelfish_volatility 'test_sp_babelfish_volatility_schema2.test_sp_babelfish_volatility_f1'
@@ -246,7 +246,7 @@ go
 ALTER USER test_sp_babelfish_volatility_user WITH DEFAULT_SCHEMA=test_sp_babelfish_volatility_schema2
 GO
 
--- tsql      user=test_sp_babelfish_volatility_login password='abc'
+-- tsql      user=test_sp_babelfish_volatility_login password=12345678
 use test_sp_babelfish_volatility_db1
 go
 select current_user
@@ -278,7 +278,7 @@ go
 grant connect to guest
 go
 
--- tsql     user=test_sp_babelfish_volatility_login_2 password='abc'
+-- tsql     user=test_sp_babelfish_volatility_login_2 password=12345678
 use test_sp_babelfish_volatility_db1
 go
 SELECT current_user


### PR DESCRIPTION
3_X PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1283
Signed-off-by: Shlok Kumar Kyal ([skkyal@amazon.com](mailto:skkyal@amazon.com))

### Description

Earlier inverted comma were used in providing password while logging as a user. It should not be provided with inverted comma. Previously it didnot gave an error on github as the auth in github is set to `trust` (So login would not depend on password).
Have fixed test with correct password value.

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).