### PR TITLE
Fix uninitialized error on context_info

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1771,7 +1771,7 @@ host_name(PG_FUNCTION_ARGS)
 Datum
 context_info(PG_FUNCTION_ARGS)
 {
-	Datum context_info;
+	Datum context_info = (Datum) 0;
 
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->get_context_info)
 		context_info = (*pltsql_protocol_plugin_ptr)->get_context_info();


### PR DESCRIPTION

### Description
Previously context_info is not initialized and caused a uninitialized error during compilation.
Note: this error has already fixed in BABEL-748 commit internally, no need to cherry-pick again
### Issues Resolved
We initialized context_info to (Datum) 0 and solved this problem.

### Test Scenarios Covered ###
None

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).