### PR TITLE
Increase SLA for four-part-names-vu-verify test file

### DIFF
--- a/test/JDBC/input/four-part-names-vu-verify.sql
+++ b/test/JDBC/input/four-part-names-vu-verify.sql
@@ -1,3 +1,4 @@
+-- sla 60000
 CREATE TABLE fpn_table (a int, b varchar(10))
 GO
 


### PR DESCRIPTION
This commit increases the SLA for four-part-names-vu-verify test file. previous SLA was inadequate and the test was sporadically timing out.

Task: NO-JIRA
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).