### PR TITLE
Added sanity checks for domain name in Windows Login

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2454,7 +2454,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								 */
 								if (windows_domain_contains_invalid_chars(orig_loginname))
 									ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-													errmsg("'%s' is not a valid domain because it contains invalid characters.", orig_loginname)));
+													errmsg("'%s' is not valid because the domain name contains invalid characters.", orig_loginname)));
 
 								pfree(stmt->role);
 								stmt->role = convertToUPN(orig_loginname);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2448,6 +2448,13 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								if (windows_login_contains_invalid_chars(orig_loginname))
 									ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 													errmsg("'%s' is not a valid name because it contains invalid characters.", orig_loginname)));
+								
+								/*
+								 * Check whether the domain name contains invalid characters or not.
+								 */
+								if (windows_domain_contains_invalid_chars(orig_loginname))
+									ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+													errmsg("'%s' is not a valid domain because it contains invalid characters.", orig_loginname)));
 
 								pfree(stmt->role);
 								stmt->role = convertToUPN(orig_loginname);

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2245,7 +2245,7 @@ windows_login_contains_invalid_chars(char *input)
 
 /**
  * Domain name checks, doesnot allow characters like <>&*|' aong with list 
- * https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou#netbios-domain-names
+ * https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-se[…]rver/identity/naming-conventions-for-computer-domain-site-ou.md 
 */
 bool
 windows_domain_contains_invalid_chars(char *input)

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2244,7 +2244,7 @@ windows_login_contains_invalid_chars(char *input)
 }
 
 /**
- * Domain name checks, doesnot allow characters like <>&*|' aong with list 
+ * Domain name checks, doesnot allow characters like "<>&*|quotes spaces" along with list 
  * https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-se[…]rver/identity/naming-conventions-for-computer-domain-site-ou.md 
 */
 bool
@@ -2253,21 +2253,21 @@ windows_domain_contains_invalid_chars(char *input)
 	int total_length = strlen(input);
 	char *pos_slash = strchr(input, '\\');
 	int	domain_len = total_length - strlen(pos_slash);
-	int	i = 0;
+	int i = 0;
 	while (i < domain_len)
 	{
 		if (input[i] == ',' || input[i] == '~' ||
-		input[i] == ':' || input[i] == '!' ||
-		input[i] == '@' || input[i] == '#' ||
-		input[i] == '$' || input[i] == '%' || 
-		input[i] == '_' || input[i] == '^' || 
-		input[i] == '\"' || input[i] == '\'' ||
-		input[i] == '(' || input[i] == ')' || 
-		input[i] == '{' || input[i] == '}' || 
-		input[i] == '\\' || input[i] == '/'||
-		input[i] == '<' || input[i] == '>'||
-		input[i] == ' ' || input[i] == '*'||
-		input[i] == '|' || input[i] == '&' )
+			input[i] == ':' || input[i] == '!' ||
+			input[i] == '@' || input[i] == '#' ||
+			input[i] == '$' || input[i] == '%' || 
+			input[i] == '_' || input[i] == '^' || 
+			input[i] == '\"' || input[i] == '\'' ||
+			input[i] == '(' || input[i] == ')' || 
+			input[i] == '{' || input[i] == '}' || 
+			input[i] == '\\' || input[i] == '/'||
+			input[i] == '<' || input[i] == '>'||
+			input[i] == ' ' || input[i] == '*'||
+			input[i] == '|' || input[i] == '&' )
 			return true;
 		
 		i++;

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2245,31 +2245,25 @@ windows_login_contains_invalid_chars(char *input)
 
 /**
  * Domain name checks, doesnot allow characters like "<>&*|quotes spaces" along with list 
- * https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-se[…]rver/identity/naming-conventions-for-computer-domain-site-ou.md 
+ * https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-server/identity/naming-conventions-for-computer-domain-site-ou.md#netbios-domain-names
 */
 bool
 windows_domain_contains_invalid_chars(char *input)
 {
-	int total_length = strlen(input);
 	char *pos_slash = strchr(input, '\\');
-	int	domain_len = total_length - strlen(pos_slash);
+	int domain_len = pos_slash - input;
 	int i = 0;
+	if (input == NULL)
+		return true;
 	while (i < domain_len)
 	{
-		if (input[i] == ',' || input[i] == '~' ||
-			input[i] == ':' || input[i] == '!' ||
-			input[i] == '@' || input[i] == '#' ||
-			input[i] == '$' || input[i] == '%' || 
-			input[i] == '_' || input[i] == '^' || 
-			input[i] == '\"' || input[i] == '\'' ||
-			input[i] == '(' || input[i] == ')' || 
-			input[i] == '{' || input[i] == '}' || 
-			input[i] == '\\' || input[i] == '/'||
-			input[i] == '<' || input[i] == '>'||
-			input[i] == ' ' || input[i] == '*'||
-			input[i] == '|' || input[i] == '&' )
+		if (input[i] == ',' || input[i] == '~' || input[i] == ':' || input[i] == '!' ||
+			input[i] == '@' || input[i] == '#' || input[i] == '$' || input[i] == '%' || 
+			input[i] == '_' || input[i] == '^' || input[i] == '\"' || input[i] == '\'' ||
+			input[i] == '(' || input[i] == ')' || input[i] == '{' || input[i] == '}' || 
+			input[i] == '\\' || input[i] == '/'|| input[i] == '<' || input[i] == '>'||
+			input[i] == ' ' || input[i] == '*'|| input[i] == '|' || input[i] == '&' )
 			return true;
-		
 		i++;
 	}
 	return false;

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2244,9 +2244,8 @@ windows_login_contains_invalid_chars(char *input)
 }
 
 /**
- * Domain name checks, doesnot allow characters like "<>&*|quotes spaces" along with list 
- * https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-server/identity/naming-conventions-for-computer-domain-site-ou.md#netbios-domain-names
-*/
+ * Domain name checks, doesnot allow characters like "<>&*|quotes spaces"
+ * */
 bool
 windows_domain_contains_invalid_chars(char *input)
 {

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2243,6 +2243,38 @@ windows_login_contains_invalid_chars(char *input)
 	return false;
 }
 
+/**
+ * Domain name checks, doesnot allow characters like <>&*|' aong with list 
+ * https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou#netbios-domain-names
+*/
+bool
+windows_domain_contains_invalid_chars(char *input)
+{
+	int total_length = strlen(input);
+	char *pos_slash = strchr(input, '\\');
+	int	domain_len = total_length - strlen(pos_slash);
+	int	i = 0;
+	while (i < domain_len)
+	{
+		if (input[i] == ',' || input[i] == '~' ||
+		input[i] == ':' || input[i] == '!' ||
+		input[i] == '@' || input[i] == '#' ||
+		input[i] == '$' || input[i] == '%' || 
+		input[i] == '_' || input[i] == '^' || 
+		input[i] == '\"' || input[i] == '\'' ||
+		input[i] == '(' || input[i] == ')' || 
+		input[i] == '{' || input[i] == '}' || 
+		input[i] == '\\' || input[i] == '/'||
+		input[i] == '<' || input[i] == '>'||
+		input[i] == ' ' || input[i] == '*'||
+		input[i] == '|' || input[i] == '&' )
+			return true;
+		
+		i++;
+	}
+	return false;
+}
+
 /*
  * Check whether the logon_name has a valid length or not.
  */

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -77,6 +77,8 @@ extern void alter_bbf_authid_user_ext(AlterRoleStmt *stmt);
 extern bool is_active_login(Oid role_oid);
 extern char *convertToUPN(char *input);
 extern bool windows_login_contains_invalid_chars(char *input);
+extern bool windows_domain_contains_invalid_chars(char *input);
 extern bool check_windows_logon_length(char *input);
+
 
 #endif

--- a/test/JDBC/expected/test_windows_login-vu-cleanup.out
+++ b/test/JDBC/expected/test_windows_login-vu-cleanup.out
@@ -47,6 +47,9 @@ GO
 ~~ERROR (Message: Cannot drop the login 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@BABEL', because it does not exist or you do not have permission.)~~
 
 
+DROP LOGIN [ba.bel\username];
+GO
+
 -- test for non-existent login
 DROP LOGIN [babel\non_existent_login]
 GO

--- a/test/JDBC/expected/test_windows_login-vu-prepare.out
+++ b/test/JDBC/expected/test_windows_login-vu-prepare.out
@@ -342,147 +342,156 @@ GO
 ~~ERROR (Message: syntax error near '=' at line 2 and character position 55)~~
 
 
-CREATE LOGIN [ba,bel\username] from windows;
+-- test for when the domain name contains invalid characters
+CREATE LOGIN [<script>!@#$%^&*()\idontexist2] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba,bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: '<script>!@#$%^&*()\idontexist2' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba~el\username] from windows;
+CREATE LOGIN [ba,bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba~el\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba,bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba:bel\username] from windows;
+CREATE LOGIN [ba~el\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba:bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba~el\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba!bel\username] from windows;
+CREATE LOGIN [ba:bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba!bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba:bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba@bel\username] from windows;
+CREATE LOGIN [ba!bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba@bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba!bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba#bel\username] from windows;
+CREATE LOGIN [ba@bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba#bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba@bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba$bel\username] from windows;
+CREATE LOGIN [ba#bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba$bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba#bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba%bel\username] from windows;
+CREATE LOGIN [ba$bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba%bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba$bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba_bel\username] from windows;
+CREATE LOGIN [ba%bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba_bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba%bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba^bel\username] from windows;
+CREATE LOGIN [ba_bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba^bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba_bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba"bel\username] from windows;
+CREATE LOGIN [ba^bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba"bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba^bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba'bel\username] from windows;
+CREATE LOGIN [ba"bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba'bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba"bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba(bel\username] from windows;
+CREATE LOGIN [ba'bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba(bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba'bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba)bel\username] from windows;
+CREATE LOGIN [ba(bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba)bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba(bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba{bel\username] from windows;
+CREATE LOGIN [ba)bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba{bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba)bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba}bel\username] from windows;
+CREATE LOGIN [ba{bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba}bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba{bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba bel\username] from windows;
+CREATE LOGIN [ba}bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba}bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba\bel\username] from windows;
+CREATE LOGIN [ba bel\username] FROM WINDOWS;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba bel\username' is not valid because the domain name contains invalid characters.)~~
+
+CREATE LOGIN [ba\bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: 'ba\bel\username' is not a valid name because it contains invalid characters.)~~
 
-CREATE LOGIN [ba/bel\username] from windows;
+CREATE LOGIN [ba/bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba/bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba/bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba<bel\username] from windows;
+CREATE LOGIN [ba<bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba<bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba<bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba>bel\username] from windows;
+CREATE LOGIN [ba>bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba>bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba>bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba&bel\username] from windows;
+CREATE LOGIN [ba&bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba&bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba&bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba*bel\username] from windows;
+CREATE LOGIN [ba*bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba*bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba*bel\username' is not valid because the domain name contains invalid characters.)~~
 
-CREATE LOGIN [ba|bel\username] from windows;
+CREATE LOGIN [ba|bel\username] FROM WINDOWS;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ba|bel\username' is not a valid domain because it contains invalid characters.)~~
+~~ERROR (Message: 'ba|bel\username' is not valid because the domain name contains invalid characters.)~~
 
+CREATE LOGIN [ba.bel\username] FROM WINDOWS;
+GO

--- a/test/JDBC/expected/test_windows_login-vu-prepare.out
+++ b/test/JDBC/expected/test_windows_login-vu-prepare.out
@@ -341,3 +341,148 @@ GO
 
 ~~ERROR (Message: syntax error near '=' at line 2 and character position 55)~~
 
+
+CREATE LOGIN [ba,bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba,bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba~el\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba~el\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba:bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba:bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba!bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba!bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba@bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba@bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba#bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba#bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba$bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba$bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba%bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba%bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba_bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba_bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba^bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba^bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba"bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba"bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba'bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba'bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba(bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba(bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba)bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba)bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba{bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba{bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba}bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba}bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba\bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba\bel\username' is not a valid name because it contains invalid characters.)~~
+
+CREATE LOGIN [ba/bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba/bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba<bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba<bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba>bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba>bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba&bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba&bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba*bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba*bel\username' is not a valid domain because it contains invalid characters.)~~
+
+CREATE LOGIN [ba|bel\username] from windows;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ba|bel\username' is not a valid domain because it contains invalid characters.)~~
+

--- a/test/JDBC/input/test_windows_login-vu-cleanup.mix
+++ b/test/JDBC/input/test_windows_login-vu-cleanup.mix
@@ -27,6 +27,9 @@ GO
 DROP LOGIN [babel\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]
 GO
 
+DROP LOGIN [ba.bel\username];
+GO
+
 -- test for non-existent login
 DROP LOGIN [babel\non_existent_login]
 GO

--- a/test/JDBC/input/test_windows_login-vu-prepare.mix
+++ b/test/JDBC/input/test_windows_login-vu-prepare.mix
@@ -166,51 +166,56 @@ GO
 CREATE LOGIN [babel\adbabel] from windows with password='1234';
 GO
 
-CREATE LOGIN [ba,bel\username] from windows;
+-- test for when the domain name contains invalid characters
+CREATE LOGIN [<script>!@#$%^&*()\idontexist2] FROM WINDOWS;
 GO
-CREATE LOGIN [ba~el\username] from windows;
+CREATE LOGIN [ba,bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba:bel\username] from windows;
+CREATE LOGIN [ba~el\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba!bel\username] from windows;
+CREATE LOGIN [ba:bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba@bel\username] from windows;
+CREATE LOGIN [ba!bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba#bel\username] from windows;
+CREATE LOGIN [ba@bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba$bel\username] from windows;
+CREATE LOGIN [ba#bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba%bel\username] from windows;
+CREATE LOGIN [ba$bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba_bel\username] from windows;
+CREATE LOGIN [ba%bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba^bel\username] from windows;
+CREATE LOGIN [ba_bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba"bel\username] from windows;
+CREATE LOGIN [ba^bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba'bel\username] from windows;
+CREATE LOGIN [ba"bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba(bel\username] from windows;
+CREATE LOGIN [ba'bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba)bel\username] from windows;
+CREATE LOGIN [ba(bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba{bel\username] from windows;
+CREATE LOGIN [ba)bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba}bel\username] from windows;
+CREATE LOGIN [ba{bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba bel\username] from windows;
+CREATE LOGIN [ba}bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba\bel\username] from windows;
+CREATE LOGIN [ba bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba/bel\username] from windows;
+CREATE LOGIN [ba\bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba<bel\username] from windows;
+CREATE LOGIN [ba/bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba>bel\username] from windows;
+CREATE LOGIN [ba<bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba&bel\username] from windows;
+CREATE LOGIN [ba>bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba*bel\username] from windows;
+CREATE LOGIN [ba&bel\username] FROM WINDOWS;
 GO
-CREATE LOGIN [ba|bel\username] from windows;
+CREATE LOGIN [ba*bel\username] FROM WINDOWS;
+GO
+CREATE LOGIN [ba|bel\username] FROM WINDOWS;
+GO
+CREATE LOGIN [ba.bel\username] FROM WINDOWS;
 GO

--- a/test/JDBC/input/test_windows_login-vu-prepare.mix
+++ b/test/JDBC/input/test_windows_login-vu-prepare.mix
@@ -165,3 +165,52 @@ GO
 -- test for windows login with password --> should throw error
 CREATE LOGIN [babel\adbabel] from windows with password='1234';
 GO
+
+CREATE LOGIN [ba,bel\username] from windows;
+GO
+CREATE LOGIN [ba~el\username] from windows;
+GO
+CREATE LOGIN [ba:bel\username] from windows;
+GO
+CREATE LOGIN [ba!bel\username] from windows;
+GO
+CREATE LOGIN [ba@bel\username] from windows;
+GO
+CREATE LOGIN [ba#bel\username] from windows;
+GO
+CREATE LOGIN [ba$bel\username] from windows;
+GO
+CREATE LOGIN [ba%bel\username] from windows;
+GO
+CREATE LOGIN [ba_bel\username] from windows;
+GO
+CREATE LOGIN [ba^bel\username] from windows;
+GO
+CREATE LOGIN [ba"bel\username] from windows;
+GO
+CREATE LOGIN [ba'bel\username] from windows;
+GO
+CREATE LOGIN [ba(bel\username] from windows;
+GO
+CREATE LOGIN [ba)bel\username] from windows;
+GO
+CREATE LOGIN [ba{bel\username] from windows;
+GO
+CREATE LOGIN [ba}bel\username] from windows;
+GO
+CREATE LOGIN [ba bel\username] from windows;
+GO
+CREATE LOGIN [ba\bel\username] from windows;
+GO
+CREATE LOGIN [ba/bel\username] from windows;
+GO
+CREATE LOGIN [ba<bel\username] from windows;
+GO
+CREATE LOGIN [ba>bel\username] from windows;
+GO
+CREATE LOGIN [ba&bel\username] from windows;
+GO
+CREATE LOGIN [ba*bel\username] from windows;
+GO
+CREATE LOGIN [ba|bel\username] from windows;
+GO


### PR DESCRIPTION
Added sanity checks for domain name in Windows Login

Task: BABEL-4080

### Description
Domain name checks, doesn't allow characters like <>&*|' '' along with list 
Since period is a valid character in domain name it is allowed (.)
https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-server/identity/naming-conventions-for-computer-domain-site-ou.md#netbios-domain-names

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).