### PR TITLE
Add build instructions for linked servers and disable them by default

### DIFF
--- a/.github/composite-actions/build-extensions/action.yml
+++ b/.github/composite-actions/build-extensions/action.yml
@@ -36,5 +36,6 @@ runs:
         cd ../babelfishpg_tds
         make -j 4 && make install
         cd ../babelfishpg_tsql
-        make && make install
+        PG_CPPFLAGS='-I/usr/include -DENABLE_TDS_LIB' SHLIB_LINK='-lsybdb -L/usr/lib64' make
+        PG_CPPFLAGS='-I/usr/include -DENABLE_TDS_LIB' SHLIB_LINK='-lsybdb -L/usr/lib64' make install
       shell: bash

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -219,3 +219,19 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
       mvn test
       ```
 For detailed instructions on how to write, add, and run tests in JDBC test framework, refer [to the online instructions](../test/JDBC/README.md).
+
+
+# How to build the babelfishpg_tsql extension with linked servers enabled
+
+1. To work with linked servers, you must install the `tds_fdw` extension. More information about building and installing the extension can be found [at this link](https://github.com/tds-fdw/tds_fdw/blob/master/README.md).
+2. Build the babelfishpg_tsql extension as follows:
+    ```
+    PG_CPPFLAGS='-I/usr/include -DENABLE_TDS_LIB' SHLIB_LINK='-lsybdb -L/usr/lib64' make
+    PG_CPPFLAGS='-I/usr/include -DENABLE_TDS_LIB' SHLIB_LINK='-lsybdb -L/usr/lib64' make install
+    ```
+3. Create rest of the Babelfish extensions as usual, and initialize Babelfish.
+4. Create the `tds_fdw` extension in the Babelfish database:
+    ```
+    babelfish_db=> CREATE EXTENSION tds_fdw;
+    CREATE EXTENSION
+    ```

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -78,10 +78,6 @@ export ANTLR4_RUNTIME_LIB=-lantlr4-runtime
 export ANTLR4_RUNTIME_INCLUDE_DIR=/usr/local/include/antlr4-runtime
 export ANTLR4_RUNTIME_LIB_DIR=/usr/local/lib
 
-export FREE_TDS_INCLUDE_DIR=/usr/include
-export FREE_TDS_LIB_DIR=/usr/lib64
-export FREE_TDS_LIB="-lsybdb"
-
 OBJS += src/pltsql_bulkcopy.o
 
 PG_CXXFLAGS += -g -Werror
@@ -91,9 +87,9 @@ PG_CXXFLAGS += -Wno-register # otherwise C++17 gags on PostgreSQL headers
 PG_CXXFLAGS += -I$(ANTLR4_RUNTIME_INCLUDE_DIR)
 PG_CFLAGS += -g -Werror
 PG_CFLAGS += -fstack-protector-strong
-PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -I$(FREE_TDS_INCLUDE_DIR) -DFAULT_INJECTOR -DENABLE_TDS_LIB
+PG_CPPFLAGS += -I$(TSQLSRC) -I$(PG_SRC) -DFAULT_INJECTOR
 
-SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto $(FREE_TDS_LIB) -L$(FREE_TDS_LIB_DIR)
+SHLIB_LINK += -L$(ANTLR4_RUNTIME_LIB_DIR) $(ANTLR4_RUNTIME_LIB) -lcrypto
 
 UPGRADES = $(patsubst sql/upgrades/%.sql,sql/%.sql,$(wildcard sql/upgrades/*.sql))
 


### PR DESCRIPTION

### Description
This commit disables the linked servers feature by default and only keeps it enabled in the github actions. The instructions to enable the feature is added to the build instructions of the Babelfish extensions.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).