### PR TITLE
Fix babel_function test expected output

### DIFF
--- a/contrib/babelfishpg_tsql/expected/test/babel_function.out
+++ b/contrib/babelfishpg_tsql/expected/test/babel_function.out
@@ -2454,25 +2454,25 @@ SELECT a, b, COUNT(*) OVER () from t3;
 SELECT a, b, COUNT(*) OVER (ORDER BY a) from t3;
   a  | b | count 
 -----+---+-------
- abc | b |     2
- abc | a |     2
- efg | a |     4
- efg | b |     4
- xyz | a |     6
- xyz | b |     6
-     |   |     7
+     |   |     1
+ abc | a |     3
+ abc | b |     3
+ efg | a |     5
+ efg | b |     5
+ xyz | a |     7
+ xyz | b |     7
 (7 rows)
 
 SELECT a, b, COUNT(*) OVER (ORDER BY a DESC) from t3;
   a  | b | count 
 -----+---+-------
-     |   |     1
- xyz | b |     3
- xyz | a |     3
- efg | b |     5
- efg | a |     5
- abc | b |     7
- abc | a |     7
+ xyz | b |     2
+ xyz | a |     2
+ efg | a |     4
+ efg | b |     4
+ abc | b |     6
+ abc | a |     6
+     |   |     7
 (7 rows)
 
 SELECT a, b, COUNT(*) OVER(PARTITION BY a) from t3;
@@ -2532,25 +2532,25 @@ SELECT a, b, COUNT_BIG(*) OVER () from t3;
 SELECT a, b, COUNT_BIG(*) OVER (ORDER BY a) from t3;
   a  | b | count_big 
 -----+---+-----------
- abc | b |         2
- abc | a |         2
- efg | a |         4
- efg | b |         4
- xyz | a |         6
- xyz | b |         6
-     |   |         7
+     |   |         1
+ abc | a |         3
+ abc | b |         3
+ efg | a |         5
+ efg | b |         5
+ xyz | a |         7
+ xyz | b |         7
 (7 rows)
 
 SELECT a, b, COUNT_BIG(*) OVER (ORDER BY a DESC) from t3;
   a  | b | count_big 
 -----+---+-----------
-     |   |         1
- xyz | b |         3
- xyz | a |         3
- efg | b |         5
- efg | a |         5
- abc | b |         7
- abc | a |         7
+ xyz | b |         2
+ xyz | a |         2
+ efg | a |         4
+ efg | b |         4
+ abc | b |         6
+ abc | a |         6
+     |   |         7
 (7 rows)
 
 SELECT a, b, COUNT_BIG(*) OVER(PARTITION BY a) from t3;


### PR DESCRIPTION
### Description

BABEL-3991 changed result ordering related to NULL results. This changed the behavior of tests in the babel_function test file checking window functions with OVER (ORDER BY...). babel_function belongs to an old group of installcheck_extensions tests, where this cycle these tests were migrated into the JDBC framework on v15, but not v14.  Due to the migration, these changes were not picked up in v14, resulting in test failures. This change updates the v14 expected output file to match v15 and the changes made in BABEL-3991.

### Issues Resolved

NO-JIRA

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).