### PR TITLE
Change error message for Restrict drop/alter login by non-sysadmin (BABEL_2_X_DEV)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2595,8 +2595,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 						if (!has_privs_of_role(GetSessionUserId(), datdba) && !has_password)
 							ereport(ERROR,(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
-								errmsg("Current login %s does not have permission to Alter login", 
-								GetUserNameFromId(GetSessionUserId(), true))));
+								errmsg("Cannot alter the login '%s', because it does not exist or you do not have permission.", stmt->role->rolename)));
 
 						if (get_role_oid(stmt->role->rolename, true) == InvalidOid)
 							ereport(ERROR, (errcode(ERRCODE_DUPLICATE_OBJECT),
@@ -2831,7 +2830,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						if (drop_login && is_login(roleform->oid) && !has_privs_of_role(GetSessionUserId(), get_role_oid("sysadmin", false))){
 							ereport(ERROR, 
 									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), 
-									errmsg("Current login %s does not have permission to Drop login", GetUserNameFromId(GetSessionUserId(), true))));
+									errmsg("Cannot drop the login '%s', because it does not exist or you do not have permission.", role_name)));
 						}
 
 						ReleaseSysCache(tuple);

--- a/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
+++ b/test/JDBC/expected/BABEL-LOGIN-vu-verify.out
@@ -483,14 +483,14 @@ ALTER LOGIN babel_4080_testlogin1 DISABLE;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Alter login)~~
+~~ERROR (Message: Cannot alter the login 'babel_4080_testlogin1', because it does not exist or you do not have permission.)~~
 
 
 DROP LOGIN babel_4080_testlogin1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Current login babel_4080_nonsysadmin1 does not have permission to Drop login)~~
+~~ERROR (Message: Cannot drop the login 'babel_4080_testlogin1', because it does not exist or you do not have permission.)~~
 
 
 -- tsql user=babel_4080_sysadmin1 password=1234


### PR DESCRIPTION
Change error message for Restrict drop/alter login by non-sysadmin in Babelfish
Task: BABEL-4057

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).