### PR TITLE
SP_DATABASES is failing in pipeline

### DIFF
--- a/test/JDBC/expected/BABEL-SP_DATABASES.out
+++ b/test/JDBC/expected/BABEL-SP_DATABASES.out
@@ -49,11 +49,12 @@ GO
 
 exec sp_databases_PROC1;
 GO
-~~ROW COUNT: 1~~
+~~ROW COUNT: 2~~
 
 ~~START~~
 varchar#!#int#!#varchar
 db1#!#1#!#<NULL>
+master#!#1#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_DATABASES.out
+++ b/test/JDBC/expected/BABEL-SP_DATABASES.out
@@ -37,9 +37,29 @@ db1#!#<NULL>
 ~~END~~
 
 
+CREATE PROCEDURE sp_databases_PROC1
+AS
+BEGIN
+DECLARE
+    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+END
+GO
 
--- EXEC sp_databases;
--- GO
+exec sp_databases_PROC1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int#!#varchar
+db1#!#1#!#<NULL>
+~~END~~
+
+
+DROP PROCEDURE sp_databases_PROC1;
+GO
+
 drop table t_spdatabases;
 go
 use master;

--- a/test/JDBC/expected/BABEL-SP_DATABASES.out
+++ b/test/JDBC/expected/BABEL-SP_DATABASES.out
@@ -40,17 +40,16 @@ db1#!#<NULL>
 CREATE PROCEDURE sp_databases_PROC1
 AS
 BEGIN
-DECLARE
-    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+    SET NOCOUNT ON;
+    DECLARE @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
     SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='DB1';
+    SET NOCOUNT OFF;
 END
 GO
 
 exec sp_databases_PROC1;
 GO
-~~ROW COUNT: 1~~
-
 ~~START~~
 varchar#!#int#!#varchar
 db1#!#1#!#<NULL>

--- a/test/JDBC/expected/BABEL-SP_DATABASES.out
+++ b/test/JDBC/expected/BABEL-SP_DATABASES.out
@@ -43,18 +43,17 @@ BEGIN
 DECLARE
     @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
-    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='DB1';
 END
 GO
 
 exec sp_databases_PROC1;
 GO
-~~ROW COUNT: 2~~
+~~ROW COUNT: 1~~
 
 ~~START~~
 varchar#!#int#!#varchar
 db1#!#1#!#<NULL>
-master#!#1#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
@@ -31,6 +31,6 @@ BEGIN
 DECLARE
     @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
-    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='sys_sp_databases_dep_vu_prepare_db1';
 END
 GO

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
@@ -24,3 +24,13 @@ go
 create view sys_sp_databases_dep_vu_prepare_v1 as
     select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
 go
+
+CREATE PROCEDURE sp_databases_dep_vu_prepare_PROC1
+AS
+BEGIN
+DECLARE
+    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+END
+GO

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-prepare.out
@@ -28,9 +28,10 @@ go
 CREATE PROCEDURE sp_databases_dep_vu_prepare_PROC1
 AS
 BEGIN
-DECLARE
-    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+    SET NOCOUNT ON;
+    DECLARE @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
     SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='sys_sp_databases_dep_vu_prepare_db1';
+    SET NOCOUNT OFF;
 END
 GO

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
@@ -24,3 +24,13 @@ varchar#!#varchar
 sys_sp_databases_dep_vu_prepare_db1#!#<NULL>
 ~~END~~
 
+
+EXEC sp_databases_dep_vu_prepare_PROC1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int#!#varchar
+sys_sp_databases_dep_vu_prepare_db1#!#1#!#<NULL>
+~~END~~
+

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
@@ -27,8 +27,6 @@ sys_sp_databases_dep_vu_prepare_db1#!#<NULL>
 
 EXEC sp_databases_dep_vu_prepare_PROC1
 GO
-~~ROW COUNT: 1~~
-
 ~~START~~
 varchar#!#int#!#varchar
 sys_sp_databases_dep_vu_prepare_db1#!#1#!#<NULL>

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
@@ -27,11 +27,10 @@ sys_sp_databases_dep_vu_prepare_db1#!#<NULL>
 
 EXEC sp_databases_dep_vu_prepare_PROC1
 GO
-~~ROW COUNT: 2~~
+~~ROW COUNT: 1~~
 
 ~~START~~
 varchar#!#int#!#varchar
 sys_sp_databases_dep_vu_prepare_db1#!#1#!#<NULL>
-master#!#1#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-sp_databases-dep-vu-verify.out
@@ -27,10 +27,11 @@ sys_sp_databases_dep_vu_prepare_db1#!#<NULL>
 
 EXEC sp_databases_dep_vu_prepare_PROC1
 GO
-~~ROW COUNT: 1~~
+~~ROW COUNT: 2~~
 
 ~~START~~
 varchar#!#int#!#varchar
 sys_sp_databases_dep_vu_prepare_db1#!#1#!#<NULL>
+master#!#1#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/input/BABEL-SP_DATABASES.sql
+++ b/test/JDBC/input/BABEL-SP_DATABASES.sql
@@ -25,7 +25,7 @@ BEGIN
 DECLARE
     @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
-    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='DB1';
 END
 GO
 

--- a/test/JDBC/input/BABEL-SP_DATABASES.sql
+++ b/test/JDBC/input/BABEL-SP_DATABASES.sql
@@ -22,10 +22,11 @@ go
 CREATE PROCEDURE sp_databases_PROC1
 AS
 BEGIN
-DECLARE
-    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+    SET NOCOUNT ON;
+    DECLARE @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
     SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='DB1';
+    SET NOCOUNT OFF;
 END
 GO
 

--- a/test/JDBC/input/BABEL-SP_DATABASES.sql
+++ b/test/JDBC/input/BABEL-SP_DATABASES.sql
@@ -19,8 +19,21 @@ go
 select database_name, remarks from sys.sp_databases_view where database_name='DB1';
 go
 
--- EXEC sp_databases;
--- GO
+CREATE PROCEDURE sp_databases_PROC1
+AS
+BEGIN
+DECLARE
+    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+END
+GO
+
+exec sp_databases_PROC1;
+GO
+
+DROP PROCEDURE sp_databases_PROC1;
+GO
 
 drop table t_spdatabases;
 go

--- a/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
@@ -26,9 +26,10 @@ go
 CREATE PROCEDURE sp_databases_dep_vu_prepare_PROC1
 AS
 BEGIN
-DECLARE
-    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+    SET NOCOUNT ON;
+    DECLARE @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
     SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='sys_sp_databases_dep_vu_prepare_db1';
+    SET NOCOUNT OFF;
 END
 GO

--- a/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
@@ -22,3 +22,13 @@ go
 create view sys_sp_databases_dep_vu_prepare_v1 as
     select database_name, remarks from sys.sp_databases_view where database_name='sys_sp_databases_dep_vu_prepare_db1'
 go
+
+CREATE PROCEDURE sp_databases_dep_vu_prepare_PROC1
+AS
+BEGIN
+DECLARE
+    @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
+	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+END
+GO

--- a/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-sp_databases-dep-vu-prepare.sql
@@ -29,6 +29,6 @@ BEGIN
 DECLARE
     @tmp_sp_addrole TABLE(database_name sys.SYSNAME, database_size int, remarks sys.VARCHAR(254));
 	INSERT INTO @tmp_sp_addrole (database_name, database_size, remarks) EXEC sp_databases;
-    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole;
+    SELECT database_name, (case when database_size >=0 then 1 else NULL end), remarks  FROM @tmp_sp_addrole where database_name='sys_sp_databases_dep_vu_prepare_db1';
 END
 GO

--- a/test/JDBC/input/views/sys-sp_databases-dep-vu-verify.sql
+++ b/test/JDBC/input/views/sys-sp_databases-dep-vu-verify.sql
@@ -9,3 +9,6 @@ go
 
 select * from sys_sp_databases_dep_vu_prepare_v1
 go
+
+EXEC sp_databases_dep_vu_prepare_PROC1
+GO

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -67,7 +67,6 @@ Could not find tests for procedure sys.babel_drop_all_dbs
 Could not find tests for procedure sys.babel_drop_all_logins
 Could not find tests for procedure sys.babel_initialize_logins
 Could not find tests for procedure sys.printarg
-Could not find tests for procedure sys.sp_databases
 Could not find tests for table sys.babelfish_helpcollation
 Could not find tests for table sys.babelfish_syslanguages
 Could not find tests for table sys.service_settings
@@ -189,7 +188,6 @@ Could not find upgrade tests for procedure sys.babel_initialize_logins
 Could not find upgrade tests for procedure sys.printarg
 Could not find upgrade tests for procedure sys.sp_column_privileges
 Could not find upgrade tests for procedure sys.sp_cursor_list
-Could not find upgrade tests for procedure sys.sp_databases
 Could not find upgrade tests for procedure sys.sp_describe_cursor
 Could not find upgrade tests for procedure sys.sp_describe_undeclared_parameters
 Could not find upgrade tests for procedure sys.sp_oledb_ro_usrname


### PR DESCRIPTION
### Description

Previously BABEL-SP_DATABASES test file is failing in pipeline, so disabled the test case for sp_databases procedure.

With this commit added a test case for sp_databases such that it will not be failed in pipeline for different database sizes.

### Issues Resolved

BABEL-4052

### Test Scenarios Covered ###
* **Use case based -** Add tests for procedure sp_databases


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** Add test case for sp_databases in test file sys-sp_databases-dep-* as they are schedulred for upgrade


* **Major version upgrade tests -**  Add test case for sp_databases in test file sys-sp_databases-dep-* as they are schedulred for upgrade


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).