### PR TITLE
[OSS-ONLY] Add pg_stat_statements to shared_preload_libraries

### DIFF
--- a/.github/composite-actions/install-extensions/action.yml
+++ b/.github/composite-actions/install-extensions/action.yml
@@ -21,7 +21,7 @@ runs:
         ~/${{inputs.install_dir}}/bin/pg_ctl -D ~/${{inputs.install_dir}}/data/ -l logfile start
         cd ${{inputs.install_dir}}/data
         sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
-        sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
+        sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
         ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
         sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
         ~/${{inputs.install_dir}}/bin/pg_ctl -D ~/${{inputs.install_dir}}/data/ -l logfile restart


### PR DESCRIPTION


### Description

[OSS-ONLY] Add pg_stat_statements to shared_preload_libraries

Currently, minor version upgrade tests are failing because
pg_stat_statements is not being preloaded as shared libraries.

This commit resolves above issue by adding pg_stat_statements to
shared_preload_libraries.

Task: BABEL-OSS
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved
NA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).