### PR TITLE
Fix permission issues for babelfish dump/restore

### DIFF
--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -45,7 +45,7 @@ runs:
         cd upgrade
         if [[ '${{ inputs.logical_database }}' == 'null' ]];then
           echo 'Starting to dump whole Babelfish physical database'
-          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall --database jdbc_testdb --username jdbc_user --globals-only --quote-all-identifiers --verbose -f pg_dump_globals.sql 2>>error.log
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall --database jdbc_testdb --username jdbc_user --globals-only --quote-all-identifiers --verbose --no-role-passwords -f pg_dump_globals.sql 2>>error.log
           ~/${{ inputs.pg_new_dir }}/bin/pg_dump --username jdbc_user --quote-all-identifiers --verbose --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
         else
           echo "Starting to dump Babelfish logical database ${{ inputs.logical_database }}"
@@ -90,7 +90,6 @@ runs:
           base_dir="${{ inputs.logical_database }}"
         fi
 
-        # Temporarily disable certain tests until fixed
       shell: bash
 
     - name: Run Verify Tests

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -90,6 +90,8 @@ runs:
           base_dir="${{ inputs.logical_database }}"
         fi
 
+        # Temporarily disable certain tests until fixed
+        sed -i "/BABEL-3513/d" test/JDBC/upgrade/$base_dir/schedule
       shell: bash
 
     - name: Run Verify Tests

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -49,7 +49,7 @@ runs:
           ~/${{ inputs.pg_new_dir }}/bin/pg_dump --username jdbc_user --quote-all-identifiers --verbose --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
         else
           echo "Starting to dump Babelfish logical database ${{ inputs.logical_database }}"
-          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall --database jdbc_testdb --username jdbc_user --globals-only --quote-all-identifiers --verbose --bbf-database-name='${{ inputs.logical_database }}' -f pg_dump_globals.sql 2>>error.log
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall --database jdbc_testdb --username jdbc_user --globals-only --quote-all-identifiers --verbose --no-role-passwords --bbf-database-name='${{ inputs.logical_database }}' -f pg_dump_globals.sql 2>>error.log
           ~/${{ inputs.pg_new_dir }}/bin/pg_dump --username jdbc_user --quote-all-identifiers --verbose --bbf-database-name='${{ inputs.logical_database }}' --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
         fi
 

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -100,10 +100,6 @@ runs:
         fi
 
         # Temporarily disable certain tests until fixed
-        sed -i "/BABEL-3513/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/TestNotNull/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/TestSQLVariant/d" test/JDBC/upgrade/$base_dir/schedule
-        sed -i "/babel_datatype_sqlvariant/d" test/JDBC/upgrade/$base_dir/schedule
       shell: bash
 
     - name: Run Verify Tests

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -46,7 +46,7 @@ runs:
         if [[ '${{ inputs.logical_database }}' == 'null' ]];then
           echo 'Starting to dump whole Babelfish physical database'
           ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall --database jdbc_testdb --username jdbc_user --globals-only --quote-all-identifiers --verbose -f pg_dump_globals.sql 2>>error.log
-          ~/${{ inputs.pg_new_dir }}/bin/pg_dump --create --username jdbc_user --quote-all-identifiers --verbose --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dump --username jdbc_user --quote-all-identifiers --verbose --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
         else
           echo "Starting to dump Babelfish logical database ${{ inputs.logical_database }}"
           ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall --database jdbc_testdb --username jdbc_user --globals-only --quote-all-identifiers --verbose --bbf-database-name='${{ inputs.logical_database }}' -f pg_dump_globals.sql 2>>error.log
@@ -59,23 +59,14 @@ runs:
         cd ~/work/babelfish_extensions/babelfish_extensions/
         echo 'Database dump complete.'
 
-        if [[ '${{ inputs.logical_database }}' == 'null' ]];then
-          echo 'Restoring from pg_dumpall'
-          sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -f ~/upgrade/pg_dump_globals.sql 2>> ~/upgrade/error.log
-          echo 'Restoring from pg_dump'
-          sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U jdbc_user -f ~/upgrade/pg_dump.sql 2>> ~/upgrade/error.log
-        else
-          # Create and initialise Babelfish extensions in the new server if we are restoring a logical database.
-          sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -f .github/scripts/create_extension.sql
-          echo 'Restoring from pg_dumpall'
-          sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -f ~/upgrade/pg_dump_globals.sql 2>> ~/upgrade/error.log
-          echo 'Restoring from pg_dump'
-          sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -f ~/upgrade/pg_dump.sql 2>> ~/upgrade/error.log
-        fi
+        # Create and initialise Babelfish extensions in the new server to perform restore.
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -f .github/scripts/create_extension.sql
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -c "ALTER ROLE jdbc_user NOSUPERUSER NOREPLICATION;"
+        echo 'Restoring from pg_dumpall'
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -f ~/upgrade/pg_dump_globals.sql 2>> ~/upgrade/error.log
+        echo 'Restoring from pg_dump'
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -f ~/upgrade/pg_dump.sql 2>> ~/upgrade/error.log
 
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -c "SELECT pg_reload_conf();"
         export PATH=/opt/mssql-tools/bin:$PATH
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -61,7 +61,6 @@ runs:
 
         # Create and initialise Babelfish extensions in the new server to perform restore.
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -f .github/scripts/create_extension.sql
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -c "ALTER ROLE jdbc_user NOSUPERUSER NOREPLICATION;"
         echo 'Restoring from pg_dumpall'
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U jdbc_user -f ~/upgrade/pg_dump_globals.sql 2>> ~/upgrade/error.log
         echo 'Restoring from pg_dump'


### PR DESCRIPTION
### Description
- Fix ALTER ROLE commands 
- Do not dump protected roles
- Do not dump default Babelfish roles ( e.g. master_dbo, tempdb_db_owner, msdb_guest, etc. ) 
- Support dump/restore using COPY mode 
- dump sys.babelfish_authid_login_ext using INSERT operations. even in COPY mode
- remove GRANTED BY clause from GRANT commands 
- Modify isBabelfishDatabase to improve execution time of pg_dump command
- Add isBabelfishDatabase function for pg_dumpall
- Fix bug in dump sql_variant column tables with INSERT (generated columns were getting dumped incorrectly in some cases ) 
 
Extensions PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/148
### Issues Resolved

BABEL-4189
  
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
