### PR TITLE
Integrate code coverage steps in dev-tools.sh 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@
 *.DS_Store
 *.o
 *.so
+*.gcno
+*.gcda
+*.gcov
+*.gcov.out
+lcov*.info
+coverage/
+coverage-html-stamp
 test/JDBC/Info/
 test/JDBC/output/*
 test/JDBC/target/classes/*

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -264,10 +264,10 @@ build_coverage(){
     echo "  code coverage report generation completed"
     echo "  run './dev-tools.sh sum_coverage' to generate summarized code coverage for all extensions"
     echo "  HTML code coverage report for each extension is located as follows -"
-    echo "      babelfishpg_money:  TARGET_WS/babelfish_extensions/contrib/babelfishpg_money/coverage/index.html"
-    echo "      babelfishpg_common: TARGET_WS/babelfish_extensions/contrib/babelfishpg_common/coverage/index.html"
-    echo "      babelfishpg_tds:    TARGET_WS/babelfish_extensions/contrib/babelfishpg_tds/coverage/index.html"
-    echo "      babelfishpg_tsql:   TARGET_WS/babelfish_extensions/contrib/babelfishpg_tsql/coverage/index.html"
+    echo "      babelfishpg_money:  $TARGET_WS/babelfish_extensions/contrib/babelfishpg_money/coverage/index.html"
+    echo "      babelfishpg_common: $TARGET_WS/babelfish_extensions/contrib/babelfishpg_common/coverage/index.html"
+    echo "      babelfishpg_tds:    $TARGET_WS/babelfish_extensions/contrib/babelfishpg_tds/coverage/index.html"
+    echo "      babelfishpg_tsql:   $TARGET_WS/babelfish_extensions/contrib/babelfishpg_tsql/coverage/index.html"
 }
 
 sum_coverage(){

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -229,9 +229,9 @@ init_lcov(){
     fi
     cd lcov
     sudo make PREFIX=/usr install
-    # export PATH=/usr/bin/lcov
-    # export PATH=/usr/bin/gcov
-    # export PATH=/usr/bin/genhtml
+    export PATH=$PATH:/usr/bin/lcov
+    export PATH=$PATH:/usr/bin/gcov
+    export PATH=$PATH:/usr/bin/genhtml
 }
 
 init_pg_coverage(){
@@ -284,7 +284,6 @@ sum_coverage(){
     cd $1/babelfish_extensions/contrib
     lcov -a babelfishpg_tsql/lcov_test.info -a babelfishpg_tds/lcov_test.info -a babelfishpg_common/lcov_test.info -a babelfishpg_money/lcov_test.info -o lcov.info
     lcov --list lcov.info
-    echo "get html report in -- <dir> --"
 }
 
 if [ "$1" == "initdb" ]; then

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -56,7 +56,7 @@ if [ ! $1 ]; then
     echo "      same as initpg but with --enable-coverage flag to generate code coverage"
     echo ""
     echo "  build_coverage [TARGET_WS]"
-    echo "      generate cove coverage HTML report for all extensions"
+    echo "      generate code coverage HTML report for all extensions"
     echo ""
     echo "  sum_coverage [TARGET_WS]"
     echo "      summarize code coverage"
@@ -245,39 +245,29 @@ init_pg_coverage(){
     init_pghint $1 $2
 }
 
+build_extension_coverage(){
+    cd $1/babelfish_extensions/contrib/$2
+    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+    rm -rf coverage
+    genhtml -q --legend -o coverage --title=${2} --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+    touch coverage-html-stamp
+
+}
+
 build_coverage(){
-    cd $1/babelfish_extensions/contrib/babelfishpg_money
-    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-    rm -rf coverage
-    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-    touch coverage-html-stamp
-
-    cd ../babelfishpg_common
-    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-    rm -rf coverage
-    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-    touch coverage-html-stamp
-
-    cd ../babelfishpg_tds
-    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-    rm -rf coverage
-    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-    touch coverage-html-stamp
-
-    cd ../babelfishpg_tsql
-    lcov --gcov-tool gcov --no-external -q -c -i -d . -d ./ -o lcov_base.info
-    lcov --gcov-tool gcov --no-external -q -c -d . -d . -d ./ -o lcov_test.info
-    rm -rf coverage
-    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-    touch coverage-html-stamp
-
+    build_extension_coverage $1 'babelfishpg_money'
+    build_extension_coverage $1 'babelfishpg_common'
+    build_extension_coverage $1 'babelfishpg_tds'
+    build_extension_coverage $1 'babelfishpg_tsql'
     echo ""
     echo "  code coverage report generation completed"
     echo "  run './dev-tools.sh sum_coverage' to generate summarized code coverage for all extensions"
-    echo "  you can look at HTML code coverage report for each extension at TARGET_WS/babelfish_extensions/contrib/<extension>/coverage"
+    echo "  HTML code coverage report for each extension is located as follows -"
+    echo "      babelfishpg_money:  TARGET_WS/babelfish_extensions/contrib/babelfishpg_money/coverage/index.html"
+    echo "      babelfishpg_common: TARGET_WS/babelfish_extensions/contrib/babelfishpg_common/coverage/index.html"
+    echo "      babelfishpg_tds:    TARGET_WS/babelfish_extensions/contrib/babelfishpg_tds/coverage/index.html"
+    echo "      babelfishpg_tsql:   TARGET_WS/babelfish_extensions/contrib/babelfishpg_tsql/coverage/index.html"
 }
 
 sum_coverage(){

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -51,6 +51,15 @@ if [ ! $1 ]; then
     echo ""
     echo "  dumprestore SOURCE_WS [TARGET_WS]"
     echo "      dump SOURCE_WS using pg_dump and restore it on TARGET_WS"
+    echo ""
+    echo "  initpg_coverage [TARGET_WS]"
+    echo "      same as initpg but with --enable-coverage flag to generate code coverage"
+    echo ""
+    echo "  build_coverage [TARGET_WS]"
+    echo "      generate cove coverage HTML report for all extensions"
+    echo ""
+    echo "  sum_coverage [TARGET_WS]"
+    echo "      summarize code coverage"
     exit 0
 fi
 
@@ -213,6 +222,71 @@ restore() {
     fi
 }
 
+init_lcov(){
+    cd $1
+    if [ ! -d "./lcov" ]; then
+        git clone --depth 1 --branch v1.16 https://github.com/linux-test-project/lcov.git
+    fi
+    cd lcov
+    sudo make PREFIX=/usr install
+    # export PATH=/usr/bin/lcov
+    # export PATH=/usr/bin/gcov
+    # export PATH=/usr/bin/genhtml
+}
+
+init_pg_coverage(){
+    init_lcov $1
+    cd $1/postgresql_modified_for_babelfish
+    ./configure --prefix=$2/postgres/ --without-readline --without-zlib --enable-coverage --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+    make -j 4
+    make install
+    cd contrib && make && sudo make install
+    sudo cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" $2/postgres/lib/
+    init_pghint $1 $2
+}
+
+build_coverage(){
+    cd $1/babelfish_extensions/contrib/babelfishpg_money
+    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+    rm -rf coverage
+    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+    touch coverage-html-stamp
+
+    cd ../babelfishpg_common
+    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+    rm -rf coverage
+    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+    touch coverage-html-stamp
+
+    cd ../babelfishpg_tds
+    lcov --gcov-tool gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+    lcov --gcov-tool gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+    rm -rf coverage
+    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+    touch coverage-html-stamp
+
+    cd ../babelfishpg_tsql
+    lcov --gcov-tool gcov --no-external -q -c -i -d . -d ./ -o lcov_base.info
+    lcov --gcov-tool gcov --no-external -q -c -d . -d . -d ./ -o lcov_test.info
+    rm -rf coverage
+    genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+    touch coverage-html-stamp
+
+    echo ""
+    echo "  code coverage report generation completed"
+    echo "  run './dev-tools.sh sum_coverage' to generate summarized code coverage for all extensions"
+    echo "  you can look at HTML code coverage report for each extension at TARGET_WS/babelfish_extensions/contrib/<extension>/coverage"
+}
+
+sum_coverage(){
+    cd $1/babelfish_extensions/contrib
+    lcov -a babelfishpg_tsql/lcov_test.info -a babelfishpg_tds/lcov_test.info -a babelfishpg_common/lcov_test.info -a babelfishpg_money/lcov_test.info -o lcov.info
+    lcov --list lcov.info
+    echo "get html report in -- <dir> --"
+}
+
 if [ "$1" == "initdb" ]; then
     init_db $TARGET_WS
     exit 0
@@ -351,5 +425,14 @@ elif [ "$1" == "dumprestore" ]; then
 
     restore $SOURCE_WS $TARGET_WS
     echo "Restored on target workspace ($TARGET_WS)!"
+    exit 0
+elif [ "$1" == "initpg_coverage" ]; then
+    init_pg_coverage $TARGET_WS $TARGET_WS
+    exit 0
+elif [ "$1" == "build_coverage" ]; then
+    build_coverage $TARGET_WS
+    exit 0
+elif [ "$1" == "sum_coverage" ]; then
+    sum_coverage $TARGET_WS
     exit 0
 fi


### PR DESCRIPTION
### Description

In this change, steps to generate code coverage report are integrated in dev-tools.sh so that developers can use it to get code coverage on their dev-desktops. 

#### Task: TES2-12
Signed-off-by: <adiityav@amazon.com>
### Steps to generate code coverage report: 
#### Step 1: Run dev-tools.sh with initpg_coverage as parameter to build lcov and initialise postgres directory with --enable-coverage flag
```
./dev-tools.sh initpg_coverage 
```
#### Step 2: Build Babelfish extensions and restart db
```
./dev-tools.sh buildbbf 
```
#### Step 3: Initialise Database and Babelfish
```
./dev-tools.sh initdb
./dev-tools.sh initbbf
```

#### Step 4: Run tests/perform operations for which code coverage is needed 

#### Step 5: Generate code coverage HTML report and Summarized code coverage report for all extensions

```
./dev-tools.sh build_coverage 
./dev-tools.sh sum_coverage 
```


### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).