### PR TITLE
Disable windows and linked server tests in v15.2

### DIFF
--- a/test/JDBC/input/storedProcedures/Test-sp_rename-dep-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-dep-vu-verify.sql
@@ -1,4 +1,4 @@
--- sla 40000
+-- sla 45000
 
 -- tsql
 USE master

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -373,10 +373,10 @@ app_name
 atn2
 str
 case_insensitive_collation
-linked_servers
+# linked_servers
 ISC-sequences
 jira-BABEL-3504-upgrade
-test_windows_login
+# test_windows_login
 sys-has_perms_by_name
 sys-has_perms_by_name-dep
 BABEL_SCHEMATA
@@ -388,13 +388,13 @@ BABEL_OBJECT_ID
 BABEL-3802
 datediff_internal_date
 BABEL_OBJECT_NAME
-Test_user_from_win_login
+# Test_user_from_win_login
 BABEL-3914
-Babel_domain_mapping_test
-BABEL-3828
-BABEL-3844
+# Babel_domain_mapping_test
+# BABEL-3828
+# BABEL-3844
 BABEL-3748
-test_windows_alter_login
+#test_windows_alter_login
 sys-systypes
 openjson
 BABEL-3702
@@ -402,11 +402,11 @@ Test-sp_babelfish_volatility
 BABEL_OBJECT_DEFINITION
 Test-sp_rename
 Test-sp_rename-dep
-openquery_upgrd
+# openquery_upgrd
 BABEL-3657
-test_windows_alter_user
+# test_windows_alter_user
 BABEL-733
 BABEL-3938
 BABEL-NEXT-VALUE-FOR
 binary-index
-test_windows_sp_helpuser
+# test_windows_sp_helpuser


### PR DESCRIPTION
### Description
Ignoring windows and linked server related tests from 15_2 schedule file as AD and Linked servers are disabled for Ocelot release.

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).