### PR TITLE
CASTing a DATE literal without time part to TIME datatype fails

### DIFF
--- a/test/JDBC/expected/BABEL-1528-after-15-2-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-1528-after-15-2-vu-cleanup.out
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_1528_vu_prepare_t1
+GO
+
+DROP VIEW BABEL_1528_vu_prepare_v1
+GO
+
+DROP PROCEDURE BABEL_1528_vu_prepare_p1
+GO
+
+DROP FUNCTION BABEL_1528_vu_prepare_f1
+GO

--- a/test/JDBC/expected/BABEL-1528-after-15-2-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-1528-after-15-2-vu-prepare.out
@@ -1,0 +1,22 @@
+-- [BABEL-1528] CASTing a DATE literal without time part to TIME datatype should not fail
+create table BABEL_1528_vu_prepare_t1(a time)
+GO
+
+insert into BABEL_1528_vu_prepare_t1 values ('2012-02-23')
+GO
+~~ROW COUNT: 1~~
+
+
+create view BABEL_1528_vu_prepare_v1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create procedure BABEL_1528_vu_prepare_p1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create function BABEL_1528_vu_prepare_f1()
+returns time
+as
+begin
+	return (select CAST('2012-02-23' AS time) as val)
+end
+GO

--- a/test/JDBC/expected/BABEL-1528-after-15-2-vu-verify.out
+++ b/test/JDBC/expected/BABEL-1528-after-15-2-vu-verify.out
@@ -1,0 +1,39 @@
+select CAST('2012-02-23' AS time)
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+select * from BABEL_1528_vu_prepare_t1
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+select BABEL_1528_vu_prepare_f1()
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+exec BABEL_1528_vu_prepare_p1
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+select * FROM BABEL_1528_vu_prepare_v1
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+

--- a/test/JDBC/expected/BABEL-1528-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-1528-vu-cleanup.out
@@ -1,0 +1,15 @@
+DROP TABLE BABEL_1528_vu_prepare_t1
+GO
+
+DROP VIEW BABEL_1528_vu_prepare_v1
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: view "babel_1528_vu_prepare_v1" does not exist)~~
+
+
+DROP PROCEDURE BABEL_1528_vu_prepare_p1
+GO
+
+DROP FUNCTION BABEL_1528_vu_prepare_f1
+GO

--- a/test/JDBC/expected/BABEL-1528-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-1528-vu-prepare.out
@@ -1,0 +1,28 @@
+-- [BABEL-1528] CASTing a DATE literal without time part to TIME datatype should not fail
+create table BABEL_1528_vu_prepare_t1(a time)
+GO
+
+insert into BABEL_1528_vu_prepare_t1 values ('2012-02-23')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type time: "2012-02-23")~~
+
+
+create view BABEL_1528_vu_prepare_v1 as select CAST('2012-02-23' AS time) as val
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type time: "2012-02-23")~~
+
+
+create procedure BABEL_1528_vu_prepare_p1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create function BABEL_1528_vu_prepare_f1()
+returns time
+as
+begin
+	return (select CAST('2012-02-23' AS time) as val)
+end
+GO

--- a/test/JDBC/expected/BABEL-1528-vu-verify.out
+++ b/test/JDBC/expected/BABEL-1528-vu-verify.out
@@ -1,0 +1,37 @@
+select CAST('2012-02-23' AS time)
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+select * from BABEL_1528_vu_prepare_t1
+GO
+~~START~~
+time
+~~END~~
+
+
+select BABEL_1528_vu_prepare_f1()
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+exec BABEL_1528_vu_prepare_p1
+GO
+~~START~~
+time
+00:00:00.0000000
+~~END~~
+
+
+select * FROM BABEL_1528_vu_prepare_v1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_1528_vu_prepare_v1" does not exist)~~
+

--- a/test/JDBC/input/BABEL-1528-after-15-2-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-1528-after-15-2-vu-cleanup.sql
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_1528_vu_prepare_t1
+GO
+
+DROP VIEW BABEL_1528_vu_prepare_v1
+GO
+
+DROP PROCEDURE BABEL_1528_vu_prepare_p1
+GO
+
+DROP FUNCTION BABEL_1528_vu_prepare_f1
+GO

--- a/test/JDBC/input/BABEL-1528-after-15-2-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-1528-after-15-2-vu-prepare.sql
@@ -1,0 +1,20 @@
+-- [BABEL-1528] CASTing a DATE literal without time part to TIME datatype should not fail
+create table BABEL_1528_vu_prepare_t1(a time)
+GO
+
+insert into BABEL_1528_vu_prepare_t1 values ('2012-02-23')
+GO
+
+create view BABEL_1528_vu_prepare_v1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create procedure BABEL_1528_vu_prepare_p1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create function BABEL_1528_vu_prepare_f1()
+returns time
+as
+begin
+	return (select CAST('2012-02-23' AS time) as val)
+end
+GO

--- a/test/JDBC/input/BABEL-1528-after-15-2-vu-verify.sql
+++ b/test/JDBC/input/BABEL-1528-after-15-2-vu-verify.sql
@@ -1,0 +1,14 @@
+select CAST('2012-02-23' AS time)
+GO
+
+select * from BABEL_1528_vu_prepare_t1
+GO
+
+select BABEL_1528_vu_prepare_f1()
+GO
+
+exec BABEL_1528_vu_prepare_p1
+GO
+
+select * FROM BABEL_1528_vu_prepare_v1
+GO

--- a/test/JDBC/input/BABEL-1528-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-1528-vu-cleanup.sql
@@ -1,0 +1,11 @@
+DROP TABLE BABEL_1528_vu_prepare_t1
+GO
+
+DROP VIEW BABEL_1528_vu_prepare_v1
+GO
+
+DROP PROCEDURE BABEL_1528_vu_prepare_p1
+GO
+
+DROP FUNCTION BABEL_1528_vu_prepare_f1
+GO

--- a/test/JDBC/input/BABEL-1528-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-1528-vu-prepare.sql
@@ -1,0 +1,20 @@
+-- [BABEL-1528] CASTing a DATE literal without time part to TIME datatype should not fail
+create table BABEL_1528_vu_prepare_t1(a time)
+GO
+
+insert into BABEL_1528_vu_prepare_t1 values ('2012-02-23')
+GO
+
+create view BABEL_1528_vu_prepare_v1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create procedure BABEL_1528_vu_prepare_p1 as select CAST('2012-02-23' AS time) as val
+GO
+
+create function BABEL_1528_vu_prepare_f1()
+returns time
+as
+begin
+	return (select CAST('2012-02-23' AS time) as val)
+end
+GO

--- a/test/JDBC/input/BABEL-1528-vu-verify.sql
+++ b/test/JDBC/input/BABEL-1528-vu-verify.sql
@@ -1,0 +1,14 @@
+select CAST('2012-02-23' AS time)
+GO
+
+select * from BABEL_1528_vu_prepare_t1
+GO
+
+select BABEL_1528_vu_prepare_f1()
+GO
+
+exec BABEL_1528_vu_prepare_p1
+GO
+
+select * FROM BABEL_1528_vu_prepare_v1
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -114,6 +114,9 @@ ignore#!#datediff_internal_date-before-14_7-or-15_2-vu-cleanup
 ignore#!#datetime2fromparts-vu-prepare
 ignore#!#datetime2fromparts-vu-verify
 ignore#!#datetime2fromparts-vu-cleanup
+ignore#!#BABEL-1528-vu-prepare
+ignore#!#BABEL-1528-vu-verify
+ignore#!#BABEL-1528-vu-cleanup
 
 # These tests are meant for only upgrade
 ignore#!#openquery_upgrd-vu-prepare

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -203,3 +203,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -254,3 +254,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -313,3 +313,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -308,3 +308,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -308,3 +308,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -311,3 +311,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -326,3 +326,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -340,3 +340,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -366,3 +366,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -397,3 +397,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -396,3 +396,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -376,3 +376,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
+BABEL-1528

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -414,3 +414,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 orderby-before-15_3
+BABEL-1528

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -423,3 +423,4 @@ datetime2fromparts-after-15-2
 timefromparts
 orderby
 BABEL-3215
+BABEL-1528-after-15-2

--- a/test/odbc/psqlodbc/test/time.cpp
+++ b/test/odbc/psqlodbc/test/time.cpp
@@ -139,7 +139,20 @@ TEST_F(PSQL_DataTypes_Time, Insertion_Fail) {
     "00:60:0",    // Minute over range
     // "00:00:60",   // Second over range
     "00-00-00",   // Format hh-mm-ss
-
+    "December 31, 1900 CE",
+    "2080-01-01 00:00:00",        // Year
+    "1899-12-31 00:00:00",
+    "0000-01-01 00:00:00",
+    "1900-32-01 00:00:00",        // Month
+    "1900-00-01 00:00:00",
+    "1900-01-32 00:00:00",        // Day
+    "1900-01-00 00:00:00",
+    "1900-02-31 00:00:00",        // Feb 31st
+    "0001-01-01 24:00:00",            // Hour
+    "0001-01-01 00:60:00",        // Minutes
+    "0001-01-01 00:00:60",            // Seconds
+    "0001-01-01 00:00:60000",     // Milliseconds
+    "2079-06-06 23:59:39",         // Rounding up over range
     // ODBC API format for Time is hh:mm:ss
     // Below are valid in SQL Server
     "00:00:00.00 AM"


### PR DESCRIPTION
### Description

For time datatype PG considers only date value(ex.- '2012-02-23') as bad i/p format. so, above testcase is throwing error from engine code time_in() much before coming to TDS side.

However, SQL Server allows casting a date literal string to a TIME datatype when the time component in the string is missing: o/p becomes 00:00:00.0000000

Fix is to add change in time_in() so that it considers date format with missing time info like above one, as valid input when the dialect is TSQL.

-sql_server:
1> select CAST('2012-02-23' AS time)
2> go

00:00:00.0000000

-Babelfish(before fix):
1> select CAST('2012-02-23' AS time)
2> go
Msg 117440642, Level 16, State 1, Server BABEL, Line 1
invalid input syntax for type time: “2012-02-23"

Task: BABEL-1528
Signed-off-by: Satarupa Biswas [satarupb@amazon.com](mailto:satarupb@amazon.com)

### Test Scenarios Covered

     o Use case based: Original issue
     o Null testcases: N/A
     o Negative test scenarios: N/A
     o Boundary conditions, Arbitrary inputs: N/A
     o Testcases calling from procedures, views and functions
     o Minor version upgrade tests, Major version upgrade tests : Done
     o Performance tests, Tooling impact, Client tests: N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).