### PR TITLE
Update pg_stat_statement and sp_execute_postgresql tests

### DIFF
--- a/test/JDBC/expected/Test-sp_execute_postgresql-susercheck.out
+++ b/test/JDBC/expected/Test-sp_execute_postgresql-susercheck.out
@@ -1,0 +1,47 @@
+-- tsql
+-- throw error if login does not have sysadmin privilege(it has only superuser)
+create login l3 with password = '12345678'
+go
+
+-- psql
+-- grant Superuser
+alter user l3 with Superuser;
+go
+
+-- tsql user=l3 password=12345678
+exec sp_execute_postgresql 'create extension pg_stat_statements';
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied to create extension)~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l3' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+
+-- psql
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- psql
+-- revoke superuser
+ALTER USER l3 with NOSUPERUSER;
+go
+
+-- tsql
+drop login l3
+go

--- a/test/JDBC/expected/Test-sp_execute_postgresql.out
+++ b/test/JDBC/expected/Test-sp_execute_postgresql.out
@@ -180,8 +180,24 @@ pg_stat_statements
 
 
 -- psql
-SET pg_stat_statements.track = 'top';
-SET compute_query_id = 1;
+ALTER SYSTEM SET pg_stat_statements.track = 'top';
+ALTER SYSTEM SET compute_query_id = 1;
+SELECT pg_reload_conf();
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
 SELECT pg_stat_statements_reset();
 go
 ~~START~~

--- a/test/JDBC/expected/Test-sp_execute_postgresql.out
+++ b/test/JDBC/expected/Test-sp_execute_postgresql.out
@@ -168,61 +168,14 @@ void
 drop login l2
 go
 
--- throw error if login does not have sysadmin privilege(it has only superuser)
-create login l3 with password = '12345678'
-go
-
--- psql
--- grant Superuser
-alter user l3 with Superuser;
-go
-
--- tsql user=l3 password=12345678
-exec sp_execute_postgresql 'create extension pg_stat_statements';
-go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: permission denied to create extension)~~
-
-
--- psql
--- Need to terminate active session before cleaning up the login
-SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
-WHERE sys.suser_name(usesysid) = 'l3' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
-
--- psql
-select pg_sleep(1);
-GO
-~~START~~
-void
-
-~~END~~
-
-
--- psql
--- revoke superuser
-ALTER USER l3 with NOSUPERUSER;
-go
-
--- tsql
-drop login l3
-go
-
 -- Create extension
 exec sp_execute_postgresql 'create extension if not exists pg_stat_statements';
 go
-select extname, extowner, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname, extversion from pg_extension where extname = 'pg_stat_statements'
 go
 ~~START~~
-varchar#!#int#!#text
-pg_stat_statements#!#16384#!#1.10
+varchar#!#text
+pg_stat_statements#!#1.10
 ~~END~~
 
 
@@ -237,10 +190,10 @@ void
 
 -- tsql
 -- for accessing the extension we need to give schema qualifier i.e. [public].pg_stat_statements
-SELECT dbid, toplevel, query, calls, rows, plans from [public].pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from [public].pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text#!#bigint#!#bigint#!#bigint
+bit#!#text#!#bigint#!#bigint#!#bigint
 ~~END~~
 
 
@@ -304,11 +257,11 @@ go
 exec sp_execute_postgresql 'create extension pg_stat_statements with version "1.4"';
 go
 
-select extname, extowner, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname, extversion from pg_extension where extname = 'pg_stat_statements'
 go
 ~~START~~
-varchar#!#int#!#text
-pg_stat_statements#!#16384#!#1.4
+varchar#!#text
+pg_stat_statements#!#1.4
 ~~END~~
 
 
@@ -316,11 +269,11 @@ pg_stat_statements#!#16384#!#1.4
 exec sp_execute_postgresql 'alter extension pg_stat_statements update to "1.10"';
 go
 
-select extname, extowner, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname, extversion from pg_extension where extname = 'pg_stat_statements'
 go
 ~~START~~
-varchar#!#int#!#text
-pg_stat_statements#!#16384#!#1.10
+varchar#!#text
+pg_stat_statements#!#1.10
 ~~END~~
 
 
@@ -357,7 +310,7 @@ drop table proc_tmp
 go
 
 -- cannot drop extension if other objects depend on it
-create view pg_view as select query, queryid from [public].pg_stat_statements;
+create view pg_view as select query from [public].pg_stat_statements;
 go
 
 exec sp_execute_postgresql 'drop extension pg_stat_statements'
@@ -387,7 +340,7 @@ exec sp_execute_postgresql 'create extension pg_stat_statements'
 go
 
 -- Restrict option prevents the specified extensions from being dropped if other objects depend on table_schema
-create view pg_view as select query, queryid from [public].pg_stat_statements;
+create view pg_view as select query from [public].pg_stat_statements;
 go
 exec sp_execute_postgresql 'drop extension pg_stat_statements restrict'
 go

--- a/test/JDBC/expected/Test-sp_execute_postgresql.out
+++ b/test/JDBC/expected/Test-sp_execute_postgresql.out
@@ -171,22 +171,24 @@ go
 -- Create extension
 exec sp_execute_postgresql 'create extension if not exists pg_stat_statements';
 go
-select extname, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname from pg_extension where extname = 'pg_stat_statements'
 go
 ~~START~~
-varchar#!#text
-pg_stat_statements#!#1.10
+varchar
+pg_stat_statements
 ~~END~~
 
 
 -- psql
-SET pg_stat_statements.track = 'none';
+SET pg_stat_statements.track = 'top';
+SET compute_query_id = 1;
 SELECT pg_stat_statements_reset();
 go
 ~~START~~
 void
 
 ~~END~~
+
 
 -- tsql
 -- for accessing the extension we need to give schema qualifier i.e. [public].pg_stat_statements

--- a/test/JDBC/expected/pg_stat_statements_tsql.out
+++ b/test/JDBC/expected/pg_stat_statements_tsql.out
@@ -3,7 +3,8 @@ CREATE EXTENSION pg_stat_statements WITH SCHEMA sys;
 go
 
 -- psql
-SET sys.pg_stat_statements.track = 'none';
+SET sys.pg_stat_statements.track = 'top';
+SET compute_query_id = 1;
 SELECT sys.pg_stat_statements_reset();
 go
 ~~START~~

--- a/test/JDBC/expected/pg_stat_statements_tsql.out
+++ b/test/JDBC/expected/pg_stat_statements_tsql.out
@@ -3,8 +3,24 @@ CREATE EXTENSION pg_stat_statements WITH SCHEMA sys;
 go
 
 -- psql
-SET sys.pg_stat_statements.track = 'top';
-SET compute_query_id = 1;
+ALTER SYSTEM SET pg_stat_statements.track = 'top';
+ALTER SYSTEM SET compute_query_id = 1;
+SELECT pg_reload_conf();
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
 SELECT sys.pg_stat_statements_reset();
 go
 ~~START~~

--- a/test/JDBC/expected/pg_stat_statements_tsql.out
+++ b/test/JDBC/expected/pg_stat_statements_tsql.out
@@ -14,10 +14,10 @@ void
 
 
 -- tsql
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text#!#bigint#!#bigint#!#bigint
+bit#!#text#!#bigint#!#bigint#!#bigint
 ~~END~~
 
 
@@ -147,31 +147,31 @@ DROP DATABASE pgss_db
 go
 
 -- tsql
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text#!#bigint#!#bigint#!#bigint
-16385#!#1#!#BEGIN TRANSACTION#!#2#!#0#!#0
-16385#!#1#!#COMMIT#!#1#!#0#!#0
-16385#!#1#!#COMMIT TRANSACTION#!#1#!#0#!#0
-16385#!#1#!#CREATE DATABASE pgss_db#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE pgss_cursor(age int)#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE pgss_transaction(age int)#!#1#!#0#!#0
-16385#!#1#!#CREATE TYPE pgss_type from varchar(22)#!#1#!#0#!#0
-16385#!#1#!#DROP DATABASE pgss_db#!#1#!#0#!#0
-16385#!#1#!#DROP TABLE pgss_cursor#!#1#!#0#!#0
-16385#!#1#!#DROP TABLE pgss_transaction#!#1#!#0#!#0
-16385#!#1#!#DROP TYPE pgss_type#!#1#!#0#!#0
-16385#!#1#!#INSERT INTO pgss_cursor values($1),($2),($3)#!#1#!#3#!#0
-16385#!#1#!#INSERT INTO pgss_transaction values($1)#!#1#!#1#!#0
-16385#!#1#!#INSERT INTO pgss_transaction values($1),($2),($3),($4)#!#1#!#4#!#0
-16385#!#1#!#ROLLBACK TRANSACTION insertstmt#!#1#!#0#!#0
-16385#!#1#!#SAVE TRANSACTION insertstmt#!#1#!#0#!#0
-16385#!#1#!#SELECT $1<newline>  -- multiline<newline>  AS "text"#!#3#!#3#!#0
-16385#!#1#!#SELECT $1 AS "int"#!#2#!#2#!#0
-16385#!#1#!#SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != $1 ORDER BY query COLLATE "C"#!#1#!#0#!#0
-16385#!#1#!#select * from pgss_cursor#!#1#!#1#!#0
-16385#!#1#!#select * from pgss_transaction#!#1#!#5#!#0
+bit#!#text#!#bigint#!#bigint#!#bigint
+1#!#BEGIN TRANSACTION#!#2#!#0#!#0
+1#!#COMMIT#!#1#!#0#!#0
+1#!#COMMIT TRANSACTION#!#1#!#0#!#0
+1#!#CREATE DATABASE pgss_db#!#1#!#0#!#0
+1#!#CREATE TABLE pgss_cursor(age int)#!#1#!#0#!#0
+1#!#CREATE TABLE pgss_transaction(age int)#!#1#!#0#!#0
+1#!#CREATE TYPE pgss_type from varchar(22)#!#1#!#0#!#0
+1#!#DROP DATABASE pgss_db#!#1#!#0#!#0
+1#!#DROP TABLE pgss_cursor#!#1#!#0#!#0
+1#!#DROP TABLE pgss_transaction#!#1#!#0#!#0
+1#!#DROP TYPE pgss_type#!#1#!#0#!#0
+1#!#INSERT INTO pgss_cursor values($1),($2),($3)#!#1#!#3#!#0
+1#!#INSERT INTO pgss_transaction values($1)#!#1#!#1#!#0
+1#!#INSERT INTO pgss_transaction values($1),($2),($3),($4)#!#1#!#4#!#0
+1#!#ROLLBACK TRANSACTION insertstmt#!#1#!#0#!#0
+1#!#SAVE TRANSACTION insertstmt#!#1#!#0#!#0
+1#!#SELECT $1<newline>  -- multiline<newline>  AS "text"#!#3#!#3#!#0
+1#!#SELECT $1 AS "int"#!#2#!#2#!#0
+1#!#SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != $1 ORDER BY query COLLATE "C"#!#1#!#0#!#0
+1#!#select * from pgss_cursor#!#1#!#1#!#0
+1#!#select * from pgss_transaction#!#1#!#5#!#0
 ~~END~~
 
 
@@ -193,11 +193,11 @@ nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar
 ~~END~~
 
 
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text#!#bigint#!#bigint#!#bigint
-16385#!#1#!#SELECT * FROM information_schema_tsql.views WHERE TABLE_NAME = $1#!#1#!#0#!#0
+bit#!#text#!#bigint#!#bigint#!#bigint
+1#!#SELECT * FROM information_schema_tsql.views WHERE TABLE_NAME = $1#!#1#!#0#!#0
 ~~END~~
 
 
@@ -217,13 +217,13 @@ go
 DROP LOGIN  pgss_l1
 go
 
-SELECT dbid, toplevel, query from pg_stat_statements ORDER BY query COLLATE "C";
+SELECT toplevel, query from pg_stat_statements ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text
-16385#!#1#!#<insufficient privilege>
-16385#!#1#!#<insufficient privilege>
-16385#!#1#!#<insufficient privilege>
+bit#!#text
+1#!#<insufficient privilege>
+1#!#<insufficient privilege>
+1#!#<insufficient privilege>
 ~~END~~
 
 
@@ -289,26 +289,26 @@ int#!#char#!#varchar
 ~~END~~
 
 
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text#!#bigint#!#bigint#!#bigint
-16385#!#1#!#ALTER TABLE pgss_test DISABLE  TRIGGER pgss_trigger1#!#1#!#0#!#0
-16385#!#1#!#ALTER TABLE pgss_test ENABLE TRIGGER pgss_trigger1#!#1#!#0#!#0
-16385#!#1#!#ALTER TABLE pgss_test add c varchar(22)#!#1#!#0#!#0
-16385#!#1#!#CREATE ROLE pgss_test_role#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE pgss_test (a int, b char(20))#!#1#!#0#!#0
-16385#!#1#!#CREATE TRIGGER pgss_trigger1 on [dbo].[pgss_test] for insert as<newline>PRINT 'after insert trigger called'#!#1#!#0#!#0
-16385#!#1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
-16385#!#1#!#GRANT INSERT, UPDATE, SELECT ON pgss_test TO pgss_test_role#!#1#!#0#!#0
-16385#!#1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3, $4)#!#1#!#10#!#0
-16385#!#1#!#REVOKE INSERT, UPDATE, SELECT ON pgss_test FROM pgss_test_role#!#1#!#0#!#0
-16385#!#1#!#SELECT * FROM pgss_test#!#1#!#0#!#0
-16385#!#1#!#SELECT * FROM pgss_test ORDER BY a#!#1#!#0#!#0
-16385#!#1#!#SELECT * FROM pgss_test WHERE a IN ($1, $2, $3, $4, $5)#!#1#!#0#!#0
-16385#!#1#!#SELECT dbid, toplevel, query from pg_stat_statements ORDER BY query COLLATE "C"#!#1#!#3#!#0
-16385#!#1#!#TRUNCATE TABLE pgss_test#!#1#!#0#!#0
-16385#!#1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
+bit#!#text#!#bigint#!#bigint#!#bigint
+1#!#ALTER TABLE pgss_test DISABLE  TRIGGER pgss_trigger1#!#1#!#0#!#0
+1#!#ALTER TABLE pgss_test ENABLE TRIGGER pgss_trigger1#!#1#!#0#!#0
+1#!#ALTER TABLE pgss_test add c varchar(22)#!#1#!#0#!#0
+1#!#CREATE ROLE pgss_test_role#!#1#!#0#!#0
+1#!#CREATE TABLE pgss_test (a int, b char(20))#!#1#!#0#!#0
+1#!#CREATE TRIGGER pgss_trigger1 on [dbo].[pgss_test] for insert as<newline>PRINT 'after insert trigger called'#!#1#!#0#!#0
+1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
+1#!#GRANT INSERT, UPDATE, SELECT ON pgss_test TO pgss_test_role#!#1#!#0#!#0
+1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3, $4)#!#1#!#10#!#0
+1#!#REVOKE INSERT, UPDATE, SELECT ON pgss_test FROM pgss_test_role#!#1#!#0#!#0
+1#!#SELECT * FROM pgss_test#!#1#!#0#!#0
+1#!#SELECT * FROM pgss_test ORDER BY a#!#1#!#0#!#0
+1#!#SELECT * FROM pgss_test WHERE a IN ($1, $2, $3, $4, $5)#!#1#!#0#!#0
+1#!#SELECT toplevel, query from pg_stat_statements ORDER BY query COLLATE "C"#!#1#!#3#!#0
+1#!#TRUNCATE TABLE pgss_test#!#1#!#0#!#0
+1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
 ~~END~~
 
 
@@ -586,45 +586,45 @@ go
 
 
 -- tsql
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 ~~START~~
-int#!#bit#!#text#!#bigint#!#bigint#!#bigint
-16385#!#1#!#CREATE FUNCTION [dbo].[getCustomers](@age int) returns table as return <newline>(select pgss_cust.customerid, pgss_cust.name, pgss_cust.age from pgss_cust<newline>where age >= @age)#!#1#!#0#!#0
-16385#!#1#!#CREATE FUNCTION pgss_f1(@a INT) RETURNS INT AS BEGIN RETURN (@a + 1) END;#!#1#!#0#!#0
-16385#!#1#!#CREATE PROC pgss_p1 @a INT, @b FLOAT AS SELECT @a, @b;#!#1#!#0#!#0
-16385#!#1#!#CREATE SEQUENCE [dbo].[newCounter] AS int START WITH 5 increment by 5#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE #pgss_demo(age int)#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE pgss_cust(customerid int not null, name varchar(22), age int, check (age>=18), primary key(customerid))#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE pgss_orders(orderid int not null, customerid int, country varchar(20) default 'INDIA', primary key(orderid), foreign key(customerid) references pgss_cust(customerid))#!#1#!#0#!#0
-16385#!#1#!#CREATE TABLE pgss_test (a int, b char(20))#!#2#!#0#!#0
-16385#!#1#!#CREATE VIEW [India customers] as select customerid from pgss_orders where country = 'India'#!#1#!#0#!#0
-16385#!#1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
-16385#!#1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
-16385#!#1#!#DROP FUNCTION [dbo].[getCustomers]#!#1#!#0#!#0
-16385#!#1#!#DROP FUNCTION pgss_f1#!#1#!#0#!#0
-16385#!#1#!#DROP PROCEDURE pgss_p1#!#1#!#0#!#0
-16385#!#1#!#DROP SEQUENCE [dbo].[newCounter]#!#1#!#0#!#0
-16385#!#1#!#DROP TABLE pgss_cust#!#1#!#0#!#0
-16385#!#1#!#DROP TABLE pgss_orders#!#1#!#0#!#0
-16385#!#1#!#DROP TABLE pgss_test#!#2#!#0#!#0
-16385#!#1#!#DROP VIEW  [India customers]#!#1#!#0#!#0
-16385#!#1#!#INSERT INTO pgss_cust values($1, $2, $3),($4,$5, $6), ($7, $8, $9),($10, $11, $12),($13, $14, $15)#!#1#!#5#!#0
-16385#!#1#!#INSERT INTO pgss_orders values($1, $2, $3), ($4, $5, $6), ($7, $8, $9), ($10, $11, $12),($13, $14, $15),($16, $17, $18)#!#1#!#6#!#0
-16385#!#1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3)#!#1#!#10#!#0
-16385#!#1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3)#!#1#!#10#!#0
-16385#!#1#!#SELECT    nextval($1)#!#1#!#1#!#0
-16385#!#1#!#SELECT * FROM [India customers]#!#1#!#2#!#0
-16385#!#1#!#SELECT * FROM [dbo].[getCustomers]($1)#!#1#!#4#!#0
-16385#!#1#!#SELECT * FROM pgss_cust#!#1#!#5#!#0
-16385#!#1#!#SELECT AVG(age) FROM pgss_cust#!#1#!#1#!#0
-16385#!#1#!#SELECT COUNT(*) from pgss_orders where country =$1#!#1#!#1#!#0
-16385#!#1#!#SELECT REVERSE(name) FROM pgss_cust#!#1#!#5#!#0
-16385#!#1#!#SELECT pgss_cust.name, pgss_orders.orderid, pgss_orders.country from pgss_orders inner join pgss_cust on pgss_cust.customerid = pgss_orders.customerid#!#1#!#6#!#0
-16385#!#1#!#SELECT query, calls, rows<newline>FROM pg_stat_statements where total_exec_time > $1 and min_exec_time > $2  ORDER BY query COLLATE "C"#!#1#!#10#!#0
-16385#!#1#!#SELECT query, calls, rows<newline>FROM pg_stat_statements where wal_bytes != $1 and wal_records != $2 ORDER BY query COLLATE "C"#!#1#!#5#!#0
-16385#!#1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
-16385#!#1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
+bit#!#text#!#bigint#!#bigint#!#bigint
+1#!#CREATE FUNCTION [dbo].[getCustomers](@age int) returns table as return <newline>(select pgss_cust.customerid, pgss_cust.name, pgss_cust.age from pgss_cust<newline>where age >= @age)#!#1#!#0#!#0
+1#!#CREATE FUNCTION pgss_f1(@a INT) RETURNS INT AS BEGIN RETURN (@a + 1) END;#!#1#!#0#!#0
+1#!#CREATE PROC pgss_p1 @a INT, @b FLOAT AS SELECT @a, @b;#!#1#!#0#!#0
+1#!#CREATE SEQUENCE [dbo].[newCounter] AS int START WITH 5 increment by 5#!#1#!#0#!#0
+1#!#CREATE TABLE #pgss_demo(age int)#!#1#!#0#!#0
+1#!#CREATE TABLE pgss_cust(customerid int not null, name varchar(22), age int, check (age>=18), primary key(customerid))#!#1#!#0#!#0
+1#!#CREATE TABLE pgss_orders(orderid int not null, customerid int, country varchar(20) default 'INDIA', primary key(orderid), foreign key(customerid) references pgss_cust(customerid))#!#1#!#0#!#0
+1#!#CREATE TABLE pgss_test (a int, b char(20))#!#2#!#0#!#0
+1#!#CREATE VIEW [India customers] as select customerid from pgss_orders where country = 'India'#!#1#!#0#!#0
+1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
+1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
+1#!#DROP FUNCTION [dbo].[getCustomers]#!#1#!#0#!#0
+1#!#DROP FUNCTION pgss_f1#!#1#!#0#!#0
+1#!#DROP PROCEDURE pgss_p1#!#1#!#0#!#0
+1#!#DROP SEQUENCE [dbo].[newCounter]#!#1#!#0#!#0
+1#!#DROP TABLE pgss_cust#!#1#!#0#!#0
+1#!#DROP TABLE pgss_orders#!#1#!#0#!#0
+1#!#DROP TABLE pgss_test#!#2#!#0#!#0
+1#!#DROP VIEW  [India customers]#!#1#!#0#!#0
+1#!#INSERT INTO pgss_cust values($1, $2, $3),($4,$5, $6), ($7, $8, $9),($10, $11, $12),($13, $14, $15)#!#1#!#5#!#0
+1#!#INSERT INTO pgss_orders values($1, $2, $3), ($4, $5, $6), ($7, $8, $9), ($10, $11, $12),($13, $14, $15),($16, $17, $18)#!#1#!#6#!#0
+1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3)#!#1#!#10#!#0
+1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3)#!#1#!#10#!#0
+1#!#SELECT    nextval($1)#!#1#!#1#!#0
+1#!#SELECT * FROM [India customers]#!#1#!#2#!#0
+1#!#SELECT * FROM [dbo].[getCustomers]($1)#!#1#!#4#!#0
+1#!#SELECT * FROM pgss_cust#!#1#!#5#!#0
+1#!#SELECT AVG(age) FROM pgss_cust#!#1#!#1#!#0
+1#!#SELECT COUNT(*) from pgss_orders where country =$1#!#1#!#1#!#0
+1#!#SELECT REVERSE(name) FROM pgss_cust#!#1#!#5#!#0
+1#!#SELECT pgss_cust.name, pgss_orders.orderid, pgss_orders.country from pgss_orders inner join pgss_cust on pgss_cust.customerid = pgss_orders.customerid#!#1#!#6#!#0
+1#!#SELECT query, calls, rows<newline>FROM pg_stat_statements where total_exec_time > $1 and min_exec_time > $2  ORDER BY query COLLATE "C"#!#1#!#10#!#0
+1#!#SELECT query, calls, rows<newline>FROM pg_stat_statements where wal_bytes != $1 and wal_records != $2 ORDER BY query COLLATE "C"#!#1#!#5#!#0
+1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
+1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
 ~~END~~
 
 

--- a/test/JDBC/input/pg_stat_statements_tsql.mix
+++ b/test/JDBC/input/pg_stat_statements_tsql.mix
@@ -3,7 +3,8 @@ CREATE EXTENSION pg_stat_statements WITH SCHEMA sys;
 go
 
 -- psql
-SET sys.pg_stat_statements.track = 'none';
+SET sys.pg_stat_statements.track = 'top';
+SET compute_query_id = 1;
 SELECT sys.pg_stat_statements_reset();
 go
 

--- a/test/JDBC/input/pg_stat_statements_tsql.mix
+++ b/test/JDBC/input/pg_stat_statements_tsql.mix
@@ -9,7 +9,7 @@ SELECT sys.pg_stat_statements_reset();
 go
 
 -- tsql
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 
 --
@@ -93,7 +93,7 @@ DROP DATABASE pgss_db
 go
 
 -- tsql
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 
 -- psql
@@ -105,7 +105,7 @@ go
 SELECT * FROM information_schema.views WHERE TABLE_NAME = 'india customers';
 go
 
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 
 -- psql
@@ -119,7 +119,7 @@ go
 DROP LOGIN  pgss_l1
 go
 
-SELECT dbid, toplevel, query from pg_stat_statements ORDER BY query COLLATE "C";
+SELECT toplevel, query from pg_stat_statements ORDER BY query COLLATE "C";
 go
 
 -- create insert alter select update delete trigger truncate on test table
@@ -162,7 +162,7 @@ SELECT * FROM pgss_test ORDER BY a;
 SELECT * FROM pgss_test WHERE a IN (1, 2, 3, 4, 5);
 go
 
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 
 -- psql
@@ -299,7 +299,7 @@ go
 
 
 -- tsql
-SELECT dbid, toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 
 -- psql

--- a/test/JDBC/input/pg_stat_statements_tsql.mix
+++ b/test/JDBC/input/pg_stat_statements_tsql.mix
@@ -3,8 +3,14 @@ CREATE EXTENSION pg_stat_statements WITH SCHEMA sys;
 go
 
 -- psql
-SET sys.pg_stat_statements.track = 'top';
-SET compute_query_id = 1;
+ALTER SYSTEM SET pg_stat_statements.track = 'top';
+ALTER SYSTEM SET compute_query_id = 1;
+SELECT pg_reload_conf();
+go
+
+SELECT pg_sleep(1);
+go
+
 SELECT sys.pg_stat_statements_reset();
 go
 

--- a/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql-susercheck.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql-susercheck.mix
@@ -1,0 +1,33 @@
+-- tsql
+-- throw error if login does not have sysadmin privilege(it has only superuser)
+create login l3 with password = '12345678'
+go
+
+-- grant Superuser
+-- psql
+alter user l3 with Superuser;
+go
+
+-- tsql user=l3 password=12345678
+exec sp_execute_postgresql 'create extension pg_stat_statements';
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l3' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+
+-- psql
+select pg_sleep(1);
+GO
+
+-- psql
+-- revoke superuser
+ALTER USER l3 with NOSUPERUSER;
+go
+
+-- tsql
+drop login l3
+go

--- a/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql.mix
@@ -100,8 +100,14 @@ select extname from pg_extension where extname = 'pg_stat_statements'
 go
 
 -- psql
-SET pg_stat_statements.track = 'top';
-SET compute_query_id = 1;
+ALTER SYSTEM SET pg_stat_statements.track = 'top';
+ALTER SYSTEM SET compute_query_id = 1;
+SELECT pg_reload_conf();
+go
+
+SELECT pg_sleep(1);
+go
+
 SELECT pg_stat_statements_reset();
 go
 

--- a/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql.mix
@@ -93,52 +93,21 @@ GO
 drop login l2
 go
 
--- throw error if login does not have sysadmin privilege(it has only superuser)
-create login l3 with password = '12345678'
-go
-
--- grant Superuser
--- psql
-alter user l3 with Superuser;
-go
-
--- tsql user=l3 password=12345678
-exec sp_execute_postgresql 'create extension pg_stat_statements';
-go
-
--- psql
--- Need to terminate active session before cleaning up the login
-SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
-WHERE sys.suser_name(usesysid) = 'l3' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
-GO
-
-
--- psql
-select pg_sleep(1);
-GO
-
--- psql
--- revoke superuser
-ALTER USER l3 with NOSUPERUSER;
-go
-
--- tsql
-drop login l3
-go
-
 -- Create extension
 exec sp_execute_postgresql 'create extension if not exists pg_stat_statements';
 go
-select extname, extowner, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname from pg_extension where extname = 'pg_stat_statements'
 go
 
 -- psql
-SET pg_stat_statements.track = 'none';
+SET pg_stat_statements.track = 'top';
+SET compute_query_id = 1;
 SELECT pg_stat_statements_reset();
 go
+
 -- tsql
 -- for accessing the extension we need to give schema qualifier i.e. [public].pg_stat_statements
-SELECT dbid, toplevel, query, calls, rows, plans from [public].pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from [public].pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
 go
 
 -- create extension without using 'if not exists' option will throw error
@@ -185,14 +154,14 @@ go
 exec sp_execute_postgresql 'create extension pg_stat_statements with version "1.4"';
 go
 
-select extname, extowner, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname, extversion from pg_extension where extname = 'pg_stat_statements'
 go
 
 -- alter extension version
 exec sp_execute_postgresql 'alter extension pg_stat_statements update to "1.10"';
 go
 
-select extname, extowner, extversion from pg_extension where extname = 'pg_stat_statements'
+select extname, extversion from pg_extension where extname = 'pg_stat_statements'
 go
 
 -- throw an error if user tries to alter schema
@@ -216,7 +185,7 @@ drop table proc_tmp
 go
 
 -- cannot drop extension if other objects depend on it
-create view pg_view as select query, queryid from [public].pg_stat_statements;
+create view pg_view as select query from [public].pg_stat_statements;
 go
 
 exec sp_execute_postgresql 'drop extension pg_stat_statements'
@@ -238,7 +207,7 @@ exec sp_execute_postgresql 'create extension pg_stat_statements'
 go
 
 -- Restrict option prevents the specified extensions from being dropped if other objects depend on table_schema
-create view pg_view as select query, queryid from [public].pg_stat_statements;
+create view pg_view as select query from [public].pg_stat_statements;
 go
 exec sp_execute_postgresql 'drop extension pg_stat_statements restrict'
 go


### PR DESCRIPTION
### Description

Moved superuser checks to a different test file Test-sp_execute_postgresql-susercheck. Set pg_stat_statements.track and compute_query_id GUCs beforehand. Removed Oid from the output to make it deterministic.

Task: BABEL-1361, BABEL-3686
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved

Task: BABEL-1361, BABEL-3686

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).