### PR TITLE
Fix UNION regression

### DIFF
--- a/test/JDBC/expected/BABEL-3215-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3215-vu-verify.out
@@ -352,3 +352,34 @@ drop table dbo.unionorder1;
 drop table dbo.unionorder2;
 drop table dbo.unionorder1b;
 go
+
+-- BABEL-4169 resjunk issue with sort key outside tl
+create table dbo.babel4169_t1 (a int, b int, c int); 
+create table dbo.babel4169_t2 (a int, b int, c int); 
+go
+
+insert into dbo.babel4169_t1 values (1, 2, 3), (10, 2, 3), (100, 2, 99);
+insert into dbo.babel4169_t2 values (4, 5, 6), (40, 5, 6), (400, 5, 99);
+go
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+
+select sum(a), b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by babel4169_t1.a
+go
+~~START~~
+int#!#int
+11#!#2
+44#!#5
+100#!#2
+400#!#5
+~~END~~
+
+
+drop table dbo.babel4169_t1;
+drop table dbo.babel4169_t2;
+go

--- a/test/JDBC/expected/BABEL-3215-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3215-vu-verify.out
@@ -81,6 +81,22 @@ int
 ~~END~~
 
 
+SELECT u.c1 FROM unionorder1 u
+UNION ALL
+SELECT u.c1 FROM unionorder1 u
+ORDER BY u.c1;
+go
+~~START~~
+int
+1
+1
+2
+2
+3
+3
+~~END~~
+
+
 SELECT c1 FROM dbo.unionorder1
 UNION
 SELECT c2 FROM dbo.unionorder2
@@ -139,6 +155,20 @@ go
 ~~START~~
 int#!#int
 2#!#2
+3#!#3
+~~END~~
+
+
+SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
+UNION ALL
+SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
+ORDER BY u2.c2
+go
+~~START~~
+int#!#int
+2#!#2
+2#!#2
+3#!#3
 3#!#3
 ~~END~~
 
@@ -298,6 +328,34 @@ int
 ~~END~~
 
 
+create view v1 as
+    select u1b.c1
+    from unionorder1 u1
+    inner join unionorder2 u2
+    on u1.c1 = u2.c2
+    inner join unionorder1b u1b
+    on u1.c1 = u1b.c1
+union 
+    select u1b.c1
+    from unionorder1 u1
+    inner join unionorder2 u2
+    on u1.c1 = u2.c2
+    inner join unionorder1b u1b
+    on u1.c1 = u1b.c1
+go
+
+select * from v1;
+go
+~~START~~
+int
+2
+3
+~~END~~
+
+
+drop view v1;
+go
+
 -- Test babel_613 UNION ALL with numeric issue
 create table dbo.unionorder_numeric (a numeric(6,4), b numeric(6,3));
 insert into unionorder_numeric values (4, 16);
@@ -369,7 +427,21 @@ go
 select sum(a), b from dbo.babel4169_t1 group by b, c
 union
 select sum(a), b from dbo.babel4169_t2 group by b, c
-order by babel4169_t1.a
+order by b
+go
+~~START~~
+int#!#int
+11#!#2
+100#!#2
+44#!#5
+400#!#5
+~~END~~
+
+
+select sum(a) as sum, b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by sum
 go
 ~~START~~
 int#!#int
@@ -380,6 +452,41 @@ int#!#int
 ~~END~~
 
 
+select sum(a), b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by c
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid UNION/INTERSECT/EXCEPT ORDER BY clause)~~
+
+
+create function babel4169_add_one (@x INT)
+RETURNS INT
+AS BEGIN
+    RETURN @x + 1;
+END;
+GO
+
+select babel4169_add_one(a) as added, b from dbo.babel4169_t1
+union
+select a, b from dbo.babel4169_t2
+order by added
+go
+~~START~~
+int#!#int
+2#!#2
+4#!#5
+11#!#2
+40#!#5
+101#!#2
+400#!#5
+~~END~~
+
+
+drop function babel4169_add_one;
+go
 drop table dbo.babel4169_t1;
 drop table dbo.babel4169_t2;
 go

--- a/test/JDBC/input/BABEL-3215-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3215-vu-verify.sql
@@ -187,3 +187,22 @@ drop table dbo.unionorder1;
 drop table dbo.unionorder2;
 drop table dbo.unionorder1b;
 go
+
+-- BABEL-4169 resjunk issue with sort key outside tl
+create table dbo.babel4169_t1 (a int, b int, c int); 
+create table dbo.babel4169_t2 (a int, b int, c int); 
+go
+
+insert into dbo.babel4169_t1 values (1, 2, 3), (10, 2, 3), (100, 2, 99);
+insert into dbo.babel4169_t2 values (4, 5, 6), (40, 5, 6), (400, 5, 99);
+go
+
+select sum(a) as sum, b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by sum
+go
+
+drop table dbo.babel4169_t1;
+drop table dbo.babel4169_t2;
+go


### PR DESCRIPTION

### Description

Previous work to fix ORDER BY clauses with UNION statements introduced a regression. These changes temporarily replace the top-level target list, which is checked to ensure the length does not change. The problem arises when the new target list contains resjunk columns, which results in a different length than the original target list. This change fixes this issue.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).