### PR TITLE
Correct ODBC test function

### DIFF
--- a/test/odbc/mssqlodbc/test_data_types.cpp
+++ b/test/odbc/mssqlodbc/test_data_types.cpp
@@ -49,24 +49,20 @@ bool is_empty(std::ifstream& pFile)
 
 // Helper function that reads from a file and returns the contents as a string
 string readFromFile(string relativePath) {
-  int bufferLen = 1024;
-  char * buffer = new char [bufferLen];
-  char * fname;
-
   std::ifstream dataFile(relativePath);
   if (is_empty(dataFile)) {
     return "";
   }
-
-  std::filesystem::path fp{relativePath};
-  int fsize = std::filesystem::file_size(fp);
-  while (fsize > bufferLen){
-    dataFile.read(buffer, bufferLen);
-    fsize -= bufferLen;
+  
+  auto stream = std::ifstream(relativePath.data());
+  constexpr auto read_size = std::size_t(4096);
+  auto out = std::string();
+  auto buf = std::string(read_size,'\0');
+  while (stream.read(& buf[0], read_size)) {
+        out.append(buf, 0, stream.gcount());
   }
-  dataFile.read(buffer, fsize);
-  dataFile.close();
-  return string(buffer);
+  out.append(buf, 0, stream.gcount());
+  return out;
 }
 
 // Helper function that iterates over & fetches data, and compares retrieved value to expected value 


### PR DESCRIPTION
### Description

The ODBC test failed in our pipeline, the root cause is when reading the text from file, the buffer doesn’t include any EOF so we get some random message in the end.


### Issues Resolved

NO-JIRA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).