### PR TITLE
fix the problem, fetch not work properly in psql endpoint

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -465,7 +465,9 @@ pltsql_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count, 
 		return;
 	}
 
-	if ((count == 0 || count > pltsql_rowcount) && queryDesc->operation == CMD_SELECT)
+	if ((count == 0 || (count > pltsql_rowcount && pltsql_rowcount != 0))
+		 && queryDesc->operation == CMD_SELECT
+		 && sql_dialect == SQL_DIALECT_TSQL)
 		count = pltsql_rowcount;
 
 	if (prev_ExecutorRun)

--- a/test/JDBC/expected/pg_fetch.out
+++ b/test/JDBC/expected/pg_fetch.out
@@ -1,0 +1,40 @@
+-- psql
+
+create table t1( a int);
+GO
+
+insert into t1 select generate_series(1,5); 
+GO
+~~ROW COUNT: 5~~
+
+
+begin;
+GO
+
+DECLARE _test_cursor CURSOR FOR SELECT a from only t1;
+GO
+
+FETCH 2 from _test_cursor; 
+GO
+~~START~~
+int4
+1
+2
+~~END~~
+
+
+FETCH 2 from _test_cursor; 
+GO
+~~START~~
+int4
+3
+4
+~~END~~
+
+
+commit;
+GO
+
+drop table t1;
+GO
+

--- a/test/JDBC/input/pg_fetch.mix
+++ b/test/JDBC/input/pg_fetch.mix
@@ -1,0 +1,26 @@
+-- psql
+
+create table t1( a int);
+GO
+
+insert into t1 select generate_series(1,5); 
+GO
+
+begin;
+GO
+
+DECLARE _test_cursor CURSOR FOR SELECT a from only t1;
+GO
+
+FETCH 2 from _test_cursor; 
+GO
+
+FETCH 2 from _test_cursor; 
+GO
+
+commit;
+GO
+
+drop table t1;
+GO
+


### PR DESCRIPTION
previously fetch will return all rows in psql endpoint using babel database it's due to wrongly change the fetch row to 0 in not Tsql dialect

Task: babel-4102




### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).