### PR TITLE
Long TVP PARAMETER names in RPC throw error

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2004,7 +2004,7 @@ FetchTvpTypeOid(const ParameterToken token, char *tvpName)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+								(superuser() ? PGC_SUSET : PGC_USERSET),
 									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "SPI_connect() failed in TDS Listener "
 									"with return code %d", rc);
@@ -2017,7 +2017,7 @@ FetchTvpTypeOid(const ParameterToken token, char *tvpName)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+								(superuser() ? PGC_SUSET : PGC_USERSET),
 									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
 	}
@@ -2120,7 +2120,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+								(superuser() ? PGC_SUSET : PGC_USERSET),
 									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to create the underlying table for table-valued parameter: %d", rc);
 	}
@@ -2241,7 +2241,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				/* Reset dialect. */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+								(superuser() ? PGC_SUSET : PGC_USERSET),
 									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "SPI_connect() failed in TDS Listener "
 							"with return code %d", rc);
@@ -2256,7 +2256,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				/* Reset dialect. */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+								(superuser() ? PGC_SUSET : PGC_USERSET),
 									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
 			}

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -120,6 +120,8 @@ Datum TdsTypeXMLToDatum(StringInfo buf);
 Datum TdsTypeUIDToDatum(StringInfo buf);
 Datum TdsTypeSqlVariantToDatum(StringInfo buf);
 
+static void FetchTvpTypeOid(const ParameterToken token, char *tvpName);
+
 /* Local structures for the Function Cache by TDS Type ID */
 typedef struct FunctionCacheByTdsIdKey
 {
@@ -1983,6 +1985,53 @@ TdsRecvTypeNumeric(const char *message, const ParameterToken token)
 	PG_RETURN_NUMERIC(res);
 }
 
+/*
+ * FetchTvpTypeOid - Fetches the table type to store in
+ * ParameterToken->TdsColumnMetaData which is later used to declare
+ * the bind varaibles.
+ * The caller should be in a Transaction and in PSQL dialect.
+ */
+static void
+FetchTvpTypeOid(const ParameterToken token, char *tvpName)
+{
+	int rc;
+	HeapTuple                               row;
+	bool isnull;
+	TupleDesc tupdesc;
+	char *query;
+
+	if ((rc = SPI_connect()) < 0)
+	{
+		/* Reset dialect. */
+		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
+								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+		elog(ERROR, "SPI_connect() failed in TDS Listener "
+									"with return code %d", rc);
+	}
+
+	query = psprintf("SELECT '%s'::regtype::oid", tvpName);
+
+	rc = SPI_execute(query, false, 1);
+	if(rc != SPI_OK_SELECT)
+	{
+		/* Reset dialect. */
+		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
+								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+		elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
+	}
+	tupdesc = SPI_tuptable->tupdesc;
+	row = SPI_tuptable->vals[0];
+
+	token->paramMeta.pgTypeOid = DatumGetObjectId(SPI_getbinval(row, tupdesc,
+																			1, &isnull));
+
+	pfree(query);
+	SPI_finish();
+}
+
+
 /* --------------------------------
  * TdsRecvTypeTable - creates a temp-table from the data being recevied on the wire
  * and sends this temp-table's name to the engine.
@@ -1991,22 +2040,53 @@ TdsRecvTypeNumeric(const char *message, const ParameterToken token)
 Datum
 TdsRecvTypeTable(const char *message, const ParameterToken token)
 {
-	char * tableName;
-	char * query;
+	char *tableName;
+	char *query;
 	StringInfo temp;
 	int rc;
 	TvpRowData *row = token->tvpInfo->rowData;
 	TvpColMetaData *colMetaData = token->tvpInfo->colMetaData;
 	bool xactStarted = IsTransactionOrTransactionBlock();
 	char *finalTableName;
+	char *tvpTypeName;
 	TvpLookupItem *item; 
 	temp = palloc(sizeof(StringInfoData));
 	initStringInfo(temp);
 
 	TDSInstrumentation(INSTR_TDS_DATATYPE_TABLE_VALUED_PARAMETER);
 
+	tvpTypeName = downcase_truncate_identifier(token->tvpInfo->tvpTypeName,
+						strlen(token->tvpInfo->tvpTypeName), true);
+
+	/*
+	 * If schema is provided we convert it to physical schema
+	 * and then update the tvpTypeName to have 2 part names.
+	 */
+	if (token->tvpInfo->tvpTypeSchemaName)
+	{
+		char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
+		char *logical_schema = downcase_truncate_identifier(token->tvpInfo->tvpTypeSchemaName,
+										strlen(token->tvpInfo->tvpTypeSchemaName), true);
+		char *physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name, logical_schema);
+		char *tempStr = psprintf("%s.%s", physical_schema, tvpTypeName);
+
+		pfree(tvpTypeName);
+		tvpTypeName = tempStr;
+
+		pfree(physical_schema);
+		pfree(db_name);
+	}
+
 	 /* Setting a unique name for TVP temp table. */
 	tableName = psprintf("%s_TDS_TVP_TEMP_TABLE_%d", token->tvpInfo->tableName, rand());
+	finalTableName = downcase_truncate_identifier(tableName, strlen(tableName), true);
+	pfree(tableName);
+
+	/* Connect to the SPI manager. */
+	if ((rc = SPI_connect()) < 0)
+		elog(ERROR, "SPI_connect() failed in TDS Listener "
+					"with return code %d", rc);
+
 
 	/*
 	 * We change the dialect to postgres to create temp tables
@@ -2016,19 +2096,17 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 						  (superuser() ? PGC_SUSET : PGC_USERSET),
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
-	/* Connect to the SPI manager. */
-	if ((rc = SPI_connect()) < 0)
-		elog(ERROR, "SPI_connect() failed in TDS Listener "
-					"with return code %d", rc);
-
 	if (!xactStarted)
 		StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot()); 
 
-
+	/* Explicity retrieve the oid for TVP type and map it. */
+	if (token->paramMeta.pgTypeOid == InvalidOid)
+		FetchTvpTypeOid(token, tvpTypeName);
 
 	query = psprintf("CREATE TEMPORARY TABLE IF NOT EXISTS %s (like %s including all)",
-		tableName, token->tvpInfo->tvpTypeName);
+		finalTableName, tvpTypeName);
+	pfree(tvpTypeName);
 
 
 	/*
@@ -2038,7 +2116,13 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 	rc = SPI_execute(query, false, 1);
 
 	if (rc != SPI_OK_UTILITY)
+	{
+		/* Reset dialect. */
+		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
+								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to create the underlying table for table-valued parameter: %d", rc);
+	}
 
 	SPI_finish();
 	PopActiveSnapshot();
@@ -2151,10 +2235,16 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		{
 			query[1] = ' '; /* Convert the first ',' into a blank space. */
 
-			src = psprintf("Insert into %s values %s", tableName, query);
+			src = psprintf("Insert into %s values %s", finalTableName, query);
 			if ((rc = SPI_connect()) < 0)
+			{
+				/* Reset dialect. */
+				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
+								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "SPI_connect() failed in TDS Listener "
 							"with return code %d", rc);
+			}
 
 			rc = SPI_execute_with_args(src,
 				  nargs, argtypes,
@@ -2162,7 +2252,13 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 				  false, 1);
 
 			if (rc != SPI_OK_INSERT)
+			{
+				/* Reset dialect. */
+				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
+								(superuser() ? PGC_SUSET : (rds_superuser() ? PGC_RDSSUSET : PGC_USERSET)),
+									PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
+			}
 
 			SPI_finish();
 			PopActiveSnapshot();
@@ -2183,8 +2279,6 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		pfree(tempRow);
 	}
 	pfree(token->tvpInfo->colMetaData);
-
-	finalTableName = downcase_truncate_identifier(tableName, strlen(tableName), true);
 
 	item = (TvpLookupItem *) palloc(sizeof(TvpLookupItem));
 	item->name = downcase_truncate_identifier(token->paramMeta.colName.data,

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2073,6 +2073,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		pfree(tvpTypeName);
 		tvpTypeName = tempStr;
 
+		pfree(logical_schema);
 		pfree(physical_schema);
 		pfree(db_name);
 	}

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -477,8 +477,6 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 	char *tempString;
 	int i = 0;
 	char *messageData = message->data;
-	char *db_name =  pltsql_plugin_handler_ptr->get_cur_db_name();
-	char *physical_schema = NULL;
 	StringInfo tempStringInfo = palloc( sizeof(StringInfoData));
 	uint32_t collation;
 
@@ -505,16 +503,9 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 
 			*offset +=  len * 2;
 			temp->len += len;
-			
-			if(i==1)
-				physical_schema = pltsql_plugin_handler_ptr->get_physical_schema_name(db_name,tempStringInfo->data);
-			/* if schema name is specified */
-			else if(physical_schema)
-			{
-				temp->tvpInfo->tvpTypeName = psprintf("%s.%s", physical_schema, tempStringInfo->data);
-				pfree(physical_schema);
-			}
-			/* if schema name not specified */
+
+			if(i == 1)
+				temp->tvpInfo->tvpTypeSchemaName = tempStringInfo->data;
 			else
 				temp->tvpInfo->tvpTypeName = tempStringInfo->data;
 
@@ -529,7 +520,6 @@ SetColMetadataForTvp(ParameterToken temp,const StringInfo message, uint64_t *off
 						 temp->paramOrdinal + 1)));
 		}
 	}
-	pfree(db_name);
 
 	temp->tvpInfo->tableName = tempStringInfo->data;
 	i = 0;

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -222,6 +222,7 @@ typedef struct TvpRowData
 typedef struct TvpData
 {
 	char 			*tvpTypeName;
+	char 			*tvpTypeSchemaName;
 	char 			*tableName;
 	int 			colCount;
 	int 			rowCount;

--- a/test/dotnet/ExpectedOutput/TestTvp.out
+++ b/test/dotnet/ExpectedOutput/TestTvp.out
@@ -10,3 +10,25 @@
 1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
 #Q#drop type testtvp.tableType
 #Q#drop schema testtvp
+#Q#create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+#Q#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+#Q#Create table tvp_table(a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+#Q#create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+#Q#create procedure tvp_proc @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong READONLY AS BEGIN insert into tvp_table select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+#Q#tvp_proc
+#Q#Select * from tvp_table
+#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#drop procedure tvp_proc
+#Q#drop table tvp_table
+#Q#drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+#Q#create schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
+#Q#create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+#Q#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+#D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
+1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#drop type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+#Q#drop schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong

--- a/test/dotnet/input/Datatypes/TestTvp.txt
+++ b/test/dotnet/input/Datatypes/TestTvp.txt
@@ -9,3 +9,25 @@ create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, 
 prepst#!#Select * from @a #!#tvp|-|a|-|testtvp.tableType|-|../../../utils/tvp-dotnet.csv
 drop type testtvp.tableType
 drop schema testtvp
+
+#test tvp with huge type name and parameter name
+create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+prepst#!#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|../../../utils/tvp-dotnet.csv
+drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+
+#test tvp with huge type name and parameter name but this time executing a stored proc using SP CUSTOMTYPE
+Create table tvp_table(a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+create procedure tvp_proc @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong READONLY AS BEGIN insert into tvp_table select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+storedproc#!#prep#!#tvp_proc#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|../../../utils/tvp-dotnet.csv
+Select * from tvp_table
+drop procedure tvp_proc
+drop table tvp_table
+drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+
+#testt tvp with huge type name and parameter name and huge schema name
+create schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
+create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
+prepst#!#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|../../../utils/tvp-dotnet.csv
+drop type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
+drop schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong


### PR DESCRIPTION
### Description
ISSUE: We create a unique temp-table-name by adding the following suffix: "{}TDSTVP_TEMP_TABLE{_}%d", (int)rand() Now if we create a temp table with this unique temp-table-name (however long), it gets created. But we have a tvp_lookup_list which maintains the list of tvps the TSQL Extension has to read. For that list we have inserted a modified and truncated TVP name. Rather than storing tableName we store finalTableName, which CAN be different from what was created. Although the though behind it seems logical but it(truncation) should have been done for the temp-table which got created.

FIX: So to fix this we had to truncate the actual tvp name along with its schema name, if provided. We also had to move the logic to fetch tvp type oid from ReadParameter - fetch phase to Recv Function - process phase because we required the truncated names to do so. NOTE: We cannot do truncation in Fetch phase because we require 1. A transaction 2. MessageMemoryContext which are both available during Process phase

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>

### Issues Resolved

BABEL-4056
BABEL-4058

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).