### PR TITLE
Support reordered list of columns for bulk copy

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -656,14 +656,20 @@ ExecuteBulkCopy(BulkCopyState cstate, int rowCount, int colCount,
 				else
 				{
 					/*
-					 * j will never be >= colCount since that is handled by
-					 * protocol.
+					 * In case of reordered list of columns, we get the next index(col_index_to_insert)
+					 * from cstate->attnumlist which points to the original column index in the
+					 * TupleTableSlot. On the other hand we also need to maintain the index
+					 * (col_index_to_fetch) which points to the next column's value in the order as received.
+					 * NOTE: j will never be >= colCount since that is handled by protocol.
 					 */
-					if (Nulls[cur_row_in_batch * colCount + j])
-						myslot->tts_isnull[i] = Nulls[cur_row_in_batch * colCount + j];
+					int col_index_to_insert = lfirst_int(&cstate->attnumlist->elements[j]) - 1;
+					int col_index_to_fetch  = cur_row_in_batch * colCount + j;
+
+					if (Nulls[col_index_to_fetch])
+						myslot->tts_isnull[col_index_to_insert] = Nulls[col_index_to_fetch];
 					else
 					{
-						myslot->tts_values[i] = Values[cur_row_in_batch * colCount + j];
+						myslot->tts_values[col_index_to_insert] = Values[col_index_to_fetch];
 					}
 					j++;
 

--- a/test/dotnet/ExpectedOutput/bcp.out
+++ b/test/dotnet/ExpectedOutput/bcp.out
@@ -644,3 +644,19 @@ bcp -k#!#in#!#bcp_source#!#destinationTable
 
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b text, c int) 
+#Q#Create table destinationTable(a int, b text, c int) 
+#Q#insert into sourceTable values (1, 'hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello', 2)
+#Q#insert into sourceTable values (NULL, NULL, NULL)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#text#!#int
+1#!#hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello#!#2
+#!##!#
+#Q#select * from destinationTable
+#D#int#!#text#!#int
+1#!#hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello#!#2
+#!##!#
+#Q#drop table sourceTable
+#Q#drop table destinationTable

--- a/test/dotnet/input/bcp.txt
+++ b/test/dotnet/input/bcp.txt
@@ -458,3 +458,15 @@ select a from sourceTable
 select a from destinationTable 
 drop table sourceTable
 drop table destinationTable
+
+# reordering of column list with large value
+Create table sourceTable(a int, b text, c int) 
+Create table destinationTable(a int, b text, c int) 
+insert into sourceTable values (1, 'hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello hellohello', 2)
+insert into sourceTable values (NULL, NULL, NULL)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+select * from destinationTable
+drop table sourceTable
+drop table destinationTable


### PR DESCRIPTION
### Description
For Some reason BCP was reordering the list of columns and placing the LOB type columns at the end, maybe as part of optimisation. There could also be other scenarios where there is some rearrangement of column order and this was not accounted for and not supported.
A mismatch in the attribute list and the tuple-desc list was resulting in a crash when creating the heap tuple using the tuple desc and the mismatched list of values.
To fix this I have appropriately stored the Slots's values/nulls in the order of the columns received.

Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)

### Issues Resolved
BABEL-4230

### Test Scenarios Covered ###
* **Use case based -**
Added test case

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).