### PR TITLE
Typeproperty Function

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -3401,6 +3401,135 @@ END;
 $$
 LANGUAGE plpgsql STABLE;
 
+CREATE OR REPLACE FUNCTION typeproperty(
+    typename sys.VARCHAR,
+    property sys.VARCHAR
+    )
+RETURNS INT
+AS $$
+DECLARE
+    var_sc int;
+    schemaid int;
+    preci int;
+    schema_name VARCHAR;
+    type_name VARCHAR;
+    type_namee VARCHAR;
+    sys_id int;
+    testt VARCHAR;
+BEGIN
+
+    property := RTRIM(LOWER(COALESCE(property COLLATE "C",'')));
+
+    IF typename LIKE '%.%'  THEN
+    schema_name := RTRIM(lower(split_part(typename COLLATE "C", '.', 1)));
+    type_name :=  RTRIM(lower((split_part(typename COLLATE "C",'.', 2))));
+    ELSE
+    schema_name := 'dbo';
+    type_name := RTRIM(LOWER(typename));
+    END IF;
+
+
+    IF NOT EXISTS (SELECT ao.name FROM sys.types ao WHERE ao.name = type_name COLLATE sys.database_default)
+    THEN
+        RETURN NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT ao.name FROM sys.schemas ao WHERE ao.name = schema_name COLLATE sys.database_default OR schema_name = 'sys' OR schema_name = 'pg_catalog')
+    THEN
+        RETURN NULL ;
+    END IF;
+
+    IF NOT EXISTS (SELECT ty.name FROM sys.types ty WHERE ty.name = type_name COLLATE sys.database_default AND ty.is_user_defined = 0) THEN
+    schemaid := (SELECT sc.schema_id FROM sys.schemas sc WHERE sc.name = schema_name COLLATE sys.database_default);
+    ELSE
+        schemaid := (SELECT sc.schema_id FROM sys.types sc WHERE sc.name = type_name COLLATE sys.database_default);
+        IF schema_name = 'dbo'
+        THEN
+        schema_name := schema_name(schemaid);
+        END IF;
+    END IF;
+
+
+    if (SELECT schema_id(schema_name)) <> schemaid
+    THEN
+    RETURN NULL;
+    END IF;
+
+    sys_id := (SELECT CAST(dc.system_type_id AS INT) FROM sys.types dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.schema_id = schemaid);
+    type_namee := (SELECT CAST(dc.name AS VARCHAR) FROM sys.types dc WHERE dc.system_type_id = sys_id AND dc.is_user_defined = 0);
+
+    IF property = 'allowsnull'
+    THEN
+        RETURN (
+            SELECT CAST( t1.is_nullable AS INT)
+            FROM sys.types t1
+            WHERE t1.name = type_name COLLATE sys.database_default AND t1.schema_id = schemaid );
+
+    ELSEIF property = 'precision'
+    THEN
+        preci := (SELECT CAST(dc.precision AS INT) FROM sys.types dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.schema_id = schemaid);
+        IF sys_id = 0
+        THEN
+            RETURN preci;
+        END IF;
+
+        IF preci = 0
+        THEN
+            preci = (SELECT CAST(dc.prec AS INT) FROM sys.systypes dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.uid = schemaid);
+            IF preci IS NULL
+            THEN
+                IF type_namee = 'image' or type_namee = 'text'
+                THEN
+                RETURN 2147483647;
+                ELSEIF type_namee = 'ntext'
+                THEN
+                RETURN 1073741823;
+                END IF;
+            END IF;
+            RETURN preci;
+        ELSE
+            RETURN preci;
+        END IF;        
+
+    ELSEIF property = 'scale'
+    THEN
+        preci := (SELECT CAST(dc.precision AS INT) FROM sys.types dc WHERE dc.name = type_namee COLLATE sys.database_default AND dc.system_type_id = sys_id);
+        IF sys_id = 0
+        THEN
+            RETURN preci;
+        END IF;
+        IF preci = 0 or type_namee = 'float' or type_namee = 'real' or type_namee = 'bit'
+        THEN
+            RETURN NULL;
+        ELSE
+            RETURN(SELECT CAST(dc.scale AS INT) FROM sys.types dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.schema_id = schemaid);
+        END IF;
+    ELSEIF property = 'ownerid'
+    THEN
+        IF NOT EXISTS (SELECT ty.name FROM sys.types ty WHERE ty.name = type_name COLLATE sys.database_default AND ty.is_user_defined = 0) THEN
+        RETURN(SELECT CAST(dc.nspowner AS INT) FROM  pg_catalog.pg_namespace dc WHERE dc.oid = schemaid);
+        ELSE
+        RETURN 10;
+        END IF;
+
+    ELSEIF property = 'usesansitrim'
+    THEN
+        IF type_name::regtype IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'tinyint'::regtype,
+            'numeric'::regtype, 'float'::regtype, 'real'::regtype, 'money'::regtype)
+        THEN
+            RETURN NULL;
+        ELSE
+            RETURN 1;
+        END IF;
+
+    END IF;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
+
 CREATE OR REPLACE FUNCTION OBJECTPROPERTYEX(
     id INT,
     property SYS.VARCHAR

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1057,7 +1057,7 @@ create or replace view sys.types As
 with RECURSIVE type_code_list as
 (
     select distinct  pg_typname as pg_type_name, tsql_typname as tsql_type_name
-    from sys.babelfish_typecode_list()
+    from sys.babelfish_typecode_list() where pg_typname <> 'rowversion'
 ),
 tt_internal as MATERIALIZED
 (
@@ -1077,7 +1077,11 @@ select
     WHEN 'default' THEN default_collation_name
     ELSE  c.collname
     END as collation_name
-  , case when typnotnull then 0 else 1 end as is_nullable
+  , CASE ti.tsql_type_name
+    WHEN 'timestamp' THEN 0
+    WHEN 'sysname' THEN 0
+    ELSE case when typnotnull then 0 else 1 end
+    end as is_nullable
   , 0 as is_user_defined
   , 0 as is_assembly_type
   , 0 as default_object_id
@@ -1107,9 +1111,11 @@ select cast(t.typname as text) as name
     ELSE  c.collname 
     END as collation_name
   , case when tt.typrelid is not null then 0
-         else case when typnotnull then 0 else 1 end
-    end
-    as is_nullable
+         else CASE t.typbasetype
+              WHEN 18043 THEN 0
+              WHEN 17171 THEN 0
+              ELSE case when typnotnull then 0 else 1 end
+    end end as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , 1 as is_user_defined
   , 0 as is_assembly_type

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -40,6 +40,137 @@ LANGUAGE C IMMUTABLE STRICT;
 
 CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'parsename_deprecated_in_3_3_0');
 
+
+CREATE OR REPLACE FUNCTION typeproperty(
+    typename sys.VARCHAR,
+    property sys.VARCHAR
+    )
+RETURNS INT
+AS $$
+DECLARE
+    var_sc int;
+    schemaid int;
+    preci int;
+    schema_name VARCHAR;
+    type_name VARCHAR;
+    type_namee VARCHAR;
+    sys_id int;
+    testt VARCHAR;
+BEGIN
+
+    property := RTRIM(LOWER(COALESCE(property COLLATE "C",'')));
+
+    IF typename LIKE '%.%'  THEN
+    schema_name := RTRIM(lower(split_part(typename COLLATE "C", '.', 1)));
+    type_name :=  RTRIM(lower((split_part(typename COLLATE "C",'.', 2))));
+    ELSE
+    schema_name := 'dbo';
+    type_name := RTRIM(LOWER(typename));
+    END IF;
+
+
+    IF NOT EXISTS (SELECT ao.name FROM sys.types ao WHERE ao.name = type_name COLLATE sys.database_default)
+    THEN
+        RETURN NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT ao.name FROM sys.schemas ao WHERE ao.name = schema_name COLLATE sys.database_default OR schema_name = 'sys' OR schema_name = 'pg_catalog')
+    THEN
+        RETURN NULL ;
+    END IF;
+
+    IF NOT EXISTS (SELECT ty.name FROM sys.types ty WHERE ty.name = type_name COLLATE sys.database_default AND ty.is_user_defined = 0) THEN
+    schemaid := (SELECT sc.schema_id FROM sys.schemas sc WHERE sc.name = schema_name COLLATE sys.database_default);
+    ELSE
+        schemaid := (SELECT sc.schema_id FROM sys.types sc WHERE sc.name = type_name COLLATE sys.database_default);
+        IF schema_name = 'dbo'
+        THEN
+        schema_name := schema_name(schemaid);
+        END IF;
+    END IF;
+
+
+    if (SELECT schema_id(schema_name)) <> schemaid
+    THEN
+    RETURN NULL;
+    END IF;
+
+    sys_id := (SELECT CAST(dc.system_type_id AS INT) FROM sys.types dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.schema_id = schemaid);
+    type_namee := (SELECT CAST(dc.name AS VARCHAR) FROM sys.types dc WHERE dc.system_type_id = sys_id AND dc.is_user_defined = 0);
+
+    IF property = 'allowsnull'
+    THEN
+        RETURN (
+            SELECT CAST( t1.is_nullable AS INT)
+            FROM sys.types t1
+            WHERE t1.name = type_name COLLATE sys.database_default AND t1.schema_id = schemaid );
+
+    ELSEIF property = 'precision'
+    THEN
+        preci := (SELECT CAST(dc.precision AS INT) FROM sys.types dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.schema_id = schemaid);
+        IF sys_id = 0
+        THEN
+            RETURN preci;
+        END IF;
+
+        IF preci = 0
+        THEN
+            preci = (SELECT CAST(dc.prec AS INT) FROM sys.systypes dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.uid = schemaid);
+            IF preci IS NULL
+            THEN
+                IF type_namee = 'image' or type_namee = 'text'
+                THEN
+                RETURN 2147483647;
+                ELSEIF type_namee = 'ntext'
+                THEN
+                RETURN 1073741823;
+                END IF;
+            END IF;
+            RETURN preci;
+        ELSE
+            RETURN preci;
+        END IF;        
+
+    ELSEIF property = 'scale'
+    THEN
+        preci := (SELECT CAST(dc.precision AS INT) FROM sys.types dc WHERE dc.name = type_namee COLLATE sys.database_default AND dc.system_type_id = sys_id);
+        IF sys_id = 0
+        THEN
+            RETURN preci;
+        END IF;
+        IF preci = 0 or type_namee = 'float' or type_namee = 'real' or type_namee = 'bit'
+        THEN
+            RETURN NULL;
+        ELSE
+            RETURN(SELECT CAST(dc.scale AS INT) FROM sys.types dc WHERE dc.name = type_name COLLATE sys.database_default AND dc.schema_id = schemaid);
+        END IF;
+    ELSEIF property = 'ownerid'
+    THEN
+        IF NOT EXISTS (SELECT ty.name FROM sys.types ty WHERE ty.name = type_name COLLATE sys.database_default AND ty.is_user_defined = 0) THEN
+        RETURN(SELECT CAST(dc.nspowner AS INT) FROM  pg_catalog.pg_namespace dc WHERE dc.oid = schemaid);
+        ELSE
+        RETURN 10;
+        END IF;
+
+    ELSEIF property = 'usesansitrim'
+    THEN
+        IF type_name::regtype IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'tinyint'::regtype,
+            'numeric'::regtype, 'float'::regtype, 'real'::regtype, 'money'::regtype)
+        THEN
+            RETURN NULL;
+        ELSE
+            RETURN 1;
+        END IF;
+
+    END IF;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
+
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/BABEL-2869.out
+++ b/test/JDBC/expected/BABEL-2869.out
@@ -64,7 +64,6 @@ sysname
 text
 time
 timestamp
-timestamp
 tinyint
 uniqueidentifier
 varbinary

--- a/test/JDBC/expected/sys-systypes-vu-verify.out
+++ b/test/JDBC/expected/sys-systypes-vu-verify.out
@@ -30,11 +30,10 @@ smallmoney#!#0#!#4#!#0#!#1#!#<NULL>#!#<NULL>
 sql_variant#!#0#!#8016#!#0#!#1#!#<NULL>#!#bbf_unicode_cp1_ci_as
 sys_systypes_type#!#0#!#4#!#0#!#1#!#<NULL>#!#<NULL>
 sys_systypes_type2#!#0#!#1#!#1#!#1#!#<NULL>#!#bbf_unicode_cp1_ci_as
-sysname#!#0#!#256#!#1#!#1#!#<NULL>#!#bbf_unicode_cp1_ci_as
+sysname#!#1#!#256#!#1#!#0#!#<NULL>#!#bbf_unicode_cp1_ci_as
 text#!#0#!#16#!#0#!#1#!#<NULL>#!#sql_latin1_general_cp1_ci_as
 time#!#0#!#5#!#0#!#1#!#<NULL>#!#<NULL>
-timestamp#!#0#!#8#!#0#!#1#!#<NULL>#!#<NULL>
-timestamp#!#0#!#8#!#0#!#1#!#<NULL>#!#<NULL>
+timestamp#!#1#!#8#!#0#!#0#!#<NULL>#!#<NULL>
 tinyint#!#0#!#1#!#0#!#1#!#<NULL>#!#<NULL>
 uniqueidentifier#!#0#!#16#!#0#!#1#!#<NULL>#!#<NULL>
 varbinary#!#0#!#8000#!#1#!#1#!#<NULL>#!#<NULL>

--- a/test/JDBC/expected/sys-types-vu-verify.out
+++ b/test/JDBC/expected/sys-types-vu-verify.out
@@ -33,7 +33,6 @@ sysname#!#256#!#0#!#0#!#bbf_unicode_cp1_ci_as
 text#!#16#!#0#!#0#!#sql_latin1_general_cp1_ci_as
 time#!#5#!#15#!#6#!#<NULL>
 timestamp#!#8#!#0#!#0#!#<NULL>
-timestamp#!#8#!#0#!#0#!#<NULL>
 tinyint#!#1#!#3#!#0#!#<NULL>
 uniqueidentifier#!#16#!#0#!#0#!#<NULL>
 varbinary#!#8000#!#0#!#0#!#<NULL>

--- a/test/JDBC/expected/sys-types.out
+++ b/test/JDBC/expected/sys-types.out
@@ -33,7 +33,6 @@ sysname#!#256#!#0#!#0#!#bbf_unicode_cp1_ci_as
 text#!#16#!#0#!#0#!#sql_latin1_general_cp1_ci_as
 time#!#5#!#15#!#6#!#<NULL>
 timestamp#!#8#!#0#!#0#!#<NULL>
-timestamp#!#8#!#0#!#0#!#<NULL>
 tinyint#!#1#!#3#!#0#!#<NULL>
 uniqueidentifier#!#16#!#0#!#0#!#<NULL>
 varbinary#!#8000#!#0#!#0#!#<NULL>

--- a/test/JDBC/expected/typeproperty-dep-vu-cleanup.out
+++ b/test/JDBC/expected/typeproperty-dep-vu-cleanup.out
@@ -1,0 +1,15 @@
+DROP VIEW typeproperty_vu_prepare_dep_view
+GO
+
+DROP PROC typeproperty_vu_prepare_dep_proc
+GO
+
+DROP FUNCTION typeproperty_vu_prepare_dep_func
+GO
+
+DROP TYPE typeproperty_test1_dep_vu.null_check1_dep_vu
+GO
+
+DROP SCHEMA typeproperty_test1_dep_vu
+GO
+

--- a/test/JDBC/expected/typeproperty-dep-vu-prepare.out
+++ b/test/JDBC/expected/typeproperty-dep-vu-prepare.out
@@ -1,0 +1,22 @@
+CREATE SCHEMA typeproperty_test1_dep_vu
+GO
+
+CREATE TYPE typeproperty_test1_dep_vu.null_check1_dep_vu FROM varchar(11) NOT NULL ;
+GO
+
+CREATE VIEW typeproperty_vu_prepare_dep_view AS
+SELECT TYPEPROPERTY('typeproperty_test1_dep_vu.null_check1_dep_vu', 'scale')
+GO
+
+CREATE PROC typeproperty_vu_prepare_dep_proc AS
+SELECT TYPEPROPERTY('typeproperty_test1_dep_vu.null_check1_dep_vu', 'allowsnull')
+GO
+
+CREATE FUNCTION typeproperty_vu_prepare_dep_func()
+RETURNS INT
+AS
+BEGIN
+RETURN TYPEPROPERTY('typeproperty_test1_dep_vu.null_check1_dep_vu', 'precision')
+END
+GO
+

--- a/test/JDBC/expected/typeproperty-dep-vu-verify.out
+++ b/test/JDBC/expected/typeproperty-dep-vu-verify.out
@@ -1,0 +1,23 @@
+SELECT * FROM typeproperty_vu_prepare_dep_view
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+EXEC typeproperty_vu_prepare_dep_proc
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM typeproperty_vu_prepare_dep_func()
+GO
+~~START~~
+int
+11
+~~END~~
+

--- a/test/JDBC/expected/typeproperty-vu-cleanup.out
+++ b/test/JDBC/expected/typeproperty-vu-cleanup.out
@@ -1,0 +1,18 @@
+DROP TYPE typeproperty_test1.null_check1
+Go
+
+DROP TYPE typeproperty_test1.null_check2
+Go
+
+DROP TYPE typeproperty_test2.null_check1
+Go
+
+DROP TYPE typeproperty_test2.null_check2
+Go
+
+DROP SCHEMA typeproperty_test1
+GO
+
+DROP SCHEMA typeproperty_test2
+GO
+

--- a/test/JDBC/expected/typeproperty-vu-prepare.out
+++ b/test/JDBC/expected/typeproperty-vu-prepare.out
@@ -1,0 +1,18 @@
+Create schema typeproperty_test1
+Go
+
+Create schema typeproperty_test2
+Go
+
+Create type typeproperty_test1.null_check1 FROM varchar(11) NOT NULL ;
+GO
+
+Create type typeproperty_test1.null_check2 FROM int  NULL ;
+GO
+
+Create type typeproperty_test2.null_check1 FROM varchar(11)  NULL ;
+GO
+
+Create type typeproperty_test2.null_check2 FROM int  NOT NULL ;
+GO
+

--- a/test/JDBC/expected/typeproperty-vu-verify.out
+++ b/test/JDBC/expected/typeproperty-vu-verify.out
@@ -1,0 +1,319 @@
+-- =============== AllowsNull ===============
+Select typeproperty('sys.int','allowsnull')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('pg_catalog.int','allowsnull')
+Go
+~~START~~
+int
+1
+~~END~~
+
+
+Select typeproperty('pg_catalog.int','allowsnul')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('pg_catalog.int',' allowsnull   ')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('typeproperty_test1.null_check1','allowsnull')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+Select typeproperty('typeproperty_test1.null_check2','allowsnull')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Select typeproperty('typeproperty_test2.null_check1','allowsnull')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Select typeproperty('typeproperty_test2.null_check2','allowsnull')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+-- =============== Precision ===============
+Select typeproperty('sys.int','precision')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('pg_catalog.int','precision')
+Go
+~~START~~
+int
+10
+~~END~~
+
+
+Select typeproperty('pg_catalog.int','precisusn')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('pg_catalog.int',' precision   ')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('typeproperty_test1.null_check1','precision')
+GO
+~~START~~
+int
+11
+~~END~~
+
+
+Select typeproperty('typeproperty_test1.null_check2','precision')
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+Select typeproperty('typeproperty_test2.null_check1','precision')
+GO
+~~START~~
+int
+11
+~~END~~
+
+
+Select typeproperty('typeproperty_test2.null_check2','precision')
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+
+-- ===============Scale===============
+Select typeproperty('sys.int','scale')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('pg_catalog.int','scale')
+Go
+~~START~~
+int
+0
+~~END~~
+
+
+Select typeproperty('pg_catalog.int','scael')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('pg_catalog.int',' scale   ')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('sys.char',' scale   ')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('sys.money',' scale   ')
+Go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('typeproperty_test1.null_check1','scale')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('typeproperty_test1.null_check2','scale')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+Select typeproperty('typeproperty_test2.null_check1','scale')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+Select typeproperty('typeproperty_test2.null_check2','scale')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+-- ===============OwnerId===============
+SELECT CASE
+    WHEN typeproperty('sys.int','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+FAILED
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('pg_catalog.int','ownerid') IS NOT  NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+SUCCESS
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('pg_catalog.int','ownerdi') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+FAILED
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('pg_catalog.int',' ownerid   ') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+FAILED
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test1.null_check1','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+SUCCESS
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test1.null_check2','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+SUCCESS
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test2.null_check1','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+SUCCESS
+~~END~~
+
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test2.null_check2','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+~~START~~
+text
+SUCCESS
+~~END~~
+
+

--- a/test/JDBC/input/functions/typeproperty-dep-vu-cleanup.sql
+++ b/test/JDBC/input/functions/typeproperty-dep-vu-cleanup.sql
@@ -1,0 +1,15 @@
+DROP VIEW typeproperty_vu_prepare_dep_view
+GO
+
+DROP PROC typeproperty_vu_prepare_dep_proc
+GO
+
+DROP FUNCTION typeproperty_vu_prepare_dep_func
+GO
+
+DROP TYPE typeproperty_test1_dep_vu.null_check1_dep_vu
+GO
+
+DROP SCHEMA typeproperty_test1_dep_vu
+GO
+

--- a/test/JDBC/input/functions/typeproperty-dep-vu-prepare.sql
+++ b/test/JDBC/input/functions/typeproperty-dep-vu-prepare.sql
@@ -1,0 +1,22 @@
+CREATE SCHEMA typeproperty_test1_dep_vu
+GO
+
+CREATE TYPE typeproperty_test1_dep_vu.null_check1_dep_vu FROM varchar(11) NOT NULL ;
+GO
+
+CREATE VIEW typeproperty_vu_prepare_dep_view AS
+SELECT TYPEPROPERTY('typeproperty_test1_dep_vu.null_check1_dep_vu', 'scale')
+GO
+
+CREATE PROC typeproperty_vu_prepare_dep_proc AS
+SELECT TYPEPROPERTY('typeproperty_test1_dep_vu.null_check1_dep_vu', 'allowsnull')
+GO
+
+CREATE FUNCTION typeproperty_vu_prepare_dep_func()
+RETURNS INT
+AS
+BEGIN
+RETURN TYPEPROPERTY('typeproperty_test1_dep_vu.null_check1_dep_vu', 'precision')
+END
+GO
+

--- a/test/JDBC/input/functions/typeproperty-dep-vu-verify.sql
+++ b/test/JDBC/input/functions/typeproperty-dep-vu-verify.sql
@@ -1,0 +1,8 @@
+SELECT * FROM typeproperty_vu_prepare_dep_view
+GO
+
+EXEC typeproperty_vu_prepare_dep_proc
+GO
+
+SELECT * FROM typeproperty_vu_prepare_dep_func()
+GO

--- a/test/JDBC/input/functions/typeproperty-vu-cleanup.sql
+++ b/test/JDBC/input/functions/typeproperty-vu-cleanup.sql
@@ -1,0 +1,18 @@
+DROP TYPE typeproperty_test1.null_check1
+Go
+
+DROP TYPE typeproperty_test1.null_check2
+Go
+
+DROP TYPE typeproperty_test2.null_check1
+Go
+
+DROP TYPE typeproperty_test2.null_check2
+Go
+
+DROP SCHEMA typeproperty_test1
+GO
+
+DROP SCHEMA typeproperty_test2
+GO
+

--- a/test/JDBC/input/functions/typeproperty-vu-prepare.sql
+++ b/test/JDBC/input/functions/typeproperty-vu-prepare.sql
@@ -1,0 +1,18 @@
+Create schema typeproperty_test1
+Go
+
+Create schema typeproperty_test2
+Go
+
+Create type typeproperty_test1.null_check1 FROM varchar(11) NOT NULL ;
+GO
+
+Create type typeproperty_test1.null_check2 FROM int  NULL ;
+GO
+
+Create type typeproperty_test2.null_check1 FROM varchar(11)  NULL ;
+GO
+
+Create type typeproperty_test2.null_check2 FROM int  NOT NULL ;
+GO
+

--- a/test/JDBC/input/functions/typeproperty-vu-verify.sql
+++ b/test/JDBC/input/functions/typeproperty-vu-verify.sql
@@ -1,0 +1,149 @@
+-- =============== AllowsNull ===============
+Select typeproperty('sys.int','allowsnull')
+Go
+
+Select typeproperty('pg_catalog.int','allowsnull')
+Go
+
+Select typeproperty('pg_catalog.int','allowsnul')
+GO
+
+Select typeproperty('pg_catalog.int',' allowsnull   ')
+Go
+
+Select typeproperty('typeproperty_test1.null_check1','allowsnull')
+GO
+
+Select typeproperty('typeproperty_test1.null_check2','allowsnull')
+GO
+
+Select typeproperty('typeproperty_test2.null_check1','allowsnull')
+GO
+
+Select typeproperty('typeproperty_test2.null_check2','allowsnull')
+GO
+
+-- =============== Precision ===============
+
+Select typeproperty('sys.int','precision')
+Go
+
+Select typeproperty('pg_catalog.int','precision')
+Go
+
+Select typeproperty('pg_catalog.int','precisusn')
+GO
+
+Select typeproperty('pg_catalog.int',' precision   ')
+Go
+
+Select typeproperty('typeproperty_test1.null_check1','precision')
+GO
+
+Select typeproperty('typeproperty_test1.null_check2','precision')
+GO
+
+Select typeproperty('typeproperty_test2.null_check1','precision')
+GO
+
+Select typeproperty('typeproperty_test2.null_check2','precision')
+GO
+
+-- ===============Scale===============
+
+Select typeproperty('sys.int','scale')
+Go
+
+Select typeproperty('pg_catalog.int','scale')
+Go
+
+Select typeproperty('pg_catalog.int','scael')
+GO
+
+Select typeproperty('pg_catalog.int',' scale   ')
+Go
+
+Select typeproperty('sys.char',' scale   ')
+Go
+
+Select typeproperty('sys.money',' scale   ')
+Go
+
+Select typeproperty('typeproperty_test1.null_check1','scale')
+GO
+
+Select typeproperty('typeproperty_test1.null_check2','scale')
+GO
+
+Select typeproperty('typeproperty_test2.null_check1','scale')
+GO
+
+Select typeproperty('typeproperty_test2.null_check2','scale')
+GO
+
+-- ===============OwnerId===============
+
+SELECT CASE
+    WHEN typeproperty('sys.int','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('pg_catalog.int','ownerid') IS NOT  NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('pg_catalog.int','ownerdi') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('pg_catalog.int',' ownerid   ') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test1.null_check1','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test1.null_check2','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test2.null_check1','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+
+SELECT CASE
+    WHEN typeproperty('typeproperty_test2.null_check2','ownerid') IS NOT NULL
+        Then 'SUCCESS'
+    ELSE
+        'FAILED'
+END
+GO
+

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -431,4 +431,5 @@ test_windows_sp_helpuser
 TestXML
 timefromparts
 triggers_with_transaction
+typeproperty
 datetimeoffset-timezone

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -432,4 +432,6 @@ test_windows_sp_helpuser
 TestXML
 timefromparts
 triggers_with_transaction
+typeproperty
+typeproperty-dep
 datetimeoffset-timezone


### PR DESCRIPTION
### Description

Implemented the typeproperty to support user defined datatypes.
The Typeproperty  function returns information based on data type  from the current object . It supports 2 parameters, an TYPE (string expression) and PROPERTY (string expression). The function returns an int and the values depend on the PROPERTY parameter.

Supported Property:-
- Owner ID
- AllowsNull
- Precision
- Scale


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).