### PR TITLE
[OSS-ONLY] Add manual github workflow for creating tag

### DIFF
--- a/.github/scripts/create-tag.sh
+++ b/.github/scripts/create-tag.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/bash
+
+set -e
+
+# Set user name and email
+git config user.name "${GITHUB_ACTOR}"
+git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+export usage="$(basename "$0") [-h] [-c commit] [-r repo][-m]\n
+  -h    help\n
+  -c    commit hash; Default commit:HEAD\n
+  -t    tag name"
+
+
+while getopts hc:t:m flag
+do
+    case "${flag}" in
+        h) echo -e "Usage: $usage"
+            exit;;
+        c) commit=${OPTARG};;
+        t) new=${OPTARG};;
+    esac
+done
+
+# get current commit hash for tag if not provided
+if [ -z "$commit" ]
+then
+    commit=$(git rev-parse HEAD)
+fi
+
+# if tagname is not provided, exit
+if [ -z "$new" ]
+then
+    echo "Error: Tag not provided!"
+    exit 1
+fi
+
+# check the tag format (need manual update when necessary)
+format=BABEL_
+if ! [[ "$new" =~ "$format"[0-9]_[0-9]_[0-9] ]]
+then
+    echo "Error: Invalid tag prefix, expected: ${format}<digit>_<digit>_<digit>"
+    exit 1
+fi
+
+echo Creating tag $new for commit $commit
+
+git tag -a "${new}" $commit -m "${message}"
+git push origin "${new}"

--- a/.github/workflows/manual_tags.yml
+++ b/.github/workflows/manual_tags.yml
@@ -1,0 +1,40 @@
+name: Manual workflow for tags
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      # tag id that is to be created
+      tagId:
+        required: true
+      # message for the tag
+      message:
+        required: false
+      # commit hash on top of which the tag will be created
+      commit_hash:
+        required: false
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run create-tag script
+        env:
+          message: ${{ github.event.inputs.message }}
+        # Run when commit hash is not provided (then the tag will be created on the latest commit of the current branch)
+        if: ${{github.event.inputs.commit_hash == ''}} 
+        run: |
+            bash ./.github/scripts/create-tag.sh -t ${{github.event.inputs.tagId}}
+      - name: Run create-tag script when commit hash is provided
+        env:
+          message: ${{ github.event.inputs.message }}
+        # Run when commit hash is provided, tag will be created on top of the commit hash
+        if: ${{github.event.inputs.commit_hash != ''}} 
+        run: |
+            bash ./.github/scripts/create-tag.sh -c ${{github.event.inputs.commit_hash}} -t ${{github.event.inputs.tagId}}


### PR DESCRIPTION
Signed-off-by: Shameem Ahmed <shameemahmed20apr2000@gmail.com>

### Description

Adding new manual github workflow to create tags. If the commit hash is provided, then the tag is. created on top of that commit, else, tag will be created on the latest commit on the branch from where the action is invoked.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).