### PR TITLE
Switch to showplan from statistics profile in test

### DIFF
--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -43,7 +43,36 @@ off
 ~~END~~
 
 
-SET BABELFISH_STATISTICS PROFILE ON
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL ON
+GO
+
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+~~START~~
+text
+Query Text: select a, count(*) from t_babel4261 group by a order by 2
+Sort
+  Sort Key: (count(*)) NULLS FIRST
+  ->  Finalize HashAggregate
+        Group Key: a
+        ->  Gather
+              Workers Planned: 2
+              ->  Partial HashAggregate
+                    Group Key: a
+                    ->  Parallel Seq Scan on t_babel4261
+~~END~~
+
+
+-- set configurations back
+SET BABELFISH_SHOWPLAN_ALL OFF
 GO
 
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
@@ -52,31 +81,6 @@ GO
 int#!#int
 ~~END~~
 
-~~START~~
-text
-Query Text: select a, count(*) from t_babel4261 group by a order by 2
-Sort  (cost=38.27..38.77 rows=200 width=8) (actual rows=0 loops=1)
-  Sort Key: (count(*)) NULLS FIRST
-  Sort Method: quicksort  Memory: 25kB
-  ->  Finalize HashAggregate  (cost=28.13..30.63 rows=200 width=8) (actual rows=0 loops=1)
-        Group Key: a
-        Batches: 1  Memory Usage: 40kB
-        ->  Gather  (cost=24.13..26.13 rows=400 width=12) (actual rows=0 loops=1)
-              Workers Planned: 2
-              Workers Launched: 2
-              ->  Partial HashAggregate  (cost=24.13..26.13 rows=200 width=12) (actual rows=0 loops=3)
-                    Group Key: a
-                    Batches: 1  Memory Usage: 40kB
-                    Worker 0:  Batches: 1  Memory Usage: 40kB
-                    Worker 1:  Batches: 1  Memory Usage: 40kB
-                    ->  Parallel Seq Scan on t_babel4261  (cost=0.00..19.42 rows=942 width=4) (actual rows=0 loops=3)
-~~END~~
-
-
-
--- set configurations back
-SET BABELFISH_STATISTICS PROFILE OFF
-GO
 
 select set_config('babelfishpg_tsql.explain_timing', 'on', false);
 GO
@@ -87,6 +91,14 @@ on
 
 
 select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false);
 GO
 ~~START~~
 text

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -18,21 +18,29 @@ GO
 select set_config('babelfishpg_tsql.explain_summary', 'off', false);
 GO
 
-SET BABELFISH_STATISTICS PROFILE ON
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false);
+GO
+
+SET BABELFISH_SHOWPLAN_ALL ON
 GO
 
 select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
 GO
 
-
 -- set configurations back
-SET BABELFISH_STATISTICS PROFILE OFF
+SET BABELFISH_SHOWPLAN_ALL OFF
+GO
+
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
 GO
 
 select set_config('babelfishpg_tsql.explain_timing', 'on', false);
 GO
 
 select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false);
 GO
 
 -- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default


### PR DESCRIPTION
Test case used statistics profile to show a query used a parrallel scan. Statitics gave memory usage would could lead to test failure if memory usage was different than expected. This change uses showplan_all instead to fix the issue.