### PR TITLE
Removed incorrect check in table variable visibility functions

### DIFF
--- a/contrib/babelfishpg_tsql/src/table_variable_mvcc.c
+++ b/contrib/babelfishpg_tsql/src/table_variable_mvcc.c
@@ -350,9 +350,6 @@ TVHeapTupleSatisfiesNonVacuumable(HeapTuple htup, Snapshot snapshot, Buffer buff
 bool
 TVHeapTupleSatisfiesVisibility(HeapTuple tup, Snapshot snapshot, Buffer buffer)
 {
-    if (!IS_TDS_CLIENT())
-        ereport(ERROR, (errmsg("Table Variables on non-TDS clients are unsupported")));
-
     switch (snapshot->snapshot_type)
     {
         case SNAPSHOT_MVCC:
@@ -395,9 +392,6 @@ TM_Result TVHeapTupleSatisfiesUpdate(HeapTuple htup, CommandId curcid, Buffer bu
 
     Assert(ItemPointerIsValid(&htup->t_self));
     Assert(htup->t_tableOid != InvalidOid);
-
-    if (!IS_TDS_CLIENT())
-        ereport(ERROR, (errmsg("Table Variables on non-TDS clients are unsupported")));
 
     if (!HeapTupleHeaderXminCommitted(tuple))
     {
@@ -541,9 +535,6 @@ TVHeapTupleSatisfiesVacuumHorizon(HeapTuple htup, Buffer buffer, TransactionId *
     Assert(dead_after != NULL);
 
     *dead_after = InvalidTransactionId;
-
-    if (!IS_TDS_CLIENT())
-        ereport(ERROR, (errmsg("Table Variables on non-TDS clients are unsupported")));
 
     /*
     * Has inserting transaction committed?

--- a/test/JDBC/expected/table-variable-psql.out
+++ b/test/JDBC/expected/table-variable-psql.out
@@ -1,0 +1,28 @@
+-- psql
+set babelfishpg_tsql.sql_dialect = "tsql";
+GO
+
+create type tableType as table(
+    a text not null,
+    b int primary key,
+    c int);
+GO
+
+create procedure itvf8_proc as
+begin
+    declare @tableVariable tableType
+    insert into @tableVariable values('hello1', 1, 1001)
+    insert into @tableVariable values('hello2', 2, 1002)
+    update @tableVariable set a = 'hello1_v2' where b = 1
+end;
+GO
+
+-- should be clean and no error
+CALL itvf8_proc();
+GO
+
+DROP PROCEDURE itvf8_proc;
+GO
+
+DROP TYPE tableType;
+GO

--- a/test/JDBC/input/table_variables/table-variable-psql.mix
+++ b/test/JDBC/input/table_variables/table-variable-psql.mix
@@ -1,0 +1,28 @@
+-- psql
+set babelfishpg_tsql.sql_dialect = "tsql";
+GO
+
+create type tableType as table(
+    a text not null,
+    b int primary key,
+    c int);
+GO
+
+create procedure itvf8_proc as
+begin
+    declare @tableVariable tableType
+    insert into @tableVariable values('hello1', 1, 1001)
+    insert into @tableVariable values('hello2', 2, 1002)
+    update @tableVariable set a = 'hello1_v2' where b = 1
+end;
+GO
+
+-- should be clean and no error
+CALL itvf8_proc();
+GO
+
+DROP PROCEDURE itvf8_proc;
+GO
+
+DROP TYPE tableType;
+GO


### PR DESCRIPTION
### Description
Table Variables can still be used in psql port, see example below.
I added an incorrect check in Table Variable visibility assuming table variables cannot be used in psql port.

This was caught during installcheck test for 2x and the same test was converted into tsql in 3x so it was not caught during review.
```
set babelfishpg_tsql.sql_dialect = "tsql";


create type tableType as table(
    a text not null,
    b int primary key,
    c int);

create function itvf8 (@number int, @tableVar tableType READONLY) returns table as return (
select c from @tableVar
);

create procedure itvf8_proc as
begin
    declare @tableVariable tableType
    insert into @tableVariable values('hello1', 1, 1001)
    insert into @tableVariable values('hello2', 2, 1002)
    select * from itvf8(1004, @tableVariable)
end;

call itvf8_proc();
```
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).