### PR TITLE
Loss of decimal digits when converting from REAL to DECIMAL

### DIFF
--- a/test/JDBC/expected/TestDecimal-vu-verify.out
+++ b/test/JDBC/expected/TestDecimal-vu-verify.out
@@ -265,3 +265,11 @@ select in3 * in4 from testdecimal_vu_prepare_tab2;
 
 ~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
 
+
+#BABEL-3066
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS value_casted_to_decimal_30_2;
+~~START~~
+real#!#numeric
+123456.25#!#123456.25
+~~END~~
+

--- a/test/JDBC/expected/TestDecimal.out
+++ b/test/JDBC/expected/TestDecimal.out
@@ -832,3 +832,11 @@ select in3 * in4 from testdecimal_tab;
 
 
 drop table testdecimal_tab;
+
+#BABEL-3066
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS value_casted_to_decimal_30_2;
+~~START~~
+real#!#numeric
+123456.25#!#123456.25
+~~END~~
+

--- a/test/JDBC/input/datatypes/TestDecimal-vu-verify.txt
+++ b/test/JDBC/input/datatypes/TestDecimal-vu-verify.txt
@@ -50,3 +50,6 @@ select in4 * in5 from testdecimal_vu_prepare_tab2;
 
 #resultant precision = 49 > 38, scale = 3 < 6, precision - scale = 46 > 38; will cause arithmetic overflow
 select in3 * in4 from testdecimal_vu_prepare_tab2;
+
+#BABEL-3066
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS value_casted_to_decimal_30_2;

--- a/test/JDBC/input/datatypes/TestDecimal.txt
+++ b/test/JDBC/input/datatypes/TestDecimal.txt
@@ -272,3 +272,6 @@ select in4 * in5 from testdecimal_tab;
 select in3 * in4 from testdecimal_tab;
 
 drop table testdecimal_tab;
+
+#BABEL-3066
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS value_casted_to_decimal_30_2;


### PR DESCRIPTION
### Description

123456.25 requires 37 bits ( > 4 bytes) to get stored without any dataloss. REAL datatype can store upto 4B of floating point data; anything larger than that gets truncated while casting by underlying PG functions. REAL datatype in sql server relaxes this storage restriction and hence can cast the entire data without any further dataloss.

Task: BABEL-3066
Signed-off-by: Satarupa Biswas [satarupb@amazon.com]

### Test Scenarios Covered ###
    o Use case based: Original issue
    o Null testcases: N/A
    o Negative test scenarios: N/A
    o Boundary conditions, Arbitrary inputs: N/A
    o Minor version upgrade tests, Major version upgrade tests : Done
    o Performance tests, Tooling impact, Client tests: N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).