### PR TITLE
Fix crash in ExecuteBulkCopy

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -102,6 +102,8 @@ BulkCopy(BulkCopyStmt *stmt, uint64 *processed)
 	{
 		if (!stmt->cstate)
 			stmt->cstate = BeginBulkCopy(rel, attnums);
+		else
+			stmt->cstate->rel = rel;
 
 		*processed = ExecuteBulkCopy(stmt->cstate, stmt->nrow, stmt->ncol, stmt->Values, stmt->Nulls);
 		stmt->rows_processed += *processed;


### PR DESCRIPTION
Signed-off-by: Shlok Kumar Kyal ([skkyal@amazon.com](mailto:skkyal@amazon.com))

### Description
In BulkCopy a new variable ```rel``` is created for each batch but for the case of implicit batching, the old value of ```rel``` is being used inside ```cstate->rel``` (set during the first batch). 
With this PR made the change to set ```cstate->rel``` to new value of ```rel``` for each batch.


### Issues Resolved
BABEL-4100

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).