### PR TITLE
Added upgrade script file in babelfishpg_common

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.5.0--3.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.5.0--3.0.0.sql
@@ -1,0 +1,29 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '3.0.0'" to load this file. \quit
+
+SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+/* This helper function would only be useful and strictly be used during 1.x->2.3 and 2.3->3.0 upgrade. */
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+SELECT sys.babelfish_update_server_collation_name();
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- And reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
+
+-- Reset search_path to not affect any subsequent scripts
+SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.1.0--3.2.0.sql
@@ -11,28 +11,36 @@ RETURNS int4
 AS 'babelfishpg_common', 'int4varbinary_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-DROP OPERATOR IF EXISTS sys./ (int4, sys.bbf_varbinary);
-
+DO $$
+BEGIN
+IF NOT EXISTS(Select 1 from pg_operator where oprname = '/' and oprcode = 'sys.int4varbinarydiv'::regproc) THEN
 CREATE OPERATOR sys./ (
     LEFTARG = int4,
     RIGHTARG = sys.bbf_varbinary,
     FUNCTION = int4varbinarydiv,
     COMMUTATOR = /
 );
+END IF;
+END $$;
+
+
 
 CREATE OR REPLACE FUNCTION sys.varbinaryint4div(leftarg sys.bbf_varbinary , rightarg int4)
 RETURNS int4
 AS 'babelfishpg_common', 'varbinaryint4_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-DROP OPERATOR IF EXISTS sys./ (sys.bbf_varbinary,int4);
-
+DO $$
+BEGIN
+IF NOT EXISTS(Select 1 from pg_operator where oprname = '/' and oprcode = 'sys.varbinaryint4div'::regproc) THEN
 CREATE OPERATOR sys./ (
     LEFTARG = sys.bbf_varbinary,
     RIGHTARG = int4,
     FUNCTION = varbinaryint4div,
     COMMUTATOR = /
 );
+END IF;
+END $$;
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.1.0--3.2.0.sql
@@ -6,11 +6,12 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 DROP CAST IF EXISTS(NUMERIC AS sys.BIT);
 CREATE CAST (NUMERIC AS sys.BIT) WITH FUNCTION sys.numeric_bit (NUMERIC) AS IMPLICIT;
 
-CREATE FUNCTION sys.int4varbinarydiv(leftarg int4 , rightarg sys.bbf_varbinary)
+CREATE OR REPLACE FUNCTION sys.int4varbinarydiv(leftarg int4 , rightarg sys.bbf_varbinary)
 RETURNS int4
 AS 'babelfishpg_common', 'int4varbinary_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+DROP OPERATOR IF EXISTS sys./ (int4, sys.bbf_varbinary);
 
 CREATE OPERATOR sys./ (
     LEFTARG = int4,
@@ -19,11 +20,12 @@ CREATE OPERATOR sys./ (
     COMMUTATOR = /
 );
 
-CREATE FUNCTION sys.varbinaryint4div(leftarg sys.bbf_varbinary , rightarg int4)
+CREATE OR REPLACE FUNCTION sys.varbinaryint4div(leftarg sys.bbf_varbinary , rightarg int4)
 RETURNS int4
 AS 'babelfishpg_common', 'varbinaryint4_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+DROP OPERATOR IF EXISTS sys./ (sys.bbf_varbinary,int4);
 
 CREATE OPERATOR sys./ (
     LEFTARG = sys.bbf_varbinary,

--- a/contrib/babelfishpg_common/sql/varbinary.sql
+++ b/contrib/babelfishpg_common/sql/varbinary.sql
@@ -288,11 +288,12 @@ CREATE OPERATOR sys.<= (
 );
 
 
-CREATE FUNCTION sys.int4varbinarydiv(leftarg int4 , rightarg sys.bbf_varbinary)
+CREATE OR REPLACE FUNCTION sys.int4varbinarydiv(leftarg int4 , rightarg sys.bbf_varbinary)
 RETURNS int4
 AS 'babelfishpg_common', 'int4varbinary_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+DROP OPERATOR IF EXISTS sys./ (int4,sys.bbf_varbinary);
 
 CREATE OPERATOR sys./ (
     LEFTARG = int4,
@@ -301,11 +302,12 @@ CREATE OPERATOR sys./ (
     COMMUTATOR = /
 );
 
-CREATE FUNCTION sys.varbinaryint4div(leftarg sys.bbf_varbinary , rightarg int4)
+CREATE OR REPLACE FUNCTION sys.varbinaryint4div(leftarg sys.bbf_varbinary , rightarg int4)
 RETURNS int4
 AS 'babelfishpg_common', 'varbinaryint4_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+DROP OPERATOR IF EXISTS sys./ (sys.bbf_varbinary,int4);
 
 CREATE OPERATOR sys./ (
     LEFTARG = sys.bbf_varbinary,

--- a/contrib/babelfishpg_common/sql/varbinary.sql
+++ b/contrib/babelfishpg_common/sql/varbinary.sql
@@ -293,8 +293,6 @@ RETURNS int4
 AS 'babelfishpg_common', 'int4varbinary_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-DROP OPERATOR IF EXISTS sys./ (int4,sys.bbf_varbinary);
-
 CREATE OPERATOR sys./ (
     LEFTARG = int4,
     RIGHTARG = sys.bbf_varbinary,
@@ -306,8 +304,6 @@ CREATE OR REPLACE FUNCTION sys.varbinaryint4div(leftarg sys.bbf_varbinary , righ
 RETURNS int4
 AS 'babelfishpg_common', 'varbinaryint4_div'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-DROP OPERATOR IF EXISTS sys./ (sys.bbf_varbinary,int4);
 
 CREATE OPERATOR sys./ (
     LEFTARG = sys.bbf_varbinary,

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -20,6 +20,8 @@ Unexpected drop found for operator sys.+ in file babelfishpg_common--1.1.0--1.2.
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
+Unexpected drop found for operator sys./ in file babelfishpg_common--3.1.0--3.2.0.sql
+Unexpected drop found for operator sys./ in file babelfishpg_common--3.1.0--3.2.0.sql
 Unexpected drop found for procedure babelfish_drop_deprecated_opclass in file babelfishpg_common--1.0.0--1.1.0.sql
 Unexpected drop found for procedure sys.babel_create_guest_schemas in file babelfishpg_tsql--2.3.0--2.4.0.sql
 Unexpected drop found for procedure sys.babel_create_guest_schemas in file babelfishpg_tsql--3.0.0--3.1.0.sql

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -8,6 +8,7 @@ Unexpected drop found for function get_bbf_binary_ops_count in file babelfishpg_
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.0.0--2.1.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.3.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.4.0--3.0.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.5.0--3.0.0.sql
 Unexpected drop found for function sys.babelfishpg_common_get_babel_server_collation_oid in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.3.0--3.0.0.sql

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -20,8 +20,6 @@ Unexpected drop found for operator sys.+ in file babelfishpg_common--1.1.0--1.2.
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql
-Unexpected drop found for operator sys./ in file babelfishpg_common--3.1.0--3.2.0.sql
-Unexpected drop found for operator sys./ in file babelfishpg_common--3.1.0--3.2.0.sql
 Unexpected drop found for procedure babelfish_drop_deprecated_opclass in file babelfishpg_common--1.0.0--1.1.0.sql
 Unexpected drop found for procedure sys.babel_create_guest_schemas in file babelfishpg_tsql--2.3.0--2.4.0.sql
 Unexpected drop found for procedure sys.babel_create_guest_schemas in file babelfishpg_tsql--3.0.0--3.1.0.sql


### PR DESCRIPTION
### Description

We have added a upgrade script (2.4.0-2.5.0) in babelfishpg_common in BABEL_2_X_DEV , which requires an update script (2.5.0--3.0.0)  upgarde script in babelfishpg_common so that while updating major version the upgrade does not breaks.



### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).