### PR TITLE
Do not use local time zone with datetimeoffset in JDBC tests

### DIFF
--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
@@ -13,7 +13,9 @@ import java.sql.*;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -130,7 +132,10 @@ public class JDBCPreparedStatement {
                     pstmt.setTime(j - 1, Time.valueOf(LocalTime.parse(parameter[2])));
                 } else if (parameter[0].equalsIgnoreCase("datetimeoffset")) {
                     SQLServerPreparedStatement ssPstmt = (SQLServerPreparedStatement) pstmt;
-                    ssPstmt.setDateTimeOffset(j - 1, DateTimeOffset.valueOf(Timestamp.valueOf(parameter[2]), 0));
+                    Timestamp tsLocal = Timestamp.valueOf(parameter[2]);
+                    long millis = tsLocal.toLocalDateTime().toInstant(ZoneOffset.UTC).toEpochMilli();
+                    Timestamp ts = new Timestamp(millis);
+                    ssPstmt.setDateTimeOffset(j - 1, DateTimeOffset.valueOf(ts, 0));
                     pstmt = ssPstmt;
                 } else if (parameter[0].equalsIgnoreCase("text")
                         || parameter[0].equalsIgnoreCase("ntext")) {


### PR DESCRIPTION
### Description

This change converts `Timestamp` to `UTC` first before getting milliseconds from it to create a `DateTimeOffset`.

### Issues Resolved

#1419

### Test Scenarios Covered ###

[TestNotNull](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/test/JDBC/input/TestNotNull.txt#L241)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).