### PR TITLE
Fix error message when creating views on temporary tables

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -934,7 +934,6 @@ class tsqlSelectStatementMutator : public TSqlParserBaseListener
 	 */
 public:
 	PLtsql_expr_query_mutator *mutator;
-	
 public:
 	tsqlSelectStatementMutator() = default;
 	/* Corner case check. If a view is created on a temporary table, we should throw an exception.
@@ -951,7 +950,7 @@ public:
 	}
 
 	void exitSelect_statement(TSqlParser::Select_statementContext *ctx) override
-	{	
+	{
 		if (mutator)
 			process_select_statement(ctx, mutator);
 	}

--- a/test/JDBC/expected/BABEL-1645.out
+++ b/test/JDBC/expected/BABEL-1645.out
@@ -1,0 +1,28 @@
+CREATE TABLE test(c1 int)
+go
+CREATE VIEW vt
+AS
+SELECT * FROM test
+go
+
+-- Below should fail
+CREATE TABLE #t(c1 int)
+go
+CREATE VIEW v
+AS
+SELECT * FROM #t
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Views or functions are not allowed on temporary tables. Table names that begin with '#' denote temporary tables.)~~
+
+
+-- clean up
+DROP VIEW vt
+go
+
+DROP TABLE test
+go
+
+DROP TABLE #t
+go

--- a/test/JDBC/input/BABEL-1645.sql
+++ b/test/JDBC/input/BABEL-1645.sql
@@ -1,0 +1,24 @@
+CREATE TABLE test(c1 int)
+go
+CREATE VIEW vt
+AS
+SELECT * FROM test
+go
+
+-- Below should fail
+CREATE TABLE #t(c1 int)
+go
+CREATE VIEW v
+AS
+SELECT * FROM #t
+go
+
+-- clean up
+DROP VIEW vt
+go
+
+DROP TABLE test
+go
+
+DROP TABLE #t
+go


### PR DESCRIPTION
### Description

Previously when creating views on temporary tables, Babelfish would throw a general error message which does not explain the reason. This commit corrects the error message and keeps it the same as in T-SQL.


### Issues Resolved
Corrected the error message when creating views on temporary tables

### Test Scenarios Covered ###
* **Use case based -**
Create views on temporary tables

* **Negative test cases -**
Create views on regular tables

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).