### PR TITLE
[BABEL-3238] Protect get_tsql_error_details() from potential infinite…

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/err_handler.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/err_handler.c
@@ -193,8 +193,10 @@ get_tsql_error_details(ErrorData *edata,
 
 		TDSInstrumentation(INSTR_TDS_UNMAPPED_ERROR);
 
-		elog(LOG, "Unmapped error found. Code: %d, Message: %s, File: %s, Line: %d, Context: %s",
-			 edata->sqlerrcode, edata->message, edata->filename, edata->lineno, error_context);
+		/* Possible infinite loop of errors. Do not touch it further. */
+		if (!error_stack_full())
+			elog(LOG, "Unmapped error found. Code: %d, Message: %s, File: %s, Line: %d, Context: %s",
+				 edata->sqlerrcode, edata->message, edata->filename, edata->lineno, error_context);
 
 		return false;
 	}
@@ -263,8 +265,10 @@ get_tsql_error_details(ErrorData *edata,
 		{
 			TDSInstrumentation(INSTR_TDS_UNMAPPED_ERROR);
 
-			elog(LOG, "Unmapped error found. Code: %d, Message: %s, File: %s, Line: %d, Context: %s",
-				 edata->sqlerrcode, edata->message, edata->filename, edata->lineno, error_context);
+			/* Possible infinite loop of errors. Do not touch it further. */	
+			if (!error_stack_full())
+				elog(LOG, "Unmapped error found. Code: %d, Message: %s, File: %s, Line: %d, Context: %s",
+					 edata->sqlerrcode, edata->message, edata->filename, edata->lineno, error_context);
 
 			*tsql_error_code = ERRCODE_PLTSQL_ERROR_NOT_MAPPED;
 			*tsql_error_severity = 16;


### PR DESCRIPTION

### Description

Prevent calling elog() in get_tsql_error_details() when error stack is full



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).