### PR TITLE
[BABEL-3697] Added upgrade testing and fixed const case

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -616,6 +616,12 @@ TsqlJsonModifyMakeFuncCall(Node* expr, Node* path, Node* newValue)
 		case T_A_Expr:
 			func_args = lappend(func_args, newValue);
 			break;
+		case T_A_Const:
+			if(((A_Const*) newValue)->isnull || ((A_Const*) newValue)->val.sval.type == T_String)
+				func_args = lappend(func_args, makeTypeCast(newValue, makeTypeName("text"), -1));
+			else
+				func_args = lappend(func_args, newValue);
+			break;
 		default:
 			func_args = lappend(func_args, makeTypeCast(newValue, makeTypeName("text"), -1));
 	}

--- a/test/JDBC/expected/BABEL-3697-before-15-3-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3697-before-15-3-vu-cleanup.out
@@ -1,0 +1,26 @@
+DROP VIEW babel_3697_before_15_3_1
+GO
+
+DROP VIEW babel_3697_before_15_3_2
+GO
+
+DROP VIEW babel_3697_before_15_3_3
+GO
+
+DROP VIEW babel_3697_before_15_3_4
+GO
+
+DROP VIEW babel_3697_before_15_3_5
+GO
+
+DROP PROCEDURE babel_3697_before_15_3_6
+GO
+
+DROP PROCEDURE babel_3697_before_15_3_7
+GO
+
+DROP PROCEDURE babel_3697_before_15_3_8
+GO
+
+DROP VIEW babel_3697_before_15_3_multi_function
+GO

--- a/test/JDBC/expected/BABEL-3697-before-15-3-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3697-before-15-3-vu-prepare.out
@@ -1,0 +1,47 @@
+create view babel_3697_before_15_3_1 as
+SELECT JSON_MODIFY('{"click_count": 173}', '$.click_count', CAST(JSON_VALUE('{"click_count": 173}','$.click_count') AS INT)+1)
+go
+
+create view babel_3697_before_15_3_2 as
+SELECT JSON_MODIFY('{"click_count": 173.12345342}', '$.click_count', CAST(JSON_VALUE('{"click_count": 173.12345342}','$.click_count') AS NUMERIC(7, 3)))
+go
+
+create view babel_3697_before_15_3_3 as
+SELECT JSON_MODIFY('{"click_count": 173}', '$.click_count', 25)
+go
+
+create view babel_3697_before_15_3_4 as
+SELECT JSON_MODIFY('{"click_count": 1900-01-01}', '$.click_count', CAST('1900-02-02' as DATE))
+go
+
+create view babel_3697_before_15_3_5 as
+SELECT JSON_MODIFY('{"click_count": 04:05:06}', '$.click_count', CAST('04:05:06' as TIME))
+go
+
+
+create procedure babel_3697_before_15_3_6
+as begin
+DECLARE @data NVARCHAR(100)='{"click_count": 12345}'
+SELECT JSON_MODIFY(@data, '$.click_count', CAST(JSON_VALUE(@data,'$.click_count') AS CHAR(2)))
+end;
+go
+
+create procedure babel_3697_before_15_3_7
+as begin
+DECLARE @data NVARCHAR(100)='{"click_count": 12345}'
+SELECT JSON_MODIFY(@data, '$.click_count', 0)
+end;
+go
+
+create procedure babel_3697_before_15_3_8
+as begin
+DECLARE @data NVARCHAR(100)='{"click_count": 12345}'
+SELECT JSON_MODIFY(@data, '$.click_count', 6 + 235)
+end;
+go
+
+-- To check multi function call query
+create view babel_3697_before_15_3_multi_function as
+SELECT JSON_MODIFY(JSON_MODIFY(JSON_MODIFY('{"name":"John","skills":["C#","SQL"]}','$.name','Mike'),'$.surname','Smith'),'append $.skills','Azure') AS mf_1, 
+       JSON_MODIFY(JSON_MODIFY('{"price":49.99}','$.Price',CAST(JSON_VALUE('{"price":49.99}','$.price') AS NUMERIC(4,2))),'$.price',NULL) AS mf_2;
+go

--- a/test/JDBC/expected/BABEL-3697-before-15-3-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3697-before-15-3-vu-verify.out
@@ -1,0 +1,73 @@
+SELECT * FROM babel_3697_before_15_3_1
+GO
+~~START~~
+nvarchar
+{"click_count": "174"}
+~~END~~
+
+
+SELECT * FROM babel_3697_before_15_3_2
+GO
+~~START~~
+nvarchar
+{"click_count": "173.123"}
+~~END~~
+
+
+SELECT * FROM babel_3697_before_15_3_3
+GO
+~~START~~
+nvarchar
+{"click_count": "25"}
+~~END~~
+
+
+SELECT * FROM babel_3697_before_15_3_4
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type json)~~
+
+
+SELECT * FROM babel_3697_before_15_3_5
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type json)~~
+
+
+EXEC babel_3697_before_15_3_6
+GO
+~~START~~
+nvarchar
+{"click_count": "12"}
+~~END~~
+
+
+EXEC babel_3697_before_15_3_7
+GO
+~~START~~
+nvarchar
+{"click_count": "0"}
+~~END~~
+
+
+EXEC babel_3697_before_15_3_8
+GO
+~~START~~
+nvarchar
+{"click_count": "241"}
+~~END~~
+
+
+SELECT * FROM babel_3697_before_15_3_multi_function
+GO
+~~START~~
+nvarchar#!#nvarchar
+{"name": "Mike", "skills": ["C#", "SQL", "Azure"], "surname": "Smith"}#!#{"Price": "49.99"}
+~~END~~
+

--- a/test/JDBC/expected/BABEL-3697-before-15-3-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3697-before-15-3-vu-verify.out
@@ -52,7 +52,7 @@ EXEC babel_3697_before_15_3_7
 GO
 ~~START~~
 nvarchar
-{"click_count": "0"}
+{"click_count": 0}
 ~~END~~
 
 
@@ -60,7 +60,7 @@ EXEC babel_3697_before_15_3_8
 GO
 ~~START~~
 nvarchar
-{"click_count": "241"}
+{"click_count": 241}
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-3697-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3697-vu-verify.out
@@ -18,7 +18,7 @@ SELECT * FROM babel_3697_3
 GO
 ~~START~~
 nvarchar
-{"click_count": "25"}
+{"click_count": 25}
 ~~END~~
 
 
@@ -52,7 +52,7 @@ EXEC babel_3697_7
 GO
 ~~START~~
 nvarchar
-{"click_count": "0"}
+{"click_count": 0}
 ~~END~~
 
 

--- a/test/JDBC/input/json_modify/BABEL-3697-before-15-3-vu-cleanup.sql
+++ b/test/JDBC/input/json_modify/BABEL-3697-before-15-3-vu-cleanup.sql
@@ -1,0 +1,26 @@
+DROP VIEW babel_3697_before_15_3_1
+GO
+
+DROP VIEW babel_3697_before_15_3_2
+GO
+
+DROP VIEW babel_3697_before_15_3_3
+GO
+
+DROP VIEW babel_3697_before_15_3_4
+GO
+
+DROP VIEW babel_3697_before_15_3_5
+GO
+
+DROP PROCEDURE babel_3697_before_15_3_6
+GO
+
+DROP PROCEDURE babel_3697_before_15_3_7
+GO
+
+DROP PROCEDURE babel_3697_before_15_3_8
+GO
+
+DROP VIEW babel_3697_before_15_3_multi_function
+GO

--- a/test/JDBC/input/json_modify/BABEL-3697-before-15-3-vu-prepare.sql
+++ b/test/JDBC/input/json_modify/BABEL-3697-before-15-3-vu-prepare.sql
@@ -1,0 +1,47 @@
+create view babel_3697_before_15_3_1 as
+SELECT JSON_MODIFY('{"click_count": 173}', '$.click_count', CAST(JSON_VALUE('{"click_count": 173}','$.click_count') AS INT)+1)
+go
+
+create view babel_3697_before_15_3_2 as
+SELECT JSON_MODIFY('{"click_count": 173.12345342}', '$.click_count', CAST(JSON_VALUE('{"click_count": 173.12345342}','$.click_count') AS NUMERIC(7, 3)))
+go
+
+create view babel_3697_before_15_3_3 as
+SELECT JSON_MODIFY('{"click_count": 173}', '$.click_count', 25)
+go
+
+create view babel_3697_before_15_3_4 as
+SELECT JSON_MODIFY('{"click_count": 1900-01-01}', '$.click_count', CAST('1900-02-02' as DATE))
+go
+
+create view babel_3697_before_15_3_5 as
+SELECT JSON_MODIFY('{"click_count": 04:05:06}', '$.click_count', CAST('04:05:06' as TIME))
+go
+
+
+create procedure babel_3697_before_15_3_6
+as begin
+DECLARE @data NVARCHAR(100)='{"click_count": 12345}'
+SELECT JSON_MODIFY(@data, '$.click_count', CAST(JSON_VALUE(@data,'$.click_count') AS CHAR(2)))
+end;
+go
+
+create procedure babel_3697_before_15_3_7
+as begin
+DECLARE @data NVARCHAR(100)='{"click_count": 12345}'
+SELECT JSON_MODIFY(@data, '$.click_count', 0)
+end;
+go
+
+create procedure babel_3697_before_15_3_8
+as begin
+DECLARE @data NVARCHAR(100)='{"click_count": 12345}'
+SELECT JSON_MODIFY(@data, '$.click_count', 6 + 235)
+end;
+go
+
+-- To check multi function call query
+create view babel_3697_before_15_3_multi_function as
+SELECT JSON_MODIFY(JSON_MODIFY(JSON_MODIFY('{"name":"John","skills":["C#","SQL"]}','$.name','Mike'),'$.surname','Smith'),'append $.skills','Azure') AS mf_1, 
+       JSON_MODIFY(JSON_MODIFY('{"price":49.99}','$.Price',CAST(JSON_VALUE('{"price":49.99}','$.price') AS NUMERIC(4,2))),'$.price',NULL) AS mf_2;
+go

--- a/test/JDBC/input/json_modify/BABEL-3697-before-15-3-vu-verify.sql
+++ b/test/JDBC/input/json_modify/BABEL-3697-before-15-3-vu-verify.sql
@@ -1,0 +1,26 @@
+SELECT * FROM babel_3697_before_15_3_1
+GO
+
+SELECT * FROM babel_3697_before_15_3_2
+GO
+
+SELECT * FROM babel_3697_before_15_3_3
+GO
+
+SELECT * FROM babel_3697_before_15_3_4
+GO
+
+SELECT * FROM babel_3697_before_15_3_5
+GO
+
+EXEC babel_3697_before_15_3_6
+GO
+
+EXEC babel_3697_before_15_3_7
+GO
+
+EXEC babel_3697_before_15_3_8
+GO
+
+SELECT * FROM babel_3697_before_15_3_multi_function
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -71,6 +71,9 @@ ignore#!#sys-all_sql_modules_before-14_7-or-15_2-vu-cleanup
 ignore#!#sys-sql_modules_before-14_7-or-15_2-vu-prepare
 ignore#!#sys-sql_modules_before-14_7-or-15_2-vu-verify
 ignore#!#sys-sql_modules_before-14_7-or-15_2-vu-cleanup
+ignore#!#BABEL-3697-before-15-3-vu-prepare
+ignore#!#BABEL-3697-before-15-3-vu-verify
+ignore#!#BABEL-3697-before-15-3-vu-cleanup
 
 # These tests are meant for upgrade scenario where source version is 13_X
 ignore#!#sys_database_principals_dep_for_13_x-vu-cleanup

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -347,6 +347,7 @@ sys-table_types_internal
 sys-table_types_internal-dep
 BABEL-CHECK-CONSTRAINT
 BABEL-3640
+BABEL-3697-before-15-3
 sys-sysindexes
 sys-system_objects
 ISC-Tables

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -398,6 +398,7 @@ BABEL-3748
 sys-systypes
 openjson
 BABEL-3702
+BABEL-3697-before-15-3
 Test-sp_babelfish_volatility
 BABEL_OBJECT_DEFINITION
 Test-sp_rename


### PR DESCRIPTION
### Description
This is a supplementary pr to https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1328 that adds upgrade testing and fixes a bug in the constant case


### Issues Resolved
BABEL-3697

### Test Scenarios Covered ###
* **Use case based -**
```
1> SELECT JSON_MODIFY('{"click_count": 173}', '$.click_count', 25)
2> go
json_modify                                                                                                                                                                                                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
{"click_count": 25}  
```

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).