### PR TITLE
Fix the bug: like expression will error out unexpectly

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -504,6 +504,10 @@ pltsql_predicate_transformer(Node *expr)
 			expr = expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
 			return transform_funcexpr(expr);
 		}
+		else if (IsA(expr, SubLink))
+		{
+			return expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
+		}
 		else
 			return expr;
 
@@ -523,7 +527,7 @@ pltsql_predicate_transformer(Node *expr)
 			else if (IsA(qual, OpExpr))
 			{
 				new_predicates = lappend(new_predicates,
-										 transform_likenode(qual));
+										 expression_tree_mutator(qual, pgtsql_expression_tree_mutator, NULL));
 			}
 			else
 				new_predicates = lappend(new_predicates, qual);

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -526,6 +526,7 @@ pltsql_predicate_transformer(Node *expr)
 			}
 			else if (IsA(qual, OpExpr))
 			{
+				qual = transform_likenode(qual);
 				new_predicates = lappend(new_predicates,
 										 expression_tree_mutator(qual, pgtsql_expression_tree_mutator, NULL));
 			}

--- a/test/JDBC/expected/BABEL-4046-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4046-vu-cleanup.out
@@ -7,7 +7,7 @@ GO
 drop table t;
 go
 
-drop table t1;
+drop table t2;
 go
 
 drop table svc_defs;

--- a/test/JDBC/expected/BABEL-4046-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4046-vu-cleanup.out
@@ -1,0 +1,23 @@
+drop VIEW babel4046;
+GO
+
+drop VIEW babel4046_2;
+GO
+
+drop table t;
+go
+
+drop table t1;
+go
+
+drop table svc_defs;
+go
+
+drop table options;
+go
+
+drop table [dbo].[t3];
+go
+
+drop table [dbo].[t4];
+GO

--- a/test/JDBC/expected/BABEL-4046-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4046-vu-cleanup.out
@@ -13,7 +13,7 @@ go
 drop table svc_defs;
 go
 
-drop table options;
+drop table options_t;
 go
 
 drop table [dbo].[t3];

--- a/test/JDBC/expected/BABEL-4046-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4046-vu-cleanup.out
@@ -7,7 +7,7 @@ GO
 drop table t;
 go
 
-drop table t2;
+drop table t_babel4046;
 go
 
 drop table svc_defs;

--- a/test/JDBC/expected/BABEL-4046-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4046-vu-prepare.out
@@ -23,25 +23,25 @@ go
 ~~ROW COUNT: 1~~
 
 
-create table t2 (b varchar(30));
+create table t_babel4046 (b varchar(30));
 go
 
-insert into t2 values ('a%');
+insert into t_babel4046 values ('a%');
 go
 ~~ROW COUNT: 1~~
 
 
-insert into t2 values ('A%');
+insert into t_babel4046 values ('A%');
 go
 ~~ROW COUNT: 1~~
 
 
 CREATE VIEW babel4046 as 
-select * from t join t2 on a like b;
+select * from t join t_babel4046 on a like b;
 GO
 
 CREATE VIEW babel4046_2 as
-select * from t join t2 on a like 'aa%';
+select * from t join t_babel4046 on a like 'aa%';
 GO
 
 CREATE TABLE [dbo].[t3](

--- a/test/JDBC/expected/BABEL-4046-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4046-vu-prepare.out
@@ -1,5 +1,5 @@
-create table options(name varchar(30))
-insert options values('abc')
+create table options_t(name varchar(30))
+insert options_t values('abc')
 go
 ~~ROW COUNT: 1~~
 

--- a/test/JDBC/expected/BABEL-4046-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4046-vu-prepare.out
@@ -23,25 +23,25 @@ go
 ~~ROW COUNT: 1~~
 
 
-create table t1 (b varchar(30));
+create table t2 (b varchar(30));
 go
 
-insert into t1 values ('a%');
+insert into t2 values ('a%');
 go
 ~~ROW COUNT: 1~~
 
 
-insert into t1 values ('A%');
+insert into t2 values ('A%');
 go
 ~~ROW COUNT: 1~~
 
 
 CREATE VIEW babel4046 as 
-select * from t join t1 on a like b;
+select * from t join t2 on a like b;
 GO
 
 CREATE VIEW babel4046_2 as
-select * from t join t1 on a like 'aa%';
+select * from t join t2 on a like 'aa%';
 GO
 
 CREATE TABLE [dbo].[t3](

--- a/test/JDBC/expected/BABEL-4046-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4046-vu-prepare.out
@@ -1,23 +1,13 @@
-create table options(name varchar(30) collate bbf_unicode_cp1_ci_as)
+create table options(name varchar(30))
 insert options values('abc')
 go
 ~~ROW COUNT: 1~~
 
 
-create table svc_defs(svc_name varchar(30) collate bbf_unicode_cp1_ci_as)
+create table svc_defs(svc_name varchar(30))
 insert svc_defs values('def')
 go
 ~~ROW COUNT: 1~~
-
-
-select options.name
-  from options
- inner join svc_defs
-    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
-go
-~~START~~
-varchar
-~~END~~
 
 
 create table t (a varchar(30));
@@ -33,7 +23,7 @@ go
 ~~ROW COUNT: 1~~
 
 
-create table t1 (a varchar(30));
+create table t1 (b varchar(30));
 go
 
 insert into t1 values ('a%');
@@ -46,41 +36,14 @@ go
 ~~ROW COUNT: 1~~
 
 
-select * from t join t1 on t.a like t1.a;
-go
-~~START~~
-varchar#!#varchar
-aaa#!#a%
-aaa#!#A%
-AAA#!#a%
-AAA#!#A%
-~~END~~
+CREATE VIEW babel4046 as 
+select * from t join t1 on a like b;
+GO
 
+CREATE VIEW babel4046_2 as
+select * from t join t1 on a like 'aa%';
+GO
 
-select * from t join t1 on t.a like 'aa%';
-go
-~~START~~
-varchar#!#varchar
-aaa#!#a%
-aaa#!#A%
-AAA#!#a%
-AAA#!#A%
-~~END~~
-
-
-drop table t;
-go
-
-drop table t1;
-go
-
-drop table svc_defs;
-go
-
-drop table options;
-go
-
---Table and data
 CREATE TABLE [dbo].[t3](
 	[EMPNO] [int] NOT NULL,
 	[ENAME] [nvarchar](10) NULL,
@@ -147,51 +110,3 @@ GO
 
 ~~ROW COUNT: 1~~
 
-
-;with EMP_T AS (
-                select empno,
-				ename,
-				CASE			            
-			            WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A')
-					    WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C')
-						WHEN baseloc LIKE 'BOS%' THEN REPLACE(baseloc,'BOSTON','B')
-                ELSE
-		                baseloc
-                END AS baseloc,
-				deptno
-				from t3)
-				select
-				DM.empno,
-				DM.ename,
-				DM.baseloc
-				from EMP_T DM
-				INNER JOIN t4 SR ON DM.baseloc = SR.loc AND DM.deptno = SR.deptno
-GO
-~~START~~
-int#!#nvarchar#!#text
-7782#!#CLARK#!#NEW YORK
-~~END~~
-
-
-;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
-	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4) 
-GO
-~~START~~
-int#!#nvarchar#!#text
-7369#!#SMITH#!#BOSTON
-7499#!#ALLEN#!#CHICAGO
-7521#!#WARD#!#CHICAGO
-7566#!#JONES#!#A
-7654#!#MARTIN#!#A
-7698#!#BLAKE#!#BOSTON
-7782#!#CLARK#!#NEW YORK
-7788#!#SCOTT#!#NEW YORK
-7839#!#KING#!#A
-~~END~~
-
-
-drop table [dbo].[t3];
-go
-
-drop table [dbo].[t4];
-GO

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -1,0 +1,78 @@
+
+select options.name
+  from options
+ inner join svc_defs
+    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
+go
+~~START~~
+varchar
+~~END~~
+
+
+select * from babel4046;
+GO
+~~START~~
+varchar#!#varchar
+aaa#!#a%
+aaa#!#A%
+AAA#!#a%
+AAA#!#A%
+~~END~~
+
+
+select * from babel4046_2;
+GO
+~~START~~
+varchar#!#varchar
+aaa#!#a%
+aaa#!#A%
+AAA#!#a%
+AAA#!#A%
+~~END~~
+
+
+;with EMP_T AS (
+                select empno,
+				ename,
+				CASE			            
+			            WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A')
+					    WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C')
+						WHEN baseloc LIKE 'BOS%' THEN REPLACE(baseloc,'BOSTON','B')
+                ELSE
+		                baseloc
+                END AS baseloc,
+				deptno
+				from t3)
+				select
+				DM.empno,
+				DM.ename,
+				DM.baseloc
+				from EMP_T DM
+				INNER JOIN t4 SR ON DM.baseloc = SR.loc AND DM.deptno = SR.deptno order by DM.empno;
+GO
+~~START~~
+int#!#nvarchar#!#text
+7782#!#CLARK#!#NEW YORK
+~~END~~
+
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4)  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#text
+7369#!#SMITH#!#BOSTON
+7499#!#ALLEN#!#CHICAGO
+7521#!#WARD#!#CHICAGO
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7698#!#BLAKE#!#BOSTON
+7782#!#CLARK#!#NEW YORK
+7788#!#SCOTT#!#NEW YORK
+7839#!#KING#!#A
+~~END~~
+
+
+
+
+

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -1,8 +1,8 @@
 
-select options.name
-  from options
+select options_t.name
+  from options_t
  inner join svc_defs
-    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
+    on options_t.name like 'UM\_%' + svc_defs.svc_name escape '\'
 go
 ~~START~~
 varchar

--- a/test/JDBC/expected/BABEL-4046.out
+++ b/test/JDBC/expected/BABEL-4046.out
@@ -1,0 +1,197 @@
+create table options(name varchar(30) collate bbf_unicode_cp1_ci_as)
+insert options values('abc')
+go
+~~ROW COUNT: 1~~
+
+
+create table svc_defs(svc_name varchar(30) collate bbf_unicode_cp1_ci_as)
+insert svc_defs values('def')
+go
+~~ROW COUNT: 1~~
+
+
+select options.name
+  from options
+ inner join svc_defs
+    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
+go
+~~START~~
+varchar
+~~END~~
+
+
+create table t (a varchar(30));
+go
+
+insert into t values ('aaa');
+go
+~~ROW COUNT: 1~~
+
+
+insert into t values ('AAA');
+go
+~~ROW COUNT: 1~~
+
+
+create table t1 (a varchar(30));
+go
+
+insert into t1 values ('a%');
+go
+~~ROW COUNT: 1~~
+
+
+insert into t1 values ('A%');
+go
+~~ROW COUNT: 1~~
+
+
+select * from t join t1 on t.a like t1.a;
+go
+~~START~~
+varchar#!#varchar
+aaa#!#a%
+aaa#!#A%
+AAA#!#a%
+AAA#!#A%
+~~END~~
+
+
+select * from t join t1 on t.a like 'aa%';
+go
+~~START~~
+varchar#!#varchar
+aaa#!#a%
+aaa#!#A%
+AAA#!#a%
+AAA#!#A%
+~~END~~
+
+
+drop table t;
+go
+
+drop table t1;
+go
+
+drop table svc_defs;
+go
+
+drop table options;
+go
+
+--Table and data
+CREATE TABLE [dbo].[t3](
+	[EMPNO] [int] NOT NULL,
+	[ENAME] [nvarchar](10) NULL,
+	[BASELOC] [nvarchar](13) NULL,
+	[DEPTNO] [int] NOT NULL,
+PRIMARY KEY CLUSTERED 
+(
+	[EMPNO] ASC
+) ON [PRIMARY])
+GO
+
+CREATE TABLE [dbo].[t4](
+	[DEPTNO] [int] NOT NULL,
+	[DNAME] [nvarchar](14) NULL,
+	[LOC] [nvarchar](13) NULL,
+PRIMARY KEY CLUSTERED 
+(
+	[DEPTNO] ASC
+) ON [PRIMARY])
+GO
+
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (10, N'ACCOUNTING', N'NEW YORK')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (20, N'RESEARCH', N'DALLAS')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (30, N'SALES', N'CHICAGO')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (40, N'SECURITY', N'BOSTON')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (50, N'LEGAL', N'AUSTIN')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7369, N'SMITH', N'BOSTON', 20)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7499, N'ALLEN', N'CHICAGO', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7521, N'WARD', N'CHICAGO', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7566, N'JONES', N'AUSTIN', 20)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7654, N'MARTIN', N'AUSTIN', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7698, N'BLAKE', N'BOSTON', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7782, N'CLARK', N'NEW YORK', 10)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7788, N'SCOTT', N'NEW YORK', 20)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7839, N'KING', N'AUSTIN', 100)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+;with EMP_T AS (
+                select empno,
+				ename,
+				CASE			            
+			            WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A')
+					    WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C')
+						WHEN baseloc LIKE 'BOS%' THEN REPLACE(baseloc,'BOSTON','B')
+                ELSE
+		                baseloc
+                END AS baseloc,
+				deptno
+				from t3)
+				select
+				DM.empno,
+				DM.ename,
+				DM.baseloc
+				from EMP_T DM
+				INNER JOIN t4 SR ON DM.baseloc = SR.loc AND DM.deptno = SR.deptno
+GO
+~~START~~
+int#!#nvarchar#!#text
+7782#!#CLARK#!#NEW YORK
+~~END~~
+
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4) 
+GO
+~~START~~
+int#!#nvarchar#!#text
+7369#!#SMITH#!#BOSTON
+7499#!#ALLEN#!#CHICAGO
+7521#!#WARD#!#CHICAGO
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7698#!#BLAKE#!#BOSTON
+7782#!#CLARK#!#NEW YORK
+7788#!#SCOTT#!#NEW YORK
+7839#!#KING#!#A
+~~END~~
+
+
+drop table [dbo].[t3];
+go
+
+drop table [dbo].[t4];
+GO

--- a/test/JDBC/input/BABEL-4046-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4046-vu-cleanup.sql
@@ -7,7 +7,7 @@ GO
 drop table t;
 go
 
-drop table t1;
+drop table t2;
 go
 
 drop table svc_defs;

--- a/test/JDBC/input/BABEL-4046-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4046-vu-cleanup.sql
@@ -1,0 +1,23 @@
+drop VIEW babel4046;
+GO
+
+drop VIEW babel4046_2;
+GO
+
+drop table t;
+go
+
+drop table t1;
+go
+
+drop table svc_defs;
+go
+
+drop table options;
+go
+
+drop table [dbo].[t3];
+go
+
+drop table [dbo].[t4];
+GO

--- a/test/JDBC/input/BABEL-4046-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4046-vu-cleanup.sql
@@ -13,7 +13,7 @@ go
 drop table svc_defs;
 go
 
-drop table options;
+drop table options_t;
 go
 
 drop table [dbo].[t3];

--- a/test/JDBC/input/BABEL-4046-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4046-vu-cleanup.sql
@@ -7,7 +7,7 @@ GO
 drop table t;
 go
 
-drop table t2;
+drop table t_babel4046;
 go
 
 drop table svc_defs;

--- a/test/JDBC/input/BABEL-4046-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4046-vu-prepare.sql
@@ -15,21 +15,21 @@ go
 insert into t values ('AAA');
 go
 
-create table t1 (b varchar(30));
+create table t2 (b varchar(30));
 go
 
-insert into t1 values ('a%');
+insert into t2 values ('a%');
 go
 
-insert into t1 values ('A%');
+insert into t2 values ('A%');
 go
 
 CREATE VIEW babel4046 as 
-select * from t join t1 on a like b;
+select * from t join t2 on a like b;
 GO
 
 CREATE VIEW babel4046_2 as
-select * from t join t1 on a like 'aa%';
+select * from t join t2 on a like 'aa%';
 GO
 
 CREATE TABLE [dbo].[t3](

--- a/test/JDBC/input/BABEL-4046-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4046-vu-prepare.sql
@@ -1,15 +1,9 @@
-create table options(name varchar(30) collate bbf_unicode_cp1_ci_as)
+create table options(name varchar(30))
 insert options values('abc')
 go
 
-create table svc_defs(svc_name varchar(30) collate bbf_unicode_cp1_ci_as)
+create table svc_defs(svc_name varchar(30))
 insert svc_defs values('def')
-go
-
-select options.name
-  from options
- inner join svc_defs
-    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
 go
 
 create table t (a varchar(30));
@@ -21,7 +15,7 @@ go
 insert into t values ('AAA');
 go
 
-create table t1 (a varchar(30));
+create table t1 (b varchar(30));
 go
 
 insert into t1 values ('a%');
@@ -30,25 +24,14 @@ go
 insert into t1 values ('A%');
 go
 
-select * from t join t1 on t.a like t1.a;
-go
+CREATE VIEW babel4046 as 
+select * from t join t1 on a like b;
+GO
 
-select * from t join t1 on t.a like 'aa%';
-go
+CREATE VIEW babel4046_2 as
+select * from t join t1 on a like 'aa%';
+GO
 
-drop table t;
-go
-
-drop table t1;
-go
-
-drop table svc_defs;
-go
-
-drop table options;
-go
-
---Table and data
 CREATE TABLE [dbo].[t3](
 	[EMPNO] [int] NOT NULL,
 	[ENAME] [nvarchar](10) NULL,
@@ -86,34 +69,4 @@ INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7698, N'BLAKE'
 INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7782, N'CLARK', N'NEW YORK', 10)
 INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7788, N'SCOTT', N'NEW YORK', 20)
 INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7839, N'KING', N'AUSTIN', 100)
-GO
-
-;with EMP_T AS (
-                select empno,
-				ename,
-				CASE			            
-			            WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A')
-					    WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C')
-						WHEN baseloc LIKE 'BOS%' THEN REPLACE(baseloc,'BOSTON','B')
-                ELSE
-		                baseloc
-                END AS baseloc,
-				deptno
-				from t3)
-				select
-				DM.empno,
-				DM.ename,
-				DM.baseloc
-				from EMP_T DM
-				INNER JOIN t4 SR ON DM.baseloc = SR.loc AND DM.deptno = SR.deptno
-GO
-
-;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
-	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4) 
-GO
-
-drop table [dbo].[t3];
-go
-
-drop table [dbo].[t4];
 GO

--- a/test/JDBC/input/BABEL-4046-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4046-vu-prepare.sql
@@ -15,21 +15,21 @@ go
 insert into t values ('AAA');
 go
 
-create table t2 (b varchar(30));
+create table t_babel4046 (b varchar(30));
 go
 
-insert into t2 values ('a%');
+insert into t_babel4046 values ('a%');
 go
 
-insert into t2 values ('A%');
+insert into t_babel4046 values ('A%');
 go
 
 CREATE VIEW babel4046 as 
-select * from t join t2 on a like b;
+select * from t join t_babel4046 on a like b;
 GO
 
 CREATE VIEW babel4046_2 as
-select * from t join t2 on a like 'aa%';
+select * from t join t_babel4046 on a like 'aa%';
 GO
 
 CREATE TABLE [dbo].[t3](

--- a/test/JDBC/input/BABEL-4046-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4046-vu-prepare.sql
@@ -1,5 +1,5 @@
-create table options(name varchar(30))
-insert options values('abc')
+create table options_t(name varchar(30))
+insert options_t values('abc')
 go
 
 create table svc_defs(svc_name varchar(30))

--- a/test/JDBC/input/BABEL-4046-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4046-vu-verify.sql
@@ -1,8 +1,8 @@
 
-select options.name
-  from options
+select options_t.name
+  from options_t
  inner join svc_defs
-    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
+    on options_t.name like 'UM\_%' + svc_defs.svc_name escape '\'
 go
 
 select * from babel4046;

--- a/test/JDBC/input/BABEL-4046-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4046-vu-verify.sql
@@ -1,0 +1,40 @@
+
+select options.name
+  from options
+ inner join svc_defs
+    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
+go
+
+select * from babel4046;
+GO
+
+select * from babel4046_2;
+GO
+
+;with EMP_T AS (
+                select empno,
+				ename,
+				CASE			            
+			            WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A')
+					    WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C')
+						WHEN baseloc LIKE 'BOS%' THEN REPLACE(baseloc,'BOSTON','B')
+                ELSE
+		                baseloc
+                END AS baseloc,
+				deptno
+				from t3)
+				select
+				DM.empno,
+				DM.ename,
+				DM.baseloc
+				from EMP_T DM
+				INNER JOIN t4 SR ON DM.baseloc = SR.loc AND DM.deptno = SR.deptno order by DM.empno;
+GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4)  order by DM.empno
+GO
+
+
+
+

--- a/test/JDBC/input/BABEL-4046.sql
+++ b/test/JDBC/input/BABEL-4046.sql
@@ -1,0 +1,119 @@
+create table options(name varchar(30) collate bbf_unicode_cp1_ci_as)
+insert options values('abc')
+go
+
+create table svc_defs(svc_name varchar(30) collate bbf_unicode_cp1_ci_as)
+insert svc_defs values('def')
+go
+
+select options.name
+  from options
+ inner join svc_defs
+    on options.name like 'UM\_%' + svc_defs.svc_name escape '\'
+go
+
+create table t (a varchar(30));
+go
+
+insert into t values ('aaa');
+go
+
+insert into t values ('AAA');
+go
+
+create table t1 (a varchar(30));
+go
+
+insert into t1 values ('a%');
+go
+
+insert into t1 values ('A%');
+go
+
+select * from t join t1 on t.a like t1.a;
+go
+
+select * from t join t1 on t.a like 'aa%';
+go
+
+drop table t;
+go
+
+drop table t1;
+go
+
+drop table svc_defs;
+go
+
+drop table options;
+go
+
+--Table and data
+CREATE TABLE [dbo].[t3](
+	[EMPNO] [int] NOT NULL,
+	[ENAME] [nvarchar](10) NULL,
+	[BASELOC] [nvarchar](13) NULL,
+	[DEPTNO] [int] NOT NULL,
+PRIMARY KEY CLUSTERED 
+(
+	[EMPNO] ASC
+) ON [PRIMARY])
+GO
+
+CREATE TABLE [dbo].[t4](
+	[DEPTNO] [int] NOT NULL,
+	[DNAME] [nvarchar](14) NULL,
+	[LOC] [nvarchar](13) NULL,
+PRIMARY KEY CLUSTERED 
+(
+	[DEPTNO] ASC
+) ON [PRIMARY])
+GO
+
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (10, N'ACCOUNTING', N'NEW YORK')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (20, N'RESEARCH', N'DALLAS')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (30, N'SALES', N'CHICAGO')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (40, N'SECURITY', N'BOSTON')
+INSERT [dbo].[t4] ([DEPTNO], [DNAME], [LOC]) VALUES (50, N'LEGAL', N'AUSTIN')
+GO
+
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7369, N'SMITH', N'BOSTON', 20)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7499, N'ALLEN', N'CHICAGO', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7521, N'WARD', N'CHICAGO', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7566, N'JONES', N'AUSTIN', 20)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7654, N'MARTIN', N'AUSTIN', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7698, N'BLAKE', N'BOSTON', 30)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7782, N'CLARK', N'NEW YORK', 10)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7788, N'SCOTT', N'NEW YORK', 20)
+INSERT [dbo].[t3] ([EMPNO], [ENAME], [BASELOC], [DEPTNO]) VALUES (7839, N'KING', N'AUSTIN', 100)
+GO
+
+;with EMP_T AS (
+                select empno,
+				ename,
+				CASE			            
+			            WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A')
+					    WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C')
+						WHEN baseloc LIKE 'BOS%' THEN REPLACE(baseloc,'BOSTON','B')
+                ELSE
+		                baseloc
+                END AS baseloc,
+				deptno
+				from t3)
+				select
+				DM.empno,
+				DM.ename,
+				DM.baseloc
+				from EMP_T DM
+				INNER JOIN t4 SR ON DM.baseloc = SR.loc AND DM.deptno = SR.deptno
+GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4) 
+GO
+
+drop table [dbo].[t3];
+go
+
+drop table [dbo].[t4];
+GO

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -213,3 +213,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -266,3 +266,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -319,3 +319,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -314,3 +314,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -314,3 +314,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -315,3 +315,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -332,3 +332,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -346,3 +346,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -380,3 +380,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -403,3 +403,4 @@ TestXML
 timefromparts
 triggers_with_transaction
 datetimeoffset-timezone-before-15_3
+BABEL-4046

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -401,3 +401,4 @@ TestXML
 timefromparts
 triggers_with_transaction
 datetimeoffset-timezone-before-15_3
+BABEL-4046

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -402,3 +402,4 @@ binary-index
 BABEL-4078
 BABEL-3215
 orderby
+BABEL-4046

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -381,3 +381,4 @@ test_windows_login_before_15_2
 TestXML
 timefromparts
 triggers_with_transaction
+BABEL-4046

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -409,3 +409,4 @@ TestXML
 timefromparts
 triggers_with_transaction
 datetimeoffset-timezone-before-15_3
+BABEL-4046

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -432,3 +432,4 @@ TestXML
 timefromparts
 triggers_with_transaction
 datetimeoffset-timezone
+BABEL-4046

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -433,3 +433,4 @@ TestXML
 timefromparts
 triggers_with_transaction
 datetimeoffset-timezone
+BABEL-4046

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -136,6 +136,7 @@ Could not find upgrade tests for function sys.openjson_object
 Could not find upgrade tests for function sys.openjson_simple
 Could not find upgrade tests for function sys.openjson_with
 Could not find upgrade tests for function sys.openquery_internal
+Could not find upgrade tests for function sys.options
 Could not find upgrade tests for function sys.pgerror
 Could not find upgrade tests for function sys.role_id
 Could not find upgrade tests for function sys.servername

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -136,9 +136,7 @@ Could not find upgrade tests for function sys.openjson_object
 Could not find upgrade tests for function sys.openjson_simple
 Could not find upgrade tests for function sys.openjson_with
 Could not find upgrade tests for function sys.openquery_internal
-Could not find upgrade tests for function sys.options
 Could not find upgrade tests for function sys.pgerror
-Could not find upgrade tests for function sys.replace
 Could not find upgrade tests for function sys.role_id
 Could not find upgrade tests for function sys.servername
 Could not find upgrade tests for function sys.servicename


### PR DESCRIPTION
Previously, like expression unexpectly error out in certain cases:
1. Like expression inside Join on condition
2. Like expression inside one of the multiple case whens
3. Like expression as one of the sublink condition in sublink query

This fix has solved those three issues by adding corresponding Like collation change transform into Like expression node.

Task: BABEL-4046
Signed-off-by: Zhibai Song <szh@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).