### PR TITLE
Fix Memory Corruption in update_DropRoleStmt

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -693,8 +693,6 @@ update_DropRoleStmt(Node *n, const char *role)
 		if (strcmp(tmp->rolename, "is_role") == 0)
 			stmt->roles = list_delete_cell(stmt->roles, list_head(stmt->roles));
 
-		pfree(tmp);
-
 		if (!stmt->roles)
 			return;
 


### PR DESCRIPTION
### Description
Previously, sys.drop_all_logins() function call was throwing error and failing to drop it when it encounters login or user with considerably long name due to memory corruption in update_DropRoleStmt(). It caused by unwanted pfree() on the first element of stmt->roles which was still being used in subsequent logic.

To fix above issue, We removed explicit memory deallocation of first element of stmt->roles list. It is not needed because list_delete_cell already handles the memory deallocation.

Task: BABEL-4041

### Issues Resolved
BABEL-4041

### Testing
Before
```
--tsql
1> create login lllllllllllllllllllllll with password='12345678';
2> go
1> exit

--psql
jdbc_testdb=# CALL sys.babel_drop_all_logins();
ERROR:  Cannot drop the login 'llllllllЯk', because it does not exist or you do not have permission.
```
After
```
--tsql
1> create login lllllllllllllllllllllll with password='12345678';
2> go
1> exit

--psql
jdbc_testdb=# CALL sys.babel_drop_all_logins();
CALL
```

### Test Scenarios Covered ###
* **Use case based -**
Included in Description

* **Boundary conditions -**
NA

* **Arbitrary inputs -**
NA

* **Negative test cases -**
NA

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).