### PR TITLE
Fix the output style for NVARCHAR datatype in CONVERT function

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -201,7 +201,7 @@ TsqlFunctionConvert(TypeName *typename, Node *arg, Node *style, bool try, int lo
 	else if (type_oid == typenameTypeId(NULL, makeTypeName("datetime")))
 		result = (Node *) makeFuncCall(TsqlSystemFuncName("babelfish_conv_helper_to_datetime"), args, COERCE_EXPLICIT_CALL, location);
 
-	else if (strcmp(typename_string, "varchar") == 0)
+	else if ((strcmp(typename_string, "varchar") == 0) || (strcmp(typename_string, "nvarchar") == 0))
 	{
 		Node	   *helperFuncCall;
 

--- a/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-cleanup.out
@@ -1,0 +1,50 @@
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view1
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view11
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view2
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view22
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc1
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc11
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc2
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc22
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func1
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func11
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func2
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func22
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view3
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view4
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view5
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view6
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view7
+GO

--- a/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-prepare.out
@@ -1,73 +1,73 @@
 -- default style
-CREATE VIEW babel_4078_vu_prepare_view1 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view1 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) result
 GO
 
 -- different style
-CREATE VIEW babel_4078_vu_prepare_view11 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view11 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
 GO
 
 -- default style
-CREATE VIEW babel_4078_vu_prepare_view2 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view2 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
 GO
 
 -- different style
-CREATE VIEW babel_4078_vu_prepare_view22 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view22 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20) result
 GO
 
 -- default style
-CREATE PROCEDURE babel_4078_vu_prepare_proc1 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc1 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result
 GO
 
 -- different style
-CREATE PROCEDURE babel_4078_vu_prepare_proc11 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc11 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105)  result
 GO
 
 -- default style
-CREATE PROCEDURE babel_4078_vu_prepare_proc2 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc2 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
 GO
 
 -- different style
-CREATE PROCEDURE babel_4078_vu_prepare_proc22 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc22 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20)  result
 GO
 
 -- default style
-CREATE FUNCTION babel_4078_vu_prepare_func1()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func1()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result)
 GO
 
 -- different style
-CREATE FUNCTION babel_4078_vu_prepare_func11()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func11()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105)  result)
 GO
 
 -- different style
-CREATE FUNCTION babel_4078_vu_prepare_func2()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func2()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result)
 GO
 
 -- different style
-CREATE FUNCTION babel_4078_vu_prepare_func22()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func22()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20)  result)
 GO
 
 -- to verify that is returning expected the default style
-CREATE VIEW babel_4078_vu_prepare_view3 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view3 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 20)
        THEN 'true'
@@ -75,7 +75,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view4 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view4 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 25)
        THEN 'true'
@@ -83,7 +83,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view5 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view5 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME), 0)
        THEN 'true'
@@ -91,7 +91,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view6 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view6 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as float)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as float), 0)
        THEN 'true'
@@ -99,7 +99,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view7 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view7 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money), 0)
        THEN 'true'

--- a/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-verify.out
@@ -42,7 +42,7 @@ EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc11
 GO
 ~~START~~
 nvarchar
-2023-02-03
+03-02-2023
 ~~END~~
 
 
@@ -58,7 +58,7 @@ EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc22
 GO
 ~~START~~
 nvarchar
-19:08:35.5
+19:08:35
 ~~END~~
 
 
@@ -74,7 +74,7 @@ SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func11()
 GO
 ~~START~~
 nvarchar
-2023-02-03
+03-02-2023
 ~~END~~
 
 
@@ -90,7 +90,7 @@ SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func22()
 GO
 ~~START~~
 nvarchar
-19:08:35.5
+19:08:35
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4078-before-14_8-or-15_3-vu-verify.out
@@ -1,0 +1,135 @@
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view1
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view11
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view2
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view22
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc1
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc11
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc2
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc22
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func1()
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func11()
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func2()
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func22()
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view3
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view4
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view5
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view6
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view7
+GO
+~~START~~
+text
+true
+~~END~~
+

--- a/test/JDBC/expected/BABEL-4078-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4078-vu-cleanup.out
@@ -13,13 +13,25 @@ GO
 DROP PROCEDURE babel_4078_vu_prepare_proc1
 GO
 
+DROP PROCEDURE babel_4078_vu_prepare_proc11
+GO
+
 DROP PROCEDURE babel_4078_vu_prepare_proc2
+GO
+
+DROP PROCEDURE babel_4078_vu_prepare_proc22
 GO
 
 DROP FUNCTION babel_4078_vu_prepare_func1
 GO
 
+DROP FUNCTION babel_4078_vu_prepare_func11
+GO
+
 DROP FUNCTION babel_4078_vu_prepare_func2
+GO
+
+DROP FUNCTION babel_4078_vu_prepare_func22
 GO
 
 DROP VIEW babel_4078_vu_prepare_view3

--- a/test/JDBC/expected/BABEL-4078-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4078-vu-cleanup.out
@@ -1,0 +1,38 @@
+DROP VIEW babel_4078_vu_prepare_view1
+GO
+
+DROP VIEW babel_4078_vu_prepare_view11
+GO
+
+DROP VIEW babel_4078_vu_prepare_view2
+GO
+
+DROP VIEW babel_4078_vu_prepare_view22
+GO
+
+DROP PROCEDURE babel_4078_vu_prepare_proc1
+GO
+
+DROP PROCEDURE babel_4078_vu_prepare_proc2
+GO
+
+DROP FUNCTION babel_4078_vu_prepare_func1
+GO
+
+DROP FUNCTION babel_4078_vu_prepare_func2
+GO
+
+DROP VIEW babel_4078_vu_prepare_view3
+GO
+
+DROP VIEW babel_4078_vu_prepare_view4
+GO
+
+DROP VIEW babel_4078_vu_prepare_view5
+GO
+
+DROP VIEW babel_4078_vu_prepare_view6
+GO
+
+DROP VIEW babel_4078_vu_prepare_view7
+GO

--- a/test/JDBC/expected/BABEL-4078-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4078-vu-prepare.out
@@ -1,0 +1,77 @@
+CREATE VIEW babel_4078_vu_prepare_view1 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view11 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view2 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view22 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
+GO
+
+CREATE PROCEDURE babel_4078_vu_prepare_proc1 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result
+GO
+
+CREATE PROCEDURE babel_4078_vu_prepare_proc2 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
+GO
+
+CREATE FUNCTION babel_4078_vu_prepare_func1()
+RETURNS TABLE
+AS
+RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result)
+GO
+
+CREATE FUNCTION babel_4078_vu_prepare_func2()
+RETURNS TABLE
+AS
+RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result)
+GO
+
+-- to verify that is returning expected the default style
+CREATE VIEW babel_4078_vu_prepare_view3 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 20)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view4 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 25)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view5 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME), 0)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view6 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as float)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as float), 0)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view7 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money), 0)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+

--- a/test/JDBC/expected/BABEL-4078-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4078-vu-verify.out
@@ -1,0 +1,103 @@
+SELECT * FROM babel_4078_vu_prepare_view1
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view11
+GO
+~~START~~
+nvarchar
+03-02-2023
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view2
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view22
+GO
+~~START~~
+nvarchar
+03-02-2023
+~~END~~
+
+
+EXEC babel_4078_vu_prepare_proc1
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+EXEC babel_4078_vu_prepare_proc2
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_func1()
+GO
+~~START~~
+nvarchar
+2023-02-03
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_func2()
+GO
+~~START~~
+nvarchar
+19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view3
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view4
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view5
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view6
+GO
+~~START~~
+text
+true
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_view7
+GO
+~~START~~
+text
+true
+~~END~~
+

--- a/test/JDBC/expected/BABEL-4078-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4078-vu-verify.out
@@ -26,7 +26,7 @@ SELECT * FROM babel_4078_vu_prepare_view22
 GO
 ~~START~~
 nvarchar
-03-02-2023
+19:08:35
 ~~END~~
 
 
@@ -38,11 +38,27 @@ nvarchar
 ~~END~~
 
 
+EXEC babel_4078_vu_prepare_proc11
+GO
+~~START~~
+nvarchar
+03-02-2023
+~~END~~
+
+
 EXEC babel_4078_vu_prepare_proc2
 GO
 ~~START~~
 nvarchar
 19:08:35.5
+~~END~~
+
+
+EXEC babel_4078_vu_prepare_proc22
+GO
+~~START~~
+nvarchar
+19:08:35
 ~~END~~
 
 
@@ -54,11 +70,27 @@ nvarchar
 ~~END~~
 
 
+SELECT * FROM babel_4078_vu_prepare_func11()
+GO
+~~START~~
+nvarchar
+03-02-2023
+~~END~~
+
+
 SELECT * FROM babel_4078_vu_prepare_func2()
 GO
 ~~START~~
 nvarchar
 19:08:35.5
+~~END~~
+
+
+SELECT * FROM babel_4078_vu_prepare_func22()
+GO
+~~START~~
+nvarchar
+19:08:35
 ~~END~~
 
 

--- a/test/JDBC/expected/ISC-Check-Constraints-vu-verify.out
+++ b/test/JDBC/expected/ISC-Check-Constraints-vu-verify.out
@@ -33,7 +33,7 @@ isc_check_constraints_db1#!#dbo#!#test_datetime_c_time_check#!#(((c_time < '09:0
 isc_check_constraints_db1#!#dbo#!#test_functioncall_col1_check#!#((isjson(col1) > 0))
 isc_check_constraints_db1#!#dbo#!#test_functioncall_col1_check1#!#(("right"(col1, 1) <> ','))
 isc_check_constraints_db1#!#dbo#!#test_functioncall_col1_check2#!#((ltrim(col1) <> ''))
-isc_check_constraints_db1#!#dbo#!#test_functioncall_col1_check3#!#((CAST((getutcdate() AT TIME ZONE col1) AS nvarchar(128)) <> ''))
+isc_check_constraints_db1#!#dbo#!#test_functioncall_col1_check3#!#((CAST((babelfish_conv_helper_to_varchar('character varying(128)', getutcdate() AT TIME ZONE col1, false)) AS nvarchar(128)) <> ''))
 isc_check_constraints_db1#!#dbo#!#test_null_a_check#!#((a IS NOT NULL))
 isc_check_constraints_db1#!#dbo#!#test_null1_a_check#!#((a <> CAST(NULL AS int)))
 isc_check_constraints_db1#!#dbo#!#test_null1_b_check#!#((b = CAST(NULL AS int)))

--- a/test/JDBC/input/BABEL-4078-before-14_8-or-15_3-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4078-before-14_8-or-15_3-vu-cleanup.sql
@@ -1,0 +1,50 @@
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view1
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view11
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view2
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view22
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc1
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc11
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc2
+GO
+
+DROP PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc22
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func1
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func11
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func2
+GO
+
+DROP FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func22
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view3
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view4
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view5
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view6
+GO
+
+DROP VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view7
+GO

--- a/test/JDBC/input/BABEL-4078-before-14_8-or-15_3-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4078-before-14_8-or-15_3-vu-prepare.sql
@@ -1,73 +1,73 @@
 -- default style
-CREATE VIEW babel_4078_vu_prepare_view1 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view1 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) result
 GO
 
 -- different style
-CREATE VIEW babel_4078_vu_prepare_view11 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view11 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
 GO
 
 -- default style
-CREATE VIEW babel_4078_vu_prepare_view2 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view2 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
 GO
 
 -- different style
-CREATE VIEW babel_4078_vu_prepare_view22 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view22 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20) result
 GO
 
 -- default style
-CREATE PROCEDURE babel_4078_vu_prepare_proc1 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc1 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result
 GO
 
 -- different style
-CREATE PROCEDURE babel_4078_vu_prepare_proc11 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc11 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105)  result
 GO
 
 -- default style
-CREATE PROCEDURE babel_4078_vu_prepare_proc2 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc2 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
 GO
 
 -- different style
-CREATE PROCEDURE babel_4078_vu_prepare_proc22 AS
+CREATE PROCEDURE babel_4078_before_14_8_or_15_3_vu_prepare_proc22 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20)  result
 GO
 
 -- default style
-CREATE FUNCTION babel_4078_vu_prepare_func1()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func1()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result)
 GO
 
 -- different style
-CREATE FUNCTION babel_4078_vu_prepare_func11()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func11()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105)  result)
 GO
 
 -- different style
-CREATE FUNCTION babel_4078_vu_prepare_func2()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func2()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result)
 GO
 
 -- different style
-CREATE FUNCTION babel_4078_vu_prepare_func22()
+CREATE FUNCTION babel_4078_before_14_8_or_15_3_vu_prepare_func22()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20)  result)
 GO
 
 -- to verify that is returning expected the default style
-CREATE VIEW babel_4078_vu_prepare_view3 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view3 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 20)
        THEN 'true'
@@ -75,7 +75,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view4 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view4 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 25)
        THEN 'true'
@@ -83,7 +83,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view5 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view5 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME), 0)
        THEN 'true'
@@ -91,7 +91,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view6 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view6 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as float)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as float), 0)
        THEN 'true'
@@ -99,7 +99,7 @@ SELECT CASE
        END  result
 GO
 
-CREATE VIEW babel_4078_vu_prepare_view7 AS
+CREATE VIEW babel_4078_before_14_8_or_15_3_vu_prepare_view7 AS
 SELECT CASE 
        WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money), 0)
        THEN 'true'

--- a/test/JDBC/input/BABEL-4078-before-14_8-or-15_3-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4078-before-14_8-or-15_3-vu-verify.sql
@@ -1,0 +1,50 @@
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view1
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view11
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view2
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view22
+GO
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc1
+GO
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc11
+GO
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc2
+GO
+
+EXEC babel_4078_before_14_8_or_15_3_vu_prepare_proc22
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func1()
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func11()
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func2()
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_func22()
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view3
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view4
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view5
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view6
+GO
+
+SELECT * FROM babel_4078_before_14_8_or_15_3_vu_prepare_view7
+GO

--- a/test/JDBC/input/BABEL-4078-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4078-vu-cleanup.sql
@@ -13,13 +13,25 @@ GO
 DROP PROCEDURE babel_4078_vu_prepare_proc1
 GO
 
+DROP PROCEDURE babel_4078_vu_prepare_proc11
+GO
+
 DROP PROCEDURE babel_4078_vu_prepare_proc2
+GO
+
+DROP PROCEDURE babel_4078_vu_prepare_proc22
 GO
 
 DROP FUNCTION babel_4078_vu_prepare_func1
 GO
 
+DROP FUNCTION babel_4078_vu_prepare_func11
+GO
+
 DROP FUNCTION babel_4078_vu_prepare_func2
+GO
+
+DROP FUNCTION babel_4078_vu_prepare_func22
 GO
 
 DROP VIEW babel_4078_vu_prepare_view3

--- a/test/JDBC/input/BABEL-4078-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4078-vu-cleanup.sql
@@ -1,0 +1,38 @@
+DROP VIEW babel_4078_vu_prepare_view1
+GO
+
+DROP VIEW babel_4078_vu_prepare_view11
+GO
+
+DROP VIEW babel_4078_vu_prepare_view2
+GO
+
+DROP VIEW babel_4078_vu_prepare_view22
+GO
+
+DROP PROCEDURE babel_4078_vu_prepare_proc1
+GO
+
+DROP PROCEDURE babel_4078_vu_prepare_proc2
+GO
+
+DROP FUNCTION babel_4078_vu_prepare_func1
+GO
+
+DROP FUNCTION babel_4078_vu_prepare_func2
+GO
+
+DROP VIEW babel_4078_vu_prepare_view3
+GO
+
+DROP VIEW babel_4078_vu_prepare_view4
+GO
+
+DROP VIEW babel_4078_vu_prepare_view5
+GO
+
+DROP VIEW babel_4078_vu_prepare_view6
+GO
+
+DROP VIEW babel_4078_vu_prepare_view7
+GO

--- a/test/JDBC/input/BABEL-4078-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4078-vu-prepare.sql
@@ -1,0 +1,77 @@
+CREATE VIEW babel_4078_vu_prepare_view1 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view11 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view2 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view22 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
+GO
+
+CREATE PROCEDURE babel_4078_vu_prepare_proc1 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result
+GO
+
+CREATE PROCEDURE babel_4078_vu_prepare_proc2 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
+GO
+
+CREATE FUNCTION babel_4078_vu_prepare_func1()
+RETURNS TABLE
+AS
+RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result)
+GO
+
+CREATE FUNCTION babel_4078_vu_prepare_func2()
+RETURNS TABLE
+AS
+RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result)
+GO
+
+-- to verify that is returning expected the default style
+CREATE VIEW babel_4078_vu_prepare_view3 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 20)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view4 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 25)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view5 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME)) =  CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as sys.DATETIME), 0)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view6 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as float)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as float), 0)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+
+CREATE VIEW babel_4078_vu_prepare_view7 AS
+SELECT CASE 
+       WHEN CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money)) =  CONVERT(NVARCHAR(10), CAST('1.0001' as sys.money), 0)
+       THEN 'true'
+       else 'false'
+       END  result
+GO
+

--- a/test/JDBC/input/BABEL-4078-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4078-vu-prepare.sql
@@ -1,37 +1,69 @@
+-- default style
 CREATE VIEW babel_4078_vu_prepare_view1 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE)) result
 GO
 
+-- different style
 CREATE VIEW babel_4078_vu_prepare_view11 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
 GO
 
+-- default style
 CREATE VIEW babel_4078_vu_prepare_view2 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
 GO
 
+-- different style
 CREATE VIEW babel_4078_vu_prepare_view22 AS
-SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105) result
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20) result
 GO
 
+-- default style
 CREATE PROCEDURE babel_4078_vu_prepare_proc1 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result
 GO
 
+-- different style
+CREATE PROCEDURE babel_4078_vu_prepare_proc11 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105)  result
+GO
+
+-- default style
 CREATE PROCEDURE babel_4078_vu_prepare_proc2 AS
 SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result
 GO
 
+-- different style
+CREATE PROCEDURE babel_4078_vu_prepare_proc22 AS
+SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20)  result
+GO
+
+-- default style
 CREATE FUNCTION babel_4078_vu_prepare_func1()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE))  result)
 GO
 
+-- different style
+CREATE FUNCTION babel_4078_vu_prepare_func11()
+RETURNS TABLE
+AS
+RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as DATE), 105)  result)
+GO
+
+-- different style
 CREATE FUNCTION babel_4078_vu_prepare_func2()
 RETURNS TABLE
 AS
 RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME))  result)
+GO
+
+-- different style
+CREATE FUNCTION babel_4078_vu_prepare_func22()
+RETURNS TABLE
+AS
+RETURN (SELECT CONVERT(NVARCHAR(10), CAST('2023-02-03 19:08:35.527' as TIME), 20)  result)
 GO
 
 -- to verify that is returning expected the default style

--- a/test/JDBC/input/BABEL-4078-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4078-vu-verify.sql
@@ -1,0 +1,38 @@
+SELECT * FROM babel_4078_vu_prepare_view1
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view11
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view2
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view22
+GO
+
+EXEC babel_4078_vu_prepare_proc1
+GO
+
+EXEC babel_4078_vu_prepare_proc2
+GO
+
+SELECT * FROM babel_4078_vu_prepare_func1()
+GO
+
+SELECT * FROM babel_4078_vu_prepare_func2()
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view3
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view4
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view5
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view6
+GO
+
+SELECT * FROM babel_4078_vu_prepare_view7
+GO

--- a/test/JDBC/input/BABEL-4078-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4078-vu-verify.sql
@@ -13,13 +13,25 @@ GO
 EXEC babel_4078_vu_prepare_proc1
 GO
 
+EXEC babel_4078_vu_prepare_proc11
+GO
+
 EXEC babel_4078_vu_prepare_proc2
+GO
+
+EXEC babel_4078_vu_prepare_proc22
 GO
 
 SELECT * FROM babel_4078_vu_prepare_func1()
 GO
 
+SELECT * FROM babel_4078_vu_prepare_func11()
+GO
+
 SELECT * FROM babel_4078_vu_prepare_func2()
+GO
+
+SELECT * FROM babel_4078_vu_prepare_func22()
 GO
 
 SELECT * FROM babel_4078_vu_prepare_view3

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -106,7 +106,7 @@ ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-prepare
 ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-verify
 # These tests are meant for upgrade scenario prior to (potential) 15_2 release
 ignore#!#test_windows_login_before_15_2-vu-prepare
-ignore#!#test_windows_login_before_15_ 2-vu-verify
+ignore#!#test_windows_login_before_15_2-vu-verify
 ignore#!#test_windows_login_before_15_2-vu-cleanup
 ignore#!#datediff_internal_date-before-14_7-or-15_2-vu-prepare
 ignore#!#datediff_internal_date-before-14_7-or-15_2-vu-verify

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -106,7 +106,7 @@ ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-prepare
 ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-verify
 # These tests are meant for upgrade scenario prior to (potential) 15_2 release
 ignore#!#test_windows_login_before_15_2-vu-prepare
-ignore#!#test_windows_login_before_15_2-vu-verify
+ignore#!#test_windows_login_before_15_ 2-vu-verify
 ignore#!#test_windows_login_before_15_2-vu-cleanup
 ignore#!#datediff_internal_date-before-14_7-or-15_2-vu-prepare
 ignore#!#datediff_internal_date-before-14_7-or-15_2-vu-verify
@@ -122,3 +122,8 @@ ignore#!#openquery_upgrd-vu-cleanup
 ignore#!#Test-Identity-before-14_7-or-15_2-vu-prepare
 ignore#!#Test-Identity-before-14_7-or-15_2-vu-verify
 ignore#!#Test-Identity-before-14_7-or-15_2-vu-cleanup
+
+# These tests are meant for upgrade scenario prior to (potential) 14_8 or 15_3 release
+ignore#!#BABEL-4078-before-14_8-or-15_3-vu-prepare
+ignore#!#BABEL-4078-before-14_8-or-15_3-vu-verify
+ignore#!#BABEL-4078-before-14_8-or-15_3-vu-cleanup

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -203,3 +203,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -203,4 +203,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -254,3 +254,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -254,4 +254,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -313,4 +313,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -313,3 +313,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -308,3 +308,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -308,4 +308,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -308,3 +308,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -308,4 +308,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -311,4 +311,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -311,3 +311,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -327,4 +327,4 @@ BABEL-3818
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -327,3 +327,4 @@ BABEL-3818
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -341,3 +341,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -341,4 +341,4 @@ BABEL-3474
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -368,4 +368,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -368,3 +368,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -399,3 +399,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -399,4 +399,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -398,4 +398,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -398,3 +398,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -378,3 +378,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
+BABEL-4078

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -378,4 +378,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -416,3 +416,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 orderby-before-15_3
+BABEL-4078

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -416,4 +416,4 @@ dateadd_internal_df
 datetime2fromparts
 timefromparts
 orderby-before-15_3
-BABEL-4078
+BABEL-4078-before-14_8-or-15_3

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -427,3 +427,4 @@ timefromparts
 orderby
 sys_sysusers_dep
 BABEL-3215
+BABEL-4078


### PR DESCRIPTION
### Description

Earlier when we were converting from DATE/TIME types to NVARCHAR type using CONVERT function the output style was not getting into account as we have not handled the case for NVARCHAR type in TsqlFunctionConvert function correctly. This commit add changes to handle the case for NVARCHAR correctly.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Issues Resolved

Task: BABEL-4078


### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** Yes


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).