### PR TITLE
Fix backward scan flag for parallel queries

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -59,7 +59,7 @@ runs:
         elif [[ ${{inputs.engine_branch}} != *"__PG_13_"* ]]; then
           cd ../..
           rm -rf pg_hint_plan
-          git clone --depth 1 --branch PG15 https://github.com/ossc-db/pg_hint_plan.git
+          git clone --depth 1 --branch REL15_1_5_0 https://github.com/ossc-db/pg_hint_plan.git
           cd pg_hint_plan
           export PATH=$HOME/${{ inputs.install_dir }}/bin:$PATH
           make

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -21,10 +21,69 @@ text
 ~~END~~
 
 
+-- show explicitly this is a parallel query plan
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
 GO
 ~~START~~
 int#!#int
+~~END~~
+
+~~START~~
+text
+Query Text: select a, count(*) from t_babel4261 group by a order by 2
+Sort  (cost=38.27..38.77 rows=200 width=8) (actual rows=0 loops=1)
+  Sort Key: (count(*)) NULLS FIRST
+  Sort Method: quicksort  Memory: 25kB
+  ->  Finalize HashAggregate  (cost=28.13..30.63 rows=200 width=8) (actual rows=0 loops=1)
+        Group Key: a
+        Batches: 1  Memory Usage: 40kB
+        ->  Gather  (cost=24.13..26.13 rows=400 width=12) (actual rows=0 loops=1)
+              Workers Planned: 2
+              Workers Launched: 2
+              ->  Partial HashAggregate  (cost=24.13..26.13 rows=200 width=12) (actual rows=0 loops=3)
+                    Group Key: a
+                    Batches: 1  Memory Usage: 40kB
+                    Worker 0:  Batches: 1  Memory Usage: 40kB
+                    Worker 1:  Batches: 1  Memory Usage: 40kB
+                    ->  Parallel Seq Scan on t_babel4261  (cost=0.00..19.42 rows=942 width=4) (actual rows=0 loops=3)
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -32,4 +32,3 @@ int#!#int
 DROP TABLE t_babel4261;
 GO
 
-

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -1,0 +1,35 @@
+CREATE TABLE t_babel4261 (a int, b int);
+GO
+
+select set_config('parallel_setup_cost', 0, false);
+select set_config('parallel_tuple_cost', 0, false);
+select set_config('min_parallel_table_scan_size', 0, false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+
+-- execution
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+DROP TABLE t_babel4261;
+GO
+
+

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -1,9 +1,13 @@
+BEGIN TRAN BABEL4261_T1; 
+GO
+
 CREATE TABLE t_babel4261 (a int, b int);
 GO
 
-select set_config('parallel_setup_cost', 0, false);
-select set_config('parallel_tuple_cost', 0, false);
-select set_config('min_parallel_table_scan_size', 0, false);
+-- The third parameter is true to set config back to default after transaction is committed
+select set_config('parallel_setup_cost', 0, true);
+select set_config('parallel_tuple_cost', 0, true);
+select set_config('min_parallel_table_scan_size', 0, true);
 GO
 ~~START~~
 text
@@ -19,6 +23,7 @@ text
 text
 0
 ~~END~~
+
 
 
 -- show explicitly this is a parallel query plan
@@ -68,6 +73,8 @@ Sort  (cost=38.27..38.77 rows=200 width=8) (actual rows=0 loops=1)
 ~~END~~
 
 
+
+-- set configurations back
 SET BABELFISH_STATISTICS PROFILE OFF
 GO
 
@@ -85,6 +92,11 @@ GO
 text
 on
 ~~END~~
+
+
+-- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
+COMMIT TRAN BABEL4261_T1;
+GO
 
 
 DROP TABLE t_babel4261;

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -21,7 +21,6 @@ text
 ~~END~~
 
 
--- execution
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
 GO
 ~~START~~

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -6,7 +6,6 @@ select set_config('parallel_tuple_cost', 0, false);
 select set_config('min_parallel_table_scan_size', 0, false);
 GO
 
--- execution
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
 GO
 

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -6,7 +6,26 @@ select set_config('parallel_tuple_cost', 0, false);
 select set_config('min_parallel_table_scan_size', 0, false);
 GO
 
+-- show explicitly this is a parallel query plan
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
 GO
 
 DROP TABLE t_babel4261;

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -13,5 +13,3 @@ GO
 DROP TABLE t_babel4261;
 GO
 
-
--- quip doc : https://quip-amazon.com/MQ3PAadoDe2n/Full-text-search-parallel-query-backward-scan-issue

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -1,10 +1,15 @@
+BEGIN TRAN BABEL4261_T1; 
+GO
+
 CREATE TABLE t_babel4261 (a int, b int);
 GO
 
-select set_config('parallel_setup_cost', 0, false);
-select set_config('parallel_tuple_cost', 0, false);
-select set_config('min_parallel_table_scan_size', 0, false);
+-- The third parameter is true to set config back to default after transaction is committed
+select set_config('parallel_setup_cost', 0, true);
+select set_config('parallel_tuple_cost', 0, true);
+select set_config('min_parallel_table_scan_size', 0, true);
 GO
+
 
 -- show explicitly this is a parallel query plan
 select set_config('babelfishpg_tsql.explain_timing', 'off', false);
@@ -19,6 +24,8 @@ GO
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
 GO
 
+
+-- set configurations back
 SET BABELFISH_STATISTICS PROFILE OFF
 GO
 
@@ -27,6 +34,11 @@ GO
 
 select set_config('babelfishpg_tsql.explain_summary', 'on', false);
 GO
+
+-- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
+COMMIT TRAN BABEL4261_T1;
+GO
+
 
 DROP TABLE t_babel4261;
 GO

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -1,0 +1,17 @@
+CREATE TABLE t_babel4261 (a int, b int);
+GO
+
+select set_config('parallel_setup_cost', 0, false);
+select set_config('parallel_tuple_cost', 0, false);
+select set_config('min_parallel_table_scan_size', 0, false);
+GO
+
+-- execution
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+
+DROP TABLE t_babel4261;
+GO
+
+
+-- quip doc : https://quip-amazon.com/MQ3PAadoDe2n/Full-text-search-parallel-query-backward-scan-issue


### PR DESCRIPTION
### Description

Currently there is a bug in Babelfish that allows the backward scan flag to be set for parallel queries. However, backward scans cannot be parallelized. This bug results in assertion failures in the Postgres engine and leads Babelfish queries to crash.

### Issues Resolved

In this commit, we fix the issue by disallowing backward scan flag to be set when a query is in parallel mode. This issue occurs during the implementation of full text search in Babelfish. Fixing the issue unblocks full text search implementation.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).