### PR TITLE
Fix sp_database test cases

### DIFF
--- a/test/JDBC/expected/BABEL-SP_DATABASES.out
+++ b/test/JDBC/expected/BABEL-SP_DATABASES.out
@@ -21,19 +21,19 @@ go
 ~~ROW COUNT: 1~~
 
 
-select * from sys.sp_databases_view where database_name='db1';
+select database_name, remarks from sys.sp_databases_view where database_name='db1';
 go
 ~~START~~
-varchar#!#int#!#varchar
-db1#!#8#!#<NULL>
+varchar#!#varchar
+db1#!#<NULL>
 ~~END~~
 
 
-select * from sys.sp_databases_view where database_name='DB1';
+select database_name, remarks from sys.sp_databases_view where database_name='DB1';
 go
 ~~START~~
-varchar#!#int#!#varchar
-db1#!#8#!#<NULL>
+varchar#!#varchar
+db1#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
@@ -10,7 +10,7 @@ go
 
 
 create procedure sys_sp_databases_dep_vu_prepare_p1 as
-    select * from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
+    select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
 go
 
 create function sys_sp_databases_dep_vu_prepare_f1()
@@ -22,5 +22,5 @@ end
 go
 
 create view sys_sp_databases_dep_vu_prepare_v1 as
-    select * from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
+    select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
 go

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
@@ -4,8 +4,8 @@ go
 exec sys_sp_databases_dep_vu_prepare_p1
 go
 ~~START~~
-varchar#!#int#!#varchar
-sys_sp_databases_dep_vu_prepare_db1#!#8#!#<NULL>
+varchar#!#varchar
+sys_sp_databases_dep_vu_prepare_db1#!#<NULL>
 ~~END~~
 
 
@@ -20,7 +20,7 @@ int
 select * from sys_sp_databases_dep_vu_prepare_v1
 go
 ~~START~~
-varchar#!#int#!#varchar
-sys_sp_databases_dep_vu_prepare_db1#!#8#!#<NULL>
+varchar#!#varchar
+sys_sp_databases_dep_vu_prepare_db1#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/sys-sp_databases-vu-verify.out
+++ b/test/JDBC/expected/sys-sp_databases-vu-verify.out
@@ -1,10 +1,10 @@
 use sys_sp_databases_vu_prepare_db1;
 go
 
-select * from sys.sp_databases_view where database_name='sys_sp_databases_vu_prepare_db1';
+select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_vu_prepare_db1';
 go
 ~~START~~
-varchar#!#int#!#varchar
-sys_sp_databases_vu_prepare_db1#!#8#!#<NULL>
+varchar#!#varchar
+sys_sp_databases_vu_prepare_db1#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/input/BABEL-SP_DATABASES.sql
+++ b/test/JDBC/input/BABEL-SP_DATABASES.sql
@@ -13,10 +13,10 @@ go
 insert into t_spdatabases(a) values(10);
 go
 
-select * from sys.sp_databases_view where database_name='db1';
+select database_name, remarks from sys.sp_databases_view where database_name='db1';
 go
 
-select * from sys.sp_databases_view where database_name='DB1';
+select database_name, remarks from sys.sp_databases_view where database_name='DB1';
 go
 
 EXEC sp_databases;

--- a/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
@@ -8,7 +8,7 @@ insert into sys_sp_databases_dep_vu_prepare_t1(a) values(10);
 go
 
 create procedure sys_sp_databases_dep_vu_prepare_p1 as
-    select * from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
+    select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
 go
 
 create function sys_sp_databases_dep_vu_prepare_f1()
@@ -20,5 +20,5 @@ end
 go
 
 create view sys_sp_databases_dep_vu_prepare_v1 as
-    select * from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
+    select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
 go

--- a/test/JDBC/input/views/sys-sp_databases-vu-verify.sql
+++ b/test/JDBC/input/views/sys-sp_databases-vu-verify.sql
@@ -1,5 +1,5 @@
 use sys_sp_databases_vu_prepare_db1;
 go
 
-select * from sys.sp_databases_view where database_name='sys_sp_databases_vu_prepare_db1';
+select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_vu_prepare_db1';
 go


### PR DESCRIPTION
### Description
Previously, we were having test cases for sp_databases which also test the database size. But database size is subject to change, it will cause the test failure. So this commit updates the test cases to not check the database size.

### Issues Resolved

Task: None
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).