### PR TITLE
Fix bug: can't drop the database with a trigger defined under schema

### DIFF
--- a/test/JDBC/expected/drop_database.out
+++ b/test/JDBC/expected/drop_database.out
@@ -1,0 +1,31 @@
+use master
+go
+
+CREATE DATABASE errdb
+GO
+
+USE errdb
+GO
+
+CREATE SCHEMA Purchasing;
+GO
+
+CREATE TYPE NameType FROM varchar(50);
+GO
+
+CREATE TABLE Purchasing.Vendor(VendorName NameType)
+GO
+
+CREATE TRIGGER dVendor ON Purchasing.Vendor
+FOR DELETE AS
+BEGIN
+RETURN;
+END;
+GO
+
+USE master
+go
+
+DROP DATABASE errdb
+go
+

--- a/test/JDBC/input/drop_database.sql
+++ b/test/JDBC/input/drop_database.sql
@@ -1,0 +1,31 @@
+use master
+go
+
+CREATE DATABASE errdb
+GO
+
+USE errdb
+GO
+
+CREATE SCHEMA Purchasing;
+GO
+
+CREATE TYPE NameType FROM varchar(50);
+GO
+
+CREATE TABLE Purchasing.Vendor(VendorName NameType)
+GO
+
+CREATE TRIGGER dVendor ON Purchasing.Vendor
+FOR DELETE AS
+BEGIN
+RETURN;
+END;
+GO
+
+USE master
+go
+
+DROP DATABASE errdb
+go
+


### PR DESCRIPTION
fix the problem when try to drop a database which defined a table in a schema and that table has a trigger define bind with it, it'll return error msg like :

unrecognized object class: 0

This commit fix the bug by delete redundant code in searching for the corresponding trigger to drop in cascade drop database execution.

Task: BABEL-4086

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).