### PR TITLE
Create Syslogins Catalog View in Babelfish

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -304,6 +304,61 @@ FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ex
 
 GRANT SELECT ON sys.server_principals TO PUBLIC;
 
+-- SYSLOGINS
+CREATE OR REPLACE VIEW sys.syslogins
+AS SELECT 
+Base.sid AS sid,
+CAST(9 AS SYS.TINYINT) AS status,
+Base.create_date AS createdate,
+Base.modify_date AS updatedate,
+Base.create_date AS accdate,
+CAST(0 AS INT) AS totcpu,
+CAST(0 AS INT) AS totio,
+CAST(0 AS INT) AS spacelimit,
+CAST(0 AS INT) AS timelimit,
+CAST(0 AS INT) AS resultlimit,
+Base.name AS name,
+Base.default_database_name AS dbname,
+Base.default_language_name AS default_language_name,
+CAST(Base.name AS SYS.NVARCHAR(128)) AS loginname,
+CAST(NULL AS SYS.NVARCHAR(128)) AS password,
+CAST(0 AS INT) AS denylogin,
+CAST(1 AS INT) AS hasaccess,
+CAST( 
+  CASE 
+    WHEN BASE.type_desc = 'WINDOWS_LOGIN' OR BASE.type_desc = 'WINDOWS_GROUP' THEN 1 
+    ELSE 0
+  END
+AS INT) AS isntname,
+CAST(
+   CASE 
+    WHEN BASE.type_desc = 'WINDOWS_GROUP' THEN 1 
+    ELSE 0
+  END
+  AS INT) AS isntgroup,
+CAST(
+  CASE 
+    WHEN BASE.type_desc = 'WINDOWS_LOGIN' THEN 1 
+    ELSE 0
+  END
+AS INT) AS isntuser,
+CAST(
+    CASE
+        WHEN pg_has_role(CAST('sysadmin' AS TEXT), Base.principal_id , 'MEMBER') = true THEN 1
+        ELSE 0
+    END
+AS INT) AS sysadmin,
+CAST(0 AS INT) AS securityadmin,
+CAST(0 AS INT) AS serveradmin,
+CAST(0 AS INT) AS setupadmin,
+CAST(0 AS INT) AS processadmin,
+CAST(0 AS INT) AS diskadmin,
+CAST(0 AS INT) AS dbcreator,
+CAST(0 AS INT) AS bulkadmin
+FROM sys.server_principals AS Base;
+
+GRANT SELECT ON sys.syslogins TO PUBLIC;
+
 -- USER extension
 CREATE TABLE sys.babelfish_authid_user_ext (
 rolname NAME NOT NULL,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -1466,6 +1466,61 @@ FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dumm
 GRANT SELECT ON sys.database_principals TO PUBLIC;
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'database_principals_deprecated_3_2_0');
 
+-- SYSLOGINS
+CREATE OR REPLACE VIEW sys.syslogins
+AS SELECT 
+Base.sid AS sid,
+CAST(9 AS SYS.TINYINT) AS status,
+Base.create_date AS createdate,
+Base.modify_date AS updatedate,
+Base.create_date AS accdate,
+CAST(0 AS INT) AS totcpu,
+CAST(0 AS INT) AS totio,
+CAST(0 AS INT) AS spacelimit,
+CAST(0 AS INT) AS timelimit,
+CAST(0 AS INT) AS resultlimit,
+Base.name AS name,
+Base.default_database_name AS dbname,
+Base.default_language_name AS default_language_name,
+CAST(Base.name AS SYS.NVARCHAR(128)) AS loginname,
+CAST(NULL AS SYS.NVARCHAR(128)) AS password,
+CAST(0 AS INT) AS denylogin,
+CAST(1 AS INT) AS hasaccess,
+CAST( 
+  CASE 
+    WHEN BASE.type_desc = 'WINDOWS_LOGIN' OR BASE.type_desc = 'WINDOWS_GROUP' THEN 1 
+    ELSE 0
+  END
+AS INT) AS isntname,
+CAST(
+   CASE 
+    WHEN BASE.type_desc = 'WINDOWS_GROUP' THEN 1 
+    ELSE 0
+  END
+  AS INT) AS isntgroup,
+CAST(
+  CASE 
+    WHEN BASE.type_desc = 'WINDOWS_LOGIN' THEN 1 
+    ELSE 0
+  END
+AS INT) AS isntuser,
+CAST(
+    CASE
+        WHEN pg_has_role(CAST('sysadmin' AS TEXT), Base.principal_id , 'MEMBER') = true THEN 1
+        ELSE 0
+    END
+AS INT) AS sysadmin,
+CAST(0 AS INT) AS securityadmin,
+CAST(0 AS INT) AS serveradmin,
+CAST(0 AS INT) AS setupadmin,
+CAST(0 AS INT) AS processadmin,
+CAST(0 AS INT) AS diskadmin,
+CAST(0 AS INT) AS dbcreator,
+CAST(0 AS INT) AS bulkadmin
+FROM sys.server_principals AS Base;
+
+GRANT SELECT ON sys.syslogins TO PUBLIC;
+
 CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
     SELECT
         o.object_id         AS object_id,

--- a/test/JDBC/expected/sys_syslogins_dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys_syslogins_dep-vu-cleanup.out
@@ -1,0 +1,20 @@
+DROP VIEW sys_syslogins_dep_vu_prepare_view
+GO
+
+DROP PROC sys_syslogins_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_syslogins_dep_vu_prepare_func
+GO
+
+DROP LOGIN sys_syslogins_dep_vu_prepare_login1
+GO
+
+DROP LOGIN sys_syslogins_dep_vu_prepare_login2
+GO
+
+DROP LOGIN [sysloginsxyz\domain_login1]
+GO
+
+EXEC babelfish_remove_domain_mapping_entry 'sysloginsxyz'
+GO

--- a/test/JDBC/expected/sys_syslogins_dep-vu-prepare.out
+++ b/test/JDBC/expected/sys_syslogins_dep-vu-prepare.out
@@ -1,0 +1,32 @@
+CREATE LOGIN sys_syslogins_dep_vu_prepare_login1 WITH PASSWORD = '12345'
+GO
+
+CREATE LOGIN sys_syslogins_dep_vu_prepare_login2 WITH PASSWORD = '12345'
+GO
+
+CREATE VIEW sys_syslogins_dep_vu_prepare_view
+AS
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins 
+WHERE name LIKE '%sys_syslogins_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE PROC sys_syslogins_dep_vu_prepare_proc
+AS
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins 
+WHERE name LIKE '%sys_syslogins_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_syslogins_dep_vu_prepare_func()
+RETURNS INT AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.syslogins WHERE name LIKE '%sys_syslogins_dep_vu_prepare%')
+END
+GO

--- a/test/JDBC/expected/sys_syslogins_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_syslogins_dep-vu-verify.out
@@ -1,0 +1,59 @@
+SELECT * FROM sys_syslogins_dep_vu_prepare_view
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#tinyint#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sys_syslogins_dep_vu_prepare_login1#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sys_syslogins_dep_vu_prepare_login1#!#<NULL>#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+sys_syslogins_dep_vu_prepare_login2#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sys_syslogins_dep_vu_prepare_login2#!#<NULL>#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+~~END~~
+
+
+EXEC sys_syslogins_dep_vu_prepare_proc
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#tinyint#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sys_syslogins_dep_vu_prepare_login1#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sys_syslogins_dep_vu_prepare_login1#!#<NULL>#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+sys_syslogins_dep_vu_prepare_login2#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sys_syslogins_dep_vu_prepare_login2#!#<NULL>#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+~~END~~
+
+
+SELECT sys_syslogins_dep_vu_prepare_func()
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins
+WHERE name LIKE 'sys_syslogins_dep_vu_prepare_login%'
+ORDER BY name
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#tinyint#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sys_syslogins_dep_vu_prepare_login1#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sys_syslogins_dep_vu_prepare_login1#!#<NULL>#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+sys_syslogins_dep_vu_prepare_login2#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sys_syslogins_dep_vu_prepare_login2#!#<NULL>#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+~~END~~
+
+
+-- temporary adding next two cases to verify script because of issue with upgrade of babelfish_add_domain_mapping_entry
+EXEC sys.babelfish_add_domain_mapping_entry 'sysloginsxyz', 'sysloginsxyz.babel';
+GO
+
+CREATE LOGIN [sysloginsxyz\domain_login1] FROM WINDOWS;
+GO
+
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins 
+WHERE name = 'sysloginsxyz\domain_login1'
+ORDER BY name
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#tinyint#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sysloginsxyz\domain_login1#!#master#!#English#!#9#!#0#!#0#!#0#!#0#!#0#!#sysloginsxyz\domain_login1#!#<NULL>#!#0#!#1#!#1#!#0#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0
+~~END~~
+

--- a/test/JDBC/input/sys_syslogins_dep-vu-cleanup.sql
+++ b/test/JDBC/input/sys_syslogins_dep-vu-cleanup.sql
@@ -1,0 +1,20 @@
+DROP VIEW sys_syslogins_dep_vu_prepare_view
+GO
+
+DROP PROC sys_syslogins_dep_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_syslogins_dep_vu_prepare_func
+GO
+
+DROP LOGIN sys_syslogins_dep_vu_prepare_login1
+GO
+
+DROP LOGIN sys_syslogins_dep_vu_prepare_login2
+GO
+
+DROP LOGIN [sysloginsxyz\domain_login1]
+GO
+
+EXEC babelfish_remove_domain_mapping_entry 'sysloginsxyz'
+GO

--- a/test/JDBC/input/sys_syslogins_dep-vu-prepare.sql
+++ b/test/JDBC/input/sys_syslogins_dep-vu-prepare.sql
@@ -1,0 +1,32 @@
+CREATE LOGIN sys_syslogins_dep_vu_prepare_login1 WITH PASSWORD = '12345'
+GO
+
+CREATE LOGIN sys_syslogins_dep_vu_prepare_login2 WITH PASSWORD = '12345'
+GO
+
+CREATE VIEW sys_syslogins_dep_vu_prepare_view
+AS
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins 
+WHERE name LIKE '%sys_syslogins_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE PROC sys_syslogins_dep_vu_prepare_proc
+AS
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins 
+WHERE name LIKE '%sys_syslogins_dep_vu_prepare%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_syslogins_dep_vu_prepare_func()
+RETURNS INT AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.syslogins WHERE name LIKE '%sys_syslogins_dep_vu_prepare%')
+END
+GO

--- a/test/JDBC/input/sys_syslogins_dep-vu-verify.sql
+++ b/test/JDBC/input/sys_syslogins_dep-vu-verify.sql
@@ -1,0 +1,31 @@
+SELECT * FROM sys_syslogins_dep_vu_prepare_view
+GO
+
+EXEC sys_syslogins_dep_vu_prepare_proc
+GO
+
+SELECT sys_syslogins_dep_vu_prepare_func()
+GO
+
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins
+WHERE name LIKE 'sys_syslogins_dep_vu_prepare_login%'
+ORDER BY name
+GO
+
+-- temporary adding next two cases to verify script because of issue with upgrade of babelfish_add_domain_mapping_entry
+EXEC sys.babelfish_add_domain_mapping_entry 'sysloginsxyz', 'sysloginsxyz.babel';
+GO
+
+CREATE LOGIN [sysloginsxyz\domain_login1] FROM WINDOWS;
+GO
+
+SELECT name,dbname,default_language_name,status,totcpu,totio,spacelimit,timelimit,
+resultlimit,loginname,password,denylogin,hasaccess,isntname,isntgroup,isntuser,sysadmin,securityadmin,serveradmin,setupadmin,
+processadmin,diskadmin,dbcreator,bulkadmin 
+FROM sys.syslogins 
+WHERE name = 'sysloginsxyz\domain_login1'
+ORDER BY name
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -263,6 +263,7 @@ sys-database_files
 sys-database_filestream_options
 sys-database_mirroring
 sys_database_principals_dep
+sys_syslogins_dep
 sys-database_recovery_status
 sys-databases
 sys-databases-dep


### PR DESCRIPTION
Create Syslogins Catalog View in Babelfish
Task: BABEL-2476 

### Description
Create Syslogins Catalog View in Babelfish

### Issues Resolved
Syslogins catalog added to Babelfish

### Test Scenarios Covered ###
* **Use case based -**
- Tested Syslogins view using two logins

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).