### PR TITLE
Created macro for (superuser() ? PGC_SUSET : PGC_USERSET)

### DIFF
--- a/contrib/babelfishpg_common/src/coerce.c
+++ b/contrib/babelfishpg_common/src/coerce.c
@@ -242,20 +242,20 @@ pltsql_text_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);
@@ -303,20 +303,20 @@ pltsql_bpchar_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);

--- a/contrib/babelfishpg_common/src/sqlvariant.c
+++ b/contrib/babelfishpg_common/src/sqlvariant.c
@@ -365,7 +365,7 @@ gen_type_datum_from_sqlvariant_bytea(bytea *sv, uint8_t target_typcode, int32_t 
 	}
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	if (typcode == target_typcode)
@@ -425,7 +425,7 @@ do_compare(char *oprname, bytea *arg1, bytea *arg2, Oid fncollation)
 		memcpy(&d2, SV_DATUM_PTR(arg2, svhdr_size2), data_len2);
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	/* Check Type Code */

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2118,7 +2118,7 @@ FetchTvpTypeOid(const ParameterToken token, char *tvpName)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "SPI_connect() failed in TDS Listener "
 			 "with return code %d", rc);
@@ -2131,7 +2131,7 @@ FetchTvpTypeOid(const ParameterToken token, char *tvpName)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
 	}
@@ -2209,7 +2209,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 	 * prep/exec insert query via SPI.
 	 */
 	set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	if (!xactStarted)
@@ -2235,7 +2235,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to create the underlying table for table-valued parameter: %d", rc);
 	}
@@ -2362,7 +2362,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				/* Reset dialect. */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "SPI_connect() failed in TDS Listener "
 					 "with return code %d", rc);
@@ -2377,7 +2377,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				/* Reset dialect. */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
 			}
@@ -2389,7 +2389,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		}
 
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -747,19 +747,19 @@ create_builtin_dbs(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		do_create_bbf_db("master", NULL, sa_name);
 		do_create_bbf_db("tempdb", NULL, sa_name);
 		do_create_bbf_db("msdb", NULL, sa_name);
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	}
@@ -785,17 +785,17 @@ create_msdb_if_not_exists(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		create_bbf_db_internal("msdb", NULL, sa_name, 4);
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	}
@@ -822,7 +822,7 @@ drop_all_dbs(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		/* drop built-in DBs */
 		drop_bbf_db("master", false, true);
@@ -859,13 +859,13 @@ drop_all_dbs(PG_FUNCTION_ARGS)
 				all_db_dropped = true;
 		}
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		PG_RE_THROW();
@@ -1100,7 +1100,7 @@ create_guest_schema_for_all_dbs(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		/*
@@ -1129,14 +1129,14 @@ create_guest_schema_for_all_dbs(PG_FUNCTION_ARGS)
 
 		creating_extension = creating_extension_backup;
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_FINALLY();
 	{
 		creating_extension = creating_extension_backup;
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_END_TRY();

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -1468,20 +1468,20 @@ truncate_tsql_identifier(char *ident)
 	{
 		/* this is BBF help function. use BBF truncation logic */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		truncate_identifier(ident, strlen(ident), false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 }

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3711,20 +3711,20 @@ pltsql_truncate_identifier_func(PG_FUNCTION_ARGS)
 	{
 		/* this is BBF help function. use BBF truncation logic */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		truncate_identifier(name, len, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	PG_RETURN_TEXT_P(cstring_to_text(name));

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -1367,20 +1367,20 @@ pltsql_text_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);
@@ -1429,20 +1429,20 @@ pltsql_bpchar_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -897,7 +897,7 @@ get_pltsql_function_signature_internal(const char *funcname,
 		 * string
 		 */
 		set_config_option("quote_all_identifiers", "true",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		appendStringInfo(&argbuf, "%s(", funcname);
@@ -912,7 +912,7 @@ get_pltsql_function_signature_internal(const char *funcname,
 	PG_FINALLY();
 	{
 		set_config_option("quote_all_identifiers", prev_quote_ident,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_END_TRY();

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -127,7 +127,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 
 	old_dialect = GetConfigOption("babelfishpg_tsql.sql_dialect", true, true);
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION,
 					  GUC_ACTION_SAVE,
 					  true,
@@ -152,7 +152,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", old_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION,
 						  GUC_ACTION_SAVE,
 						  true,
@@ -163,7 +163,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 	PG_END_TRY();
 
 	set_config_option("babelfishpg_tsql.sql_dialect", old_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION,
 					  GUC_ACTION_SAVE,
 					  true,
@@ -444,13 +444,13 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 			 * TSQL Syntax.
 			 */
 			set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 			if ((rc = SPI_execute(query, false, 1)) < 0)
 			{
 				sp_describe_first_result_set_inprogress = false;
 				set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
 			}
@@ -458,7 +458,7 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 			sp_describe_first_result_set_inprogress = false;
 
 			set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 			pfree(query);
 
@@ -1595,7 +1595,7 @@ sp_addrole(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -1686,13 +1686,13 @@ sp_addrole(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -1752,7 +1752,7 @@ sp_droprole(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -1824,13 +1824,13 @@ sp_droprole(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -1888,7 +1888,7 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -1993,13 +1993,13 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -2059,7 +2059,7 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -2152,13 +2152,13 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -2879,7 +2879,7 @@ sp_rename_internal(PG_FUNCTION_ARGS)
 	{
 		/* 1. set dialect to TSQL */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		/* 2. read the input arguments */
@@ -3018,13 +3018,13 @@ sp_rename_internal(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson_old.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson_old.c
@@ -193,7 +193,7 @@ tsql_query_to_json_internal(const char *query, int mode, bool include_null_value
 	uint64		i;
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	result = makeStringInfo();
 

--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml_old.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml_old.c
@@ -219,7 +219,7 @@ tsql_query_to_xml_internal(const char *query, int mode,
 	uint64		i;
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	result = makeStringInfo();
 


### PR DESCRIPTION
Description

This pr creates a macro for (superuser() ? PGC_SUSET : PGC_USERSET) named GUC_CONTEXT_CONFIG to avoid future merge conflicts when cherry-picking from the open source to internal repo



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).