### PR TITLE
fix the issue alter table with unique will crash

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1517,11 +1517,20 @@ is_nullable_constraint(Constraint *cst, Oid rel_oid)
 	/* Loop through the constraint keys */
 	foreach(lc, cst->keys)
 	{
-		String	   *strval = (String *) lfirst(lc);
+		Node       *node = (Node *) lfirst(lc);
+		String	   *strval;
 		const char *col_name = NULL;
 		AttrNumber	attnum = InvalidAttrNumber;
 
-		col_name = strVal(strval);
+		if (nodeTag(node) == T_IndexElem){
+			col_name = ((IndexElem *)node)->name;
+		}
+		else
+		{
+			strval = (String *)node;
+			col_name = strVal(strval);
+		}
+
 		attnum = get_attnum(rel_oid, col_name);
 
 		if (get_attnotnull(rel_oid, attnum))

--- a/test/JDBC/expected/alter_table.out
+++ b/test/JDBC/expected/alter_table.out
@@ -1,0 +1,72 @@
+
+create table trans2(id int identity(1,1) primary key, source int not null , target int not null, amount int );
+insert into TRANS2 (source, amount, a, c ) values (1,1,1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "a" of relation "trans2" does not exist)~~
+
+
+ALTER TABLE trans2 ADD a int4 default 3;
+GO
+
+ALTER TABLE trans2 ADD b varchar;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "c" of relation "trans2" already exists)~~
+
+
+ALTER TABLE trans2 ADD c varchar(30) not null default 'aaa';
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "c" of relation "trans2" already exists)~~
+
+
+ALTER TABLE trans2 WITH NOCHECK ADD CONSTRAINT exd_check CHECK (source > 1) ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ALTER TABLE WITH [NO]CHECK ADD' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_nocheck_add_constraint to ignore)~~
+
+
+ALTER TABLE trans2 ADD CONSTRAINT col_b_def DEFAULT 50 FOR target ;
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+~~ROW COUNT: 1~~
+
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() with values ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'values' is not currently supported in Babelfish)~~
+
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() ;
+GO
+
+alter table trans2 add unique (source asc);
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "trans2_source_key")~~
+
+
+ALTER TABLE trans2 DROP COLUMN AddDate
+GO
+
+drop table trans2
+GO

--- a/test/JDBC/input/alter_table.sql
+++ b/test/JDBC/input/alter_table.sql
@@ -1,0 +1,46 @@
+create table trans2(id int identity(1,1) primary key, source int not null , target int not null, amount int );
+
+insert into TRANS2 (source, amount, a, c ) values (1,1,1)
+GO
+
+ALTER TABLE trans2 ADD a int4 default 3;
+GO
+
+ALTER TABLE trans2 ADD b varchar;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(30) not null default 'aaa';
+go
+
+ALTER TABLE trans2 WITH NOCHECK ADD CONSTRAINT exd_check CHECK (source > 1) ;
+GO
+
+ALTER TABLE trans2 ADD CONSTRAINT col_b_def DEFAULT 50 FOR target ;
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() with values ;
+GO
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() ;
+GO
+
+alter table trans2 add unique (source asc);
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+
+ALTER TABLE trans2 DROP COLUMN AddDate
+GO
+
+drop table trans2
+GO


### PR DESCRIPTION
Previously alter table add unique will crash the instance due to not handle the node type properly in post analyzer.
This commit fix this issue by properly handle indexElem in post analyzer.

Task: BABEL-3823

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).