### PR TITLE
Fix: Corrected compatibility level returned by sp_helpdb (BABEL_2_X_DEV)

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -436,7 +436,7 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 		values[4] = CStringGetTextDatum(tmstmp_str);
 
         nulls[5] = 1;
-		nulls[6] = 1;
+		values[6] = UInt8GetDatum(120);
 
         tuplestore_putvalues(tupstore, tupdesc, values, nulls);
     }

--- a/test/JDBC/expected/BABEL-3549.out
+++ b/test/JDBC/expected/BABEL-3549.out
@@ -29,8 +29,8 @@ SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_help
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint
-master#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
-babel_3549_db1#!#<NULL>#!#babel_3549_login1#!#<NULL>#!#<NULL>
+master#!#<NULL>#!#jdbc_user#!#<NULL>#!#120
+babel_3549_db1#!#<NULL>#!#babel_3549_login1#!#<NULL>#!#120
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-sp_helpdb-vu-verify.out
+++ b/test/JDBC/expected/BABEL-sp_helpdb-vu-verify.out
@@ -2,8 +2,8 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('mas
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
-babel_sp_helpdb_db#!#<NULL>
+master#!#120
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 
@@ -12,14 +12,14 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb('master');
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
+master#!#120
 ~~END~~
 
 SELECT name, compatibility_level FROM sys.babelfish_helpdb('babel_sp_helpdb_db');
 GO
 ~~START~~
 varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 
@@ -46,14 +46,14 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR');
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
+master#!#120
 ~~END~~
 
 SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db');
 GO
 ~~START~~
 varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 
@@ -62,14 +62,14 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR        ');
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
+master#!#120
 ~~END~~
 
 SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db ');
 GO
 ~~START~~
 varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
@@ -1,11 +1,3 @@
-SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
-GO
-~~START~~
-text#!#tinyint#!#nvarchar
-db_sys_databases_dep_vu_prepare#!#120#!#bbf_unicode_cp1_ci_as
-~~END~~
-
-
 EXEC sys_databases_proc_dep_vu_prepare
 GO
 ~~START~~

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
@@ -1,10 +1,10 @@
+--compatibility level returned will be NULL because View created before Upgrade is not updated.
 SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
 GO
 ~~START~~
 text#!#tinyint#!#nvarchar
 db_sys_databases_dep_vu_prepare#!#<NULL>#!#bbf_unicode_cp1_ci_as
 ~~END~~
---compatibility level returned will be NULL because View created before Upgrade is not updated.
 
 
 EXEC sys_databases_proc_dep_vu_prepare

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
@@ -1,3 +1,12 @@
+SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
+GO
+~~START~~
+text#!#tinyint#!#nvarchar
+db_sys_databases_dep_vu_prepare#!#<NULL>#!#bbf_unicode_cp1_ci_as
+~~END~~
+--compatibility level returned will be NULL because View created before Upgrade is not updated.
+
+
 EXEC sys_databases_proc_dep_vu_prepare
 GO
 ~~START~~

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
@@ -2,7 +2,7 @@ SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_
 GO
 ~~START~~
 text#!#tinyint#!#nvarchar
-db_sys_databases_dep_vu_prepare#!#<NULL>#!#bbf_unicode_cp1_ci_as
+db_sys_databases_dep_vu_prepare#!#120#!#bbf_unicode_cp1_ci_as
 ~~END~~
 
 

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
@@ -1,6 +1,3 @@
-SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
-GO
-
 EXEC sys_databases_proc_dep_vu_prepare
 GO
 

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
@@ -1,6 +1,6 @@
+--compatibility level returned will be NULL because View created before Upgrade is not updated.
 SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
 GO
---compatibility level returned will be NULL because View created before Upgrade is not updated.
 
 EXEC sys_databases_proc_dep_vu_prepare
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
@@ -1,3 +1,7 @@
+SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
+GO
+--compatibility level returned will be NULL because View created before Upgrade is not updated.
+
 EXEC sys_databases_proc_dep_vu_prepare
 GO
 


### PR DESCRIPTION
### Description
BABEL-4029 for BABEL_2_X_DEV
sys.databases and sys.sysdatabases  show the correct value of 120 for compatibility level column. However, sp_helpdb shows NULL for this value - it should show 120 as well 

### Issues resolved
sp_helpdb will show 120 as well for compatibility level same as Sys.databases and sys.sysdatabases result.

### Test Scenarios Covered
- test Compatibility Level for master and custom database

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).