### PR TITLE
Updated error message for sp_serveroption procedure

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2278,7 +2278,7 @@ update_bbf_server_options(char *servername, char *optname, char *optvalue, bool 
 				table_close(bbf_servers_def_rel, RowExclusiveLock);
 				ereport(ERROR,
 						(errcode(ERRCODE_FDW_ERROR),
-				 		errmsg("server \"%s\" does not exist", servername)));
+				 		errmsg("The server '%s' does not exist. Use sp_linkedservers to show available servers.", servername)));
 			}
 			new_record_repl[Anum_bbf_servers_def_query_timeout - 1] = true;
 			tuple = heap_modify_tuple(old_tuple, bbf_servers_def_rel_dsc,
@@ -2693,7 +2693,7 @@ sp_serveroption_internal(PG_FUNCTION_ARGS)
 	else
 		ereport(ERROR,
 			(errcode(ERRCODE_FDW_ERROR),
-				errmsg("Invalid option provided for sp_serveroption. Only 'query timeout' option is supported")));
+				errmsg("Invalid option provided for sp_serveroption. Only 'query timeout' is currently supported.")));
 
 	if(servername)
 		pfree(servername);

--- a/test/JDBC/expected/openquery-vu-prepare.out
+++ b/test/JDBC/expected/openquery-vu-prepare.out
@@ -32,7 +32,7 @@ EXEC sp_serveroption @server='invalid_server', @optname='query timeout', @optval
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: server "invalid_server" does not exist)~~
+~~ERROR (Message: The server 'invalid_server' does not exist. Use sp_linkedservers to show available servers.)~~
 
 
 -- sp_serveroption with invalid server option. Should throw error
@@ -40,7 +40,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='invalid option', @optvalu
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' option is supported)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' is currently supported.)~~
 
 
 -- sp_serveroption with server as NULL. Should throw error
@@ -197,7 +197,7 @@ EXEC sp_serveroption @server='  bbf_server_1', @optname='query timeout', @optval
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: server "  bbf_server_1" does not exist)~~
+~~ERROR (Message: The server '  bbf_server_1' does not exist. Use sp_linkedservers to show available servers.)~~
 
 
 -- do not ignore leading spaces in @optname argument
@@ -205,7 +205,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='  query timeout', @optval
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' option is supported)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' is currently supported.)~~
 
 
 -- ignore leading spaces in @optvalue argument

--- a/test/JDBC/expected/openquery_upgrd-vu-prepare.out
+++ b/test/JDBC/expected/openquery_upgrd-vu-prepare.out
@@ -25,7 +25,7 @@ EXEC sp_serveroption @server='invalid_server', @optname='query timeout', @optval
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: server "invalid_server" does not exist)~~
+~~ERROR (Message: The server 'invalid_server' does not exist. Use sp_linkedservers to show available servers.)~~
 
 
 -- sp_serveroption with invalid server option. Should throw error
@@ -33,7 +33,7 @@ EXEC sp_serveroption @server='bbf_server_1', @optname='invalid option', @optvalu
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' option is supported)~~
+~~ERROR (Message: Invalid option provided for sp_serveroption. Only 'query timeout' is currently supported.)~~
 
 
 -- sp_serveroption with server as NULL. Should throw error


### PR DESCRIPTION
### Description

Needed some changes in the error message when the server does not exist and when an invalid option is provided. This change updates both the error messages

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Issues Resolved

BABEL-3730

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** openquery-upgrd-vu-*


* **Major version upgrade tests -** openquery-upgrd-vu-*


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).