### PR TITLE
dev-tools.sh supporting MVU upgrades

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -32,8 +32,11 @@ if [ ! $1 ]; then
     echo "  pg_upgrade SOURCE_WS [TARGET_WS]"
     echo "      run pg_upgrade from SOURCE_WS to TARGET_WS"
     echo ""
-    echo "  test INPUT_DIR [MIGRATION_MODE]"
-    echo "      run JDBC test, default migration_mode is single-db"
+    echo "  test normal [MIGRATION_MODE] [TEST_BASE_DIR]"
+    echo "      run a normal JDBC test, default migration mode and test dir are single-db and input, respectively"
+    echo ""
+    echo "  test TEST_MODE MIGRATION_MODE TEST_BASE_DIR"
+    echo "      run a prepare/verify JDBC test using a schedule file in TEST_BASE_DIR"
     echo ""
     echo "  minor_version_upgrade SOURCE_WS [TARGET_WS]"
     echo "      upgrade minor version using ALTER EXTENSION ... UPDATE"
@@ -60,9 +63,32 @@ if [ "$1" == "pg_upgrade" ] || [ "$1" == "minor_version_upgrade" ] || [ "$1" == 
     TARGET_WS=$3
 elif [ "$1" == "test" ]; then
     TARGET_WS=$CUR_WS
+    TEST_MODE=$2
+    if [ ! $TEST_MODE ]; then
+        echo "Error: TEST_MODE should be specified, normal, prepare or verify" 1>&2
+        exit 1
+    elif [ "${TEST_MODE}" != "normal" ] && [ "${TEST_MODE}" != "prepare" ] && [ "${TEST_MODE}" != "verify" ]; then
+        echo "Error: TEST_MODE should be one of: normal, prepare or verify" 1>&2
+        exit 1
+    fi
+
     MIGRATION_MODE=$3
-    if [ ! $MIGRATION_MODE ]; then
-        MIGRATION_MODE="single-db"
+    if [ ! ${MIGRATION_MODE} ]; then
+        if [ "${TEST_MODE?}" == "normal" ]; then
+            MIGRATION_MODE="single-db"
+        else
+            echo "Error: MIGRATION_MODE should be specified, single-db or multi-db" 1>&2
+            exit 1
+        fi
+    fi
+
+    TEST_BASE_DIR=$4
+    if [ ! $TEST_BASE_DIR ]; then
+        if [ "${TEST_MODE?}" == "normal" ]; then
+            TEST_BASE_DIR="input"
+        else
+            echo "Error: TEST_BASE_DIR should be specified" 1>&2
+        fi
     fi
 fi
 if [ ! $TARGET_WS ]; then
@@ -211,8 +237,8 @@ elif [ "$1" == "pg_upgrade" ]; then
     cd $TARGET_WS
     if [ ! -d "./upgrade" ]; then
         mkdir upgrade
-    else
-        rm upgrade/*
+    #else
+    #    rm upgrade/*
     fi
     cd upgrade
     ../postgres/bin/pg_upgrade -U $USER \
@@ -235,18 +261,80 @@ elif [ "$1" == "pg_upgrade" ]; then
         "SELECT pg_reload_conf();"
     exit 0
 elif [ "$1" == "test" ]; then
-    INPUT_DIR=$2
-    cd $TARGET_WS/postgres
 
+    # Set migration_mode
+    cd $TARGET_WS/postgres
     bin/psql -d $TEST_DB -U $USER -c \
         "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '$MIGRATION_MODE';"
     bin/psql -d $TEST_DB -U $USER -c \
         "SELECT pg_reload_conf();"
 
+    # Remove output directory
     cd $CUR_WS/babelfish_extensions/test/JDBC
-    rm -rf output
-    export inputFilesPath=$INPUT_DIR
+    rm -rf output temp_schedule
+
+    export inputFilesPath=input
+    if [ "$TEST_MODE" == "normal" ]; then
+        export inputFilesPath=${TEST_BASE_DIR?}
+    elif [ "$TEST_MODE" == "prepare" ]; then
+        for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" $TEST_BASE_DIR/schedule); do
+          if [[ ! ($(find input/ -name $filename"-vu-prepare.*") || $(find input/ -name $filename"-vu-verify.*")) ]]; then 
+            printf '%s\n' "ERROR: Cannot find Test file "$filename"-vu-prepare or "$filename"-vu-verify in input directory !!" >&2
+            exit 1
+          fi
+        done
+        cat $TEST_BASE_DIR/schedule > temp_schedule
+        for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" temp_schedule); do
+          sed -i "s/$filename[ ]*$/$filename-vu-prepare/g" temp_schedule
+        done
+        export scheduleFile=temp_schedule
+    elif [ "$TEST_MODE" == "verify" ]; then
+        for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" $TEST_BASE_DIR/schedule); do
+        #   sed -i "s/$filename[ ]*$/$filename-vu-verify\\n$filename-vu-cleanup/g" temp_schedule
+        #    sed -i "s/$filename[ ]*$/$filename-vu-verify/g" temp_schedule
+        trimmed=$(awk '{$1=$1;print}' <<< "$filename")
+        echo $trimmed-vu-verify >> temp_schedule;
+        echo $trimmed-vu-cleanup >> temp_schedule;
+        done
+        export scheduleFile=temp_schedule
+    fi
+
     mvn test
+    rm -rf temp_schedule
+    exit 0
+elif [ "$1" == "bbf_dump_test" ]; then
+    cd $TARGET_WS/babelfish_extensions
+    ./dev-tools.sh initdb
+    ./dev-tools.sh initbbf
+    ./dev-tools.sh test prepare multi-db latest
+
+    cd $TARGET_WS/postgres
+    ./bin/pg_dumpall --username jdbc_user --globals-only --quote-all-identifiers --verbose -f pg_upgrade_dump_globals.sql
+    ./bin/pg_dump --username jdbc_user --column-inserts --quote-all-identifiers --verbose --file="pg_upgrade_dump.sql" --dbname=jdbc_testdb
+
+    cd $TARGET_WS/babelfish_extensions
+    ./dev-tools.sh initdb
+
+    cd $TARGET_WS/postgres
+    ./bin/psql -U $USER -d postgres -f pg_upgrade_dump_globals.sql
+
+    bin/psql -d postgres -U $USER -c \
+        "CREATE DATABASE jdbc_testdb OWNER jdbc_user;"
+
+    ./bin/psql -U jdbc_user -d jdbc_testdb -f pg_upgrade_dump.sql
+
+    bin/psql -d jdbc_testdb -U jdbc_user -c \
+        "GRANT ALL ON SCHEMA sys to jdbc_user;"
+    bin/psql -d jdbc_testdb -U jdbc_user -c \
+        "ALTER USER jdbc_user CREATEDB;"
+    bin/psql -d jdbc_testdb -U jdbc_user -c \
+        "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
+    bin/psql -d jdbc_testdb -U $USER -c \
+        "SELECT pg_reload_conf();"
+
+    cd $TARGET_WS/babelfish_extensions
+    ./dev-tools.sh test verify multi-db latest
+
     exit 0
 elif [ "$1" == "minor_version_upgrade" ]; then
     echo "Building from $SOURCE_WS..."


### PR DESCRIPTION
### Description

Modified `dev-tools.sh` to support running MVU test cases manually. 

### High-Level Description of the changes

* The dev-tools.sh script has been updated to support running MVU (upgrade) testing.
* A new parameter has been introduced called TEST_MODE : [normal, prepare, verify]. Executing `./dev-tools.sh` without any parameter shows more information.
* In order to run the non-MVU tests under input/ directory, the command now becomes `./dev-tools.sh test normal` instead of the old way `./dev-tools.sh test input`.

### Example steps to Run MVU tests:

Let's assume we are upgrading from `14_6` to `latest` and the code for `14_6` is downloaded under `~/pg14` (we will call this the baseline directory) while the code for `latest` is under `~/pg15` (we will call this the target directory).

#### Step 1. Set up baseline directory.

Perform the usual steps of setting up an instance
```
cd ~/pg14 
sudo rm -rf ../postgres && ./dev-tools.sh initpg && ./dev-tools.sh buildall
./dev-tools.sh initdb && ./dev-tools.sh initbbf
```

#### Step 2: Set up the target directory

You just need to build it
```
cd ~/pg15
sudo rm -rf ../postgres && ./dev-tools.sh initpg && ./dev-tools.sh buildall
```

#### Step 3: Execute MVU prepare testcases specific to the baseline.

These are the files found `test/JDBC/upgrade/14_6/preparation`. The following command should run all tests under `test/JDBC/upgrade/14_6/preparation`.
```
cd ~/pg15 && ./dev-tools.sh test normal multi-db upgrade/14_6/preparation
```

#### Step 4. Execute generic MVU prepare test files

These are the test files listed in `test/JDBC/upgrade/14_6/schedule`. The script generates a temp_schedule  file and runs all the `<testcase>-vu-prepare` testcases 
```
./dev-tools.sh test prepare multi-db upgrade/14_6
```

#### Step 5. Run the actual pg_upgrade 
```
./dev-tools.sh pg_upgrade ~/pg14
```

#### Step 6. Execute the MVU verification and cleanup testcases specific to baseline
```
./dev-tools.sh test normal multi-db upgrade/latest/verification_cleanup/14_6
```

#### Step 7. Finally, execute the generic MVU verification and cleanup tests
```
./dev-tools.sh test verify multi-db upgrade/14_6
```
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).