### PR TITLE
Add null check to forxml/forjson datetime format functions to prevent crash

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/tsql_for.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/tsql_for.c
@@ -18,9 +18,16 @@ void
 tsql_for_datetime_format(StringInfo format_output, const char *outputstr)
 {
 	char	   *date;
-	char	   *spaceptr = strstr(outputstr, " ");
+	char	   *spaceptr;
 	int			len;
 
+	/* if we receive a null value, set the output as an empty string */
+	if(outputstr == NULL) {
+		appendStringInfoChar(format_output, '\0');
+		return;
+	}
+
+	spaceptr = strstr(outputstr, " ");
 	len = spaceptr - outputstr;
 	date = palloc(len + 1);
 	strncpy(date, outputstr, len);
@@ -43,8 +50,16 @@ tsql_for_datetimeoffset_format(StringInfo format_output, const char *str)
 			   *endptr,
 			   *time,
 			   *offset;
-	char	   *spaceptr = strstr(str, " ");
+	char	   *spaceptr;
 	int			len;
+
+	/* if we receive a null value, set the output as an empty string */
+	if(str == NULL) {
+		appendStringInfoChar(format_output, '\0');
+		return;
+	}
+
+	spaceptr = strstr(str, " ");
 
 	/* append date part of string */
 	len = spaceptr - str;

--- a/test/JDBC/expected/forjson-datatypes-vu-cleanup.out
+++ b/test/JDBC/expected/forjson-datatypes-vu-cleanup.out
@@ -40,6 +40,19 @@ GO
 DROP VIEW forjson_datatypes_vu_v_unicode_strings
 GO
 
+-- NULL datetimes
+DROP VIEW forjson_datatypes_vu_v_nulldatetime;
+go
+
+DROP VIEW forjson_datatypes_vu_v_nullsmalldatetime;
+go
+
+DROP VIEW forjson_datatypes_vu_v_nulldatetime2;
+go
+
+DROP VIEW forjson_datatypes_vu_v_nulldatetimeoffset;
+go
+
 -- DROP TABLE
 DROP TABLE forjson_datatypes_vu_t_exact_numerics
 GO

--- a/test/JDBC/expected/forjson-datatypes-vu-prepare.out
+++ b/test/JDBC/expected/forjson-datatypes-vu-prepare.out
@@ -152,3 +152,31 @@ SELECT
     FOR JSON PATH
 ) as c1;
 GO
+
+CREATE VIEW forjson_datatypes_vu_v_nulldatetime AS
+SELECT
+(
+    select cast(null as datetime) for JSON PATH
+) as c1;
+GO
+
+CREATE VIEW forjson_datatypes_vu_v_nullsmalldatetime AS
+SELECT
+(
+    select cast(null as smalldatetime) for JSON PATH
+) as c1;
+GO
+
+CREATE VIEW forjson_datatypes_vu_v_nulldatetime2 AS
+SELECT
+(
+    select cast(null as datetime2) for JSON PATH
+) as c1;
+GO
+
+CREATE VIEW forjson_datatypes_vu_v_nulldatetimeoffset AS
+SELECT
+(
+    select cast(null as datetimeoffset) for JSON PATH
+) as c1;
+GO

--- a/test/JDBC/expected/forjson-datatypes-vu-verify.out
+++ b/test/JDBC/expected/forjson-datatypes-vu-verify.out
@@ -99,3 +99,37 @@ nvarchar
 [{"anchar":"abc  ","anvarchar":"abc","antext":"abc"}]
 ~~END~~
 
+
+
+-- NULL datetime and datetimeoffset
+SELECT * FROM forjson_datatypes_vu_v_nulldatetime
+GO
+~~START~~
+nvarchar
+[{}]
+~~END~~
+
+
+SELECT * FROM forjson_datatypes_vu_v_nullsmalldatetime
+GO
+~~START~~
+nvarchar
+[{}]
+~~END~~
+
+
+SELECT * FROM forjson_datatypes_vu_v_nulldatetime2
+GO
+~~START~~
+nvarchar
+[{}]
+~~END~~
+
+
+SELECT * FROM forjson_datatypes_vu_v_nulldatetimeoffset
+GO
+~~START~~
+nvarchar
+[{}]
+~~END~~
+

--- a/test/JDBC/expected/forxml-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-vu-cleanup.out
@@ -4,9 +4,9 @@ drop procedure forxml_vu_p_employee_select;
 go
 drop procedure forxml_vu_p_employee_select2;
 go
-drop view forxml_vu_v1;
+drop view forxml_vu_view1;
 go
-drop view forxml_vu_v2;
+drop view forxml_vu_view2;
 go
 drop view forxml_vu_v_cte1;
 go
@@ -25,4 +25,12 @@ go
 drop table forxml_vu_t_employees;
 go
 drop table forxml_vu_t_employees2;
+go
+drop procedure forxml_vu_p_nullval1
+go
+drop procedure forxml_vu_p_nullval2
+go
+drop procedure forxml_vu_p_nullval3
+go
+drop procedure forxml_vu_p_nullval4
 go

--- a/test/JDBC/expected/forxml-vu-prepare.out
+++ b/test/JDBC/expected/forxml-vu-prepare.out
@@ -227,11 +227,11 @@ end;
 go
 
 -- Test for xml in create view
-create view forxml_vu_v1 (col1) as select * from forxml_vu_t1 for xml raw, type;
+create view forxml_vu_view1 (col1) as select * from forxml_vu_t1 for xml raw, type;
 go
 
 -- Test for xml on pure relational view
-create view forxml_vu_v2 (col1, col2) as select * from forxml_vu_t1;
+create view forxml_vu_view2 (col1, col2) as select * from forxml_vu_t1;
 go
 
 -- Test for xml and union all
@@ -336,4 +336,21 @@ go
 -- test string variable can be binded with for xml query
 create procedure forxml_vu_p_strvar @pid int, @str varchar(10) as
 select * from forxml_vu_t1 where id = @pid and a = @str for xml raw;
+go
+
+-- test null value handling in datetime, smalldatetime, datetime2, and datetimeoffset
+create procedure forxml_vu_p_nullval1 as
+select cast(null as datetime) for xml path;
+go
+
+create procedure forxml_vu_p_nullval2 as
+select cast(null as smalldatetime) for xml path;
+go
+
+create procedure forxml_vu_p_nullval3 as
+select cast(null as datetime2) for xml path;
+go
+
+create procedure forxml_vu_p_nullval4 as
+select cast(null as datetimeoffset) for xml path;
 go

--- a/test/JDBC/expected/forxml-vu-verify.out
+++ b/test/JDBC/expected/forxml-vu-verify.out
@@ -16,7 +16,7 @@ ntext
 ~~END~~
 
 
-select * from forxml_vu_v1;
+select * from forxml_vu_view1;
 go
 ~~START~~
 xml
@@ -25,7 +25,7 @@ xml
 
 
 -- Test for xml on view with xml column
-select * from forxml_vu_v1 for xml path;
+select * from forxml_vu_view1 for xml path;
 go
 ~~START~~
 ntext
@@ -33,7 +33,7 @@ ntext
 ~~END~~
 
 
-select * from forxml_vu_v2 for xml path;
+select * from forxml_vu_view2 for xml path;
 go
 ~~START~~
 ntext
@@ -91,5 +91,37 @@ exec forxml_vu_p_strvar 1, NULL;
 go
 ~~START~~
 ntext
+~~END~~
+
+
+exec forxml_vu_p_nullval1
+go
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+exec forxml_vu_p_nullval2
+go
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+exec forxml_vu_p_nullval3
+go
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+exec forxml_vu_p_nullval4
+go
+~~START~~
+ntext
+<row/>
 ~~END~~
 

--- a/test/JDBC/input/forjson/forjson-datatypes-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjson-datatypes-vu-cleanup.sql
@@ -40,6 +40,19 @@ GO
 DROP VIEW forjson_datatypes_vu_v_unicode_strings
 GO
 
+-- NULL datetimes
+DROP VIEW forjson_datatypes_vu_v_nulldatetime;
+go
+
+DROP VIEW forjson_datatypes_vu_v_nullsmalldatetime;
+go
+
+DROP VIEW forjson_datatypes_vu_v_nulldatetime2;
+go
+
+DROP VIEW forjson_datatypes_vu_v_nulldatetimeoffset;
+go
+
 -- DROP TABLE
 DROP TABLE forjson_datatypes_vu_t_exact_numerics
 GO

--- a/test/JDBC/input/forjson/forjson-datatypes-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjson-datatypes-vu-prepare.sql
@@ -142,3 +142,31 @@ SELECT
     FOR JSON PATH
 ) as c1;
 GO
+
+CREATE VIEW forjson_datatypes_vu_v_nulldatetime AS
+SELECT
+(
+    select cast(null as datetime) for JSON PATH
+) as c1;
+GO
+
+CREATE VIEW forjson_datatypes_vu_v_nullsmalldatetime AS
+SELECT
+(
+    select cast(null as smalldatetime) for JSON PATH
+) as c1;
+GO
+
+CREATE VIEW forjson_datatypes_vu_v_nulldatetime2 AS
+SELECT
+(
+    select cast(null as datetime2) for JSON PATH
+) as c1;
+GO
+
+CREATE VIEW forjson_datatypes_vu_v_nulldatetimeoffset AS
+SELECT
+(
+    select cast(null as datetimeoffset) for JSON PATH
+) as c1;
+GO

--- a/test/JDBC/input/forjson/forjson-datatypes-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjson-datatypes-vu-verify.sql
@@ -39,3 +39,17 @@ GO
 -- Unicode character strings
 SELECT * FROM forjson_datatypes_vu_v_unicode_strings
 GO
+
+-- NULL datetime and datetimeoffset
+
+SELECT * FROM forjson_datatypes_vu_v_nulldatetime
+GO
+
+SELECT * FROM forjson_datatypes_vu_v_nullsmalldatetime
+GO
+
+SELECT * FROM forjson_datatypes_vu_v_nulldatetime2
+GO
+
+SELECT * FROM forjson_datatypes_vu_v_nulldatetimeoffset
+GO

--- a/test/JDBC/input/forxml/forxml-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-vu-cleanup.sql
@@ -4,9 +4,9 @@ drop procedure forxml_vu_p_employee_select;
 go
 drop procedure forxml_vu_p_employee_select2;
 go
-drop view forxml_vu_v1;
+drop view forxml_vu_view1;
 go
-drop view forxml_vu_v2;
+drop view forxml_vu_view2;
 go
 drop view forxml_vu_v_cte1;
 go
@@ -25,4 +25,12 @@ go
 drop table forxml_vu_t_employees;
 go
 drop table forxml_vu_t_employees2;
+go
+drop procedure forxml_vu_p_nullval1
+go
+drop procedure forxml_vu_p_nullval2
+go
+drop procedure forxml_vu_p_nullval3
+go
+drop procedure forxml_vu_p_nullval4
 go

--- a/test/JDBC/input/forxml/forxml-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-vu-prepare.sql
@@ -104,11 +104,11 @@ end;
 go
 
 -- Test for xml in create view
-create view forxml_vu_v1 (col1) as select * from forxml_vu_t1 for xml raw, type;
+create view forxml_vu_view1 (col1) as select * from forxml_vu_t1 for xml raw, type;
 go
 
 -- Test for xml on pure relational view
-create view forxml_vu_v2 (col1, col2) as select * from forxml_vu_t1;
+create view forxml_vu_view2 (col1, col2) as select * from forxml_vu_t1;
 go
 
 -- Test for xml and union all
@@ -184,4 +184,21 @@ go
 -- test string variable can be binded with for xml query
 create procedure forxml_vu_p_strvar @pid int, @str varchar(10) as
 select * from forxml_vu_t1 where id = @pid and a = @str for xml raw;
+go
+
+-- test null value handling in datetime, smalldatetime, datetime2, and datetimeoffset
+create procedure forxml_vu_p_nullval1 as
+select cast(null as datetime) for xml path;
+go
+
+create procedure forxml_vu_p_nullval2 as
+select cast(null as smalldatetime) for xml path;
+go
+
+create procedure forxml_vu_p_nullval3 as
+select cast(null as datetime2) for xml path;
+go
+
+create procedure forxml_vu_p_nullval4 as
+select cast(null as datetimeoffset) for xml path;
 go

--- a/test/JDBC/input/forxml/forxml-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-vu-verify.sql
@@ -6,14 +6,14 @@ go
 execute forxml_vu_p_employee_select2 150, 300;
 go
 
-select * from forxml_vu_v1;
+select * from forxml_vu_view1;
 go
 
 -- Test for xml on view with xml column
-select * from forxml_vu_v1 for xml path;
+select * from forxml_vu_view1 for xml path;
 go
 
-select * from forxml_vu_v2 for xml path;
+select * from forxml_vu_view2 for xml path;
 go
 
 SELECT * FROM forxml_vu_v_cte1;
@@ -32,4 +32,16 @@ exec forxml_vu_p_strvar 1, 't1_a1';
 go
 -- test NULL parameter
 exec forxml_vu_p_strvar 1, NULL;
+go
+
+exec forxml_vu_p_nullval1
+go
+
+exec forxml_vu_p_nullval2
+go
+
+exec forxml_vu_p_nullval3
+go
+
+exec forxml_vu_p_nullval4
 go


### PR DESCRIPTION
### Description

Currently Babelfish crashes when a null datetime value is passed into forxml. This commit adds a check to properly handle the null values and prevent a crash. Instead of passing the null value into forxml and forjson, Babelfish now passes an empty string.

### Issues Resolved
Task: Babel-4280
Signed-off-by: Jacob Owen <owjco@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**

```
1> select cast(null as datetime) for xml path
2> go
xml                                                                                                                                                                                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
<row/>                                                                                                                                                                                                                                                          

(1 rows affected)
```

```
1> select cast(null as datetimeoffset) for xml path
2> go
xml                                                                                                                                                                                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
<row/>                                                                                                                                                                                                                                                          

(1 rows affected)
```

```
1> select cast(null as datetime) for json path
2> go
json                                                                                                                                                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[{}]                                                                                                                                                                                                                                                            

(1 rows affected)
```

```
1> select cast(null as datetimeoffset) for json path
2> go
json                                                                                                                                                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[{}]                                                                                                                                                                                                                                                            

(1 rows affected)
```

* **Boundary conditions -**


* **Arbitrary inputs -**
```
1> select cast(cast(null as datetime) as datetimeoffset) for xml path
2> go
xml                                                                                                                                                                                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
<row/>  
```

* **Negative test cases -**


* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).