### PR TITLE
Fixed Babelfish top_clause that accept number without parens

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -1697,7 +1697,7 @@ merge_not_matched
 // https://msdn.microsoft.com/en-us/library/ms189835.aspx
 delete_statement
     : with_expression?
-      DELETE (TOP LR_BRACKET expression RR_BRACKET PERCENT? | TOP DECIMAL)?
+      DELETE (TOP LR_BRACKET expression RR_BRACKET PERCENT?)?
       FROM? delete_statement_from
       with_table_hints?
       output_clause?

--- a/test/JDBC/expected/BABEL-4175-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4175-vu-cleanup.out
@@ -1,0 +1,5 @@
+DROP TABLE insertTest;
+GO
+
+DROP TABLE Purchasing;
+GO

--- a/test/JDBC/expected/BABEL-4175-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4175-vu-prepare.out
@@ -1,0 +1,33 @@
+CREATE TABLE Purchasing (
+  OrderID int,
+  EmployeeID int,
+  VendorID int
+);
+GO
+
+CREATE TABLE insertTest(VendorID INT)
+GO
+
+
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (1, 52, 158);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (2, 44, 146);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (3, 25, 142);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (4, 66, 460);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (5, 37, 154);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (6, 53, 564);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (7, 36, 156);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/BABEL-4175-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4175-vu-verify.out
@@ -1,0 +1,98 @@
+SELECT * FROM Purchasing;
+GO
+~~START~~
+int#!#int#!#int
+1#!#52#!#158
+2#!#44#!#146
+3#!#25#!#142
+4#!#66#!#460
+5#!#37#!#154
+6#!#53#!#564
+7#!#36#!#156
+~~END~~
+
+
+-- Verify DELETE TOP without parens
+-- This should fail
+DELETE TOP 2 FROM Purchasing;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '2' at line 3 and character position 11)~~
+
+
+DELETE TOP (2) FROM Purchasing;
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM Purchasing;
+GO
+~~START~~
+int#!#int#!#int
+3#!#25#!#142
+4#!#66#!#460
+5#!#37#!#154
+6#!#53#!#564
+7#!#36#!#156
+~~END~~
+
+
+-- Verify UPDATE TOP without parens
+-- This should fail
+UPDATE TOP 2 Purchasing SET VendorID = 0;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '2' at line 3 and character position 11)~~
+
+
+UPDATE TOP (2) Purchasing SET VendorID = 0;
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM Purchasing;
+GO
+~~START~~
+int#!#int#!#int
+5#!#37#!#154
+6#!#53#!#564
+7#!#36#!#156
+3#!#25#!#0
+4#!#66#!#0
+~~END~~
+
+
+SELECT * FROM insertTest
+GO
+~~START~~
+int
+~~END~~
+
+
+
+-- Verify INSERT TOP without parens
+-- This should fail
+INSERT TOP 3 INTO insertTest(VendorID) SELECT VendorID FROM Purchasing
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '3' at line 3 and character position 11)~~
+
+
+INSERT TOP (3) INTO insertTest(VendorID) SELECT VendorID FROM Purchasing
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT * FROM insertTest
+GO
+~~START~~
+int
+154
+564
+156
+~~END~~
+
+

--- a/test/JDBC/expected/babel_output_in_dml.out
+++ b/test/JDBC/expected/babel_output_in_dml.out
@@ -1513,7 +1513,7 @@ go
 
 
 -- delete with top
-delete top 2 t1
+delete top (2) t1
 output deleted.* into t2
 where num<5;
 go
@@ -1542,7 +1542,7 @@ int#!#varchar
 -- delete with top in subquery
 delete t1
 output deleted.num, deleted.word into t2
-from (select top 2 * from t1 order by num asc) as x
+from (select top (2) * from t1 order by num asc) as x
 where t1.num = x.num and t1.num<5;
 go
 ~~ROW COUNT: 2~~

--- a/test/JDBC/input/BABEL-4175-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4175-vu-cleanup.sql
@@ -1,0 +1,5 @@
+DROP TABLE insertTest;
+GO
+
+DROP TABLE Purchasing;
+GO

--- a/test/JDBC/input/BABEL-4175-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4175-vu-prepare.sql
@@ -1,0 +1,19 @@
+CREATE TABLE Purchasing (
+  OrderID int,
+  EmployeeID int,
+  VendorID int
+);
+GO
+
+CREATE TABLE insertTest(VendorID INT)
+GO
+
+
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (1, 52, 158);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (2, 44, 146);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (3, 25, 142);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (4, 66, 460);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (5, 37, 154);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (6, 53, 564);
+INSERT INTO Purchasing(OrderID, EmployeeID, VendorID) VALUES (7, 36, 156);
+GO

--- a/test/JDBC/input/BABEL-4175-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4175-vu-verify.sql
@@ -1,0 +1,40 @@
+SELECT * FROM Purchasing;
+GO
+
+-- Verify DELETE TOP without parens
+-- This should fail
+DELETE TOP 2 FROM Purchasing;
+GO
+
+DELETE TOP (2) FROM Purchasing;
+GO
+
+SELECT * FROM Purchasing;
+GO
+
+-- Verify UPDATE TOP without parens
+-- This should fail
+UPDATE TOP 2 Purchasing SET VendorID = 0;
+GO
+
+UPDATE TOP (2) Purchasing SET VendorID = 0;
+GO
+
+SELECT * FROM Purchasing;
+GO
+
+SELECT * FROM insertTest
+GO
+
+-- Verify INSERT TOP without parens
+-- This should fail
+
+INSERT TOP 3 INTO insertTest(VendorID) SELECT VendorID FROM Purchasing
+GO
+
+INSERT TOP (3) INTO insertTest(VendorID) SELECT VendorID FROM Purchasing
+GO
+
+SELECT * FROM insertTest
+GO
+

--- a/test/JDBC/input/dml/babel_output_in_dml.sql
+++ b/test/JDBC/input/dml/babel_output_in_dml.sql
@@ -856,7 +856,7 @@ insert into t1 values(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four'), (5, 'fiv
 go
 
 -- delete with top
-delete top 2 t1
+delete top (2) t1
 output deleted.* into t2
 where num<5;
 go
@@ -870,7 +870,7 @@ go
 -- delete with top in subquery
 delete t1
 output deleted.num, deleted.word into t2
-from (select top 2 * from t1 order by num asc) as x
+from (select top (2) * from t1 order by num asc) as x
 where t1.num = x.num and t1.num<5;
 go
 

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -444,3 +444,4 @@ BABEL-4046
 host_id
 linked_srv_4229
 waitfor
+BABEL-4175


### PR DESCRIPTION
### Description

TOP statements should have parenthesis around the number of rows to limit. This commit fixed Babelfish's top statement which accept number without parens.

### Issues Resolved
BABEL-4175

### Test Scenarios Covered ###

- DELETE TOP without parens
- DELETE TOP with parens
- UPDATE TOP without parens
- UPDATE TOP with parens
- INSERT TOP without parens
- INSERT TOP with parens

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).