### PR TITLE
Update dotnet tests to use .NET 7.0

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -53,9 +53,9 @@ jobs:
           sudo dpkg -i packages-microsoft-prod.deb
           rm packages-microsoft-prod.deb
           sudo apt-get install -y apt-transport-https
-          sudo apt-get install -y dotnet-sdk-5.0
+          sudo apt-get install -y dotnet-sdk-7.0
           sudo apt-get install -y apt-transport-https
-          sudo apt-get install -y aspnetcore-runtime-5.0
+          sudo apt-get install -y aspnetcore-runtime-7.0
 
       - name: Run Dotnet Tests
         if: always() && steps.install-dotnet.outcome == 'success'

--- a/test/dotnet/dotnet.csproj
+++ b/test/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Starting 3rd July 2023, all the pre-cached .NET 3.1 versions will be removed from all operating systems. To fix this, we have updated the dotnet sdk version and TFM to use .NET 7.0.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).