### PR TITLE
Fixed memory and release compilation related issues

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1040,7 +1040,7 @@ handle_alter_role(AlterRoleStmt* alter_role_stmt)
     Oid role_oid;
     Oid	babelfish_db_oid;
     HeapTuple tp;
-    Form_pg_authid authForm;
+    Form_pg_authid authForm = NULL;
 
     /* If the role does not exist, just let the normal Postgres checks happen. */
     if (name == NULL)

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -509,10 +509,10 @@ schema_name(PG_FUNCTION_ARGS)
 Datum
 schema_id(PG_FUNCTION_ARGS)
 {
-	char	   *name;
 	char	   *input_name;
 	char	   *physical_name;
 	int			id;
+	char	   *name = NULL;
 
 	/* when no argument is passed, then ID of default schema of the caller */
 	if (PG_NARGS() == 0)

--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -1545,8 +1545,7 @@ pltsql_post_expand_star(ParseState *pstate, ColumnRef *cref, List *l)
 	Datum	   *optiondatums;
 	int			noptions,
 				i;
-	char	   *optstr,
-			   *bbf_original_name;
+	char	   *optstr;
 
 	foreach(li, l)
 	{
@@ -1596,12 +1595,8 @@ pltsql_post_expand_star(ParseState *pstate, ColumnRef *cref, List *l)
 			optstr = VARDATA(optiondatums[i]);
 			if (strncmp(optstr, "bbf_original_name=", 18) == 0)
 			{
-				/*
-				 * We found the original name; rewrite it as bbf_original_name
-				 */
-				bbf_original_name = &optstr[18];
-				bbf_original_name[strlen(te->resname)] = '\0';
-				te->resname = pstrdup(bbf_original_name);
+				/* preserve the case */
+				te->resname = pnstrdup((char *) &optstr[18], strlen(te->resname));
 				break;
 			}
 		}

--- a/contrib/babelfishpg_tsql/src/pl_funcs.c
+++ b/contrib/babelfishpg_tsql/src/pl_funcs.c
@@ -798,6 +798,7 @@ void
 pltsql_free_function_memory(PLtsql_function *func)
 {
 	int			i;
+	MemoryContext fn_cxt = NULL;
 
 	/* Better not call this on an in-use function */
 	Assert(func->use_count == 0);
@@ -862,10 +863,14 @@ pltsql_free_function_memory(PLtsql_function *func)
 	 * And finally, release all memory except the PLtsql_function struct
 	 * itself (which has to be kept around because there may be multiple
 	 * fn_extra pointers to it).
+	 * Be careful though, because pltsql_inline_handler does palloc the
+	 * PLtsql_function struct in fn_cxt memory context itself.
 	 */
-	if (func->fn_cxt)
-		MemoryContextDelete(func->fn_cxt);
+	fn_cxt = func->fn_cxt;
 	func->fn_cxt = NULL;
+
+	if (fn_cxt)
+		MemoryContextDelete(fn_cxt);
 }
 
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1694,7 +1694,7 @@ pltsql_sequence_datatype_map(ParseState *pstate,
 	Oid			tsqlSeqTypOid;
 	TypeName   *type_def;
 	List	   *type_names;
-	List	   *new_type_names;
+	List	   *new_type_names = NIL;
 	AclResult	aclresult;
 	Oid			base_type;
 	int			list_len;
@@ -2437,7 +2437,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								if (windows_login_contains_invalid_chars(orig_loginname))
 									ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 													errmsg("'%s' is not a valid name because it contains invalid characters.", orig_loginname)));
-								
+
 								/*
 								 * Check whether the domain name contains invalid characters or not.
 								 */
@@ -2844,8 +2844,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 
 						if (!has_privs_of_role(GetSessionUserId(), datdba) && !has_password)
-							ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
-								errmsg("Current login %s does not have permission to Alter login", 
+							ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+								errmsg("Current login %s does not have permission to Alter login",
 								GetUserNameFromId(GetSessionUserId(), true))));
 
 						if (get_role_oid(stmt->role->rolename, true) == InvalidOid)
@@ -2979,9 +2979,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							drop_user = true;
 						else if (strcmp(headrol->rolename, "is_role") == 0)
 							drop_role = true;
-						else 
+						else
 							drop_login = true;
-						
+
 						if (drop_user || drop_role)
 						{
 							char	   *db_name = NULL;
@@ -3109,8 +3109,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							other = true;
 
 						if (drop_login && is_login(roleform->oid) && !has_privs_of_role(GetSessionUserId(), get_role_oid("sysadmin", false))){
-							ereport(ERROR, 
-									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
+							ereport(ERROR,
+									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 									errmsg("Current login %s does not have permission to Drop login", GetUserNameFromId(GetSessionUserId(), true))));
 						}
 
@@ -4577,7 +4577,7 @@ pltsql_validator(PG_FUNCTION_ARGS)
 	bool 		is_itvf;
 	char		*prosrc = NULL;
 	bool		is_mstvf = false;
-	
+
 	MemoryContext oldMemoryContext = CurrentMemoryContext;
 	int			saved_dialect = sql_dialect;
 
@@ -4725,9 +4725,9 @@ pltsql_validator(PG_FUNCTION_ARGS)
 				func = pltsql_compile(fake_fcinfo, true);
 
 			if(func && func->table_varnos)
-			{	
+			{
 				is_mstvf = func->is_mstvf;
-				/* 
+				/*
 				 * if a function has tvp declared or as argument in the function
 				 * or it is a TVF has_table_var will be true
 				 */
@@ -4742,10 +4742,10 @@ pltsql_validator(PG_FUNCTION_ARGS)
 		}
 
 		ReleaseSysCache(tuple);
-		
-		/* 
-		 * If the function has TVP in its arguments or function body 
-		 * it should be declared as VOLATILE by default 
+
+		/*
+		 * If the function has TVP in its arguments or function body
+		 * it should be declared as VOLATILE by default
 		 * TVF are VOLATILE by default so we donot need to update tuple for it
 		 */
 		if(prokind == PROKIND_FUNCTION && (has_table_var && !is_itvf && !is_mstvf))
@@ -5324,5 +5324,5 @@ pltsql_remove_current_query_env(void)
 		(currentQueryEnv == topLevelQueryEnv && get_namedRelList() == NIL))
 	{
 		destroy_failed_transactions_map();
-	} 
+	}
 }


### PR DESCRIPTION
1. pg_log has a lot of the following WARNING: "problem in alloc set %s: detected write past chunk end in block %p, chunk %p"

The memory being allocated has a magic byte at the end to catch memory related issues but it is being overwritten by the code in pltsql_post_expand_star()

2. valgrind complains with "Invalid write of size 8" in pltsql_free_function_memory().

This is because the PLtsql_function
struct itself points to func->fn_cxt context where the struct was allocated. After deleting func->fn_cxt, the function should not access func anymore but it still does.

3. Fixed compilation errors when trying to build release mode

Task: [NO-JIRA]



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).