### PR TITLE
Implementing Unit Tests for SSL

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -61,6 +61,11 @@ typedef union TDSPacketHeader {
 static int	pkt_bytes_read = 0;
 static TDSPacketHeader pkt_data = {0};
 
+static TdsSecureSocketApi tds_secure_raw_read;
+static TdsSecureSocketApiConst tds_secure_raw_write;
+static bool unit_testing;
+
+
 /*
  * SslRead - TDS secure read function, similar to my_sock_read
  */
@@ -71,7 +76,7 @@ SslRead(BIO * h, char *buf, int size)
 
 	if (buf != NULL)
 	{
-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
+		res = tds_secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
 		BIO_clear_retry_flags(h);
 		if (res <= 0)
 		{
@@ -126,7 +131,7 @@ SslHandShakeRead(BIO * h, char *buf, int size)
 		}
 
 		if (unlikely(pkt_data.header.pkt_type != TDS_PRELOGIN))
-			ereport(FATAL,
+			ereport(unit_testing ? ERROR : FATAL,
 					(errcode(ERRCODE_ADMIN_SHUTDOWN),
 					 errmsg("terminating connection due to unexpected ssl packet header")));
 
@@ -163,6 +168,30 @@ SslHandShakeRead(BIO * h, char *buf, int size)
 	return res;
 }
 
+
+ssize_t
+test_ssl_handshake_read(BIO * h, char *buf, int size, TdsSecureSocketApi mock_socket_read, int ReadPointer)
+{
+
+	/*
+	 *  Accessing SslHandShakeRead() function directly from our testing functions created in the test_ssl_read.c file is not possible due to its static nature
+	 *  This intermediary function serves as a gateway, allowing us to invoke the SslHandShakeRead() function from our testing function
+	 */
+
+	int res;
+	tds_secure_raw_read = mock_socket_read;
+	unit_testing = true;
+	pkt_bytes_read = ReadPointer;
+
+    res = SslHandShakeRead(h, buf, size);
+
+	unit_testing = false;
+
+	return res;
+}
+
+
+
 /*
  * SslWrite - Tds secure write function, similar to my_sock_write.
  */
@@ -171,7 +200,7 @@ SslWrite(BIO * h, const char *buf, int size)
 {
 	int			res = 0;
 
-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
+	res = tds_secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
 	BIO_clear_retry_flags(h);
 	if (res <= 0)
 	{
@@ -245,6 +274,29 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 	return (res - TDS_PACKET_HEADER_SIZE);
 }
 
+
+ssize_t
+test_ssl_handshake_write(BIO * h, char *buf, int size, TdsSecureSocketApiConst mock_socket_write)
+{
+
+	/*
+	 *  Accessing SslHandShakeWrite() function directly from our testing functions created in the test_ssl_write.c file is not possible due to its static nature
+	 *  This intermediary function serves as a gateway, allowing us to invoke the SslHandShakeWrite() function from our testing function
+	 */
+
+	int res;
+	tds_secure_raw_write = mock_socket_write;
+	unit_testing = true;
+
+    res = SslHandShakeWrite(h, buf, size);
+
+	unit_testing = false;
+
+	return res;
+}
+
+
+
 /*
  * TdsBioSecureSocket - Similar to my_BIO_s_socket
  * Used to setup, TDS listener read and write API
@@ -255,6 +307,9 @@ TdsBioSecureSocket(BIO_METHOD * my_bio_methods)
 {
 	/* reset the tds packet data state*/
 	pkt_bytes_read = 0;
+
+	tds_secure_raw_read = secure_raw_read;
+	tds_secure_raw_write = secure_raw_write;
 
 	if (my_bio_methods == NULL)
 	{
@@ -337,7 +392,7 @@ retry:
 	else
 #endif
 	{
-		n = secure_raw_read(port, ptr, len);
+		n = tds_secure_raw_read(port, ptr, len);
 		waitfor = WL_SOCKET_READABLE;
 	}
 
@@ -422,7 +477,7 @@ retry:
 	else
 #endif
 	{
-		n = secure_raw_write(port, ptr, len);
+		n = tds_secure_raw_write(port, ptr, len);
 		waitfor = WL_SOCKET_WRITEABLE;
 	}
 

--- a/contrib/babelfishpg_tds/src/include/tds_secure.h
+++ b/contrib/babelfishpg_tds/src/include/tds_secure.h
@@ -38,6 +38,9 @@
 #endif
 #endif
 
+typedef ssize_t (*TdsSecureSocketApi) (Port *port, void *ptr, size_t len);
+typedef ssize_t (*TdsSecureSocketApiConst) (Port *port, const void *ptr, size_t len);
+
 BIO_METHOD *TdsBioSecureSocket(BIO_METHOD * my_bio_methods);
 
 extern int	tds_ssl_min_protocol_version;
@@ -60,3 +63,7 @@ ssize_t
 
 /* function defined in tdssecure.c and called from tdslogin.c */
 void		TdsFreeSslStruct(Port *port);
+
+
+extern ssize_t test_ssl_handshake_read(BIO * h, char *buf, int size, TdsSecureSocketApi mock_socket_read, int ReadPointer);
+extern ssize_t test_ssl_handshake_write(BIO * h, char *buf, int size, TdsSecureSocketApiConst mock_socket_write);

--- a/contrib/babelfishpg_unit/Makefile
+++ b/contrib/babelfishpg_unit/Makefile
@@ -5,6 +5,7 @@ OBJS = $(SRCS:.c=.o)       # object files
 
  # source code files
 SRCS    = babelfishpg_unit.c test_money.c \
+		  test_ssl_read.c test_ssl_write.c
 
 # for posgres build
 PG_CONFIG = pg_config

--- a/contrib/babelfishpg_unit/babelfishpg_unit.c
+++ b/contrib/babelfishpg_unit/babelfishpg_unit.c
@@ -51,7 +51,7 @@ static char* DISABLED = "disabled";
  *  
  *      . Add function declaration
  *      . Add row to tests array that identifies your test containing:
- *          . Pointer to test function (takes no params and returns a TestResult pointer
+ *          . Pointer to test function (takes no params and returns a TestResult pointer)
  *          . enabled flag, true to enable
  *          . Human readable test name
  *          . Human readable category, tests can then be run by category, name, or all
@@ -76,6 +76,13 @@ TestInfo tests[]=
     {&test_fixeddecimal_int2_gt, true, "GreaterThanCheck_FIXEDDECIMAL_INT2", "babelfish_money_datatype"},
     {&test_fixeddecimal_int2_ne, true, "NotEqualToCheck_FIXEDDECIMAL_INT2", "babelfish_money_datatype"},
     {&test_fixeddecimal_int2_cmp, true, "Comparison_FIXEDDECIMAL_INT2", "babelfish_money_datatype"},
+
+    {&test_ssl_handshakeRead, true, "Testing_SSL_HANDSHAKE_READ", "babelfishpg_tds_ssl_read"},
+    {&test_ssl_handshakeRead_oversize, true, "TestingOverSize_SSL_HANDSHAKE_READ", "babelfishpg_tds_ssl_read"},
+    {&test_ssl_handshakeRead_pkt_type, true, "TestingPacketType_SSL_HANDSHAKE_READ", "babelfishpg_tds_ssl_read"},
+
+    {&test_ssl_handshakeWrite, true, "Testing_SSL_HANDSHAKE_WRITE", "babelfishpg_tds_ssl_write"},
+    {&test_ssl_handshakeWrite_sizeCheck, true, "TestingSizeCheck_SSL_HANDSHAKE_WRITE", "babelfishpg_tds_ssl_write"},
 };
 
 

--- a/contrib/babelfishpg_unit/babelfishpg_unit.h
+++ b/contrib/babelfishpg_unit/babelfishpg_unit.h
@@ -67,3 +67,10 @@ extern TestResult *test_fixeddecimal_int2_le(void);
 extern TestResult *test_fixeddecimal_int2_gt(void);
 extern TestResult *test_fixeddecimal_int2_ne(void);
 extern TestResult *test_fixeddecimal_int2_cmp(void);
+
+extern TestResult *test_ssl_handshakeRead(void);
+extern TestResult *test_ssl_handshakeRead_pkt_type(void);
+extern TestResult *test_ssl_handshakeRead_oversize(void);
+
+extern TestResult *test_ssl_handshakeWrite(void);
+extern TestResult *test_ssl_handshakeWrite_sizeCheck(void);

--- a/contrib/babelfishpg_unit/test_ssl_read.c
+++ b/contrib/babelfishpg_unit/test_ssl_read.c
@@ -1,0 +1,184 @@
+#include "babelfishpg_unit.h"
+#include "../babelfishpg_tds/src/include/tds_secure.h"
+
+
+static char *prelogin_request;
+static int ReadPointer = 0;
+
+
+static ssize_t
+mock_socket_read(Port *port, void *ptr, size_t len)
+{
+
+	/*
+	 *  Mock function of tds_secure_raw_read() present in tdssecure.c file
+     */
+
+	int i;
+	for (i = ReadPointer; i < ReadPointer + len; i++) 
+		sscanf(&prelogin_request[i * 2], "%2hhx", (unsigned char *)ptr + i);
+	ReadPointer += len;
+	return len;
+}
+
+
+TestResult*
+test_ssl_handshakeRead(void)
+{
+
+	/*
+	 *  We will generate a prelogin request message and pass it to the handshake read function for processing
+	 *  By comparing the number of bytes read against the expected value, we can verify the accuracy of the read operation 
+ 	 */
+
+	BIO *h = NULL;
+	char *buf = NULL;
+
+	int expected;
+	int obtained;
+
+	char expected_str[MAX_TEST_MESSAGE_LENGTH];
+    char obtained_str[MAX_TEST_MESSAGE_LENGTH];
+
+	TestResult* testResult = palloc0(sizeof(TestResult));
+    testResult->result = true;
+
+	h = BIO_new(BIO_s_mem());
+	ReadPointer = 0;
+
+	prelogin_request = strdup("1201000F0000010011A25E4571");
+	buf = malloc(strlen(prelogin_request)/2);
+	
+	
+	expected = strlen(prelogin_request)/2 - 8;
+	obtained = test_ssl_handshake_read(h, buf, expected, mock_socket_read, ReadPointer);
+
+	snprintf(expected_str, MAX_TEST_MESSAGE_LENGTH, "%d", expected);
+    snprintf(obtained_str, MAX_TEST_MESSAGE_LENGTH, "%d", obtained);
+	
+	TEST_ASSERT_TESTCASE(expected == obtained, "1", expected_str, obtained_str, testResult);
+
+
+	prelogin_request = strdup("32C4");
+	buf = malloc(strlen(prelogin_request)/2);
+
+	expected = strlen(prelogin_request)/2;
+	obtained = test_ssl_handshake_read(h, buf, expected, mock_socket_read, ReadPointer);
+
+	snprintf(expected_str, MAX_TEST_MESSAGE_LENGTH, "%d", expected);
+    snprintf(obtained_str, MAX_TEST_MESSAGE_LENGTH, "%d", obtained);
+	
+	TEST_ASSERT_TESTCASE(expected == obtained, "2", expected_str, obtained_str, testResult);
+	TEST_ASSERT(expected == obtained, testResult);
+
+
+	free(buf);
+    free(prelogin_request);
+
+	return testResult;
+}
+
+
+TestResult*
+test_ssl_handshakeRead_oversize(void)
+{
+
+	/*
+	 *  In this scenario, we will send a message size that exceeds the total packet length
+	 *  We will examine whether the function effectively detects the oversized message and generates the appropriate response
+ 	 */
+
+	BIO *h = NULL;
+	char *buf = NULL;
+
+	int expected;
+	int obtained;
+
+	char expected_str[MAX_TEST_MESSAGE_LENGTH];
+    char obtained_str[MAX_TEST_MESSAGE_LENGTH];
+
+	TestResult* testResult = palloc0(sizeof(TestResult));
+	testResult->result = true;
+
+	prelogin_request = strdup("1201000B00000100115461A23E");
+	buf = malloc(strlen(prelogin_request)/2);
+
+	h = BIO_new(BIO_s_mem());
+	ReadPointer = 0;
+
+    expected = strlen(prelogin_request)/2 - 8;
+	obtained = test_ssl_handshake_read(h, buf, expected, mock_socket_read, ReadPointer);
+
+	snprintf(expected_str, MAX_TEST_MESSAGE_LENGTH, "%d", expected);
+    snprintf(obtained_str, MAX_TEST_MESSAGE_LENGTH, "%d", obtained);
+	
+	TEST_ASSERT_TESTCASE(expected != obtained, "1", expected_str, obtained_str, testResult);
+	TEST_ASSERT(expected != obtained, testResult);
+	if(testResult->result == true)
+	{
+        strncpy(testResult->message, ", SSL packet expand more than one TDS packet", MAX_TEST_MESSAGE_LENGTH);
+	}
+
+	free(buf);
+    free(prelogin_request);
+	ReadPointer = 0;
+ 
+    return testResult;
+
+}
+
+
+TestResult*
+test_ssl_handshakeRead_pkt_type(void)
+{
+
+	/*
+	 *  We will generate a message other than the prelogin request by modifying the packet type field within the packet.
+	 *  We will verify if the function correctly identifies and handles messages other than the prelogin request
+	 *  ensuring appropriate error handling and response generation.
+ 	 */
+
+	BIO *h = NULL;
+	char *buf = NULL;
+
+	ErrorData *errorData;
+	MemoryContext oldcontext;
+
+	TestResult* testResult = palloc0(sizeof(TestResult));
+	testResult->result = false;
+
+	prelogin_request = strdup("100100090000010011");
+	buf = malloc(strlen(prelogin_request)/2);
+
+	h = BIO_new(BIO_s_mem());
+	ReadPointer = 0;
+
+	oldcontext = CurrentMemoryContext;
+    PG_TRY();
+    {
+        test_ssl_handshake_read(h, buf, 0, mock_socket_read, ReadPointer);
+    }
+    PG_CATCH();
+    {
+        MemoryContextSwitchTo(oldcontext);
+        errorData = CopyErrorData();
+        FlushErrorState();
+        snprintf(testResult->message, MAX_TEST_MESSAGE_LENGTH, "%s, %s", testResult->message, errorData->message);
+        testResult->result = true;
+        FreeErrorData(errorData);
+    }
+    PG_END_TRY();
+
+    // If the error doesn't occurr, then the following message gets displayed
+    if(testResult->result == false)
+	{
+        strncpy(testResult->message, ", Error doesn't occur since packet type is PRE_LOGIN", MAX_TEST_MESSAGE_LENGTH);
+	}
+
+	free(buf);
+    free(prelogin_request);
+	ReadPointer = 0;
+ 
+    return testResult;
+
+}

--- a/contrib/babelfishpg_unit/test_ssl_write.c
+++ b/contrib/babelfishpg_unit/test_ssl_write.c
@@ -1,0 +1,102 @@
+#include "babelfishpg_unit.h"
+#include "../babelfishpg_tds/src/include/tds_secure.h"
+
+static char *prelogin; 
+
+static ssize_t 
+mock_socket_write(Port *port, const void *ptr, size_t len)
+{
+
+	/*
+	 *  Mock function of tds_secure_raw_write() present in tdssecure.c file
+     */
+
+    const unsigned char *ptr_u8 = (const unsigned char *) ptr;
+    signed char *prelogin_ptr = (signed char *) prelogin;
+    int i;
+    for (i = 0; i < len; i++) 
+        sscanf((const char *) &ptr_u8[i * 2], "%2hhx", (signed char *) &prelogin_ptr[i]);
+    return len;
+}
+
+
+
+TestResult*
+test_ssl_handshakeWrite(void)
+{
+
+	/*
+	 *  We will generate a message and pass it to the handshake write function
+	 *  We will be comparing the number of bytes written against the expected value
+	 */
+
+	BIO *h = NULL;
+	char *buf = "011103";
+
+	int expected;
+	int obtained;
+
+	char expected_str[MAX_TEST_MESSAGE_LENGTH];
+    char obtained_str[MAX_TEST_MESSAGE_LENGTH];
+
+	TestResult* testResult = palloc0(sizeof(TestResult));
+    testResult->result = true;
+
+	h = BIO_new(BIO_s_mem());
+
+	prelogin = malloc(strlen(buf)/2 + 8);
+
+	expected = strlen(buf)/2;
+	obtained = test_ssl_handshake_write(h, buf, expected, mock_socket_write);
+
+	snprintf(expected_str, MAX_TEST_MESSAGE_LENGTH, "%d", expected);
+    snprintf(obtained_str, MAX_TEST_MESSAGE_LENGTH, "%d", obtained);
+
+	TEST_ASSERT_TESTCASE(expected == obtained, "1", expected_str, obtained_str, testResult);
+	TEST_ASSERT(expected == obtained, testResult);
+
+	return testResult;
+}
+
+
+TestResult*
+test_ssl_handshakeWrite_sizeCheck(void)
+{
+
+	/*
+	 *  We will send a message of size less than zero
+	 *  We will evaluate whether the function correctly detects and handles this condition.
+	 */
+
+	BIO *h = NULL;
+	char *buf = NULL; 
+
+	int expected;
+	int obtained;
+
+	char expected_str[MAX_TEST_MESSAGE_LENGTH];
+    char obtained_str[MAX_TEST_MESSAGE_LENGTH];
+
+	TestResult* testResult = palloc0(sizeof(TestResult));
+    testResult->result = true;
+
+	h = BIO_new(BIO_s_mem());
+
+    expected = -1;
+	obtained = test_ssl_handshake_write(h, buf, expected, mock_socket_write);
+
+	snprintf(expected_str, MAX_TEST_MESSAGE_LENGTH, "%d", expected);
+    snprintf(obtained_str, MAX_TEST_MESSAGE_LENGTH, "%d", obtained);
+
+	TEST_ASSERT_TESTCASE(expected == obtained, "1", expected_str, obtained_str, testResult);
+	if(testResult->result == true)
+	{
+		snprintf(testResult->message, MAX_TEST_MESSAGE_LENGTH, "%s, There is nothing to write", testResult->message);
+	}
+	else
+	{
+		snprintf(testResult->message, MAX_TEST_MESSAGE_LENGTH, "%s, We need to write %ld bytes", testResult->message, strlen(buf));
+	}
+
+	return testResult;
+}


### PR DESCRIPTION
### Description
SSL (Secure Sockets Layer) is a cryptographic protocol used to establish secure connections between clients and servers.Adding tests for SSL involves testing the Babelfish codebase's handling of SSL connections, verifying some SSL-related operations are performed correctly. Testing SSL functionality ensures a secure transmission of data between clients and servers.  We have a keen interest in conducting thorough unit testing of the Ssl handshake process that occurs during the prelogin stage. Our unit testing approach will involve meticulously examining each step of the ssl handshake, simulating different scenarios, and verifying that the it is implemented correctly.


### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**

```
jdbc_testdb=# select * from babelfishpg_unit_run_tests();
                  test_name                  | status | runtime(µs) | enabled 
---------------------------------------------+--------+-------------+---------
 GreaterThanOrEqualToCheck_INT4_FIXEDDECIMAL | pass   |           8 | enabled
 LesserThanOrEqualToCheck_INT4_FIXEDDECIMAL  | pass   |           6 | enabled
 NotEqualToCheck_INT4_FIXEDDECIMAL           | pass   |           6 | enabled
 EqualToCheck_INT4_FIXEDDECIMAL              | pass   |           6 | enabled
 LesserThanCheck_INT4_FIXEDDECIMAL           | pass   |           5 | enabled
 Comparison_INT4_FIXEDDECIMAL                | pass   |           9 | enabled
 FIXEDDECIMALUM                              | pass   |           6 | enabled
 GreaterThanOrEqualToCheck_FIXEDDECIMAL_INT2 | pass   |           5 | enabled
 LesserThanOrEqualToCheck_FIXEDDECIMAL_INT2  | pass   |           5 | enabled
 GreaterThanCheck_FIXEDDECIMAL_INT2          | pass   |           5 | enabled
 NotEqualToCheck_FIXEDDECIMAL_INT2           | pass   |           3 | enabled
 Comparison_FIXEDDECIMAL_INT2                | pass   |           7 | enabled
 Testing_SSL_HANDSHAKE_READ                  | pass   |          16 | enabled
 TestingOverSize_SSL_HANDSHAKE_READ          | pass   |          20 | enabled
 TestingPacketType_SSL_HANDSHAKE_READ        | pass   |           8 | enabled
 Testing_SSL_HANDSHAKE_WRITE                 | pass   |           7 | enabled
 TestingSizeCheck_SSL_HANDSHAKE_WRITE        | pass   |           4 | enabled
(17 rows)
```



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).