### PR TITLE
Handle exception gracefully inside JDBC test framework if remote server is crashed

### DIFF
--- a/test/JDBC/src/main/java/com/sqlsamples/HandleException.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/HandleException.java
@@ -36,16 +36,23 @@ public class HandleException {
                         errorMsg += "\n  ";
                     }
                     bw.write("~~ERROR (Message: "+ errorMsg + "  Server SQLState: " + e.getSQLState() + ")~~");
-                } else if (e instanceof SQLServerException && "08S01".equals(e.getSQLState())){
-                    // Handling this particular exception where server might have crashed.
-                    System.out.println("Remote server might have crashed.");
-                    System.out.println("Error: " + e.getErrorCode());
-                    System.out.println("SQL State: " + e.getSQLState());
-                    System.out.println("Error message: "+ e.getMessage());
-                    bw.close();
-                    System.exit(0);
                 }
-                else {
+                else if(e instanceof SQLServerException) {
+                    // Handling this particular exception where server might have crashed.
+                    if ("08S01".equals(e.getSQLState())){
+                        System.out.println("Remote server might have crashed.");
+                        System.out.println("Error: " + e.getErrorCode());
+                        System.out.println("SQL State: " + e.getSQLState());
+                        System.out.println("Error message: "+ e.getMessage());
+
+                        bw.write("Remote server might have crashed.\n");
+                        bw.write("Error: " + e.getErrorCode() + "\n");
+                        bw.write("SQL State: " + e.getSQLState() + "\n");
+                        bw.write("Error message: "+ e.getMessage() + "\n");
+
+                        bw.close();
+                        System.exit(0);
+                    }
                     String errorMsg = e.getMessage();
                     //Do not print ClientConnectionId as part of error message
                     int index = errorMsg.indexOf("ClientConnectionId");

--- a/test/JDBC/src/main/java/com/sqlsamples/HandleException.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/HandleException.java
@@ -8,13 +8,15 @@ import java.sql.SQLException;
 
 import org.postgresql.util.PSQLException;
 
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+
 import static com.sqlsamples.Config.outputErrorCode;
 
 public class HandleException {
 
     // function to handle SQL exception
     // writes error message to a file
-    static void handleSQLExceptionWithFile(SQLException e, BufferedWriter bw, Logger logger){
+    static void handleSQLExceptionWithFile(SQLException e, BufferedWriter bw, Logger logger) {
         try {
             if (outputErrorCode) {
                 bw.write("~~ERROR (Code: " + e.getErrorCode() + ")~~");
@@ -34,7 +36,16 @@ public class HandleException {
                         errorMsg += "\n  ";
                     }
                     bw.write("~~ERROR (Message: "+ errorMsg + "  Server SQLState: " + e.getSQLState() + ")~~");
-                } else {
+                } else if (e instanceof SQLServerException && "08S01".equals(e.getSQLState())){
+                    // Handling this particular exception where server might have crashed.
+                    System.out.println("Remote server might have crashed.");
+                    System.out.println("Error: " + e.getErrorCode());
+                    System.out.println("SQL State: " + e.getSQLState());
+                    System.out.println("Error message: "+ e.getMessage());
+                    bw.close();
+                    System.exit(0);
+                }
+                else {
                     String errorMsg = e.getMessage();
                     //Do not print ClientConnectionId as part of error message
                     int index = errorMsg.indexOf("ClientConnectionId");


### PR DESCRIPTION
Current behaviour of test framework in event of remote server crash is that framework will get stuck without any error or anything. Recently we understood that it may also got stuck in infinite loop of exception which would keep on getting buffered in corresponding test output file. This will keep on bloating output file if java process is not terminated which may in theory can cause out of disk space situation. This commit fixes that issue by identifying such exception and exiting the process.

Task: None
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).