### PR TITLE
Update sp_serveroption procedure to ignore trailing spaces in name arguments

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2685,7 +2685,7 @@ sp_serveroption_internal(PG_FUNCTION_ARGS)
 	remove_trailing_spaces(newoptionvalue);
 
 	/* we need to ignore leading spaces in optionvalue argument */
-	while (isspace((unsigned char) *newoptionvalue))
+	while (*newoptionvalue != '\0' && isspace((unsigned char) *newoptionvalue))
 		newoptionvalue++;
 
 	if (optionname && strlen(optionname) == 13 && strncmp(optionname, "query timeout", 13) == 0)

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2693,7 +2693,7 @@ sp_serveroption_internal(PG_FUNCTION_ARGS)
 	else
 		ereport(ERROR,
 			(errcode(ERRCODE_FDW_ERROR),
-				errmsg("Invalid option provided for sp_serveroption. Only query timeout option is supported")));
+				errmsg("Invalid option provided for sp_serveroption. Only 'query timeout' option is supported")));
 
 	if(servername)
 		pfree(servername);

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2657,6 +2657,7 @@ sp_serveroption_internal(PG_FUNCTION_ARGS)
 	char *servername = PG_ARGISNULL(0) ? NULL : lowerstr(text_to_cstring(PG_GETARG_VARCHAR_PP(0)));
 	char *optionname = PG_ARGISNULL(1) ? NULL : lowerstr(text_to_cstring(PG_GETARG_VARCHAR_PP(1)));
 	char *optionvalue = PG_ARGISNULL(2) ? NULL : lowerstr(text_to_cstring(PG_GETARG_VARCHAR_PP(2)));
+	char *newoptionvalue = optionvalue;
 
 	if(!pltsql_enable_linked_servers)
 		ereport(ERROR,
@@ -2678,12 +2679,21 @@ sp_serveroption_internal(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_FDW_ERROR),
 				 errmsg("@optvalue parameter cannot be NULL")));
 
+	/* we need to ignore trailing spaces in all the arguments */
+	remove_trailing_spaces(servername);
+	remove_trailing_spaces(optionname);
+	remove_trailing_spaces(newoptionvalue);
+
+	/* we need to ignore leading spaces in optionvalue argument */
+	while (isspace((unsigned char) *newoptionvalue))
+		newoptionvalue++;
+
 	if (optionname && strlen(optionname) == 13 && strncmp(optionname, "query timeout", 13) == 0)
-		update_bbf_server_options(servername, optionname, optionvalue, false);
+		update_bbf_server_options(servername, optionname, newoptionvalue, false);
 	else
 		ereport(ERROR,
 			(errcode(ERRCODE_FDW_ERROR),
-				errmsg("Invalid option provided for sp_serveroption")));
+				errmsg("Invalid option provided for sp_serveroption. Only query timeout option is supported")));
 
 	if(servername)
 		pfree(servername);

--- a/test/JDBC/expected/openquery-vu-prepare.out
+++ b/test/JDBC/expected/openquery-vu-prepare.out
@@ -40,7 +40,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='invalid option', @optvalu
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only query timeout option is supported)~~
 
 
 -- sp_serveroption with server as NULL. Should throw error
@@ -186,6 +186,30 @@ GO
 
 -- optname is case insensitive
 EXEC sp_serveroption @server='bbf_server_1', @optname='queRY tiMEoUt', @optvalue='1'
+GO
+
+-- ignore trailing spaces in all the arguments
+EXEC sp_serveroption @server='bbf_server_1  ', @optname='query timeout   ', @optvalue='1    '
+GO
+
+-- do not ignore leading spaces in @server argument
+EXEC sp_serveroption @server='  bbf_server_1', @optname='query timeout', @optvalue='1'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "  bbf_server_1" does not exist)~~
+
+
+-- do not ignore leading spaces in @optname argument
+EXEC sp_serveroption @server='bbf_server_1', @optname='  query timeout', @optvalue='1'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only query timeout option is supported)~~
+
+
+-- ignore leading spaces in @optvalue argument
+EXEC sp_serveroption @server='bbf_server_1', @optname='query timeout', @optvalue='  1'
 GO
 
 -- psql

--- a/test/JDBC/expected/openquery-vu-prepare.out
+++ b/test/JDBC/expected/openquery-vu-prepare.out
@@ -40,7 +40,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='invalid option', @optvalu
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption. Only query timeout option is supported)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' option is supported)~~
 
 
 -- sp_serveroption with server as NULL. Should throw error
@@ -205,7 +205,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='  query timeout', @optval
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption. Only query timeout option is supported)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' option is supported)~~
 
 
 -- ignore leading spaces in @optvalue argument

--- a/test/JDBC/expected/openquery_upgrd-vu-prepare.out
+++ b/test/JDBC/expected/openquery_upgrd-vu-prepare.out
@@ -33,7 +33,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='invalid option', @optvalu
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption. Only query timeout option is supported)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' option is supported)~~
 
 
 -- sp_serveroption with server as NULL. Should throw error

--- a/test/JDBC/expected/openquery_upgrd-vu-prepare.out
+++ b/test/JDBC/expected/openquery_upgrd-vu-prepare.out
@@ -33,7 +33,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='invalid option', @optvalu
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only query timeout option is supported)~~
 
 
 -- sp_serveroption with server as NULL. Should throw error

--- a/test/JDBC/input/openquery-vu-prepare.mix
+++ b/test/JDBC/input/openquery-vu-prepare.mix
@@ -119,6 +119,22 @@ GO
 EXEC sp_serveroption @server='bbf_server_1', @optname='queRY tiMEoUt', @optvalue='1'
 GO
 
+-- ignore trailing spaces in all the arguments
+EXEC sp_serveroption @server='bbf_server_1  ', @optname='query timeout   ', @optvalue='1    '
+GO
+
+-- do not ignore leading spaces in @server argument
+EXEC sp_serveroption @server='  bbf_server_1', @optname='query timeout', @optvalue='1'
+GO
+
+-- do not ignore leading spaces in @optname argument
+EXEC sp_serveroption @server='bbf_server_1', @optname='  query timeout', @optvalue='1'
+GO
+
+-- ignore leading spaces in @optvalue argument
+EXEC sp_serveroption @server='bbf_server_1', @optname='query timeout', @optvalue='  1'
+GO
+
 -- psql
 SELECT * FROM sys.babelfish_inconsistent_metadata() where schema_name='pg_catalog' AND object_name='srvname';
 GO


### PR DESCRIPTION
### Description

In sp_serveroption procedure, trailing spaces in @server, @optname and @optvalue arguments need to be ignored. Leading spaces in @optvalue also need to be ignored. Currently we are not ignoring it.

This PR includes the following changes : 
-  Ignores trailing spaces in @server, @optname, @optvalue arguments
- Ignores leading spaces in @optvalue parameter
- Updates error message when the @optname is invalid

### Issues Resolved

BABEL-3730

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** Yes


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).