### PR TITLE
Disallow ALTER ROLE of bbf roles/users in PG

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1039,8 +1039,8 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
     ListCell *opt;
     Oid role_oid;
     Oid	babelfish_db_oid;
-	HeapTuple	tp;
-	Form_pg_authid authForm;
+    HeapTuple tp;
+    Form_pg_authid authForm;
 
     /* If the role does not exist, just let the normal Postgres checks happen. */
     if (name == NULL)
@@ -1050,11 +1050,11 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
 
     if (sql_dialect != SQL_DIALECT_TSQL && is_babelfish_role(name))
     {
-		tp = SearchSysCache1(AUTHNAME, CStringGetDatum(name));
-		if (HeapTupleIsValid(tp))
-		{
-			authForm = (Form_pg_authid) GETSTRUCT(tp);
-		}
+	    tp = SearchSysCache1(AUTHNAME, CStringGetDatum(name));
+	    if (HeapTupleIsValid(tp))
+	    {
+		    authForm = (Form_pg_authid) GETSTRUCT(tp);
+	    }
 	    babelfish_db_name = GetConfigOption("babelfishpg_tsql.database_name", true, false);
 	    babelfish_db_oid = get_database_oid(babelfish_db_name, true);
 	    role_oid = get_role_oid(name, true);
@@ -1099,8 +1099,8 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
 			    }
 		    }
 	    }
-		if (authForm)
-			ReleaseSysCache(tp);
+	    if (authForm)
+		    ReleaseSysCache(tp);
 	    check_babelfish_alterrole_restictions(allow_alter_role_operation);
     }
     pfree(name);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1039,6 +1039,8 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
     ListCell *opt;
     Oid role_oid;
     Oid	babelfish_db_oid;
+	HeapTuple	tp;
+	Form_pg_authid authForm;
 
     /* If the role does not exist, just let the normal Postgres checks happen. */
     if (name == NULL)
@@ -1048,6 +1050,11 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
 
     if (sql_dialect != SQL_DIALECT_TSQL && is_babelfish_role(name))
     {
+		tp = SearchSysCache1(AUTHNAME, CStringGetDatum(name));
+		if (HeapTupleIsValid(tp))
+		{
+			authForm = (Form_pg_authid) GETSTRUCT(tp);
+		}
 	    babelfish_db_name = GetConfigOption("babelfishpg_tsql.database_name", true, false);
 	    babelfish_db_oid = get_database_oid(babelfish_db_name, true);
 	    role_oid = get_role_oid(name, true);
@@ -1081,9 +1088,9 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
 		    }
 		    else
 		    {
-			    if (strcmp(defel->defname, "password") == 0 ||
+			    if ((authForm && authForm->rolcanlogin) && (strcmp(defel->defname, "password") == 0 ||
 					    strcmp(defel->defname, "connectionlimit") == 0 ||
-					    strcmp(defel->defname, "validUntil") == 0)
+					    strcmp(defel->defname, "validUntil") == 0))
 				    allow_alter_role_operation = true;
 			    else
 			    {
@@ -1092,6 +1099,8 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
 			    }
 		    }
 	    }
+		if (authForm)
+			ReleaseSysCache(tp);
 	    check_babelfish_alterrole_restictions(allow_alter_role_operation);
     }
     pfree(name);

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -16,9 +16,10 @@ CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' in
 go
 
 -- psql user=ownership_restrictions_from_pg_login1 password=12345678
--- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
+-- If tsql login connected through psql Alter ROLE of an bbf created logins for password,
 -- connection limit and valid until should be working fine
--- and the rest of alter role operations should throw an error.
+-- and the rest of alter role operations and all alter role operations for bbf created users/roles
+-- should throw an error.
 DROP ROLE master_ownership_restrictions_from_pg_role1;
 GO
 ~~ERROR (Code: 0)~~
@@ -29,6 +30,11 @@ GO
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 rename to master_ownership_restrictions_from_pg_role5;
 GO
@@ -40,12 +46,27 @@ GO
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '12345678';
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
 GO
@@ -161,6 +182,11 @@ GO
 
 ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
 
 ALTER ROLE ALL IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
@@ -221,8 +247,24 @@ GO
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
+-- after password changes, connecting with wrong password should throw an error
 alter role ownership_restrictions_from_pg_login1 with password '12345678';
 GO
+
+-- tsql user=ownership_restrictions_from_pg_login1 password=12345678
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Login failed for user "ownership_restrictions_from_pg_login1" )~~
+
+-- after connection limit set to 1, shouldn't be able to login multiple sessions
+alter role ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login1 password=12345678
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: too many connections for role "ownership_restrictions_from_pg_login1" )~~
+
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
@@ -265,7 +307,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -281,7 +323,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -289,7 +331,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -297,7 +339,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -417,7 +459,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -236,7 +236,10 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
+ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 rename to master_ownership_restrictions_from_pg_role5;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -244,26 +247,143 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
+ALTER ROLE ownership_restrictions_from_pg_login1 with ENCRYPTED password '12345678';
 GO
 
--- after password changes, connecting with wrong password should throw an error
-alter role ownership_restrictions_from_pg_login1 with password '12345678';
+ALTER ROLE ownership_restrictions_from_pg_login1 with password NULL;
 GO
 
--- tsql user=ownership_restrictions_from_pg_login1 password=12345678
-~~ERROR (Code: 33557097)~~
+ALTER ROLE ownership_restrictions_from_pg_login1 with password '12345678';
+GO
 
-~~ERROR (Message: Login failed for user "ownership_restrictions_from_pg_login1" )~~
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEROLE;
+GO
+~~ERROR (Code: 0)~~
 
--- after connection limit set to 1, shouldn't be able to login multiple sessions
-alter role ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOLOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 LOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOSUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 SUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOINHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 INHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 REPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOREPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 BYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- after connection limit set to 1, shouldn't be able to connect to multiple sessions
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
 GO
 
 -- tsql user=ownership_restrictions_from_pg_login1 password=12345678
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: too many connections for role "ownership_restrictions_from_pg_login1" )~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
 
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
@@ -292,9 +412,10 @@ GO
 
 
 -- psql user=ownership_restrictions_from_pg_test_user password=12345678
--- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
+-- For plain psql user Alter ROLE of an bbf created logins for password,
 -- connection limit and valid until should be working fine
--- and the rest of alter role operations should throw an error.
+-- and the rest of alter role operations and all alter role operations for bbf created users/roles
+-- should throw an error.
 DROP ROLE master_ownership_restrictions_from_pg_role1;
 GO
 ~~ERROR (Code: 0)~~
@@ -511,14 +632,6 @@ GO
     Server SQLState: 3D000)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 ~~ERROR (Code: 0)~~
@@ -527,11 +640,163 @@ GO
     Server SQLState: 42501)~~
 
 
-alter role ownership_restrictions_from_pg_login1 with password '12345678';
+ALTER ROLE ownership_restrictions_from_pg_login1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with ENCRYPTED password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
 ~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with password NULL;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with password '12345678';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOLOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 LOGIN;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOSUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 SUPERUSER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOINHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 INHERIT;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 REPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOREPLICATION;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 BYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE ownership_restrictions_from_pg_login1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -101,23 +101,71 @@ GO
 ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
-GO
-
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
--- after password changes, connecting with wrong password should throw an error
-alter role ownership_restrictions_from_pg_login1 with password '12345678';
+ALTER ROLE ownership_restrictions_from_pg_login1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with ENCRYPTED password '12345678';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with password NULL;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with password '12345678';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEROLE;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEROLE;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEDB;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOLOGIN;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 LOGIN;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOSUPERUSER;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 SUPERUSER;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOINHERIT;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 INHERIT;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 REPLICATION;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOREPLICATION;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 BYPASSRLS;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
+GO
+
+-- after connection limit set to 1, shouldn't be able to connect to multiple sessions
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
 GO
 
 -- tsql user=ownership_restrictions_from_pg_login1 password=12345678
 
--- after connection limit set to 1, shouldn't be able to login multiple sessions
-alter role ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
+ALTER ROLE ownership_restrictions_from_pg_login1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
-
--- tsql user=ownership_restrictions_from_pg_login1 password=12345678
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
@@ -130,9 +178,10 @@ ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMI
 GO
 
 -- psql user=ownership_restrictions_from_pg_test_user password=12345678
--- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
+-- For plain psql user Alter ROLE of an bbf created logins for password,
 -- connection limit and valid until should be working fine
--- and the rest of alter role operations should throw an error.
+-- and the rest of alter role operations and all alter role operations for bbf created users/roles
+-- should throw an error.
 DROP ROLE master_ownership_restrictions_from_pg_role1;
 GO
 
@@ -214,13 +263,67 @@ GO
 ALTER ROLE SESSION_USER IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 RENAME TO ownership_restrictions_from_pg_role2;
-GO
-
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
-alter role ownership_restrictions_from_pg_login1 with password '12345678';
+ALTER ROLE ownership_restrictions_from_pg_login1 rename to master_ownership_restrictions_from_pg_role5;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with ENCRYPTED password '12345678';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with password NULL;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 with password '12345678';
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEROLE;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEROLE;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEDB;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOLOGIN;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 LOGIN;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOSUPERUSER;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 SUPERUSER;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOINHERIT;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 INHERIT;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 REPLICATION;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOREPLICATION;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 BYPASSRLS;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
+GO
+
+ALTER ROLE ownership_restrictions_from_pg_login1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -16,9 +16,10 @@ CREATE USER ownership_restrictions_from_pg_test_user WITH PASSWORD '12345678' in
 go
 
 -- psql user=ownership_restrictions_from_pg_login1 password=12345678
--- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
+-- If tsql login connected through psql Alter ROLE of an bbf created logins for password,
 -- connection limit and valid until should be working fine
--- and the rest of alter role operations should throw an error.
+-- and the rest of alter role operations and all alter role operations for bbf created users/roles
+-- should throw an error.
 DROP ROLE master_ownership_restrictions_from_pg_role1;
 GO
 
@@ -106,8 +107,17 @@ GO
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
 
+-- after password changes, connecting with wrong password should throw an error
 alter role ownership_restrictions_from_pg_login1 with password '12345678';
 GO
+
+-- tsql user=ownership_restrictions_from_pg_login1 password=12345678
+
+-- after connection limit set to 1, shouldn't be able to login multiple sessions
+alter role ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login1 password=12345678
 
 ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE ownership_restrictions_from_pg_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO


### PR DESCRIPTION
### Description

Previously, ALTER ROLE operations like password change, connection limit and valid until are allowed for bbf created roles/users. The bbf created roles/users are nologin by default so allowing listed above alter role operations doesn't seem correct.

This commit fixes the issue by disallowing all kind of alter role operations for bbf created roles/users.

### Issues Resolved

 BABEL-2976
Signed-off-by: vasavi suthapalli <svasusri@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Add all kind of alter role operation for bbf created login for different types of psql user


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** Add tests for different kind of alter role operations for bbf roles/users which should throw error, added tests for connection limit.


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).