### PR TITLE
Fixed testcase in psql_logical_babelfish_db JDBC test

### DIFF
--- a/test/JDBC/expected/psql_logical_babelfish_db.out
+++ b/test/JDBC/expected/psql_logical_babelfish_db.out
@@ -144,7 +144,7 @@ go
 alter server role sysadmin add member logical_database_l1
 go
 
--- psql user=logical_database_l1 password='12345678'
+-- psql user=logical_database_l1 password=12345678
 select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases';
 go
 ~~START~~

--- a/test/JDBC/input/psql_logical_babelfish_db.mix
+++ b/test/JDBC/input/psql_logical_babelfish_db.mix
@@ -57,7 +57,7 @@ go
 alter server role sysadmin add member logical_database_l1
 go
 
--- psql user=logical_database_l1 password='12345678'
+-- psql user=logical_database_l1 password=12345678
 select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases';
 go
 


### PR DESCRIPTION
### Description

While logging into psql endpoint using logical_database_l1, password authentication was failing. This change fixes the issue

### Issues Resolved
This change fixes the test failure in psql_logical_babelfish_db.mix

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).