### PR TITLE
Fix invalid newval assignment in check_version_number

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/guc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/guc.c
@@ -113,6 +113,17 @@ TdsGucDefaultPacketSizeCheck(int *newvalue, void **extra, GucSource source)
 	return true;
 }
 
+static void
+set_newval_to_product_version(char **newval)
+{
+	free(*newval);
+	*newval = strdup(product_version);
+	if (*newval == NULL)
+			ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("out of memory")));
+}
+
 static bool
 check_version_number(char **newval, void **extra, GucSource source)
 {
@@ -134,7 +145,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by \'.\' ")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 
@@ -143,7 +154,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 
@@ -155,7 +166,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 
@@ -167,7 +178,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 		part++;
@@ -177,7 +188,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 	{
 		ereport(WARNING,
 				(errmsg("babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by \'.\' ")));
-		*newval = product_version;
+		set_newval_to_product_version(newval);
 		return true;
 	}
 


### PR DESCRIPTION
### Description

When new value of a GUC version field is set [like this](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/test/JDBC/input/BABEL-VERSION.mix#L2), this value is passed to `check_version_number` function in [tds/guc.c](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/contrib/babelfishpg_tds/src/backend/tds/guc.c#L116) as a `newval`. Memory for the value copy in `newal` is [allocated with strdup](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/ff43eb60c73a7da7d20ea7d691edbc4b67ce0445/src/backend/utils/misc/guc.c#L7517).

When `check_version_number` founds a problem, it re-assigns `newal` [to a product_version](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/contrib/babelfishpg_tds/src/backend/tds/guc.c#L146) that was [initialized with a string literal](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/contrib/babelfishpg_tds/src/backend/tds/guc.c#L42). Original strdupped `newal` value is leaked at this point. When `check_version_number` returns `true` (it happens always) and `parse_and_validate_value` returns, the `newal` pointer is being `free`'d [in the caller function AlterSystemSetConfigFile](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/ff43eb60c73a7da7d20ea7d691edbc4b67ce0445/src/backend/utils/misc/guc.c#L8988) effectively freeing `product_version` value.

When the offending `alter system` is run multiple times, it manifests itself in Valgrind the following way:

```
2023-04-08 14:25:00.314 IST [55573] WARNING:  babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16
2023-04-08 14:25:04.686 IST [55573] WARNING:  babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16
==55573== Invalid free() / delete / delete[] / realloc()
==55573==    at 0x48480E4: free (vg_replace_malloc.c:872)
==55573==    by 0xAD2941: AlterSystemSetConfigFile (guc.c:8988)
==55573==    by 0x92562C: standard_ProcessUtility (utility.c:886)
==55573==    by 0x1528AE7A: call_next_ProcessUtility (tdsutils.c:744)
==55573==    by 0x1528AD4F: tdsutils_ProcessUtility (tdsutils.c:692)
==55573==    by 0x924D6E: ProcessUtility (utility.c:527)
==55573==    by 0x923BE7: PortalRunUtility (pquery.c:1158)
==55573==    by 0x923DE6: PortalRunMulti (pquery.c:1315)
==55573==    by 0x9233CE: PortalRun (pquery.c:791)
==55573==    by 0x91D26F: exec_simple_query (postgres.c:1252)
==55573==    by 0x921739: PostgresMain (postgres.c:4647)
==55573==    by 0x86E44B: libpq_mainfunc (postmaster.c:1554)
==55573==  Address 0x7a0fa70 is 0 bytes inside a block of size 8 free'd
==55573==    at 0x48480E4: free (vg_replace_malloc.c:872)
==55573==    by 0xAD2941: AlterSystemSetConfigFile (guc.c:8988)
==55573==    by 0x92562C: standard_ProcessUtility (utility.c:886)
==55573==    by 0x1528AE7A: call_next_ProcessUtility (tdsutils.c:744)
==55573==    by 0x1528AD4F: tdsutils_ProcessUtility (tdsutils.c:692)
==55573==    by 0x924D6E: ProcessUtility (utility.c:527)
==55573==    by 0x923BE7: PortalRunUtility (pquery.c:1158)
==55573==    by 0x923DE6: PortalRunMulti (pquery.c:1315)
==55573==    by 0x9233CE: PortalRun (pquery.c:791)
==55573==    by 0x91D26F: exec_simple_query (postgres.c:1252)
==55573==    by 0x921739: PostgresMain (postgres.c:4647)
==55573==    by 0x86E44B: libpq_mainfunc (postmaster.c:1554)
==55573==  Block was alloc'd at
==55573==    at 0x484586F: malloc (vg_replace_malloc.c:381)
==55573==    by 0x55E952D: strdup (strdup.c:42)
==55573==    by 0xACC132: guc_strdup (guc.c:5256)
==55573==    by 0xACD80F: InitializeOneGUCOption (guc.c:6089)
==55573==    by 0xAD371A: define_custom_variable (guc.c:9431)
==55573==    by 0xAD3E36: DefineCustomStringVariable (guc.c:9707)
==55573==    by 0x1527BB11: TdsDefineGucs (guc.c:254)
==55573==    by 0x152874A4: _PG_init (tds.c:208)
==55573==    by 0xAB9ABC: internal_load_library (dfmgr.c:289)
==55573==    by 0xAB9647: load_file (dfmgr.c:156)
==55573==    by 0xAC669C: load_libraries (miscinit.c:1668)
==55573==    by 0xAC6785: process_shared_preload_libraries (miscinit.c:1686)
```

It is suggested to copy `product_version` value before assigning it to `newval` and to `free` the old value (that was allocated with `strdup`).


### Issues Resolved

Current behaviour, while being a UB, does not seem to cause problems besides a minor memory leak.

### Test Scenarios Covered ###

[BABEL-VERSION.mix](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/test/JDBC/input/BABEL-VERSION.mix)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).