### PR TITLE
Fix Memory Corruption in update_DropRoleStmt (#1434)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -670,8 +670,6 @@ update_DropRoleStmt(Node *n, const char *role)
 		if (strcmp(tmp->rolename, "is_role") == 0)
 			stmt->roles = list_delete_cell(stmt->roles, list_head(stmt->roles));
 
-		pfree(tmp);
-
 		if (!stmt->roles)
 			return;
 


### PR DESCRIPTION
### Description

Previously, sys.drop_all_logins() function call was throwing error when it encounters login or user with considerably long name due to memory corruption in update_DropRoleStmt().

To fix above issue, We removed explicit memory deallocation of first element of stmt->roles list. It is not needed because list_delete_cell already handles the memory deallocation.

Task: BABEL-4041

### Issues Resolved

Task: BABEL-4041

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).