### PR TITLE
Add instruction to build and configure Babelfish with SSL

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -45,7 +45,7 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     make check
     ```
 
-    Alternatively, if you want to build with SSL support, configure the PG engine with `--with-openssl`:
+    Alternatively, if you want to build the engine with SSL support, configure the PG engine with `--with-openssl`:
     ```
     ./configure --prefix=$HOME/postgres/ --without-readline --without-zlib --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --with-openssl
     ```


### PR DESCRIPTION
### Description

ODBC Driver 18 for SQL Server by default will encrypt connections. So out of the box configuration of Babelfish cannot be connected to from SQLCMD using this ODBC Driver.

This commit adds instructions on how to build and configure the babelfish server with SSL enabled.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).