### PR TITLE
Support sysusers catalog

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -410,8 +410,7 @@ CASE
     OR Dbp.name = 'sys'
     OR Dbp.type_desc = 'DATABASE_ROLE'
     THEN 0
-  WHEN Dbp.name = 'guest' AND Ext.user_can_connect = 1 THEN 1
-  WHEN Dbp.type_desc = 'WINDOWS_USER' OR Dbp.name = 'dbo' THEN 1
+  WHEN (Dbp.type_desc = 'WINDOWS_USER' OR Dbp.type_desc = 'SQL_USER') AND Ext.user_can_connect = 1 THEN 1
   ELSE 0
 END AS hasdbaccess,
 CASE
@@ -420,7 +419,7 @@ CASE
     OR Dbp.name = 'guest'
     OR Dbp.name = 'dbo' 
     THEN 1
-  WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1
+  WHEN Dbp.type_desc = 'WINDOWS_USER' OR Dbp.type_desc = 'SQL_USER' THEN 1
   ELSE 0
 END AS islogin,
 CASE WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1 ELSE 0 END AS isntname,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -37,6 +37,51 @@ LANGUAGE plpgsql;
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+ 
+-- SYSUSERS
+CREATE OR REPLACE VIEW sys.sysusers AS SELECT
+Dbp.principal_id AS uid,
+CAST(0 AS INT) AS status,
+Dbp.name AS name,
+Dbp.sid AS sid,
+CAST(NULL AS SYS.VARBINARY(2048)) AS roles,
+Dbp.create_date AS createdate,
+Dbp.modify_date AS updatedate,
+CAST(0 AS INT) AS altuid,
+CAST(NULL AS SYS.VARBINARY(256)) AS password,
+CAST(0 AS INT) AS gid,
+CAST(NULL AS SYS.VARCHAR(85)) AS environ,
+CASE
+  WHEN Dbp.name = 'INFORMATION_SCHEMA'
+    OR Dbp.name = 'sys'
+    OR Dbp.type_desc = 'DATABASE_ROLE'
+    THEN 0
+  WHEN Dbp.name = 'guest' AND Ext.user_can_connect = 1 THEN 1
+  WHEN Dbp.type_desc = 'WINDOWS_USER' OR Dbp.name = 'dbo' THEN 1
+  ELSE 0
+END AS hasdbaccess,
+CASE
+  WHEN Dbp.name = 'INFORMATION_SCHEMA'
+    OR Dbp.name = 'sys'
+    OR Dbp.name = 'guest'
+    OR Dbp.name = 'dbo' 
+    THEN 1
+  WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1
+  ELSE 0
+END AS islogin,
+CASE WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1 ELSE 0 END AS isntname,
+CAST(0 AS INT) AS isntgroup,
+CASE WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1 ELSE 0 END AS isntuser,
+CASE WHEN Dbp.type_desc = 'SQL_USER' THEN 1 ELSE 0 END AS issqluser,
+CAST(0 AS INT) AS isaliased,
+CASE WHEN Dbp.type_desc = 'DATABASE_ROLE' THEN 1 ELSE 0 END AS issqlrole,
+CAST(0 AS INT) AS isapprole
+FROM sys.database_principals AS Dbp LEFT JOIN 
+  (SELECT orig_username, user_can_connect FROM sys.babelfish_authid_user_ext 
+    WHERE database_name = DB_NAME()) AS Ext
+ON Dbp.name = Ext.orig_username;
+ 
+GRANT SELECT ON sys.sysusers TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.syslanguages
 AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -56,8 +56,7 @@ CASE
     OR Dbp.name = 'sys'
     OR Dbp.type_desc = 'DATABASE_ROLE'
     THEN 0
-  WHEN Dbp.name = 'guest' AND Ext.user_can_connect = 1 THEN 1
-  WHEN Dbp.type_desc = 'WINDOWS_USER' OR Dbp.name = 'dbo' THEN 1
+  WHEN (Dbp.type_desc = 'WINDOWS_USER' OR Dbp.type_desc = 'SQL_USER') AND Ext.user_can_connect = 1 THEN 1
   ELSE 0
 END AS hasdbaccess,
 CASE
@@ -66,7 +65,7 @@ CASE
     OR Dbp.name = 'guest'
     OR Dbp.name = 'dbo' 
     THEN 1
-  WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1
+  WHEN Dbp.type_desc = 'WINDOWS_USER' OR Dbp.type_desc = 'SQL_USER' THEN 1
   ELSE 0
 END AS islogin,
 CASE WHEN Dbp.type_desc = 'WINDOWS_USER' THEN 1 ELSE 0 END AS isntname,

--- a/test/JDBC/expected/sys_sysusers_dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-cleanup.out
@@ -1,4 +1,4 @@
-USE testdb
+USE sysusersdb
 GO
 
 DROP VIEW sysusers_dep_vu_prepare_view
@@ -25,5 +25,5 @@ GO
 USE master
 GO
 
-DROP DATABASE testdb
+DROP DATABASE sysusersdb
 GO

--- a/test/JDBC/expected/sys_sysusers_dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-cleanup.out
@@ -1,3 +1,6 @@
+USE testdb
+GO
+
 DROP VIEW sysusers_dep_vu_prepare_view
 GO
 
@@ -19,3 +22,8 @@ GO
 DROP LOGIN sysusers_dep_vu_prepare_login2
 GO
 
+USE master
+GO
+
+DROP DATABASE testdb
+GO

--- a/test/JDBC/expected/sys_sysusers_dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-cleanup.out
@@ -1,0 +1,21 @@
+DROP VIEW sysusers_dep_vu_prepare_view
+GO
+
+DROP PROC sysusers_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION sysusers_dep_vu_prepare_func
+GO
+
+DROP USER sysusers_dep_vu_prepare_user1
+GO
+
+DROP USER sysusers_dep_vu_prepare_user2
+GO
+
+DROP LOGIN sysusers_dep_vu_prepare_login1
+GO
+
+DROP LOGIN sysusers_dep_vu_prepare_login2
+GO
+

--- a/test/JDBC/expected/sys_sysusers_dep-vu-prepare.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-prepare.out
@@ -1,0 +1,35 @@
+CREATE LOGIN sysusers_dep_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE USER sysusers_dep_vu_prepare_user1 FOR LOGIN sysusers_dep_vu_prepare_login1
+GO
+
+CREATE LOGIN sysusers_dep_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE USER sysusers_dep_vu_prepare_user2 FOR LOGIN sysusers_dep_vu_prepare_login2
+GO
+
+CREATE VIEW sysusers_dep_vu_prepare_view
+AS
+SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE PROC sysusers_dep_vu_prepare_proc
+AS
+SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sysusers_dep_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.sysusers WHERE name LIKE '%sysusers_dep_vu_prepare_%')
+END
+GO

--- a/test/JDBC/expected/sys_sysusers_dep-vu-prepare.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-prepare.out
@@ -1,3 +1,9 @@
+CREATE DATABASE testdb
+GO
+
+USE testdb
+GO
+
 CREATE LOGIN sysusers_dep_vu_prepare_login1 WITH PASSWORD = '123'
 GO
 
@@ -7,29 +13,31 @@ GO
 CREATE LOGIN sysusers_dep_vu_prepare_login2 WITH PASSWORD = '123'
 GO
 
-CREATE USER sysusers_dep_vu_prepare_user2 FOR LOGIN sysusers_dep_vu_prepare_login2
+CREATE USER sysusers_dep_vu_prepare_user2 FOR LOGIN sysusers_dep_vu_prepare_login2;
 GO
 
 CREATE VIEW sysusers_dep_vu_prepare_view
 AS
-SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%'
-ORDER BY name
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+ORDER BY name offset 0 rows
 GO
 
 CREATE PROC sysusers_dep_vu_prepare_proc
 AS
-SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
 ORDER BY name
 GO
 
 CREATE FUNCTION sysusers_dep_vu_prepare_func()
-RETURNS INT
+RETURNS TABLE
 AS
-BEGIN
-RETURN (SELECT COUNT(*) FROM sys.sysusers WHERE name LIKE '%sysusers_dep_vu_prepare_%')
-END
+RETURN
+    SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
+    FROM sys.sysusers
+    WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+    ORDER BY name offset 0 rows
 GO

--- a/test/JDBC/expected/sys_sysusers_dep-vu-prepare.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-prepare.out
@@ -1,7 +1,7 @@
-CREATE DATABASE testdb
+CREATE DATABASE sysusersdb
 GO
 
-USE testdb
+USE sysusersdb
 GO
 
 CREATE LOGIN sysusers_dep_vu_prepare_login1 WITH PASSWORD = '123'
@@ -20,7 +20,7 @@ CREATE VIEW sysusers_dep_vu_prepare_view
 AS
 SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
 ORDER BY name offset 0 rows
 GO
 
@@ -28,7 +28,7 @@ CREATE PROC sysusers_dep_vu_prepare_proc
 AS
 SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
 ORDER BY name
 GO
 
@@ -38,6 +38,6 @@ AS
 RETURN
     SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
     FROM sys.sysusers
-    WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+    WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
     ORDER BY name offset 0 rows
 GO

--- a/test/JDBC/expected/sys_sysusers_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-verify.out
@@ -1,0 +1,37 @@
+SELECT * FROM sysusers_dep_vu_prepare_view
+GO
+~~START~~
+varchar#!#varbinary#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sysusers_dep_vu_prepare_user1#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
+sysusers_dep_vu_prepare_user2#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
+~~END~~
+
+
+EXEC sysusers_dep_vu_prepare_proc
+GO
+~~START~~
+varchar#!#varbinary#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sysusers_dep_vu_prepare_user1#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
+sysusers_dep_vu_prepare_user2#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
+~~END~~
+
+
+SELECT sysusers_dep_vu_prepare_func()
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT name FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+ORDER BY name
+GO
+~~START~~
+varchar
+sysusers_dep_vu_prepare_user1
+sysusers_dep_vu_prepare_user2
+~~END~~
+
+

--- a/test/JDBC/expected/sys_sysusers_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-verify.out
@@ -1,4 +1,4 @@
-USE testdb
+USE sysusersdb
 GO
 
 -- test view created on sys.sysusers
@@ -8,9 +8,6 @@ GO
 varchar#!#int#!#int#!#int#!#int#!#int
 dbo#!#1#!#1#!#0#!#1#!#0
 guest#!#0#!#1#!#0#!#1#!#0
-INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
-public#!#0#!#0#!#0#!#0#!#1
-sys#!#0#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 ~~END~~
@@ -23,9 +20,6 @@ GO
 varchar#!#int#!#int#!#int#!#int#!#int
 dbo#!#1#!#1#!#0#!#1#!#0
 guest#!#0#!#1#!#0#!#1#!#0
-INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
-public#!#0#!#0#!#0#!#0#!#1
-sys#!#0#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 ~~END~~
@@ -38,9 +32,6 @@ GO
 varchar#!#int#!#int#!#int#!#int#!#int
 dbo#!#1#!#1#!#0#!#1#!#0
 guest#!#0#!#1#!#0#!#1#!#0
-INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
-public#!#0#!#0#!#0#!#0#!#1
-sys#!#0#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 ~~END~~
@@ -49,32 +40,15 @@ sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 -- test sys.sysusers view, hasdbaccess should be 1 for newly created user 
 SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
 ORDER BY name
 GO
 ~~START~~
 varchar#!#int#!#int#!#int#!#int#!#int
 dbo#!#1#!#1#!#0#!#1#!#0
 guest#!#0#!#1#!#0#!#1#!#0
-INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
-public#!#0#!#0#!#0#!#0#!#1
-sys#!#0#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
 sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
-~~END~~
-
-
--- test [REVOKE CONNECT FROM], hasdbaccess should be 0
-REVOKE CONNECT FROM guest
-GO
-
-SELECT name, hasdbaccess, islogin
-FROM sys.sysusers
-WHERE name = 'guest'
-GO
-~~START~~
-varchar#!#int#!#int
-guest#!#0#!#1
 ~~END~~
 
 
@@ -89,6 +63,20 @@ GO
 ~~START~~
 varchar#!#int#!#int
 guest#!#1#!#1
+~~END~~
+
+
+-- test [REVOKE CONNECT FROM], hasdbaccess should be 0
+REVOKE CONNECT FROM guest
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'guest'
+GO
+~~START~~
+varchar#!#int#!#int
+guest#!#0#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/sys_sysusers_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_sysusers_dep-vu-verify.out
@@ -1,37 +1,122 @@
+USE testdb
+GO
+
+-- test view created on sys.sysusers
 SELECT * FROM sysusers_dep_vu_prepare_view
 GO
 ~~START~~
-varchar#!#varbinary#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-sysusers_dep_vu_prepare_user1#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
-sysusers_dep_vu_prepare_user2#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
+varchar#!#int#!#int#!#int#!#int#!#int
+dbo#!#1#!#1#!#0#!#1#!#0
+guest#!#0#!#1#!#0#!#1#!#0
+INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
+public#!#0#!#0#!#0#!#0#!#1
+sys#!#0#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 ~~END~~
 
 
+-- test procedure created on sys.sysusers
 EXEC sysusers_dep_vu_prepare_proc
 GO
 ~~START~~
-varchar#!#varbinary#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-sysusers_dep_vu_prepare_user1#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
-sysusers_dep_vu_prepare_user2#!#<NULL>#!#0#!#0#!#0#!#0#!#0#!#1#!#0#!#0#!#0
+varchar#!#int#!#int#!#int#!#int#!#int
+dbo#!#1#!#1#!#0#!#1#!#0
+guest#!#0#!#1#!#0#!#1#!#0
+INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
+public#!#0#!#0#!#0#!#0#!#1
+sys#!#0#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 ~~END~~
 
 
-SELECT sysusers_dep_vu_prepare_func()
+-- test function created on sys.sysusers
+SELECT * FROM sysusers_dep_vu_prepare_func()
 GO
 ~~START~~
-int
-2
+varchar#!#int#!#int#!#int#!#int#!#int
+dbo#!#1#!#1#!#0#!#1#!#0
+guest#!#0#!#1#!#0#!#1#!#0
+INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
+public#!#0#!#0#!#0#!#0#!#1
+sys#!#0#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
 ~~END~~
 
 
-SELECT name FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+-- test sys.sysusers view, hasdbaccess should be 1 for newly created user 
+SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
+FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
 ORDER BY name
 GO
 ~~START~~
-varchar
-sysusers_dep_vu_prepare_user1
-sysusers_dep_vu_prepare_user2
+varchar#!#int#!#int#!#int#!#int#!#int
+dbo#!#1#!#1#!#0#!#1#!#0
+guest#!#0#!#1#!#0#!#1#!#0
+INFORMATION_SCHEMA#!#0#!#1#!#0#!#1#!#0
+public#!#0#!#0#!#0#!#0#!#1
+sys#!#0#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user1#!#1#!#1#!#0#!#1#!#0
+sysusers_dep_vu_prepare_user2#!#1#!#1#!#0#!#1#!#0
+~~END~~
+
+
+-- test [REVOKE CONNECT FROM], hasdbaccess should be 0
+REVOKE CONNECT FROM guest
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'guest'
+GO
+~~START~~
+varchar#!#int#!#int
+guest#!#0#!#1
+~~END~~
+
+
+-- test [GRANT CONNECT TO], hasdbaccess should be 1
+GRANT CONNECT TO guest
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'guest'
+GO
+~~START~~
+varchar#!#int#!#int
+guest#!#1#!#1
+~~END~~
+
+
+-- test [REVOKE CONNECT FROM], hasdbaccess should be 0
+REVOKE CONNECT FROM sysusers_dep_vu_prepare_user1
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'sysusers_dep_vu_prepare_user1'
+GO
+~~START~~
+varchar#!#int#!#int
+sysusers_dep_vu_prepare_user1#!#0#!#1
+~~END~~
+
+
+-- test [GRANT CONNECT TO], hasdbaccess should be 1
+GRANT CONNECT TO sysusers_dep_vu_prepare_user1
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'sysusers_dep_vu_prepare_user1'
+GO
+~~START~~
+varchar#!#int#!#int
+sysusers_dep_vu_prepare_user1#!#1#!#1
 ~~END~~
 
 

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-cleanup.sql
@@ -1,4 +1,4 @@
-USE testdb
+USE sysusersdb
 GO
 
 DROP VIEW sysusers_dep_vu_prepare_view
@@ -25,5 +25,5 @@ GO
 USE master
 GO
 
-DROP DATABASE testdb
+DROP DATABASE sysusersdb
 GO

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-cleanup.sql
@@ -1,3 +1,6 @@
+USE testdb
+GO
+
 DROP VIEW sysusers_dep_vu_prepare_view
 GO
 
@@ -19,3 +22,8 @@ GO
 DROP LOGIN sysusers_dep_vu_prepare_login2
 GO
 
+USE master
+GO
+
+DROP DATABASE testdb
+GO

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-cleanup.sql
@@ -1,0 +1,21 @@
+DROP VIEW sysusers_dep_vu_prepare_view
+GO
+
+DROP PROC sysusers_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION sysusers_dep_vu_prepare_func
+GO
+
+DROP USER sysusers_dep_vu_prepare_user1
+GO
+
+DROP USER sysusers_dep_vu_prepare_user2
+GO
+
+DROP LOGIN sysusers_dep_vu_prepare_login1
+GO
+
+DROP LOGIN sysusers_dep_vu_prepare_login2
+GO
+

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-prepare.sql
@@ -1,0 +1,35 @@
+CREATE LOGIN sysusers_dep_vu_prepare_login1 WITH PASSWORD = '123'
+GO
+
+CREATE USER sysusers_dep_vu_prepare_user1 FOR LOGIN sysusers_dep_vu_prepare_login1
+GO
+
+CREATE LOGIN sysusers_dep_vu_prepare_login2 WITH PASSWORD = '123'
+GO
+
+CREATE USER sysusers_dep_vu_prepare_user2 FOR LOGIN sysusers_dep_vu_prepare_login2
+GO
+
+CREATE VIEW sysusers_dep_vu_prepare_view
+AS
+SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE PROC sysusers_dep_vu_prepare_proc
+AS
+SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sysusers_dep_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.sysusers WHERE name LIKE '%sysusers_dep_vu_prepare_%')
+END
+GO

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-prepare.sql
@@ -1,3 +1,9 @@
+CREATE DATABASE testdb
+GO
+
+USE testdb
+GO
+
 CREATE LOGIN sysusers_dep_vu_prepare_login1 WITH PASSWORD = '123'
 GO
 
@@ -7,29 +13,31 @@ GO
 CREATE LOGIN sysusers_dep_vu_prepare_login2 WITH PASSWORD = '123'
 GO
 
-CREATE USER sysusers_dep_vu_prepare_user2 FOR LOGIN sysusers_dep_vu_prepare_login2
+CREATE USER sysusers_dep_vu_prepare_user2 FOR LOGIN sysusers_dep_vu_prepare_login2;
 GO
 
 CREATE VIEW sysusers_dep_vu_prepare_view
 AS
-SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%'
-ORDER BY name
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+ORDER BY name offset 0 rows
 GO
 
 CREATE PROC sysusers_dep_vu_prepare_proc
 AS
-SELECT name, roles, islogin, hasdbaccess, isntname, isntgroup, isntuser, issqluser, isaliased, issqlrole, isapprole
+SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
 ORDER BY name
 GO
 
 CREATE FUNCTION sysusers_dep_vu_prepare_func()
-RETURNS INT
+RETURNS TABLE
 AS
-BEGIN
-RETURN (SELECT COUNT(*) FROM sys.sysusers WHERE name LIKE '%sysusers_dep_vu_prepare_%')
-END
+RETURN
+    SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
+    FROM sys.sysusers
+    WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+    ORDER BY name offset 0 rows
 GO

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-prepare.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE testdb
+CREATE DATABASE sysusersdb
 GO
 
-USE testdb
+USE sysusersdb
 GO
 
 CREATE LOGIN sysusers_dep_vu_prepare_login1 WITH PASSWORD = '123'
@@ -20,7 +20,7 @@ CREATE VIEW sysusers_dep_vu_prepare_view
 AS
 SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
 ORDER BY name offset 0 rows
 GO
 
@@ -28,7 +28,7 @@ CREATE PROC sysusers_dep_vu_prepare_proc
 AS
 SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
 ORDER BY name
 GO
 
@@ -38,6 +38,6 @@ AS
 RETURN
     SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
     FROM sys.sysusers
-    WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+    WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
     ORDER BY name offset 0 rows
 GO

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-verify.sql
@@ -1,14 +1,58 @@
+USE testdb
+GO
+
+-- test view created on sys.sysusers
 SELECT * FROM sysusers_dep_vu_prepare_view
 GO
 
+-- test procedure created on sys.sysusers
 EXEC sysusers_dep_vu_prepare_proc
 GO
 
-SELECT sysusers_dep_vu_prepare_func()
+-- test function created on sys.sysusers
+SELECT * FROM sysusers_dep_vu_prepare_func()
 GO
 
-SELECT name FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+-- test sys.sysusers view, hasdbaccess should be 1 for newly created user 
+SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
+FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
 ORDER BY name
+GO
+
+-- test [REVOKE CONNECT FROM], hasdbaccess should be 0
+REVOKE CONNECT FROM guest
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'guest'
+GO
+
+-- test [GRANT CONNECT TO], hasdbaccess should be 1
+GRANT CONNECT TO guest
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'guest'
+GO
+
+-- test [REVOKE CONNECT FROM], hasdbaccess should be 0
+REVOKE CONNECT FROM sysusers_dep_vu_prepare_user1
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'sysusers_dep_vu_prepare_user1'
+GO
+
+-- test [GRANT CONNECT TO], hasdbaccess should be 1
+GRANT CONNECT TO sysusers_dep_vu_prepare_user1
+GO
+
+SELECT name, hasdbaccess, islogin
+FROM sys.sysusers
+WHERE name = 'sysusers_dep_vu_prepare_user1'
 GO
 

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-verify.sql
@@ -1,4 +1,4 @@
-USE testdb
+USE sysusersdb
 GO
 
 -- test view created on sys.sysusers
@@ -16,12 +16,12 @@ GO
 -- test sys.sysusers view, hasdbaccess should be 1 for newly created user 
 SELECT name, hasdbaccess, islogin, isntname, issqluser, issqlrole
 FROM sys.sysusers
-WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest' OR name = 'sys' OR name = 'public' OR name = 'INFORMATION_SCHEMA'
+WHERE name LIKE '%sysusers_dep_vu_prepare_%' OR name = 'dbo' or name = 'guest'
 ORDER BY name
 GO
 
--- test [REVOKE CONNECT FROM], hasdbaccess should be 0
-REVOKE CONNECT FROM guest
+-- test [GRANT CONNECT TO], hasdbaccess should be 1
+GRANT CONNECT TO guest
 GO
 
 SELECT name, hasdbaccess, islogin
@@ -29,8 +29,8 @@ FROM sys.sysusers
 WHERE name = 'guest'
 GO
 
--- test [GRANT CONNECT TO], hasdbaccess should be 1
-GRANT CONNECT TO guest
+-- test [REVOKE CONNECT FROM], hasdbaccess should be 0
+REVOKE CONNECT FROM guest
 GO
 
 SELECT name, hasdbaccess, islogin

--- a/test/JDBC/input/ownership/sys_sysusers_dep-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_sysusers_dep-vu-verify.sql
@@ -1,0 +1,14 @@
+SELECT * FROM sysusers_dep_vu_prepare_view
+GO
+
+EXEC sysusers_dep_vu_prepare_proc
+GO
+
+SELECT sysusers_dep_vu_prepare_func()
+GO
+
+SELECT name FROM sys.sysusers
+WHERE name LIKE '%sysusers_dep_vu_prepare_%'
+ORDER BY name
+GO
+

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -423,5 +423,6 @@ BABEL-3474
 dateadd_internal_df
 datetime2fromparts-after-15-2
 timefromparts
-sys_sysusers_deporderby
+orderby
+sys_sysusers_dep
 BABEL-3215

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -423,5 +423,5 @@ BABEL-3474
 dateadd_internal_df
 datetime2fromparts-after-15-2
 timefromparts
-orderby
+sys_sysusers_deporderby
 BABEL-3215


### PR DESCRIPTION
### Description

Sysusers contains the mapping between DB users and logins, and to DB roles. Currently Babelfish does not support sysusers catalog. With this commit, we support sys.sysusers catalog.

### Issues Resolved

sysusers catalog is supported in Babelfish
BABEL-2974

### Test Scenarios Covered ###
* **Use case based -**
Test sysusers catalog usage in view
Test sysusers catalog usage in procedure
Test sysusers catalog usage in function
Test sysusers columns for 'dbo', 'guest', sys', 'public', and 'INFORMATION_SCHEMA'. 
Test 'grant/revoke connect' on users.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).