### PR TITLE
GETDATE() and other date functions incorrectly return different values in the same query

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys.sql
+++ b/contrib/babelfishpg_tsql/sql/sys.sql
@@ -1,32 +1,31 @@
 /* Built in functions */
-CREATE FUNCTION sys.sysdatetime() RETURNS datetime2
-    AS $$select clock_timestamp()::datetime2;$$
+CREATE OR REPLACE FUNCTION sys.sysdatetime() RETURNS datetime2
+    AS $$select statement_timestamp()::datetime2;$$
     LANGUAGE SQL;
-GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC; 
+GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
 
-CREATE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
+CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
     -- Casting to text as there are not type cast function from timestamptz to datetimeoffset
-    AS $$select cast(cast(clock_timestamp() as text) as sys.datetimeoffset);$$
+    AS $$select cast(cast(statement_timestamp() as text) as sys.datetimeoffset);$$
     LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC; 
+GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 
 
-CREATE FUNCTION sys.sysutcdatetime() RETURNS sys.datetime2
-    AS $$select (clock_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime2;$$
+CREATE OR REPLACE FUNCTION sys.sysutcdatetime() RETURNS sys.datetime2
+    AS $$select (statement_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime2;$$
     LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.sysutcdatetime() TO PUBLIC; 
+GRANT EXECUTE ON FUNCTION sys.sysutcdatetime() TO PUBLIC;
 
 
-CREATE FUNCTION sys.getdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', clock_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
+CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
+    AS $$select date_trunc('millisecond', statement_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
     LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC; 
+GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
 
-
-CREATE FUNCTION sys.getutcdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', clock_timestamp() AT TIME ZONE 'UTC')::sys.datetime;$$
-    LANGUAGE SQL;
-GRANT EXECUTE ON FUNCTION sys.getutcdate() TO PUBLIC; 
+CREATE OR REPLACE FUNCTION sys.getutcdate() RETURNS sys.datetime
+    AS $$select date_trunc('millisecond', statement_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime;$$
+    LANGUAGE SQL STABLE;
+GRANT EXECUTE ON FUNCTION sys.getutcdate() TO PUBLIC;
 
 
 CREATE FUNCTION sys.isnull(text,text) RETURNS text AS $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -139,6 +139,34 @@ inner join sys.babelfish_namespace_ext b on t.schema_name = b.orig_name
 inner join pg_catalog.pg_namespace ns on b.nspname = ns.nspname;
 GRANT SELECT ON sys.shipped_objects_not_in_sys TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.sysdatetime() RETURNS datetime2
+    AS $$select statement_timestamp()::datetime2;$$
+    LANGUAGE SQL;
+GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
+    -- Casting to text as there are not type cast function from timestamptz to datetimeoffset
+    AS $$select cast(cast(statement_timestamp() as text) as sys.datetimeoffset);$$
+    LANGUAGE SQL STABLE;
+GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
+
+
+CREATE OR REPLACE FUNCTION sys.sysutcdatetime() RETURNS sys.datetime2
+    AS $$select (statement_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime2;$$
+    LANGUAGE SQL STABLE;
+GRANT EXECUTE ON FUNCTION sys.sysutcdatetime() TO PUBLIC;
+
+
+CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
+    AS $$select date_trunc('millisecond', statement_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
+    LANGUAGE SQL STABLE;
+GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.getutcdate() RETURNS sys.datetime
+    AS $$select date_trunc('millisecond', statement_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime;$$
+    LANGUAGE SQL STABLE;
+GRANT EXECUTE ON FUNCTION sys.getutcdate() TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/getdatetest.out
+++ b/test/JDBC/expected/getdatetest.out
@@ -1,5 +1,5 @@
 
--- NOTE: Each test is expected to tale a lot of time
+-- NOTE: Each test is expected to take a lot of time
 -- We do not need Upgrade tests for these function
 -- We can only test the stability of this function in the framework since the results are dynamic
 WITH

--- a/test/JDBC/expected/getdatetest.out
+++ b/test/JDBC/expected/getdatetest.out
@@ -1,0 +1,88 @@
+
+-- NOTE: Each test is expected to tale a lot of time
+-- We do not need Upgrade tests for these function
+-- We can only test the stability of this function in the framework since the results are dynamic
+WITH
+  Pass0 as (select sys.sysdatetime() as C union all select sys.sysdatetime()), --2 rows
+  Pass1 as (select sys.sysdatetime() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.sysdatetime() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.sysdatetime() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.sysdatetime() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.sysdatetime()
+go
+~~START~~
+int
+65536
+~~END~~
+
+
+WITH
+  Pass0 as (select sys.sysdatetimeoffset() as C union all select sys.sysdatetimeoffset()), --2 rows
+  Pass1 as (select sys.sysdatetimeoffset() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.sysdatetimeoffset() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.sysdatetimeoffset() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.sysdatetimeoffset() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.sysdatetimeoffset()
+go
+~~START~~
+int
+65536
+~~END~~
+
+
+WITH
+  Pass0 as (select sys.sysutcdatetime() as C union all select sys.sysutcdatetime()), --2 rows
+  Pass1 as (select sys.sysutcdatetime() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.sysutcdatetime() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.sysutcdatetime() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.sysutcdatetime() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sysutcdatetime()
+go
+~~START~~
+int
+65536
+~~END~~
+
+
+WITH
+  Pass0 as (select sys.getdate() as C union all select sys.getdate()), --2 rows
+  Pass1 as (select sys.getdate() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.getdate() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.getdate() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.getdate() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.getdate()
+go
+~~START~~
+int
+65536
+~~END~~
+
+
+WITH
+  Pass0 as (select sys.getutcdate() as C union all select sys.getutcdate()), --2 rows
+  Pass1 as (select sys.getutcdate() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.getutcdate() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.getutcdate() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.getutcdate() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.getutcdate()
+go
+~~START~~
+int
+65536
+~~END~~
+

--- a/test/JDBC/input/getdatetest.sql
+++ b/test/JDBC/input/getdatetest.sql
@@ -1,0 +1,63 @@
+-- NOTE: Each test is expected to tale a lot of time
+-- We do not need Upgrade tests for these function
+-- We can only test the stability of this function in the framework since the results are dynamic
+
+WITH
+  Pass0 as (select sys.sysdatetime() as C union all select sys.sysdatetime()), --2 rows
+  Pass1 as (select sys.sysdatetime() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.sysdatetime() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.sysdatetime() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.sysdatetime() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.sysdatetime()
+go
+
+WITH
+  Pass0 as (select sys.sysdatetimeoffset() as C union all select sys.sysdatetimeoffset()), --2 rows
+  Pass1 as (select sys.sysdatetimeoffset() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.sysdatetimeoffset() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.sysdatetimeoffset() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.sysdatetimeoffset() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.sysdatetimeoffset()
+go
+
+WITH
+  Pass0 as (select sys.sysutcdatetime() as C union all select sys.sysutcdatetime()), --2 rows
+  Pass1 as (select sys.sysutcdatetime() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.sysutcdatetime() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.sysutcdatetime() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.sysutcdatetime() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sysutcdatetime()
+go
+
+WITH
+  Pass0 as (select sys.getdate() as C union all select sys.getdate()), --2 rows
+  Pass1 as (select sys.getdate() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.getdate() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.getdate() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.getdate() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.getdate()
+go
+
+WITH
+  Pass0 as (select sys.getutcdate() as C union all select sys.getutcdate()), --2 rows
+  Pass1 as (select sys.getutcdate() as C from Pass0 as A, Pass0 as B),--4 rows
+  Pass2 as (select sys.getutcdate() as C from Pass1 as A, Pass1 as B),--16 rows
+  Pass3 as (select sys.getutcdate() as C from Pass2 as A, Pass2 as B),--256 rows
+  Pass4 as (select sys.getutcdate() as C from Pass3 as A, Pass3 as B),--65536 rows
+  Tally as (select row_number() over(order by C) as Number, min(C) over () as min_getdate from Pass4)
+SELECT count(min_getdate)
+FROM Tally
+WHERE min_getdate = sys.getutcdate()
+go

--- a/test/JDBC/input/getdatetest.sql
+++ b/test/JDBC/input/getdatetest.sql
@@ -1,4 +1,4 @@
--- NOTE: Each test is expected to tale a lot of time
+-- NOTE: Each test is expected to take a lot of time
 -- We do not need Upgrade tests for these function
 -- We can only test the stability of this function in the framework since the results are dynamic
 

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -42,7 +42,6 @@ Could not find tests for function sys.sp_statistics_internal
 Could not find tests for function sys.sp_tables_internal
 Could not find tests for function sys.suser_id_internal
 Could not find tests for function sys.suser_name_internal
-Could not find tests for function sys.sysdatetime
 Could not find tests for function sys.systypes_precision_helper
 Could not find tests for function sys.tsql_get_returntypmodvalue
 Could not find tests for function sys.tsql_query_to_json_ffunc


### PR DESCRIPTION
### Description
Ideally GETDATE() and other date functions are executed before the rows are fetched. The result is cached and re-used in all places within the query, to align with customer expectation of such behaviour.
However, in Babelfish the functions return different results per-row and per instance of the function in the query. This causes customers to receive wrong results in some cases.
To fix this we use statement_timestamp internally which returns the start time of the current statement and its value does not change inside the current command being executed.

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>

### Issues Resolved
BABEL-4188

### Test Scenarios Covered ###
* **Use case based -**
*Added JDBC tests and we do not require upgrade tests since there is no change in signature of the function. Moreover we cannot test the actual value being returned by the function since it is going to be dynamic, we can only test for the stability of the function in the manner in which tests are added in this PR*

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).