### PR TITLE
Add instructions to build Babelfish with kerberos authentication enabled

### DIFF
--- a/INSTALLING.md.tmpl
+++ b/INSTALLING.md.tmpl
@@ -35,6 +35,8 @@ sudo apt-get update && sudo apt install -y --no-install-recommends \
   gnupg unixodbc-dev net-tools unzip
 ```
 
+If you would like to work with Kerberos authentication then additional dependency is required on `libkrb5-dev` package.
+
 Many of the Babelfish prerequisites are part of a typical Linux distribution.  You may find that the packages on your distribution use a similar (but not identical) name.  
 
 To build Babelfish, you will need access to a user with root privileges, so you can convey privileges with `sudo`. You'll also need a non-root user to initialize the database; PostgreSQL does not allow a root user to own the `data` directory or start the server.
@@ -108,6 +110,7 @@ make DESTDIR=${BABELFISH_HOME}/ -j $JOBS 2>error.txt
           
 sudo make install
 ```
+> NOTE: To build Babelfish with Kerberos authentication support, use the option `--with-gssapi` during configuration. 
 
 > WARNING: Using the --with-extra-version option during the configuration phase can break the sys.get_host_os() output; we do not recommend including it.
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -242,4 +242,4 @@ For detailed instructions on how to write, add, and run tests in JDBC test frame
 Please note that Kerberos authentication feature is available on Babelfish server with version 3.1.0 or higher. 
 
 1. To build the Babelfish server with Kerberos authentication enabled, you will need to install `build-essential` and `libkrb5-dev` packages. 
-2. Build the Babelfish server according to the instructions mentioned [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/README.md) and use --with-gssapi flag to configure Babelfish in order to enable the GSSAPI APIs.
+2. Build the Babelfish server according to the instructions mentioned [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/README.md#build-the-postgres-engine) and use --with-gssapi flag to configure Babelfish in order to enable the GSSAPI APIs.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -235,3 +235,11 @@ For detailed instructions on how to write, add, and run tests in JDBC test frame
     babelfish_db=> CREATE EXTENSION tds_fdw;
     CREATE EXTENSION
     ```
+
+
+# How to build the Babelfish server with Kerberos authentication enabled
+
+Please note that Kerberos authentication feature is available on Babelfish server with version 3.1.0 or higher. 
+
+1. To build the Babelfish server with Kerberos authentication enabled, you will need to install `build-essential` and `libkrb5-dev` packages. 
+2. Build the Babelfish server according to the instructions mentioned [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/README.md) and use --with-gssapi flag to configure Babelfish in order to enable the GSSAPI APIs.


### PR DESCRIPTION
### Description

This commit adds instructions to build Babelfish with Kerberos authentication enabled

Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).