### PR TITLE
Fix testfile name in 14_8 upgrade schedule file

### DIFF
--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -399,4 +399,4 @@ datetime2fromparts
 timefromparts
 orderby-before-15_3
 BABEL-3215
-BABEL-4078-before-14_8-or-15_3
+BABEL-4078


### PR DESCRIPTION
### Description
We were getting upgrade failure when source version is 14_8 because test which was not suppose to run was running for that upgrade. This commit update test name in 14_8 upgrade schedule file.


### Issues Resolved

NA

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).