### PR TITLE
Fixed crash in SPI_execute_plan during SELECT INTO with EXPLAIN mode

### DIFF
--- a/test/JDBC/expected/BABEL-2844.out
+++ b/test/JDBC/expected/BABEL-2844.out
@@ -373,3 +373,101 @@ drop table babel_2844_t1;
 go
 drop table babel_2844_t2;
 go
+
+-- BABEL-3677: SELECT INTO
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT);
+GO
+
+SET BABELFISH_SHOWPLAN_ALL ON;
+GO
+
+-- should not crash
+SELECT * INTO t3 FROM t1 WHERE t1.b = 1;
+GO
+~~START~~
+text
+Query Text: SELECT * INTO t3 FROM t1 WHERE t1.b = 1
+~~END~~
+
+
+-- should fail with t3 does not exist because previous query was not executed
+INSERT INTO t3 VALUES (1, 1), (2, 1), (3, 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "t3" does not exist)~~
+
+
+-- DMLs should also not be executed
+INSERT INTO t1 VALUES (1, 1), (2, 1), (3, 1);
+GO
+~~START~~
+text
+Query Text: INSERT INTO t1 VALUES (1, 1), (2, 1), (3, 1);
+Insert on t1  (cost=0.00..0.04 rows=0 width=0)
+  ->  Values Scan on "*VALUES*"  (cost=0.00..0.04 rows=3 width=8)
+~~END~~
+
+
+DELETE FROM t1 WHERE a = 3;
+GO
+~~START~~
+text
+Query Text: DELETE FROM t1 WHERE a = 3;
+Delete on t1  (cost=0.15..8.17 rows=0 width=0)
+  ->  Index Scan using t1_pkey on t1  (cost=0.15..8.17 rows=1 width=6)
+        Index Cond: (a = 3)
+~~END~~
+
+
+UPDATE t1 SET a = 2 WHERE a = 1;
+GO
+~~START~~
+text
+Query Text: UPDATE t1 SET a = 2 WHERE a = 1;
+Update on t1  (cost=0.15..8.17 rows=0 width=0)
+  ->  Index Scan using t1_pkey on t1  (cost=0.15..8.17 rows=1 width=10)
+        Index Cond: (a = 1)
+~~END~~
+
+
+-- also create function just for the sake of testing it
+CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
+BEGIN
+    DECLARE @TSQL NVARCHAR(MAX)
+    RETURN @TSQL
+END
+GO
+~~START~~
+text
+Query Text: CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
+BEGIN
+    DECLARE @TSQL NVARCHAR(MAX)
+    RETURN @TSQL
+END
+~~END~~
+
+
+-- function should not be created but should not crash
+SELECT dbo.WOSQL_BuildRevenueDetailOLUQuery()
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function master_dbo.wosql_buildrevenuedetailoluquery() does not exist)~~
+
+
+SET BABELFISH_SHOWPLAN_ALL OFF;
+GO
+
+-- should be empty
+SELECT * FROM t1;
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+DROP TABLE t1;
+GO

--- a/test/JDBC/input/BABEL-2844.sql
+++ b/test/JDBC/input/BABEL-2844.sql
@@ -189,3 +189,51 @@ drop table babel_2844_t1;
 go
 drop table babel_2844_t2;
 go
+
+-- BABEL-3677: SELECT INTO
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT);
+GO
+
+SET BABELFISH_SHOWPLAN_ALL ON;
+GO
+
+-- should not crash
+SELECT * INTO t3 FROM t1 WHERE t1.b = 1;
+GO
+
+-- should fail with t3 does not exist because previous query was not executed
+INSERT INTO t3 VALUES (1, 1), (2, 1), (3, 1);
+GO
+
+-- DMLs should also not be executed
+INSERT INTO t1 VALUES (1, 1), (2, 1), (3, 1);
+GO
+
+DELETE FROM t1 WHERE a = 3;
+GO
+
+UPDATE t1 SET a = 2 WHERE a = 1;
+GO
+
+-- also create function just for the sake of testing it
+CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
+BEGIN
+    DECLARE @TSQL NVARCHAR(MAX)
+    RETURN @TSQL
+END
+GO
+
+-- function should not be created but should not crash
+SELECT dbo.WOSQL_BuildRevenueDetailOLUQuery()
+GO
+
+SET BABELFISH_SHOWPLAN_ALL OFF;
+GO
+
+-- should be empty
+SELECT * FROM t1;
+GO
+
+DROP TABLE t1;
+GO


### PR DESCRIPTION
Fixed crash in SPI_execute_plan during SELECT INTO with EXPLAIN mode

### Description

The crash is happening because we are hitting the following Assert in SPI_execute_plan

```
Line 2769: Assert(ctastmt->if_not_exists || ctastmt->into->skipData); 
```

At high-level, the problematic logic in SPI_execute_plan is this:
```
_SPI_execute_plan()
  QueryCompletion qc;
  ProcessUtility(..., &qc);

  // In explain mode, this always goes to the else statement because
  // qc is never initialized.
  if (qc.commandTag == CMDTAG_SELECT)
    _SPI_current->processed = qc.nprocessed;
  else
    Assert(ctastmt->if_not_exists || ctastmt->into->skipData); 

---

ProcessUtility()
  bbf_ProcessUtility(..., qc)
     if (process_utility_stmt_explain_only_mode(queryString, parsetree))
         return; // does not execute so qc is never initialized
```




### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).