### PR TITLE
Restrict drop/alter login by non-sysadmin in Babelfish

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2812,9 +2812,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 							if (strcmp(defel->defname, "password") == 0)
 							{
-								if (!is_member_of_role(GetSessionUserId(), datdba))
-									ereport(ERROR,
-											(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+								if (get_role_oid(stmt->role->rolename, true) != GetSessionUserId() && !is_member_of_role(GetSessionUserId(), datdba))
+									ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 											 errmsg("Current login does not have privileges to alter password")));
 
 								has_password = true;
@@ -2848,7 +2847,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							stmt->role->rolename = temp_login_name;
 						}
 
-						if (!has_privs_of_role(GetSessionUserId(), datdba))
+						if (!has_privs_of_role(GetSessionUserId(), datdba) && !has_password)
 							ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
 								errmsg("Current login %s does not have permission to Alter login", 
 								GetUserNameFromId(GetSessionUserId(), true))));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2852,8 +2852,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								errmsg("Current login %s does not have permission to Alter login", 
 								GetUserNameFromId(GetSessionUserId(), true))));
 
-
-
 						if (get_role_oid(stmt->role->rolename, true) == InvalidOid)
 							ereport(ERROR, (errcode(ERRCODE_DUPLICATE_OBJECT),
 											errmsg("Cannot drop the login '%s', because it does not exist or you do not have permission.", stmt->role->rolename)));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2966,14 +2966,13 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					DropRoleStmt *stmt = (DropRoleStmt *) parsetree;
 					bool		drop_user = false;
 					bool		drop_role = false;
-					bool drop_login = false;
+					bool        drop_login = false;
 					bool		all_logins = false;
 					bool		all_users = false;
 					bool		all_roles = false;
 					char	   *role_name = NULL;
 					bool		other = false;
 					ListCell   *item;
-
 
 					/* Check if roles are users that need role name mapping */
 					if (stmt->roles != NIL)
@@ -3113,13 +3112,10 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						else
 							other = true;
 
-						if (drop_login && is_login(roleform->oid)){
-							if (!has_privs_of_role(GetSessionUserId(), get_role_oid("sysadmin", false)))
-							{
-								ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-								errmsg("Current login %s does not have permission to Drop login",
-									GetUserNameFromId(GetSessionUserId(), true))));
-							}
+						if (drop_login && is_login(roleform->oid) && !has_privs_of_role(GetSessionUserId(), get_role_oid("sysadmin", false))){
+							ereport(ERROR, 
+									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
+									errmsg("Current login %s does not have permission to Drop login", GetUserNameFromId(GetSessionUserId(), true))));
 						}
 
 						ReleaseSysCache(tuple);

--- a/test/JDBC/expected/BABEL-2440.out
+++ b/test/JDBC/expected/BABEL-2440.out
@@ -21,10 +21,6 @@ guest#!#guest#!#master
 
 ALTER LOGIN r1 WITH PASSWORD = 'abc';
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login does not have privileges to alter password)~~
-
 
 SELECT session_user, current_user, db_name();
 GO
@@ -51,10 +47,6 @@ ignore
 
 ALTER LOGIN r1 WITH PASSWORD = '123abc' OLD_PASSWORD = 'abc';
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login does not have privileges to alter password)~~
-
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_login_old_password', 'strict', 'false')
 GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
@@ -19,3 +19,12 @@ go
 
 DROP DATABASE babel_login_vu_prepare_db1
 go
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
@@ -28,28 +28,17 @@ END
 go
 
 -- tsql
-CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '1234';
 GO
 
-CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
 GO
 
 ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
 GO
 
-CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
 GO
 
-CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '1234';
 GO
-
-SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
-GO
-~~START~~
-varchar#!#char#!#nvarchar
-babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
-babel_4080_sysadmin1#!#S#!#SQL_LOGIN
-babel_4080_testlogin1#!#S#!#SQL_LOGIN
-babel_4080_testlogin2#!#S#!#SQL_LOGIN
-~~END~~
-

--- a/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
@@ -34,9 +34,6 @@ GO
 CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
 GO
 
-ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
-GO
-
 CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
 GO
 

--- a/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
@@ -26,3 +26,30 @@ WHERE rolname LIKE 'babel_login_vu_prepare%'
 ORDER BY rolname
 END
 go
+
+-- tsql
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '12345678';
+GO
+
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '12345678';
+GO
+
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '12345678';
+GO
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
+babel_4080_sysadmin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin2#!#S#!#SQL_LOGIN
+~~END~~
+

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -461,9 +461,13 @@ go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
 
+-- tsql
+-- babel_4080 tests start here
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
 -- tsql user=babel_4080_nonsysadmin1 password=1234
 
--- babel-4080 tests start here
 SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
 GO
 ~~START~~

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -460,3 +460,117 @@ DROP USER babel_login_vu_prepare_r4
 go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
+
+
+-- tsql user=babel_4080_nonsysadmin1 password=12345678
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Alter login)~~
+
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Alter login)~~
+
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Drop login)~~
+
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
+babel_4080_sysadmin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin2#!#S#!#SQL_LOGIN
+~~END~~
+
+
+-- tsql user=babel_4080_sysadmin1 password=12345678
+SELECT SUSER_NAME();
+GO
+~~START~~
+nvarchar
+babel_4080_sysadmin1
+~~END~~
+
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcdefgh' OLD_PASSWORD = '12345678';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'OLD_PASSWORD' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_login_old_password to ignore)~~
+
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = '12345678';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -461,17 +461,21 @@ go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
 
+-- tsql user=babel_4080_nonsysadmin1 password=1234
 
--- tsql user=babel_4080_nonsysadmin1 password=12345678
+-- babel-4080 tests start here
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
+babel_4080_sysadmin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin2#!#S#!#SQL_LOGIN
+~~END~~
+
 
 ALTER LOGIN babel_4080_testlogin1 DISABLE;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Alter login)~~
-
-
-ALTER LOGIN babel_4080_testlogin1 ENABLE;
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -485,49 +489,59 @@ GO
 ~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Drop login)~~
 
 
-SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+-- tsql user=babel_4080_sysadmin1 password=1234
+ALTER LOGIN babel_4080_sysadmin1 WITH PASSWORD = 'abcd';
 GO
-~~START~~
-varchar#!#char#!#nvarchar
-babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
-babel_4080_sysadmin1#!#S#!#SQL_LOGIN
-babel_4080_testlogin1#!#S#!#SQL_LOGIN
-babel_4080_testlogin2#!#S#!#SQL_LOGIN
-~~END~~
 
-
--- tsql user=babel_4080_sysadmin1 password=12345678
-SELECT SUSER_NAME();
-GO
-~~START~~
-nvarchar
-babel_4080_sysadmin1
-~~END~~
-
-
-ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcdefgh' OLD_PASSWORD = '12345678';
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: 'OLD_PASSWORD' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_login_old_password to ignore)~~
-
-
-ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = '12345678';
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcd';
 GO
 
 ALTER LOGIN babel_4080_testlogin1 DISABLE;
 GO
 
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#bit
+babel_4080_testlogin1#!#0
+~~END~~
+
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#int
+babel_4080_testlogin1#!#1
+~~END~~
+
+
 ALTER LOGIN babel_4080_testlogin1 ENABLE;
 GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#bit
+babel_4080_testlogin1#!#1
+~~END~~
+
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#int
+babel_4080_testlogin1#!#0
+~~END~~
+
 
 DROP LOGIN babel_4080_testlogin1;
 GO
 
-DROP LOGIN babel_4080_testlogin2;
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
 GO
 
-ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+-- tsql user=babel_4080_testlogin2 password=1234
+ALTER LOGIN babel_4080_testlogin2 WITH PASSWORD = 'abcd';
 GO
 
 -- psql
@@ -540,7 +554,6 @@ t
 ~~END~~
 
 
--- Wait to sync with another session
 SELECT pg_sleep(1);
 GO
 ~~START~~
@@ -549,7 +562,6 @@ void
 ~~END~~
 
 
--- psql
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
@@ -559,7 +571,6 @@ t
 ~~END~~
 
 
--- Wait to sync with another session
 SELECT pg_sleep(1);
 GO
 ~~START~~
@@ -567,10 +578,3 @@ void
 
 ~~END~~
 
-
--- tsql
-DROP LOGIN babel_4080_sysadmin1;
-GO
-
-DROP LOGIN babel_4080_nonsysadmin1;
-GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
@@ -19,3 +19,12 @@ go
 
 DROP DATABASE babel_login_vu_prepare_db1
 go
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
@@ -28,20 +28,17 @@ END
 go
 
 -- tsql
-CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '1234';
 GO
 
-CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
 GO
 
 ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
 GO
 
-CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '12345678';
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
 GO
 
-CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '12345678';
-GO
-
-SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '1234';
 GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
@@ -34,9 +34,6 @@ GO
 CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
 GO
 
-ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
-GO
-
 CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
 GO
 

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
@@ -26,3 +26,22 @@ WHERE rolname LIKE 'babel_login_vu_prepare%'
 ORDER BY rolname
 END
 go
+
+-- tsql
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '12345678';
+GO
+
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '12345678';
+GO
+
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '12345678';
+GO
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -261,3 +261,68 @@ DROP USER babel_login_vu_prepare_r4
 go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
+
+
+-- tsql user=babel_4080_nonsysadmin1 password=12345678
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+
+-- tsql user=babel_4080_sysadmin1 password=12345678
+SELECT SUSER_NAME();
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcdefgh' OLD_PASSWORD = '12345678';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = '12345678';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -262,7 +262,11 @@ go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
 
--- babel-4080 tests start here
+-- babel_4080 tests start here
+-- tsql
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
 -- tsql user=babel_4080_nonsysadmin1 password=1234
 
 SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -262,44 +262,51 @@ go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
 
-
--- tsql user=babel_4080_nonsysadmin1 password=12345678
-
-ALTER LOGIN babel_4080_testlogin1 DISABLE;
-GO
-
-ALTER LOGIN babel_4080_testlogin1 ENABLE;
-GO
-
-DROP LOGIN babel_4080_testlogin1;
-GO
+-- babel-4080 tests start here
+-- tsql user=babel_4080_nonsysadmin1 password=1234
 
 SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
 GO
 
--- tsql user=babel_4080_sysadmin1 password=12345678
-SELECT SUSER_NAME();
-GO
-
-ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcdefgh' OLD_PASSWORD = '12345678';
-GO
-
-ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = '12345678';
-GO
-
 ALTER LOGIN babel_4080_testlogin1 DISABLE;
-GO
-
-ALTER LOGIN babel_4080_testlogin1 ENABLE;
 GO
 
 DROP LOGIN babel_4080_testlogin1;
 GO
 
-DROP LOGIN babel_4080_testlogin2;
+-- tsql user=babel_4080_sysadmin1 password=1234
+ALTER LOGIN babel_4080_sysadmin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+
+DROP LOGIN babel_4080_testlogin1;
 GO
 
 ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_testlogin2 password=1234
+ALTER LOGIN babel_4080_testlogin2 WITH PASSWORD = 'abcd';
 GO
 
 -- psql
@@ -307,22 +314,12 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 
--- Wait to sync with another session
 SELECT pg_sleep(1);
 GO
 
--- psql
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 
--- Wait to sync with another session
 SELECT pg_sleep(1);
-GO
-
--- tsql
-DROP LOGIN babel_4080_sysadmin1;
-GO
-
-DROP LOGIN babel_4080_nonsysadmin1;
 GO


### PR DESCRIPTION
Task: BABEL-4057


### Description
Restrict drop/alter login by non-sysadmin in Babelfish

### Issues Resolved
User will always be able to change their own password, even if they don't have sysadmin role

### Test Scenarios Covered ###
* **Use case based -**

- Sysadmin login is able to alter/drop BBF login
- NonSysadmin login is not able to alter/drop BBF login
- Sysadmin/NonSysadmin logins are able to change their own password
- Sysadmin logins are able to change everyone's password (same as test case 1)



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).