### PR TITLE
Fix: Corrected compatibility level returned by sp_helpdb

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -404,7 +404,7 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 		values[4] = CStringGetTextDatum(tmstmp_str);
 
         nulls[5] = 1;
-		nulls[6] = 1;
+		values[6] = UInt8GetDatum(120);
 
         tuplestore_putvalues(tupstore, tupdesc, values, nulls);
     }


### PR DESCRIPTION
Task: BABEL-4029

### Description
sp_helpdb will show  120 as well for compatibility level same as  Sys.databases and sys.sysdatabases' result. 

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).