### PR TITLE
Expose extension_config_remove function through a wrapper

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1952,7 +1952,7 @@ pg_extension_config_remove(PG_FUNCTION_ARGS)
 				 errmsg("table \"%s\" is not a member of the extension being created",
 						tablename)));
 	
-	extension_config_remove(CurrentExtensionObject, tableoid);
+	extension_config_remove_wrapper(CurrentExtensionObject, tableoid);
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
### Description
Expose extension_config_remove function through a wrapper so that it can be used by the extensions.

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).