### PR TITLE
Do not access function fields after deleting its memory context

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_funcs.c
+++ b/contrib/babelfishpg_tsql/src/pl_funcs.c
@@ -863,6 +863,9 @@ pltsql_free_function_memory(PLtsql_function *func)
 	 * And finally, release all memory except the PLtsql_function struct
 	 * itself (which has to be kept around because there may be multiple
 	 * fn_extra pointers to it).
+	 * It is also possible that PLtsql_function struct was allocated in
+	 * the same func->fn_cxt memory context, so we avoid accessing struct
+	 * fields after memory context is released.
 	 */
 	if (func->fn_cxt)
 	{

--- a/contrib/babelfishpg_tsql/src/pl_funcs.c
+++ b/contrib/babelfishpg_tsql/src/pl_funcs.c
@@ -798,6 +798,7 @@ void
 pltsql_free_function_memory(PLtsql_function *func)
 {
 	int			i;
+	MemoryContext func_cxt = NULL;
 
 	/* Better not call this on an in-use function */
 	Assert(func->use_count == 0);
@@ -864,8 +865,11 @@ pltsql_free_function_memory(PLtsql_function *func)
 	 * fn_extra pointers to it).
 	 */
 	if (func->fn_cxt)
-		MemoryContextDelete(func->fn_cxt);
-	func->fn_cxt = NULL;
+	{
+		func_cxt = func->fn_cxt;
+		func->fn_cxt = NULL;
+		MemoryContextDelete(func_cxt);
+	}
 }
 
 


### PR DESCRIPTION
### Description

When an anonymous code block is being executed, the compiled function for it [is allocated](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/aaa7127d18f01188b8945029eb5a27dc2298f378/contrib/babelfishpg_tsql/src/pl_comp.c#L1058) in the same memory context that is used for the contents of the function (`fn_cxt` field).

When `pltsql_free_function_memory` is called on such function, the memory context is being deleted first and [fn_cxt field is assigned after that](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/aaa7127d18f01188b8945029eb5a27dc2298f378/contrib/babelfishpg_tsql/src/pl_funcs.c#L868). That is effectively a "use after free" situation, but due to the memory contexts (and I assume libc allocator too) caching, this write almost never leads to a crash.

Proposed patch moves the assignment to `fn_cxt` to happen before the `MemoryContextDelete` call, otherwise the logic is kept the same.

I believe this fixes the root cause for #1581 (at least I cannot reproduce the problem with patch applied).

### Issues Resolved

#1581

### Test Scenarios Covered ###
* **Use case based -**

Unable to create a simple reproducer.

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).