### PR TITLE
Restrict drop/alter login by non-sysadmin in Babelfish (BABEL_2_X_DEV)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2637,33 +2637,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							}
 						}
 
-						/*
-						 * Leveraging the fact that convertToUPN API returns
-						 * the login name in UPN format if login name contains
-						 * '\' i,e,. windows login. For windows login '\' must
-						 * be present and for password based login '\' is not
-						 * acceptable. So, combining these, if the login is of
-						 * windows then it will be converted to UPN format or
-						 * else it will be as it was
-						 */
-						temp_login_name = convertToUPN(stmt->role->rolename);
-
-						/*
-						 * If the previous rolname is same as current, then it
-						 * is password based login else, it is windows based
-						 * login. If, user is trying to alter password for
-						 * windows login, throw error
-						 */
-						if (temp_login_name != stmt->role->rolename)
-						{
-							if (has_password)
-								ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-												errmsg("Cannot use parameter PASSWORD for a windows login")));
-
-							pfree(stmt->role->rolename);
-							stmt->role->rolename = temp_login_name;
-						}
-
 						if (!has_privs_of_role(GetSessionUserId(), datdba) && !has_password)
 							ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
 								errmsg("Current login %s does not have permission to Alter login", 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2618,6 +2618,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					if (islogin)
 					{
 						Oid			datdba;
+						bool		has_password = false;
 
 						datdba = get_role_oid("sysadmin", false);
 
@@ -2634,6 +2635,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								if (get_role_oid(stmt->role->rolename, true) != GetSessionUserId() && !is_member_of_role(GetSessionUserId(), datdba))
 									ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 											 errmsg("Current login does not have privileges to alter password")));
+								
+								has_password = true;
 							}
 						}
 

--- a/test/JDBC/expected/BABEL-2440.out
+++ b/test/JDBC/expected/BABEL-2440.out
@@ -21,10 +21,6 @@ guest#!#guest#!#master
 
 ALTER LOGIN r1 WITH PASSWORD = 'abc';
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login does not have privileges to alter password)~~
-
 
 SELECT session_user, current_user, db_name();
 GO
@@ -51,10 +47,6 @@ ignore
 
 ALTER LOGIN r1 WITH PASSWORD = '123abc' OLD_PASSWORD = 'abc';
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login does not have privileges to alter password)~~
-
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_login_old_password', 'strict', 'false')
 GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
@@ -19,3 +19,12 @@ go
 
 DROP DATABASE babel_login_vu_prepare_db1
 go
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
@@ -26,3 +26,16 @@ WHERE rolname LIKE 'babel_login_vu_prepare%'
 ORDER BY rolname
 END
 go
+
+-- tsql
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '1234';
+GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -460,3 +460,125 @@ DROP USER babel_login_vu_prepare_r4
 go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
+
+-- tsql
+-- babel_4080 tests start here
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_nonsysadmin1 password=1234
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
+babel_4080_sysadmin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin2#!#S#!#SQL_LOGIN
+~~END~~
+
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Alter login)~~
+
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Drop login)~~
+
+
+-- tsql user=babel_4080_sysadmin1 password=1234
+ALTER LOGIN babel_4080_sysadmin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#bit
+babel_4080_testlogin1#!#0
+~~END~~
+
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#int
+babel_4080_testlogin1#!#1
+~~END~~
+
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#bit
+babel_4080_testlogin1#!#1
+~~END~~
+
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#int
+babel_4080_testlogin1#!#0
+~~END~~
+
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_testlogin2 password=1234
+ALTER LOGIN babel_4080_testlogin2 WITH PASSWORD = 'abcd';
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
@@ -19,3 +19,12 @@ go
 
 DROP DATABASE babel_login_vu_prepare_db1
 go
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
@@ -26,3 +26,16 @@ WHERE rolname LIKE 'babel_login_vu_prepare%'
 ORDER BY rolname
 END
 go
+
+-- tsql
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '1234';
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -261,3 +261,69 @@ DROP USER babel_login_vu_prepare_r4
 go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
+
+-- babel_4080 tests start here
+-- tsql
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_nonsysadmin1 password=1234
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+-- tsql user=babel_4080_sysadmin1 password=1234
+ALTER LOGIN babel_4080_sysadmin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_testlogin2 password=1234
+ALTER LOGIN babel_4080_testlogin2 WITH PASSWORD = 'abcd';
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_sleep(1);
+GO
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_sleep(1);
+GO


### PR DESCRIPTION
Task: BABEL-4057


### Description
Restrict drop/alter login by non-sysadmin in Babelfish
Added has_password variable declaration and assignment for supporting backward compatibility. The addition of variable will have no negative impact to other test cases. 

### Issues Resolved
User will always be able to change their own password, even if they don't have sysadmin role

### Test Scenarios Covered ###
* **Use case based -**

- Sysadmin login is able to alter/drop BBF login
- NonSysadmin login is not able to alter/drop BBF login
- Sysadmin/NonSysadmin logins are able to change their own password
- Sysadmin logins are able to change everyone's password (same as test case 1)



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).