### PR TITLE
sp_rename COLUMN not working for delimited column names

### DIFF
--- a/test/JDBC/expected/Test-sp_rename-vu-cleanup.out
+++ b/test/JDBC/expected/Test-sp_rename-vu-cleanup.out
@@ -14,6 +14,9 @@ GO
 DROP TABLE sp_rename_vu_table1;
 GO
 
+DROP TABLE sp_rename_vu_table_delim;
+GO
+
 DROP TABLE sp_rename_vu_schema1.sp_rename_vu_table1;
 GO
 

--- a/test/JDBC/expected/Test-sp_rename-vu-prepare.out
+++ b/test/JDBC/expected/Test-sp_rename-vu-prepare.out
@@ -8,6 +8,12 @@ GO
 CREATE TABLE sp_rename_vu_table2(sp_rename_vu_t2_col1 int, sp_rename_vu_t2_col2 int);
 GO
 
+SET quoted_identifier ON
+GO
+
+CREATE TABLE sp_rename_vu_table_delim("sp_rename_vu_td1_col1" int, [sp_rename_vu_td1_col2] int);
+GO
+
 CREATE SCHEMA sp_rename_vu_schema1;
 GO
 

--- a/test/JDBC/expected/Test-sp_rename-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_rename-vu-verify.out
@@ -9,6 +9,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -48,6 +49,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_new#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -78,6 +80,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_new#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -284,6 +287,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_case_insensitive1#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -303,6 +307,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_case_insensitive2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -322,6 +327,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_case_insensitive2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -361,6 +367,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_case_insensitive2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -537,6 +544,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_case_insensitive2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1#!#BASE TABLE
@@ -570,6 +578,7 @@ ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
+master#!#dbo#!#sp_rename_vu_table_delim#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table1_case_insensitive2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_table2#!#BASE TABLE
 master#!#dbo#!#sp_rename_vu_tabletype1_new#!#BASE TABLE
@@ -659,6 +668,77 @@ GO
 
 ~~ERROR (Message: column "sp_rename_vu_s1_t2_wrong_col" does not exist)~~
 
+
+-- COLUMN: delimited identifer
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+sp_rename_vu_td1_col1#!#dbo#!#sp_rename_vu_table_delim
+sp_rename_vu_td1_col2#!#dbo#!#sp_rename_vu_table_delim
+~~END~~
+
+
+EXEC sp_rename 'sp_rename_vu_table_delim."sp_rename_vu_td1_col1"', 'sp_rename_vu_td1_col1_new', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+sp_rename_vu_td1_col1_new#!#dbo#!#sp_rename_vu_table_delim
+sp_rename_vu_td1_col2#!#dbo#!#sp_rename_vu_table_delim
+~~END~~
+
+
+EXEC sp_rename 'sp_rename_vu_table_delim.[sp_rename_vu_td1_col1_new]', '[sp_rename_vu_td1_col1_new]', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+[sp_rename_vu_td1_col1_new]#!#dbo#!#sp_rename_vu_table_delim
+sp_rename_vu_td1_col2#!#dbo#!#sp_rename_vu_table_delim
+~~END~~
+
+
+EXEC sp_rename 'sp_rename_vu_table_delim."[sp_rename_vu_td1_col1_new]"', '[SP_rename_vu_td1_col1_MIXED]', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+[sp_rename_vu_td1_col1_mixed]#!#dbo#!#sp_rename_vu_table_delim
+sp_rename_vu_td1_col2#!#dbo#!#sp_rename_vu_table_delim
+~~END~~
+
+
+EXEC sp_rename 'sp_rename_vu_table_delim."[SP_rename_vu_td1_col1_MIXED]"', '[  SP_rename_vu_td1_col1_MIXED_spaces   ]', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+[  sp_rename_vu_td1_col1_mixed_spaces   ]#!#dbo#!#sp_rename_vu_table_delim
+sp_rename_vu_td1_col2#!#dbo#!#sp_rename_vu_table_delim
+~~END~~
+
+
+SET quoted_identifier OFF
+GO
 
 -- USERDATATYPE
 SELECT t1.name, s1.name

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-vu-cleanup.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-vu-cleanup.sql
@@ -14,6 +14,9 @@ GO
 DROP TABLE sp_rename_vu_table1;
 GO
 
+DROP TABLE sp_rename_vu_table_delim;
+GO
+
 DROP TABLE sp_rename_vu_schema1.sp_rename_vu_table1;
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-vu-prepare.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-vu-prepare.sql
@@ -8,6 +8,12 @@ GO
 CREATE TABLE sp_rename_vu_table2(sp_rename_vu_t2_col1 int, sp_rename_vu_t2_col2 int);
 GO
 
+SET quoted_identifier ON
+GO
+
+CREATE TABLE sp_rename_vu_table_delim("sp_rename_vu_td1_col1" int, [sp_rename_vu_td1_col2] int);
+GO
+
 CREATE SCHEMA sp_rename_vu_schema1;
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_rename-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_rename-vu-verify.sql
@@ -305,6 +305,47 @@ GO
 EXEC sp_rename 'sp_rename_vu_schema1.sp_rename_vu_table2_new.sp_rename_vu_s1_t2_wrong_col', 'sp_rename_vu_s1_t2_col1_new', 'COLUMN';
 GO
 
+-- COLUMN: delimited identifer
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+
+EXEC sp_rename 'sp_rename_vu_table_delim."sp_rename_vu_td1_col1"', 'sp_rename_vu_td1_col1_new', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+
+EXEC sp_rename 'sp_rename_vu_table_delim.[sp_rename_vu_td1_col1_new]', '[sp_rename_vu_td1_col1_new]', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+
+EXEC sp_rename 'sp_rename_vu_table_delim."[sp_rename_vu_td1_col1_new]"', '[SP_rename_vu_td1_col1_MIXED]', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+
+EXEC sp_rename 'sp_rename_vu_table_delim."[SP_rename_vu_td1_col1_MIXED]"', '[  SP_rename_vu_td1_col1_MIXED_spaces   ]', 'COLUMN';
+GO
+
+SELECT COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'sp_rename_vu_table_delim'
+ORDER BY COLUMN_NAME, TABLE_SCHEMA, TABLE_NAME;
+GO
+
+SET quoted_identifier OFF
+GO
+
 -- USERDATATYPE
 SELECT t1.name, s1.name
 FROM sys.types t1 INNER JOIN sys.schemas s1 ON t1.schema_id = s1.schema_id 


### PR DESCRIPTION
Previously, sp_rename column did not interpret delimited column names properly, causing wrong actions when inputs had delimited identifiers. Now, the delimited column names cases are handled, so that sp_rename executes properly.

Task: BABEL-4135

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).