### PR TITLE
USE database statement shouldn't be allowed in proc/func/Trig (#1503)

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -234,6 +234,10 @@ protected:
 
 	void checkSupportedGrantStmt(TSqlParser::Grant_statementContext *grant);
 	void checkSupportedRevokeStmt(TSqlParser::Revoke_statementContext *revoke);
+
+	void visitSqlClauses(vector<TSqlParser::Sql_clausesContext *> sql_clauses);
+	void visitSqlClauses(TSqlParser::Sql_clausesContext* option);
+
 };
 
 std::unique_ptr<TsqlUnsupportedFeatureHandler> TsqlUnsupportedFeatureHandler::create()
@@ -311,6 +315,11 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_or_alter_function(T
 		}
 	}
 
+	if(ctx->func_body_returns_table())
+		visitSqlClauses(ctx->func_body_returns_table()->sql_clauses());
+	if(ctx->func_body_returns_scalar())
+		visitSqlClauses(ctx->func_body_returns_scalar()->sql_clauses());
+
 	if (ctx->func_body_returns_scalar() && ctx->func_body_returns_scalar()->external_name())
 		handle(INSTR_UNSUPPORTED_TSQL_ALTER_FUNCTION_EXTERNAL_NAME_OPTION, "EXTERNAL NAME", getLineAndPos(ctx->func_body_returns_scalar()->external_name()));
 	if (ctx->func_body_returns_table_clr() && ctx->func_body_returns_table_clr()->external_name())
@@ -360,6 +369,8 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_or_alter_procedure(
 				handle(INSTR_UNSUPPORTED_TSQL_EXECUTE_AS_STMT, "EXECUTE AS SELF|OWNER|<user>|<login>", getLineAndPos(option->execute_as_clause()));
 		}
 	}
+
+	visitSqlClauses(ctx->sql_clauses());
 
 	if (ctx->atomic_proc_body())
 		handle(INSTR_UNSUPPORTED_TSQL_ALTER_PROCEDURE_ATOMIC_WITH_OPTION, "ATOMIC WITH", getLineAndPos(ctx->atomic_proc_body()));
@@ -429,6 +440,8 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_or_alter_trigger(TS
 			}
 		}
 
+		visitSqlClauses(dctx->sql_clauses());
+
 		if (dctx->external_name())
 			handle(INSTR_UNSUPPORTED_TSQL_DML_TRIGGER_EXTERNAL_NAME_OPTION, "EXERNAL NAME", getLineAndPos(dctx->external_name()));
 	}
@@ -449,6 +462,8 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_or_alter_trigger(TS
 					handle(INSTR_UNSUPPORTED_TSQL_EXECUTE_AS_STMT, "EXECUTE AS SELF|OWNER|<user>|<login>", getLineAndPos(option->execute_as_clause()));
 			}
 		}
+
+		visitSqlClauses(dctx->sql_clauses());
 
 		if (dctx->external_name())
 			handle(INSTR_UNSUPPORTED_TSQL_DDL_TRIGGER_EXTERNAL_NAME_OPTION, "EXERNAL NAME", getLineAndPos(dctx->external_name()));
@@ -1675,6 +1690,39 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedGrantStmt(TSqlParser::Gran
 		handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, "GRANT AS", getLineAndPos(grant->AS()));
 }
 
+void TsqlUnsupportedFeatureHandlerImpl::visitSqlClauses(vector<TSqlParser::Sql_clausesContext *> sql_clauses)
+{
+	for (auto option : sql_clauses)
+	{
+		visitSqlClauses(option);
+	}
+}
+
+void TsqlUnsupportedFeatureHandlerImpl::visitSqlClauses(TSqlParser::Sql_clausesContext* option)
+{
+	if(option->another_statement() && option->another_statement()->use_statement())
+		throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "a USE database statement is not allowed in a procedure, function or trigger.", getLineAndPos(option));
+
+	if(option->cfl_statement())
+	{
+		if(option->cfl_statement()->block_statement())
+			visitSqlClauses(option->cfl_statement()->block_statement()->sql_clauses());
+
+		if(option->cfl_statement()->if_statement())
+			visitSqlClauses(option->cfl_statement()->if_statement()->sql_clauses());
+
+		if(option->cfl_statement()->while_statement())
+			visitSqlClauses(option->cfl_statement()->while_statement()->sql_clauses());
+		if(option->cfl_statement()->try_catch_statement())
+		{
+			if(option->cfl_statement()->try_catch_statement()->try_block())
+				visitSqlClauses(option->cfl_statement()->try_catch_statement()->try_block()->sql_clauses());
+
+			if(option->cfl_statement()->try_catch_statement()->catch_block())
+				visitSqlClauses(option->cfl_statement()->try_catch_statement()->catch_block()->sql_clauses());
+		}
+	}
+}
 void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Revoke_statementContext *revoke)
 {
 	std::string unsupported_feature;

--- a/test/JDBC/expected/BABEL-Use_Statement.out
+++ b/test/JDBC/expected/BABEL-Use_Statement.out
@@ -1,0 +1,241 @@
+-- Procedures
+-- block statement
+CREATE PROCEDURE p AS BEGIN
+	USE db;
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+-- if_statement
+CREATE PROCEDURE p AS BEGIN
+	DECLARE @i INT = 2; 
+	IF (@i = 2) BEGIN 
+		USE db 
+	END
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+-- else statement
+CREATE PROCEDURE p AS BEGIN
+	DECLARE @i INT =2;
+	IF (@i=2) BEGIN
+		SELECT 1
+	END
+	ELSE BEGIN 
+		USE db
+	END
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+-- try-catch block
+CREATE PROCEDURE p AS BEGIN
+	BEGIN TRY
+  		USE db
+	END TRY
+	BEGIN CATCH
+  		SELECT 1
+	END CATCH
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE PROCEDURE p AS BEGIN
+	BEGIN TRY
+ 		SELECT 1
+	END TRY
+	BEGIN CATCH
+  		USE db
+	END CATCH
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+-- while loop
+CREATE PROCEDURE p AS BEGIN
+	DECLARE @i INT = 2
+	WHILE @i > 0 BEGIN
+		USE db
+		SET @i = @i-1
+	END
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+-- multiple loops
+CREATE PROCEDURE P(@total INT) AS BEGIN
+	DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+-- Triggers
+CREATE TABLE tb(i INT);
+GO
+
+CREATE TRIGGER t ON tb
+FOR INSERT AS BEGIN
+    USE db;
+	INSERT INTo t VALUES(1);
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE TRIGGER t ON tb
+AFTER DELETE AS
+    DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+DROP TABLE tb;
+GO
+
+-- Functions
+-- sql_clauses is not supported for function of return type func_body_returns_table_clr
+CREATE FUNCTION func() RETURNS TABLE AS
+	USE db;
+	RETURN (SELECT * FROM babel_execute_as_caller_table)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'USE' at line 4 and character position 1)~~
+
+
+CREATE FUNCTION func(@i INT) returns @tableVar table(a text not null) AS
+BEGIN
+	USE db;
+    RETURN
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE FUNCTION func(@c INT) RETURNS INT AS
+BEGIN
+	USE db;
+	RETURN (SELECT 1)
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE FUNCTION func(@c INT) RETURNS INT AS
+BEGIN
+	DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE FUNCTION func() RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= SUM(c1) FROM babel_execute_as_caller_table
+	if(@ans!=1)
+		USE db;
+    RETURN @ans
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE FUNCTION func (@v INT) RETURNS INT WITH RETURNS NULL ON NULL INPUT AS
+BEGIN
+	DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+
+
+CREATE FUNCTION func (@v INT) RETURNS INT WITH RETURNS NULL ON NULL INPUT
+BEGIN
+	USE db;
+    RETURN @v+1
+END;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: a USE database statement is not allowed in a procedure, function or trigger.)~~
+

--- a/test/JDBC/input/BABEL-Use_Statement.sql
+++ b/test/JDBC/input/BABEL-Use_Statement.sql
@@ -1,0 +1,177 @@
+-- Procedures
+-- block statement
+CREATE PROCEDURE p AS BEGIN
+	USE db;
+END
+GO
+
+-- if_statement
+CREATE PROCEDURE p AS BEGIN
+	DECLARE @i INT = 2; 
+	IF (@i = 2) BEGIN 
+		USE db 
+	END
+END
+GO
+
+-- else statement
+CREATE PROCEDURE p AS BEGIN
+	DECLARE @i INT =2;
+	IF (@i=2) BEGIN
+		SELECT 1
+	END
+	ELSE BEGIN 
+		USE db
+	END
+END
+GO
+
+-- try-catch block
+CREATE PROCEDURE p AS BEGIN
+	BEGIN TRY
+  		USE db
+	END TRY
+	BEGIN CATCH
+  		SELECT 1
+	END CATCH
+END
+GO
+
+CREATE PROCEDURE p AS BEGIN
+	BEGIN TRY
+ 		SELECT 1
+	END TRY
+	BEGIN CATCH
+  		USE db
+	END CATCH
+END
+GO
+
+-- while loop
+CREATE PROCEDURE p AS BEGIN
+	DECLARE @i INT = 2
+	WHILE @i > 0 BEGIN
+		USE db
+		SET @i = @i-1
+	END
+END
+GO
+
+-- multiple loops
+CREATE PROCEDURE P(@total INT) AS BEGIN
+	DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+END
+GO
+
+-- Triggers
+CREATE TABLE tb(i INT);
+GO
+
+CREATE TRIGGER t ON tb
+FOR INSERT AS BEGIN
+    USE db;
+	INSERT INTo t VALUES(1);
+END
+GO
+
+CREATE TRIGGER t ON tb
+AFTER DELETE AS
+    DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+GO
+
+DROP TABLE tb;
+GO
+
+-- Functions
+-- sql_clauses is not supported for function of return type func_body_returns_table_clr
+CREATE FUNCTION func() RETURNS TABLE AS
+	USE db;
+	RETURN (SELECT * FROM babel_execute_as_caller_table)
+GO
+
+CREATE FUNCTION func(@i INT) returns @tableVar table(a text not null) AS
+BEGIN
+	USE db;
+    RETURN
+END
+GO
+
+CREATE FUNCTION func(@c INT) RETURNS INT AS
+BEGIN
+	USE db;
+	RETURN (SELECT 1)
+END
+GO
+
+CREATE FUNCTION func(@c INT) RETURNS INT AS
+BEGIN
+	DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+END
+GO
+
+CREATE FUNCTION func() RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= SUM(c1) FROM babel_execute_as_caller_table
+	if(@ans!=1)
+		USE db;
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION func (@v INT) RETURNS INT WITH RETURNS NULL ON NULL INPUT AS
+BEGIN
+	DECLARE @cnt INT = 0
+	WHILE @cnt < @total
+	  BEGIN
+		SELECT 1
+		IF @cnt >= 5
+    		USE db;
+			BREAK
+		SELECT 2
+		IF (@cnt < 5)
+			SELECT 3
+		SET @cnt = @cnt + 1
+	END
+END
+GO
+
+CREATE FUNCTION func (@v INT) RETURNS INT WITH RETURNS NULL ON NULL INPUT
+BEGIN
+	USE db;
+    RETURN @v+1
+END;
+GO


### PR DESCRIPTION
Cherry-picked commit 28bd8a6683c57576ed3a1048bdb19b2424045194
### Description

Previously BBF allowed 'use <databasename>' inside procedure, function and trigger, this type of behaviour shouldn't be allowed.

This commit doesn't support the syntax of 'use <databasename>' inside the procedure, function and trigger.


### Issues Resolved

Babel-3308

### Test Scenarios Covered ###
* **Use case based -** Add different types of functions, procedures and triggers having use statement inside them.


* **Boundary conditions -** Add `use statement` inside different if-else/while/for loops


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A(As tests were added which will throw error if use statement in func/proc/trig)


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).