### PR TITLE
Adding explicit numeic casting to sys.sp_databases_view

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1081,8 +1081,8 @@ DROP VIEW IF EXISTS sys.sp_databases_view CASCADE;
 CREATE VIEW sys.sp_databases_view AS
 	SELECT CAST(database_name AS sys.SYSNAME),
 	-- DATABASE_SIZE returns a NULL value for databases larger than 2.15 TB
-	CASE WHEN (sum(table_size)/1024.0) > 2.15 * 1024.0 * 1024.0 * 1024.0 THEN NULL
-		ELSE CAST((sum(table_size)/1024.0) AS int) END as database_size,
+	CASE WHEN (sum(table_size)::NUMERIC/1024.0) > 2.15 * 1024.0 * 1024.0 * 1024.0 THEN NULL
+		ELSE CAST((sum(table_size)::NUMERIC/1024.0) AS int) END as database_size,
 	CAST(NULL AS sys.VARCHAR(254)) as remarks
 	FROM (
 		SELECT pg_catalog.pg_namespace.oid as schema_oid,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -1489,8 +1489,8 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
 CREATE OR REPLACE VIEW sys.sp_databases_view AS
 	SELECT CAST(database_name AS sys.SYSNAME),
 	-- DATABASE_SIZE returns a NULL value for databases larger than 2.15 TB
-	CASE WHEN (sum(table_size)/1024.0) > 2.15 * 1024.0 * 1024.0 * 1024.0 THEN NULL
-		ELSE CAST((sum(table_size)/1024.0) AS int) END as database_size,
+	CASE WHEN (sum(table_size)::NUMERIC/1024.0) > 2.15 * 1024.0 * 1024.0 * 1024.0 THEN NULL
+		ELSE CAST((sum(table_size)::NUMERIC/1024.0) AS int) END as database_size,
 	CAST(NULL AS sys.VARCHAR(254)) as remarks
 	FROM (
 		SELECT pg_catalog.pg_namespace.oid as schema_oid,


### PR DESCRIPTION
### Description

Error found in GitFarm while upgrading babelfishpg_tsql extension

running sql: ALTER EXTENSION "babelfishpg_tsql" UPDATE, error: ERROR: operator is not unique: bigint / numeric Hint: Could not choose a best candidate operator. You might need to add explicit type casts.
Local bbf testing shows

babelfish_db=# select pg_relation_size('sys.babelfish_namespace_ext')/1024.0; ERROR: operator is not unique: bigint / numeric LINE 1: ...lect pg_relation_size('sys.babelfish_namespace_ext')/1024.0; ^ HINT: Could not choose a best candidate operator. You might need to add explicit type casts.

babelfish_db=# select pg_relation_size('sys.babelfish_namespace_ext')/1024;
?column?

    8

(1 row)

### Investigation

Looks like Numeric/BigInt CAST actually exists, the same statement runs successfully when sys schema is not in the path:

babelfish_db=# show search_path;

search_path     

pg_catalog, public (1 row)

babelfish_db=# select pg_relation_size('sys.babelfish_namespace_ext')/1024.0;

  ?column?      

8.0000000000000000 (1 row)

But fails if we add sys in the path.

### Solution

Following the error hint (as below) resolves the issue, so adding explicit NUMERIC casting to sys.sp_databases_view:

select pg_relation_size('sys.babelfish_namespace_ext')::numeric/1024.0;


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).