### PR TITLE
Fix @@NESTLEVEL is 1 too high (BABEL_2_X_DEV)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1781,8 +1781,8 @@ DECLARE
     result integer;
 BEGIN
     GET DIAGNOSTICS stack = PG_CONTEXT;
-    result := array_length(string_to_array(stack, 'function'), 1) - 2;
-    IF result < 0 THEN
+    result := array_length(string_to_array(stack, 'function'), 1) - 3; 
+    IF result < -1 THEN
         RAISE EXCEPTION 'Invalid output, check stack trace %', stack;
     ELSE
         RETURN result;

--- a/test/JDBC/expected/BABEL-2843.out
+++ b/test/JDBC/expected/BABEL-2843.out
@@ -289,7 +289,7 @@ Result  (cost=0.00..0.26 rows=1 width=4) (actual rows=1 loops=1)
 ~~START~~
 text
 Query Text: insert into "@tab" select * from babel_2843_t1 where a1 = "@param";
-Insert on "@tab_2"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
+Insert on "@tab_1"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
   ->  Seq Scan on babel_2843_t1  (cost=0.00..38.25 rows=11 width=8) (actual rows=1 loops=1)
         Filter: (a1 = 1)
         Rows Removed by Filter: 2
@@ -298,15 +298,15 @@ Insert on "@tab_2"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
 ~~START~~
 text
 Query Text: insert into "@tab" select * from babel_2843_t2 where a2 = "@param";
-Insert on "@tab_2"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
+Insert on "@tab_1"  (cost=0.00..38.25 rows=0 width=0) (actual rows=0 loops=1)
   ->  Seq Scan on babel_2843_t2  (cost=0.00..38.25 rows=11 width=8) (actual rows=1 loops=1)
         Filter: (a2 = 1)
 ~~END~~
 
 ~~START~~
 text
-Query Text: select * from @tab_2
-Seq Scan on "@tab_2"  (cost=0.00..32.60 rows=2260 width=8) (actual rows=2 loops=1)
+Query Text: select * from @tab_1
+Seq Scan on "@tab_1"  (cost=0.00..32.60 rows=2260 width=8) (actual rows=2 loops=1)
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/BABEL-2903.out
+++ b/test/JDBC/expected/BABEL-2903.out
@@ -60,7 +60,7 @@ Query Text: ASSIGN @b = SELECT 5
   ->  Result  (cost=0.00..0.01 rows=1 width=4)
 Query Text: EXEC babel_2903_outer_proc @a, @b
   Query Text: DECLARE TABLE @t
-    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_2 (a int, b int)
+    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_1 (a int, b int)
   Query Text: ASSIGN @a = SELECT 3
     Query Text: SELECT 3
     ->  Result  (cost=0.00..0.01 rows=1 width=4)
@@ -80,11 +80,11 @@ Query Text: EXEC babel_2903_outer_proc @a, @b
     ->  Insert on babel_2903_t1  (cost=0.00..0.01 rows=0 width=0)
           ->  Result  (cost=0.00..0.01 rows=1 width=8)
   Query Text: insert into "@t" select * from babel_2903_t1;
-  ->  Insert on "@t_2"  (cost=0.00..32.60 rows=0 width=0)
+  ->  Insert on "@t_1"  (cost=0.00..32.60 rows=0 width=0)
         ->  Seq Scan on babel_2903_t1  (cost=0.00..32.60 rows=2260 width=8)
   Query Text: select * from "@t"
-  ->  Seq Scan on "@t_2"  (cost=0.00..32.60 rows=2260 width=8)
-  Query Text: DROP TABLE @t_2
+  ->  Seq Scan on "@t_1"  (cost=0.00..32.60 rows=2260 width=8)
+  Query Text: DROP TABLE @t_1
 Query Text: select "@a", "@b"
 Result  (cost=0.00..0.01 rows=1 width=8)
 ~~END~~

--- a/test/JDBC/expected/TestTableType-vu-verify.out
+++ b/test/JDBC/expected/TestTableType-vu-verify.out
@@ -36,7 +36,7 @@ int#!#varchar
 
 ~~ERROR (Code: 547)~~
 
-~~ERROR (Message: new row for relation "@tv_1" violates check constraint "testtabletype_vu_prepare_t2_c1_check")~~
+~~ERROR (Message: new row for relation "@tv_0" violates check constraint "testtabletype_vu_prepare_t2_c1_check")~~
 
 
 declare @tv TestTableType_vu_prepare_t3;
@@ -66,7 +66,7 @@ go
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_a_key")~~
 
 ~~START~~
 varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric

--- a/test/JDBC/expected/sys-nestlevel-dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys-nestlevel-dep-vu-cleanup.out
@@ -1,0 +1,20 @@
+USE nextleveldb
+GO
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/expected/sys-nestlevel-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-nestlevel-dep-vu-prepare.out
@@ -1,0 +1,31 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO

--- a/test/JDBC/expected/sys-nestlevel-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-nestlevel-dep-vu-verify.out
@@ -1,0 +1,50 @@
+USE nextleveldb
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/sys-nestlevel.out
+++ b/test/JDBC/expected/sys-nestlevel.out
@@ -1,0 +1,131 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO
+
+CREATE VIEW v0
+AS
+SELECT @@NESTLEVEL AS v0ShouldBe0
+GO
+
+CREATE VIEW v1
+AS
+SELECT * FROM v0
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- should expect print out of 0
+SELECT * from v0
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- should expect print out of 0
+SELECT * from v1
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+DROP VIEW v1
+GO
+
+DROP VIEW v0
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -70,7 +70,7 @@ Query Text: ASSIGN @b = SELECT 5
   ->  Result  (cost=0.00..0.01 rows=1 width=4)
 Query Text: EXEC table_variable_vu_prepareouter_proc @a, @b
   Query Text: DECLARE TABLE @t
-    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_2 (a int, b int)
+    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_1 (a int, b int)
   Query Text: ASSIGN @a = SELECT 3
     Query Text: SELECT 3
     ->  Result  (cost=0.00..0.01 rows=1 width=4)
@@ -90,11 +90,11 @@ Query Text: EXEC table_variable_vu_prepareouter_proc @a, @b
     ->  Insert on table_variable_vu_preparet1  (cost=0.00..0.01 rows=0 width=0)
           ->  Result  (cost=0.00..0.01 rows=1 width=8)
   Query Text: insert into "@t" select * from table_variable_vu_preparet1;
-  ->  Insert on "@t_2"  (cost=0.00..32.60 rows=0 width=0)
+  ->  Insert on "@t_1"  (cost=0.00..32.60 rows=0 width=0)
         ->  Seq Scan on table_variable_vu_preparet1  (cost=0.00..32.60 rows=2260 width=8)
   Query Text: select * from "@t"
-  ->  Seq Scan on "@t_2"  (cost=0.00..32.60 rows=2260 width=8)
-  Query Text: DROP TABLE @t_2
+  ->  Seq Scan on "@t_1"  (cost=0.00..32.60 rows=2260 width=8)
+  Query Text: DROP TABLE @t_1
 Query Text: select "@a", "@b"
 Result  (cost=0.00..0.01 rows=1 width=8)
 ~~END~~

--- a/test/JDBC/expected/table_variable_xact_basic.out
+++ b/test/JDBC/expected/table_variable_xact_basic.out
@@ -51,7 +51,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -95,7 +95,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -186,7 +186,7 @@ int
 
 ~~START~~
 text
-@tvp2_1
+@tvp2_0
 ~~END~~
 
 
@@ -445,7 +445,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -468,7 +468,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -498,7 +498,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char
@@ -508,10 +508,10 @@ varchar#!#int#!#char
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1_a_key
+@tv1_0_a_key
 ~~END~~
 
 
@@ -533,7 +533,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char

--- a/test/JDBC/expected/table_variable_xact_basic_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_basic_isolation_snapshot.out
@@ -53,7 +53,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -97,7 +97,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -188,7 +188,7 @@ int
 
 ~~START~~
 text
-@tvp2_1
+@tvp2_0
 ~~END~~
 
 
@@ -447,7 +447,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -470,7 +470,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 ~~START~~
 int#!#int#!#char
@@ -500,7 +500,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char
@@ -510,10 +510,10 @@ varchar#!#int#!#char
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1_a_key
+@tv1_0_a_key
 ~~END~~
 
 
@@ -535,7 +535,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 ~~START~~
 varchar#!#int#!#char

--- a/test/JDBC/expected/table_variable_xact_basic_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_basic_xact_abort_on.out
@@ -53,7 +53,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -97,7 +97,7 @@ int#!#int
 
 ~~START~~
 text
-@tv1_1
+@tv1_0
 ~~END~~
 
 
@@ -188,7 +188,7 @@ int
 
 ~~START~~
 text
-@tvp2_1
+@tvp2_0
 ~~END~~
 
 
@@ -447,7 +447,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 
 -------------------------------------------------------------------------------
@@ -465,7 +465,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_pkey")~~
 
 
 DROP TYPE tv_table_primary_key
@@ -490,7 +490,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 
 -------------------------------------------------------------------------------
@@ -511,7 +511,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv1_1_a_key")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv1_0_a_key")~~
 
 
 DROP TYPE tv_table_constraint

--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -43,7 +43,7 @@ int#!#int
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -45,7 +45,7 @@ int#!#int
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -45,7 +45,7 @@ int#!#int
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 
 -------------------------------------------------------------------------------

--- a/test/JDBC/expected/table_variable_xact_nested.out
+++ b/test/JDBC/expected/table_variable_xact_nested.out
@@ -70,7 +70,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 1~~
 
@@ -110,14 +110,14 @@ savepoint_t3
 
 ~~START~~
 text
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~
@@ -155,7 +155,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int
@@ -166,8 +166,8 @@ int#!#int
 
 ~~START~~
 text
-@tv_1
-@tv_1_pkey
+@tv_0
+@tv_0_pkey
 ~~END~~
 
 
@@ -213,7 +213,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tvf_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tvf_0_pkey")~~
 
 ~~START~~
 int#!#char
@@ -223,10 +223,10 @@ int#!#char
 
 ~~START~~
 text
-@tvf_1
+@tvf_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tvf_1_pkey
+@tvf_0_pkey
 ~~END~~
 
 
@@ -355,19 +355,19 @@ SELECT * FROM TableVariableTracker
 GO
 ~~START~~
 int#!#text
-4#!#inserted
-4#!#deleted
-4#!#@table_variable_in_trigger_4
-4#!#@pg_toast_#oid_masked#
-4#!#@pg_toast_#oid_masked#_index
 3#!#inserted
 3#!#deleted
 3#!#@table_variable_in_trigger_3
 3#!#@pg_toast_#oid_masked#
 3#!#@pg_toast_#oid_masked#_index
-2#!#@tv_2
+2#!#inserted
+2#!#deleted
+2#!#@table_variable_in_trigger_2
 2#!#@pg_toast_#oid_masked#
 2#!#@pg_toast_#oid_masked#_index
+1#!#@tv_1
+1#!#@pg_toast_#oid_masked#
+1#!#@pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -442,7 +442,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 2~~
 
@@ -507,17 +507,17 @@ savepoint_t3
 
 ~~START~~
 text
-@accumulator_1
+@accumulator_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~

--- a/test/JDBC/expected/table_variable_xact_nested_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_nested_isolation_snapshot.out
@@ -72,7 +72,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 1~~
 
@@ -112,14 +112,14 @@ savepoint_t3
 
 ~~START~~
 text
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~
@@ -157,7 +157,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 ~~START~~
 int#!#int
@@ -168,8 +168,8 @@ int#!#int
 
 ~~START~~
 text
-@tv_1
-@tv_1_pkey
+@tv_0
+@tv_0_pkey
 ~~END~~
 
 
@@ -215,7 +215,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tvf_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tvf_0_pkey")~~
 
 ~~START~~
 int#!#char
@@ -225,10 +225,10 @@ int#!#char
 
 ~~START~~
 text
-@tvf_1
+@tvf_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tvf_1_pkey
+@tvf_0_pkey
 ~~END~~
 
 
@@ -357,19 +357,19 @@ SELECT * FROM TableVariableTracker
 GO
 ~~START~~
 int#!#text
-4#!#inserted
-4#!#deleted
-4#!#@table_variable_in_trigger_4
-4#!#@pg_toast_#oid_masked#
-4#!#@pg_toast_#oid_masked#_index
 3#!#inserted
 3#!#deleted
 3#!#@table_variable_in_trigger_3
 3#!#@pg_toast_#oid_masked#
 3#!#@pg_toast_#oid_masked#_index
-2#!#@tv_2
+2#!#inserted
+2#!#deleted
+2#!#@table_variable_in_trigger_2
 2#!#@pg_toast_#oid_masked#
 2#!#@pg_toast_#oid_masked#_index
+1#!#@tv_1
+1#!#@pg_toast_#oid_masked#
+1#!#@pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -444,7 +444,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 ~~ROW COUNT: 2~~
 
@@ -509,17 +509,17 @@ savepoint_t3
 
 ~~START~~
 text
-@accumulator_1
+@accumulator_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1
+@table2_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@table2_1_pkey
-@tv3_1
+@table2_0_pkey
+@tv3_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
-@tv1_1
+@tv1_0
 @pg_toast_#oid_masked#
 @pg_toast_#oid_masked#_index
 ~~END~~

--- a/test/JDBC/expected/table_variable_xact_nested_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_nested_xact_abort_on.out
@@ -72,7 +72,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 
 DROP FUNCTION table_var_func1
@@ -107,7 +107,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tv_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_0_pkey")~~
 
 
 
@@ -152,7 +152,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@tvf_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@tvf_0_pkey")~~
 
 
 SELECT * FROM @tvf                           -- Table Variable not valid anymore
@@ -280,19 +280,19 @@ SELECT * FROM TableVariableTracker
 GO
 ~~START~~
 int#!#text
-4#!#inserted
-4#!#deleted
-4#!#@table_variable_in_trigger_4
-4#!#@pg_toast_#oid_masked#
-4#!#@pg_toast_#oid_masked#_index
 3#!#inserted
 3#!#deleted
 3#!#@table_variable_in_trigger_3
 3#!#@pg_toast_#oid_masked#
 3#!#@pg_toast_#oid_masked#_index
-2#!#@tv_2
+2#!#inserted
+2#!#deleted
+2#!#@table_variable_in_trigger_2
 2#!#@pg_toast_#oid_masked#
 2#!#@pg_toast_#oid_masked#_index
+1#!#@tv_1
+1#!#@pg_toast_#oid_masked#
+1#!#@pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -367,7 +367,7 @@ GO
 
 ~~ERROR (Code: 2627)~~
 
-~~ERROR (Message: duplicate key value violates unique constraint "@table2_1_pkey")~~
+~~ERROR (Message: duplicate key value violates unique constraint "@table2_0_pkey")~~
 
 
 

--- a/test/JDBC/input/sys-nestlevel-dep-vu-cleanup.sql
+++ b/test/JDBC/input/sys-nestlevel-dep-vu-cleanup.sql
@@ -1,0 +1,20 @@
+USE nextleveldb
+GO
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/input/sys-nestlevel-dep-vu-prepare.sql
+++ b/test/JDBC/input/sys-nestlevel-dep-vu-prepare.sql
@@ -1,0 +1,31 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO

--- a/test/JDBC/input/sys-nestlevel-dep-vu-verify.sql
+++ b/test/JDBC/input/sys-nestlevel-dep-vu-verify.sql
@@ -1,0 +1,10 @@
+USE nextleveldb
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO

--- a/test/JDBC/input/sys-nestlevel.sql
+++ b/test/JDBC/input/sys-nestlevel.sql
@@ -1,0 +1,81 @@
+CREATE DATABASE nextleveldb
+GO
+
+USE nextleveldb
+GO
+
+CREATE PROC p1
+AS
+SELECT @@NESTLEVEL AS p1BeforeShouldBe1
+EXEC p2
+SELECT @@NESTLEVEL AS p1AfterShouldBe1
+GO
+
+CREATE PROC p2
+    AS
+        SELECT @@NESTLEVEL AS p2BeforeShouldBe2
+        EXEC p3
+        SELECT @@NESTLEVEL AS p2AfterShouldBe2
+GO
+
+CREATE PROC p3
+AS
+SELECT @@NESTLEVEL AS p3BeforeShouldBe3
+EXEC p4
+SELECT @@NESTLEVEL AS p3AfterShouldBe3
+GO
+
+CREATE PROC p4
+AS
+SELECT @@NESTLEVEL AS p4ShouldBe4
+GO
+
+CREATE VIEW v0
+AS
+SELECT @@NESTLEVEL AS v0ShouldBe0
+GO
+
+CREATE VIEW v1
+AS
+SELECT * FROM v0
+GO
+
+-- should expect print out of 1, 2, 3, 4, 3, 2, 1
+EXEC p1
+GO
+
+-- should expect print out of 0
+SELECT @@NESTLEVEL
+GO
+
+-- should expect print out of 0
+SELECT * from v0
+GO
+
+-- should expect print out of 0
+SELECT * from v1
+GO
+
+DROP PROC p4
+GO
+
+DROP PROC p3
+GO
+
+DROP PROC p2
+GO
+
+DROP PROC p1
+GO
+
+DROP VIEW v1
+GO
+
+DROP VIEW v0
+GO
+
+USE master
+GO
+
+DROP DATABASE nextleveldb
+GO

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -62,6 +62,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -108,6 +108,7 @@ sys-datefirst
 sys-databases
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-schema-name

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -112,6 +112,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -109,6 +109,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -109,6 +109,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -107,6 +107,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -110,6 +110,7 @@ sys-column-property
 sys-datefirst
 sys-lock_timeout
 sys-max_connections
+sys-nestlevel-dep
 sys-objects
 sys-original_login
 sys-procedures

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -269,6 +269,7 @@ sys-index_columns
 sys-indexes
 sys-key_constraints
 sys-master_files
+sys-nestlevel-dep
 sys-registered_search_property_lists
 sys-schemas
 sys-selective_xml_index_paths

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -286,6 +286,7 @@ sys-index_columns
 sys-indexes
 sys-key_constraints
 sys-master_files
+sys-nestlevel-dep
 sys-partitions
 sys-registered_search_property_lists
 sys-schemas

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -304,6 +304,7 @@ sys-index_columns
 sys-indexes
 sys-key_constraints
 sys-master_files
+sys-nestlevel-dep
 sys-partitions
 sys-partitions-dep
 sys-registered_search_property_lists

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -137,7 +137,6 @@ Could not find upgrade tests for function sys.is_rolemember_internal
 Could not find upgrade tests for function sys.language
 Could not find upgrade tests for function sys.max_precision
 Could not find upgrade tests for function sys.microsoftversion
-Could not find upgrade tests for function sys.nestlevel
 Could not find upgrade tests for function sys.openjson_array
 Could not find upgrade tests for function sys.openjson_object
 Could not find upgrade tests for function sys.openjson_simple

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -18,6 +18,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_function in fi
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--2.0.0--2.1.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--2.3.0--2.4.0.sql
+Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--2.4.0--2.5.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_table in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--1.0.0--1.1.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql


### PR DESCRIPTION
### Description

Previously, @@NESTLEVEL in Babelfish is always 1 unit high, but in Postgres backend, the value is correct. Since we only use @@NESTLEVEL in Babelfish, we changed the value to 1 unit lower in its implementation. 

Cherry-picked from [PR 1422](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1442) 

Fixed @@NESTLEVEL is 1 too high
Task: BABEL-2810

Merged files:
```
Unmerged paths:
  (use "git add/rm <file>..." as appropriate to mark resolution)
        deleted by us:   contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
        both modified:   test/JDBC/upgrade/13_4/schedule
        both modified:   test/JDBC/upgrade/14_5/schedule
        both modified:   test/JDBC/upgrade/14_6/schedule
        deleted by us:   test/JDBC/upgrade/14_7/schedule
        deleted by us:   test/JDBC/upgrade/14_8/schedule
        deleted by us:   test/JDBC/upgrade/15_1/schedule
        deleted by us:   test/JDBC/upgrade/15_2/schedule
        both modified:   test/JDBC/upgrade/latest/schedule

### Issues Resolved
```


### Test Scenarios Covered ###
* **Use case based -**
  * Tested @@NESTLEVEL value in nested procedures


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).