### PR TITLE
Created macro for (superuser() ? PGC_SUSET : PGC_USERSET)

### DIFF
--- a/contrib/babelfishpg_common/src/coerce.c
+++ b/contrib/babelfishpg_common/src/coerce.c
@@ -243,20 +243,20 @@ pltsql_text_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);
@@ -304,20 +304,20 @@ pltsql_bpchar_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);

--- a/contrib/babelfishpg_common/src/sqlvariant.c
+++ b/contrib/babelfishpg_common/src/sqlvariant.c
@@ -365,7 +365,7 @@ gen_type_datum_from_sqlvariant_bytea(bytea *sv, uint8_t target_typcode, int32_t 
 	}
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	if (typcode == target_typcode)
@@ -425,7 +425,7 @@ do_compare(char *oprname, bytea *arg1, bytea *arg2, Oid fncollation)
 		memcpy(&d2, SV_DATUM_PTR(arg2, svhdr_size2), data_len2);
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	/* Check Type Code */

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2118,7 +2118,7 @@ FetchTvpTypeOid(const ParameterToken token, char *tvpName)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "SPI_connect() failed in TDS Listener "
 			 "with return code %d", rc);
@@ -2131,7 +2131,7 @@ FetchTvpTypeOid(const ParameterToken token, char *tvpName)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
 	}
@@ -2209,7 +2209,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 	 * prep/exec insert query via SPI.
 	 */
 	set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	if (!xactStarted)
@@ -2235,7 +2235,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 	{
 		/* Reset dialect. */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		elog(ERROR, "Failed to create the underlying table for table-valued parameter: %d", rc);
 	}
@@ -2362,7 +2362,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				/* Reset dialect. */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "SPI_connect() failed in TDS Listener "
 					 "with return code %d", rc);
@@ -2377,7 +2377,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				/* Reset dialect. */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "Failed to insert in the underlying table for table-valued parameter: %d", rc);
 			}
@@ -2389,7 +2389,7 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		}
 
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -681,19 +681,19 @@ Datum create_builtin_dbs(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		do_create_bbf_db("master", NULL, sa_name);
 		do_create_bbf_db("tempdb", NULL, sa_name);
 		do_create_bbf_db("msdb", NULL, sa_name);
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	}
@@ -718,17 +718,17 @@ Datum create_msdb_if_not_exists(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-				  			(superuser() ? PGC_SUSET : PGC_USERSET),
+				  			GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		create_bbf_db_internal("msdb", NULL, sa_name, 4);
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-				  			(superuser() ? PGC_SUSET : PGC_USERSET),
+				  			GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-				  			(superuser() ? PGC_SUSET : PGC_USERSET),
+				  			GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	}
@@ -754,7 +754,7 @@ Datum drop_all_dbs(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		/* drop built-in DBs */
 		drop_bbf_db("master", false, true);
@@ -789,13 +789,13 @@ Datum drop_all_dbs(PG_FUNCTION_ARGS)
 				all_db_dropped = true;
 		}
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		PG_RE_THROW();
@@ -1024,7 +1024,7 @@ Datum create_guest_schema_for_all_dbs(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", tsql_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		/*
@@ -1053,14 +1053,14 @@ Datum create_guest_schema_for_all_dbs(PG_FUNCTION_ARGS)
 
 		creating_extension = creating_extension_backup;
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_FINALLY();
 	{
 		creating_extension = creating_extension_backup;
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 				  			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_END_TRY();

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -1301,20 +1301,20 @@ truncate_tsql_identifier(char *ident)
 	{
 		/* this is BBF help function. use BBF truncation logic */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		truncate_identifier(ident, strlen(ident), false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 }

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3441,20 +3441,20 @@ pltsql_truncate_identifier_func(PG_FUNCTION_ARGS)
 	{
 		/* this is BBF help function. use BBF truncation logic */
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		truncate_identifier(name, len, false);
 	}
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	PG_RETURN_TEXT_P(cstring_to_text(name));

--- a/contrib/babelfishpg_tsql/src/plerrcodes.h
+++ b/contrib/babelfishpg_tsql/src/plerrcodes.h
@@ -1003,3 +1003,4 @@
 {
 	"pltsql_error_not_mapped", ERRCODE_PLTSQL_ERROR_NOT_MAPPED
 },
+

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -1368,20 +1368,20 @@ pltsql_text_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);
@@ -1430,20 +1430,20 @@ pltsql_bpchar_name(PG_FUNCTION_ARGS)
 			{
 				/* T-SQL casting. follow T-SQL truncation rule */
 				set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
 			PG_CATCH();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-								  (superuser() ? PGC_SUSET : PGC_USERSET),
+								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  (superuser() ? PGC_SUSET : PGC_USERSET),
+							  GUC_CONTEXT_CONFIG,
 							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -897,7 +897,7 @@ get_pltsql_function_signature_internal(const char *funcname,
 		 * string
 		 */
 		set_config_option("quote_all_identifiers", "true",
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		appendStringInfo(&argbuf, "%s(", funcname);
@@ -912,7 +912,7 @@ get_pltsql_function_signature_internal(const char *funcname,
 	PG_FINALLY();
 	{
 		set_config_option("quote_all_identifiers", prev_quote_ident,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
 	PG_END_TRY();

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -116,7 +116,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 
 	old_dialect = GetConfigOption("babelfishpg_tsql.sql_dialect", true, true);
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION,
 					  GUC_ACTION_SAVE,
 					  true,
@@ -140,7 +140,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", old_dialect,
-						  (superuser() ? PGC_SUSET : PGC_USERSET),
+						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION,
 						  GUC_ACTION_SAVE,
 						  true,
@@ -151,7 +151,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 	PG_END_TRY();
 
 	set_config_option("babelfishpg_tsql.sql_dialect", old_dialect,
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION,
 					  GUC_ACTION_SAVE,
 					  true,
@@ -416,13 +416,13 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 	
 			/* Switch Dialect so that SPI_execute creates a TSQL View, obeying TSQL Syntax. */
 			set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-										(superuser() ? PGC_SUSET : PGC_USERSET),
+										GUC_CONTEXT_CONFIG,
 											PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 			if ((rc = SPI_execute(query, false, 1)) < 0)
 			{
 				sp_describe_first_result_set_inprogress = false;
 				set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-										(superuser() ? PGC_SUSET : PGC_USERSET),
+										GUC_CONTEXT_CONFIG,
 											PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
 			}
@@ -430,7 +430,7 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 			sp_describe_first_result_set_inprogress = false;
 
 			set_config_option("babelfishpg_tsql.sql_dialect", "postgres",
-										(superuser() ? PGC_SUSET : PGC_USERSET),
+										GUC_CONTEXT_CONFIG,
 											PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 			pfree(query);
 
@@ -1499,7 +1499,7 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -1586,13 +1586,13 @@ Datum sp_addrole(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -1651,7 +1651,7 @@ Datum sp_droprole(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -1720,13 +1720,13 @@ Datum sp_droprole(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -1780,7 +1780,7 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -1876,13 +1876,13 @@ Datum sp_addrolemember(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -1939,7 +1939,7 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 		rolname = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_TEXT_PP(0));
@@ -2023,13 +2023,13 @@ Datum sp_droprolemember(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
@@ -2374,7 +2374,7 @@ Datum sp_rename_internal(PG_FUNCTION_ARGS)
 	{
 		//1. set dialect to TSQL
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		
 		//2. read the input arguments
@@ -2493,13 +2493,13 @@ Datum sp_rename_internal(PG_FUNCTION_ARGS)
 	PG_CATCH();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							(superuser() ? PGC_SUSET : PGC_USERSET),
+							GUC_CONTEXT_CONFIG,
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson_old.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson_old.c
@@ -193,7 +193,7 @@ tsql_query_to_json_internal(const char *query, int mode, bool include_null_value
 	uint64		i;
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	result = makeStringInfo();
 

--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml_old.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml_old.c
@@ -219,7 +219,7 @@ tsql_query_to_xml_internal(const char *query, int mode,
 	uint64		i;
 
 	set_config_option("babelfishpg_tsql.sql_dialect", "tsql",
-					  (superuser() ? PGC_SUSET : PGC_USERSET),
+					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	result = makeStringInfo();
 


### PR DESCRIPTION
### Description
This pr creates a macro for `(superuser() ? PGC_SUSET : PGC_USERSET)` named `GUC_CONTEXT_CONFIG` to avoid future merge conflicts when cherry-picking from the open source to internal repo

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).