### PR TITLE
Disallow alter role for babelfish created roles

### DIFF
--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -3,20 +3,627 @@ CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '123';
 GO
 
 CREATE ROLE ownership_restrictions_from_pg_role1;
-go
+GO
+
+CREATE DATABASE ownership_restrictions_from_pg_db;
+GO
+
+DECLARE @ownership_restrictions_from_pg_test_variable  int = 100;
+GO
 
 -- psql
 CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' inherit;
 go
 
--- psql user=ownership_restrictions_from_pg_test_user password=12345678
+CREATE USER ownership_restrictions_from_pg_test_su_user WITH SUPERUSER LOGIN PASSWORD 'abc';
+GO
+
+-- psql user=ownership_restrictions_from_pg_login1 password=12345678
+-- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
 DROP ROLE master_ownership_restrictions_from_pg_role1;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created users/roles cannot be dropped or altered outside of a Babelfish session
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOSUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 SUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOINHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 INHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 REPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOREPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 BYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOBYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
+GO
+
+ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: database "ownership_restrictions_from_pg_db" does not exist
+    Server SQLState: 3D000)~~
+
+
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_ROLE IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+alter role ownership_restrictions_from_pg_login1 with password '123';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- If the stmt contains a non-allowed option then altering of role not allowed
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=ownership_restrictions_from_pg_test_user password=12345678
+-- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
+DROP ROLE master_ownership_restrictions_from_pg_role1;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOSUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 SUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOINHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 INHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 REPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOREPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 BYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOBYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: database "ownership_restrictions_from_pg_db" does not exist
+    Server SQLState: 3D000)~~
+
+
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_ROLE IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: database "ownership_restrictions_from_pg_db" does not exist
+    Server SQLState: 3D000)~~
+
+
+ALTER ROLE CURRENT_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: database "ownership_restrictions_from_pg_db" does not exist
+    Server SQLState: 3D000)~~
+
+
+ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: database "ownership_restrictions_from_pg_db" does not exist
+    Server SQLState: 3D000)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+alter role ownership_restrictions_from_pg_login1 with password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- If the stmt contains a non-allowed option then altering of role not allowed
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=ownership_restrictions_from_pg_test_su_user password=abc
+-- Altering of babelfish created logins/roles should suceeded for superuser
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
 
 -- psql
 -- Dropping login from psql port should fail
@@ -83,12 +690,28 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role4;
 GO
 
+SET enable_drop_babelfish_role = true;
+go
+DROP USER ownership_restrictions_from_pg_test_su_user;
+go
+SET enable_drop_babelfish_role = false;
+go
+
 DROP USER ownership_restrictions_from_pg_test_user;
 GO
 
--- tsql
-DROP ROLE ownership_restrictions_from_pg_role1;
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'ownership_restrictions_from_pg_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
+~~START~~
+bool
+t
+~~END~~
 
+
+-- tsql
+DROP DATABASE ownership_restrictions_from_pg_db;
+DROP ROLE ownership_restrictions_from_pg_role1;
 DROP LOGIN ownership_restrictions_from_pg_login1;
 GO

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -3,14 +3,271 @@ CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '123';
 GO
 
 CREATE ROLE ownership_restrictions_from_pg_role1;
-go
+GO
+
+CREATE DATABASE ownership_restrictions_from_pg_db;
+GO
+
+DECLARE @ownership_restrictions_from_pg_test_variable  int = 100;
+GO
 
 -- psql
 CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' inherit;
 go
 
--- psql user=ownership_restrictions_from_pg_test_user password=12345678
+CREATE USER ownership_restrictions_from_pg_test_su_user WITH SUPERUSER LOGIN PASSWORD 'abc';
+GO
+
+-- psql user=ownership_restrictions_from_pg_login1 password=12345678
+-- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
 DROP ROLE master_ownership_restrictions_from_pg_role1;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEDB;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOSUPERUSER;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 SUPERUSER;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOINHERIT;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 INHERIT;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 REPLICATION;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOREPLICATION;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 BYPASSRLS;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOBYPASSRLS;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
+GO
+
+ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_ROLE IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+alter role ownership_restrictions_from_pg_login1 with password '123';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+-- If the stmt contains a non-allowed option then altering of role not allowed
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+
+-- psql user=ownership_restrictions_from_pg_test_user password=12345678
+-- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
+DROP ROLE master_ownership_restrictions_from_pg_role1;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEDB;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOSUPERUSER;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 SUPERUSER;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOINHERIT;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 INHERIT;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 REPLICATION;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOREPLICATION;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 BYPASSRLS;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 NOBYPASSRLS;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
+GO
+
+ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_ROLE IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+alter role ownership_restrictions_from_pg_login1 with password '123';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+-- If the stmt contains a non-allowed option then altering of role not allowed
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+GO
+
+-- psql user=ownership_restrictions_from_pg_test_su_user password=abc
+-- Altering of babelfish created logins/roles should suceeded for superuser
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
 GO
 
 -- psql
@@ -63,12 +320,23 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role4;
 GO
 
+SET enable_drop_babelfish_role = true;
+go
+DROP USER ownership_restrictions_from_pg_test_su_user;
+go
+SET enable_drop_babelfish_role = false;
+go
+
 DROP USER ownership_restrictions_from_pg_test_user;
 GO
 
--- tsql
-DROP ROLE ownership_restrictions_from_pg_role1;
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'ownership_restrictions_from_pg_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 
+-- tsql
+DROP DATABASE ownership_restrictions_from_pg_db;
+DROP ROLE ownership_restrictions_from_pg_role1;
 DROP LOGIN ownership_restrictions_from_pg_login1;
 GO


### PR DESCRIPTION
### Description

[OSS-ONLY] Previously, it is possible for an PG user to break a Babelfish instance by ALTER ROLE of babelfish created logins/users/roles or master user to block logins, change role membership, change passwords, and other changes that would have a dramatic effect on Babelfish functionality.

This commit fixes the issue by disallowing few ALTER ROLE operations of babelfish created logins/users/roles and master user in PG for users other than superuser. Only a few ALTER ROLE operations are allowed for babelfish created logins/users/roles which are password change, valid until and connection limit and ALTER ROLE of master user is only allowed to change password. As allowing limited ALTER ROLE operations for roles will help in case of babelfish extensions got disabled.

### Issues Resolved
BABEL-2976

### Test Scenarios Covered ###
* **Use case based -** Test all different kind of alter role operations on babelfish created logins/roles and master user



* **Boundary conditions -** Add tests for allowed alter role operations to check permissions for the pg users



* **Arbitrary inputs -** Tested all kind of alter role operations on different pg_users


* **Negative test cases -** Add negative tests for scenarios which should throw error


* **Minor version upgrade tests -**  N/A


* **Major version upgrade tests -**  N/A


* **Performance tests -**  N/A


* **Tooling impact -**  N/A


* **Client tests -**  N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).