### PR TITLE
Made dbname arg in sp_heapdb case-insensitive (BABEL_2_X_DEV)

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -17,6 +17,7 @@
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/formatting.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 #include "utils/tuplestore.h"
@@ -278,6 +279,7 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 {
     ReturnSetInfo 		*rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	char 				*dbname;
+	char				*dbname_lower;
 	ScanKeyData 		scanKey;
     TupleDesc 			tupdesc;
     Tuplestorestate 	*tupstore;
@@ -291,7 +293,7 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 	bool				typIsVarlena;
 	Oid 				datetime_type;
     Oid 				sys_nspoid = get_namespace_oid("sys", false);
-
+	int					index;
 
     /* check to see if caller supports us returning a tuplestore */
     if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
@@ -338,14 +340,25 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 	if (PG_NARGS() > 0)
 	{
 		dbname = TextDatumGetCString(PG_GETARG_DATUM(0));
-		if (!DbidIsValid(get_db_id(dbname)))
+		dbname_lower = str_tolower(dbname, strlen(dbname), DEFAULT_COLLATION_OID);
+		/* Remove trailing spaces at the end of user typed dbname */
+		index = -1;
+		for (int i = 0; dbname_lower[i]!='\0'; i++)
+		{
+			if (dbname_lower[i]!=' ')
+			{
+				index = i;
+			}
+		}
+		dbname_lower[index + 1] = '\0';
+		if (!DbidIsValid(get_db_id(dbname_lower)))
 			ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_DATABASE),
 				 errmsg("The database '%s' does not exist. Supply a valid database name. To see available databases, use sys.databases.", dbname)));
 		ScanKeyInit(&scanKey,
 			Anum_sysdatabaese_name,
 			BTEqualStrategyNumber, F_TEXTEQ,
-			CStringGetTextDatum(dbname));
+			CStringGetTextDatum(dbname_lower));
 		scan = systable_beginscan(rel, sysdatabaese_idx_name_oid, true,
 								NULL, 1, &scanKey);
 	}

--- a/test/JDBC/expected/BABEL-sp_helpdb-vu-verify.out
+++ b/test/JDBC/expected/BABEL-sp_helpdb-vu-verify.out
@@ -1,42 +1,75 @@
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('master', 'babel_sp_helpdb_db');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('master', 'babel_sp_helpdb_db');
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint
-master#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
-babel_sp_helpdb_db#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
+varchar#!#smallint
+master#!#<NULL>
+babel_sp_helpdb_db#!#<NULL>
 ~~END~~
 
 
 -- Executing sp_helpdb with already existing dbname as an input
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('master');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('master');
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint
-master#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
+varchar#!#smallint
+master#!#<NULL>
 ~~END~~
 
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('babel_sp_helpdb_db');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('babel_sp_helpdb_db');
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
+varchar#!#smallint
+babel_sp_helpdb_db#!#<NULL>
 ~~END~~
 
 
 -- Executing sp_helpdb with wrong input
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('abc');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('abc');
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint
+varchar#!#smallint
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The database 'abc' does not exist. Supply a valid database name. To see available databases, use sys.databases.)~~
 
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('  wrongInput');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('  wrongInput');
 GO
 ~~START~~
-varchar#!#varchar#!#varchar#!#varchar#!#smallint
+varchar#!#smallint
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The database '  wrongInput' does not exist. Supply a valid database name. To see available databases, use sys.databases.)~~
+
+
+-- Executing sp_helpdb with a existing dbname but in mixed upper, lower cases as an input
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR');
+GO
+~~START~~
+varchar#!#smallint
+master#!#<NULL>
+~~END~~
+
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db');
+GO
+~~START~~
+varchar#!#smallint
+babel_sp_helpdb_db#!#<NULL>
+~~END~~
+
+
+-- Executing sp_helpdb with a existing dbname but end with trailing spaces as an input
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR        ');
+GO
+~~START~~
+varchar#!#smallint
+master#!#<NULL>
+~~END~~
+
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db ');
+GO
+~~START~~
+varchar#!#smallint
+babel_sp_helpdb_db#!#<NULL>
+~~END~~
+
 

--- a/test/JDBC/input/BABEL-sp_helpdb-vu-verify.sql
+++ b/test/JDBC/input/BABEL-sp_helpdb-vu-verify.sql
@@ -1,14 +1,27 @@
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('master', 'babel_sp_helpdb_db');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('master', 'babel_sp_helpdb_db');
 GO
 
 -- Executing sp_helpdb with already existing dbname as an input
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('master');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('master');
 GO
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('babel_sp_helpdb_db');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('babel_sp_helpdb_db');
 GO
 
 -- Executing sp_helpdb with wrong input
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('abc');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('abc');
 GO
-SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_helpdb('  wrongInput');
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('  wrongInput');
 GO
+
+-- Executing sp_helpdb with a existing dbname but in mixed upper, lower cases as an input
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR');
+GO
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db');
+GO
+
+-- Executing sp_helpdb with a existing dbname but end with trailing spaces as an input
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR        ');
+GO
+SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db ');
+GO
+


### PR DESCRIPTION
### Description

Previously sp_helpdb in babelfish treats dbname as case-sensitive whereas tsql treats the dbname argument as case-insensitive. This commit implemented a str_to_lower function for dbname and resolved the case-senstive issue.



### Issues Resolved

Made dbname arg in babelfish sp_helpdb case-insensitive

### Test Scenarios Covered ###
* **Use case based -**
test dbname with mixed letters of uppercase and lowercase
test dbname that end with trailing spaces

* **Negative test cases -**
test dbname with all lowercase letters

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).