### PR TITLE
Introduce drop_relation_refcnt_hook to be called during drop table

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -20,6 +20,7 @@ extern void rename_update_bbf_catalog(RenameStmt *stmt);
 extern bool IsPLtsqlExtendedCatalog(Oid relationId);
 extern bool IsPltsqlToastRelationHook(Relation relation);
 extern bool IsPltsqlToastClassHook(Form_pg_class pg_class_tup);
+extern void pltsql_drop_relation_refcnt_hook(Relation relation);
 
 /*****************************************
  *			SYS schema

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -209,6 +209,7 @@ static table_variable_satisfies_visibility_hook_type prev_table_variable_satisfi
 static table_variable_satisfies_update_hook_type prev_table_variable_satisfies_update = NULL;
 static table_variable_satisfies_vacuum_hook_type prev_table_variable_satisfies_vacuum = NULL;
 static table_variable_satisfies_vacuum_horizon_hook_type prev_table_variable_satisfies_vacuum_horizon = NULL;
+static drop_relation_refcnt_hook_type prev_drop_relation_refcnt_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -354,6 +355,9 @@ InstallExtendedHooks(void)
 
 	PrevIsToastClassHook = IsToastClassHook;
 	IsToastClassHook = IsPltsqlToastClassHook;
+
+	prev_drop_relation_refcnt_hook = drop_relation_refcnt_hook;
+	drop_relation_refcnt_hook = pltsql_drop_relation_refcnt_hook;
 }
 
 void
@@ -411,6 +415,7 @@ UninstallExtendedHooks(void)
 	table_variable_satisfies_vacuum_horizon_hook = prev_table_variable_satisfies_vacuum_horizon;
 	IsToastRelationHook = PrevIsToastRelationHook;
 	IsToastClassHook = PrevIsToastClassHook;
+	drop_relation_refcnt_hook = prev_drop_relation_refcnt_hook;
 }
 
 /*****************************************

--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -55,6 +55,7 @@ int#!#int
 
 -------------------------------------------------------------------------------
 -- Test 2: Procedure with Table Variables and THROW
+--         Test with PROC + Table Variable and error while relation is open
 -------------------------------------------------------------------------------
 CREATE PROC table_variable_throw_proc1 AS
 BEGIN
@@ -88,6 +89,38 @@ GO
 
 
 DROP PROCEDURE table_variable_throw_proc1
+GO
+
+CREATE PROCEDURE tv_function_1
+AS
+BEGIN TRY
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+END TRY
+BEGIN CATCH
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+    SELECT * FROM @tv
+END CATCH;
+GO
+
+EXEC tv_function_1
+GO
+~~ROW COUNT: 3~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_3_pkey")~~
+
+~~START~~
+int#!#int
+1#!#10
+2#!#20
+3#!#30
+~~END~~
+
+
+DROP PROCEDURE tv_function_1
 GO
 
 -------------------------------------------------------------------------------
@@ -166,5 +199,260 @@ date#!#date
 
 
 DROP TYPE empDates
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4225: Error inside function should not cause crash
+-------------------------------------------------------------------------------
+CREATE SCHEMA [Control]
+GO
+
+CREATE FUNCTION [Control].[csf_script_delete_row] (
+   @SetIDLocal  INT,
+   @InternalID  VARCHAR(64)
+) RETURNS VARCHAR(MAX)
+AS
+BEGIN
+   DECLARE @Template          VARCHAR(MAX);
+   DECLARE @Results           VARCHAR(MAX);
+   DECLARE @DeletePredicates  VARCHAR(MAX);
+   DECLARE @Ordinal           INT;   -- NOTE: In this circumstance, each column is either an update or a predicate but not both.
+   DECLARE @Columns
+   TABLE   ( Ordinal          INT IDENTITY(1, 1) NOT NULL,
+             ColumnPredicate  VARCHAR(MAX)           NULL,
+             PRIMARY KEY ( Ordinal )
+           );
+   SET @Template = 'DELETE [SchemaName].[TableName] WHERE DeleteConditionPredicates;';
+   INSERT INTO @Columns (ColumnPredicate )
+   SELECT '[' + LRV.ColumnName + '] ' + ISNULL(('= ' + NULLIF(LRV.Expression, 'NULL')), 'IS NULL')
+   FROM   [Control].[DataRow] AS RLR
+          INNER JOIN [Control].[DataRowValue] AS LRV
+          ON (RLR.SetID      = LRV.SetID         AND
+              RLR.InternalID = LRV.InternalIDRow    )
+          INNER JOIN [Control].[cvw_local_column_base] AS STC
+          ON (RLR.SchemaName = STC.SchemaName AND
+              RLR.TableName  = STC.TableName  AND
+              LRV.ColumnName = STC.ColumnName    )
+   WHERE  RLR.SetID      =  @SetIDLocal
+   AND    RLR.InternalID =  @InternalID
+   AND    LRV.MatchType  != 'N'
+   ORDER BY STC.ColumnID ASC;END; -- [Control].[csf_script_delete_row]
+go
+
+SELECT Control.csf_script_delete_row('1', ' ')
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "master_control.datarow" does not exist)~~
+
+
+DROP FUNCTION [Control].[csf_script_delete_row]
+GO
+
+DROP SCHEMA [Control]
+GO
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4226: Error while table and index are open.
+-------------------------------------------------------------------------------
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+~~START~~
+int#!#varchar
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "b" of relation "@tab_1" violates not-null constraint)~~
+
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT PRIMARY KEY, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+~~START~~
+int#!#varchar
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "b" of relation "@tab_1" violates not-null constraint)~~
+
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION [dbo].[tv_function_1]() RETURNS @tab TABLE(a int, b int PRIMARY KEY) AS
+BEGIN
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tab(a, b) SELECT c1, c2 FROM @tv
+    INSERT INTO @tab VALUES(4, 30) -- duplicate key, fail while table and index are open
+    INSERT INTO @tab VALUES(1, 2)
+    RETURN
+END
+GO
+
+SELECT * FROM [dbo].[tv_function_1]()
+GO
+~~START~~
+int#!#int
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@tab_2_pkey")~~
+
+
+DROP FUNCTION [dbo].[tv_function_1]
+GO
+
+
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4227: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE FUNCTION LevenschteinDifference
+(
+@FirstString nVarchar(255), @SecondString nVarchar(255)
+)
+RETURNS int
+as begin
+Declare @PseudoMatrix table
+     (location int identity primary key,
+      firstorder int not null,
+      Firstch nchar(1),
+      secondorder int not null,
+      Secondch nchar(1),
+      Thevalue int not null default 0,
+      PreviousRowValues varchar(200)
+      )
+insert into @PseudoMatrix (firstorder, firstch, secondorder, secondch, TheValue )
+SELECT TheFirst.number,TheFirst.ch, TheSecond.number,TheSecond.ch,0
+  FROM
+   (SELECT number, SUBSTRING(@FirstString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@FirstString) union all Select 0,Char(0)) TheFirst
+  cross JOIN
+   (SELECT number, SUBSTRING(@SecondString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@SecondString) union all Select 0,Char(0)) TheSecond
+order by TheFirst.number, TheSecond.number
+Declare @current Varchar(255)
+Declare @previous Varchar(255)
+Declare @TheValue int
+Declare @Deletion int, @Insertion int, @Substitution int, @minim int
+Select @current='', @previous=''
+Update @PseudoMatrix
+    Set
+    @Deletion=@TheValue+1,
+    @Insertion=ascii(substring(@previous,secondorder+1,1))+1,
+    @Substitution=ascii(substring(@previous,(secondorder),1)) +1,
+    @minim=case when @Deletion<@Insertion then @Deletion else @insertion end,
+    @TheValue = Thevalue = case
+ when SecondOrder=0 then FirstOrder
+ When FirstOrder=0 then Secondorder
+     when FirstCh=SecondCh then ascii(substring(@previous,(secondorder),1))
+     else case when @Minim<@Substitution then @Minim else @Substitution end
+   end,
+    @Previous=PreviousRowValues=case when secondorder =0 then @current else @Previous end,
+    @current= case when secondorder =0 then char(@TheValue) else @Current+char(@TheValue) end
+return @TheValue
+End
+go
+
+SELECT dbo.LevenschteinDifference(NULL, NULL)
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "numbers" does not exist)~~
+
+
+SELECT dbo.LevenschteinDifference(' ', ' ')
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "numbers" does not exist)~~
+
+
+DROP FUNCTION dbo.LevenschteinDifference
+GO
+
+
+
+-------------------------------------------------------------------------------
+-- Other errors with sp_executesql
+-------------------------------------------------------------------------------
+CREATE procedure temp_table_sp_exec AS
+BEGIN
+    DECLARE @SQLString NVARCHAR(500);
+    SET @SQLString = N'declare @table_t1 table(a int); INSERT INTO @table_t1 values(1);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+    SET @SQLString = N'declare @table_t1 table(a int NOT NULL); INSERT INTO @table_t1 values(NULL);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+END;
+GO
+
+EXEC temp_table_sp_exec
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "a" of relation "@table_t1_2" violates not-null constraint)~~
+
+~~START~~
+int
+~~END~~
+
+
+DROP PROCEDURE temp_table_sp_exec
+GO
+
+
+-------------------------------------------------------------------------------
+-- Drop type used by table variable
+-------------------------------------------------------------------------------
+CREATE TYPE typa FROM int
+GO
+
+CREATE TYPE typb FROM nvarchar(100)
+GO
+
+
+DECLARE @tv_3 TABLE(a typa, b typb)
+DROP TYPE typb
+INSERT INTO @tv_3 VALUES(1, 'Hello')
+SELECT * FROM @tv_3
+GO
+~~ERROR (Code: 3732)~~
+
+~~ERROR (Message: cannot drop type typb because other objects depend on it)~~
+
+
+DROP TYPE typa
+GO
+
+DROP TYPE typb
 GO
 

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -57,6 +57,7 @@ int#!#int
 
 -------------------------------------------------------------------------------
 -- Test 2: Procedure with Table Variables and THROW
+--         Test with PROC + Table Variable and error while relation is open
 -------------------------------------------------------------------------------
 CREATE PROC table_variable_throw_proc1 AS
 BEGIN
@@ -90,6 +91,38 @@ GO
 
 
 DROP PROCEDURE table_variable_throw_proc1
+GO
+
+CREATE PROCEDURE tv_function_1
+AS
+BEGIN TRY
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+END TRY
+BEGIN CATCH
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+    SELECT * FROM @tv
+END CATCH;
+GO
+
+EXEC tv_function_1
+GO
+~~ROW COUNT: 3~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_3_pkey")~~
+
+~~START~~
+int#!#int
+1#!#10
+2#!#20
+3#!#30
+~~END~~
+
+
+DROP PROCEDURE tv_function_1
 GO
 
 -------------------------------------------------------------------------------
@@ -168,5 +201,260 @@ date#!#date
 
 
 DROP TYPE empDates
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4225: Error inside function should not cause crash
+-------------------------------------------------------------------------------
+CREATE SCHEMA [Control]
+GO
+
+CREATE FUNCTION [Control].[csf_script_delete_row] (
+   @SetIDLocal  INT,
+   @InternalID  VARCHAR(64)
+) RETURNS VARCHAR(MAX)
+AS
+BEGIN
+   DECLARE @Template          VARCHAR(MAX);
+   DECLARE @Results           VARCHAR(MAX);
+   DECLARE @DeletePredicates  VARCHAR(MAX);
+   DECLARE @Ordinal           INT;   -- NOTE: In this circumstance, each column is either an update or a predicate but not both.
+   DECLARE @Columns
+   TABLE   ( Ordinal          INT IDENTITY(1, 1) NOT NULL,
+             ColumnPredicate  VARCHAR(MAX)           NULL,
+             PRIMARY KEY ( Ordinal )
+           );
+   SET @Template = 'DELETE [SchemaName].[TableName] WHERE DeleteConditionPredicates;';
+   INSERT INTO @Columns (ColumnPredicate )
+   SELECT '[' + LRV.ColumnName + '] ' + ISNULL(('= ' + NULLIF(LRV.Expression, 'NULL')), 'IS NULL')
+   FROM   [Control].[DataRow] AS RLR
+          INNER JOIN [Control].[DataRowValue] AS LRV
+          ON (RLR.SetID      = LRV.SetID         AND
+              RLR.InternalID = LRV.InternalIDRow    )
+          INNER JOIN [Control].[cvw_local_column_base] AS STC
+          ON (RLR.SchemaName = STC.SchemaName AND
+              RLR.TableName  = STC.TableName  AND
+              LRV.ColumnName = STC.ColumnName    )
+   WHERE  RLR.SetID      =  @SetIDLocal
+   AND    RLR.InternalID =  @InternalID
+   AND    LRV.MatchType  != 'N'
+   ORDER BY STC.ColumnID ASC;END; -- [Control].[csf_script_delete_row]
+go
+
+SELECT Control.csf_script_delete_row('1', ' ')
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "master_control.datarow" does not exist)~~
+
+
+DROP FUNCTION [Control].[csf_script_delete_row]
+GO
+
+DROP SCHEMA [Control]
+GO
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4226: Error while table and index are open.
+-------------------------------------------------------------------------------
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+~~START~~
+int#!#varchar
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "b" of relation "@tab_1" violates not-null constraint)~~
+
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT PRIMARY KEY, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+~~START~~
+int#!#varchar
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "b" of relation "@tab_1" violates not-null constraint)~~
+
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION [dbo].[tv_function_1]() RETURNS @tab TABLE(a int, b int PRIMARY KEY) AS
+BEGIN
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tab(a, b) SELECT c1, c2 FROM @tv
+    INSERT INTO @tab VALUES(4, 30) -- duplicate key, fail while table and index are open
+    INSERT INTO @tab VALUES(1, 2)
+    RETURN
+END
+GO
+
+SELECT * FROM [dbo].[tv_function_1]()
+GO
+~~START~~
+int#!#int
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@tab_2_pkey")~~
+
+
+DROP FUNCTION [dbo].[tv_function_1]
+GO
+
+
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4227: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE FUNCTION LevenschteinDifference
+(
+@FirstString nVarchar(255), @SecondString nVarchar(255)
+)
+RETURNS int
+as begin
+Declare @PseudoMatrix table
+     (location int identity primary key,
+      firstorder int not null,
+      Firstch nchar(1),
+      secondorder int not null,
+      Secondch nchar(1),
+      Thevalue int not null default 0,
+      PreviousRowValues varchar(200)
+      )
+insert into @PseudoMatrix (firstorder, firstch, secondorder, secondch, TheValue )
+SELECT TheFirst.number,TheFirst.ch, TheSecond.number,TheSecond.ch,0
+  FROM
+   (SELECT number, SUBSTRING(@FirstString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@FirstString) union all Select 0,Char(0)) TheFirst
+  cross JOIN
+   (SELECT number, SUBSTRING(@SecondString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@SecondString) union all Select 0,Char(0)) TheSecond
+order by TheFirst.number, TheSecond.number
+Declare @current Varchar(255)
+Declare @previous Varchar(255)
+Declare @TheValue int
+Declare @Deletion int, @Insertion int, @Substitution int, @minim int
+Select @current='', @previous=''
+Update @PseudoMatrix
+    Set
+    @Deletion=@TheValue+1,
+    @Insertion=ascii(substring(@previous,secondorder+1,1))+1,
+    @Substitution=ascii(substring(@previous,(secondorder),1)) +1,
+    @minim=case when @Deletion<@Insertion then @Deletion else @insertion end,
+    @TheValue = Thevalue = case
+ when SecondOrder=0 then FirstOrder
+ When FirstOrder=0 then Secondorder
+     when FirstCh=SecondCh then ascii(substring(@previous,(secondorder),1))
+     else case when @Minim<@Substitution then @Minim else @Substitution end
+   end,
+    @Previous=PreviousRowValues=case when secondorder =0 then @current else @Previous end,
+    @current= case when secondorder =0 then char(@TheValue) else @Current+char(@TheValue) end
+return @TheValue
+End
+go
+
+SELECT dbo.LevenschteinDifference(NULL, NULL)
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "numbers" does not exist)~~
+
+
+SELECT dbo.LevenschteinDifference(' ', ' ')
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "numbers" does not exist)~~
+
+
+DROP FUNCTION dbo.LevenschteinDifference
+GO
+
+
+
+-------------------------------------------------------------------------------
+-- Other errors with sp_executesql
+-------------------------------------------------------------------------------
+CREATE procedure temp_table_sp_exec AS
+BEGIN
+    DECLARE @SQLString NVARCHAR(500);
+    SET @SQLString = N'declare @table_t1 table(a int); INSERT INTO @table_t1 values(1);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+    SET @SQLString = N'declare @table_t1 table(a int NOT NULL); INSERT INTO @table_t1 values(NULL);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+END;
+GO
+
+EXEC temp_table_sp_exec
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "a" of relation "@table_t1_2" violates not-null constraint)~~
+
+~~START~~
+int
+~~END~~
+
+
+DROP PROCEDURE temp_table_sp_exec
+GO
+
+
+-------------------------------------------------------------------------------
+-- Drop type used by table variable
+-------------------------------------------------------------------------------
+CREATE TYPE typa FROM int
+GO
+
+CREATE TYPE typb FROM nvarchar(100)
+GO
+
+
+DECLARE @tv_3 TABLE(a typa, b typb)
+DROP TYPE typb
+INSERT INTO @tv_3 VALUES(1, 'Hello')
+SELECT * FROM @tv_3
+GO
+~~ERROR (Code: 3732)~~
+
+~~ERROR (Message: cannot drop type typb because other objects depend on it)~~
+
+
+DROP TYPE typa
+GO
+
+DROP TYPE typb
 GO
 

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -50,6 +50,7 @@ int#!#int
 
 -------------------------------------------------------------------------------
 -- Test 2: Procedure with Table Variables and THROW
+--         Test with PROC + Table Variable and error while relation is open
 -------------------------------------------------------------------------------
 CREATE PROC table_variable_throw_proc1 AS
 BEGIN
@@ -83,6 +84,31 @@ GO
 
 
 DROP PROCEDURE table_variable_throw_proc1
+GO
+
+CREATE PROCEDURE tv_function_1
+AS
+BEGIN TRY
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+END TRY
+BEGIN CATCH
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+    SELECT * FROM @tv
+END CATCH;
+GO
+
+EXEC tv_function_1
+GO
+~~ROW COUNT: 3~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@tv_3_pkey")~~
+
+
+DROP PROCEDURE tv_function_1
 GO
 
 -------------------------------------------------------------------------------
@@ -161,5 +187,256 @@ date#!#date
 
 
 DROP TYPE empDates
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4225: Error inside function should not cause crash
+-------------------------------------------------------------------------------
+CREATE SCHEMA [Control]
+GO
+
+CREATE FUNCTION [Control].[csf_script_delete_row] (
+   @SetIDLocal  INT,
+   @InternalID  VARCHAR(64)
+) RETURNS VARCHAR(MAX)
+AS
+BEGIN
+   DECLARE @Template          VARCHAR(MAX);
+   DECLARE @Results           VARCHAR(MAX);
+   DECLARE @DeletePredicates  VARCHAR(MAX);
+   DECLARE @Ordinal           INT;   -- NOTE: In this circumstance, each column is either an update or a predicate but not both.
+   DECLARE @Columns
+   TABLE   ( Ordinal          INT IDENTITY(1, 1) NOT NULL,
+             ColumnPredicate  VARCHAR(MAX)           NULL,
+             PRIMARY KEY ( Ordinal )
+           );
+   SET @Template = 'DELETE [SchemaName].[TableName] WHERE DeleteConditionPredicates;';
+   INSERT INTO @Columns (ColumnPredicate )
+   SELECT '[' + LRV.ColumnName + '] ' + ISNULL(('= ' + NULLIF(LRV.Expression, 'NULL')), 'IS NULL')
+   FROM   [Control].[DataRow] AS RLR
+          INNER JOIN [Control].[DataRowValue] AS LRV
+          ON (RLR.SetID      = LRV.SetID         AND
+              RLR.InternalID = LRV.InternalIDRow    )
+          INNER JOIN [Control].[cvw_local_column_base] AS STC
+          ON (RLR.SchemaName = STC.SchemaName AND
+              RLR.TableName  = STC.TableName  AND
+              LRV.ColumnName = STC.ColumnName    )
+   WHERE  RLR.SetID      =  @SetIDLocal
+   AND    RLR.InternalID =  @InternalID
+   AND    LRV.MatchType  != 'N'
+   ORDER BY STC.ColumnID ASC;END; -- [Control].[csf_script_delete_row]
+go
+
+SELECT Control.csf_script_delete_row('1', ' ')
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "master_control.datarow" does not exist)~~
+
+
+DROP FUNCTION [Control].[csf_script_delete_row]
+GO
+
+DROP SCHEMA [Control]
+GO
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4226: Error while table and index are open.
+-------------------------------------------------------------------------------
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+~~START~~
+int#!#varchar
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "b" of relation "@tab_1" violates not-null constraint)~~
+
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT PRIMARY KEY, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+~~START~~
+int#!#varchar
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "b" of relation "@tab_1" violates not-null constraint)~~
+
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION [dbo].[tv_function_1]() RETURNS @tab TABLE(a int, b int PRIMARY KEY) AS
+BEGIN
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tab(a, b) SELECT c1, c2 FROM @tv
+    INSERT INTO @tab VALUES(4, 30) -- duplicate key, fail while table and index are open
+    INSERT INTO @tab VALUES(1, 2)
+    RETURN
+END
+GO
+
+SELECT * FROM [dbo].[tv_function_1]()
+GO
+~~START~~
+int#!#int
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@tab_2_pkey")~~
+
+
+DROP FUNCTION [dbo].[tv_function_1]
+GO
+
+
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4227: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE FUNCTION LevenschteinDifference
+(
+@FirstString nVarchar(255), @SecondString nVarchar(255)
+)
+RETURNS int
+as begin
+Declare @PseudoMatrix table
+     (location int identity primary key,
+      firstorder int not null,
+      Firstch nchar(1),
+      secondorder int not null,
+      Secondch nchar(1),
+      Thevalue int not null default 0,
+      PreviousRowValues varchar(200)
+      )
+insert into @PseudoMatrix (firstorder, firstch, secondorder, secondch, TheValue )
+SELECT TheFirst.number,TheFirst.ch, TheSecond.number,TheSecond.ch,0
+  FROM
+   (SELECT number, SUBSTRING(@FirstString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@FirstString) union all Select 0,Char(0)) TheFirst
+  cross JOIN
+   (SELECT number, SUBSTRING(@SecondString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@SecondString) union all Select 0,Char(0)) TheSecond
+order by TheFirst.number, TheSecond.number
+Declare @current Varchar(255)
+Declare @previous Varchar(255)
+Declare @TheValue int
+Declare @Deletion int, @Insertion int, @Substitution int, @minim int
+Select @current='', @previous=''
+Update @PseudoMatrix
+    Set
+    @Deletion=@TheValue+1,
+    @Insertion=ascii(substring(@previous,secondorder+1,1))+1,
+    @Substitution=ascii(substring(@previous,(secondorder),1)) +1,
+    @minim=case when @Deletion<@Insertion then @Deletion else @insertion end,
+    @TheValue = Thevalue = case
+ when SecondOrder=0 then FirstOrder
+ When FirstOrder=0 then Secondorder
+     when FirstCh=SecondCh then ascii(substring(@previous,(secondorder),1))
+     else case when @Minim<@Substitution then @Minim else @Substitution end
+   end,
+    @Previous=PreviousRowValues=case when secondorder =0 then @current else @Previous end,
+    @current= case when secondorder =0 then char(@TheValue) else @Current+char(@TheValue) end
+return @TheValue
+End
+go
+
+SELECT dbo.LevenschteinDifference(NULL, NULL)
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "numbers" does not exist)~~
+
+
+SELECT dbo.LevenschteinDifference(' ', ' ')
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "numbers" does not exist)~~
+
+
+DROP FUNCTION dbo.LevenschteinDifference
+GO
+
+
+
+-------------------------------------------------------------------------------
+-- Other errors with sp_executesql
+-------------------------------------------------------------------------------
+CREATE procedure temp_table_sp_exec AS
+BEGIN
+    DECLARE @SQLString NVARCHAR(500);
+    SET @SQLString = N'declare @table_t1 table(a int); INSERT INTO @table_t1 values(1);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+    SET @SQLString = N'declare @table_t1 table(a int NOT NULL); INSERT INTO @table_t1 values(NULL);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+END;
+GO
+
+EXEC temp_table_sp_exec
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "a" of relation "@table_t1_2" violates not-null constraint)~~
+
+
+DROP PROCEDURE temp_table_sp_exec
+GO
+
+
+-------------------------------------------------------------------------------
+-- Drop type used by table variable
+-------------------------------------------------------------------------------
+CREATE TYPE typa FROM int
+GO
+
+CREATE TYPE typb FROM nvarchar(100)
+GO
+
+
+DECLARE @tv_3 TABLE(a typa, b typb)
+DROP TYPE typb
+INSERT INTO @tv_3 VALUES(1, 'Hello')
+SELECT * FROM @tv_3
+GO
+~~ERROR (Code: 3732)~~
+
+~~ERROR (Message: cannot drop type typb because other objects depend on it)~~
+
+
+DROP TYPE typa
+GO
+
+DROP TYPE typb
 GO
 

--- a/test/JDBC/input/table_variables/table_variable_xact_errors.sql
+++ b/test/JDBC/input/table_variables/table_variable_xact_errors.sql
@@ -26,6 +26,7 @@ GO
 
 -------------------------------------------------------------------------------
 -- Test 2: Procedure with Table Variables and THROW
+--         Test with PROC + Table Variable and error while relation is open
 -------------------------------------------------------------------------------
 CREATE PROC table_variable_throw_proc1 AS
 BEGIN
@@ -44,6 +45,25 @@ SELECT * FROM @tv
 GO
 
 DROP PROCEDURE table_variable_throw_proc1
+GO
+
+CREATE PROCEDURE tv_function_1
+AS
+BEGIN TRY
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+END TRY
+BEGIN CATCH
+    INSERT INTO @tv VALUES(3, 30) -- duplicate key, fail while table and index are open
+    SELECT * FROM @tv
+END CATCH;
+GO
+
+EXEC tv_function_1
+GO
+
+DROP PROCEDURE tv_function_1
 GO
 
 -------------------------------------------------------------------------------
@@ -89,5 +109,205 @@ SELECT * FROM @empJobHist
 GO
 
 DROP TYPE empDates
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4225: Error inside function should not cause crash
+-------------------------------------------------------------------------------
+CREATE SCHEMA [Control]
+GO
+
+CREATE FUNCTION [Control].[csf_script_delete_row] (
+   @SetIDLocal  INT,
+   @InternalID  VARCHAR(64)
+) RETURNS VARCHAR(MAX)
+AS
+BEGIN
+   DECLARE @Template          VARCHAR(MAX);
+   DECLARE @Results           VARCHAR(MAX);
+   DECLARE @DeletePredicates  VARCHAR(MAX);
+   DECLARE @Ordinal           INT;   -- NOTE: In this circumstance, each column is either an update or a predicate but not both.
+   DECLARE @Columns
+   TABLE   ( Ordinal          INT IDENTITY(1, 1) NOT NULL,
+             ColumnPredicate  VARCHAR(MAX)           NULL,
+             PRIMARY KEY ( Ordinal )
+           );
+   SET @Template = 'DELETE [SchemaName].[TableName] WHERE DeleteConditionPredicates;';
+   INSERT INTO @Columns (ColumnPredicate )
+   SELECT '[' + LRV.ColumnName + '] ' + ISNULL(('= ' + NULLIF(LRV.Expression, 'NULL')), 'IS NULL')
+   FROM   [Control].[DataRow] AS RLR
+          INNER JOIN [Control].[DataRowValue] AS LRV
+          ON (RLR.SetID      = LRV.SetID         AND
+              RLR.InternalID = LRV.InternalIDRow    )
+          INNER JOIN [Control].[cvw_local_column_base] AS STC
+          ON (RLR.SchemaName = STC.SchemaName AND
+              RLR.TableName  = STC.TableName  AND
+              LRV.ColumnName = STC.ColumnName    )
+   WHERE  RLR.SetID      =  @SetIDLocal
+   AND    RLR.InternalID =  @InternalID
+   AND    LRV.MatchType  != 'N'
+   ORDER BY STC.ColumnID ASC;END; -- [Control].[csf_script_delete_row]
+go
+
+SELECT Control.csf_script_delete_row('1', ' ')
+GO
+
+DROP FUNCTION [Control].[csf_script_delete_row]
+GO
+
+DROP SCHEMA [Control]
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4226: Error while table and index are open.
+-------------------------------------------------------------------------------
+
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION dbo.foo() RETURNS @tab TABLE (a INT PRIMARY KEY, b VARCHAR(MAX) NOT NULL) AS
+BEGIN
+        INSERT @tab(a, b) VALUES (1, NULL)
+        RETURN
+END
+GO
+
+SELECT * FROM dbo.foo()
+GO
+
+DROP FUNCTION dbo.foo()
+GO
+
+CREATE FUNCTION [dbo].[tv_function_1]() RETURNS @tab TABLE(a int, b int PRIMARY KEY) AS
+BEGIN
+    DECLARE @tv TABLE(c1 INT PRIMARY KEY, c2 INT)
+    INSERT INTO @tv VALUES(1, 10), (2, 20), (3, 30)
+    INSERT INTO @tab(a, b) SELECT c1, c2 FROM @tv
+    INSERT INTO @tab VALUES(4, 30) -- duplicate key, fail while table and index are open
+    INSERT INTO @tab VALUES(1, 2)
+    RETURN
+END
+GO
+
+SELECT * FROM [dbo].[tv_function_1]()
+GO
+
+DROP FUNCTION [dbo].[tv_function_1]
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4227: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE FUNCTION LevenschteinDifference
+(
+@FirstString nVarchar(255), @SecondString nVarchar(255)
+)
+RETURNS int
+as begin
+Declare @PseudoMatrix table
+     (location int identity primary key,
+      firstorder int not null,
+      Firstch nchar(1),
+      secondorder int not null,
+      Secondch nchar(1),
+      Thevalue int not null default 0,
+      PreviousRowValues varchar(200)
+      )
+
+insert into @PseudoMatrix (firstorder, firstch, secondorder, secondch, TheValue )
+SELECT TheFirst.number,TheFirst.ch, TheSecond.number,TheSecond.ch,0
+  FROM
+   (SELECT number, SUBSTRING(@FirstString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@FirstString) union all Select 0,Char(0)) TheFirst
+  cross JOIN
+   (SELECT number, SUBSTRING(@SecondString,number,1) AS ch
+    FROM numbers WHERE number <= LEN(@SecondString) union all Select 0,Char(0)) TheSecond
+
+order by TheFirst.number, TheSecond.number
+
+Declare @current Varchar(255)
+Declare @previous Varchar(255)
+Declare @TheValue int
+Declare @Deletion int, @Insertion int, @Substitution int, @minim int
+Select @current='', @previous=''
+Update @PseudoMatrix
+    Set
+    @Deletion=@TheValue+1,
+    @Insertion=ascii(substring(@previous,secondorder+1,1))+1,
+    @Substitution=ascii(substring(@previous,(secondorder),1)) +1,
+    @minim=case when @Deletion<@Insertion then @Deletion else @insertion end,
+    @TheValue = Thevalue = case
+ when SecondOrder=0 then FirstOrder
+ When FirstOrder=0 then Secondorder
+     when FirstCh=SecondCh then ascii(substring(@previous,(secondorder),1))
+     else case when @Minim<@Substitution then @Minim else @Substitution end
+   end,
+    @Previous=PreviousRowValues=case when secondorder =0 then @current else @Previous end,
+    @current= case when secondorder =0 then char(@TheValue) else @Current+char(@TheValue) end
+return @TheValue
+End
+go
+
+SELECT dbo.LevenschteinDifference(NULL, NULL)
+GO
+
+SELECT dbo.LevenschteinDifference(' ', ' ')
+GO
+
+DROP FUNCTION dbo.LevenschteinDifference
+GO
+
+-------------------------------------------------------------------------------
+-- Other errors with sp_executesql
+-------------------------------------------------------------------------------
+
+CREATE procedure temp_table_sp_exec AS
+BEGIN
+    DECLARE @SQLString NVARCHAR(500);
+    SET @SQLString = N'declare @table_t1 table(a int); INSERT INTO @table_t1 values(1);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+
+    SET @SQLString = N'declare @table_t1 table(a int NOT NULL); INSERT INTO @table_t1 values(NULL);SELECT * FROM @table_t1';
+    EXECUTE sp_executesql @SQLString;
+END;
+GO
+
+EXEC temp_table_sp_exec
+GO
+
+DROP PROCEDURE temp_table_sp_exec
+GO
+
+-------------------------------------------------------------------------------
+-- Drop type used by table variable
+-------------------------------------------------------------------------------
+
+CREATE TYPE typa FROM int
+GO
+
+CREATE TYPE typb FROM nvarchar(100)
+GO
+
+DECLARE @tv_3 TABLE(a typa, b typb)
+DROP TYPE typb
+
+INSERT INTO @tv_3 VALUES(1, 'Hello')
+SELECT * FROM @tv_3
+GO
+
+DROP TYPE typa
+GO
+
+DROP TYPE typb
 GO
 


### PR DESCRIPTION
### Description

Introduce drop_relation_refcnt_hook to be called during drop table variable when BBF error handling does not properly close table variables

There were three options discussed

1. Integrate a new hook function in heap_drop_with_catalog() and index_drop() to decrement refcnt before dropping. This is the preferred one and the cleanest approach.

2. As part of error handling, open relation in pltsql_clean_table_variables and pltsql_remove_current_query_env and decrement refcount there. The reason this was rejected is because for each relation, it needs to open all index and toast tables and decrement their refcounts as well. The code would become a bit complicated and long.

3. Skip table variable cleanup if an error is encountered inside a function let caller do it, that way caller will call rollback and issue will not arise. The reason this was rejected is because we would go out of scope and would not be able to cleanup the table variable once we exit the function.

engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/152


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).