### PR TITLE
Support PARSENAME() T-SQL function

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2083,6 +2083,64 @@ numeric_radians(PG_FUNCTION_ARGS)
 	PG_RETURN_NUMERIC(result);
 }
 
+PG_FUNCTION_INFO_V1(parsename);
+Datum parsename(PG_FUNCTION_ARGS)
+{
+    text *object_name = PG_GETARG_TEXT_P(0);
+    int object_piece = PG_GETARG_INT32(1);
+    char *delim = ".";
+    char *token;
+    char *save_ptr;
+    char *database_name = NULL;
+    char *schema_name = NULL;
+    char *table_name = NULL;
+    int count = 0;
+    // Copy the object name from text to a C string
+    char *object_name_str = text_to_cstring(object_name);
+    // Tokenize the object name using the period delimiter
+    token = strtok_r(object_name_str, delim, &save_ptr);
+
+    while (token != NULL) {
+        count++;
+        if (count == 1) {
+            // Store the database name
+            // database_name = token;
+			schema_name = token;
+        }
+        else if (count == 2) {
+            // Store the schema name
+            // schema_name = token;
+			table_name = token;
+        }
+        else if (count == 3) {
+            // Store the table name
+            // table_name = token;
+			database_name = token;
+        }
+        else if (count > 3) {
+            // We don't care about any further pieces, so break out of the loop
+            break;
+        }
+        token = strtok_r(NULL, delim, &save_ptr);
+    }
+    if (object_piece == 1) {
+        // Return the specified object piece as a text value
+        PG_RETURN_TEXT_P(cstring_to_text(database_name));
+    }
+    else if (object_piece == 2) {
+        // Return the specified object piece as a text value
+        PG_RETURN_TEXT_P(cstring_to_text(table_name));
+    }
+    else if (object_piece == 3) {
+        // Return the specified object piece as a text value
+        PG_RETURN_TEXT_P(cstring_to_text(schema_name));
+    }
+    else {
+        // Invalid object piece, so return NULL
+        PG_RETURN_NULL();
+    }
+}
+
 /* Returns the database schema name for schema-scoped objects. */
 Datum
 object_schema_name(PG_FUNCTION_ARGS)

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -103,7 +103,7 @@ PG_FUNCTION_INFO_V1(numeric_degrees);
 PG_FUNCTION_INFO_V1(numeric_radians);
 PG_FUNCTION_INFO_V1(object_schema_name);
 PG_FUNCTION_INFO_V1(pg_extension_config_remove);
-PG_FUNCTION_INFO_V1(parsename);
+// PG_FUNCTION_INFO_V1(parsename);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -2084,50 +2084,50 @@ numeric_radians(PG_FUNCTION_ARGS)
 	PG_RETURN_NUMERIC(result);
 }
 
-Datum parsename(PG_FUNCTION_ARGS)
-{
-    text *object_name = PG_GETARG_TEXT_P(0);
-    int object_piece = PG_GETARG_INT32(1);
-    char *delim = ".";
-    char *token;
-    char *save_ptr;
-    char *database_name = NULL;
-    char *schema_name = NULL;
-    char *table_name = NULL;
-    int count = 0;
+// Datum parsename(PG_FUNCTION_ARGS)
+// {
+//     text *object_name = PG_GETARG_TEXT_P(0);
+//     int object_piece = PG_GETARG_INT32(1);
+//     char *delim = ".";
+//     char *token;
+//     char *save_ptr;
+//     char *database_name = NULL;
+//     char *schema_name = NULL;
+//     char *table_name = NULL;
+//     int count = 0;
 
-    char *object_name_str = text_to_cstring(object_name);
-    token = strtok_r(object_name_str, delim, &save_ptr);
+//     char *object_name_str = text_to_cstring(object_name);
+//     token = strtok_r(object_name_str, delim, &save_ptr);
 
-    while (token != NULL) {
-        count++;
-        if (count == 1) {
-			schema_name = token;
-        }
-        else if (count == 2) {
-			table_name = token;
-        }
-        else if (count == 3) {
-			database_name = token;
-        }
-        else if (count > 3) {
-            break;
-        }
-        token = strtok_r(NULL, delim, &save_ptr);
-    }
-    if (object_piece == 1) {
-        PG_RETURN_TEXT_P(cstring_to_text(database_name));
-    }
-    else if (object_piece == 2) {
-        PG_RETURN_TEXT_P(cstring_to_text(table_name));
-    }
-    else if (object_piece == 3) {
-        PG_RETURN_TEXT_P(cstring_to_text(schema_name));
-    }
-    else {
-        PG_RETURN_NULL();
-    }
-}
+//     while (token != NULL) {
+//         count++;
+//         if (count == 1) {
+// 			schema_name = token;
+//         }
+//         else if (count == 2) {
+// 			table_name = token;
+//         }
+//         else if (count == 3) {
+// 			database_name = token;
+//         }
+//         else if (count > 3) {
+//             break;
+//         }
+//         token = strtok_r(NULL, delim, &save_ptr);
+//     }
+//     if (object_piece == 1) {
+//         PG_RETURN_TEXT_P(cstring_to_text(database_name));
+//     }
+//     else if (object_piece == 2) {
+//         PG_RETURN_TEXT_P(cstring_to_text(table_name));
+//     }
+//     else if (object_piece == 3) {
+//         PG_RETURN_TEXT_P(cstring_to_text(schema_name));
+//     }
+//     else {
+//         PG_RETURN_NULL();
+//     }
+// }
 
 /* Returns the database schema name for schema-scoped objects. */
 Datum

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -103,6 +103,7 @@ PG_FUNCTION_INFO_V1(numeric_degrees);
 PG_FUNCTION_INFO_V1(numeric_radians);
 PG_FUNCTION_INFO_V1(object_schema_name);
 PG_FUNCTION_INFO_V1(pg_extension_config_remove);
+PG_FUNCTION_INFO_V1(parsename);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -2083,7 +2084,6 @@ numeric_radians(PG_FUNCTION_ARGS)
 	PG_RETURN_NUMERIC(result);
 }
 
-PG_FUNCTION_INFO_V1(parsename);
 Datum parsename(PG_FUNCTION_ARGS)
 {
     text *object_name = PG_GETARG_TEXT_P(0);
@@ -2095,48 +2095,36 @@ Datum parsename(PG_FUNCTION_ARGS)
     char *schema_name = NULL;
     char *table_name = NULL;
     int count = 0;
-    // Copy the object name from text to a C string
+
     char *object_name_str = text_to_cstring(object_name);
-    // Tokenize the object name using the period delimiter
     token = strtok_r(object_name_str, delim, &save_ptr);
 
     while (token != NULL) {
         count++;
         if (count == 1) {
-            // Store the database name
-            // database_name = token;
 			schema_name = token;
         }
         else if (count == 2) {
-            // Store the schema name
-            // schema_name = token;
 			table_name = token;
         }
         else if (count == 3) {
-            // Store the table name
-            // table_name = token;
 			database_name = token;
         }
         else if (count > 3) {
-            // We don't care about any further pieces, so break out of the loop
             break;
         }
         token = strtok_r(NULL, delim, &save_ptr);
     }
     if (object_piece == 1) {
-        // Return the specified object piece as a text value
         PG_RETURN_TEXT_P(cstring_to_text(database_name));
     }
     else if (object_piece == 2) {
-        // Return the specified object piece as a text value
         PG_RETURN_TEXT_P(cstring_to_text(table_name));
     }
     else if (object_piece == 3) {
-        // Return the specified object piece as a text value
         PG_RETURN_TEXT_P(cstring_to_text(schema_name));
     }
     else {
-        // Invalid object piece, so return NULL
         PG_RETURN_NULL();
     }
 }

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -551,10 +551,30 @@ RETURNS INTEGER AS
 'babelfishpg_tsql', 'object_id'
 LANGUAGE C STABLE;
 
-CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
-RETURNS text
-AS 'babelfishpg_tsql', 'parsename'
-LANGUAGE C IMMUTABLE STRICT;
+-- CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
+-- RETURNS text
+-- AS 'babelfishpg_tsql', 'parsename'
+-- LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.parsename (
+    object_name VARCHAR,
+    object_piece INT
+)
+RETURNS VARCHAR AS $$
+/***************************************************************
+EXTENSION PACK function PARSENAME(x)
+****************************************************************/
+SELECT CASE
+    WHEN object_name IS NULL OR object_piece IS NULL THEN NULL
+    WHEN object_piece < 1 OR object_piece > 4 THEN NULL
+    WHEN char_length(object_name) > 1024 THEN NULL
+    WHEN char_length(object_name) - length(replace(object_name, '.', '')) < object_piece - 1 THEN NULL
+    WHEN object_piece = 1 THEN reverse(substring(reverse(object_name) from '[^.]*'))
+    WHEN object_piece = 2 THEN reverse(substring(reverse(substring((object_name) from '[^.]*\.[^.]*')) from '[^.]*'))
+    WHEN object_piece = 3 THEN (substring(reverse(substring(reverse(CASE WHEN substring(object_name from 1 for 1) = '.' THEN 'NULL'||object_name ELSE object_name END) from '[^.]*\.[^.]*\.[^.]*')) from '[^.]*'))
+    WHEN object_piece = 4 THEN reverse(substring(reverse(CASE WHEN substring(object_name from 1 for 1) = '.' THEN 'NULL'||object_name ELSE object_name END) from '^[^.]*\.[^.]*\.[^.]*\.(.*)'))
+    ELSE NULL
+    END $$ immutable LANGUAGE 'sql';
 
 
 CREATE OR REPLACE FUNCTION sys.timefromparts(IN p_hour NUMERIC,

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -551,23 +551,6 @@ RETURNS INTEGER AS
 'babelfishpg_tsql', 'object_id'
 LANGUAGE C STABLE;
 
--- CREATE OR REPLACE FUNCTION sys.parsename (
--- 	object_name VARCHAR
--- 	,object_piece INT
--- 	)
--- RETURNS VARCHAR AS $$
--- /***************************************************************
--- EXTENSION PACK function PARSENAME(x)
--- ***************************************************************/
--- SELECT CASE
--- 		WHEN char_length($1) < char_length(pg_catalog.replace($1, '.', '')) + 4
--- 			AND $2 BETWEEN 1
--- 				AND 4
--- 			THEN reverse(split_part(reverse($1), '.', $2))
--- 		ELSE NULL
--- 		END $$ immutable LANGUAGE 'sql';
-
-
 CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
 RETURNS text
 AS 'babelfishpg_tsql', 'parsename'

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -546,26 +546,38 @@ LANGUAGE plpgsql
 STABLE CALLED ON NULL INPUT;
 
 -- Return the object ID given the object name. Can specify optional type.
-CREATE OR REPLACE FUNCTION sys.object_id(IN object_name sys.VARCHAR, IN object_type sys.VARCHAR DEFAULT NULL)
-RETURNS INTEGER AS
-'babelfishpg_tsql', 'object_id'
-LANGUAGE C STABLE;
+-- CREATE OR REPLACE FUNCTION sys.object_id(IN object_name sys.VARCHAR, IN object_type sys.VARCHAR DEFAULT NULL)
+-- RETURNS INTEGER AS
+-- 'babelfishpg_tsql', 'object_id'
+-- LANGUAGE C STABLE;
 
-CREATE OR REPLACE FUNCTION sys.parsename (
-	object_name VARCHAR
-	,object_piece INT
-	)
-RETURNS VARCHAR AS $$
-/***************************************************************
-EXTENSION PACK function PARSENAME(x)
-***************************************************************/
-SELECT CASE
-		WHEN char_length($1) < char_length(pg_catalog.replace($1, '.', '')) + 4
-			AND $2 BETWEEN 1
-				AND 4
-			THEN reverse(split_part(reverse($1), '.', $2))
-		ELSE NULL
-		END $$ immutable LANGUAGE 'sql';
+-- CREATE OR REPLACE FUNCTION sys.parsename (
+-- 	object_name VARCHAR
+-- 	,object_piece INT
+-- 	)
+-- RETURNS VARCHAR AS $$
+-- /***************************************************************
+-- EXTENSION PACK function PARSENAME(x)
+-- ***************************************************************/
+-- SELECT CASE
+-- 		WHEN char_length($1) < char_length(pg_catalog.replace($1, '.', '')) + 4
+-- 			AND $2 BETWEEN 1
+-- 				AND 4
+-- 			THEN reverse(split_part(reverse($1), '.', $2))
+-- 		ELSE NULL
+-- 		END $$ immutable LANGUAGE 'sql';
+
+-- CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
+-- RETURNS text
+-- AS 'babelfishpg_tsql', 'parsename'
+-- LANGUAGE C IMMUTABLE STRICT;
+
+
+CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
+RETURNS text
+AS 'babelfishpg_tsql', 'parsename'
+LANGUAGE C IMMUTABLE STRICT;
+
 
 CREATE OR REPLACE FUNCTION sys.timefromparts(IN p_hour NUMERIC,
                                                            IN p_minute NUMERIC,

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -546,10 +546,10 @@ LANGUAGE plpgsql
 STABLE CALLED ON NULL INPUT;
 
 -- Return the object ID given the object name. Can specify optional type.
--- CREATE OR REPLACE FUNCTION sys.object_id(IN object_name sys.VARCHAR, IN object_type sys.VARCHAR DEFAULT NULL)
--- RETURNS INTEGER AS
--- 'babelfishpg_tsql', 'object_id'
--- LANGUAGE C STABLE;
+CREATE OR REPLACE FUNCTION sys.object_id(IN object_name sys.VARCHAR, IN object_type sys.VARCHAR DEFAULT NULL)
+RETURNS INTEGER AS
+'babelfishpg_tsql', 'object_id'
+LANGUAGE C STABLE;
 
 -- CREATE OR REPLACE FUNCTION sys.parsename (
 -- 	object_name VARCHAR
@@ -566,11 +566,6 @@ STABLE CALLED ON NULL INPUT;
 -- 			THEN reverse(split_part(reverse($1), '.', $2))
 -- 		ELSE NULL
 -- 		END $$ immutable LANGUAGE 'sql';
-
--- CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
--- RETURNS text
--- AS 'babelfishpg_tsql', 'parsename'
--- LANGUAGE C IMMUTABLE STRICT;
 
 
 CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -557,9 +557,9 @@ LANGUAGE C STABLE;
 -- LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION sys.parsename (
-    object_name VARCHAR,
-    object_piece INT
-)
+        object_name VARCHAR
+        ,object_piece INT
+        )
 RETURNS VARCHAR AS $$
 /***************************************************************
 EXTENSION PACK function PARSENAME(x)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -780,6 +780,11 @@ CREATE AGGREGATE sys.VARP(float8) (
 CREATE OR REPLACE FUNCTION sys.rowcount_big()
 RETURNS BIGINT AS 'babelfishpg_tsql' LANGUAGE C STABLE;
 
+CREATE OR REPLACE FUNCTION sys.parsename(object_name text, object_piece int)
+RETURNS text
+AS 'babelfishpg_tsql', 'parsename'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION sys.database_principal_id(IN user_name sys.sysname)
 RETURNS OID
 AS 'babelfishpg_tsql', 'user_id'

--- a/test/JDBC/expected/BABEL-808-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-808-vu-cleanup.out
@@ -1,0 +1,20 @@
+DROP VIEW IF EXISTS EmployeeDatabaseView1;
+GO
+
+DROP PROCEDURE IF EXISTS GetEmployeeDatabaseName1;
+GO
+
+DROP VIEW IF EXISTS EmployeeDatabaseView2;
+GO
+
+DROP PROCEDURE IF EXISTS GetEmployeeDatabaseName2;
+GO
+
+DROP VIEW IF EXISTS EmployeeDatabaseView3;
+GO
+
+DROP PROCEDURE IF EXISTS GetEmployeeDatabaseName3;
+GO
+
+DROP TABLE IF EXISTS Employee;
+GO

--- a/test/JDBC/expected/BABEL-808-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-808-vu-prepare.out
@@ -1,0 +1,56 @@
+CREATE TABLE Employee (
+ EmployeeID INT PRIMARY KEY,
+ FirstName NVARCHAR(50),
+ LastName NVARCHAR(50),
+ HireDate DATETIME,
+ Salary MONEY
+);
+GO
+
+-- Insert some sample data
+INSERT INTO Employee (EmployeeID, FirstName, LastName, HireDate, Salary)
+VALUES (1, 'John', 'Doe', '2020-01-01', 50000),
+ (2, 'Jane', 'Smith', '2020-02-01', 60000),
+ (3, 'Bob', 'Johnson', '2020-03-01', 70000);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE VIEW EmployeeDatabaseView1
+AS
+SELECT PARSENAME('tempdb.dbo.Employee', 3) AS [Database Name]
+GO
+
+CREATE PROCEDURE GetEmployeeDatabaseName1
+AS
+BEGIN
+ SELECT PARSENAME('tempdb.dbo.Employee', 3) AS [Database Name]
+END
+GO
+
+
+CREATE VIEW EmployeeDatabaseView2
+AS
+SELECT PARSENAME('tempdb.dbo.Employee', 2) AS [Schema Name]
+GO
+
+CREATE PROCEDURE GetEmployeeDatabaseName2
+AS
+BEGIN
+ SELECT PARSENAME('tempdb.dbo.Employee', 2) AS [Schema Name]
+END
+GO
+
+
+CREATE VIEW EmployeeDatabaseView3
+AS
+SELECT PARSENAME('tempdb.dbo.Employee', 1) AS [Table Name]
+GO
+
+CREATE PROCEDURE GetEmployeeDatabaseName3
+AS
+BEGIN
+ SELECT PARSENAME('tempdb.dbo.Employee', 1) AS [Table Name]
+END
+GO

--- a/test/JDBC/expected/BABEL-808-vu-verify.out
+++ b/test/JDBC/expected/BABEL-808-vu-verify.out
@@ -7,17 +7,17 @@ Employee
 ORDER BY HireDate DESC;
 GO
 ~~START~~
-text#!#text#!#text#!#int#!#nvarchar#!#nvarchar#!#datetime#!#money
-tempdb#!#dbo#!#Employee#!#3#!#Bob#!#Johnson#!#2020-03-01 00:00:00.0#!#70000.0000
-tempdb#!#dbo#!#Employee#!#2#!#Jane#!#Smith#!#2020-02-01 00:00:00.0#!#60000.0000
-tempdb#!#dbo#!#Employee#!#1#!#John#!#Doe#!#2020-01-01 00:00:00.0#!#50000.0000
+varchar#!#varchar#!#varchar#!#int#!#nvarchar#!#nvarchar#!#datetime#!#money
+tempdb#!#dbo#!#employee#!#3#!#Bob#!#Johnson#!#2020-03-01 00:00:00.0#!#70000.0000
+tempdb#!#dbo#!#employee#!#2#!#Jane#!#Smith#!#2020-02-01 00:00:00.0#!#60000.0000
+tempdb#!#dbo#!#employee#!#1#!#John#!#Doe#!#2020-01-01 00:00:00.0#!#50000.0000
 ~~END~~
 
 
 SELECT * FROM EmployeeDatabaseView1
 GO
 ~~START~~
-text
+varchar
 tempdb
 ~~END~~
 
@@ -25,7 +25,7 @@ tempdb
 EXEC GetEmployeeDatabaseName1
 GO
 ~~START~~
-text
+varchar
 tempdb
 ~~END~~
 
@@ -33,7 +33,7 @@ tempdb
 SELECT * FROM EmployeeDatabaseView2
 GO
 ~~START~~
-text
+varchar
 dbo
 ~~END~~
 
@@ -41,7 +41,7 @@ dbo
 EXEC GetEmployeeDatabaseName2
 GO
 ~~START~~
-text
+varchar
 dbo
 ~~END~~
 
@@ -49,15 +49,15 @@ dbo
 SELECT * FROM EmployeeDatabaseView3
 GO
 ~~START~~
-text
-Employee
+varchar
+employee
 ~~END~~
 
 
 EXEC GetEmployeeDatabaseName3
 GO
 ~~START~~
-text
-Employee
+varchar
+employee
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-808-vu-verify.out
+++ b/test/JDBC/expected/BABEL-808-vu-verify.out
@@ -1,0 +1,63 @@
+SELECT PARSENAME('tempdb.dbo.Employee', 3) AS [Database Name],
+PARSENAME('tempdb.dbo.Employee', 2) AS [Schema Name],
+PARSENAME('tempdb.dbo.Employee', 1) AS [Table Name],
+*
+FROM
+Employee
+ORDER BY HireDate DESC;
+GO
+~~START~~
+text#!#text#!#text#!#int#!#nvarchar#!#nvarchar#!#datetime#!#money
+tempdb#!#dbo#!#Employee#!#3#!#Bob#!#Johnson#!#2020-03-01 00:00:00.0#!#70000.0000
+tempdb#!#dbo#!#Employee#!#2#!#Jane#!#Smith#!#2020-02-01 00:00:00.0#!#60000.0000
+tempdb#!#dbo#!#Employee#!#1#!#John#!#Doe#!#2020-01-01 00:00:00.0#!#50000.0000
+~~END~~
+
+
+SELECT * FROM EmployeeDatabaseView1
+GO
+~~START~~
+text
+tempdb
+~~END~~
+
+
+EXEC GetEmployeeDatabaseName1
+GO
+~~START~~
+text
+tempdb
+~~END~~
+
+
+SELECT * FROM EmployeeDatabaseView2
+GO
+~~START~~
+text
+dbo
+~~END~~
+
+
+EXEC GetEmployeeDatabaseName2
+GO
+~~START~~
+text
+dbo
+~~END~~
+
+
+SELECT * FROM EmployeeDatabaseView3
+GO
+~~START~~
+text
+Employee
+~~END~~
+
+
+EXEC GetEmployeeDatabaseName3
+GO
+~~START~~
+text
+Employee
+~~END~~
+

--- a/test/JDBC/input/BABEL-808-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-808-vu-cleanup.sql
@@ -1,0 +1,20 @@
+DROP VIEW IF EXISTS EmployeeDatabaseView1;
+GO
+
+DROP PROCEDURE IF EXISTS GetEmployeeDatabaseName1;
+GO
+
+DROP VIEW IF EXISTS EmployeeDatabaseView2;
+GO
+
+DROP PROCEDURE IF EXISTS GetEmployeeDatabaseName2;
+GO
+
+DROP VIEW IF EXISTS EmployeeDatabaseView3;
+GO
+
+DROP PROCEDURE IF EXISTS GetEmployeeDatabaseName3;
+GO
+
+DROP TABLE IF EXISTS Employee;
+GO

--- a/test/JDBC/input/BABEL-808-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-808-vu-prepare.sql
@@ -1,0 +1,54 @@
+CREATE TABLE Employee (
+ EmployeeID INT PRIMARY KEY,
+ FirstName NVARCHAR(50),
+ LastName NVARCHAR(50),
+ HireDate DATETIME,
+ Salary MONEY
+);
+GO
+
+-- Insert some sample data
+INSERT INTO Employee (EmployeeID, FirstName, LastName, HireDate, Salary)
+VALUES (1, 'John', 'Doe', '2020-01-01', 50000),
+ (2, 'Jane', 'Smith', '2020-02-01', 60000),
+ (3, 'Bob', 'Johnson', '2020-03-01', 70000);
+GO
+
+
+CREATE VIEW EmployeeDatabaseView1
+AS
+SELECT PARSENAME('tempdb.dbo.Employee', 3) AS [Database Name]
+GO
+
+CREATE PROCEDURE GetEmployeeDatabaseName1
+AS
+BEGIN
+ SELECT PARSENAME('tempdb.dbo.Employee', 3) AS [Database Name]
+END
+GO
+
+
+CREATE VIEW EmployeeDatabaseView2
+AS
+SELECT PARSENAME('tempdb.dbo.Employee', 2) AS [Schema Name]
+GO
+
+CREATE PROCEDURE GetEmployeeDatabaseName2
+AS
+BEGIN
+ SELECT PARSENAME('tempdb.dbo.Employee', 2) AS [Schema Name]
+END
+GO
+
+
+CREATE VIEW EmployeeDatabaseView3
+AS
+SELECT PARSENAME('tempdb.dbo.Employee', 1) AS [Table Name]
+GO
+
+CREATE PROCEDURE GetEmployeeDatabaseName3
+AS
+BEGIN
+ SELECT PARSENAME('tempdb.dbo.Employee', 1) AS [Table Name]
+END
+GO

--- a/test/JDBC/input/BABEL-808-vu-verify.sql
+++ b/test/JDBC/input/BABEL-808-vu-verify.sql
@@ -1,0 +1,26 @@
+SELECT PARSENAME('tempdb.dbo.Employee', 3) AS [Database Name],
+PARSENAME('tempdb.dbo.Employee', 2) AS [Schema Name],
+PARSENAME('tempdb.dbo.Employee', 1) AS [Table Name],
+*
+FROM
+Employee
+ORDER BY HireDate DESC;
+GO
+
+SELECT * FROM EmployeeDatabaseView1
+GO
+
+EXEC GetEmployeeDatabaseName1
+GO
+
+SELECT * FROM EmployeeDatabaseView2
+GO
+
+EXEC GetEmployeeDatabaseName2
+GO
+
+SELECT * FROM EmployeeDatabaseView3
+GO
+
+EXEC GetEmployeeDatabaseName3
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,8 +8,10 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
-
+#all
+BABEL-808-vu-prepare
+BABEL-808-vu-verify
+BABEL-808-vu-cleanup
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,10 +8,8 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-#all
-BABEL-808-vu-prepare
-BABEL-808-vu-verify
-BABEL-808-vu-cleanup
+all
+
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.


### PR DESCRIPTION
The PARSENAME() function in T-SQL is used to parse a string representing a four-part SQL Server object name, such as "database.schema.object.column".

Signed-off-by: Pratik Zode [pzode@amazon.com](mailto:pzode@amazon.com)