### PR TITLE
Add ENABLE_TDS_LIB flag check in sp_testlinkedserver

### DIFF
--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -1359,10 +1359,8 @@ sp_testlinkedserver_internal(PG_FUNCTION_ARGS)
 
 	if(servername)
 		pfree(servername);
-
 #else
 	NO_CLIENT_LIB_ERROR();
-
 #endif
 	PG_RETURN_VOID();
 

--- a/contrib/babelfishpg_tsql/src/linked_servers.c
+++ b/contrib/babelfishpg_tsql/src/linked_servers.c
@@ -1331,6 +1331,7 @@ openquery_internal(PG_FUNCTION_ARGS)
 Datum
 sp_testlinkedserver_internal(PG_FUNCTION_ARGS)
 {
+#ifdef ENABLE_TDS_LIB
 	char *servername = PG_ARGISNULL(0) ? NULL : lowerstr(text_to_cstring(PG_GETARG_VARCHAR_PP(0)));
 
 	LinkedServerProcess lsproc = NULL;
@@ -1359,6 +1360,10 @@ sp_testlinkedserver_internal(PG_FUNCTION_ARGS)
 	if(servername)
 		pfree(servername);
 
+#else
+	NO_CLIENT_LIB_ERROR();
+
+#endif
 	PG_RETURN_VOID();
 
 }


### PR DESCRIPTION
### Description

This commit fixes the build issue that occured after the merge of the PR #1551 .

The issue is fixed by adding ENABLE_TDS_LIB flag check in the sp_testlinkedserver_internal() function.

Task: BABEL-4070
Signed-off-by: Shriramu A R [shriraar@amazon.com](mailto:shriraar@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).