### PR TITLE
Fix the column "is_ms_shipped" of the view "sys.all_views" 

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1523,7 +1523,10 @@ SELECT
   , CAST('VIEW'as sys.nvarchar(60)) as type_desc
   , CAST(null as sys.datetime) as create_date
   , CAST(null as sys.datetime) as modify_date
-  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(case when (c.relnamespace::regnamespace::text = 'sys') then 1
+	when c.relname in (select name from sys.shipped_objects_not_in_sys nis
+		where nis.name = c.relname and nis.schemaid = c.relnamespace and nis.type = 'V') then 1
+	else 0 end as sys.bit) AS is_ms_shipped
   , CAST(0 as sys.bit) as is_published
   , CAST(0 as sys.bit) as is_schema_published
   , CAST(0 as sys.BIT) AS is_replicated

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.3.0--2.4.0.sql
@@ -1937,7 +1937,10 @@ SELECT
   , CAST('VIEW'as sys.nvarchar(60)) as type_desc
   , CAST(null as sys.datetime) as create_date
   , CAST(null as sys.datetime) as modify_date
-  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(case when (c.relnamespace::regnamespace::text = 'sys') then 1
+	when c.relname in (select name from sys.shipped_objects_not_in_sys nis
+		where nis.name = c.relname and nis.schemaid = c.relnamespace and nis.type = 'V') then 1
+	else 0 end as sys.bit) AS is_ms_shipped
   , CAST(0 as sys.bit) as is_published
   , CAST(0 as sys.bit) as is_schema_published
   , CAST(0 as sys.BIT) AS is_replicated

--- a/test/JDBC/expected/sys-all_views-vu-verify.out
+++ b/test/JDBC/expected/sys-all_views-vu-verify.out
@@ -74,6 +74,32 @@ sys_all_views_select_chk_option_vu_prepare#!#<NULL>#!#V #!#VIEW#!#<NULL>#!#<NULL
 ~~END~~
 
 
+-- query a system view
+SELECT
+    name
+  , principal_id
+  , type
+  , type_desc
+  , create_date
+  , modify_date
+  , is_ms_shipped
+  , is_published
+  , is_schema_published
+  , is_replicated
+  , has_replication_filter
+  , has_opaque_metadata
+  , has_unchecked_assembly_data
+  , with_check_option
+  , is_date_correlation_view
+FROM sys.all_views
+WHERE name = 'all_views'
+GO
+~~START~~
+varchar#!#int#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit
+all_views#!#<NULL>#!#V #!#VIEW#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+~~END~~
+
+
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.all_views');
 GO
 ~~START~~

--- a/test/JDBC/input/views/sys-all_views-vu-verify.sql
+++ b/test/JDBC/input/views/sys-all_views-vu-verify.sql
@@ -49,5 +49,26 @@ FROM sys.all_views
 WHERE name = 'sys_all_views_select_chk_option_vu_prepare'
 GO
 
+-- query a system view
+SELECT
+    name
+  , principal_id
+  , type
+  , type_desc
+  , create_date
+  , modify_date
+  , is_ms_shipped
+  , is_published
+  , is_schema_published
+  , is_replicated
+  , has_replication_filter
+  , has_opaque_metadata
+  , has_unchecked_assembly_data
+  , with_check_option
+  , is_date_correlation_view
+FROM sys.all_views
+WHERE name = 'all_views'
+GO
+
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.all_views');
 GO


### PR DESCRIPTION

The column "is_ms_shipped" of the view "sys.all_views" should be correctly set to 0 or 1 based on the view being a system view or a user created view.

Currently, is_ms_shipped is hardcoded to "0" which means SSMS treats all the system views as User defined views which is incorrect.

Task: BABEL-4040
Signed-off-by: Shalini Lohia <lshalini@amazon.com>