### PR TITLE
DATETIME with ".xx3" converted to string incorrectly as ".xx0" for any time below "02:18:53.003"

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstimestamp.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstimestamp.c
@@ -208,8 +208,7 @@ TdsTimeDifferenceDatetime(Datum value, uint32 *numDays,
 	fsec_t		fsec;
 	int			msec = 0,
 				unit = 0,
-				round_val = 0;
-
+				extra_ticks = 0;
 	/*
 	 * 1 tick = 1/300 sec = 3.3333333 ms babelfish uses tick count to
 	 * accommodate millisecound count in 4 bytes
@@ -235,43 +234,39 @@ TdsTimeDifferenceDatetime(Datum value, uint32 *numDays,
 
 		/*
 		 * millisecond value rounded to increments of .000, .003, or .007
-		 * seconds
+		 * seconds. We add the number of extra ticks to final value based 
+		 * on the unit digit milliseconds.
 		 */
 		switch (unit)
 		{
 			case 0:
 			case 1:
-				round_val = 0;
+				extra_ticks = 0;
 				break;
 			case 2:
 			case 3:
 			case 4:
-				round_val = 3;
-
-				/*
-				 * slightly different from default tick value at 7th decimal
-				 * place
-				 */
-				tick = 3.3333332;
+				extra_ticks = 1;
 				break;
 			case 5:
 			case 6:
 			case 7:
 			case 8:
-				round_val = 7;
+				extra_ticks = 2;
 				break;
 			case 9:
-				round_val = 10;
+				extra_ticks = 3;
 				break;
 			default:
 				break;
 		}
-		msec = msec - unit + round_val;
+		msec = msec - unit;
 	}
 	milliCount = ((tm->tm_hour * 60 + tm->tm_min) * 60 +
 				  tm->tm_sec) * 1000 + msec;
 
-	*numTicks = (int) (milliCount / tick);
+	*numTicks = (int) (milliCount / tick) + extra_ticks;
+
 }
 
 /*

--- a/test/JDBC/expected/TestDatetime-vu-verify.out
+++ b/test/JDBC/expected/TestDatetime-vu-verify.out
@@ -276,3 +276,22 @@ datetime
 <NULL>
 ~~END~~
 
+
+select convert(datetime, '1900-01-01 02:18:53.003')
+~~START~~
+datetime
+1900-01-01 02:18:53.003
+~~END~~
+
+select convert(datetime, '1900-01-02 00:00:00.003')
+~~START~~
+datetime
+1900-01-02 00:00:00.003
+~~END~~
+
+select convert(datetime, '1900-01-02 01:00:00.003')
+~~START~~
+datetime
+1900-01-02 01:00:00.003
+~~END~~
+

--- a/test/JDBC/expected/TestDatetime.out
+++ b/test/JDBC/expected/TestDatetime.out
@@ -395,3 +395,22 @@ datetime
 <NULL>
 ~~END~~
 
+
+select convert(datetime, '1900-01-01 02:18:53.003')
+~~START~~
+datetime
+1900-01-01 02:18:53.003
+~~END~~
+
+select convert(datetime, '1900-01-02 00:00:00.003')
+~~START~~
+datetime
+1900-01-02 00:00:00.003
+~~END~~
+
+select convert(datetime, '1900-01-02 01:00:00.003')
+~~START~~
+datetime
+1900-01-02 01:00:00.003
+~~END~~
+

--- a/test/JDBC/input/datatypes/TestDatetime-vu-verify.txt
+++ b/test/JDBC/input/datatypes/TestDatetime-vu-verify.txt
@@ -42,3 +42,7 @@ select convert(datetime, '9999-12-31 23:59:59.999');
 select convert(datetime, '1752-12-31 23:59:59.997');
 select convert(datetime, '0000-00-00 00:00:00.000');
 select convert(datetime, NULL);
+
+select convert(datetime, '1900-01-01 02:18:53.003')
+select convert(datetime, '1900-01-02 00:00:00.003')
+select convert(datetime, '1900-01-02 01:00:00.003')

--- a/test/JDBC/input/datatypes/TestDatetime.txt
+++ b/test/JDBC/input/datatypes/TestDatetime.txt
@@ -77,3 +77,7 @@ select convert(datetime, '9999-12-31 23:59:59.999');
 select convert(datetime, '1752-12-31 23:59:59.997');
 select convert(datetime, '0000-00-00 00:00:00.000');
 select convert(datetime, NULL);
+
+select convert(datetime, '1900-01-01 02:18:53.003')
+select convert(datetime, '1900-01-02 00:00:00.003')
+select convert(datetime, '1900-01-02 01:00:00.003')


### PR DESCRIPTION
### Description

cherry pick https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/6e7f34b61b4c3568a9912009d203e0dbb8bc4a97 from 3_X_DEV

### Issues Resolved

BABEL-4167

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).