### PR TITLE
Rethrow error in create_builtin_dbs() and create_msdb_if_not_exists()

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -762,6 +762,7 @@ create_builtin_dbs(PG_FUNCTION_ARGS)
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
+		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	PG_RETURN_INT32(0);
@@ -798,6 +799,7 @@ create_msdb_if_not_exists(PG_FUNCTION_ARGS)
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
+		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	PG_RETURN_INT32(0);


### PR DESCRIPTION
### Description

Previously, we were not rethrowing any exception encountered in the create_builtin_dbs() and create_msdb_if_not_exists() methods. This was causing some incosistencies during version upgrades.

In this commit, we rethrow the error when executing these methods. So now, if during upgrade these methods encounter an exception the upgrade would fail then and there instead of succeeding and later causing inconsistencies.

Task: BABEL-4112
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).