### PR TITLE
Fix uninitialized variables to avoid build error for weekly build

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5105,8 +5105,8 @@ static List *transformSelectIntoStmt(CreateTableAsStmt *stmt, const char *queryS
 
 				int type_oid;
 				char *type = NULL;
-				TypeName *ofTypename;
-				int64 seed_value;
+				TypeName *ofTypename = NULL;
+				int64 seed_value = 0;
 				int arg_num;
 
 				if (seen_identity)


### PR DESCRIPTION
Fix uninitialized variables to avoid build error for weekly build

Task: BABEL-539


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).