### PR TITLE
Fix test failures in sp_tablecollations_100 and sys.sql_modules after restore 

### DIFF
--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -104,9 +104,7 @@ runs:
         sed -i "/TestNotNull/d" test/JDBC/upgrade/$base_dir/schedule
         sed -i "/TestSQLVariant/d" test/JDBC/upgrade/$base_dir/schedule
         sed -i "/babel_datatype_sqlvariant/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/sp_tablecollations/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/sys-sql_modules/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/sys-system_sql_modules/d" test/JDBC/upgrade/$base_dir/schedule
+        sed -i "/schema_resolution_proc/d" test/JDBC/upgrade/$base_dir/schedule
       shell: bash
 
     - name: Run Verify Tests

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -104,7 +104,6 @@ runs:
         sed -i "/TestNotNull/d" test/JDBC/upgrade/$base_dir/schedule
         sed -i "/TestSQLVariant/d" test/JDBC/upgrade/$base_dir/schedule
         sed -i "/babel_datatype_sqlvariant/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/schema_resolution_proc/d" test/JDBC/upgrade/$base_dir/schedule
       shell: bash
 
     - name: Run Verify Tests

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -708,8 +708,8 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         o.object_id         AS object_id,
         o.schema_id         AS schema_id,
         c.column_id         AS colid,
-        CASE WHEN p.attoptions[1] LIKE 'bbf_original_name=%' THEN CAST(split_part(p.attoptions[1], '=', 2) AS sys.VARCHAR(128))
-		ELSE c.name COLLATE sys.database_default END AS name,
+        CASE WHEN p.attoptions[1] LIKE 'bbf_original_name=%' THEN CAST(split_part(p.attoptions[1], '=', 2) AS sys.SYSNAME)
+			ELSE c.name COLLATE sys.database_default END AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -708,7 +708,7 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         o.object_id         AS object_id,
         o.schema_id         AS schema_id,
         c.column_id         AS colid,
-        CASE WHEN p.attoptions[1] LIKE 'bbf_original_name=%' THEN split_part(p.attoptions[1], '=', 2)
+        CASE WHEN p.attoptions[1] LIKE 'bbf_original_name=%' THEN CAST(split_part(p.attoptions[1], '=', 2) AS sys.VARCHAR(128))
 		ELSE c.name COLLATE sys.database_default END AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -568,7 +568,7 @@ update_AlterTableStmt(Node *n, const char *tbl_schema, const char *newowner)
 				break;
 		}
 	}
-}
+}  
 
 void
 update_CreateRoleStmt(Node *n, const char *role, const char *member, const char *addto)
@@ -893,16 +893,16 @@ get_pltsql_function_signature(PG_FUNCTION_ARGS)
 	const char	*func_signature;
 
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcoid));
-	if (!HeapTupleIsValid(proctup))
-		elog(ERROR, "cache lookup failed for function %u", funcoid);
-	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
-
-	func_signature = (char *) get_pltsql_function_signature_internal(NameStr(form_proctup->proname),
+	if (HeapTupleIsValid(proctup)){
+		form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
+		func_signature = (char *) get_pltsql_function_signature_internal(NameStr(form_proctup->proname),
 															form_proctup->pronargs,
 															form_proctup->proargtypes.values);
 
-	ReleaseSysCache(proctup);
-	PG_RETURN_TEXT_P(cstring_to_text(func_signature));
+		ReleaseSysCache(proctup);
+		PG_RETURN_TEXT_P(cstring_to_text(func_signature));
+	}
+	PG_RETURN_NULL();
 }
 
 void

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -568,7 +568,7 @@ update_AlterTableStmt(Node *n, const char *tbl_schema, const char *newowner)
 				break;
 		}
 	}
-}  
+}
 
 void
 update_CreateRoleStmt(Node *n, const char *role, const char *member, const char *addto)

--- a/test/JDBC/upgrade/master/schedule
+++ b/test/JDBC/upgrade/master/schedule
@@ -321,7 +321,7 @@ sys-syscharsets
 # sys-syscolumns
 # sys-sysforeignkeys
 sys-syslanguages
-sys-system_sql_modules
+# sys-system_sql_modules
 # sys-sql_modules
 sys-table_types
 # sys-tables

--- a/test/JDBC/upgrade/master/schedule
+++ b/test/JDBC/upgrade/master/schedule
@@ -321,7 +321,7 @@ sys-syscharsets
 # sys-syscolumns
 # sys-sysforeignkeys
 sys-syslanguages
-# sys-system_sql_modules
+sys-system_sql_modules
 # sys-sql_modules
 sys-table_types
 # sys-tables


### PR DESCRIPTION
### Description

The datatype of column 'name' in the output of sp_tablecollations_100 procedure changed from sys.sysname to text after performing dump/restore on latest->latest path. Further, cache looked failed error was observed when sys.sql_modules was called after dump/restore on the same upgrade path. Both these issues led to failures in tests, which this PR aims to resolve. 

### Issues Resolved
BABEL-4016, BABEL-4017

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).