### PR TITLE
Update Github Actions to use md5 instead of trust auth-method

### DIFF
--- a/.github/composite-actions/install-extensions/action.yml
+++ b/.github/composite-actions/install-extensions/action.yml
@@ -23,7 +23,7 @@ runs:
         sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
         sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
         ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
-        sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+        sudo echo "host    all             all             $ipaddress/32            md5" >> pg_hba.conf
         ~/${{inputs.install_dir}}/bin/pg_ctl -D ~/${{inputs.install_dir}}/data/ -l logfile restart
         cd ~/work/babelfish_extensions/babelfish_extensions/
         sudo ~/${{inputs.install_dir}}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -f .github/scripts/create_extension.sql

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -60,6 +60,7 @@ runs:
         tar_dir: ${{ matrix.upgrade-path.last_version }}
       run: |
         cd test/JDBC/
+        export URL=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
         export isUpgradeTestMode=false
         base_dir=${{ matrix.upgrade-path.path[0] }}
         tar_dir=${{ matrix.upgrade-path.last_version }}

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -28,6 +28,7 @@ runs:
         echo "all" > dummy_schedule
         export scheduleFile=dummy_schedule
         export isUpgradeTestMode=false
+        export URL=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
 
         if [[ "$migr_mode" == "multi-db" ]];then
           base_dir=${{ matrix.upgrade-path.path[0] }}

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -71,7 +71,7 @@ runs:
         sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
         sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
         ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
-        sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+        sudo echo "host    all             all             $ipaddress/32            md5" >> pg_hba.conf
         ~/${{ inputs.install_dir }}/bin/pg_ctl -D ~/${{ inputs.install_dir }}/data/ -l logfile restart
         sudo ~/${{ inputs.install_dir }}/bin/psql -d postgres -U runner -c "CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;"
         sudo ~/${{ inputs.install_dir }}/bin/psql -d postgres -U runner -c "DROP DATABASE IF EXISTS jdbc_testdb;"

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -121,6 +121,7 @@ runs:
         fi
 
         export inputFilesPath=upgrade/$base_dir/preparation
+        export URL=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
         mvn test
         for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" upgrade/$base_dir/schedule); do
           if [[ ! ($(find input/ -name $filename"-vu-prepare.*") || $(find input/ -name $filename"-vu-verify.*")) ]]; then 

--- a/.github/composite-actions/setup-new-version/action.yml
+++ b/.github/composite-actions/setup-new-version/action.yml
@@ -54,5 +54,5 @@ runs:
         sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
         sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
         ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
-        sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+        sudo echo "host    all             all             $ipaddress/32            md5" >> pg_hba.conf
       shell: bash

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -44,6 +44,7 @@ jobs:
         timeout-minutes: 60
         run: |
           cd test/JDBC/
+          export URL=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
           mvn test
 
       - name: Cleanup babelfish database

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -132,6 +132,7 @@ jobs:
           cd test/JDBC/
           # temporarily ignore test BABEL-2086
           echo 'ignore#!#BABEL-2086' >> jdbc_schedule
+          export URL=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
           mvn test
      
       - name: Upload Postgres log

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -73,7 +73,7 @@ jobs:
           sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
           sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
           ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
-          sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+          sudo echo "host    all             all             $ipaddress/32            md5" >> pg_hba.conf
           ~/${{env.OLD_INSTALL_DIR}}/bin/pg_ctl -D ~/${{env.OLD_INSTALL_DIR}}/data -l logfile13 restart
           cd ~/work/babelfish_extensions/babelfish_extensions/
           sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/create_extension.sql
@@ -116,7 +116,7 @@ jobs:
           sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
           sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
           ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
-          sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+          sudo echo "host    all             all             $ipaddress/32            md5" >> pg_hba.conf
         shell: bash
 
       - name: Run pg_upgrade

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -84,6 +84,7 @@ jobs:
         timeout-minutes: 60
         run: |
           cd test/JDBC/
+          export URL=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
           mvn test
 
       - name: Upload Log


### PR DESCRIPTION
### Description

In this commit, we change the authentication method of the pg_hba.conf entry we addin our Github Actions from trust to md5.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).