### PR TITLE
Support numeric representation for DATENAME() and DATEPART() function

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1235,36 +1235,40 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
+    datapart_date DATETIME;
 BEGIN
     IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
     'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
-        arg = CAST(arg AS sys.DATETIME);
+        datapart_date = CAST(arg AS sys.DATETIME);
+    ELSE
+        datapart_date = arg;
+    END IF;
 	CASE datepart
 	WHEN 'dow' THEN
-		result = (date_part(datepart, arg)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
+		result = (date_part(datepart, datapart_date)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
 	WHEN 'tsql_week' THEN
-		first_day = make_date(date_part('year', arg)::INTEGER, 1, 1);
+		first_day = make_date(date_part('year', datapart_date)::INTEGER, 1, 1);
 		first_week_end = 8 - sys.datepart_internal('dow', first_day)::INTEGER;
-		day = date_part('doy', arg)::INTEGER;
+		day = date_part('doy', datapart_date)::INTEGER;
 		IF day <= first_week_end THEN
 			result = 1;
 		ELSE
 			result = 2 + (day - first_week_end - 1) / 7;
 		END IF;
 	WHEN 'second' THEN
-		result = TRUNC(date_part(datepart, arg))::INTEGER;
+		result = TRUNC(date_part(datepart, datapart_date))::INTEGER;
 	WHEN 'millisecond' THEN
-		result = right(date_part(datepart, arg)::TEXT, 3)::INTEGER;
+		result = right(date_part(datepart, datapart_date)::TEXT, 3)::INTEGER;
 	WHEN 'microsecond' THEN
-		result = right(date_part(datepart, arg)::TEXT, 6)::INTEGER;
+		result = right(date_part(datepart, datapart_date)::TEXT, 6)::INTEGER;
 	WHEN 'nanosecond' THEN
 		-- Best we can do - Postgres does not support nanosecond precision
-		result = right(date_part('microsecond', arg)::TEXT, 6)::INTEGER * 1000;
+		result = right(date_part('microsecond', datapart_date)::TEXT, 6)::INTEGER * 1000;
 	WHEN 'tzoffset' THEN
 		-- timezone for datetimeoffset
 		result = df_tz;
 	ELSE
-		result = date_part(datepart, arg)::INTEGER;
+		result = date_part(datepart, datapart_date)::INTEGER;
 	END CASE;
 	RETURN result;
 EXCEPTION WHEN invalid_parameter_value or feature_not_supported THEN

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1723,10 +1723,10 @@ $BODY$
 SELECT
     CASE
     WHEN dp = 'month'::text THEN
-        to_char(arg::datetime, 'TMMonth')
+        to_char(arg::sys.DATETIME;, 'TMMonth')
     -- '1969-12-28' is a Sunday
     WHEN dp = 'dow'::text THEN
-        to_char(arg::datetime, 'TMDay')
+        to_char(arg::sys.DATETIME;, 'TMDay')
     ELSE
         sys.datepart(dp, arg)::TEXT
     END 

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1235,7 +1235,7 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-    datapart_date DATETIME;
+    datapart_date sys.DATETIME;
 BEGIN
     IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
      'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1723,10 +1723,10 @@ $BODY$
 SELECT
     CASE
     WHEN dp = 'month'::text THEN
-        to_char(arg::sys.DATETIME;, 'TMMonth')
+        to_char(arg::sys.DATETIME, 'TMMonth')
     -- '1969-12-28' is a Sunday
     WHEN dp = 'dow'::text THEN
-        to_char(arg::sys.DATETIME;, 'TMDay')
+        to_char(arg::sys.DATETIME, 'TMDay')
     ELSE
         sys.datepart(dp, arg)::TEXT
     END 

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1235,7 +1235,7 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-    datapart_date DATE;
+    datapart_date DATETIME;
 BEGIN
     IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
      'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1193,7 +1193,7 @@ CREATE OR REPLACE FUNCTION sys.dateadd_numeric_representation_helper(IN datepart
 DECLARE
     digit_to_startdate DATETIME;
 BEGIN
-    IF pg_typeof(startdate) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
+    IF pg_typeof(startdate) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,
     'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
         digit_to_startdate := CAST('1900-01-01 00:00:00.0' AS sys.DATETIME) + CAST(startdate as sys.DATETIME);
     END IF;
@@ -1235,40 +1235,63 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-    datapart_date DATETIME;
+    datapart_date DATE;
 BEGIN
-    IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
-    'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
+    IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
+     'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
         datapart_date = CAST(arg AS sys.DATETIME);
-    ELSE
-        datapart_date = arg;
+        CASE datepart
+        WHEN 'dow' THEN
+            result = (date_part(datepart, datapart_date)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
+        WHEN 'tsql_week' THEN
+            first_day = make_date(date_part('year', datapart_date)::INTEGER, 1, 1);
+            first_week_end = 8 - sys.datepart_internal('dow', first_day)::INTEGER;
+            day = date_part('doy', datapart_date)::INTEGER;
+            IF day <= first_week_end THEN
+                result = 1;
+            ELSE
+                result = 2 + (day - first_week_end - 1) / 7;
+            END IF;
+        WHEN 'second' THEN
+            result = TRUNC(date_part(datepart, datapart_date))::INTEGER;
+        WHEN 'millisecond' THEN
+            result = right(date_part(datepart, datapart_date)::TEXT, 3)::INTEGER;
+        WHEN 'microsecond' THEN
+            result = right(date_part(datepart, datapart_date)::TEXT, 6)::INTEGER;
+        WHEN 'nanosecond' THEN
+            -- Best we can do - Postgres does not support nanosecond precision
+            result = right(date_part('microsecond', datapart_date)::TEXT, 6)::INTEGER * 1000;
+        ELSE
+            result = date_part(datepart, datapart_date)::INTEGER;
+        END CASE;
+        RETURN result;
     END IF;
 	CASE datepart
 	WHEN 'dow' THEN
-		result = (date_part(datepart, datapart_date)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
+		result = (date_part(datepart, arg)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
 	WHEN 'tsql_week' THEN
-		first_day = make_date(date_part('year', datapart_date)::INTEGER, 1, 1);
+		first_day = make_date(date_part('year', arg)::INTEGER, 1, 1);
 		first_week_end = 8 - sys.datepart_internal('dow', first_day)::INTEGER;
-		day = date_part('doy', datapart_date)::INTEGER;
+		day = date_part('doy', arg)::INTEGER;
 		IF day <= first_week_end THEN
 			result = 1;
 		ELSE
 			result = 2 + (day - first_week_end - 1) / 7;
 		END IF;
 	WHEN 'second' THEN
-		result = TRUNC(date_part(datepart, datapart_date))::INTEGER;
+		result = TRUNC(date_part(datepart, arg))::INTEGER;
 	WHEN 'millisecond' THEN
-		result = right(date_part(datepart, datapart_date)::TEXT, 3)::INTEGER;
+		result = right(date_part(datepart, arg)::TEXT, 3)::INTEGER;
 	WHEN 'microsecond' THEN
-		result = right(date_part(datepart, datapart_date)::TEXT, 6)::INTEGER;
+		result = right(date_part(datepart, arg)::TEXT, 6)::INTEGER;
 	WHEN 'nanosecond' THEN
 		-- Best we can do - Postgres does not support nanosecond precision
-		result = right(date_part('microsecond', datapart_date)::TEXT, 6)::INTEGER * 1000;
+		result = right(date_part('microsecond', arg)::TEXT, 6)::INTEGER * 1000;
 	WHEN 'tzoffset' THEN
 		-- timezone for datetimeoffset
 		result = df_tz;
 	ELSE
-		result = date_part(datepart, datapart_date)::INTEGER;
+		result = date_part(datepart, arg)::INTEGER;
 	END CASE;
 	RETURN result;
 EXCEPTION WHEN invalid_parameter_value or feature_not_supported THEN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -124,10 +124,10 @@ $BODY$
 SELECT
     CASE
     WHEN dp = 'month'::text THEN
-        to_char(arg::datetime, 'TMMonth')
+        to_char(arg::sys.DATETIME, 'TMMonth')
     -- '1969-12-28' is a Sunday
     WHEN dp = 'dow'::text THEN
-        to_char(arg::datetime, 'TMDay')
+        to_char(arg::sys.DATETIME, 'TMDay')
     ELSE
         sys.datepart(dp, arg)::TEXT
     END 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -125,7 +125,7 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-    datapart_date DATETIME;
+	datapart_date sys.DATETIME;
 BEGIN
     IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
      'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -125,7 +125,7 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-    datapart_date DATE;
+    datapart_date DATETIME;
 BEGIN
     IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
      'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -125,40 +125,63 @@ DECLARE
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-    datapart_date DATETIME;
+    datapart_date DATE;
 BEGIN
-    IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
-    'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
+    IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
+     'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
         datapart_date = CAST(arg AS sys.DATETIME);
-    ELSE
-        datapart_date = arg;
+        CASE datepart
+        WHEN 'dow' THEN
+            result = (date_part(datepart, datapart_date)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
+        WHEN 'tsql_week' THEN
+            first_day = make_date(date_part('year', datapart_date)::INTEGER, 1, 1);
+            first_week_end = 8 - sys.datepart_internal('dow', first_day)::INTEGER;
+            day = date_part('doy', datapart_date)::INTEGER;
+            IF day <= first_week_end THEN
+                result = 1;
+            ELSE
+                result = 2 + (day - first_week_end - 1) / 7;
+            END IF;
+        WHEN 'second' THEN
+            result = TRUNC(date_part(datepart, datapart_date))::INTEGER;
+        WHEN 'millisecond' THEN
+            result = right(date_part(datepart, datapart_date)::TEXT, 3)::INTEGER;
+        WHEN 'microsecond' THEN
+            result = right(date_part(datepart, datapart_date)::TEXT, 6)::INTEGER;
+        WHEN 'nanosecond' THEN
+            -- Best we can do - Postgres does not support nanosecond precision
+            result = right(date_part('microsecond', datapart_date)::TEXT, 6)::INTEGER * 1000;
+        ELSE
+            result = date_part(datepart, datapart_date)::INTEGER;
+        END CASE;
+        RETURN result;
     END IF;
 	CASE datepart
 	WHEN 'dow' THEN
-		result = (date_part(datepart, datapart_date)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
+		result = (date_part(datepart, arg)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
 	WHEN 'tsql_week' THEN
-		first_day = make_date(date_part('year', datapart_date)::INTEGER, 1, 1);
+		first_day = make_date(date_part('year', arg)::INTEGER, 1, 1);
 		first_week_end = 8 - sys.datepart_internal('dow', first_day)::INTEGER;
-		day = date_part('doy', datapart_date)::INTEGER;
+		day = date_part('doy', arg)::INTEGER;
 		IF day <= first_week_end THEN
 			result = 1;
 		ELSE
 			result = 2 + (day - first_week_end - 1) / 7;
 		END IF;
 	WHEN 'second' THEN
-		result = TRUNC(date_part(datepart, datapart_date))::INTEGER;
+		result = TRUNC(date_part(datepart, arg))::INTEGER;
 	WHEN 'millisecond' THEN
-		result = right(date_part(datepart, datapart_date)::TEXT, 3)::INTEGER;
+		result = right(date_part(datepart, arg)::TEXT, 3)::INTEGER;
 	WHEN 'microsecond' THEN
-		result = right(date_part(datepart, datapart_date)::TEXT, 6)::INTEGER;
+		result = right(date_part(datepart, arg)::TEXT, 6)::INTEGER;
 	WHEN 'nanosecond' THEN
 		-- Best we can do - Postgres does not support nanosecond precision
-		result = right(date_part('microsecond', datapart_date)::TEXT, 6)::INTEGER * 1000;
+		result = right(date_part('microsecond', arg)::TEXT, 6)::INTEGER * 1000;
 	WHEN 'tzoffset' THEN
 		-- timezone for datetimeoffset
 		result = df_tz;
 	ELSE
-		result = date_part(datepart, datapart_date)::INTEGER;
+		result = date_part(datepart, arg)::INTEGER;
 	END CASE;
 	RETURN result;
 EXCEPTION WHEN invalid_parameter_value or feature_not_supported THEN
@@ -240,7 +263,7 @@ CREATE OR REPLACE FUNCTION sys.dateadd_numeric_representation_helper(IN datepart
 DECLARE
     digit_to_startdate DATETIME;
 BEGIN
-    IF pg_typeof(startdate) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
+    IF pg_typeof(startdate) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,
     'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
         digit_to_startdate := CAST('1900-01-01 00:00:00.0' AS sys.DATETIME) + CAST(startdate as sys.DATETIME);
     END IF;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -119,11 +119,87 @@ SELECT
 FROM sys.babelfish_syslanguages;
 GRANT SELECT ON sys.syslanguages TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.datepart_internal(IN datepart PG_CATALOG.TEXT, IN arg anyelement,IN df_tz INTEGER DEFAULT 0) RETURNS INTEGER AS $$
+DECLARE
+	result INTEGER;
+	first_day DATE;
+	first_week_end INTEGER;
+	day INTEGER;
+BEGIN
+    IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
+    'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN
+        arg = CAST(arg AS sys.DATETIME);
+	CASE datepart
+	WHEN 'dow' THEN
+		result = (date_part(datepart, arg)::INTEGER - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1;
+	WHEN 'tsql_week' THEN
+		first_day = make_date(date_part('year', arg)::INTEGER, 1, 1);
+		first_week_end = 8 - sys.datepart_internal('dow', first_day)::INTEGER;
+		day = date_part('doy', arg)::INTEGER;
+		IF day <= first_week_end THEN
+			result = 1;
+		ELSE
+			result = 2 + (day - first_week_end - 1) / 7;
+		END IF;
+	WHEN 'second' THEN
+		result = TRUNC(date_part(datepart, arg))::INTEGER;
+	WHEN 'millisecond' THEN
+		result = right(date_part(datepart, arg)::TEXT, 3)::INTEGER;
+	WHEN 'microsecond' THEN
+		result = right(date_part(datepart, arg)::TEXT, 6)::INTEGER;
+	WHEN 'nanosecond' THEN
+		-- Best we can do - Postgres does not support nanosecond precision
+		result = right(date_part('microsecond', arg)::TEXT, 6)::INTEGER * 1000;
+	WHEN 'tzoffset' THEN
+		-- timezone for datetimeoffset
+		result = df_tz;
+	ELSE
+		result = date_part(datepart, arg)::INTEGER;
+	END CASE;
+	RETURN result;
+EXCEPTION WHEN invalid_parameter_value or feature_not_supported THEN
+    -- date_part() throws an exception when trying to get day/month/year etc. from
+	-- TIME, so we just need to catch the exception in this case
+	-- date_part() returns 0 when trying to get hour/minute/second etc. from
+	-- DATE, which is the desirable behavior for datepart() as well.
+    -- If the date argument data type does not have the specified datepart,
+    -- date_part() will return the default value for that datepart.
+    CASE datepart
+	-- Case for datepart is year, yy and yyyy, all mappings are defined in gram.y.
+    WHEN 'year' THEN RETURN 1900;
+    -- Case for datepart is quater, qq and q
+    WHEN 'quarter' THEN RETURN 1;
+    -- Case for datepart is month, mm and m
+    WHEN 'month' THEN RETURN 1;
+    -- Case for datepart is day, dd and d
+    WHEN 'day' THEN RETURN 1;
+    -- Case for datepart is dayofyear, dy
+    WHEN 'doy' THEN RETURN 1;
+    -- Case for datepart is y(also refers to dayofyear)
+    WHEN 'y' THEN RETURN 1;
+    -- Case for datepart is week, wk and ww
+    WHEN 'tsql_week' THEN RETURN 1;
+    -- Case for datepart is iso_week, isowk and isoww
+    WHEN 'week' THEN RETURN 1;
+    -- Case for datepart is tzoffset and tz
+    WHEN 'tzoffset' THEN RETURN 0;
+    -- Case for datepart is weekday and dw, return dow according to datefirst
+    WHEN 'dow' THEN
+        RETURN (1 - current_setting('babelfishpg_tsql.datefirst')::INTEGER + 7) % 7 + 1 ;
+	ELSE
+        RAISE EXCEPTION '''%'' is not a recognized datepart option', datepart;
+        RETURN -1;
+	END CASE;
+END;
+$$
+STRICT
+LANGUAGE plpgsql IMMUTABLE;
+
 CREATE OR REPLACE FUNCTION sys.dateadd(IN datepart PG_CATALOG.TEXT, IN num INTEGER, IN startdate sys.bit) RETURNS DATETIME
 AS
 $body$
 BEGIN
-        RAISE EXCEPTION 'Argument data type bit is invalid for argument 2 of dateadd function.';
+        return sys.dateadd_numeric_representation_helper(datepart, num, startdate);
 END;
 $body$
 LANGUAGE plpgsql IMMUTABLE;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -119,13 +119,29 @@ SELECT
 FROM sys.babelfish_syslanguages;
 GRANT SELECT ON sys.syslanguages TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.datename(IN dp PG_CATALOG.TEXT, IN arg anyelement) RETURNS TEXT AS 
+$BODY$
+SELECT
+    CASE
+    WHEN dp = 'month'::text THEN
+        to_char(arg::datetime, 'TMMonth')
+    -- '1969-12-28' is a Sunday
+    WHEN dp = 'dow'::text THEN
+        to_char(arg::datetime, 'TMDay')
+    ELSE
+        sys.datepart(dp, arg)::TEXT
+    END 
+$BODY$
+STRICT
+LANGUAGE sql IMMUTABLE;
+
 CREATE OR REPLACE FUNCTION sys.datepart_internal(IN datepart PG_CATALOG.TEXT, IN arg anyelement,IN df_tz INTEGER DEFAULT 0) RETURNS INTEGER AS $$
 DECLARE
 	result INTEGER;
 	first_day DATE;
 	first_week_end INTEGER;
 	day INTEGER;
-	datapart_date sys.DATETIME;
+    datapart_date sys.DATETIME;
 BEGIN
     IF pg_typeof(arg) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
      'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype) THEN

--- a/test/JDBC/expected/TestDatetime-numeric-dateaddfunction-vu-prepare.out
+++ b/test/JDBC/expected/TestDatetime-numeric-dateaddfunction-vu-prepare.out
@@ -111,28 +111,341 @@ smalldatetime
 ~~ERROR (Message: data out of range for smalldatetime)~~
 
 
+-- Should all fail
+SELECT CONVERT(DATETIME2, CAST(-2.5 as DECIMAL))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type "decimal" to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as NUMERIC(30,8)))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type numeric to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as FLOAT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type double precision to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as REAL))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type real to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as INT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type integer to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as BIGINT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type bigint to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as SMALLINT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallint to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as MONEY))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type money to datetime2)~~
+
+SELECT CONVERT(DATETIME2, CAST(-2.5 as SMALLMONEY))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallmoney to datetime2)~~
+
+
+-- Should all fail
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as DECIMAL))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type "decimal" to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as NUMERIC(30,8)))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type numeric to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as FLOAT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type double precision to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as REAL))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type real to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as INT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type integer to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as BIGINT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type bigint to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as SMALLINT))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallint to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as MONEY))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type money to datetimeoffset)~~
+
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as SMALLMONEY))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallmoney to datetimeoffset)~~
+
+
+-- Should all fail
+SELECT CONVERT(DATE, CAST(-2.5 as DECIMAL))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type "decimal" to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as NUMERIC(30,8)))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type numeric to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as FLOAT))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type double precision to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as REAL))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type real to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as INT))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type integer to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as BIGINT))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type bigint to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as SMALLINT))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallint to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as MONEY))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type money to date)~~
+
+SELECT CONVERT(DATE, CAST(-2.5 as SMALLMONEY))
+GO
+~~START~~
+date
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallmoney to date)~~
+
+
+-- Should all fail
+SELECT CONVERT(TIME, CAST(-2.5 as DECIMAL))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type "decimal" to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as NUMERIC(30,8)))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type numeric to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as FLOAT))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type double precision to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as REAL))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type real to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as INT))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type integer to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as BIGINT))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type bigint to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as SMALLINT))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallint to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as MONEY))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type money to time without time zone)~~
+
+SELECT CONVERT(TIME, CAST(-2.5 as SMALLMONEY))
+GO
+~~START~~
+time
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot cast type smallmoney to time without time zone)~~
+
 
 CREATE VIEW Datetime_view5 as (
     SELECT 
-        DATEADD(minute, CAST(1 as DECIMAL), CAST(2.5 as DECIMAL)) as re1,
-        DATEADD(minute, CAST(1 as NUMERIC(30,8)), CAST(2.5 as NUMERIC(30,8))) as re2,
-        DATEADD(minute, CAST(1 as FLOAT), CAST(2.5 as FLOAT)) as re3,
-        DATEADD(minute, CAST(1 as REAL), CAST(2.5 as REAL)) as re4,
-        DATEADD(minute, CAST(1 as INT), CAST(2.5 as INT)) as re5,
-        DATEADD(minute, CAST(1 as BIGINT), CAST(2.5 as BIGINT)) as re6,
-        DATEADD(minute, CAST(1 as SMALLINT), CAST(2.5 as SMALLINT)) as re7,
-        DATEADD(minute, CAST(1 as TINYINT), CAST(2.5 as TINYINT)) as re8,
-        DATEADD(minute, CAST(1 as MONEY), CAST(2.5 as MONEY)) as re9,
-        DATEADD(minute, CAST(1 as SMALLMONEY), CAST(2.5 as SMALLMONEY)) as re10,
-        DATEADD(minute, CAST(-1 as DECIMAL), CAST(-2.5 as DECIMAL)) as re11,
-        DATEADD(minute, CAST(-1 as NUMERIC(30,8)), CAST(-2.5 as NUMERIC(30,8))) as re12,
-        DATEADD(minute, CAST(-1 as FLOAT), CAST(-2.5 as FLOAT)) as re13,
-        DATEADD(minute, CAST(-1 as REAL), CAST(-2.5 as REAL)) as re14,
-        DATEADD(minute, CAST(-1 as INT), CAST(-2.5 as INT)) as re15,
-        DATEADD(minute, CAST(-1 as BIGINT), CAST(-2.5 as BIGINT)) as re16,
-        DATEADD(minute, CAST(-1 as SMALLINT), CAST(-2.5 as SMALLINT)) as re17,
-        DATEADD(minute, CAST(-1 as MONEY), CAST(-2.5 as MONEY)) as re18,
-        DATEADD(minute, CAST(-1 as SMALLMONEY), CAST(-2.5 as SMALLMONEY)) as re19
+        DATEADD(minute, 1, CAST(2.5 as DECIMAL)) as re1,
+        DATEADD(minute, 1, CAST(2.5 as NUMERIC(30,8))) as re2,
+        DATEADD(minute, 1, CAST(2.5 as FLOAT)) as re3,
+        DATEADD(minute, 1, CAST(2.5 as REAL)) as re4,
+        DATEADD(minute, 1, CAST(2.5 as INT)) as re5,
+        DATEADD(minute, 1, CAST(2.5 as BIGINT)) as re6,
+        DATEADD(minute, 1, CAST(2.5 as SMALLINT)) as re7,
+        DATEADD(minute, 1, CAST(2.5 as TINYINT)) as re8,
+        DATEADD(minute, 1, CAST(2.5 as MONEY)) as re9,
+        DATEADD(minute, 1, CAST(2.5 as SMALLMONEY)) as re10,
+        DATEADD(minute, 1, CAST(-2.5 as BIT)) as re11,
+        DATEADD(minute, 1, CAST(-2.5 as DECIMAL)) as re12,
+        DATEADD(minute, 1, CAST(-2.5 as NUMERIC(30,8))) as re13,
+        DATEADD(minute, 1, CAST(-2.5 as FLOAT)) as re14,
+        DATEADD(minute, 1, CAST(-2.5 as REAL)) as re15,
+        DATEADD(minute, 1, CAST(-2.5 as INT)) as re16,
+        DATEADD(minute, 1, CAST(-2.5 as BIGINT)) as re17,
+        DATEADD(minute, 1, CAST(-2.5 as SMALLINT)) as re18,
+        DATEADD(minute, 1, CAST(-2.5 as MONEY)) as re19,
+        DATEADD(minute, 1, CAST(-2.5 as SMALLMONEY)) as re20,
+        DATEADD(minute, 1, CAST(-2.5 as BIT)) as re21
+);
+GO
+
+CREATE VIEW Datetime_view7 as (
+    SELECT 
+        DATENAME(day, CAST(2.5 as DECIMAL)) as re1,
+        DATENAME(day, CAST(2.5 as NUMERIC(30,8))) as re2,
+        DATENAME(day, CAST(2.5 as FLOAT)) as re3,
+        DATENAME(day, CAST(2.5 as REAL)) as re4,
+        DATENAME(day, CAST(2.5 as INT)) as re5,
+        DATENAME(day, CAST(2.5 as BIGINT)) as re6,
+        DATENAME(day, CAST(2.5 as SMALLINT)) as re7,
+        DATENAME(day, CAST(2.5 as TINYINT)) as re8,
+        DATENAME(day, CAST(2.5 as MONEY)) as re9,
+        DATENAME(day, CAST(2.5 as SMALLMONEY)) as re10,
+        DATENAME(day, CAST(2.5 as BIT)) as re11,
+        DATENAME(day, CAST(-2.5 as DECIMAL)) as re12,
+        DATENAME(day, CAST(-2.5 as NUMERIC(30,8))) as re13,
+        DATENAME(day, CAST(-2.5 as FLOAT)) as re14,
+        DATENAME(day, CAST(-2.5 as REAL)) as re15,
+        DATENAME(day, CAST(-2.5 as INT)) as re16,
+        DATENAME(day, CAST(-2.5 as BIGINT)) as re17,
+        DATENAME(day, CAST(-2.5 as SMALLINT)) as re18,
+        DATENAME(day, CAST(-2.5 as MONEY)) as re19,
+        DATENAME(day, CAST(-2.5 as SMALLMONEY)) as re20,
+        DATENAME(day, CAST(-2.5 as BIT)) as re21
+);
+GO
+
+CREATE VIEW Datetime_view8 as (
+    SELECT 
+        DATEPART(day, CAST(2.5 as DECIMAL)) as re1,
+        DATEPART(day, CAST(2.5 as NUMERIC(30,8))) as re2,
+        DATEPART(day, CAST(2.5 as FLOAT)) as re3,
+        DATEPART(day, CAST(2.5 as REAL)) as re4,
+        DATEPART(day, CAST(2.5 as INT)) as re5,
+        DATEPART(day, CAST(2.5 as BIGINT)) as re6,
+        DATEPART(day, CAST(2.5 as SMALLINT)) as re7,
+        DATEPART(day, CAST(2.5 as TINYINT)) as re8,
+        DATEPART(day, CAST(2.5 as MONEY)) as re9,
+        DATEPART(day, CAST(2.5 as SMALLMONEY)) as re10,
+        DATEPART(day, CAST(2.5 as BIT)) as re11,
+        DATEPART(day, CAST(-2.5 as DECIMAL)) as re12,
+        DATEPART(day, CAST(-2.5 as NUMERIC(30,8))) as re13,
+        DATEPART(day, CAST(-2.5 as FLOAT)) as re14,
+        DATEPART(day, CAST(-2.5 as REAL)) as re15,
+        DATEPART(day, CAST(-2.5 as INT)) as re16,
+        DATEPART(day, CAST(-2.5 as BIGINT)) as re17,
+        DATEPART(day, CAST(-2.5 as SMALLINT)) as re18,
+        DATEPART(day, CAST(-2.5 as MONEY)) as re19,
+        DATEPART(day, CAST(-2.5 as SMALLMONEY)) as re20,
+        DATEPART(day, CAST(-2.5 as BIT)) as re21
 );
 GO
 

--- a/test/JDBC/expected/TestDatetime-numeric-dateaddfunction-vu-verify.out
+++ b/test/JDBC/expected/TestDatetime-numeric-dateaddfunction-vu-verify.out
@@ -22,24 +22,40 @@ smalldatetime#!#smalldatetime#!#smalldatetime#!#smalldatetime#!#smalldatetime#!#
 DROP VIEW Datetime_view4
 GO
 
--- Should throw ERROR : Argument data type bit is invalid for argument 2 of dateadd function.
-SELECT DATEADD(minute, CAST(1 as BIT), CAST(2.5 as BIT))
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Argument data type bit is invalid for argument 2 of dateadd function.)~~
-
-
 -- output from SQL Server :
 -- 1900-01-04 00:01:00.000	1900-01-03 12:01:00.000	1900-01-03 12:01:00.000	1900-01-03 12:01:00.000	1900-01-03 00:01:00.000	1900-01-03 00:01:00.000	1900-01-03 00:01:00.000	1900-01-03 00:01:00.000	1900-01-03 12:01:00.000	1900-01-03 12:01:00.000	1899-12-28 23:59:00.000	1899-12-29 11:59:00.000	1899-12-29 11:59:00.000	1899-12-29 11:59:00.000	1899-12-29 23:59:00.000	1899-12-29 23:59:00.000	1899-12-29 23:59:00.000	1899-12-29 11:59:00.000	1899-12-29 11:59:00.000
 SELECT * FROM Datetime_view5
 GO
 ~~START~~
-datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime
-1900-01-04 00:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 12:01:00.0#!#1899-12-28 23:59:00.0#!#1899-12-29 11:59:00.0#!#1899-12-29 11:59:00.0#!#1899-12-29 11:59:00.0#!#1899-12-29 23:59:00.0#!#1899-12-29 23:59:00.0#!#1899-12-29 23:59:00.0#!#1899-12-29 11:59:00.0#!#1899-12-29 11:59:00.0
+datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime#!#datetime
+1900-01-04 00:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 00:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-03 12:01:00.0#!#1900-01-02 00:01:00.0#!#1899-12-29 00:01:00.0#!#1899-12-29 12:01:00.0#!#1899-12-29 12:01:00.0#!#1899-12-29 12:01:00.0#!#1899-12-30 00:01:00.0#!#1899-12-30 00:01:00.0#!#1899-12-30 00:01:00.0#!#1899-12-29 12:01:00.0#!#1899-12-29 12:01:00.0#!#1900-01-02 00:01:00.0
 ~~END~~
 
 DROP VIEW Datetime_view5
+GO
+
+-- output from SQL Server :
+-- 4	3	3	3	3	3	3	3	3	3	2	29	29	29	29	30	30	30	29	29	2
+SELECT * FROM Datetime_view7
+GO
+~~START~~
+text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text#!#text
+4#!#3#!#3#!#3#!#3#!#3#!#3#!#3#!#3#!#3#!#2#!#29#!#29#!#29#!#29#!#30#!#30#!#30#!#29#!#29#!#2
+~~END~~
+
+DROP VIEW Datetime_view7
+GO
+
+-- output from SQL Server :
+-- 4	3	3	3	3	3	3	3	3	3	2	29	29	29	29	30	30	30	29	29	2
+SELECT * FROM Datetime_view8
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+4#!#3#!#3#!#3#!#3#!#3#!#3#!#3#!#3#!#3#!#2#!#29#!#29#!#29#!#29#!#30#!#30#!#30#!#29#!#29#!#2
+~~END~~
+
+DROP VIEW Datetime_view8
 GO
 
 -- Procedures
@@ -261,9 +277,10 @@ GO
 
 SELECT * FROM dateadd_view_4
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Argument data type bit is invalid for argument 2 of dateadd function.)~~
+~~START~~
+datetime
+1901-01-02 00:00:00.0
+~~END~~
 
 
 DROP VIEW dateadd_view_4

--- a/test/JDBC/input/datatypes/TestDatetime-numeric-dateaddfunction-vu-prepare.sql
+++ b/test/JDBC/input/datatypes/TestDatetime-numeric-dateaddfunction-vu-prepare.sql
@@ -65,28 +65,161 @@ GO
 SELECT CONVERT(SMALLDATETIME, CAST(-2.5 as SMALLMONEY))
 GO
 
+-- Should all fail
+SELECT CONVERT(DATETIME2, CAST(-2.5 as DECIMAL))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as NUMERIC(30,8)))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as FLOAT))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as REAL))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as INT))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as BIGINT))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as SMALLINT))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as MONEY))
+GO
+SELECT CONVERT(DATETIME2, CAST(-2.5 as SMALLMONEY))
+GO
+
+-- Should all fail
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as DECIMAL))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as NUMERIC(30,8)))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as FLOAT))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as REAL))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as INT))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as BIGINT))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as SMALLINT))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as MONEY))
+GO
+SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as SMALLMONEY))
+GO
+
+-- Should all fail
+SELECT CONVERT(DATE, CAST(-2.5 as DECIMAL))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as NUMERIC(30,8)))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as FLOAT))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as REAL))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as INT))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as BIGINT))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as SMALLINT))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as MONEY))
+GO
+SELECT CONVERT(DATE, CAST(-2.5 as SMALLMONEY))
+GO
+
+-- Should all fail
+SELECT CONVERT(TIME, CAST(-2.5 as DECIMAL))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as NUMERIC(30,8)))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as FLOAT))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as REAL))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as INT))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as BIGINT))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as SMALLINT))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as MONEY))
+GO
+SELECT CONVERT(TIME, CAST(-2.5 as SMALLMONEY))
+GO
 
 CREATE VIEW Datetime_view5 as (
     SELECT 
-        DATEADD(minute, CAST(1 as DECIMAL), CAST(2.5 as DECIMAL)) as re1,
-        DATEADD(minute, CAST(1 as NUMERIC(30,8)), CAST(2.5 as NUMERIC(30,8))) as re2,
-        DATEADD(minute, CAST(1 as FLOAT), CAST(2.5 as FLOAT)) as re3,
-        DATEADD(minute, CAST(1 as REAL), CAST(2.5 as REAL)) as re4,
-        DATEADD(minute, CAST(1 as INT), CAST(2.5 as INT)) as re5,
-        DATEADD(minute, CAST(1 as BIGINT), CAST(2.5 as BIGINT)) as re6,
-        DATEADD(minute, CAST(1 as SMALLINT), CAST(2.5 as SMALLINT)) as re7,
-        DATEADD(minute, CAST(1 as TINYINT), CAST(2.5 as TINYINT)) as re8,
-        DATEADD(minute, CAST(1 as MONEY), CAST(2.5 as MONEY)) as re9,
-        DATEADD(minute, CAST(1 as SMALLMONEY), CAST(2.5 as SMALLMONEY)) as re10,
-        DATEADD(minute, CAST(-1 as DECIMAL), CAST(-2.5 as DECIMAL)) as re11,
-        DATEADD(minute, CAST(-1 as NUMERIC(30,8)), CAST(-2.5 as NUMERIC(30,8))) as re12,
-        DATEADD(minute, CAST(-1 as FLOAT), CAST(-2.5 as FLOAT)) as re13,
-        DATEADD(minute, CAST(-1 as REAL), CAST(-2.5 as REAL)) as re14,
-        DATEADD(minute, CAST(-1 as INT), CAST(-2.5 as INT)) as re15,
-        DATEADD(minute, CAST(-1 as BIGINT), CAST(-2.5 as BIGINT)) as re16,
-        DATEADD(minute, CAST(-1 as SMALLINT), CAST(-2.5 as SMALLINT)) as re17,
-        DATEADD(minute, CAST(-1 as MONEY), CAST(-2.5 as MONEY)) as re18,
-        DATEADD(minute, CAST(-1 as SMALLMONEY), CAST(-2.5 as SMALLMONEY)) as re19
+        DATEADD(minute, 1, CAST(2.5 as DECIMAL)) as re1,
+        DATEADD(minute, 1, CAST(2.5 as NUMERIC(30,8))) as re2,
+        DATEADD(minute, 1, CAST(2.5 as FLOAT)) as re3,
+        DATEADD(minute, 1, CAST(2.5 as REAL)) as re4,
+        DATEADD(minute, 1, CAST(2.5 as INT)) as re5,
+        DATEADD(minute, 1, CAST(2.5 as BIGINT)) as re6,
+        DATEADD(minute, 1, CAST(2.5 as SMALLINT)) as re7,
+        DATEADD(minute, 1, CAST(2.5 as TINYINT)) as re8,
+        DATEADD(minute, 1, CAST(2.5 as MONEY)) as re9,
+        DATEADD(minute, 1, CAST(2.5 as SMALLMONEY)) as re10,
+        DATEADD(minute, 1, CAST(-2.5 as BIT)) as re11,
+        DATEADD(minute, 1, CAST(-2.5 as DECIMAL)) as re12,
+        DATEADD(minute, 1, CAST(-2.5 as NUMERIC(30,8))) as re13,
+        DATEADD(minute, 1, CAST(-2.5 as FLOAT)) as re14,
+        DATEADD(minute, 1, CAST(-2.5 as REAL)) as re15,
+        DATEADD(minute, 1, CAST(-2.5 as INT)) as re16,
+        DATEADD(minute, 1, CAST(-2.5 as BIGINT)) as re17,
+        DATEADD(minute, 1, CAST(-2.5 as SMALLINT)) as re18,
+        DATEADD(minute, 1, CAST(-2.5 as MONEY)) as re19,
+        DATEADD(minute, 1, CAST(-2.5 as SMALLMONEY)) as re20,
+        DATEADD(minute, 1, CAST(-2.5 as BIT)) as re21
+);
+GO
+
+CREATE VIEW Datetime_view7 as (
+    SELECT 
+        DATENAME(day, CAST(2.5 as DECIMAL)) as re1,
+        DATENAME(day, CAST(2.5 as NUMERIC(30,8))) as re2,
+        DATENAME(day, CAST(2.5 as FLOAT)) as re3,
+        DATENAME(day, CAST(2.5 as REAL)) as re4,
+        DATENAME(day, CAST(2.5 as INT)) as re5,
+        DATENAME(day, CAST(2.5 as BIGINT)) as re6,
+        DATENAME(day, CAST(2.5 as SMALLINT)) as re7,
+        DATENAME(day, CAST(2.5 as TINYINT)) as re8,
+        DATENAME(day, CAST(2.5 as MONEY)) as re9,
+        DATENAME(day, CAST(2.5 as SMALLMONEY)) as re10,
+        DATENAME(day, CAST(2.5 as BIT)) as re11,
+        DATENAME(day, CAST(-2.5 as DECIMAL)) as re12,
+        DATENAME(day, CAST(-2.5 as NUMERIC(30,8))) as re13,
+        DATENAME(day, CAST(-2.5 as FLOAT)) as re14,
+        DATENAME(day, CAST(-2.5 as REAL)) as re15,
+        DATENAME(day, CAST(-2.5 as INT)) as re16,
+        DATENAME(day, CAST(-2.5 as BIGINT)) as re17,
+        DATENAME(day, CAST(-2.5 as SMALLINT)) as re18,
+        DATENAME(day, CAST(-2.5 as MONEY)) as re19,
+        DATENAME(day, CAST(-2.5 as SMALLMONEY)) as re20,
+        DATENAME(day, CAST(-2.5 as BIT)) as re21
+);
+GO
+
+CREATE VIEW Datetime_view8 as (
+    SELECT 
+        DATEPART(day, CAST(2.5 as DECIMAL)) as re1,
+        DATEPART(day, CAST(2.5 as NUMERIC(30,8))) as re2,
+        DATEPART(day, CAST(2.5 as FLOAT)) as re3,
+        DATEPART(day, CAST(2.5 as REAL)) as re4,
+        DATEPART(day, CAST(2.5 as INT)) as re5,
+        DATEPART(day, CAST(2.5 as BIGINT)) as re6,
+        DATEPART(day, CAST(2.5 as SMALLINT)) as re7,
+        DATEPART(day, CAST(2.5 as TINYINT)) as re8,
+        DATEPART(day, CAST(2.5 as MONEY)) as re9,
+        DATEPART(day, CAST(2.5 as SMALLMONEY)) as re10,
+        DATEPART(day, CAST(2.5 as BIT)) as re11,
+        DATEPART(day, CAST(-2.5 as DECIMAL)) as re12,
+        DATEPART(day, CAST(-2.5 as NUMERIC(30,8))) as re13,
+        DATEPART(day, CAST(-2.5 as FLOAT)) as re14,
+        DATEPART(day, CAST(-2.5 as REAL)) as re15,
+        DATEPART(day, CAST(-2.5 as INT)) as re16,
+        DATEPART(day, CAST(-2.5 as BIGINT)) as re17,
+        DATEPART(day, CAST(-2.5 as SMALLINT)) as re18,
+        DATEPART(day, CAST(-2.5 as MONEY)) as re19,
+        DATEPART(day, CAST(-2.5 as SMALLMONEY)) as re20,
+        DATEPART(day, CAST(-2.5 as BIT)) as re21
 );
 GO
 

--- a/test/JDBC/input/datatypes/TestDatetime-numeric-dateaddfunction-vu-verify.sql
+++ b/test/JDBC/input/datatypes/TestDatetime-numeric-dateaddfunction-vu-verify.sql
@@ -12,15 +12,25 @@ GO
 DROP VIEW Datetime_view4
 GO
 
--- Should throw ERROR : Argument data type bit is invalid for argument 2 of dateadd function.
-SELECT DATEADD(minute, CAST(1 as BIT), CAST(2.5 as BIT))
-GO
-
 -- output from SQL Server :
 -- 1900-01-04 00:01:00.000	1900-01-03 12:01:00.000	1900-01-03 12:01:00.000	1900-01-03 12:01:00.000	1900-01-03 00:01:00.000	1900-01-03 00:01:00.000	1900-01-03 00:01:00.000	1900-01-03 00:01:00.000	1900-01-03 12:01:00.000	1900-01-03 12:01:00.000	1899-12-28 23:59:00.000	1899-12-29 11:59:00.000	1899-12-29 11:59:00.000	1899-12-29 11:59:00.000	1899-12-29 23:59:00.000	1899-12-29 23:59:00.000	1899-12-29 23:59:00.000	1899-12-29 11:59:00.000	1899-12-29 11:59:00.000
 SELECT * FROM Datetime_view5
 GO
 DROP VIEW Datetime_view5
+GO
+
+-- output from SQL Server :
+-- 4	3	3	3	3	3	3	3	3	3	2	29	29	29	29	30	30	30	29	29	2
+SELECT * FROM Datetime_view7
+GO
+DROP VIEW Datetime_view7
+GO
+
+-- output from SQL Server :
+-- 4	3	3	3	3	3	3	3	3	3	2	29	29	29	29	30	30	30	29	29	2
+SELECT * FROM Datetime_view8
+GO
+DROP VIEW Datetime_view8
 GO
 
 -- Procedures

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,10 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-TestDatetime-numeric-dateaddfunction-vu-prepare
-TestDatetime-numeric-dateaddfunction-vu-verify
-BABEL-1475-vu-prepare
-
+all
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,10 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+TestDatetime-numeric-dateaddfunction-vu-prepare
+TestDatetime-numeric-dateaddfunction-vu-verify
+BABEL-1475-vu-prepare
+
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 


### PR DESCRIPTION
### Description
Before this PR, we didn't support numeric representation for DATENAME() and DATEPART() function. In this PR, for DATEPART() function, we added the code to CAST numeric representation to DATETIME first. And for DATENAME() function, we CAST the input into DATETIME instead of DATE to make sure  DATENAME() function accept numeric representation input.


### Issues Resolved

Task: BABEL-323

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).