### PR TITLE
Fix UNION regression

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_analyze.c
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.c
@@ -23,7 +23,7 @@
 
 static RangeVar *find_matching_table(RangeVar *target, Node *tblref);
 
-List *sv_setop_targetlist = NIL;
+List *sv_setop_exprs = NIL;
 namespace_stack_t *set_op_ns_stack = NULL;
 
 /*
@@ -294,6 +294,12 @@ rewrite_update_outer_join(Node *stmt, CmdType command, RangeVar *target)
 	}
 }
 
+/* 
+ * Allocate an empty space to hold a parsing namespace
+ * This space will be filled by post_transform_from_clause, to save the
+ * leftmost select's namespace for processing UNION statements. This is needed 
+ * to resolve table aliases in the top-level of a UNION and other set ops.
+ */
 void
 push_namespace_stack(void)
 {
@@ -308,6 +314,11 @@ push_namespace_stack(void)
 	set_op_ns_stack = ns_stack_item;
 }
 
+/* 
+ * After tranforming a from clause, if we've allocated space on the stack in
+ * push_namespace_stack, save the namespace here for use in
+ * pre_transform_sort_clause.
+ */
 void 
 post_transform_from_clause(ParseState *pstate)
 {
@@ -316,35 +327,57 @@ post_transform_from_clause(ParseState *pstate)
 		ns->namespace = pstate->p_namespace;
 }
 
+/* 
+ * Prior to handling a UNION or othe SetOp's ORDER BY clause, this hook:
+ * 1. Modifies the query's top-level target list, so that we can match columns
+ * 		with those in the sort clause
+ * 2. Pop from the namespace stack and restore the leftmost select's namespace
+ * 		for table alias resolution. The caller is expected to save and restore
+ * 		the original top-level parse state
+ */
 void
 pre_transform_sort_clause(ParseState *pstate, Query *qry, Query *leftmostQuery)
 {
 	namespace_stack_t *old_ns_stack_item = set_op_ns_stack;
+	ListCell *lc, *lc_l;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
 
-	sv_setop_targetlist = qry->targetList;
+	sv_setop_exprs = NIL;
+	forboth(lc, qry->targetList, lc_l, leftmostQuery->targetList)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+		TargetEntry *lefttle = (TargetEntry *) lfirst(lc_l);
 
-	qry->targetList = leftmostQuery->targetList;
+		Assert(!lefttle->resjunk);
+		sv_setop_exprs = lappend(sv_setop_exprs, tle->expr);
+		if (IsA(lefttle->expr, Var))
+			tle->expr = (Expr*) lefttle->expr;
+	}
+
 	pstate->p_namespace = set_op_ns_stack->namespace;
 
 	set_op_ns_stack = set_op_ns_stack->prev;
 	pfree(old_ns_stack_item);
 }
 
+/* 
+ * Reset the targetList back to it's original vars
+ * This is necessary in some cases, like UNION ALL and when the targetlist
+ * includes items from a joined table
+ */
 void 
 post_transform_sort_clause(Query *qry)
 {
 	ListCell *lc_q, *lc_sv;
-	if (sql_dialect != SQL_DIALECT_TSQL || sv_setop_targetlist == NIL)
+	if (sql_dialect != SQL_DIALECT_TSQL || sv_setop_exprs == NIL)
 		return;
-	/* Copy the ressortgroupref from the leftmost target list to the previous tl */
-	forboth(lc_q, qry->targetList, lc_sv, sv_setop_targetlist)
+	forboth(lc_q, qry->targetList, lc_sv, sv_setop_exprs)
 	{
-		TargetEntry *tle_q= (TargetEntry *) lfirst(lc_q);
-		TargetEntry *tle_sv = (TargetEntry *) lfirst(lc_sv);
-		tle_sv->ressortgroupref = tle_q->ressortgroupref;
+		TargetEntry *tle_q = (TargetEntry *) lfirst(lc_q);
+		Expr 		*expr_sv = (Expr *) lfirst(lc_sv);
+		tle_q->expr = expr_sv;
 	}
-	qry->targetList = sv_setop_targetlist;
+	sv_setop_exprs = NIL;
 }

--- a/test/JDBC/expected/BABEL-3215-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3215-vu-verify.out
@@ -81,6 +81,22 @@ int
 ~~END~~
 
 
+SELECT u.c1 FROM unionorder1 u
+UNION ALL
+SELECT u.c1 FROM unionorder1 u
+ORDER BY u.c1;
+go
+~~START~~
+int
+1
+1
+2
+2
+3
+3
+~~END~~
+
+
 SELECT c1 FROM dbo.unionorder1
 UNION
 SELECT c2 FROM dbo.unionorder2
@@ -139,6 +155,20 @@ go
 ~~START~~
 int#!#int
 2#!#2
+3#!#3
+~~END~~
+
+
+SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
+UNION ALL
+SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
+ORDER BY u2.c2
+go
+~~START~~
+int#!#int
+2#!#2
+2#!#2
+3#!#3
 3#!#3
 ~~END~~
 
@@ -298,6 +328,34 @@ int
 ~~END~~
 
 
+create view v1 as
+    select u1b.c1
+    from unionorder1 u1
+    inner join unionorder2 u2
+    on u1.c1 = u2.c2
+    inner join unionorder1b u1b
+    on u1.c1 = u1b.c1
+union 
+    select u1b.c1
+    from unionorder1 u1
+    inner join unionorder2 u2
+    on u1.c1 = u2.c2
+    inner join unionorder1b u1b
+    on u1.c1 = u1b.c1
+go
+
+select * from v1;
+go
+~~START~~
+int
+2
+3
+~~END~~
+
+
+drop view v1;
+go
+
 -- Test babel_613 UNION ALL with numeric issue
 create table dbo.unionorder_numeric (a numeric(6,4), b numeric(6,3));
 insert into unionorder_numeric values (4, 16);
@@ -351,4 +409,84 @@ drop table dbo.unionorder_char;
 drop table dbo.unionorder1;
 drop table dbo.unionorder2;
 drop table dbo.unionorder1b;
+go
+
+-- BABEL-4169 resjunk issue with sort key outside tl
+create table dbo.babel4169_t1 (a int, b int, c int); 
+create table dbo.babel4169_t2 (a int, b int, c int); 
+go
+
+insert into dbo.babel4169_t1 values (1, 2, 3), (10, 2, 3), (100, 2, 99);
+insert into dbo.babel4169_t2 values (4, 5, 6), (40, 5, 6), (400, 5, 99);
+go
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+
+select sum(a), b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by b
+go
+~~START~~
+int#!#int
+11#!#2
+100#!#2
+44#!#5
+400#!#5
+~~END~~
+
+
+select sum(a) as sum, b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by sum
+go
+~~START~~
+int#!#int
+11#!#2
+44#!#5
+100#!#2
+400#!#5
+~~END~~
+
+
+select sum(a), b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by c
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid UNION/INTERSECT/EXCEPT ORDER BY clause)~~
+
+
+create function babel4169_add_one (@x INT)
+RETURNS INT
+AS BEGIN
+    RETURN @x + 1;
+END;
+GO
+
+select babel4169_add_one(a) as added, b from dbo.babel4169_t1
+union
+select a, b from dbo.babel4169_t2
+order by added
+go
+~~START~~
+int#!#int
+2#!#2
+4#!#5
+11#!#2
+40#!#5
+101#!#2
+400#!#5
+~~END~~
+
+
+drop function babel4169_add_one;
+go
+drop table dbo.babel4169_t1;
+drop table dbo.babel4169_t2;
 go

--- a/test/JDBC/input/BABEL-3215-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3215-vu-verify.sql
@@ -37,6 +37,12 @@ SELECT c2 FROM unionorder2
 ORDER BY u.c1;
 go
 
+SELECT u.c1 FROM unionorder1 u
+UNION ALL
+SELECT u.c1 FROM unionorder1 u
+ORDER BY u.c1;
+go
+
 SELECT c1 FROM dbo.unionorder1
 UNION
 SELECT c2 FROM dbo.unionorder2
@@ -63,6 +69,12 @@ go
 
 SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
 UNION
+SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
+ORDER BY u2.c2
+go
+
+SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
+UNION ALL
 SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
 ORDER BY u2.c2
 go
@@ -157,6 +169,28 @@ SELECT c1 FROM unionorder1
 ORDER BY u.c2;
 go
 
+create view v1 as
+    select u1b.c1
+    from unionorder1 u1
+    inner join unionorder2 u2
+    on u1.c1 = u2.c2
+    inner join unionorder1b u1b
+    on u1.c1 = u1b.c1
+union 
+    select u1b.c1
+    from unionorder1 u1
+    inner join unionorder2 u2
+    on u1.c1 = u2.c2
+    inner join unionorder1b u1b
+    on u1.c1 = u1b.c1
+go
+
+select * from v1;
+go
+
+drop view v1;
+go
+
 -- Test babel_613 UNION ALL with numeric issue
 create table dbo.unionorder_numeric (a numeric(6,4), b numeric(6,3));
 insert into unionorder_numeric values (4, 16);
@@ -186,4 +220,50 @@ drop table dbo.unionorder_char;
 drop table dbo.unionorder1;
 drop table dbo.unionorder2;
 drop table dbo.unionorder1b;
+go
+
+-- BABEL-4169 resjunk issue with sort key outside tl
+create table dbo.babel4169_t1 (a int, b int, c int); 
+create table dbo.babel4169_t2 (a int, b int, c int); 
+go
+
+insert into dbo.babel4169_t1 values (1, 2, 3), (10, 2, 3), (100, 2, 99);
+insert into dbo.babel4169_t2 values (4, 5, 6), (40, 5, 6), (400, 5, 99);
+go
+
+select sum(a), b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by b
+go
+
+select sum(a) as sum, b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by sum
+go
+
+select sum(a), b from dbo.babel4169_t1 group by b, c
+union
+select sum(a), b from dbo.babel4169_t2 group by b, c
+order by c
+go
+
+create function babel4169_add_one (@x INT)
+RETURNS INT
+AS BEGIN
+    RETURN @x + 1;
+END;
+GO
+
+select babel4169_add_one(a) as added, b from dbo.babel4169_t1
+union
+select a, b from dbo.babel4169_t2
+order by added
+go
+
+drop function babel4169_add_one;
+go
+drop table dbo.babel4169_t1;
+drop table dbo.babel4169_t2;
 go


### PR DESCRIPTION
### Description

Previous work to fix ORDER BY clauses with UNION statements introduced a regression. These changes temporarily replace the top-level target list, which is checked to ensure the length does not change. The problem arises when the new target list contains resjunk columns, which results in a different length than the original target list. This change fixes this issue.

### Issues Resolved

BABEL-4169

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).