### PR TITLE
Fix UNION ORDER BY issue with multiple joins

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -161,10 +161,8 @@ static core_yylex_hook_type prev_core_yylex_hook = NULL;
 static pre_transform_returning_hook_type prev_pre_transform_returning_hook = NULL;
 static pre_transform_insert_hook_type prev_pre_transform_insert_hook = NULL;
 static post_transform_insert_row_hook_type prev_post_transform_insert_row_hook = NULL;
-static push_namespace_stack_hook_type prev_push_namespace_stack_hook = NULL;
-static pre_transform_sort_clause_hook_type prev_pre_transform_sort_clause_hook = NULL;
+static pre_transform_setop_tree_hook_type prev_pre_transform_setop_tree_hook = NULL;
 static post_transform_sort_clause_hook_type prev_post_transform_sort_clause_hook = NULL;
-static post_transform_from_clause_hook_type  prev_post_transform_from_clause_hook = NULL;
 static pre_transform_target_entry_hook_type prev_pre_transform_target_entry_hook = NULL;
 static tle_name_comparison_hook_type prev_tle_name_comparison_hook = NULL;
 static get_trigger_object_address_hook_type prev_get_trigger_object_address_hook = NULL;
@@ -224,14 +222,10 @@ InstallExtendedHooks(void)
 	prev_post_transform_insert_row_hook = post_transform_insert_row_hook;
 	post_transform_insert_row_hook = check_insert_row;
 
-	prev_push_namespace_stack_hook = push_namespace_stack_hook;
-	push_namespace_stack_hook = push_namespace_stack;
-	prev_pre_transform_sort_clause_hook = pre_transform_sort_clause_hook;
-	pre_transform_sort_clause_hook = pre_transform_sort_clause;
+	prev_pre_transform_setop_tree_hook = pre_transform_setop_tree_hook;
+	pre_transform_setop_tree_hook = pre_transform_setop_tree;
 	prev_post_transform_sort_clause_hook = post_transform_sort_clause_hook;
 	post_transform_sort_clause_hook = post_transform_sort_clause;
-	prev_post_transform_from_clause_hook = post_transform_from_clause_hook;
-	post_transform_from_clause_hook = post_transform_from_clause;
 
 	post_transform_column_definition_hook = pltsql_post_transform_column_definition;
 
@@ -345,10 +339,8 @@ UninstallExtendedHooks(void)
 	pre_transform_returning_hook = prev_pre_transform_returning_hook;
 	pre_transform_insert_hook = prev_pre_transform_insert_hook;
 	post_transform_insert_row_hook = prev_post_transform_insert_row_hook;
-	push_namespace_stack_hook = prev_push_namespace_stack_hook;
-	pre_transform_sort_clause_hook = prev_pre_transform_sort_clause_hook;
+	pre_transform_setop_tree_hook = prev_pre_transform_setop_tree_hook;
 	post_transform_sort_clause_hook = prev_post_transform_sort_clause_hook;
-	post_transform_from_clause_hook = prev_post_transform_from_clause_hook;
 	post_transform_column_definition_hook = NULL;
 	post_transform_table_definition_hook = NULL;
 	pre_transform_target_entry_hook = prev_pre_transform_target_entry_hook;

--- a/contrib/babelfishpg_tsql/src/tsql_analyze.c
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.c
@@ -23,9 +23,6 @@
 
 static RangeVar *find_matching_table(RangeVar *target, Node *tblref);
 
-List *sv_setop_exprs = NIL;
-namespace_stack_t *set_op_ns_stack = NULL;
-
 /*
  * If a table alias is used when specifying the target table, we need to refer to the
  * FROM clause for table reference.
@@ -295,89 +292,45 @@ rewrite_update_outer_join(Node *stmt, CmdType command, RangeVar *target)
 }
 
 /* 
- * Allocate an empty space to hold a parsing namespace
- * This space will be filled by post_transform_from_clause, to save the
- * leftmost select's namespace for processing UNION statements. This is needed 
- * to resolve table aliases in the top-level of a UNION and other set ops.
+ * Prior to analysis of the setop (i.e. UNION) tree, move the ORDER BY clause
+ * down to the leftmost SELECT statement. This is to account for T-SQL behavior,
+ * where UNION ORDER BY names are resolved according to the leftmost select.
  */
 void
-push_namespace_stack(void)
+pre_transform_setop_tree(SelectStmt *stmt, SelectStmt *leftmostSelect)
 {
-	namespace_stack_t *ns_stack_item;
-
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
 
-	ns_stack_item = palloc(sizeof(namespace_stack_t));
-	ns_stack_item->prev = set_op_ns_stack;
-	ns_stack_item->namespace = NIL;
-	set_op_ns_stack = ns_stack_item;
+	leftmostSelect->sortClause = stmt->sortClause;
+	stmt->sortClause = NIL;
 }
 
 /* 
- * After tranforming a from clause, if we've allocated space on the stack in
- * push_namespace_stack, save the namespace here for use in
- * pre_transform_sort_clause.
+ * After the sort clause has been analyzed in the leftmost select, update the 
+ * top-level TLEs to contain a ref to the sortlist and restore the sortClause.
+ * 
+ * We can trust that the ordering of TLEs matches as PG uses the leftmost 
+ * target list as a basis for builiding the top-level target list, it just 
+ * doesn't fill in the ressortgroupref field. 
  */
 void 
-post_transform_from_clause(ParseState *pstate)
+post_transform_sort_clause(Query *qry, Query *leftmostQuery)
 {
-	namespace_stack_t *ns = set_op_ns_stack;
-	if (sql_dialect == SQL_DIALECT_TSQL && ns && ns->namespace == NIL)
-		ns->namespace = pstate->p_namespace;
-}
-
-/* 
- * Prior to handling a UNION or othe SetOp's ORDER BY clause, this hook:
- * 1. Modifies the query's top-level target list, so that we can match columns
- * 		with those in the sort clause
- * 2. Pop from the namespace stack and restore the leftmost select's namespace
- * 		for table alias resolution. The caller is expected to save and restore
- * 		the original top-level parse state
- */
-void
-pre_transform_sort_clause(ParseState *pstate, Query *qry, Query *leftmostQuery)
-{
-	namespace_stack_t *old_ns_stack_item = set_op_ns_stack;
-	ListCell *lc, *lc_l;
+	ListCell *lc, *left_tlist;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
 
-	sv_setop_exprs = NIL;
-	forboth(lc, qry->targetList, lc_l, leftmostQuery->targetList)
+	forboth(lc, qry->targetList, left_tlist, leftmostQuery->targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(lc);
-		TargetEntry *lefttle = (TargetEntry *) lfirst(lc_l);
+		TargetEntry *lefttle = (TargetEntry *) lfirst(left_tlist);
 
 		Assert(!lefttle->resjunk);
-		sv_setop_exprs = lappend(sv_setop_exprs, tle->expr);
-		if (IsA(lefttle->expr, Var))
-			tle->expr = (Expr*) lefttle->expr;
+		tle->ressortgroupref = lefttle->ressortgroupref;
 	}
 
-	pstate->p_namespace = set_op_ns_stack->namespace;
-
-	set_op_ns_stack = set_op_ns_stack->prev;
-	pfree(old_ns_stack_item);
-}
-
-/* 
- * Reset the targetList back to it's original vars
- * This is necessary in some cases, like UNION ALL and when the targetlist
- * includes items from a joined table
- */
-void 
-post_transform_sort_clause(Query *qry)
-{
-	ListCell *lc_q, *lc_sv;
-	if (sql_dialect != SQL_DIALECT_TSQL || sv_setop_exprs == NIL)
-		return;
-	forboth(lc_q, qry->targetList, lc_sv, sv_setop_exprs)
-	{
-		TargetEntry *tle_q = (TargetEntry *) lfirst(lc_q);
-		Expr 		*expr_sv = (Expr *) lfirst(lc_sv);
-		tle_q->expr = expr_sv;
-	}
-	sv_setop_exprs = NIL;
+	qry->sortClause = leftmostQuery->sortClause;
+	leftmostQuery->sortClause = NIL;
 }

--- a/contrib/babelfishpg_tsql/src/tsql_analyze.h
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.h
@@ -13,14 +13,7 @@ extern RangeVar *pltsql_get_target_table(RangeVar *orig_target, List *fromClause
 extern void pltsql_update_query_result_relation(Query *qry, Relation target_rel, List *rtable);
 extern void handle_rowversion_target_in_update_stmt(RangeVar *target_table, UpdateStmt *stmt);
 extern void rewrite_update_outer_join(Node *stmt, CmdType command, RangeVar *target);
-extern void push_namespace_stack(void);
-extern void pre_transform_sort_clause(ParseState *pstate, Query *qry, Query *leftmostQuery);
-extern void post_transform_sort_clause(Query *qry);
-extern void post_transform_from_clause(ParseState *pstate);
-
-typedef struct namespace_stack {
-	struct namespace_stack *prev;
-	List *namespace;
-} namespace_stack_t;
+extern void pre_transform_setop_tree(SelectStmt *stmt, SelectStmt *leftmostSelect);
+extern void post_transform_sort_clause(Query *qry, Query *leftmostQuery);
 
 #endif							/* TSQL_ANALYZE_H */

--- a/test/JDBC/expected/BABEL-3215-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3215-vu-verify.out
@@ -82,6 +82,20 @@ int
 
 
 SELECT u.c1 FROM unionorder1 u
+UNION
+SELECT c2 FROM unionorder2
+ORDER BY c1;
+go
+~~START~~
+int
+1
+2
+3
+4
+~~END~~
+
+
+SELECT u.c1 FROM unionorder1 u
 UNION ALL
 SELECT u.c1 FROM unionorder1 u
 ORDER BY u.c1;
@@ -109,6 +123,26 @@ int
 3
 4
 ~~END~~
+
+
+SELECT c1 FROM unionorder1 u
+UNION
+SELECT c2 FROM unionorder2
+ORDER BY unionorder1.c1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "unionorder1")~~
+
+
+SELECT u.c1 FROM dbo.unionorder1 u
+UNION
+SELECT c2 FROM dbo.unionorder2
+ORDER BY dbo.unionorder1.c1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "unionorder1")~~
 
 
 SELECT c1 FROM master.dbo.unionorder1
@@ -145,6 +179,27 @@ int
 2
 3
 ~~END~~
+
+
+SELECT u.* FROM unionorder1 u
+UNION
+SELECT u.*  FROM unionorder1 u
+ORDER BY unionorder1.c1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "unionorder1")~~
+
+
+SELECT u.* FROM unionorder1 u
+ORDER BY u.a
+UNION
+SELECT u.* FROM unionorder u
+ORDER BY u.b
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "UNION")~~
 
 
 SELECT u1.c1, u2.c2 FROM unionorder1 u1, unionorder2 u2 where u1.c1 = u2.c2
@@ -225,20 +280,29 @@ int#!#int
 ~~END~~
 
 
+SELECT c1 FROM unionorder1
+ORDER BY c1
+UNION
+SELECT c2 FROM unionorder2
+ORDER BY c2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "UNION")~~
+
+
 SELECT u1.c1 FROM unionorder1 u1
 UNION 
 SELECT c2 FROM unionorder2
 WHERE c2 IN (
-    SELECT TOP 5 c2 FROM unionorder2
+    SELECT c2 FROM unionorder2
     UNION
-    SELECT TOP 5 c1 FROM unionorder1
+    SELECT c1 FROM unionorder1
     WHERE c1 IN (
-        SELECT TOP 5 c1 FROM unionorder1
+        SELECT c1 FROM unionorder1
         UNION
-        SELECT TOP 5 c2 FROM unionorder2
-        ORDER BY unionorder1.c1
+        SELECT c2 FROM unionorder2
     )
-    ORDER BY unionorder2.c2
 )
 ORDER BY u1.c1;
 go
@@ -261,13 +325,13 @@ WHERE c2 IN (
     SELECT TOP 5 c1 FROM unionorder1
     ORDER BY unionorder2.c2
 )
-ORDER BY col2;
+ORDER BY col2, u1.c1;
 go
 ~~START~~
 int#!#int
-3#!#2
 1#!#2
 2#!#2
+3#!#2
 3#!#3
 4#!#4
 ~~END~~
@@ -275,10 +339,9 @@ int#!#int
 
 SELECT c1 FROM unionorder1
 WHERE c1 IN (
-    SELECT TOP 5 c2 FROM unionorder2
+    SELECT c2 FROM unionorder2
     UNION
-    SELECT TOP 5 c1 FROM unionorder1
-    ORDER BY unionorder2.c2
+    SELECT c1 FROM unionorder1
 )
 UNION 
 SELECT c2 FROM unionorder2
@@ -295,10 +358,9 @@ int
 
 SELECT c1 FROM unionorder1
 WHERE c1 IN (
-    SELECT TOP 5 c2 FROM unionorder2
+    SELECT c2 FROM unionorder2
     UNION
-    SELECT TOP 5 c1 FROM unionorder1
-    ORDER BY unionorder2.c2
+    SELECT c1 FROM unionorder1
 )
 UNION 
 SELECT c2 FROM unionorder2
@@ -310,10 +372,9 @@ go
 
 
 SELECT c2 FROM (
-    SELECT TOP 5 c2 FROM unionorder2
+    SELECT c2 FROM unionorder2
     UNION
-    SELECT TOP 5 c1 FROM unionorder1
-    ORDER BY unionorder2.c2
+    SELECT c1 FROM unionorder1
 ) u
 UNION 
 SELECT c1 FROM unionorder1
@@ -459,34 +520,232 @@ order by c
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: invalid UNION/INTERSECT/EXCEPT ORDER BY clause)~~
+~~ERROR (Message: ORDER/GROUP BY expression not found in targetlist)~~
 
 
-create function babel4169_add_one (@x INT)
-RETURNS INT
-AS BEGIN
-    RETURN @x + 1;
-END;
-GO
+drop table dbo.babel4169_t1;
+drop table dbo.babel4169_t2;
+go
 
-select babel4169_add_one(a) as added, b from dbo.babel4169_t1
-union
-select a, b from dbo.babel4169_t2
-order by added
+-- BABEL-4210
+create table babel4210_t1(id INT, val VARCHAR(20));
+create table babel4210_t2(t1_id INT, val VARCHAR(20));
+create table babel4210_t3(t1_id INT, val VARCHAR(20));
+go
+
+insert into babel4210_t1 values (1, 'a'), (2, 'b'), (3, 'c');
+insert into babel4210_t2 values (1, 'A'), (2, 'B'), (3, 'C');
+insert into babel4210_t3 values (1, 'x'), (2, 'Y'), (3, 'z');
+go
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+
+select babel4210_t1.id,  babel4210_t2.val, babel4210_t3.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+UNION
+select babel4210_t1.id, babel4210_t2.val, babel4210_t3.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+ORDER BY babel4210_t3.val;
 go
 ~~START~~
-int#!#int
-2#!#2
-4#!#5
-11#!#2
-40#!#5
-101#!#2
-400#!#5
+int#!#varchar#!#varchar
+1#!#A#!#x
+2#!#B#!#Y
+3#!#C#!#z
 ~~END~~
 
 
-drop function babel4169_add_one;
+select babel4210_t1.id,  babel4210_t2.val, upper(babel4210_t3.val) from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+UNION
+select babel4210_t1.id, babel4210_t3.val, upper(babel4210_t2.val) from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+ORDER BY upper(babel4210_t3.val);
 go
-drop table dbo.babel4169_t1;
-drop table dbo.babel4169_t2;
+~~START~~
+int#!#varchar#!#text
+1#!#x#!#A
+2#!#Y#!#B
+3#!#z#!#C
+1#!#A#!#X
+2#!#B#!#Y
+3#!#C#!#Z
+~~END~~
+
+
+select babel4210_t1.id,  babel4210_t2.val, upper(babel4210_t3.val) from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+UNION
+select babel4210_t1.id, babel4210_t3.val, upper(babel4210_t2.val) from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+ORDER BY babel4210_t3.val;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: ORDER/GROUP BY expression not found in targetlist)~~
+
+
+select babel4210_t1.id,  babel4210_t2.val, babel4210_t3.t1_id from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+UNION
+select babel4210_t1.id, babel4210_t2.val, babel4210_t3.t1_id from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+ORDER BY babel4210_t3.val;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: ORDER/GROUP BY expression not found in targetlist)~~
+
+
+select babel4210_t3.val from babel4210_t3
+UNION
+select babel4210_t1.val from babel4210_t1
+ORDER BY (CASE WHEN babel4210_t3.val = 'b' THEN 1 ELSE 2 END)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: ORDER/GROUP BY expression not found in targetlist)~~
+
+
+select DISTINCT babel4210_t1.id, babel4210_t2.val, babel4210_t3.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+UNION
+select babel4210_t1.id, babel4210_t2.val, babel4210_t3.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+ORDER BY babel4210_t2.val;
+go
+~~START~~
+int#!#varchar#!#varchar
+1#!#A#!#x
+2#!#B#!#Y
+3#!#C#!#z
+~~END~~
+
+
+select COUNT(DISTINCT babel4210_t3.val), babel4210_t2.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+GROUP BY babel4210_t2.val, babel4210_t3.val
+UNION ALL
+select COUNT(DISTINCT babel4210_t3.val), babel4210_t2.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+GROUP BY babel4210_t2.val, babel4210_t3.val
+ORDER BY babel4210_t3.val;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: ORDER/GROUP BY expression not found in targetlist)~~
+
+
+select COUNT(DISTINCT babel4210_t3.val), babel4210_t2.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+GROUP BY babel4210_t2.val
+UNION
+select COUNT(DISTINCT babel4210_t3.val), babel4210_t2.val from babel4210_t1
+inner join babel4210_t2 on babel4210_t1.id = babel4210_t2.t1_id
+inner join babel4210_t3 on babel4210_t1.id = babel4210_t3.t1_id
+GROUP BY babel4210_t2.val
+ORDER BY COUNT(DISTINCT babel4210_t3.val), babel4210_t2.val;
+go
+~~START~~
+int#!#varchar
+1#!#A
+1#!#B
+1#!#C
+~~END~~
+
+
+select val from babel4210_t1
+UNION
+select t1_id from babel4210_t2
+ORDER BY babel4210_t1.id
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: ORDER/GROUP BY expression not found in targetlist)~~
+
+
+WITH babel4210_cte (id, val) AS
+(
+    select babel4210_t1.id, babel4210_t3.val FROM babel4210_t1
+    INNER JOIN babel4210_t3 ON babel4210_t1.id = babel4210_t3.t1_id
+    UNION
+    select babel4210_t1.id, babel4210_t1.val from babel4210_t1
+    INNER JOIN babel4210_t3 ON babel4210_t1.id = babel4210_t3.t1_id
+)
+SELECT babel4210_cte.* FROM babel4210_cte
+UNION ALL
+SELECT babel4210_cte.* FROM babel4210_cte
+ORDER BY babel4210_cte.val, babel4210_cte.id;
+GO
+~~START~~
+int#!#varchar
+1#!#a
+1#!#a
+2#!#b
+2#!#b
+3#!#c
+3#!#c
+1#!#x
+1#!#x
+2#!#Y
+2#!#Y
+3#!#z
+3#!#z
+~~END~~
+
+
+WITH babel4210_cte (id, val) AS
+(
+    select babel4210_t1.id, babel4210_t3.val FROM babel4210_t1
+    INNER JOIN babel4210_t3 ON babel4210_t1.id = babel4210_t3.t1_id
+    UNION
+    select babel4210_t1.id, babel4210_t1.val from babel4210_t1
+    INNER JOIN babel4210_t3 ON babel4210_t1.id = babel4210_t3.t1_id
+)
+SELECT babel4210_cte.* FROM babel4210_cte
+INTERSECT
+SELECT babel4210_cte.* FROM babel4210_cte
+ORDER BY babel4210_cte.val, babel4210_cte.id;
+GO
+~~START~~
+int#!#varchar
+1#!#a
+2#!#b
+3#!#c
+1#!#x
+2#!#Y
+3#!#z
+~~END~~
+
+
+select top 2 babel4210_t1.id from babel4210_t1
+union
+select top 1 babel4210_t2.t1_id from babel4210_t2
+ORDER BY babel4210_t2.t1_id DESC
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "babel4210_t2")~~
+
+
+drop table babel4210_t1;
+drop table babel4210_t2;
+drop table babel4210_t3;
 go


### PR DESCRIPTION
Fix how UNION ORDER BY is handled

Instead of saving and restoring a namespace, push the sortClause into the leftmost stmt for processing there. Removes the need for 2 hooks, and simplifies the approach.

Task: BABEL-4210

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).