### PR TITLE
Fix hyperlink to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ extensions that comprise Babelfish. Note that these extensions depend on
 patches to community PostgreSQL. A repository of those modifications can be
 found [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish).
 
-Build instructions can be found [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_1_X_DEV/contrib/README.md).
+Build instructions can be found [here](contrib/README.md).
  
 More information about Babelfish can be found at [babelfishpg.org](https://babelfishpg.org).
 


### PR DESCRIPTION
Previously, the hyperlink for build instructions was pointing to the build instructions in BABEL_1_X_DEV branch. This commit changes the hyperlink to point to the build instructions of the checked out branch.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).