### PR TITLE
Fix Create Function cannot contain Commit, Rollback and Execute

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -750,8 +750,17 @@ public:
 	}
 
 	void enterExecute_statement(TSqlParser::Execute_statementContext *ctx) override {
-		if (in_create_or_alter_function && (ctx->EXEC() || ctx->EXECUTE() ) ){
-			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Invalid use of a side-effecting operator 'EXECUTE STRING' within a function.", 0, 0);
+		if (in_create_or_alter_function && (ctx->EXEC() || ctx->EXECUTE())){
+			TSqlParser::Execute_bodyContext *body = ctx->execute_body();
+			if (body->LR_BRACKET())
+			{
+				std::vector<TSqlParser::Execute_var_stringContext *> exec_strings = body->execute_var_string();
+				if (!exec_strings.empty())
+				{
+					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Invalid use of a side-effecting operator 'EXECUTE STRING' within a function.", 0, 0);
+				}
+				
+			}
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -730,6 +730,30 @@ class tsqlCommonMutator : public TSqlParserBaseListener
 	/* see comment above. */
 public:
 	explicit tsqlCommonMutator() = default;
+	bool in_create_or_alter_function = false;
+
+	void enterCreate_or_alter_function(TSqlParser::Create_or_alter_functionContext *ctx) override {
+		in_create_or_alter_function = true;
+	}
+
+	void exitCreate_or_alter_function(TSqlParser::Create_or_alter_functionContext *ctx) override {
+		in_create_or_alter_function = false;
+	}
+
+	void enterTransaction_statement(TSqlParser::Transaction_statementContext *ctx) override {
+		if (in_create_or_alter_function && ctx->COMMIT()){
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Invalid use of a side-effecting operator 'COMMIT TRANSACTION' within a function.", 0, 0);
+		}
+		if (in_create_or_alter_function && ctx->ROLLBACK()){
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Invalid use of a side-effecting operator 'ROLLBACK TRANSACTION' within a function.", 0, 0);
+		}
+	}
+
+	void enterExecute_statement(TSqlParser::Execute_statementContext *ctx) override {
+		if (in_create_or_alter_function && (ctx->EXEC() || ctx->EXECUTE() ) ){
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "Invalid use of a side-effecting operator 'EXECUTE STRING' within a function.", 0, 0);
+		}
+	}
 
 	/* Column Name */
 	void exitSimple_column_name(TSqlParser::Simple_column_nameContext *ctx) override

--- a/test/JDBC/expected/BABEL-1591.out
+++ b/test/JDBC/expected/BABEL-1591.out
@@ -1,0 +1,61 @@
+
+-- Allow normal function creation
+CREATE FUNCTION babel1591foo1() RETURNS INT AS BEGIN RETURN 10 END
+GO
+
+SELECT babel1591foo1();
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+DROP FUNCTION IF EXISTS babel1591foo1;
+GO
+
+-- Below Create function statements having specific keywords should fail
+CREATE FUNCTION foocommittest(@p int) RETURNS int AS BEGIN COMMIT RETURN 0 END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid use of a side-effecting operator 'COMMIT TRANSACTION' within a function.)~~
+
+
+CREATE FUNCTION foorollbacktest(@p int) RETURNS int AS BEGIN ROLLBACK RETURN 0 END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid use of a side-effecting operator 'ROLLBACK TRANSACTION' within a function.)~~
+
+
+CREATE FUNCTION fooexecutetest(@p int) RETURNS int AS BEGIN EXECUTE('select 1') RETURN 0 END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid use of a side-effecting operator 'EXECUTE STRING' within a function.)~~
+
+
+CREATE FUNCTION fooexectest(@p int) RETURNS int AS BEGIN EXEC('select 1') RETURN 0 END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid use of a side-effecting operator 'EXECUTE STRING' within a function.)~~
+
+
+-- clean up
+DROP FUNCTION IF EXISTS foocommittest
+GO
+
+DROP FUNCTION IF EXISTS foorollbacktest
+GO
+
+DROP FUNCTION IF EXISTS fooexecutetest
+GO
+
+DROP FUNCTION IF EXISTS fooexectest
+GO
+
+
+
+

--- a/test/JDBC/expected/BABEL-1591.out
+++ b/test/JDBC/expected/BABEL-1591.out
@@ -55,7 +55,3 @@ GO
 
 DROP FUNCTION IF EXISTS fooexectest
 GO
-
-
-
-

--- a/test/JDBC/expected/BABEL-1591.out
+++ b/test/JDBC/expected/BABEL-1591.out
@@ -55,3 +55,7 @@ GO
 
 DROP FUNCTION IF EXISTS fooexectest
 GO
+
+
+
+

--- a/test/JDBC/input/BABEL-1591.sql
+++ b/test/JDBC/input/BABEL-1591.sql
@@ -1,0 +1,56 @@
+-- Allow normal function creation
+
+CREATE FUNCTION babel1591foo1() RETURNS INT AS BEGIN RETURN 10 END
+GO
+
+SELECT babel1591foo1();
+GO
+
+DROP FUNCTION IF EXISTS babel1591foo1;
+GO
+
+-- Below Create function statements having specific keywords should fail
+CREATE FUNCTION foocommittest(@p int) RETURNS int AS BEGIN COMMIT RETURN 0 END
+GO
+
+CREATE FUNCTION foorollbacktest(@p int) RETURNS int AS BEGIN ROLLBACK RETURN 0 END
+GO
+
+CREATE FUNCTION fooexecutetest(@p int) RETURNS int AS BEGIN EXECUTE('select 1') RETURN 0 END
+GO
+
+CREATE FUNCTION fooexectest(@p int) RETURNS int AS BEGIN EXEC('select 1') RETURN 0 END
+GO
+
+-- clean up
+DROP FUNCTION IF EXISTS foocommittest
+GO
+
+DROP FUNCTION IF EXISTS foorollbacktest
+GO
+
+DROP FUNCTION IF EXISTS fooexecutetest
+GO
+
+DROP FUNCTION IF EXISTS fooexectest
+GO
+
+--This needs to be uncommented and tested later when support for alter function is added, 
+-- and corresponding test cases for transactions should be added
+
+-- ALTER FUNCTION babel1591foo1() RETURNS INT AS BEGIN RETURN 100; END
+-- GO
+-- select dbo.babel1591foo1();
+-- GO
+
+
+--  NOT TESTED
+-- Below Alter function statements having specific keywords should fail
+-- ALTER FUNCTION foocommittest(@p int) RETURNS int AS BEGIN COMMIT RETURN 0 END
+-- GO
+-- ALTER FUNCTION foorollbacktest(@p int) RETURNS int AS BEGIN ROLLBACK RETURN 0 END
+-- GO
+-- ALTER FUNCTION fooexecutetest(@p int) RETURNS int AS BEGIN EXECUTE('select 1') RETURN 0 END
+-- GO
+-- ALTER FUNCTION fooexectest(@p int) RETURNS int AS BEGIN EXEC('select 1') RETURN 0 END
+-- GO


### PR DESCRIPTION

Task: BABEL-1591

### Description
Currently, Babelfish allows creating function containing a Commit, Rollback, exec and execute. Although error occurs on executing such functions. After this task, Babelfish prevents such function creation and raises error message for same.

### Issues Resolved

Create function cannot contain a Commit, Rollback, exec and execute. 

### Test Scenarios Covered ###
* **Use case based -**
Error message for Create function with commit
Error message for Create function with rollback
Error message for Create function with execute string
Error message for Create function with exec string

* **Negative test cases -**
Create function normal flow


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).