### PR TITLE
CREATE USER for windows login does not work when login is provided in different case form

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1850,10 +1850,14 @@ get_fully_qualified_domain_name(char *netbios_domain)
 
 	dsc = RelationGetDescr(bbf_domain_mapping_rel);
 
-	ScanKeyInit(&scanKey,
-				Anum_bbf_domain_mapping_netbios_domain_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
-				CStringGetTextDatum(netbios_domain));
+	ScanKeyEntryInitialize(&scanKey,
+						   0,
+						   Anum_bbf_domain_mapping_netbios_domain_name,
+						   BTEqualStrategyNumber,
+						   InvalidOid,
+						   tsql_get_server_collation_oid_internal(false),
+						   F_TEXTEQ,
+						   CStringGetTextDatum(netbios_domain));
 
 	scan = systable_beginscan(bbf_domain_mapping_rel,
 							  get_bbf_domain_mapping_idx_oid(),

--- a/test/JDBC/expected/Test_user_from_win_login-vu-verify.out
+++ b/test/JDBC/expected/Test_user_from_win_login-vu-verify.out
@@ -10,10 +10,48 @@ admin@PNQ
 ~~END~~
 
 
+exec babelfish_add_domain_mapping_entry 'CORP', 'CORP.EXAMPLE.COM';
+GO
+
+create login [CORP\logina4038] from windows;
+GO
+
+create login [corp\loginb4038] from windows;
+GO
+
+select rolname from sys.babelfish_authid_login_ext where rolname like '%4038%';
+GO
+~~START~~
+varchar
+logina4038@CORP.EXAMPLE.COM
+loginb4038@CORP.EXAMPLE.COM
+~~END~~
+
+
+create user usera4038 for login [corp\logina4038];
+GO
+
+create user userb4038 for login [CORP\loginb4038];
+GO
+
+drop user usera4038;
+GO
+
+drop user userb4038;
+GO
+
+drop login [corp\logina4038];
+GO
+
+drop login [corp\loginb4038];
+GO
+
+exec babelfish_remove_domain_mapping_entry 'CORP';
+GO
+
 drop user win_admin;
 GO
 
 drop login [pnq\admin];
 GO
-
 

--- a/test/JDBC/input/Test_user_from_win_login-vu-verify.mix
+++ b/test/JDBC/input/Test_user_from_win_login-vu-verify.mix
@@ -5,10 +5,42 @@ GO
 select login_name from sys.babelfish_authid_user_ext where rolname = 'master_win_admin';
 GO
 
+exec babelfish_add_domain_mapping_entry 'CORP', 'CORP.EXAMPLE.COM';
+GO
+
+create login [CORP\logina4038] from windows;
+GO
+
+create login [corp\loginb4038] from windows;
+GO
+
+select rolname from sys.babelfish_authid_login_ext where rolname like '%4038%';
+GO
+
+create user usera4038 for login [corp\logina4038];
+GO
+
+create user userb4038 for login [CORP\loginb4038];
+GO
+
+drop user usera4038;
+GO
+
+drop user userb4038;
+GO
+
+drop login [corp\logina4038];
+GO
+
+drop login [corp\loginb4038];
+GO
+
+exec babelfish_remove_domain_mapping_entry 'CORP';
+GO
+
 drop user win_admin;
 GO
 
 drop login [pnq\admin];
 GO
-
 


### PR DESCRIPTION
### Description

Previously, While creating windows login and creating user for windows login, It was using get_fully_qualified_domain_name() API to resolve the netbios domain name to FQDN which in turn do the sys cache lookup on babelfish_domain_mapping. This lookup is being initialised via ScanKeyInit() API which uses C_COLLATION_OID (case sensitive collation) due to the lookup was failing if case is different.

This commit resolve above issue by considering current server collation while doing the lookup in babelfish_domain_mapping table using ScanKeyEntryInitialize() API.

### Issues Resolved
BABEL-4038

### Test Scenarios Covered ###
* **Use case based**
Added

* **Boundary conditions -**
NA

* **Arbitrary inputs -**
NA

* **Negative test cases -**
NA

* **Minor version upgrade tests -**
Added

* **Major version upgrade tests -**
Added

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).