### PR TITLE
Add manual and scheduled workflow for generating Code Coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -65,7 +65,7 @@ jobs:
             export PATH=$HOME/psql/bin:$PATH
             make
             make install
-          elif [[ ${{matrix.branch}} != "BABEL_1_"* ]]; then
+          elif [[ true ]]; then
             cd ../..
             rm -rf pg_hint_plan
             git clone --depth 1 --branch PG15 https://github.com/ossc-db/pg_hint_plan.git
@@ -246,30 +246,17 @@ jobs:
           export PG_CONFIG=~/psql/bin/pg_config
           export PG_SRC=~/work/postgresql_modified_for_babelfish
           export cmake=$(which cmake)
-          cd contrib/babelfishpg_tsql
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-          rm -rf coverage
-          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-          touch coverage-html-stamp
-          cd ../babelfishpg_tds
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-          rm -rf coverage
-          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-          touch coverage-html-stamp
-          cd ../babelfishpg_common
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-          rm -rf coverage
-          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-          touch coverage-html-stamp
-          cd ../babelfishpg_money
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
-          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
-          rm -rf coverage
-          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
-          touch coverage-html-stamp
+          cd contrib
+          extensions=( babelfishpg_tsql babelfishpg_tds babelfishpg_common babelfishpg_money )
+          for (( i=0; i<4; i++ )); do
+            cd ${extensions[$i]}
+            /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+            /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+            rm -rf coverage
+            /usr/bin/genhtml -q --legend -o coverage --title='${extensions[$i]}' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+            touch coverage-html-stamp
+            cd ..
+          done
         shell: bash
 
       - name: Summarize code coverage

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "::set-output name=branches::['BABEL_3_X_DEV']"
-          elif [[ true ]]; then
+          else
             echo "::set-output name=branches::['BABEL_3_X_DEV', 'BABEL_2_X_DEV']"
           fi
 
@@ -57,23 +57,17 @@ jobs:
           make -j 4 2>error.txt
           make install
           cd contrib && make && sudo make install
-          if [[ ${{matrix.branch}} == "BABEL_2_"* ]]; then
-            cd ../..
-            rm -rf pg_hint_plan
+          cd ../..
+          rm -rf pg_hint_plan
+          if [[ ${{matrix.branch}} == "BABEL_2_"* ]]; then 
             git clone --depth 1 --branch REL14_1_4_0 https://github.com/ossc-db/pg_hint_plan.git
-            cd pg_hint_plan
-            export PATH=$HOME/psql/bin:$PATH
-            make
-            make install
-          elif [[ true ]]; then
-            cd ../..
-            rm -rf pg_hint_plan
+          else
             git clone --depth 1 --branch PG15 https://github.com/ossc-db/pg_hint_plan.git
-            cd pg_hint_plan
-            export PATH=$HOME/psql/bin:$PATH
-            make
-            make install
           fi
+          cd pg_hint_plan
+          export PATH=$HOME/psql/bin:$PATH
+          make
+          make install
 
       - name: Compile ANTLR
         id: compile-antlr
@@ -247,13 +241,13 @@ jobs:
           export PG_SRC=~/work/postgresql_modified_for_babelfish
           export cmake=$(which cmake)
           cd contrib
-          extensions=( babelfishpg_tsql babelfishpg_tds babelfishpg_common babelfishpg_money )
-          for (( i=0; i<4; i++ )); do
-            cd ${extensions[$i]}
+          for ext in babelfishpg_common babelfishpg_money babelfishpg_tds babelfishpg_tsql  
+          do
+            cd $ext
             /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
             /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
             rm -rf coverage
-            /usr/bin/genhtml -q --legend -o coverage --title='${extensions[$i]}' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+            /usr/bin/genhtml -q --legend -o coverage --title='$ext' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
             touch coverage-html-stamp
             cd ..
           done

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -310,3 +310,4 @@ jobs:
         with:
           name: csv_${{ matrix.branch }}
           path: contrib/${{ matrix.branch }}.csv
+          

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -310,4 +310,3 @@ jobs:
         with:
           name: csv_${{ matrix.branch }}
           path: contrib/${{ matrix.branch }}.csv
-          

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,7 +1,7 @@
 name: Code Coverage
 on:
   schedule:
-    - cron: '* * * * *'  # runs every midnight
+    - cron: '0 0 * * *'  # runs every midnight
   workflow_dispatch:
     inputs:
       branch_name:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -3,23 +3,30 @@ on:
   schedule:
     - cron: '0 0 * * *'  # runs every midnight
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch Name'
-        required: false
-        default: 'BABEL_3_X_DEV'
 
 jobs:
 
+  generate-branch-names:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.branches }}
+    steps:
+      - id: matrix
+        run: |
+          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            echo "::set-output name=branches::['BABEL_3_X_DEV']"
+          elif [[ true ]]; then
+            echo "::set-output name=branches::['BABEL_3_X_DEV', 'BABEL_2_X_DEV']"
+          fi
+
   run-all-tests:
+    needs: [ generate-branch-names ]
     runs-on: ubuntu-20.04
     
     strategy:
       fail-fast: false
       matrix:
-        include: 
-          - branch: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.branch_name) || 'BABEL_3_X_DEV') }}
-          - branch: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.branch_name) || 'BABEL_2_X_DEV') }}   
+        branch: ${{fromJson(needs.generate-branch-names.outputs.matrix)}} 
 
     steps:
       - uses: actions/checkout@v2
@@ -91,7 +98,7 @@ jobs:
 
       - name: Build tds_fdw Extension
         id: build-tds_fdw-extension
-        if: ${{ startsWith(matrix.branch, 'BABEL_3_') && matrix.branch != 'BABEL_3_0_STABLE' && (steps.build-extensions.outcome == 'success') }}
+        if: ${{ startsWith(matrix.branch, 'BABEL_3_') && (steps.build-extensions.outcome == 'success') }}
         uses: ./.github/composite-actions/build-tds_fdw-extension
 
       - name: Run JDBC Tests
@@ -131,23 +138,13 @@ jobs:
         run: |
           cd test/dotnet
           dotnet build
-          if [[ ${{ matrix.branch }} == 'BABEL_3_X_DEV' || ${{matrix.branch}} == 'BABEL_3_1_STABLE' || ${{matrix.branch}} == 'BABEL_2_X_DEV' || ${{matrix.branch}} == 'BABEL_2_4_STABLE' ]]; then
-            babel_URL=localhost \
-              babel_port=1433 \
-              babel_databaseName=master \
-              babel_user=jdbc_user \
-              babel_password=12345678 \
-              testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestAuthentication.txt;TestText.txt" \
-              dotnet test
-          elif [[ true ]]; then
-            babel_URL=localhost \
-              babel_port=1433 \
-              babel_databaseName=master \
-              babel_user=jdbc_user \
-              babel_password=12345678 \
-              testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestTvp.txt;TestAuthentication.txt;TestText.txt" \
-              dotnet test
-          fi
+          babel_URL=localhost \
+            babel_port=1433 \
+            babel_databaseName=master \
+            babel_user=jdbc_user \
+            babel_password=12345678 \
+            testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestAuthentication.txt;TestText.txt" \
+            dotnet test
       
       - name: Install SQL Server ODBC Driver
         id: install-sql-server-odbc-driver
@@ -286,26 +283,26 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_tsql
+          name: coverage_tsql_${{ matrix.branch }}
           path: contrib/babelfishpg_tsql/coverage/
 
       - name: Upload Coverage Report for babelfishpg_tds extension
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_tds
+          name: coverage_tds_${{ matrix.branch }}
           path: contrib/babelfishpg_tds/coverage/
 
       - name: Upload Coverage Report for babelfishpg_common extension
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_common
+          name: coverage_common_${{ matrix.branch }}
           path: contrib/babelfishpg_common/coverage/
 
       - name: Upload Coverage Report for babelfishpg_money extension
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: coverage_money
+          name: coverage_money_${{ matrix.branch }}
           path: contrib/babelfishpg_money/coverage/

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -287,3 +287,26 @@ jobs:
         with:
           name: coverage_money_${{ matrix.branch }}
           path: contrib/babelfishpg_money/coverage/
+
+      - name: Download CSV report from previous run
+        if: (github.event_name == 'schedule')
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: csv_${{ matrix.branch }}
+          path: contrib/
+          search_artifacts: true
+          if_no_artifact_found: warn
+
+      - name: Add latest coverage numbers to CSV file
+        if: (github.event_name == 'schedule')
+        run: |
+          cd contrib/
+          paste -s -d, <(date +"%m/%d/%Y %H:%M:%S";lcov --summary lcov.info | grep -Po "[0-9]+\.[0-9]*") >> ${{ matrix.branch }}.csv
+        shell: bash
+
+      - name: Upload CSV report with latest coverage numbers
+        if: (github.event_name == 'schedule')
+        uses: actions/upload-artifact@v3
+        with:
+          name: csv_${{ matrix.branch }}
+          path: contrib/${{ matrix.branch }}.csv

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,307 @@
+name: Code Coverage
+on:
+  schedule:
+    - cron: '* * * * *'  # runs every midnight
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Branch Name'
+        required: false
+        default: 'BABEL_3_X_DEV'
+
+jobs:
+
+  run-all-tests:
+    runs-on: ubuntu-20.04
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include: 
+          - branch: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.branch_name) || 'BABEL_3_X_DEV') }}
+          - branch: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.branch_name) || 'BABEL_2_X_DEV') }}   
+
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+        with: 
+          ref: ${{ matrix.branch }}
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        uses: ./.github/composite-actions/install-dependencies
+
+      - name: Install Code Coverage Dependencies
+        id: install-code-coverage-dependencies
+        if: always()
+        run: |
+          sudo apt-get install lcov
+
+      - name: Build Modified Postgres
+        id: build-modified-postgres
+        if: always() && steps.install-dependencies.outcome == 'success'
+        run: |
+          cd ..
+          rm -rf postgresql_modified_for_babelfish
+          $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$GITHUB_REPOSITORY_OWNER" "${{matrix.branch}}"
+          cd postgresql_modified_for_babelfish
+          ./configure --prefix=$HOME/psql/ --with-python PYTHON=/usr/bin/python3.8 --enable-coverage --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          make -j 4 2>error.txt
+          make install
+          cd contrib && make && sudo make install
+          if [[ ${{matrix.branch}} == "BABEL_2_"* ]]; then
+            cd ../..
+            rm -rf pg_hint_plan
+            git clone --depth 1 --branch REL14_1_4_0 https://github.com/ossc-db/pg_hint_plan.git
+            cd pg_hint_plan
+            export PATH=$HOME/psql/bin:$PATH
+            make
+            make install
+          elif [[ ${{matrix.branch}} != "BABEL_1_"* ]]; then
+            cd ../..
+            rm -rf pg_hint_plan
+            git clone --depth 1 --branch PG15 https://github.com/ossc-db/pg_hint_plan.git
+            cd pg_hint_plan
+            export PATH=$HOME/psql/bin:$PATH
+            make
+            make install
+          fi
+
+      - name: Compile ANTLR
+        id: compile-antlr
+        if: always() && steps.build-modified-postgres.outcome == 'success'
+        uses: ./.github/composite-actions/compile-antlr
+        with:
+          install_dir: 'psql'
+
+      - name: Build Extensions
+        id: build-extensions
+        if: always() && steps.compile-antlr.outcome == 'success'
+        uses: ./.github/composite-actions/build-extensions
+        with:
+          install_dir: 'psql'
+
+      - name: Install Extensions
+        id: install-extensions
+        if: always() && steps.build-extensions.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
+        with:
+          install_dir: 'psql'
+
+      - name: Build tds_fdw Extension
+        id: build-tds_fdw-extension
+        if: ${{ startsWith(matrix.branch, 'BABEL_3_') && matrix.branch != 'BABEL_3_0_STABLE' && (steps.build-extensions.outcome == 'success') }}
+        uses: ./.github/composite-actions/build-tds_fdw-extension
+
+      - name: Run JDBC Tests
+        id: jdbc
+        if: always() && steps.install-extensions.outcome == 'success'
+        timeout-minutes: 60
+        run: |
+          cd test/JDBC/
+          mvn test
+        
+      - name: Install MSSQL Tools
+        id: install-mssql-tools
+        if: always() && steps.install-mssql-tools.outcome == 'success'
+        run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+          curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+          sudo apt-get update
+          sudo apt-get install mssql-tools unixodbc-dev
+          echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+          source ~/.bashrc
+      
+      - name: Install Dotnet
+        id: install-dotnet
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: | 
+          cd ~
+          wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt-get install -y apt-transport-https
+          sudo apt-get install -y dotnet-sdk-5.0
+          sudo apt-get install -y apt-transport-https
+          sudo apt-get install -y aspnetcore-runtime-5.0
+          
+      - name: Run Dotnet Tests
+        if: always() && steps.install-dotnet.outcome == 'success'
+        run: |
+          cd test/dotnet
+          dotnet build
+          if [[ ${{ matrix.branch }} == 'BABEL_3_X_DEV' || ${{matrix.branch}} == 'BABEL_3_1_STABLE' || ${{matrix.branch}} == 'BABEL_2_X_DEV' || ${{matrix.branch}} == 'BABEL_2_4_STABLE' ]]; then
+            babel_URL=localhost \
+              babel_port=1433 \
+              babel_databaseName=master \
+              babel_user=jdbc_user \
+              babel_password=12345678 \
+              testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestAuthentication.txt;TestText.txt" \
+              dotnet test
+          elif [[ true ]]; then
+            babel_URL=localhost \
+              babel_port=1433 \
+              babel_databaseName=master \
+              babel_user=jdbc_user \
+              babel_password=12345678 \
+              testName="all---TestUDD.txt;TestChar.txt;TestSqlVariant.txt;TestVarChar.txt;TestTvp.txt;TestAuthentication.txt;TestText.txt" \
+              dotnet test
+          fi
+      
+      - name: Install SQL Server ODBC Driver
+        id: install-sql-server-odbc-driver
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          cd ~
+          sudo apt-get install msodbcsql17
+      
+      - name: Install unixODBC Driver
+        id: install-unix-odbc-driver
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          cd ~
+          wget http://www.unixodbc.org/unixODBC-2.3.11.tar.gz
+          gunzip unixODBC*.tar.gz
+          tar xvf unixODBC*.tar
+          cd unixODBC-2.3.11
+          ./configure
+          make
+          sudo make install
+
+      - name: Install psqlODBC Driver
+        id: install-psql-odbc-driver
+        if: always() && steps.install-extensions.outcome == 'success' && steps.install-unix-odbc-driver.outcome=='success'
+        run: |
+          cd ~
+          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-12.01.0000.tar.gz
+          tar -zxvf psqlodbc-12.01.0000.tar.gz
+          cd psqlodbc-12.01.0000
+          ./configure
+          sudo make
+          sudo make install
+          echo '[ODBC_Driver_12_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'Description=ODBC Driver 12 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'Driver=/usr/local/lib/psqlodbcw.so' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'UsageCount=1' | sudo tee -a /etc/odbcinst.ini > /dev/null
+      
+      - name: Run ODBC Tests
+        if: always() && steps.install-sql-server-odbc-driver.outcome == 'success' && steps.install-psql-odbc-driver.outcome == 'success'
+        run: |
+          cd test/odbc
+          cmake -S . -B build
+          cmake --build build
+          MSSQL_ODBC_DRIVER_NAME="ODBC Driver 17 for SQL Server" \
+            MSSQL_BABEL_DB_SERVER=localhost \
+            MSSQL_BABEL_DB_PORT=1433 \
+            MSSQL_BABEL_DB_USER=jdbc_user \
+            MSSQL_BABEL_DB_PASSWORD=12345678 \
+            MSSQL_BABEL_DB_NAME=master \
+            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_12_for_PostgreSQL \
+            PSQL_BABEL_DB_SERVER=localhost \
+            PSQL_BABEL_DB_PORT=5432 \
+            PSQL_BABEL_DB_USER=jdbc_user \
+            PSQL_BABEL_DB_PASSWORD=12345678 \
+            PSQL_BABEL_DB_NAME=jdbc_testdb \
+            ./build/main
+
+      - name: Install Python
+        id: install-python
+        if: always() && steps.install-extensions.outcome == 'success'
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Configure Python Environment
+        id: configure-python-environment
+        if: always() && steps.install-python.outcome == 'success'
+        run: |
+          cd ~
+          curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          cd ~/work/babelfish_extensions/babelfish_extensions/test/python
+          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
+          pip3 install pyodbc==4.0.35 pymssql pytest pytest-xdist
+      
+      - name: Run Python Tests
+        if: always() && steps.configure-python-environment.outcome == 'success'
+        run: | 
+          cd test/python
+          compareWithFile=true \
+            driver=pyodbc \
+            runInParallel=false \
+            testName=all \
+            provider="ODBC Driver 17 for SQL Server" \
+            fileGenerator_URL=localhost \
+            fileGenerator_port=1433 \
+            fileGenerator_databaseName=master \
+            fileGenerator_user=jdbc_user \
+            fileGenerator_password=12345678 \
+            pytest -s --tb=long -q .
+
+      - name: Generate code coverage HTML report
+        id: code-coverage
+        if: always()
+        run: |
+          export PG_CONFIG=~/psql/bin/pg_config
+          export PG_SRC=~/work/postgresql_modified_for_babelfish
+          export cmake=$(which cmake)
+          cd contrib/babelfishpg_tsql
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+          rm -rf coverage
+          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+          touch coverage-html-stamp
+          cd ../babelfishpg_tds
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+          rm -rf coverage
+          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+          touch coverage-html-stamp
+          cd ../babelfishpg_common
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+          rm -rf coverage
+          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+          touch coverage-html-stamp
+          cd ../babelfishpg_money
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+          rm -rf coverage
+          /usr/bin/genhtml -q --legend -o coverage --title='PostgreSQL 15.2' --ignore-errors source --num-spaces=4  lcov_base.info lcov_test.info
+          touch coverage-html-stamp
+        shell: bash
+
+      - name: Summarize code coverage
+        id: code-coverage-summary
+        if: always()
+        run: |
+          cd contrib/
+          lcov -a babelfishpg_tsql/lcov_test.info -a babelfishpg_tds/lcov_test.info -a babelfishpg_common/lcov_test.info -a babelfishpg_money/lcov_test.info -o lcov.info
+          lcov --list lcov.info
+      - name: Upload Coverage Report for babelfishpg_tsql extension
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_tsql
+          path: contrib/babelfishpg_tsql/coverage/
+
+      - name: Upload Coverage Report for babelfishpg_tds extension
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_tds
+          path: contrib/babelfishpg_tds/coverage/
+
+      - name: Upload Coverage Report for babelfishpg_common extension
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_common
+          path: contrib/babelfishpg_common/coverage/
+
+      - name: Upload Coverage Report for babelfishpg_money extension
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_money
+          path: contrib/babelfishpg_money/coverage/

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -219,6 +219,10 @@ jobs:
           cd ~
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           cd ~/work/babelfish_extensions/babelfish_extensions/test/python
+          mkdir sqltoolsservice
+          cd sqltoolsservice
+          wget https://github.com/microsoft/sqltoolsservice/releases/download/4.4.0.12/Microsoft.SqlTools.ServiceLayer-rhel-x64-net6.0.tar.gz && tar -xzvf Microsoft.SqlTools.ServiceLayer-rhel-x64-net6.0.tar.gz
+          cd ../
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
           pip3 install pyodbc==4.0.35 pymssql pytest pytest-xdist
       


### PR DESCRIPTION
### Description

This change adds a code-coverage workflow which is scheduled to run at 00:00:00 UTC every day and it can also be triggered manually by specifying the branch name as an input.

1. Scheduled workflow generates code coverage for BABEL_3_X_DEV and BABEL_2_X_DEV branches.
2. We can also trigger the manual workflow for BABEL_3_X_DEV

Task: TES2-12
Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).