### PR TITLE
OPENQUERY for Linked Servers does not work when used from user created database

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -18,6 +18,7 @@
 #include "commands/prepare.h"
 #include "common/string.h"
 #include "executor/spi.h"
+#include "foreign/foreign.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "hooks.h"
@@ -2292,11 +2293,12 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	 * We prepare the following query to create a user mapping. This will
 	 * be executed using ProcessUtility():
 	 *
-	 * CREATE USER MAPPING FOR CURRENT_USER SERVER <servername> OPTIONS (username
-	 * 	'<remote server user name>', password '<remote server user password>')
+	 * CREATE USER MAPPING FOR PUBLIC SERVER <servername> OPTIONS
+	 * (username '<remote server user name>', password '<remote server user
+	 * password>')
 	 *
 	 */
-	appendStringInfo(&query, "CREATE USER MAPPING FOR CURRENT_USER SERVER \"%s\" ", servername);
+	appendStringInfo(&query, "CREATE USER MAPPING FOR PUBLIC SERVER \"%s\" ", servername);
 
 	/*
 	 * Add the relevant options
@@ -2362,20 +2364,37 @@ sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 
 	if (locallogin != NULL)
 		ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("Only @locallogin = NULL is supported. Configuring remote server access specific to local login is not yet supported")));
-	
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("Only @locallogin = NULL is supported. Configuring remote server access specific to local login is not yet supported")));
+
+	remove_trailing_spaces(servername);
+
+	/* Check if servername is valid */
+	get_foreign_server_oid(servername, false);
+
 	initStringInfo(&query);
 
 	/*
-	 * We prepare the following query to drop a linked server login. This will
+	 * We prepare the following queries to drop a linked server login. This will
 	 * be executed using ProcessUtility():
 	 *
-	 * DROP USER MAPPING FOR CURRENT_USER SERVER @SERVERNAME
-	 *
+	 * DROP USER MAPPING IF EXISTS FOR CURRENT_USER SERVER @SERVERNAME
+	 * DROP USER MAPPING IF EXISTS FOR PUBLIC SERVER @SERVERNAME
+	 * 
+	 * Linked logins were first implemented as PG USER MAPPINGs for the CURRENT_USER which
+	 * was not entirely correct because T-SQL linked logins are not user or login specific.
+	 * To address this we now create user mapping for the PG PUBLIC role internally.
+	 * 
+	 * To ensure sp_droplinkedsrvlogin works in accordance with both the older and newer
+	 * implementation of linked logins, we try to drop USER MAPPINGs for both the CURRENT_USER
+	 * and PUBLIC PG roles.
 	 */
-	appendStringInfo(&query, "DROP USER MAPPING FOR CURRENT_USER SERVER \"%s\"", servername);
+	appendStringInfo(&query, "DROP USER MAPPING IF EXISTS FOR CURRENT_USER SERVER \"%s\"", servername);
+	exec_utility_cmd_helper(query.data);
 
+	resetStringInfo(&query);
+
+	appendStringInfo(&query, "DROP USER MAPPING IF EXISTS FOR PUBLIC SERVER \"%s\"", servername);
 	exec_utility_cmd_helper(query.data);
 
 	if(locallogin)

--- a/test/JDBC/expected/linked_servers-vu-cleanup.out
+++ b/test/JDBC/expected/linked_servers-vu-cleanup.out
@@ -17,7 +17,7 @@ GO
 DO
 $$
 BEGIN
-IF NOT EXISTS (SELECT * FROM pg_user_mappings WHERE srvname = 'bbf_server') THEN
+IF NOT EXISTS (SELECT * FROM pg_user_mappings WHERE srvname = 'bbf_server' OR srvname = 'server_4229') THEN
         SET client_min_messages = 'error';
         DROP EXTENSION tds_fdw CASCADE;
 END IF;

--- a/test/JDBC/expected/linked_servers-vu-prepare.out
+++ b/test/JDBC/expected/linked_servers-vu-prepare.out
@@ -105,14 +105,6 @@ GO
 EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server2', @useself = 'FALSE', @rmtuser = 'only_user_no_password'
 GO
 
---Try to add a linked server login with same server name but different case (should throw an error)
-EXEC sp_addlinkedsrvlogin @rmtsrvname = 'MSSQL_server2', @useself = 'FALSE', @rmtuser = 'only_user_no_password'
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: user mapping for "master_dbo" already exists for server "mssql_server2")~~
-
-
 -- Create a linked server login with no @rmtuser (Won't throw error at creation time but will most likely fail remote login attempt)
 EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server3', @useself = 'FALSE', @rmtpassword = 'only_password_no_user'
 GO
@@ -125,19 +117,19 @@ GO
 CREATE FUNCTION sys_linked_servers_vu_prepare__sys_servers_func()
 RETURNS TABLE
 AS
-RETURN (SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name <> 'bbf_server' ORDER BY name);
+RETURN (SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY name);
 GO
 
 -- Create a view dependent on sys.servers view
 CREATE VIEW sys_linked_servers_vu_prepare__sys_servers_view
 AS
-SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name <> 'bbf_server' ORDER BY name
+SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY name
 GO
 
 -- Create a view dependent on sys.linked_logins view
 CREATE VIEW sys_linked_servers_vu_prepare__sys_linked_logins_view
 AS
-SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE name <> 'bbf_server' ORDER BY linked_srv_name
+SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY linked_srv_name
 GO
 
 -- tsql    user=linked_server_login_861    password=password_861

--- a/test/JDBC/expected/linked_servers-vu-verify.out
+++ b/test/JDBC/expected/linked_servers-vu-verify.out
@@ -1,5 +1,5 @@
 -- Check if the linked server added is reflected in the system view
-SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name <> 'bbf_server' ORDER BY name
+SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY name
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#nvarchar#!#nvarchar#!#varchar#!#bit
@@ -35,7 +35,7 @@ mssql_server3#!##!#tds_fdw#!#mssql_server2\ABC#!#<NULL>#!#master#!#1
 ~~END~~
 
 
-SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE s.name <> 'bbf_server' ORDER BY linked_srv_name
+SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE s.name NOT LIKE 'bbf_server%' AND s.name NOT LIKE 'server_4229%' ORDER BY linked_srv_name
 GO
 ~~START~~
 varchar#!#varchar
@@ -59,7 +59,7 @@ mssql_server3#!#<NULL>
 SET NOCOUNT ON
 DECLARE @sp_helplinkedsrvlogin_var table(a sysname, b sysname NULL, c smallint, d sysname NULL)
 INSERT INTO @sp_helplinkedsrvlogin_var EXEC sp_helplinkedsrvlogin
-SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a NOT LIKE 'bbf_server%' AND a NOT LIKE 'server_4229%' ORDER BY a
 SET NOCOUNT OFF
 GO
 ~~START~~
@@ -115,7 +115,7 @@ GO
 SET NOCOUNT ON
 DECLARE @sp_linkedservers_var table(a sysname, b nvarchar(128), c nvarchar(128), d nvarchar(4000), e nvarchar(4000), f nvarchar(4000), g sysname NULL)
 INSERT INTO @sp_linkedservers_var EXEC sp_linkedservers
-SELECT * FROM @sp_linkedservers_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_linkedservers_var WHERE a NOT LIKE 'bbf_server%' AND a NOT LIKE 'server_4229%' ORDER BY a
 SET NOCOUNT OFF
 GO
 ~~START~~
@@ -156,7 +156,16 @@ GO
 EXEC sp_droplinkedsrvlogin @rmtsrvname = "MSSQL_server2", @locallogin = NULL
 GO
 
-EXEC sp_droplinkedsrvlogin @rmtsrvname = "mssql_server3", @locallogin = NULL
+-- leading spaces are not ignored (should throw error)
+EXEC sp_droplinkedsrvlogin @rmtsrvname = "   mssql_server3", @locallogin = NULL
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "   mssql_server3" does not exist)~~
+
+
+-- trailing spaces are ignored
+EXEC sp_droplinkedsrvlogin @rmtsrvname = "mssql_server3    ", @locallogin = NULL
 GO
 
 -- Call sp_droplinkedsrvlogin from master.dbo schema

--- a/test/JDBC/expected/linked_srv_4229-vu-cleanup.out
+++ b/test/JDBC/expected/linked_srv_4229-vu-cleanup.out
@@ -1,0 +1,17 @@
+EXEC sp_dropserver 'server_4229', 'droplogins'
+GO
+
+-- psql
+-- Drop extension only if not user mapping exists for bbf_server
+-- Needed so that same test can be reused in upgrade in conjunction
+-- with tests for OPENQUERY
+DO
+$$
+BEGIN
+IF NOT EXISTS (SELECT * FROM pg_user_mappings WHERE srvname = 'bbf_server') THEN
+        SET client_min_messages = 'error';
+        DROP EXTENSION tds_fdw CASCADE;
+END IF;
+END
+$$
+GO

--- a/test/JDBC/expected/linked_srv_4229-vu-prepare.out
+++ b/test/JDBC/expected/linked_srv_4229-vu-prepare.out
@@ -1,0 +1,13 @@
+-- psql
+SET client_min_messages = 'error';
+CREATE EXTENSION IF NOT EXISTS tds_fdw;
+GO
+
+-- tsql
+-- Add localhost as linked server
+EXEC sp_addlinkedserver  @server = N'server_4229', @srvproduct=N'', @provider=N'SQLNCLI', @datasrc=N'localhost', @catalog=N'master'
+GO
+
+-- Add jdbc_user as linked server login
+EXEC sp_addlinkedsrvlogin @rmtsrvname = 'server_4229', @useself = 'FALSE', @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
+GO

--- a/test/JDBC/expected/linked_srv_4229-vu-verify.out
+++ b/test/JDBC/expected/linked_srv_4229-vu-verify.out
@@ -1,0 +1,69 @@
+-- Call OPENQUERY() / four-part-object name from a database other than master
+USE tempdb
+CREATE TABLE t_tempdb_babel_4229 (a int)
+INSERT INTO t_tempdb_babel_4229 VALUES (42290)
+SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from tempdb''')
+SELECT * FROM server_4229.tempdb.dbo.t_tempdb_babel_4229
+DROP TABLE t_tempdb_babel_4229
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Changed database context to 'tempdb'.  Server SQLState: S0001)~~
+
+~~ROW COUNT: 1~~
+
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Changed database context to 'tempdb'.  Server SQLState: S0001)~~
+
+~~START~~
+varchar
+Called from tempdb
+~~END~~
+
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Changed database context to 'tempdb'.  Server SQLState: S0001)~~
+
+~~START~~
+int
+42290
+~~END~~
+
+
+CREATE DATABASE openquery_db
+USE openquery_db
+CREATE TABLE t_openquerydb_babel_4229 (b int)
+INSERT INTO t_openquerydb_babel_4229 VALUES (42291)
+SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from openquery_db''')
+SELECT * FROM server_4229.openquery_db.dbo.t_openquerydb_babel_4229
+DROP TABLE t_openquerydb_babel_4229
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Changed database context to 'openquery_db'.  Server SQLState: S0001)~~
+
+~~ROW COUNT: 1~~
+
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Changed database context to 'openquery_db'.  Server SQLState: S0001)~~
+
+~~START~~
+varchar
+Called from openquery_db
+~~END~~
+
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Changed database context to 'openquery_db'.  Server SQLState: S0001)~~
+
+~~START~~
+int
+42291
+~~END~~
+
+
+USE master
+DROP DATABASE openquery_db
+GO

--- a/test/JDBC/expected/linked_srv_4229-vu-verify.out
+++ b/test/JDBC/expected/linked_srv_4229-vu-verify.out
@@ -3,7 +3,7 @@ USE tempdb
 CREATE TABLE t_tempdb_babel_4229 (a int)
 INSERT INTO t_tempdb_babel_4229 VALUES (42290)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from tempdb''')
-SELECT * FROM server_4229.tempdb.dbo.t_tempdb_babel_4229
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * tempdb.dbo.t_tempdb_babel_4229')
 DROP TABLE t_tempdb_babel_4229
 GO
 ~~WARNING (Code: 0)~~
@@ -36,7 +36,7 @@ USE openquery_db
 CREATE TABLE t_openquerydb_babel_4229 (b int)
 INSERT INTO t_openquerydb_babel_4229 VALUES (42291)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from openquery_db''')
-SELECT * FROM server_4229.openquery_db.dbo.t_openquerydb_babel_4229
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * openquery_db.dbo.t_openquerydb_babel_4229')
 DROP TABLE t_openquerydb_babel_4229
 GO
 ~~WARNING (Code: 0)~~

--- a/test/JDBC/expected/linked_srv_4229-vu-verify.out
+++ b/test/JDBC/expected/linked_srv_4229-vu-verify.out
@@ -3,7 +3,7 @@ USE tempdb
 CREATE TABLE t_tempdb_babel_4229 (a int)
 INSERT INTO t_tempdb_babel_4229 VALUES (42290)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from tempdb''')
-SELECT * FROM OPENQUERY(server_4229, 'SELECT * tempdb.dbo.t_tempdb_babel_4229')
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * FROM tempdb.dbo.t_tempdb_babel_4229')
 DROP TABLE t_tempdb_babel_4229
 GO
 ~~WARNING (Code: 0)~~
@@ -36,7 +36,7 @@ USE openquery_db
 CREATE TABLE t_openquerydb_babel_4229 (b int)
 INSERT INTO t_openquerydb_babel_4229 VALUES (42291)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from openquery_db''')
-SELECT * FROM OPENQUERY(server_4229, 'SELECT * openquery_db.dbo.t_openquerydb_babel_4229')
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * FROM openquery_db.dbo.t_openquerydb_babel_4229')
 DROP TABLE t_openquerydb_babel_4229
 GO
 ~~WARNING (Code: 0)~~

--- a/test/JDBC/input/linked_servers-vu-cleanup.mix
+++ b/test/JDBC/input/linked_servers-vu-cleanup.mix
@@ -17,7 +17,7 @@ GO
 DO
 $$
 BEGIN
-IF NOT EXISTS (SELECT * FROM pg_user_mappings WHERE srvname = 'bbf_server') THEN
+IF NOT EXISTS (SELECT * FROM pg_user_mappings WHERE srvname = 'bbf_server' OR srvname = 'server_4229') THEN
         SET client_min_messages = 'error';
         DROP EXTENSION tds_fdw CASCADE;
 END IF;

--- a/test/JDBC/input/linked_servers-vu-prepare.mix
+++ b/test/JDBC/input/linked_servers-vu-prepare.mix
@@ -69,10 +69,6 @@ GO
 EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server2', @useself = 'FALSE', @rmtuser = 'only_user_no_password'
 GO
 
---Try to add a linked server login with same server name but different case (should throw an error)
-EXEC sp_addlinkedsrvlogin @rmtsrvname = 'MSSQL_server2', @useself = 'FALSE', @rmtuser = 'only_user_no_password'
-GO
-
 -- Create a linked server login with no @rmtuser (Won't throw error at creation time but will most likely fail remote login attempt)
 EXEC sp_addlinkedsrvlogin @rmtsrvname = 'mssql_server3', @useself = 'FALSE', @rmtpassword = 'only_password_no_user'
 GO
@@ -85,19 +81,19 @@ GO
 CREATE FUNCTION sys_linked_servers_vu_prepare__sys_servers_func()
 RETURNS TABLE
 AS
-RETURN (SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name <> 'bbf_server' ORDER BY name);
+RETURN (SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY name);
 GO
 
 -- Create a view dependent on sys.servers view
 CREATE VIEW sys_linked_servers_vu_prepare__sys_servers_view
 AS
-SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name <> 'bbf_server' ORDER BY name
+SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY name
 GO
 
 -- Create a view dependent on sys.linked_logins view
 CREATE VIEW sys_linked_servers_vu_prepare__sys_linked_logins_view
 AS
-SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE name <> 'bbf_server' ORDER BY linked_srv_name
+SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY linked_srv_name
 GO
 
 -- tsql    user=linked_server_login_861    password=password_861

--- a/test/JDBC/input/linked_servers-vu-verify.sql
+++ b/test/JDBC/input/linked_servers-vu-verify.sql
@@ -1,5 +1,5 @@
 -- Check if the linked server added is reflected in the system view
-SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name <> 'bbf_server' ORDER BY name
+SELECT name, product, provider, data_source, provider_string, catalog, is_linked FROM sys.servers WHERE name NOT LIKE 'bbf_server%' AND name NOT LIKE 'server_4229%' ORDER BY name
 GO
 
 SELECT * FROM sys_linked_servers_vu_prepare__sys_servers_func()
@@ -8,7 +8,7 @@ GO
 SELECT * FROM sys_linked_servers_vu_prepare__sys_servers_view
 GO
 
-SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE s.name <> 'bbf_server' ORDER BY linked_srv_name
+SELECT s.name as linked_srv_name, l.remote_name as username FROM sys.servers as s INNER JOIN sys.linked_logins as l on s.server_id = l.server_id WHERE s.name NOT LIKE 'bbf_server%' AND s.name NOT LIKE 'server_4229%' ORDER BY linked_srv_name
 GO
 
 SELECT * FROM sys_linked_servers_vu_prepare__sys_linked_logins_view
@@ -18,7 +18,7 @@ GO
 SET NOCOUNT ON
 DECLARE @sp_helplinkedsrvlogin_var table(a sysname, b sysname NULL, c smallint, d sysname NULL)
 INSERT INTO @sp_helplinkedsrvlogin_var EXEC sp_helplinkedsrvlogin
-SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_helplinkedsrvlogin_var WHERE a NOT LIKE 'bbf_server%' AND a NOT LIKE 'server_4229%' ORDER BY a
 SET NOCOUNT OFF
 GO
 
@@ -45,7 +45,7 @@ GO
 SET NOCOUNT ON
 DECLARE @sp_linkedservers_var table(a sysname, b nvarchar(128), c nvarchar(128), d nvarchar(4000), e nvarchar(4000), f nvarchar(4000), g sysname NULL)
 INSERT INTO @sp_linkedservers_var EXEC sp_linkedservers
-SELECT * FROM @sp_linkedservers_var WHERE a <> 'bbf_server'
+SELECT * FROM @sp_linkedservers_var WHERE a NOT LIKE 'bbf_server%' AND a NOT LIKE 'server_4229%' ORDER BY a
 SET NOCOUNT OFF
 GO
 
@@ -65,7 +65,12 @@ GO
 EXEC sp_droplinkedsrvlogin @rmtsrvname = "MSSQL_server2", @locallogin = NULL
 GO
 
-EXEC sp_droplinkedsrvlogin @rmtsrvname = "mssql_server3", @locallogin = NULL
+-- leading spaces are not ignored (should throw error)
+EXEC sp_droplinkedsrvlogin @rmtsrvname = "   mssql_server3", @locallogin = NULL
+GO
+
+-- trailing spaces are ignored
+EXEC sp_droplinkedsrvlogin @rmtsrvname = "mssql_server3    ", @locallogin = NULL
 GO
 
 -- Call sp_droplinkedsrvlogin from master.dbo schema

--- a/test/JDBC/input/linked_srv_4229-vu-cleanup.mix
+++ b/test/JDBC/input/linked_srv_4229-vu-cleanup.mix
@@ -1,0 +1,17 @@
+EXEC sp_dropserver 'server_4229', 'droplogins'
+GO
+
+-- psql
+-- Drop extension only if not user mapping exists for bbf_server
+-- Needed so that same test can be reused in upgrade in conjunction
+-- with tests for OPENQUERY
+DO
+$$
+BEGIN
+IF NOT EXISTS (SELECT * FROM pg_user_mappings WHERE srvname = 'bbf_server') THEN
+        SET client_min_messages = 'error';
+        DROP EXTENSION tds_fdw CASCADE;
+END IF;
+END
+$$
+GO

--- a/test/JDBC/input/linked_srv_4229-vu-prepare.mix
+++ b/test/JDBC/input/linked_srv_4229-vu-prepare.mix
@@ -1,0 +1,13 @@
+-- psql
+SET client_min_messages = 'error';
+CREATE EXTENSION IF NOT EXISTS tds_fdw;
+GO
+
+-- tsql
+-- Add localhost as linked server
+EXEC sp_addlinkedserver  @server = N'server_4229', @srvproduct=N'', @provider=N'SQLNCLI', @datasrc=N'localhost', @catalog=N'master'
+GO
+
+-- Add jdbc_user as linked server login
+EXEC sp_addlinkedsrvlogin @rmtsrvname = 'server_4229', @useself = 'FALSE', @rmtuser = 'jdbc_user', @rmtpassword = '12345678'
+GO

--- a/test/JDBC/input/linked_srv_4229-vu-verify.sql
+++ b/test/JDBC/input/linked_srv_4229-vu-verify.sql
@@ -1,0 +1,21 @@
+-- Call OPENQUERY() / four-part-object name from a database other than master
+USE tempdb
+CREATE TABLE t_tempdb_babel_4229 (a int)
+INSERT INTO t_tempdb_babel_4229 VALUES (42290)
+SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from tempdb''')
+SELECT * FROM server_4229.tempdb.dbo.t_tempdb_babel_4229
+DROP TABLE t_tempdb_babel_4229
+GO
+
+CREATE DATABASE openquery_db
+USE openquery_db
+CREATE TABLE t_openquerydb_babel_4229 (b int)
+INSERT INTO t_openquerydb_babel_4229 VALUES (42291)
+SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from openquery_db''')
+SELECT * FROM server_4229.openquery_db.dbo.t_openquerydb_babel_4229
+DROP TABLE t_openquerydb_babel_4229
+GO
+
+USE master
+DROP DATABASE openquery_db
+GO

--- a/test/JDBC/input/linked_srv_4229-vu-verify.sql
+++ b/test/JDBC/input/linked_srv_4229-vu-verify.sql
@@ -3,7 +3,7 @@ USE tempdb
 CREATE TABLE t_tempdb_babel_4229 (a int)
 INSERT INTO t_tempdb_babel_4229 VALUES (42290)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from tempdb''')
-SELECT * FROM server_4229.tempdb.dbo.t_tempdb_babel_4229
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * tempdb.dbo.t_tempdb_babel_4229')
 DROP TABLE t_tempdb_babel_4229
 GO
 
@@ -12,7 +12,7 @@ USE openquery_db
 CREATE TABLE t_openquerydb_babel_4229 (b int)
 INSERT INTO t_openquerydb_babel_4229 VALUES (42291)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from openquery_db''')
-SELECT * FROM server_4229.openquery_db.dbo.t_openquerydb_babel_4229
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * openquery_db.dbo.t_openquerydb_babel_4229')
 DROP TABLE t_openquerydb_babel_4229
 GO
 

--- a/test/JDBC/input/linked_srv_4229-vu-verify.sql
+++ b/test/JDBC/input/linked_srv_4229-vu-verify.sql
@@ -3,7 +3,7 @@ USE tempdb
 CREATE TABLE t_tempdb_babel_4229 (a int)
 INSERT INTO t_tempdb_babel_4229 VALUES (42290)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from tempdb''')
-SELECT * FROM OPENQUERY(server_4229, 'SELECT * tempdb.dbo.t_tempdb_babel_4229')
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * FROM tempdb.dbo.t_tempdb_babel_4229')
 DROP TABLE t_tempdb_babel_4229
 GO
 
@@ -12,7 +12,7 @@ USE openquery_db
 CREATE TABLE t_openquerydb_babel_4229 (b int)
 INSERT INTO t_openquerydb_babel_4229 VALUES (42291)
 SELECT * FROM OPENQUERY(server_4229, 'SELECT ''Called from openquery_db''')
-SELECT * FROM OPENQUERY(server_4229, 'SELECT * openquery_db.dbo.t_openquerydb_babel_4229')
+SELECT * FROM OPENQUERY(server_4229, 'SELECT * FROM openquery_db.dbo.t_openquerydb_babel_4229')
 DROP TABLE t_openquerydb_babel_4229
 GO
 

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -412,3 +412,4 @@ binary-index
 test_windows_sp_helpuser
 BABEL-4098
 BABEL-3818
+linked_srv_4229


### PR DESCRIPTION
### Description

Previously the user mapping that got created as part of
sp_addlinkedsrvlogin was only working in master database. In T-SQL the
linked login is not specific to login unlike the user mappings in PG. To
fix this we create the user mapping for the public role so that the
linked login is not specific to any single role.

Task: BABEL-4229

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).