### PR TITLE
Fix @@NESTLEVEL is 1 too high (BABEL_2_X_DEV)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1781,8 +1781,8 @@ DECLARE
     result integer;
 BEGIN
     GET DIAGNOSTICS stack = PG_CONTEXT;
-    result := array_length(string_to_array(stack, 'function'), 1) - 2;
-    IF result < 0 THEN
+    result := array_length(string_to_array(stack, 'function'), 1) - 3; 
+    IF result < -1 THEN
         RAISE EXCEPTION 'Invalid output, check stack trace %', stack;
     ELSE
         RETURN result;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.4.0--2.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.4.0--2.5.0.sql
@@ -1,8 +1,35 @@
--- complain if script is sourced in psql, rather than via ALTER EXTENSION
+q-- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_tsql"" UPDATE TO '2.5.0'" to load this file. \quit
 
 -- add 'sys' to search path for the convenience
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+-- Drops an object if it does not have any dependent objects.
+-- Is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
+-- Please have this be one of the first statements executed in this upgrade script. 
+CREATE OR REPLACE PROCEDURE babelfish_drop_deprecated_object(object_type varchar, schema_name varchar, object_name varchar) AS
+$$
+DECLARE
+    error_msg text;
+    query1 text;
+    query2 text;
+BEGIN
+
+    query1 := pg_catalog.format('alter extension babelfishpg_tsql drop %s %s.%s', object_type, schema_name, object_name);
+    query2 := pg_catalog.format('drop %s %s.%s', object_type, schema_name, object_name);
+
+    execute query1;
+    execute query2;
+EXCEPTION
+    when object_not_in_prerequisite_state then --if 'alter extension' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+    when dependent_objects_still_exist then --if 'drop view' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+end
+$$
+LANGUAGE plpgsql;
 
 ALTER FUNCTION sys.nestlevel() RENAME TO nestlevel_deprecated_in_2_5_0;
 
@@ -45,6 +72,10 @@ CREATE OR REPLACE VIEW sys.sp_databases_view AS
 	GROUP BY database_name
 	ORDER BY database_name;
 GRANT SELECT on sys.sp_databases_view TO PUBLIC;
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -436,7 +436,7 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 		values[4] = CStringGetTextDatum(tmstmp_str);
 
         nulls[5] = 1;
-		nulls[6] = 1;
+		values[6] = UInt8GetDatum(120);
 
         tuplestore_putvalues(tupstore, tupdesc, values, nulls);
     }

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2618,6 +2618,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					if (islogin)
 					{
 						Oid			datdba;
+						bool		has_password = false;
 
 						datdba = get_role_oid("sysadmin", false);
 
@@ -2631,12 +2632,18 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 							if (strcmp(defel->defname, "password") == 0)
 							{
-								if (!is_member_of_role(GetSessionUserId(), datdba))
-									ereport(ERROR,
-											(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+								if (get_role_oid(stmt->role->rolename, true) != GetSessionUserId() && !is_member_of_role(GetSessionUserId(), datdba))
+									ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 											 errmsg("Current login does not have privileges to alter password")));
+								
+								has_password = true;
 							}
 						}
+
+						if (!has_privs_of_role(GetSessionUserId(), datdba) && !has_password)
+							ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
+								errmsg("Current login %s does not have permission to Alter login", 
+								GetUserNameFromId(GetSessionUserId(), true))));
 
 						if (get_role_oid(stmt->role->rolename, true) == InvalidOid)
 							ereport(ERROR, (errcode(ERRCODE_DUPLICATE_OBJECT),
@@ -2752,6 +2759,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					DropRoleStmt *stmt = (DropRoleStmt *) parsetree;
 					bool		drop_user = false;
 					bool		drop_role = false;
+					bool        drop_login = false;
 					bool		all_logins = false;
 					bool		all_users = false;
 					bool		all_roles = false;
@@ -2768,7 +2776,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							drop_user = true;
 						else if (strcmp(headrol->rolename, "is_role") == 0)
 							drop_role = true;
-
+						else 
+							drop_login = true;
+						
 						if (drop_user || drop_role)
 						{
 							char	   *db_name = NULL;
@@ -2864,6 +2874,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							all_roles = true;
 						else
 							other = true;
+
+						if (drop_login && is_login(roleform->oid) && !has_privs_of_role(GetSessionUserId(), get_role_oid("sysadmin", false))){
+							ereport(ERROR, 
+									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
+									errmsg("Current login %s does not have permission to Drop login", GetUserNameFromId(GetSessionUserId(), true))));
+						}
 
 						ReleaseSysCache(tuple);
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1501,12 +1501,15 @@ is_nullable_constraint(Constraint *cst, Oid rel_oid)
 		const char *col_name = NULL;
 		AttrNumber	attnum = InvalidAttrNumber;
 
-		Assert(nodeTag(value) == T_String);
-		if (nodeTag(value) == T_String)
+		if (nodeTag(value) == T_IndexElem){
+			col_name = ((IndexElem *)value)->name;
+		}
+		else
 		{
 			col_name = strVal(value);
-			attnum = get_attnum(rel_oid, col_name);
 		}
+
+		attnum = get_attnum(rel_oid, col_name);
 
 		if (get_attnotnull(rel_oid, attnum))
 		{

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -693,8 +693,6 @@ update_DropRoleStmt(Node *n, const char *role)
 		if (strcmp(tmp->rolename, "is_role") == 0)
 			stmt->roles = list_delete_cell(stmt->roles, list_head(stmt->roles));
 
-		pfree(tmp);
-
 		if (!stmt->roles)
 			return;
 

--- a/test/JDBC/expected/BABEL-2440.out
+++ b/test/JDBC/expected/BABEL-2440.out
@@ -21,10 +21,6 @@ guest#!#guest#!#master
 
 ALTER LOGIN r1 WITH PASSWORD = 'abc';
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login does not have privileges to alter password)~~
-
 
 SELECT session_user, current_user, db_name();
 GO
@@ -51,10 +47,6 @@ ignore
 
 ALTER LOGIN r1 WITH PASSWORD = '123abc' OLD_PASSWORD = 'abc';
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Current login does not have privileges to alter password)~~
-
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_login_old_password', 'strict', 'false')
 GO

--- a/test/JDBC/expected/BABEL-2843.out
+++ b/test/JDBC/expected/BABEL-2843.out
@@ -289,7 +289,7 @@ Result  (cost=0.00..0.26 rows=1 width=4) (actual rows=1 loops=1)
 ~~START~~
 text
 Query Text: insert into "@tab" select * from babel_2843_t1 where a1 = "@param";
-Insert on "@tab_2"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
+Insert on "@tab_1"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
   ->  Seq Scan on babel_2843_t1  (cost=0.00..38.25 rows=11 width=8) (actual rows=1 loops=1)
         Filter: (a1 = 1)
         Rows Removed by Filter: 2
@@ -298,15 +298,15 @@ Insert on "@tab_2"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
 ~~START~~
 text
 Query Text: insert into "@tab" select * from babel_2843_t2 where a2 = "@param";
-Insert on "@tab_2"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
+Insert on "@tab_1"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
   ->  Seq Scan on babel_2843_t2  (cost=0.00..38.25 rows=11 width=8) (actual rows=1 loops=1)
         Filter: (a2 = 1)
 ~~END~~
 
 ~~START~~
 text
-Query Text: select * from @tab_2
-Seq Scan on "@tab_2"  (cost=0.00..32.60 rows=2260 width=8) (actual rows=2 loops=1)
+Query Text: select * from @tab_1
+Seq Scan on "@tab_1"  (cost=0.00..32.60 rows=2260 width=8) (actual rows=2 loops=1)
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/BABEL-2903.out
+++ b/test/JDBC/expected/BABEL-2903.out
@@ -60,7 +60,7 @@ Query Text: ASSIGN @b = SELECT 5
   ->  Result  (cost=0.00..0.01 rows=1 width=4)
 Query Text: EXEC babel_2903_outer_proc @a, @b
   Query Text: DECLARE TABLE @t
-    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_2 (a int, b int)
+    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_1 (a int, b int)
   Query Text: ASSIGN @a = SELECT 3
     Query Text: SELECT 3
     ->  Result  (cost=0.00..0.01 rows=1 width=4)
@@ -80,11 +80,11 @@ Query Text: EXEC babel_2903_outer_proc @a, @b
     ->  Insert on babel_2903_t1  (cost=0.00..0.01 rows=0 width=0)
           ->  Result  (cost=0.00..0.01 rows=1 width=8)
   Query Text: insert into "@t" select * from babel_2903_t1;
-  ->  Insert on "@t_2"  (cost=0.00..32.60 rows=0 width=0)
+  ->  Insert on "@t_1"  (cost=0.00..32.60 rows=0 width=0)
         ->  Seq Scan on babel_2903_t1  (cost=0.00..32.60 rows=2260 width=8)
   Query Text: select * from "@t"
-  ->  Seq Scan on "@t_2"  (cost=0.00..32.60 rows=2260 width=8)
-  Query Text: DROP TABLE @t_2
+  ->  Seq Scan on "@t_1"  (cost=0.00..32.60 rows=2260 width=8)
+  Query Text: DROP TABLE @t_1
 Query Text: select "@a", "@b"
 Result  (cost=0.00..0.01 rows=1 width=8)
 ~~END~~

--- a/test/JDBC/expected/BABEL-3549.out
+++ b/test/JDBC/expected/BABEL-3549.out
@@ -29,8 +29,8 @@ SELECT name, db_size, owner, status, compatibility_level FROM sys.babelfish_help
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint
-master#!#<NULL>#!#jdbc_user#!#<NULL>#!#<NULL>
-babel_3549_db1#!#<NULL>#!#babel_3549_login1#!#<NULL>#!#<NULL>
+master#!#<NULL>#!#jdbc_user#!#<NULL>#!#120
+babel_3549_db1#!#<NULL>#!#babel_3549_login1#!#<NULL>#!#120
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-cleanup.out
@@ -19,3 +19,12 @@ go
 
 DROP DATABASE babel_login_vu_prepare_db1
 go
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-prepare.out
@@ -26,3 +26,16 @@ WHERE rolname LIKE 'babel_login_vu_prepare%'
 ORDER BY rolname
 END
 go
+
+-- tsql
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '1234';
+GO

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -460,3 +460,125 @@ DROP USER babel_login_vu_prepare_r4
 go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
+
+-- tsql
+-- babel_4080 tests start here
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_nonsysadmin1 password=1234
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+babel_4080_nonsysadmin1#!#S#!#SQL_LOGIN
+babel_4080_sysadmin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin1#!#S#!#SQL_LOGIN
+babel_4080_testlogin2#!#S#!#SQL_LOGIN
+~~END~~
+
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Alter login)~~
+
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Drop login)~~
+
+
+-- tsql user=babel_4080_sysadmin1 password=1234
+ALTER LOGIN babel_4080_sysadmin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#bit
+babel_4080_testlogin1#!#0
+~~END~~
+
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#int
+babel_4080_testlogin1#!#1
+~~END~~
+
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#bit
+babel_4080_testlogin1#!#1
+~~END~~
+
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+~~START~~
+varchar#!#int
+babel_4080_testlogin1#!#0
+~~END~~
+
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_testlogin2 password=1234
+ALTER LOGIN babel_4080_testlogin2 WITH PASSWORD = 'abcd';
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+

--- a/test/JDBC/expected/BABEL-sp_helpdb-vu-verify.out
+++ b/test/JDBC/expected/BABEL-sp_helpdb-vu-verify.out
@@ -2,8 +2,8 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb() WHERE name IN ('mas
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
-babel_sp_helpdb_db#!#<NULL>
+master#!#120
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 
@@ -12,14 +12,14 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb('master');
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
+master#!#120
 ~~END~~
 
 SELECT name, compatibility_level FROM sys.babelfish_helpdb('babel_sp_helpdb_db');
 GO
 ~~START~~
 varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 
@@ -46,14 +46,14 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR');
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
+master#!#120
 ~~END~~
 
 SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db');
 GO
 ~~START~~
 varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 
@@ -62,14 +62,14 @@ SELECT name, compatibility_level FROM sys.babelfish_helpdb('MaSteR        ');
 GO
 ~~START~~
 varchar#!#smallint
-master#!#<NULL>
+master#!#120
 ~~END~~
 
 SELECT name, compatibility_level FROM sys.babelfish_helpdb('bAbeL_sP_helPdb_Db ');
 GO
 ~~START~~
 varchar#!#smallint
-babel_sp_helpdb_db#!#<NULL>
+babel_sp_helpdb_db#!#120
 ~~END~~
 
 

--- a/test/JDBC/expected/TestTableType-vu-verify.out
+++ b/test/JDBC/expected/TestTableType-vu-verify.out
@@ -36,7 +36,7 @@ int#!#varchar
 
 ~~ERROR (Code: 547)~~
 
-~~ERROR (Message: new row for relation "@tv_1" violates check constraint "testtabletype_vu_prepare_t2_c1_check")~~
+~~ERROR (Message: new row for relation "@tv_0" violates check constraint "testtabletype_vu_prepare_t2_c1_check")~~
 
 
 declare @tv TestTableType_vu_prepare_t3;
@@ -66,7 +66,7 @@ go
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_a_key")~~
 
 ~~START~~
 varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric

--- a/test/JDBC/expected/alter_table.out
+++ b/test/JDBC/expected/alter_table.out
@@ -1,0 +1,72 @@
+
+create table trans2(id int identity(1,1) primary key, source int not null , target int not null, amount int );
+insert into TRANS2 (source, amount, a, c ) values (1,1,1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "a" of relation "trans2" does not exist)~~
+
+
+ALTER TABLE trans2 ADD a int4 default 3;
+GO
+
+ALTER TABLE trans2 ADD b varchar;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "c" of relation "trans2" already exists)~~
+
+
+ALTER TABLE trans2 ADD c varchar(30) not null default 'aaa';
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "c" of relation "trans2" already exists)~~
+
+
+ALTER TABLE trans2 WITH NOCHECK ADD CONSTRAINT exd_check CHECK (source > 1) ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ALTER TABLE WITH [NO]CHECK ADD' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_nocheck_add_constraint to ignore)~~
+
+
+ALTER TABLE trans2 ADD CONSTRAINT col_b_def DEFAULT 50 FOR target ;
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+~~ROW COUNT: 1~~
+
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() with values ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'values' is not currently supported in Babelfish)~~
+
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() ;
+GO
+
+alter table trans2 add unique (source asc);
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "trans2_source_key")~~
+
+
+ALTER TABLE trans2 DROP COLUMN AddDate
+GO
+
+drop table trans2
+GO

--- a/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_4__sys-databases-dep-vu-verify.out
@@ -1,3 +1,4 @@
+--compatibility level returned will be NULL because View created before Upgrade is not updated.
 SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
 GO
 ~~START~~

--- a/test/JDBC/expected/sys-nestlevel-dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys-nestlevel-dep-vu-cleanup.out
@@ -1,0 +1,20 @@
+USE nextleveldb
+GO
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/expected/sys-nestlevel-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-nestlevel-dep-vu-prepare.out
@@ -1,0 +1,31 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO

--- a/test/JDBC/expected/sys-nestlevel-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-nestlevel-dep-vu-verify.out
@@ -1,0 +1,50 @@
+USE nextleveldb
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/sys-nestlevel.out
+++ b/test/JDBC/expected/sys-nestlevel.out
@@ -1,0 +1,131 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO
+
+CREATE VIEW v0
+AS
+SELECT @@NESTLEVEL AS v0ShouldBe0
+GO
+
+CREATE VIEW v1
+AS
+SELECT * FROM v0
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- should expect print out of 0
+SELECT * from v0
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- should expect print out of 0
+SELECT * from v1
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+DROP VIEW v1
+GO
+
+DROP VIEW v0
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -70,7 +70,7 @@ Query Text: ASSIGN @b = SELECT 5
   ->  Result  (cost=0.00..0.01 rows=1 width=4)
 Query Text: EXEC table_variable_vu_prepareouter_proc @a, @b
   Query Text: DECLARE TABLE @t
-    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_2 (a int, b int)
+    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_1 (a int, b int)
   Query Text: ASSIGN @a = SELECT 3
     Query Text: SELECT 3
     ->  Result  (cost=0.00..0.01 rows=1 width=4)
@@ -90,11 +90,11 @@ Query Text: EXEC table_variable_vu_prepareouter_proc @a, @b
     ->  Insert on table_variable_vu_preparet1  (cost=0.00..0.01 rows=0 width=0)
           ->  Result  (cost=0.00..0.01 rows=1 width=8)
   Query Text: insert into "@t" select * from table_variable_vu_preparet1;
-  ->  Insert on "@t_2"  (cost=0.00..32.60 rows=0 width=0)
+  ->  Insert on "@t_1"  (cost=0.00..32.60 rows=0 width=0)
         ->  Seq Scan on table_variable_vu_preparet1  (cost=0.00..32.60 rows=2260 width=8)
   Query Text: select * from "@t"
-  ->  Seq Scan on "@t_2"  (cost=0.00..32.60 rows=2260 width=8)
-  Query Text: DROP TABLE @t_2
+  ->  Seq Scan on "@t_1"  (cost=0.00..32.60 rows=2260 width=8)
+  Query Text: DROP TABLE @t_1
 Query Text: select "@a", "@b"
 Result  (cost=0.00..0.01 rows=1 width=8)
 ~~END~~

--- a/test/JDBC/expected/table_variable_xact_basic.out
+++ b/test/JDBC/expected/table_variable_xact_basic.out
@@ -51,7 +51,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -95,7 +95,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -186,7 +186,7 @@ int
 
 ~~START~~
 text
-@tvp2_1
+@tvp2_0
 ~~END~~
 
 
@@ -445,7 +445,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -468,7 +468,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -498,7 +498,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char
@@ -508,10 +508,10 @@ varchar#!#int#!#char
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1_a_key
+@tv1_0_a_key
 ~~END~~
 
 
@@ -533,7 +533,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char

--- a/test/JDBC/expected/table_variable_xact_basic_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_basic_isolation_snapshot.out
@@ -53,7 +53,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -97,7 +97,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -188,7 +188,7 @@ int
 
 ~~START~~
 text
-@tvp2_1
+@tvp2_0
 ~~END~~
 
 
@@ -447,7 +447,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -470,7 +470,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -500,7 +500,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char
@@ -510,10 +510,10 @@ varchar#!#int#!#char
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1_a_key
+@tv1_0_a_key
 ~~END~~
 
 
@@ -535,7 +535,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char

--- a/test/JDBC/expected/table_variable_xact_basic_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_basic_xact_abort_on.out
@@ -53,7 +53,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -97,7 +97,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -188,7 +188,7 @@ int
 
 ~~START~~
 text
-@tvp2_1
+@tvp2_0
 ~~END~~
 
 
@@ -447,7 +447,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 
 -------------------------------------------------------------------------------
@@ -465,7 +465,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 
 DROP TYPE tv_table_primary_key
@@ -490,7 +490,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 
 -------------------------------------------------------------------------------
@@ -511,7 +511,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 
 DROP TYPE tv_table_constraint

--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -43,7 +43,7 @@ int#!#int
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -45,7 +45,7 @@ int#!#int
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -45,7 +45,7 @@ int#!#int
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 
 -------------------------------------------------------------------------------

--- a/test/JDBC/expected/table_variable_xact_nested.out
+++ b/test/JDBC/expected/table_variable_xact_nested.out
@@ -70,7 +70,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 1~~
 
@@ -110,14 +110,14 @@ savepoint_t3
 
 ~~START~~
 text
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~
@@ -155,7 +155,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int
@@ -166,8 +166,8 @@ int#!#int
 
 ~~START~~
 text
-@tv_1
-@tv_1_pkey
+@tv_0
+@tv_0_pkey
 ~~END~~
 
 
@@ -213,7 +213,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tvf_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tvf_0_pkey")~~
 
 ~~START~~
 int#!#char
@@ -223,10 +223,10 @@ int#!#char
 
 ~~START~~
 text
-@tvf_1
+@tvf_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tvf_1_pkey
+@tvf_0_pkey
 ~~END~~
 
 
@@ -355,19 +355,19 @@ SELECT * FROM TableVariableTracker
 GO
 ~~START~~
 int#!#text
-4#!#inserted
-4#!#deleted
-4#!#@table_variable_in_trigger_4
-4#!#@pg_toast_#oid_masked#
-4#!#@pg_toast_#oid_masked#_index
 3#!#inserted
 3#!#deleted
 3#!#@table_variable_in_trigger_3
 3#!#@pg_toast_#oid_masked#
 3#!#@pg_toast_#oid_masked#_index
-2#!#@tv_2
+2#!#inserted
+2#!#deleted
+2#!#@table_variable_in_trigger_2
 2#!#@pg_toast_#oid_masked#
 2#!#@pg_toast_#oid_masked#_index
+1#!#@tv_1
+1#!#@pg_toast_#oid_masked#
+1#!#@pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -442,7 +442,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 2~~
 
@@ -507,17 +507,17 @@ savepoint_t3
 
 ~~START~~
 text
-@accumulator_1
+@accumulator_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~

--- a/test/JDBC/expected/table_variable_xact_nested_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_nested_isolation_snapshot.out
@@ -72,7 +72,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 1~~
 
@@ -112,14 +112,14 @@ savepoint_t3
 
 ~~START~~
 text
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~
@@ -157,7 +157,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int
@@ -168,8 +168,8 @@ int#!#int
 
 ~~START~~
 text
-@tv_1
-@tv_1_pkey
+@tv_0
+@tv_0_pkey
 ~~END~~
 
 
@@ -215,7 +215,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tvf_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tvf_0_pkey")~~
 
 ~~START~~
 int#!#char
@@ -225,10 +225,10 @@ int#!#char
 
 ~~START~~
 text
-@tvf_1
+@tvf_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tvf_1_pkey
+@tvf_0_pkey
 ~~END~~
 
 
@@ -357,19 +357,19 @@ SELECT * FROM TableVariableTracker
 GO
 ~~START~~
 int#!#text
-4#!#inserted
-4#!#deleted
-4#!#@table_variable_in_trigger_4
-4#!#@pg_toast_#oid_masked#
-4#!#@pg_toast_#oid_masked#_index
 3#!#inserted
 3#!#deleted
 3#!#@table_variable_in_trigger_3
 3#!#@pg_toast_#oid_masked#
 3#!#@pg_toast_#oid_masked#_index
-2#!#@tv_2
+2#!#inserted
+2#!#deleted
+2#!#@table_variable_in_trigger_2
 2#!#@pg_toast_#oid_masked#
 2#!#@pg_toast_#oid_masked#_index
+1#!#@tv_1
+1#!#@pg_toast_#oid_masked#
+1#!#@pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -444,7 +444,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 2~~
 
@@ -509,17 +509,17 @@ savepoint_t3
 
 ~~START~~
 text
-@accumulator_1
+@accumulator_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~

--- a/test/JDBC/expected/table_variable_xact_nested_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_nested_xact_abort_on.out
@@ -72,7 +72,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 
 DROP FUNCTION table_var_func1
@@ -107,7 +107,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 
 
@@ -152,7 +152,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tvf_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tvf_0_pkey")~~
 
 
 SELECT * FROM @tvf                           -- Table Variable not valid anymore
@@ -280,19 +280,19 @@ SELECT * FROM TableVariableTracker
 GO
 ~~START~~
 int#!#text
-4#!#inserted
-4#!#deleted
-4#!#@table_variable_in_trigger_4
-4#!#@pg_toast_#oid_masked#
-4#!#@pg_toast_#oid_masked#_index
 3#!#inserted
 3#!#deleted
 3#!#@table_variable_in_trigger_3
 3#!#@pg_toast_#oid_masked#
 3#!#@pg_toast_#oid_masked#_index
-2#!#@tv_2
+2#!#inserted
+2#!#deleted
+2#!#@table_variable_in_trigger_2
 2#!#@pg_toast_#oid_masked#
 2#!#@pg_toast_#oid_masked#_index
+1#!#@tv_1
+1#!#@pg_toast_#oid_masked#
+1#!#@pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -367,7 +367,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 
 

--- a/test/JDBC/input/alter_table.sql
+++ b/test/JDBC/input/alter_table.sql
@@ -1,0 +1,46 @@
+create table trans2(id int identity(1,1) primary key, source int not null , target int not null, amount int );
+
+insert into TRANS2 (source, amount, a, c ) values (1,1,1)
+GO
+
+ALTER TABLE trans2 ADD a int4 default 3;
+GO
+
+ALTER TABLE trans2 ADD b varchar;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(30) not null default 'aaa';
+go
+
+ALTER TABLE trans2 WITH NOCHECK ADD CONSTRAINT exd_check CHECK (source > 1) ;
+GO
+
+ALTER TABLE trans2 ADD CONSTRAINT col_b_def DEFAULT 50 FOR target ;
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() with values ;
+GO
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() ;
+GO
+
+alter table trans2 add unique (source asc);
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+
+ALTER TABLE trans2 DROP COLUMN AddDate
+GO
+
+drop table trans2
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-cleanup.mix
@@ -19,3 +19,12 @@ go
 
 DROP DATABASE babel_login_vu_prepare_db1
 go
+
+DROP LOGIN babel_4080_testlogin2;
+GO
+
+DROP LOGIN babel_4080_sysadmin1;
+GO
+
+DROP LOGIN babel_4080_nonsysadmin1;
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-prepare.mix
@@ -26,3 +26,16 @@ WHERE rolname LIKE 'babel_login_vu_prepare%'
 ORDER BY rolname
 END
 go
+
+-- tsql
+CREATE LOGIN babel_4080_nonsysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_sysadmin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin1 with PASSWORD = '1234';
+GO
+
+CREATE LOGIN babel_4080_testlogin2 with PASSWORD = '1234';
+GO

--- a/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-LOGIN-vu-verify.mix
@@ -261,3 +261,69 @@ DROP USER babel_login_vu_prepare_r4
 go
 DROP LOGIN babel_login_vu_prepare_r4;
 go
+
+-- babel_4080 tests start here
+-- tsql
+ALTER SERVER ROLE sysadmin ADD MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_nonsysadmin1 password=1234
+
+SELECT name, type, type_desc FROM sys.server_principals where name like 'babel_4080%' order by name;
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+-- tsql user=babel_4080_sysadmin1 password=1234
+ALTER LOGIN babel_4080_sysadmin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 WITH PASSWORD = 'abcd';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 DISABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+
+ALTER LOGIN babel_4080_testlogin1 ENABLE;
+GO
+
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = 'babel_4080_testlogin1';
+GO
+
+SELECT name, is_disabled FROM sys.server_principals WHERE name = 'babel_4080_testlogin1';
+GO
+
+DROP LOGIN babel_4080_testlogin1;
+GO
+
+ALTER SERVER ROLE sysadmin DROP MEMBER babel_4080_sysadmin1;
+GO
+
+-- tsql user=babel_4080_testlogin2 password=1234
+ALTER LOGIN babel_4080_testlogin2 WITH PASSWORD = 'abcd';
+GO
+
+-- psql
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_sleep(1);
+GO
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4080_nonsysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_sleep(1);
+GO

--- a/test/JDBC/input/sys-nestlevel-dep-vu-cleanup.sql
+++ b/test/JDBC/input/sys-nestlevel-dep-vu-cleanup.sql
@@ -1,0 +1,20 @@
+USE nextleveldb
+GO
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/input/sys-nestlevel-dep-vu-prepare.sql
+++ b/test/JDBC/input/sys-nestlevel-dep-vu-prepare.sql
@@ -1,0 +1,31 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO

--- a/test/JDBC/input/sys-nestlevel-dep-vu-verify.sql
+++ b/test/JDBC/input/sys-nestlevel-dep-vu-verify.sql
@@ -1,0 +1,10 @@
+USE nextleveldb
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO

--- a/test/JDBC/input/sys-nestlevel.sql
+++ b/test/JDBC/input/sys-nestlevel.sql
@@ -1,0 +1,81 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO
+
+CREATE VIEW v0
+AS
+SELECT @@NESTLEVEL AS v0ShouldBe0
+GO
+
+CREATE VIEW v1
+AS
+SELECT * FROM v0
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO
+
+-- should expect print out of 0
+SELECT * from v0
+GO
+
+-- should expect print out of 0
+SELECT * from v1
+GO
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+DROP VIEW v1
+GO
+
+DROP VIEW v0
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -62,6 +62,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures
@@ -200,3 +201,4 @@ BABEL-3657
 BABEL-3938
 BABEL-4078-before-14_8-or-15_3
 BABEL-3215
+

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -108,6 +108,7 @@ sys-datefirst
 sys-databases
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-schema-name

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -112,6 +112,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -109,6 +109,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -109,6 +109,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -107,6 +107,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -110,6 +110,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -269,6 +269,7 @@ sys-index_columns
 sys-indexes
 sys-key_constraints
 sys-master_files
+sys-nestlevel-dep
 sys-registered_search_property_lists
 sys-schemas
 sys-selective_xml_index_paths

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -286,6 +286,7 @@ sys-index_columns
 sys-indexes
 sys-key_constraints
 sys-master_files
+sys-nestlevel-dep
 sys-partitions
 sys-registered_search_property_lists
 sys-schemas

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -304,6 +304,7 @@ sys-index_columns
 sys-indexes
 sys-key_constraints
 sys-master_files
+sys-nestlevel-dep
 sys-partitions
 sys-partitions-dep
 sys-registered_search_property_lists

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_4/sys-databases-dep-vu-verify.sql
@@ -1,3 +1,4 @@
+--compatibility level returned will be NULL because View created before Upgrade is not updated.
 SELECT name, compatibility_level, collation_name FROM sys_databases_view_dep_vu_prepare
 GO
 

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -137,7 +137,6 @@ Could not find upgrade tests for function sys.is_rolemember_internal
 Could not find upgrade tests for function sys.language
 Could not find upgrade tests for function sys.max_precision
 Could not find upgrade tests for function sys.microsoftversion
-Could not find upgrade tests for function sys.nestlevel
 Could not find upgrade tests for function sys.openjson_array
 Could not find upgrade tests for function sys.openjson_object
 Could not find upgrade tests for function sys.openjson_simple


### PR DESCRIPTION
### Description

Previously, @@NESTLEVEL in Babelfish is always 1 unit high, but in Postgres backend, the value is correct. Since we only use @@NESTLEVEL in Babelfish, we changed the value to 1 unit lower in its implementation. 

Cherry-picked from [PR 1422](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1442) 

Fixed @@NESTLEVEL is 1 too high
Task: BABEL-2810

Merged files:
```
Unmerged paths:
  (use "git add/rm <file>..." as appropriate to mark resolution)
        deleted by us:   contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
        both modified:   test/JDBC/upgrade/13_4/schedule
        both modified:   test/JDBC/upgrade/14_5/schedule
        both modified:   test/JDBC/upgrade/14_6/schedule
        deleted by us:   test/JDBC/upgrade/14_7/schedule
        deleted by us:   test/JDBC/upgrade/14_8/schedule
        deleted by us:   test/JDBC/upgrade/15_1/schedule
        deleted by us:   test/JDBC/upgrade/15_2/schedule
        both modified:   test/JDBC/upgrade/latest/schedule

### Issues Resolved
```


### Test Scenarios Covered ###
* **Use case based -**
  * Tested @@NESTLEVEL value in nested procedures


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).