### PR TITLE
TES2_14 Moving Test to JDBC

### DIFF
--- a/test/JDBC/expected/babel_function.out
+++ b/test/JDBC/expected/babel_function.out
@@ -2426,26 +2426,26 @@ SELECT a, b, COUNT(*) OVER (ORDER BY a) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#int
-abc#!#b#!#2
-abc#!#a#!#2
-efg#!#a#!#4
-efg#!#b#!#4
-xyz#!#a#!#6
-xyz#!#b#!#6
-<NULL>#!#<NULL>#!#7
+<NULL>#!#<NULL>#!#1
+abc#!#a#!#3
+abc#!#b#!#3
+efg#!#a#!#5
+efg#!#b#!#5
+xyz#!#a#!#7
+xyz#!#b#!#7
 ~~END~~
 
 SELECT a, b, COUNT(*) OVER (ORDER BY a DESC) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#int
-<NULL>#!#<NULL>#!#1
-xyz#!#b#!#3
-xyz#!#a#!#3
-efg#!#b#!#5
-efg#!#a#!#5
-abc#!#b#!#7
-abc#!#a#!#7
+xyz#!#b#!#2
+xyz#!#a#!#2
+efg#!#a#!#4
+efg#!#b#!#4
+abc#!#b#!#6
+abc#!#a#!#6
+<NULL>#!#<NULL>#!#7
 ~~END~~
 
 SELECT a, b, COUNT(*) OVER(PARTITION BY a) from t3;
@@ -2511,26 +2511,26 @@ SELECT a, b, COUNT_BIG(*) OVER (ORDER BY a) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#bigint
-abc#!#b#!#2
-abc#!#a#!#2
-efg#!#a#!#4
-efg#!#b#!#4
-xyz#!#a#!#6
-xyz#!#b#!#6
-<NULL>#!#<NULL>#!#7
+<NULL>#!#<NULL>#!#1
+abc#!#a#!#3
+abc#!#b#!#3
+efg#!#a#!#5
+efg#!#b#!#5
+xyz#!#a#!#7
+xyz#!#b#!#7
 ~~END~~
 
 SELECT a, b, COUNT_BIG(*) OVER (ORDER BY a DESC) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#bigint
-<NULL>#!#<NULL>#!#1
-xyz#!#b#!#3
-xyz#!#a#!#3
-efg#!#b#!#5
-efg#!#a#!#5
-abc#!#b#!#7
-abc#!#a#!#7
+xyz#!#b#!#2
+xyz#!#a#!#2
+efg#!#a#!#4
+efg#!#b#!#4
+abc#!#b#!#6
+abc#!#a#!#6
+<NULL>#!#<NULL>#!#7
 ~~END~~
 
 SELECT a, b, COUNT_BIG(*) OVER(PARTITION BY a) from t3;

--- a/test/JDBC/expected/babel_function.out
+++ b/test/JDBC/expected/babel_function.out
@@ -2426,26 +2426,26 @@ SELECT a, b, COUNT(*) OVER (ORDER BY a) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#int
-<NULL>#!#<NULL>#!#1
-abc#!#a#!#3
-abc#!#b#!#3
-efg#!#a#!#5
-efg#!#b#!#5
-xyz#!#a#!#7
-xyz#!#b#!#7
+abc#!#b#!#2
+abc#!#a#!#2
+efg#!#a#!#4
+efg#!#b#!#4
+xyz#!#a#!#6
+xyz#!#b#!#6
+<NULL>#!#<NULL>#!#7
 ~~END~~
 
 SELECT a, b, COUNT(*) OVER (ORDER BY a DESC) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#int
-xyz#!#b#!#2
-xyz#!#a#!#2
-efg#!#a#!#4
-efg#!#b#!#4
-abc#!#b#!#6
-abc#!#a#!#6
-<NULL>#!#<NULL>#!#7
+<NULL>#!#<NULL>#!#1
+xyz#!#b#!#3
+xyz#!#a#!#3
+efg#!#b#!#5
+efg#!#a#!#5
+abc#!#b#!#7
+abc#!#a#!#7
 ~~END~~
 
 SELECT a, b, COUNT(*) OVER(PARTITION BY a) from t3;
@@ -2511,26 +2511,26 @@ SELECT a, b, COUNT_BIG(*) OVER (ORDER BY a) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#bigint
-<NULL>#!#<NULL>#!#1
-abc#!#a#!#3
-abc#!#b#!#3
-efg#!#a#!#5
-efg#!#b#!#5
-xyz#!#a#!#7
-xyz#!#b#!#7
+abc#!#b#!#2
+abc#!#a#!#2
+efg#!#a#!#4
+efg#!#b#!#4
+xyz#!#a#!#6
+xyz#!#b#!#6
+<NULL>#!#<NULL>#!#7
 ~~END~~
 
 SELECT a, b, COUNT_BIG(*) OVER (ORDER BY a DESC) from t3;
 GO
 ~~START~~
 varchar#!#varchar#!#bigint
-xyz#!#b#!#2
-xyz#!#a#!#2
-efg#!#a#!#4
-efg#!#b#!#4
-abc#!#b#!#6
-abc#!#a#!#6
-<NULL>#!#<NULL>#!#7
+<NULL>#!#<NULL>#!#1
+xyz#!#b#!#3
+xyz#!#a#!#3
+efg#!#b#!#5
+efg#!#a#!#5
+abc#!#b#!#7
+abc#!#a#!#7
 ~~END~~
 
 SELECT a, b, COUNT_BIG(*) OVER(PARTITION BY a) from t3;

--- a/test/JDBC/expected/babel_transaction.out
+++ b/test/JDBC/expected/babel_transaction.out
@@ -423,8 +423,62 @@ int
 ~~END~~
 
 
+-- begin transaction -> save transaction name -> rollback to savepoint
+-- save transaction name -> commit transaction
+begin transaction txn1;
+insert into TxnTable values(3);
+save transaction sp1;
+insert into TxnTable values(4);
+select c1 from TxnTable;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+rollback tran sp1;
+save transaction sp2;
+insert into TxnTable values(5);
+commit transaction;
+select c1 from TxnTable;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+5
+~~END~~
 
 
+-- begin transaction -> save transaction name -> error -> rollback to savepoint
+-- commit transaction
+rollback tran sp1;
+commit transaction;
+select c1 from TxnTable;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK TO SAVEPOINT can only be used in transaction blocks)~~
+
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+~~START~~
+int
+1
+3
+5
+~~END~~
 
 
-
+drop table TxnTable;
+GO

--- a/test/JDBC/input/babel_transaction.sql
+++ b/test/JDBC/input/babel_transaction.sql
@@ -177,48 +177,20 @@ insert into TxnTable values(3);
 save transaction sp1;
 insert into TxnTable values(4);
 select c1 from TxnTable;
+GO
 rollback tran sp1;
 save transaction sp2;
 insert into TxnTable values(5);
 commit transaction;
 select c1 from TxnTable;
+GO
 
 -- begin transaction -> save transaction name -> error -> rollback to savepoint
 -- commit transaction
-begin transaction txn1;
-insert into TxnTable values(6);
-save transaction sp1;
-insert into TxnTable values(7);
-select c1 frm TxnTable;
 rollback tran sp1;
 commit transaction;
 select c1 from TxnTable;
-
--- create and execute procedure with transaction commands
--- \tsql on
--- create procedure txnproc as
--- begin tran;
--- insert into TxnTable values(8);
--- select c1 from TxnTable;
--- save tran sp1;
--- commit;
--- rollback tran;
--- go
--- execute txnproc;
--- go
--- \tsql off
--- drop procedure txnproc;
-
--- transaction syntax error
-begin;
-begin txn1;
-commit txn1;
-rollback txx1;
-
--- invalid transaction name
-begin transaction txn1;
-rollback transaction txn2;
-rollback;
+GO
 
 drop table TxnTable;
-reset babelfish_pg_tsql.sql_dialect;
+GO


### PR DESCRIPTION
Moved
babel_219,
babel_collection,
babel_datatype,
babel_ddl,
babel_delete1,
babel_function,
babel_like,
babel_typecode,
babel_uniqueidentifier
babel_set_command
babel_table_type
babel_transaction
babel_emoji
to JDBC
And removed it from babelfish_extensions/contrib/babelfishpg_tsql/sql/test directory

Modified babel_transaction file.
Forget to add Go in last few lines
Before PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1367

Task: TES2_14
Signed-off-by: Pratik Zode [pzode@amazon.com](mailto:pzode@amazon.com)