### PR TITLE
Fix ownership_restrictions_from_pg test file

### DIFF
--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -1,5 +1,5 @@
 -- tsql
-CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '123';
+CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '12345678';
 GO
 
 CREATE ROLE ownership_restrictions_from_pg_role1;
@@ -14,9 +14,6 @@ GO
 -- psql
 CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' inherit;
 go
-
-CREATE USER ownership_restrictions_from_pg_test_su_user WITH SUPERUSER LOGIN PASSWORD 'abc';
-GO
 
 -- psql user=ownership_restrictions_from_pg_login1 password=12345678
 -- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
@@ -41,10 +38,10 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '12345678';
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
@@ -173,14 +170,6 @@ GO
     Server SQLState: 3D000)~~
 
 
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
@@ -221,38 +210,6 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
 GO
 ~~ERROR (Code: 0)~~
@@ -264,7 +221,7 @@ GO
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
-alter role ownership_restrictions_from_pg_login1 with password '123';
+alter role ownership_restrictions_from_pg_login1 with password '12345678';
 GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
@@ -275,16 +232,8 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 -- If the stmt contains a non-allowed option then altering of role not allowed
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
@@ -292,7 +241,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
@@ -328,7 +277,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
@@ -336,7 +285,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
@@ -480,14 +429,6 @@ GO
     Server SQLState: 3D000)~~
 
 
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
@@ -528,38 +469,6 @@ GO
     Server SQLState: 3D000)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
-    Server SQLState: 42501)~~
-
-
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
-    Server SQLState: 42501)~~
-
-
 ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
 GO
 ~~ERROR (Code: 0)~~
@@ -576,7 +485,7 @@ GO
     Server SQLState: 42501)~~
 
 
-alter role ownership_restrictions_from_pg_login1 with password '123';
+alter role ownership_restrictions_from_pg_login1 with password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
@@ -592,16 +501,8 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 -- If the stmt contains a non-allowed option then altering of role not allowed
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
@@ -609,21 +510,13 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
 ~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
-
--- psql user=ownership_restrictions_from_pg_test_su_user password=abc
--- Altering of babelfish created logins/roles should suceeded for superuser
-ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
-GO
 
 -- psql
 -- Dropping login from psql port should fail
@@ -689,13 +582,6 @@ GO
 
 DROP ROLE ownership_restrictions_from_pg_role4;
 GO
-
-SET enable_drop_babelfish_role = true;
-go
-DROP USER ownership_restrictions_from_pg_test_su_user;
-go
-SET enable_drop_babelfish_role = false;
-go
 
 DROP USER ownership_restrictions_from_pg_test_user;
 GO

--- a/test/JDBC/expected/ownership_restrictions_from_pg_su_user.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg_su_user.out
@@ -1,0 +1,154 @@
+-- tsql
+CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '12345678';
+GO
+
+CREATE ROLE ownership_restrictions_from_pg_role1;
+GO
+
+DECLARE @ownership_restrictions_from_pg_test_variable  int = 100;
+GO
+
+-- psql
+CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' inherit;
+go
+
+CREATE USER ownership_restrictions_from_pg_test_su_user WITH SUPERUSER LOGIN PASSWORD '12345678';
+GO
+
+-- psql user=ownership_restrictions_from_pg_login1 password=12345678
+-- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=ownership_restrictions_from_pg_test_user password=12345678
+-- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set parameter "babelfishpg_tsql.ownership_restrictions_from_pg_test_variable"
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=ownership_restrictions_from_pg_test_su_user password=12345678
+-- Altering of babelfish created logins/roles should suceeded for superuser
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
+GO
+
+-- psql
+SET enable_drop_babelfish_role = true;
+go
+DROP USER ownership_restrictions_from_pg_test_su_user;
+go
+SET enable_drop_babelfish_role = false;
+go
+
+DROP USER ownership_restrictions_from_pg_test_user;
+GO
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'ownership_restrictions_from_pg_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+DROP ROLE ownership_restrictions_from_pg_role1;
+DROP LOGIN ownership_restrictions_from_pg_login1;
+GO

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -1,5 +1,5 @@
 -- tsql
-CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '123';
+CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '12345678';
 GO
 
 CREATE ROLE ownership_restrictions_from_pg_role1;
@@ -15,9 +15,6 @@ GO
 CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' inherit;
 go
 
-CREATE USER ownership_restrictions_from_pg_test_su_user WITH SUPERUSER LOGIN PASSWORD 'abc';
-GO
-
 -- psql user=ownership_restrictions_from_pg_login1 password=12345678
 -- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
 -- connection limit and valid until should be working fine
@@ -31,10 +28,10 @@ GO
 ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '12345678';
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
@@ -88,9 +85,6 @@ GO
 ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
 ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
@@ -106,38 +100,23 @@ GO
 ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
 ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
 GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
-alter role ownership_restrictions_from_pg_login1 with password '123';
+alter role ownership_restrictions_from_pg_login1 with password '12345678';
 GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
 -- If the stmt contains a non-allowed option then altering of role not allowed
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 
 -- psql user=ownership_restrictions_from_pg_test_user password=12345678
@@ -153,10 +132,10 @@ GO
 ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '12345678';
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
@@ -210,9 +189,6 @@ GO
 ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
 ALTER ROLE master_ownership_restrictions_from_pg_role1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
@@ -228,46 +204,23 @@ GO
 ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
 ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
 GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
-alter role ownership_restrictions_from_pg_login1 with password '123';
+alter role ownership_restrictions_from_pg_login1 with password '12345678';
 GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
-GO
-
 -- If the stmt contains a non-allowed option then altering of role not allowed
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
-GO
-
--- psql user=ownership_restrictions_from_pg_test_su_user password=abc
--- Altering of babelfish created logins/roles should suceeded for superuser
-ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
-GO
-
-ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '123';
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
 GO
 
 -- psql
@@ -319,13 +272,6 @@ GO
 
 DROP ROLE ownership_restrictions_from_pg_role4;
 GO
-
-SET enable_drop_babelfish_role = true;
-go
-DROP USER ownership_restrictions_from_pg_test_su_user;
-go
-SET enable_drop_babelfish_role = false;
-go
 
 DROP USER ownership_restrictions_from_pg_test_user;
 GO

--- a/test/JDBC/input/ownership_restrictions_from_pg_su_user.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg_su_user.mix
@@ -1,0 +1,89 @@
+-- tsql
+CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '12345678';
+GO
+
+CREATE ROLE ownership_restrictions_from_pg_role1;
+GO
+
+DECLARE @ownership_restrictions_from_pg_test_variable  int = 100;
+GO
+
+-- psql
+CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' inherit;
+go
+
+CREATE USER ownership_restrictions_from_pg_test_su_user WITH SUPERUSER LOGIN PASSWORD '12345678';
+GO
+
+-- psql user=ownership_restrictions_from_pg_login1 password=12345678
+-- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+-- psql user=ownership_restrictions_from_pg_test_user password=12345678
+-- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
+-- connection limit and valid until should be working fine
+-- and the rest of alter role operations should throw an error.
+ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+
+-- psql user=ownership_restrictions_from_pg_test_su_user password=12345678
+-- Altering of babelfish created logins/roles should suceeded for superuser
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTION LIMIT 1  password '12345678';
+GO
+
+-- psql
+SET enable_drop_babelfish_role = true;
+go
+DROP USER ownership_restrictions_from_pg_test_su_user;
+go
+SET enable_drop_babelfish_role = false;
+go
+
+DROP USER ownership_restrictions_from_pg_test_user;
+GO
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'ownership_restrictions_from_pg_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- tsql
+DROP ROLE ownership_restrictions_from_pg_role1;
+DROP LOGIN ownership_restrictions_from_pg_login1;
+GO


### PR DESCRIPTION
### Description

[OSS-ONLY] The test file 'ownership_restrictions_from_pg' creates an SUPERUSER and tests the changes using SUPERUSER and in jdbc_testdb(DB where BBF is initialized).

This commit creates an separate test file to test the changes for SUPERUSER and jdbc_testdb.

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).