### PR TITLE
Add support for INSERT INTO ... SELECT TOP

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2011,35 +2011,37 @@ tsql_output_insert_rest_no_paren:
 		;
 
 tsql_output_simple_select:
-			SELECT opt_all_clause opt_target_list
+			SELECT opt_all_clause opt_top_clause opt_target_list
 			into_clause from_clause where_clause
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-					n->targetList = $3;
-					n->intoClause = $4;
-					n->fromClause = $5;
-					n->whereClause = $6;
-					n->groupClause = ($7)->list;
-					n->groupDistinct = ($7)->distinct;
-					n->havingClause = $8;
-					n->windowClause = $9;
+					n->limitCount = $3;
+					n->targetList = $4;
+					n->intoClause = $5;
+					n->fromClause = $6;
+					n->whereClause = $7;
+					n->groupClause = ($8)->list;
+					n->groupDistinct = ($8)->distinct;
+					n->havingClause = $9;
+					n->windowClause = $10;
 					$$ = (Node *)n;
 				}
-			| SELECT distinct_clause target_list
+			| SELECT distinct_clause opt_top_clause target_list
 			into_clause from_clause where_clause
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
 					n->distinctClause = $2;
-					n->targetList = $3;
-					n->intoClause = $4;
-					n->fromClause = $5;
-					n->whereClause = $6;
-					n->groupClause = ($7)->list;
-					n->groupDistinct = ($7)->distinct;
-					n->havingClause = $8;
-					n->windowClause = $9;
+					n->limitCount = $3;
+					n->targetList = $4;
+					n->intoClause = $5;
+					n->fromClause = $6;
+					n->whereClause = $7;
+					n->groupClause = ($8)->list;
+					n->groupDistinct = ($8)->distinct;
+					n->havingClause = $9;
+					n->windowClause = $10;
 					$$ = (Node *)n;
 				}
 			| tsql_values_clause							{ $$ = $1; }

--- a/test/JDBC/expected/BABEL-2551.out
+++ b/test/JDBC/expected/BABEL-2551.out
@@ -1,0 +1,48 @@
+create table t1(a int);
+insert t1 values (1), (1), (3), (null);
+GO
+~~ROW COUNT: 4~~
+
+
+create table t2(a int);
+insert into t2 select top(3) a from t1 order by 1;
+GO
+~~ROW COUNT: 3~~
+
+
+select * from t2 order by 1;
+GO
+~~START~~
+int
+<NULL>
+1
+1
+~~END~~
+
+
+truncate table t1;
+truncate table t2;
+GO
+
+insert t1 values (1), (1), (1), (1), (2);
+GO
+~~ROW COUNT: 5~~
+
+
+insert into t2 select distinct top(2) a from t1 order by 1;
+GO
+~~ROW COUNT: 2~~
+
+
+select * from t2 order by 1;
+GO
+~~START~~
+int
+1
+2
+~~END~~
+
+
+drop table t1;
+drop table t2;
+GO

--- a/test/JDBC/expected/BABEL-2551.out
+++ b/test/JDBC/expected/BABEL-2551.out
@@ -1,17 +1,17 @@
-create table t1(a int);
-insert t1 values (1), (1), (3), (null);
+create table babel2551_t1(a int);
+create table babel2551_t2(a int);
+go
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (1), (3), (null);
+insert into babel2551_t2 select top(3) a from babel2551_t1 order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 ~~ROW COUNT: 4~~
 
-
-create table t2(a int);
-insert into t2 select top(3) a from t1 order by 1;
-GO
 ~~ROW COUNT: 3~~
 
-
-select * from t2 order by 1;
-GO
 ~~START~~
 int
 <NULL>
@@ -20,22 +20,16 @@ int
 ~~END~~
 
 
-truncate table t1;
-truncate table t2;
-GO
-
-insert t1 values (1), (1), (1), (1), (2);
+BEGIN TRAN
+insert babel2551_t1 values (1), (1), (1), (1), (2);
+insert into babel2551_t2 select distinct top(2) a from babel2551_t1 order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 ~~ROW COUNT: 5~~
 
-
-insert into t2 select distinct top(2) a from t1 order by 1;
-GO
 ~~ROW COUNT: 2~~
 
-
-select * from t2 order by 1;
-GO
 ~~START~~
 int
 1
@@ -43,6 +37,251 @@ int
 ~~END~~
 
 
-drop table t1;
-drop table t2;
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert top(2) into babel2551_t2 select top(3) a from babel2551_t1 order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+2
+~~END~~
+
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(2) s.a from (select top(3) a from babel2551_t1 order by 1) s order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+2
+~~END~~
+
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(2) a from babel2551_t1 where a in (select top(3) a from babel2551_t1 order by 1) order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+2
+~~END~~
+
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert babel2551_t2 values (2), (3), (4), (5);
+insert into babel2551_t2 select top(2) t1.a from babel2551_t1 t1 join babel2551_t2 t2 on t1.a = t2.a order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+2
+3
+3
+4
+5
+~~END~~
+
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert babel2551_t2 values (2), (3), (4), (5);
+insert into babel2551_t2 select distinct top(2) t1.a from babel2551_t1 t1 cross join babel2551_t2 t2 order by t1.a;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+2
+2
+3
+4
+5
+~~END~~
+
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(2) t1.a into babel2551_t3 from babel2551_t1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SELECT ... INTO is not allowed here)~~
+
+
+create view babel2551_view as select a from babel2551_t1;
+GO
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(3) a from babel2551_view order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+
+drop view babel2551_view
+GO
+
+create function babel2551_cross_appy_func(@a int) returns @ret table(a int) as
+BEGIN
+    insert into @ret select top(1) a from babel2551_t1 where a = @a
+    return
+END;
+GO
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert babel2551_t2 values (2), (3), (4), (5);
+insert into babel2551_t2 select top(2) t1.a
+from babel2551_t1 t1 cross apply babel2551_cross_appy_func(t1.a);
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+2
+2
+3
+4
+5
+~~END~~
+
+
+drop function babel2551_cross_appy_func;
+GO
+
+drop table babel2551_t1;
+drop table babel2551_t2;
+GO
+
+declare @2551_top_const INT = 2;
+declare @2551_tbl_var as table (a VARCHAR(15));
+insert into @2551_tbl_var values ('a'), ('b'), ('c'), ('d')
+insert into  @2551_tbl_var select top(@2551_top_const) tbl.a from @2551_tbl_var tbl;
+select * from @2551_tbl_var order by a;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+a
+a
+b
+b
+c
+d
+~~END~~
+
+
+-- BABEL-3312 Case
+CREATE TABLE babel2551_t1(c1 int, c2 int)
+CREATE TABLE babel2551_t2(c1 int, c2 int, c3 int)
+GO
+INSERT INTO babel2551_t1(c1, c2) VALUES(1, 10)
+INSERT INTO babel2551_t1(c1, c2) VALUES(2, 20)
+INSERT INTO babel2551_t2(c1, c2, c3) VALUES(1, 1, 100)
+INSERT INTO babel2551_t2(c1, c2, c3) VALUES(1, 2, 1001)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+--Multi-statement function with TOP
+CREATE FUNCTION myMSTVF(@a int)
+RETURNS @ret table (a int)
+AS
+BEGIN
+INSERT INTO @ret
+SELECT TOP(2) c1
+FROM babel2551_t2
+WHERE babel2551_t2.c1 = @a
+RETURN
+END
+GO
+
+SELECT * FROM babel2551_t1 CROSS APPLY myMSTVF(babel2551_t1.c1)
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#1
+1#!#10#!#1
+~~END~~
+
+
+SELECT * FROM myMSTVF(1)
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+DROP FUNCTION myMSTVF
+DROP TABLE babel2551_t1
+DROP TABLE babel2551_t2
 GO

--- a/test/JDBC/expected/babel_top_in_dml.out
+++ b/test/JDBC/expected/babel_top_in_dml.out
@@ -530,7 +530,7 @@ go
 
 ~~ROW COUNT: 2~~
 
-CREATE VIEW babel_update_view AS SELECT * FROM babel_update_tbl1 WHERE babel_update_tbl1.a > 1;
+CREATE VIEW babel_update_top_view AS SELECT * FROM babel_update_tbl1 WHERE babel_update_tbl1.a > 1;
 go
 CREATE SCHEMA babel_update_schema
 go
@@ -650,7 +650,7 @@ go
 BEGIN TRAN
 INSERT INTO babel_update_tbl1 VALUES (3, 'extra')
 UPDATE top(1) v1 SET a = 100
-FROM babel_update_view v1
+FROM babel_update_top_view v1
 WHERE a = 2
 ROLLBACK
 go
@@ -668,7 +668,7 @@ GO
 ~~ROW COUNT: 1~~
 
 
-DROP VIEW babel_update_view
+DROP VIEW babel_update_top_view
 go
 DROP TABLE babel_update_tbl1
 DROP TABLE babel_update_tbl2
@@ -801,7 +801,7 @@ go
 ~~ROW COUNT: 2~~
 
 
-CREATE VIEW babel_delete_view AS SELECT * FROM babel_delete_tbl1 WHERE babel_delete_tbl1.a > 1;
+CREATE VIEW babel_delete_top_view AS SELECT * FROM babel_delete_tbl1 WHERE babel_delete_tbl1.a > 1;
 go
 CREATE SCHEMA babel_delete_schema
 go
@@ -912,7 +912,7 @@ go
 BEGIN TRAN
 INSERT INTO babel_delete_tbl1 VALUES (3, 'extra')
 DELETE top(1) v1
-FROM babel_delete_view v1
+FROM babel_delete_top_view v1
 WHERE a = 2
 ROLLBACK
 go
@@ -957,7 +957,7 @@ GO
 
 
 
-DROP VIEW babel_delete_view
+DROP VIEW babel_delete_top_view
 go
 DROP TABLE babel_delete_tbl1
 DROP TABLE babel_delete_tbl2

--- a/test/JDBC/input/BABEL-2551.sql
+++ b/test/JDBC/input/BABEL-2551.sql
@@ -1,27 +1,137 @@
-create table t1(a int);
-insert t1 values (1), (1), (3), (null);
+create table babel2551_t1(a int);
+create table babel2551_t2(a int);
+go
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (1), (3), (null);
+insert into babel2551_t2 select top(3) a from babel2551_t1 order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-create table t2(a int);
-insert into t2 select top(3) a from t1 order by 1;
+BEGIN TRAN
+insert babel2551_t1 values (1), (1), (1), (1), (2);
+insert into babel2551_t2 select distinct top(2) a from babel2551_t1 order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-select * from t2 order by 1;
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert top(2) into babel2551_t2 select top(3) a from babel2551_t1 order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-truncate table t1;
-truncate table t2;
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(2) s.a from (select top(3) a from babel2551_t1 order by 1) s order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-insert t1 values (1), (1), (1), (1), (2);
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(2) a from babel2551_t1 where a in (select top(3) a from babel2551_t1 order by 1) order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-insert into t2 select distinct top(2) a from t1 order by 1;
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert babel2551_t2 values (2), (3), (4), (5);
+insert into babel2551_t2 select top(2) t1.a from babel2551_t1 t1 join babel2551_t2 t2 on t1.a = t2.a order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-select * from t2 order by 1;
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert babel2551_t2 values (2), (3), (4), (5);
+insert into babel2551_t2 select distinct top(2) t1.a from babel2551_t1 t1 cross join babel2551_t2 t2 order by t1.a;
+select * from babel2551_t2 order by 1;
+ROLLBACK
 GO
 
-drop table t1;
-drop table t2;
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(2) t1.a into babel2551_t3 from babel2551_t1;
+ROLLBACK
+GO
+
+create view babel2551_view as select a from babel2551_t1;
+GO
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert into babel2551_t2 select top(3) a from babel2551_view order by 1;
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+
+drop view babel2551_view
+GO
+
+create function babel2551_cross_appy_func(@a int) returns @ret table(a int) as
+BEGIN
+    insert into @ret select top(1) a from babel2551_t1 where a = @a
+    return
+END;
+GO
+
+BEGIN TRAN
+insert babel2551_t1 values (1), (2), (3), (4);
+insert babel2551_t2 values (2), (3), (4), (5);
+insert into babel2551_t2 select top(2) t1.a
+from babel2551_t1 t1 cross apply babel2551_cross_appy_func(t1.a);
+select * from babel2551_t2 order by 1;
+ROLLBACK
+GO
+
+drop function babel2551_cross_appy_func;
+GO
+
+drop table babel2551_t1;
+drop table babel2551_t2;
+GO
+
+declare @2551_top_const INT = 2;
+declare @2551_tbl_var as table (a VARCHAR(15));
+insert into @2551_tbl_var values ('a'), ('b'), ('c'), ('d')
+insert into  @2551_tbl_var select top(@2551_top_const) tbl.a from @2551_tbl_var tbl;
+select * from @2551_tbl_var order by a;
+GO
+
+-- BABEL-3312 Case
+CREATE TABLE babel2551_t1(c1 int, c2 int)
+CREATE TABLE babel2551_t2(c1 int, c2 int, c3 int)
+GO
+INSERT INTO babel2551_t1(c1, c2) VALUES(1, 10)
+INSERT INTO babel2551_t1(c1, c2) VALUES(2, 20)
+INSERT INTO babel2551_t2(c1, c2, c3) VALUES(1, 1, 100)
+INSERT INTO babel2551_t2(c1, c2, c3) VALUES(1, 2, 1001)
+GO
+
+--Multi-statement function with TOP
+CREATE FUNCTION myMSTVF(@a int)
+RETURNS @ret table (a int)
+AS
+BEGIN
+INSERT INTO @ret
+SELECT TOP(2) c1
+FROM babel2551_t2
+WHERE babel2551_t2.c1 = @a
+RETURN
+END
+GO
+
+SELECT * FROM babel2551_t1 CROSS APPLY myMSTVF(babel2551_t1.c1)
+GO
+
+SELECT * FROM myMSTVF(1)
+GO
+
+DROP FUNCTION myMSTVF
+DROP TABLE babel2551_t1
+DROP TABLE babel2551_t2
 GO

--- a/test/JDBC/input/BABEL-2551.sql
+++ b/test/JDBC/input/BABEL-2551.sql
@@ -1,0 +1,27 @@
+create table t1(a int);
+insert t1 values (1), (1), (3), (null);
+GO
+
+create table t2(a int);
+insert into t2 select top(3) a from t1 order by 1;
+GO
+
+select * from t2 order by 1;
+GO
+
+truncate table t1;
+truncate table t2;
+GO
+
+insert t1 values (1), (1), (1), (1), (2);
+GO
+
+insert into t2 select distinct top(2) a from t1 order by 1;
+GO
+
+select * from t2 order by 1;
+GO
+
+drop table t1;
+drop table t2;
+GO

--- a/test/JDBC/input/dml/babel_top_in_dml.sql
+++ b/test/JDBC/input/dml/babel_top_in_dml.sql
@@ -327,7 +327,7 @@ INSERT INTO babel_update_tbl1 VALUES (1, 'left'), (2, 'inner');
 INSERT INTO babel_update_tbl2 VALUES (10, 'inner'), (30, 'right');
 INSERT INTO babel_update_tbl3 VALUES (1, 10), (3, 10);
 go
-CREATE VIEW babel_update_view AS SELECT * FROM babel_update_tbl1 WHERE babel_update_tbl1.a > 1;
+CREATE VIEW babel_update_top_view AS SELECT * FROM babel_update_tbl1 WHERE babel_update_tbl1.a > 1;
 go
 CREATE SCHEMA babel_update_schema
 go
@@ -427,7 +427,7 @@ go
 BEGIN TRAN
 INSERT INTO babel_update_tbl1 VALUES (3, 'extra')
 UPDATE top(1) v1 SET a = 100
-FROM babel_update_view v1
+FROM babel_update_top_view v1
 WHERE a = 2
 ROLLBACK
 go
@@ -439,7 +439,7 @@ FROM babel_update_schema.babel_update_tbl1 t1
 ROLLBACK
 GO
 
-DROP VIEW babel_update_view
+DROP VIEW babel_update_top_view
 go
 DROP TABLE babel_update_tbl1
 DROP TABLE babel_update_tbl2
@@ -518,7 +518,7 @@ INSERT INTO babel_delete_tbl2 VALUES (10, 'inner'), (30, 'right');
 INSERT INTO babel_delete_tbl3 VALUES (1, 10), (3, 10);
 go
 
-CREATE VIEW babel_delete_view AS SELECT * FROM babel_delete_tbl1 WHERE babel_delete_tbl1.a > 1;
+CREATE VIEW babel_delete_top_view AS SELECT * FROM babel_delete_tbl1 WHERE babel_delete_tbl1.a > 1;
 go
 CREATE SCHEMA babel_delete_schema
 go
@@ -609,7 +609,7 @@ go
 BEGIN TRAN
 INSERT INTO babel_delete_tbl1 VALUES (3, 'extra')
 DELETE top(1) v1
-FROM babel_delete_view v1
+FROM babel_delete_top_view v1
 WHERE a = 2
 ROLLBACK
 go
@@ -638,7 +638,7 @@ FROM babel_delete_tbl2 AS babel_delete_tbl1
 GO
 
 
-DROP VIEW babel_delete_view
+DROP VIEW babel_delete_top_view
 go
 DROP TABLE babel_delete_tbl1
 DROP TABLE babel_delete_tbl2


### PR DESCRIPTION
### Description

Previously in Babelfish a statement of the form "insert into t2 seelect top(2) a from t1 order by 1" would give a syntax error, while it is allowed in T-SQL.

This syntax allows users to limit the number of rows that are inserted. Unlike the similar INSERT TOP syntax, users may specify the order making the rows inserted deterministic.

### Issues Resolved

Task: BABEL-2551, BABEL-3312, BABEL-2637

### Test Scenarios Covered ###
* **Use case based -**
Tests based on examples in JIRAs and checks all of modified parser rules

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).