### PR TITLE
Fix crash in sp_addlinkedserver

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2137,8 +2137,8 @@ Datum
 sp_addlinkedserver_internal(PG_FUNCTION_ARGS)
 {
 	char *linked_server = PG_ARGISNULL(0) ? NULL : lowerstr(text_to_cstring(PG_GETARG_TEXT_P(0)));
-	char *srv_product = PG_ARGISNULL(1) ? "" : lowerstr(text_to_cstring(PG_GETARG_TEXT_P(1)));
-	char *provider = PG_ARGISNULL(2) ? "" : lowerstr(text_to_cstring(PG_GETARG_TEXT_P(2)));
+	char *srv_product = PG_ARGISNULL(1) ? NULL : lowerstr(text_to_cstring(PG_GETARG_TEXT_P(1)));
+	char *provider = PG_ARGISNULL(2) ? NULL : lowerstr(text_to_cstring(PG_GETARG_TEXT_P(2)));
 	char *data_src = PG_ARGISNULL(3) ? NULL : text_to_cstring(PG_GETARG_TEXT_P(3));
 	char *provstr = PG_ARGISNULL(5) ? NULL : text_to_cstring(PG_GETARG_TEXT_P(5));
 	char *catalog = PG_ARGISNULL(6) ? NULL : text_to_cstring(PG_GETARG_TEXT_P(6));
@@ -2157,7 +2157,7 @@ sp_addlinkedserver_internal(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_FDW_ERROR),
 					errmsg("@server parameter cannot be NULL")));
 	
-	if (strlen(srv_product) == 10 && (strncmp(srv_product, "sql server", 10) == 0))
+	if (srv_product && (strlen(srv_product) == 10) && (strncmp(srv_product, "sql server", 10) == 0))
 	{
 		/*
 		 * if server product is "SQL Server", rest of the arguments need not be
@@ -2168,14 +2168,14 @@ sp_addlinkedserver_internal(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		if (((strlen(provider) == 7) && (strncmp(provider, "sqlncli", 7) == 0)) ||
+		if (provider && (((strlen(provider) == 7) && (strncmp(provider, "sqlncli", 7) == 0)) ||
 			((strlen(provider) == 10) && (strncmp(provider, "msoledbsql", 10) == 0)) ||
-			((strlen(provider) == 8) && (strncmp(provider, "sqloledb", 8) == 0)))
+			((strlen(provider) == 8) && (strncmp(provider, "sqloledb", 8) == 0))))
 		{
 			/* if provider is a valid T-SQL provider, we throw a warning indicating internally, we will be using tds_fdw */
 			provider_warning = true;
 		}
-		else if ((strlen(provider) != 7) || (strncmp(provider, "tds_fdw", 7) != 0))
+		else if (!provider || (strlen(provider) != 7) || (strncmp(provider, "tds_fdw", 7) != 0))
 			ereport(ERROR,
 				(errcode(ERRCODE_FDW_ERROR),
 				 	errmsg("Unsupported provider '%s'. Supported provider is 'tds_fdw'", provider)));

--- a/test/JDBC/expected/linked_servers-vu-prepare.out
+++ b/test/JDBC/expected/linked_servers-vu-prepare.out
@@ -41,9 +41,17 @@ GO
 EXEC sp_addlinkedserver  @server = N'hello.world.com', @srvproduct=N'SQL Server'
 GO
 
--- Create linked server with a non-null provider string (Will throw warning internally)
-EXEC sp_addlinkedserver  @server = N'mssql_server2', @srvproduct=N'', @provider=N'tds_fdw', @datasrc=N'localhost', @provstr='blahblahblah', @catalog=N'master'
+-- Create linked server with a non-null provider string and NULL @srvproduct (Will throw warning internally)
+EXEC sp_addlinkedserver  @server = N'mssql_server2', @provider=N'tds_fdw', @datasrc=N'localhost', @provstr='blahblahblah', @catalog=N'master'
 GO
+
+-- Try to create linked server with NULL @provider (Should throw error)
+EXEC sp_addlinkedserver  @server = N'mssql_server', @srvproduct=N'', @provider=NULL, @datasrc=N'localhost', @catalog=N'master'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unsupported provider '(null)'. Supported provider is 'tds_fdw')~~
+
 
 -- Try to create linked server with same server name (Should throw error)
 EXEC sp_addlinkedserver  @server = N'mssql_server', @srvproduct=N'', @provider=N'tds_fdw', @datasrc=N'localhost', @catalog=N'master'

--- a/test/JDBC/input/linked_servers-vu-prepare.mix
+++ b/test/JDBC/input/linked_servers-vu-prepare.mix
@@ -29,8 +29,12 @@ GO
 EXEC sp_addlinkedserver  @server = N'hello.world.com', @srvproduct=N'SQL Server'
 GO
 
--- Create linked server with a non-null provider string (Will throw warning internally)
-EXEC sp_addlinkedserver  @server = N'mssql_server2', @srvproduct=N'', @provider=N'tds_fdw', @datasrc=N'localhost', @provstr='blahblahblah', @catalog=N'master'
+-- Create linked server with a non-null provider string and NULL @srvproduct (Will throw warning internally)
+EXEC sp_addlinkedserver  @server = N'mssql_server2', @provider=N'tds_fdw', @datasrc=N'localhost', @provstr='blahblahblah', @catalog=N'master'
+GO
+
+-- Try to create linked server with NULL @provider (Should throw error)
+EXEC sp_addlinkedserver  @server = N'mssql_server', @srvproduct=N'', @provider=NULL, @datasrc=N'localhost', @catalog=N'master'
 GO
 
 -- Try to create linked server with same server name (Should throw error)


### PR DESCRIPTION
### Description

This commit fixes a crash in sp_addlinkedserver that was arising due
to an attempt to free poniter to a string literal.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).