### PR TITLE
Include public, sys, and INFORMATION_SCHEMA in sys.database_principals

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -335,17 +335,18 @@ SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_login_ext', '')
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_user_ext', '');
 
 -- DATABASE_PRINCIPALS
-CREATE OR REPLACE VIEW sys.database_principals AS SELECT
+CREATE OR REPLACE VIEW sys.database_principals AS
+SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
 CAST(Base.oid AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
 CAST(
-  CASE 
+  CASE
     WHEN Ext.type = 'S' THEN 'SQL_USER'
     WHEN Ext.type = 'R' THEN 'DATABASE_ROLE'
     WHEN Ext.type = 'U' THEN 'WINDOWS_USER'
-    ELSE NULL 
-  END 
+    ELSE NULL
+  END
   AS SYS.NVARCHAR(60)) AS type_desc,
 CAST(Ext.default_schema_name AS SYS.SYSNAME) AS default_schema_name,
 CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
@@ -362,7 +363,32 @@ FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
 ON Base.rolname = Ext.rolname
 LEFT OUTER JOIN pg_catalog.pg_roles Base2
 ON Ext.login_name = Base2.rolname
-WHERE Ext.database_name = DB_NAME();
+WHERE Ext.database_name = DB_NAME()
+UNION ALL
+SELECT
+CAST(name AS SYS.SYSNAME) AS name,
+CAST(-1 AS INT) AS principal_id,
+CAST(type AS CHAR(1)) as type,
+CAST(
+  CASE
+    WHEN type = 'S' THEN 'SQL_USER'
+    WHEN type = 'R' THEN 'DATABASE_ROLE'
+    WHEN type = 'U' THEN 'WINDOWS_USER'
+    ELSE NULL
+  END
+  AS SYS.NVARCHAR(60)) AS type_desc,
+CAST(NULL AS SYS.SYSNAME) AS default_schema_name,
+CAST(NULL AS SYS.DATETIME) AS create_date,
+CAST(NULL AS SYS.DATETIME) AS modify_date,
+CAST(-1 AS INT) AS owning_principal_id,
+CAST(CAST(0 AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(0 AS SYS.BIT) AS is_fixed_role,
+CAST(-1 AS INT) AS authentication_type,
+CAST(NULL AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(NULL AS SYS.SYSNAME) AS default_language_name,
+CAST(-1 AS INT) AS default_language_lcid,
+CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
 
 GRANT SELECT ON sys.database_principals TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -635,6 +635,67 @@ $$
 STRICT
 LANGUAGE plpgsql IMMUTABLE;
 
+-- DATABASE_PRINCIPALS: Include Hard coded public, sys, INFORMATION_SCHEMA users
+ALTER VIEW sys.database_principals RENAME TO database_principals_deprecated_3_2_0;
+
+CREATE OR REPLACE VIEW sys.database_principals AS
+SELECT
+CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
+CAST(Base.oid AS INT) AS principal_id,
+CAST(Ext.type AS CHAR(1)) as type,
+CAST(
+  CASE
+    WHEN Ext.type = 'S' THEN 'SQL_USER'
+    WHEN Ext.type = 'R' THEN 'DATABASE_ROLE'
+    WHEN Ext.type = 'U' THEN 'WINDOWS_USER'
+    ELSE NULL
+  END
+  AS SYS.NVARCHAR(60)) AS type_desc,
+CAST(Ext.default_schema_name AS SYS.SYSNAME) AS default_schema_name,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(Ext.owning_principal_id AS INT) AS owning_principal_id,
+CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(Ext.is_fixed_role AS SYS.BIT) AS is_fixed_role,
+CAST(Ext.authentication_type AS INT) AS authentication_type,
+CAST(Ext.authentication_type_desc AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(Ext.default_language_lcid AS INT) AS default_language_lcid,
+CAST(Ext.allow_encrypted_value_modifications AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
+ON Base.rolname = Ext.rolname
+LEFT OUTER JOIN pg_catalog.pg_roles Base2
+ON Ext.login_name = Base2.rolname
+WHERE Ext.database_name = DB_NAME()
+UNION ALL
+SELECT
+CAST(name AS SYS.SYSNAME) AS name,
+CAST(-1 AS INT) AS principal_id,
+CAST(type AS CHAR(1)) as type,
+CAST(
+  CASE
+    WHEN type = 'S' THEN 'SQL_USER'
+    WHEN type = 'R' THEN 'DATABASE_ROLE'
+    WHEN type = 'U' THEN 'WINDOWS_USER'
+    ELSE NULL
+  END
+  AS SYS.NVARCHAR(60)) AS type_desc,
+CAST(NULL AS SYS.SYSNAME) AS default_schema_name,
+CAST(NULL AS SYS.DATETIME) AS create_date,
+CAST(NULL AS SYS.DATETIME) AS modify_date,
+CAST(-1 AS INT) AS owning_principal_id,
+CAST(CAST(0 AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(0 AS SYS.BIT) AS is_fixed_role,
+CAST(-1 AS INT) AS authentication_type,
+CAST(NULL AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(NULL AS SYS.SYSNAME) AS default_language_name,
+CAST(-1 AS INT) AS default_language_lcid,
+CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
+
+GRANT SELECT ON sys.database_principals TO PUBLIC;
+CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'database_principals_deprecated_3_2_0');
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -960,6 +960,9 @@ varchar#!#varchar
 dbo#!#dbo
 db_owner#!#
 guest#!#
+INFORMATION_SCHEMA#!#<NULL>
+public#!#<NULL>
+sys#!#<NULL>
 ~~END~~
 
 
@@ -989,6 +992,9 @@ varchar#!#varchar
 dbo#!#dbo
 db_owner#!#
 guest#!#
+INFORMATION_SCHEMA#!#<NULL>
+public#!#<NULL>
+sys#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-ROLE-vu-verify.out
+++ b/test/JDBC/expected/BABEL-ROLE-vu-verify.out
@@ -7,9 +7,23 @@ master
 ~~END~~
 
 
+
+-- Ensure public, sys and INFORMATION_SCHEMA
+-- are in database_principals after an upgrade
+SELECT name, type, type_desc
+FROM sys.database_principals
+WHERE name IN ('public', 'sys', 'INFORMATION_SCHEMA')
+ORDER BY name
 -- Test CREATE ROLE
 CREATE ROLE babel_role_vu_prepare_role1
 GO
+~~START~~
+varchar#!#char#!#nvarchar
+INFORMATION_SCHEMA#!#S#!#SQL_USER
+public#!#R#!#DATABASE_ROLE
+sys#!#S#!#SQL_USER
+~~END~~
+
 
 EXEC babel_role_vu_prepare_user_ext_master
 GO

--- a/test/JDBC/expected/BABEL-USER.out
+++ b/test/JDBC/expected/BABEL-USER.out
@@ -73,6 +73,9 @@ varchar#!#varchar
 dbo#!#dbo
 db_owner#!#
 guest#!#
+INFORMATION_SCHEMA#!#<NULL>
+public#!#<NULL>
+sys#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/input/ownership/BABEL-ROLE-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-ROLE-vu-verify.mix
@@ -2,6 +2,13 @@
 SELECT DB_NAME()
 GO
 
+-- Ensure public, sys and INFORMATION_SCHEMA
+-- are in database_principals after an upgrade
+SELECT name, type, type_desc
+FROM sys.database_principals
+WHERE name IN ('public', 'sys', 'INFORMATION_SCHEMA')
+ORDER BY name
+
 -- Test CREATE ROLE
 CREATE ROLE babel_role_vu_prepare_role1
 GO


### PR DESCRIPTION
Include public, sys, and INFORMATION_SCHEMA in sys.database_principals

These dummy principals for read-only purposes. There are no actual objects behind them.

Task: BABEL-3230

### Description

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).