### PR TITLE
Support four-part object names

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -836,7 +836,7 @@ linked_server_establish_connection(char *servername, LinkedServerProcess * lspro
 static void
 getOpenqueryTupdescFromMetadata(char *linked_server, char *query, TupleDesc *tupdesc)
 {
-	LinkedServerProcess lsproc;
+	LinkedServerProcess lsproc = NULL;
 
 	PG_TRY();
 	{
@@ -1079,8 +1079,11 @@ getOpenqueryTupdescFromMetadata(char *linked_server, char *query, TupleDesc *tup
 	}
 	PG_FINALLY();
 	{
-		LINKED_SERVER_DEBUG("LINKED SERVER: (Metadata) - Closing connections to remote server");
-		LINKED_SERVER_EXIT();
+		if (lsproc)
+		{
+			LINKED_SERVER_DEBUG("LINKED SERVER: (Metadata) - Closing connections to remote server");
+			LINKED_SERVER_EXIT();
+		}
 	}
 	PG_END_TRY();
 }
@@ -1243,8 +1246,11 @@ openquery_imp(PG_FUNCTION_ARGS)
 	}
 	PG_FINALLY();
 	{
-		LINKED_SERVER_DEBUG("LINKED SERVER: (OPENQUERY) - Closing connections to remote server");
-		LINKED_SERVER_EXIT();
+		if (lsproc)
+		{
+			LINKED_SERVER_DEBUG("LINKED SERVER: (OPENQUERY) - Closing connections to remote server");
+			LINKED_SERVER_EXIT();
+		}
 
 		if (query)
 			pfree(query);

--- a/test/JDBC/expected/BABEL-2455.out
+++ b/test/JDBC/expected/BABEL-2455.out
@@ -315,19 +315,19 @@ go
 ~~ERROR (Message: trigger "s2455.tr2455" does not exist)~~
 
 
--- servername (not supported)
+-- insert into with servername (not supported)
 insert into yourserver.master.dbo.t1 values (1);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Remote object reference with 4-part object name is not currently supported in Babelfish)~~
+~~ERROR (Message: INSERT on a 4-part object name is not yet supported in Babelfish)~~
 
-
+-- function call with servername (not supported)
 select yourserver.master.dbo.f1(1);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Remote object reference with 4-part object name is not currently supported in Babelfish)~~
+~~ERROR (Message: Remote procedure/function reference with 4-part object name is not currently supported in Babelfish)~~
 
 
 -- cleanup

--- a/test/JDBC/expected/BABEL-2455.out
+++ b/test/JDBC/expected/BABEL-2455.out
@@ -322,6 +322,7 @@ go
 
 ~~ERROR (Message: INSERT on a 4-part object name is not yet supported in Babelfish)~~
 
+
 -- function call with servername (not supported)
 select yourserver.master.dbo.f1(1);
 go

--- a/test/JDBC/expected/four-part-names-vu-cleanup.out
+++ b/test/JDBC/expected/four-part-names-vu-cleanup.out
@@ -1,0 +1,6 @@
+EXEC sp_dropserver 'bbf_fpn_server', 'droplogins'
+GO
+
+-- psql
+DROP EXTENSION IF EXISTS tds_fdw CASCADE;
+GO

--- a/test/JDBC/expected/four-part-names-vu-prepare.out
+++ b/test/JDBC/expected/four-part-names-vu-prepare.out
@@ -1,0 +1,10 @@
+-- psql
+CREATE EXTENSION IF NOT EXISTS tds_fdw;
+GO
+
+-- tsql
+EXEC sp_addlinkedserver  @server = N'bbf_fpn_server', @srvproduct=N'', @provider=N'SQLNCLI', @datasrc=N'localhost', @catalog=N'master';
+GO
+
+EXEC sp_addlinkedsrvlogin @rmtsrvname = 'bbf_fpn_server', @useself = 'FALSE', @rmtuser = 'jdbc_user', @rmtpassword = '12345678';
+GO

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -1,0 +1,373 @@
+CREATE TABLE fpn_table (a int, b varchar(10))
+GO
+
+SELECT * FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+INSERT INTO fpn_table VALUES (1, 'one')
+INSERT INTO fpn_table VALUES (2, 'two')
+INSERT INTO fpn_table VALUES (3, 'three')
+INSERT INTO fpn_table VALUES (4, 'four')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- server_name.database_name.schema_name.object_name (table)
+SELECT a, b FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+4#!#four
+~~END~~
+
+
+-- server_name.database_name.schema_name.object_name (view)
+SELECT * FROM bbf_fpn_server.master.sys.data_spaces
+GO
+~~START~~
+varchar#!#int#!#char#!#nvarchar#!#bit#!#bit
+PRIMARY#!#1#!#FG#!#ROWS_FILEGROUP#!#1#!#0
+~~END~~
+
+
+-- server_name.database_name..object_name
+SELECT a + 1, b FROM bbf_fpn_server.master..fpn_table
+GO
+~~START~~
+int#!#varchar
+2#!#one
+3#!#two
+4#!#three
+5#!#four
+~~END~~
+
+
+-- server_name..schema_name.object_name
+SELECT * FROM bbf_fpn_server..sys.data_spaces
+GO
+~~START~~
+varchar#!#int#!#char#!#nvarchar#!#bit#!#bit
+PRIMARY#!#1#!#FG#!#ROWS_FILEGROUP#!#1#!#0
+~~END~~
+
+
+-- server_name...object_name
+SELECT a*2, REVERSE(b) FROM bbf_fpn_server...fpn_table
+GO
+~~START~~
+int#!#text
+2#!#eno
+4#!#owt
+6#!#eerht
+8#!#ruof
+~~END~~
+
+
+-- Invalid server name (Should throw error)
+SELECT * FROM invalid_server.master.dbo.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "invalid_server" does not exist)~~
+
+
+-- Invalid database name (Should throw error)
+SELECT * FROM bbf_fpn_server.invalid_db.dbo.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: database "invalid_db" does not exist. Make sure that the name is entered correctly., Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- Invalid schema name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.invalid_schema.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- Invalid object name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.dbo.invalid_fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- four part object is a procedure (Should throw error)
+EXEC bbf_fpn_server.master.dbo.sp_linkedserver
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Remote procedure reference with 4-part object name is not currently supported in Babelfish)~~
+
+
+-- INSERT should not work with four-part object name
+INSERT INTO bbf_fpn_server.master.dbo.fpn_table VALUES (5, 'five')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT on a 4-part object name is not yet supported in Babelfish)~~
+
+
+-- UPDATE should not work with four-part object name
+UPDATE bbf_fpn_server.master.dbo.fpn_table SET b = 'Update one' WHERE a = 1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: UPDATE on a 4-part object name is not yet supported in Babelfish)~~
+
+
+-- DELETE should not work with four-part object name
+DELETE FROM bbf_fpn_server.master.dbo.fpn_table WHERE a = 1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: DELETE on a 4-part object name is not yet supported in Babelfish)~~
+
+
+-- CREATE VIEW using four-part names
+CREATE VIEW four_part_names_vu_verify_view AS SELECT * FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+
+SELECT * FROM four_part_names_vu_verify_view
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+4#!#four
+~~END~~
+
+
+-- INSERT INTO ... SELECT
+CREATE TABLE fpn_table_insert_into (a int, b varchar(10))
+GO
+
+INSERT INTO fpn_table_insert_into SELECT * FROM bbf_fpn_server.master.dbo.fpn_table WHERE a < 4
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT * FROM fpn_table_insert_into
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+~~END~~
+
+
+-- SELECT INTO
+SELECT * INTO fpn_table_select_into FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+
+SELECT * FROM fpn_table_select_into
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+4#!#four
+~~END~~
+
+
+-- JOIN between local and remote table
+SELECT fpn_table.*, t2.*
+FROM fpn_table_insert_into fpn_table
+LEFT JOIN 
+bbf_fpn_server.master.dbo.fpn_table t2
+ON fpn_table.a = t2.a
+GO
+~~START~~
+int#!#varchar#!#int#!#varchar
+1#!#one#!#1#!#one
+2#!#two#!#2#!#two
+3#!#three#!#3#!#three
+~~END~~
+
+
+SELECT fpn_table.a, t2.*
+FROM bbf_fpn_server.master.dbo.fpn_table fpn_table
+LEFT JOIN 
+fpn_table_insert_into t2
+ON fpn_table.a = t2.a
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#one
+2#!#2#!#two
+3#!#3#!#three
+4#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- JOIN between two remote tables
+SELECT fpn_table.*, t2.a, t2.b
+FROM bbf_fpn_server.master.dbo.fpn_table fpn_table
+LEFT JOIN 
+bbf_fpn_server.master.dbo.fpn_table_insert_into t2
+ON fpn_table.a = t2.a
+GO
+~~START~~
+int#!#varchar#!#int#!#varchar
+1#!#one#!#1#!#one
+2#!#two#!#2#!#two
+3#!#three#!#3#!#three
+4#!#four#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- UPDATE on local table with JOIN containing remote table
+UPDATE Table_A
+SET
+Table_A.a = Table_B.a + 100,
+Table_A.b = Table_B.b + CAST(Table_B.a AS varchar(5))
+FROM
+fpn_table_insert_into AS Table_A
+INNER JOIN bbf_fpn_server.master.dbo.fpn_table AS Table_B
+ON Table_A.a = Table_B.a
+WHERE
+Table_A.a < 3
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM fpn_table_insert_into
+GO
+~~START~~
+int#!#varchar
+3#!#three
+101#!#one1
+102#!#two2
+~~END~~
+
+
+-- DELETE on local table with JOIN containing remote table
+DELETE Table_A
+FROM
+fpn_table_select_into AS Table_A
+INNER JOIN bbf_fpn_server.master.dbo.fpn_table AS Table_B
+ON Table_A.a = Table_B.a
+WHERE
+(Table_A.a + Table_B.a) % 4 = 0
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM fpn_table_select_into
+GO
+~~START~~
+int#!#varchar
+1#!#one
+3#!#three
+~~END~~
+
+
+
+-- Try SQL Injection
+-- We cannot directly inject SQL because it will break T-SQL database identifier rules
+-- We have to surround the SQL in double quotes ("") or square brackets ([]) if we want to even attempt that
+-- All cases should throw an error
+-- To allow identifiers be specified with double quotes
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- SQL Injection in server name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from fpn_table') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: servername is invalid
+select * from [bbf_fpn_server'', ''select * from fpn_table'') select * from openquery(''bbf_fpn_server].master.sys.databases
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "bbf_fpn_server', 'select * from fpn_table') select * from openquery('bbf_fpn_server" does not exist)~~
+
+
+select * from "bbf_fpn_server'', ''select * from fpn_table'') select * from openquery(''bbf_fpn_server".master.sys.databases
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "bbf_fpn_server', 'select * from fpn_table') select * from openquery('bbf_fpn_server" does not exist)~~
+
+
+-- SQL Injection in database name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from fpn_table') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: database name is invalid
+select * from bbf_fpn_server.[fpn_table'') select * from openquery(''bbf_fpn_server'', ''select * from master].sys.databases
+GO
+~~START~~
+varchar#!#int#!#int#!#varbinary#!#datetime#!#tinyint#!#varchar#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#bit#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#uniqueidentifier#!#bit#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#uniqueidentifier#!#uniqueidentifier#!#int#!#smallint#!#nvarchar#!#int#!#nvarchar#!#bit#!#bit#!#smallint#!#tinyint#!#nvarchar#!#int#!#int#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#nvarchar#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 911, Msg state: 1, Msg: database "fpn_table') select * from openq8c86d09e50d4f800f5a8c351ddbe1b23" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+select * from bbf_fpn_server."fpn_table'') select * from openquery(''bbf_fpn_server'', ''select * from master".sys.databases
+GO
+~~START~~
+varchar#!#int#!#int#!#varbinary#!#datetime#!#tinyint#!#varchar#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#bit#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#uniqueidentifier#!#bit#!#tinyint#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#uniqueidentifier#!#uniqueidentifier#!#int#!#smallint#!#nvarchar#!#int#!#nvarchar#!#bit#!#bit#!#smallint#!#tinyint#!#nvarchar#!#int#!#int#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#nvarchar#!#nvarchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 911, Msg state: 1, Msg: database "fpn_table') select * from openq8c86d09e50d4f800f5a8c351ddbe1b23" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- SQL Injection in schema name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from master.sys.tables') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: relation is invalid
+select * from bbf_fpn_server.master.[sys.tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys].databases
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_sys.tables') select * fr465ba21cd478dfdbfd9c4c52873fc1ec.databases" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+select * from bbf_fpn_server.master."sys.tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys".databases
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_sys.tables') select * fr465ba21cd478dfdbfd9c4c52873fc1ec.databases" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- SQL Injection in object name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from master.sys.tables') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: relation is invalid
+select * from bbf_fpn_server.master.sys.[tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys.databases]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "sys.tables') select * from openquer6fae7895a55a5b386bac33a1b4ac3386" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+select * from bbf_fpn_server.master.sys."tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys.databases"
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "sys.tables') select * from openquer6fae7895a55a5b386bac33a1b4ac3386" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+DROP TABLE fpn_table_insert_into
+DROP TABLE fpn_table_select_into
+DROP TABLE fpn_table
+DROP VIEW four_part_names_vu_verify_view
+GO

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -113,7 +113,7 @@ EXEC bbf_fpn_server.master.dbo.sp_linkedserver
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Remote procedure reference with 4-part object name is not currently supported in Babelfish)~~
+~~ERROR (Message: Remote procedure/function reference with 4-part object name is not currently supported in Babelfish)~~
 
 
 -- INSERT should not work with four-part object name

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -314,6 +314,18 @@ int#!#varchar
 ~~END~~
 
 
+-- In Subquery as a column
+SELECT a, (SELECT b from bbf_fpn_server.master.dbo.fpn_table where b = t.b) as c
+FROM fpn_table_insert_into t
+GO
+~~START~~
+int#!#varchar
+3#!#three
+101#!#<NULL>
+102#!#<NULL>
+~~END~~
+
+
 -- In Correlated subquery
 SELECT * FROM fpn_table_insert_into WHERE EXISTS (SELECT * FROM bbf_fpn_server.master.dbo.fpn_table as fpn_table_alias WHERE fpn_table_alias.a = fpn_table_insert_into.a)
 GO

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -281,6 +281,48 @@ int#!#varchar
 ~~END~~
 
 
+-- In CTE
+WITH cte_table_for_fpn (a)
+AS
+(
+        SELECT a from bbf_fpn_server.master.dbo.fpn_table
+)
+SELECT AVG(a) FROM cte_table_for_fpn
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- In Subquery
+SELECT * FROM fpn_table_insert_into WHERE a > (SELECT MAX(a) FROM bbf_fpn_server.master.dbo.fpn_table)
+GO
+~~START~~
+int#!#varchar
+101#!#one1
+102#!#two2
+~~END~~
+
+
+SELECT * FROM fpn_table_select_into WHERE b IN (SELECT b FROM bbf_fpn_server.master.dbo.fpn_table)
+GO
+~~START~~
+int#!#varchar
+1#!#one
+3#!#three
+~~END~~
+
+
+-- In Correlated subquery
+SELECT * FROM fpn_table_insert_into WHERE EXISTS (SELECT * FROM bbf_fpn_server.master.dbo.fpn_table as fpn_table_alias WHERE fpn_table_alias.a = fpn_table_insert_into.a)
+GO
+~~START~~
+int#!#varchar
+3#!#three
+~~END~~
+
+
 
 -- Try SQL Injection
 -- We cannot directly inject SQL because it will break T-SQL database identifier rules

--- a/test/JDBC/expected/linked_servers-vu-verify.out
+++ b/test/JDBC/expected/linked_servers-vu-verify.out
@@ -115,7 +115,7 @@ GO
 SET NOCOUNT ON
 DECLARE @sp_linkedservers_var table(a sysname, b nvarchar(128), c nvarchar(128), d nvarchar(4000), e nvarchar(4000), f nvarchar(4000), g sysname NULL)
 INSERT INTO @sp_linkedservers_var EXEC sp_linkedservers
-SELECT * FROM @sp_linkedservers_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_linkedservers_var WHERE a <> 'bbf_server' ORDER BY a
 SET NOCOUNT OFF
 GO
 ~~START~~

--- a/test/JDBC/expected/linked_servers-vu-verify.out
+++ b/test/JDBC/expected/linked_servers-vu-verify.out
@@ -59,7 +59,7 @@ mssql_server3#!#<NULL>
 SET NOCOUNT ON
 DECLARE @sp_helplinkedsrvlogin_var table(a sysname, b sysname NULL, c smallint, d sysname NULL)
 INSERT INTO @sp_helplinkedsrvlogin_var EXEC sp_helplinkedsrvlogin
-SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a <> 'bbf_server' ORDER BY a
 SET NOCOUNT OFF
 GO
 ~~START~~

--- a/test/JDBC/input/BABEL-2455.sql
+++ b/test/JDBC/input/BABEL-2455.sql
@@ -152,10 +152,11 @@ go
 DROP TRIGGER .s2455.tr2455;
 go
 
--- servername (not supported)
+-- insert into with servername (not supported)
 insert into yourserver.master.dbo.t1 values (1);
 go
 
+-- function call with servername (not supported)
 select yourserver.master.dbo.f1(1);
 go
 

--- a/test/JDBC/input/four-part-names-vu-cleanup.mix
+++ b/test/JDBC/input/four-part-names-vu-cleanup.mix
@@ -1,0 +1,6 @@
+EXEC sp_dropserver 'bbf_fpn_server', 'droplogins'
+GO
+
+-- psql
+DROP EXTENSION IF EXISTS tds_fdw CASCADE;
+GO

--- a/test/JDBC/input/four-part-names-vu-prepare.mix
+++ b/test/JDBC/input/four-part-names-vu-prepare.mix
@@ -1,0 +1,10 @@
+-- psql
+CREATE EXTENSION IF NOT EXISTS tds_fdw;
+GO
+
+-- tsql
+EXEC sp_addlinkedserver  @server = N'bbf_fpn_server', @srvproduct=N'', @provider=N'SQLNCLI', @datasrc=N'localhost', @catalog=N'master';
+GO
+
+EXEC sp_addlinkedsrvlogin @rmtsrvname = 'bbf_fpn_server', @useself = 'FALSE', @rmtuser = 'jdbc_user', @rmtpassword = '12345678';
+GO

--- a/test/JDBC/input/four-part-names-vu-verify.sql
+++ b/test/JDBC/input/four-part-names-vu-verify.sql
@@ -138,6 +138,26 @@ GO
 SELECT * FROM fpn_table_select_into
 GO
 
+-- In CTE
+WITH cte_table_for_fpn (a)
+AS
+(
+        SELECT a from bbf_fpn_server.master.dbo.fpn_table
+)
+SELECT AVG(a) FROM cte_table_for_fpn
+GO
+
+-- In Subquery
+SELECT * FROM fpn_table_insert_into WHERE a > (SELECT MAX(a) FROM bbf_fpn_server.master.dbo.fpn_table)
+GO
+
+SELECT * FROM fpn_table_select_into WHERE b IN (SELECT b FROM bbf_fpn_server.master.dbo.fpn_table)
+GO
+
+-- In Correlated subquery
+SELECT * FROM fpn_table_insert_into WHERE EXISTS (SELECT * FROM bbf_fpn_server.master.dbo.fpn_table as fpn_table_alias WHERE fpn_table_alias.a = fpn_table_insert_into.a)
+GO
+
 -- Try SQL Injection
 -- We cannot directly inject SQL because it will break T-SQL database identifier rules
 -- We have to surround the SQL in double quotes ("") or square brackets ([]) if we want to even attempt that

--- a/test/JDBC/input/four-part-names-vu-verify.sql
+++ b/test/JDBC/input/four-part-names-vu-verify.sql
@@ -154,6 +154,11 @@ GO
 SELECT * FROM fpn_table_select_into WHERE b IN (SELECT b FROM bbf_fpn_server.master.dbo.fpn_table)
 GO
 
+-- In Subquery as a column
+SELECT a, (SELECT b from bbf_fpn_server.master.dbo.fpn_table where b = t.b) as c
+FROM fpn_table_insert_into t
+GO
+
 -- In Correlated subquery
 SELECT * FROM fpn_table_insert_into WHERE EXISTS (SELECT * FROM bbf_fpn_server.master.dbo.fpn_table as fpn_table_alias WHERE fpn_table_alias.a = fpn_table_insert_into.a)
 GO

--- a/test/JDBC/input/four-part-names-vu-verify.sql
+++ b/test/JDBC/input/four-part-names-vu-verify.sql
@@ -1,0 +1,194 @@
+CREATE TABLE fpn_table (a int, b varchar(10))
+GO
+
+SELECT * FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+
+INSERT INTO fpn_table VALUES (1, 'one')
+INSERT INTO fpn_table VALUES (2, 'two')
+INSERT INTO fpn_table VALUES (3, 'three')
+INSERT INTO fpn_table VALUES (4, 'four')
+GO
+
+-- server_name.database_name.schema_name.object_name (table)
+SELECT a, b FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+
+-- server_name.database_name.schema_name.object_name (view)
+SELECT * FROM bbf_fpn_server.master.sys.data_spaces
+GO
+
+-- server_name.database_name..object_name
+SELECT a + 1, b FROM bbf_fpn_server.master..fpn_table
+GO
+
+-- server_name..schema_name.object_name
+SELECT * FROM bbf_fpn_server..sys.data_spaces
+GO
+
+-- server_name...object_name
+SELECT a*2, REVERSE(b) FROM bbf_fpn_server...fpn_table
+GO
+
+-- Invalid server name (Should throw error)
+SELECT * FROM invalid_server.master.dbo.fpn_table
+GO
+
+-- Invalid database name (Should throw error)
+SELECT * FROM bbf_fpn_server.invalid_db.dbo.fpn_table
+GO
+
+-- Invalid schema name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.invalid_schema.fpn_table
+GO
+
+-- Invalid object name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.dbo.invalid_fpn_table
+GO
+
+-- four part object is a procedure (Should throw error)
+EXEC bbf_fpn_server.master.dbo.sp_linkedserver
+GO
+
+-- INSERT should not work with four-part object name
+INSERT INTO bbf_fpn_server.master.dbo.fpn_table VALUES (5, 'five')
+GO
+
+-- UPDATE should not work with four-part object name
+UPDATE bbf_fpn_server.master.dbo.fpn_table SET b = 'Update one' WHERE a = 1
+GO
+
+-- DELETE should not work with four-part object name
+DELETE FROM bbf_fpn_server.master.dbo.fpn_table WHERE a = 1
+GO
+
+-- CREATE VIEW using four-part names
+CREATE VIEW four_part_names_vu_verify_view AS SELECT * FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+
+SELECT * FROM four_part_names_vu_verify_view
+GO
+
+-- INSERT INTO ... SELECT
+CREATE TABLE fpn_table_insert_into (a int, b varchar(10))
+GO
+
+INSERT INTO fpn_table_insert_into SELECT * FROM bbf_fpn_server.master.dbo.fpn_table WHERE a < 4
+GO
+
+SELECT * FROM fpn_table_insert_into
+GO
+
+-- SELECT INTO
+SELECT * INTO fpn_table_select_into FROM bbf_fpn_server.master.dbo.fpn_table
+GO
+
+SELECT * FROM fpn_table_select_into
+GO
+
+-- JOIN between local and remote table
+SELECT fpn_table.*, t2.*
+FROM fpn_table_insert_into fpn_table
+LEFT JOIN 
+bbf_fpn_server.master.dbo.fpn_table t2
+ON fpn_table.a = t2.a
+GO
+
+SELECT fpn_table.a, t2.*
+FROM bbf_fpn_server.master.dbo.fpn_table fpn_table
+LEFT JOIN 
+fpn_table_insert_into t2
+ON fpn_table.a = t2.a
+GO
+
+-- JOIN between two remote tables
+SELECT fpn_table.*, t2.a, t2.b
+FROM bbf_fpn_server.master.dbo.fpn_table fpn_table
+LEFT JOIN 
+bbf_fpn_server.master.dbo.fpn_table_insert_into t2
+ON fpn_table.a = t2.a
+GO
+
+-- UPDATE on local table with JOIN containing remote table
+UPDATE Table_A
+SET
+Table_A.a = Table_B.a + 100,
+Table_A.b = Table_B.b + CAST(Table_B.a AS varchar(5))
+FROM
+fpn_table_insert_into AS Table_A
+INNER JOIN bbf_fpn_server.master.dbo.fpn_table AS Table_B
+ON Table_A.a = Table_B.a
+WHERE
+Table_A.a < 3
+GO
+
+SELECT * FROM fpn_table_insert_into
+GO
+
+-- DELETE on local table with JOIN containing remote table
+DELETE Table_A
+FROM
+fpn_table_select_into AS Table_A
+INNER JOIN bbf_fpn_server.master.dbo.fpn_table AS Table_B
+ON Table_A.a = Table_B.a
+WHERE
+(Table_A.a + Table_B.a) % 4 = 0
+GO
+
+SELECT * FROM fpn_table_select_into
+GO
+
+-- Try SQL Injection
+-- We cannot directly inject SQL because it will break T-SQL database identifier rules
+-- We have to surround the SQL in double quotes ("") or square brackets ([]) if we want to even attempt that
+-- All cases should throw an error
+
+-- To allow identifiers be specified with double quotes
+SET QUOTED_IDENTIFIER ON
+GO
+
+-- SQL Injection in server name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from fpn_table') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: servername is invalid
+select * from [bbf_fpn_server'', ''select * from fpn_table'') select * from openquery(''bbf_fpn_server].master.sys.databases
+GO
+
+select * from "bbf_fpn_server'', ''select * from fpn_table'') select * from openquery(''bbf_fpn_server".master.sys.databases
+GO
+
+-- SQL Injection in database name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from fpn_table') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: database name is invalid
+select * from bbf_fpn_server.[fpn_table'') select * from openquery(''bbf_fpn_server'', ''select * from master].sys.databases
+GO
+
+select * from bbf_fpn_server."fpn_table'') select * from openquery(''bbf_fpn_server'', ''select * from master".sys.databases
+GO
+
+-- SQL Injection in schema name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from master.sys.tables') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: relation is invalid
+select * from bbf_fpn_server.master.[sys.tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys].databases
+GO
+
+select * from bbf_fpn_server.master."sys.tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys".databases
+GO
+
+-- SQL Injection in object name
+-- Try to inject SQL such that the final rewritten query looks like:
+-- select * from openquery('bbf_fpn_server', 'select * from master.sys.tables') select * from openquery('bbf_fpn_server', 'select * from master.sys.databases')
+-- Will throw error: relation is invalid
+select * from bbf_fpn_server.master.sys.[tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys.databases]
+GO
+
+select * from bbf_fpn_server.master.sys."tables'') select * from openquery(''bbf_fpn_server'', ''select * from master.sys.databases"
+GO
+
+DROP TABLE fpn_table_insert_into
+DROP TABLE fpn_table_select_into
+DROP TABLE fpn_table
+DROP VIEW four_part_names_vu_verify_view
+GO

--- a/test/JDBC/input/linked_servers-vu-verify.sql
+++ b/test/JDBC/input/linked_servers-vu-verify.sql
@@ -18,7 +18,7 @@ GO
 SET NOCOUNT ON
 DECLARE @sp_helplinkedsrvlogin_var table(a sysname, b sysname NULL, c smallint, d sysname NULL)
 INSERT INTO @sp_helplinkedsrvlogin_var EXEC sp_helplinkedsrvlogin
-SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a <> 'bbf_server' ORDER BY a
 SET NOCOUNT OFF
 GO
 

--- a/test/JDBC/input/linked_servers-vu-verify.sql
+++ b/test/JDBC/input/linked_servers-vu-verify.sql
@@ -45,7 +45,7 @@ GO
 SET NOCOUNT ON
 DECLARE @sp_linkedservers_var table(a sysname, b nvarchar(128), c nvarchar(128), d nvarchar(4000), e nvarchar(4000), f nvarchar(4000), g sysname NULL)
 INSERT INTO @sp_linkedservers_var EXEC sp_linkedservers
-SELECT * FROM @sp_linkedservers_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_linkedservers_var WHERE a <> 'bbf_server' ORDER BY a
 SET NOCOUNT OFF
 GO
 


### PR DESCRIPTION
### Description

In this commit, we add support for referencing remote objects i.e.
objects that reside in a remote server using four-part object names.

Four-part object names have been implemented by rewritting such
references using T-SQL OPENQUERY().

Currently, read-only operations are permitted on objects referenced
using a four-part object names. DMLs are not supported yet.

Task: BABEL-856
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** Already covered by existing OPENQUERY() tests


* **Major version upgrade tests -** Already covered by existing OPENQUERY() tests


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).