### PR TITLE
Need to throw an error while establishing a connection to remote server when pltsql_enable_linked_servers GUC is off

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -9,6 +9,7 @@
 
 #include "pltsql.h"
 #include "linked_servers.h"
+#include "guc.h"
 
 #define NO_CLIENT_LIB_ERROR() \
 	ereport(ERROR, \
@@ -700,6 +701,11 @@ linked_server_establish_connection(char* servername, LinkedServerProcess *lsproc
 	ListCell *option;
 	char *data_src = NULL;
 	char *database = NULL;
+
+	if(!pltsql_enable_linked_servers)
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_ERROR),
+				errmsg("'openquery' is not currently supported in Babelfish")));
 
 	PG_TRY();
 	{


### PR DESCRIPTION
### Description

Currently if pltsql_enable_linked_servers GUC is off (meaning linked servers features are disabled), while calling openquery from sys schema through psql, we are not throwing any error saying that the openquery is not supported. This change throws an error while establishing a connection to remote server when pltsql_enable_linked_servers GUC is off


### Issues Resolved

BABEL-4037
Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).