### PR TITLE
Add 243e3294c5fee7863e7846b30d8a821b7e4b4242 to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,18 @@
+# As of git 2.23, git-blame supports ignoring specific commits.  This is useful
+# with commits that make bulk formatting changes without truly changing any
+# code.
+#
+# This file lists ignorable pgindent, pgperltidy, and reformat-dat-files
+# related commits only.  Please don't add commits that are not in this
+# category.
+#
+# You can use the ignore list file by running:
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Add new entries by adding the output of the following to the top of the file:
+#
+# $ git log --pretty=format:"%H # %cd%n# %s" $PGINDENTGITHASH -1 --date=iso
+
+243e3294c5fee7863e7846b30d8a821b7e4b4242 # 2023-03-22 21:34:35 -0700
+# Run pgindent on each babelfish extensions code (#1357)


### PR DESCRIPTION
### Description

Add 243e3294c5fee7863e7846b30d8a821b7e4b4242 to .git-blame-ignore-revs

Task: Run pgindent on babelfish extensions code
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).