### PR TITLE
fix the issue alter table with unique will crash (#1432)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1501,12 +1501,15 @@ is_nullable_constraint(Constraint *cst, Oid rel_oid)
 		const char *col_name = NULL;
 		AttrNumber	attnum = InvalidAttrNumber;
 
-		Assert(nodeTag(value) == T_String);
-		if (nodeTag(value) == T_String)
+		if (nodeTag(value) == T_IndexElem){
+			col_name = ((IndexElem *)value)->name;
+		}
+		else
 		{
 			col_name = strVal(value);
-			attnum = get_attnum(rel_oid, col_name);
 		}
+
+		attnum = get_attnum(rel_oid, col_name);
 
 		if (get_attnotnull(rel_oid, attnum))
 		{

--- a/test/JDBC/expected/alter_table.out
+++ b/test/JDBC/expected/alter_table.out
@@ -1,0 +1,72 @@
+
+create table trans2(id int identity(1,1) primary key, source int not null , target int not null, amount int );
+insert into TRANS2 (source, amount, a, c ) values (1,1,1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "a" of relation "trans2" does not exist)~~
+
+
+ALTER TABLE trans2 ADD a int4 default 3;
+GO
+
+ALTER TABLE trans2 ADD b varchar;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "c" of relation "trans2" already exists)~~
+
+
+ALTER TABLE trans2 ADD c varchar(30) not null default 'aaa';
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "c" of relation "trans2" already exists)~~
+
+
+ALTER TABLE trans2 WITH NOCHECK ADD CONSTRAINT exd_check CHECK (source > 1) ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'ALTER TABLE WITH [NO]CHECK ADD' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_nocheck_add_constraint to ignore)~~
+
+
+ALTER TABLE trans2 ADD CONSTRAINT col_b_def DEFAULT 50 FOR target ;
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+~~ROW COUNT: 1~~
+
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() with values ;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'values' is not currently supported in Babelfish)~~
+
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() ;
+GO
+
+alter table trans2 add unique (source asc);
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "trans2_source_key")~~
+
+
+ALTER TABLE trans2 DROP COLUMN AddDate
+GO
+
+drop table trans2
+GO

--- a/test/JDBC/input/alter_table.sql
+++ b/test/JDBC/input/alter_table.sql
@@ -1,0 +1,46 @@
+create table trans2(id int identity(1,1) primary key, source int not null , target int not null, amount int );
+
+insert into TRANS2 (source, amount, a, c ) values (1,1,1)
+GO
+
+ALTER TABLE trans2 ADD a int4 default 3;
+GO
+
+ALTER TABLE trans2 ADD b varchar;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(10) NOT null;
+GO
+
+ALTER TABLE trans2 ADD c varchar(30) not null default 'aaa';
+go
+
+ALTER TABLE trans2 WITH NOCHECK ADD CONSTRAINT exd_check CHECK (source > 1) ;
+GO
+
+ALTER TABLE trans2 ADD CONSTRAINT col_b_def DEFAULT 50 FOR target ;
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() with values ;
+GO
+
+ALTER TABLE trans2 ADD AddDate smalldatetime NULL CONSTRAINT AddDateDflt DEFAULT GETDATE() ;
+GO
+
+alter table trans2 add unique (source asc);
+GO
+
+insert into TRANS2 (source, amount, a, c ) values (3,1,1,'ddd')
+GO
+
+ALTER TABLE trans2 DROP COLUMN AddDate
+GO
+
+drop table trans2
+GO


### PR DESCRIPTION
Previously alter table add unique will crash the instance due to not handle the node type properly in post analyzer.
This commit fix this issue by properly handle indexElem in post analyzer.

Task: BABEL-3823

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).