### PR TITLE
support '[' and ']' wildcharacter for Like operater

### DIFF
--- a/test/JDBC/expected/BABEL-SP_COLUMN_PRIVILEGES.out
+++ b/test/JDBC/expected/BABEL-SP_COLUMN_PRIVILEGES.out
@@ -263,11 +263,18 @@ db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
 EXEC sp_column_privileges @table_name = 't4', @table_owner = 'dbo', @COLUMN_NAME='t[ea]stcolumn'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#UPDATE#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -275,6 +282,10 @@ EXEC sp_column_privileges @table_name = 't4', @table_owner = 'dbo', @COLUMN_NAME
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -282,6 +293,14 @@ EXEC sp_column_privileges @table_name = 't4', @table_owner = 'dbo', @COLUMN_NAME
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#t4#!#tastcolumn#!#dbo#!#dbo#!#UPDATE#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#t4#!#testcolumn#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_STORED_PROCEDURES-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_STORED_PROCEDURES-vu-verify.out
@@ -125,6 +125,8 @@ EXEC sp_stored_procedures @sp_name='babel_sp_stored_procedures_vu_prepare_sel[eu
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#int#!#int#!#int#!#varchar#!#smallint
+babel_sp_stored_procedures_vu_prepare_db1#!#dbo#!#babel_sp_stored_procedures_vu_prepare_select_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
+babel_sp_stored_procedures_vu_prepare_db1#!#dbo#!#babel_sp_stored_procedures_vu_prepare_seluct_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
 ~~END~~
 
 
@@ -132,6 +134,7 @@ EXEC sp_stored_procedures @sp_name='babel_sp_stored_procedures_vu_prepare_sel[^u
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#int#!#int#!#int#!#varchar#!#smallint
+babel_sp_stored_procedures_vu_prepare_db1#!#dbo#!#babel_sp_stored_procedures_vu_prepare_select_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
 ~~END~~
 
 
@@ -139,5 +142,7 @@ EXEC sp_stored_procedures @sp_name='babel_sp_stored_procedures_vu_prepare_sel[a-
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#int#!#int#!#int#!#varchar#!#smallint
+babel_sp_stored_procedures_vu_prepare_db1#!#dbo#!#babel_sp_stored_procedures_vu_prepare_select_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
+babel_sp_stored_procedures_vu_prepare_db1#!#dbo#!#babel_sp_stored_procedures_vu_prepare_seluct_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-SP_STORED_PROCEDURES.out
+++ b/test/JDBC/expected/BABEL-SP_STORED_PROCEDURES.out
@@ -176,6 +176,8 @@ EXEC sp_stored_procedures @sp_name='sel[eu]ct_all'
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#int#!#int#!#int#!#varchar#!#smallint
+db1#!#dbo#!#select_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
+db1#!#dbo#!#seluct_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
 ~~END~~
 
 
@@ -183,6 +185,7 @@ EXEC sp_stored_procedures @sp_name='sel[^u]ct_all'
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#int#!#int#!#int#!#varchar#!#smallint
+db1#!#dbo#!#select_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
 ~~END~~
 
 
@@ -190,6 +193,8 @@ EXEC sp_stored_procedures @sp_name='sel[a-u]ct_all'
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#int#!#int#!#int#!#varchar#!#smallint
+db1#!#dbo#!#select_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
+db1#!#dbo#!#seluct_all;1#!#-1#!#-1#!#-1#!#<NULL>#!#2
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_TABLE_PRIVILEGES.out
+++ b/test/JDBC/expected/BABEL-SP_TABLE_PRIVILEGES.out
@@ -243,6 +243,16 @@ exec sp_table_privileges @table_name = 'fo[ol]bar1'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#DELETE#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#UPDATE#!#YES
+db1#!#dbo#!#foobar1#!#dbo#!#dbo#!#DELETE#!#YES
+db1#!#dbo#!#foobar1#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#foobar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#foobar1#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#foobar1#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -250,6 +260,11 @@ exec sp_table_privileges @table_name = 'fo[^o]bar1'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#DELETE#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -257,6 +272,11 @@ exec sp_table_privileges @table_name = 'fo[a-l]bar1'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#DELETE#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#INSERT#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#SELECT#!#YES
+db1#!#dbo#!#folbar1#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_TABLE_PRIVILIGES-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_TABLE_PRIVILIGES-vu-verify.out
@@ -223,6 +223,16 @@ exec sp_table_privileges @table_name = 'babel_sp_table_priviliges_vu_prepare_fo[
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#DELETE#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#INSERT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#SELECT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#UPDATE#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_foobar1#!#dbo#!#dbo#!#DELETE#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_foobar1#!#dbo#!#dbo#!#INSERT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_foobar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_foobar1#!#dbo#!#dbo#!#SELECT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_foobar1#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -230,6 +240,11 @@ exec sp_table_privileges @table_name = 'babel_sp_table_priviliges_vu_prepare_fo[
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#DELETE#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#INSERT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#SELECT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 
@@ -237,6 +252,11 @@ exec sp_table_privileges @table_name = 'babel_sp_table_priviliges_vu_prepare_fo[
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#DELETE#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#INSERT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#REFERENCES#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#SELECT#!#YES
+babel_sp_table_priviliges_vu_prepare_db1#!#dbo#!#babel_sp_table_priviliges_vu_prepare_folbar1#!#dbo#!#dbo#!#UPDATE#!#YES
 ~~END~~
 
 

--- a/test/JDBC/expected/like_expression.out
+++ b/test/JDBC/expected/like_expression.out
@@ -1,9 +1,35 @@
 create table t ( a varchar(30))
 GO
 
-insert into t values ('abc'),('bbc'),('cbc')
+insert into t values ('abc'),('bbc'),('cbc'),('=bc'),('Abc');
 GO
-~~ROW COUNT: 3~~
+~~ROW COUNT: 5~~
+
+
+select * from t where a like '[c-a]bc'
+GO
+~~START~~
+varchar
+cbc
+~~END~~
+
+
+select * from t where a like '[<->]bc'
+GO
+~~START~~
+varchar
+=bc
+~~END~~
+
+
+select * from t where a like '[0-a]bc';
+GO
+~~START~~
+varchar
+abc
+=bc
+Abc
+~~END~~
 
 
 select * from t where a like '[abc]bc';
@@ -13,6 +39,7 @@ varchar
 abc
 bbc
 cbc
+Abc
 ~~END~~
 
 
@@ -23,6 +50,7 @@ varchar
 abc
 bbc
 cbc
+Abc
 ~~END~~
 
 
@@ -33,6 +61,7 @@ varchar
 abc
 bbc
 cbc
+Abc
 ~~END~~
 
 
@@ -41,6 +70,7 @@ GO
 ~~START~~
 varchar
 abc
+Abc
 ~~END~~
 
 
@@ -51,6 +81,8 @@ varchar
 abc
 bbc
 cbc
+=bc
+Abc
 ~~END~~
 
 
@@ -73,6 +105,7 @@ GO
 ~~START~~
 varchar
 abc
+Abc
 ~~END~~
 
 
@@ -83,6 +116,7 @@ varchar
 abc
 bbc
 cbc
+Abc
 ~~END~~
 
 
@@ -92,6 +126,7 @@ GO
 varchar
 bbc
 cbc
+=bc
 ~~END~~
 
 
@@ -100,6 +135,7 @@ GO
 ~~START~~
 varchar
 cbc
+=bc
 ~~END~~
 
 
@@ -110,6 +146,7 @@ varchar
 abc
 bbc
 cbc
+Abc
 ~~END~~
 
 
@@ -154,9 +191,9 @@ varchar
 create table t2 ( b varchar(30) collate BBF_Unicode_General_CS_AS)
 GO
 
-insert into t2 values ('[abc]bc'),('[abc]_c'),('[]]bc'),('[[]bc'),('%[abc]c'),('[^ a-b][a-z]c'),('[0-9][0-9].[0-9][0-9]')
+insert into t2 values ('[abc]bc'),('[abc]_c'),('[]]bc'),('[[]bc'),('%[abc]c'),('[^ a-b][a-z]c'),('[0-9][0-9].[0-9][0-9]'),('[<->]bc')
 GO
-~~ROW COUNT: 7~~
+~~ROW COUNT: 8~~
 
 
 select * from t2 join t on a like b;
@@ -173,12 +210,17 @@ varchar#!#varchar
 %[abc]c#!#abc
 %[abc]c#!#bbc
 %[abc]c#!#cbc
+%[abc]c#!#=bc
+%[abc]c#!#Abc
 %[abc]c#!#]bc
 %[abc]c#!#[bc
 [^ a-b][a-z]c#!#cbc
+[^ a-b][a-z]c#!#=bc
+[^ a-b][a-z]c#!#Abc
 [^ a-b][a-z]c#!#]bc
 [^ a-b][a-z]c#!#[bc
 [0-9][0-9].[0-9][0-9]#!#11.22
+[<->]bc#!#=bc
 ~~END~~
 
 

--- a/test/JDBC/expected/like_expression.out
+++ b/test/JDBC/expected/like_expression.out
@@ -1,0 +1,189 @@
+create table t ( a varchar(30))
+GO
+
+insert into t values ('abc'),('bbc'),('cbc')
+GO
+~~ROW COUNT: 3~~
+
+
+select * from t where a like '[abc]bc';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+~~END~~
+
+
+select * from t where a like '[a-c]bc';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+~~END~~
+
+
+select * from t where a like '[abc]_c';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+~~END~~
+
+
+select * from t where a like '[a]%c';
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+select * from t where a like '%[abc]c';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+~~END~~
+
+
+select * from t where a like '[%]bc';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+select * from t where a like '[_]bc';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+select * from t where a like 'a[bc]c';
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+select * from t where a like '[a-z][a-z]c';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+~~END~~
+
+
+select * from t where a like '[^ a][a-z]c';
+GO
+~~START~~
+varchar
+bbc
+cbc
+~~END~~
+
+
+select * from t where a like '[^ a-b][a-z]c';
+GO
+~~START~~
+varchar
+cbc
+~~END~~
+
+
+select * from t where a like '[0-9a-f][0-9a-f][0-9a-f]';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+~~END~~
+
+
+insert into t values (']bc')
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t values ('[bc')
+GO
+~~ROW COUNT: 1~~
+
+
+select * from t where a like ('[]]bc');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+select * from t where a like ('[[]bc');
+GO
+~~START~~
+varchar
+[bc
+~~END~~
+
+
+insert into t values ('11.22');
+GO
+~~ROW COUNT: 1~~
+
+
+select * from t where a like '[0-9][0-9].[0-9][0-9]'
+GO
+~~START~~
+varchar
+11.22
+~~END~~
+
+
+create table t2 ( b varchar(30) collate BBF_Unicode_General_CS_AS)
+GO
+
+insert into t2 values ('[abc]bc'),('[abc]_c'),('[]]bc'),('[[]bc'),('%[abc]c'),('[^ a-b][a-z]c'),('[0-9][0-9].[0-9][0-9]')
+GO
+~~ROW COUNT: 7~~
+
+
+select * from t2 join t on a like b;
+GO
+~~START~~
+varchar#!#varchar
+[abc]bc#!#abc
+[abc]bc#!#bbc
+[abc]bc#!#cbc
+[abc]_c#!#abc
+[abc]_c#!#bbc
+[abc]_c#!#cbc
+[[]bc#!#[bc
+%[abc]c#!#abc
+%[abc]c#!#bbc
+%[abc]c#!#cbc
+%[abc]c#!#]bc
+%[abc]c#!#[bc
+[^ a-b][a-z]c#!#cbc
+[^ a-b][a-z]c#!#]bc
+[^ a-b][a-z]c#!#[bc
+[0-9][0-9].[0-9][0-9]#!#11.22
+~~END~~
+
+
+drop table t2;
+GO
+
+drop table t;
+GO

--- a/test/JDBC/expected/like_expression.out
+++ b/test/JDBC/expected/like_expression.out
@@ -1,9 +1,9 @@
 create table t ( a varchar(30))
 GO
 
-insert into t values ('abc'),('bbc'),('cbc'),('=bc'),('Abc');
+insert into t values ('abc'),('bbc'),('cbc'),('=bc'),('Abc'),('a[bc'),('a]bc');
 GO
-~~ROW COUNT: 5~~
+~~ROW COUNT: 7~~
 
 
 select * from t where a like '[c-a]bc'
@@ -71,6 +71,8 @@ GO
 varchar
 abc
 Abc
+a[bc
+a]bc
 ~~END~~
 
 
@@ -83,6 +85,8 @@ bbc
 cbc
 =bc
 Abc
+a[bc
+a]bc
 ~~END~~
 
 
@@ -139,6 +143,20 @@ cbc
 ~~END~~
 
 
+select * from t where a like '%bc';
+GO
+~~START~~
+varchar
+abc
+bbc
+cbc
+=bc
+Abc
+a[bc
+a]bc
+~~END~~
+
+
 select * from t where a like '[0-9a-f][0-9a-f][0-9a-f]';
 GO
 ~~START~~
@@ -172,6 +190,14 @@ GO
 ~~START~~
 varchar
 [bc
+~~END~~
+
+
+select * from t where a like ']bc';
+GO
+~~START~~
+varchar
+]bc
 ~~END~~
 
 
@@ -212,6 +238,8 @@ varchar#!#varchar
 %[abc]c#!#cbc
 %[abc]c#!#=bc
 %[abc]c#!#Abc
+%[abc]c#!#a[bc
+%[abc]c#!#a]bc
 %[abc]c#!#]bc
 %[abc]c#!#[bc
 [^ a-b][a-z]c#!#cbc

--- a/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
+++ b/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
@@ -108,7 +108,6 @@ GO
 EXEC sp_column_privileges @table_name = 't4', @table_owner = 'dbo', @COLUMN_NAME='t_stcolumn'
 GO
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
 EXEC sp_column_privileges @table_name = 't4', @table_owner = 'dbo', @COLUMN_NAME='t[ea]stcolumn'
 GO
 

--- a/test/JDBC/input/like_expression.sql
+++ b/test/JDBC/input/like_expression.sql
@@ -1,0 +1,74 @@
+create table t ( a varchar(30))
+GO
+
+insert into t values ('abc'),('bbc'),('cbc')
+GO
+
+select * from t where a like '[abc]bc';
+GO
+
+select * from t where a like '[a-c]bc';
+GO
+
+select * from t where a like '[abc]_c';
+GO
+
+select * from t where a like '[a]%c';
+GO
+
+select * from t where a like '%[abc]c';
+GO
+
+select * from t where a like '[%]bc';
+GO
+
+select * from t where a like '[_]bc';
+GO
+
+select * from t where a like 'a[bc]c';
+GO
+
+select * from t where a like '[a-z][a-z]c';
+GO
+
+select * from t where a like '[^ a][a-z]c';
+GO
+
+select * from t where a like '[^ a-b][a-z]c';
+GO
+
+select * from t where a like '[0-9a-f][0-9a-f][0-9a-f]';
+GO
+
+insert into t values (']bc')
+GO
+
+insert into t values ('[bc')
+GO
+
+select * from t where a like ('[]]bc');
+GO
+
+select * from t where a like ('[[]bc');
+GO
+
+insert into t values ('11.22');
+GO
+
+select * from t where a like '[0-9][0-9].[0-9][0-9]'
+GO
+
+create table t2 ( b varchar(30) collate BBF_Unicode_General_CS_AS)
+GO
+
+insert into t2 values ('[abc]bc'),('[abc]_c'),('[]]bc'),('[[]bc'),('%[abc]c'),('[^ a-b][a-z]c'),('[0-9][0-9].[0-9][0-9]')
+GO
+
+select * from t2 join t on a like b;
+GO
+
+drop table t2;
+GO
+
+drop table t;
+GO

--- a/test/JDBC/input/like_expression.sql
+++ b/test/JDBC/input/like_expression.sql
@@ -1,7 +1,16 @@
 create table t ( a varchar(30))
 GO
 
-insert into t values ('abc'),('bbc'),('cbc')
+insert into t values ('abc'),('bbc'),('cbc'),('=bc'),('Abc');
+GO
+
+select * from t where a like '[c-a]bc'
+GO
+
+select * from t where a like '[<->]bc'
+GO
+
+select * from t where a like '[0-a]bc';
 GO
 
 select * from t where a like '[abc]bc';
@@ -61,7 +70,7 @@ GO
 create table t2 ( b varchar(30) collate BBF_Unicode_General_CS_AS)
 GO
 
-insert into t2 values ('[abc]bc'),('[abc]_c'),('[]]bc'),('[[]bc'),('%[abc]c'),('[^ a-b][a-z]c'),('[0-9][0-9].[0-9][0-9]')
+insert into t2 values ('[abc]bc'),('[abc]_c'),('[]]bc'),('[[]bc'),('%[abc]c'),('[^ a-b][a-z]c'),('[0-9][0-9].[0-9][0-9]'),('[<->]bc')
 GO
 
 select * from t2 join t on a like b;

--- a/test/JDBC/input/like_expression.sql
+++ b/test/JDBC/input/like_expression.sql
@@ -1,7 +1,7 @@
 create table t ( a varchar(30))
 GO
 
-insert into t values ('abc'),('bbc'),('cbc'),('=bc'),('Abc');
+insert into t values ('abc'),('bbc'),('cbc'),('=bc'),('Abc'),('a[bc'),('a]bc');
 GO
 
 select * from t where a like '[c-a]bc'
@@ -46,6 +46,9 @@ GO
 select * from t where a like '[^ a-b][a-z]c';
 GO
 
+select * from t where a like '%bc';
+GO
+
 select * from t where a like '[0-9a-f][0-9a-f][0-9a-f]';
 GO
 
@@ -59,6 +62,9 @@ select * from t where a like ('[]]bc');
 GO
 
 select * from t where a like ('[[]bc');
+GO
+
+select * from t where a like ']bc';
 GO
 
 insert into t values ('11.22');

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,8 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+babel_like
+like_expression
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,8 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-babel_like
-like_expression
+all
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 


### PR DESCRIPTION

Previously Babelfish didn't support '[' and ']' for like operator. This commit support this feature by changing the like execution. Add support to deal with '[' and ']' when it appears in pattern.

### Description

We have followed the document of : https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/language-elements/like-transact-sql.md to add the implement of '[' and ']' into like expression, like expression only works when it's tsql_dialect.
 
### Issues Resolved

Solved the issue customer complain about when they use '[' and ']' in like expression, they'll got un supported error msg

postgres change : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/132

### Test Scenarios Covered ###

- added like_expression test cases, covers all the test mentioned from sql server document
- validated the sp_x like expression test cases

### Check List
- [ x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).