### PR TITLE
Fix output param values in stored procedures where the parameter names are in mixed case

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -895,7 +895,7 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 					foreach(paramcell, stmt->params)
 					{
 						tsql_exec_param *p = (tsql_exec_param *) lfirst(paramcell);
-						if (argnames[i] && p->name && strcmp(argnames[i], p->name) == 0)
+						if (argnames[i] && p->name && pg_strcasecmp(argnames[i], p->name) == 0)
 							break;
 						relativeArgIndex++;
 					}

--- a/test/JDBC/expected/TestStoredProcedures.out
+++ b/test/JDBC/expected/TestStoredProcedures.out
@@ -455,3 +455,104 @@ int#!#int#!#int#!#int
 
 DROP PROCEDURE sp_test21
 
+CREATE PROCEDURE sp_test22 (@MixedCaseArg_1 INT, @MixedCaseArg_2 INT OUTPUT) AS BEGIN SET @MixedCaseArg_2=100; SET @MixedCaseArg_1=1000; Select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2; END;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1 OUT, @MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+DROP PROCEDURE sp_test22

--- a/test/JDBC/input/storedProcedures/TestStoredProcedures.txt
+++ b/test/JDBC/input/storedProcedures/TestStoredProcedures.txt
@@ -169,3 +169,14 @@ storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output#!#i
 storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|output
 DROP PROCEDURE sp_test21
 
+CREATE PROCEDURE sp_test22 (@MixedCaseArg_1 INT, @MixedCaseArg_2 INT OUTPUT) AS BEGIN SET @MixedCaseArg_2=100; SET @MixedCaseArg_1=1000; Select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2; END;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1 OUT, @MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+DROP PROCEDURE sp_test22


### PR DESCRIPTION
### Description
Currently, if the argument names in the procedure are in mixed case, the OUTPUT params are not being set properly. This changes fixes the same.

### Issues Resolved
BABEL-4235

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** 


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).