### PR TITLE
Loss of decimal digits when converting from REAL to DECIMAL

### DIFF
--- a/test/JDBC/expected/BABEL-3066-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3066-vu-cleanup.out
@@ -1,0 +1,5 @@
+DROP TABLE babel_3066_vu_prepare_t1;
+GO
+
+DROP TABLE babel_3066_vu_prepare_t2;
+GO

--- a/test/JDBC/expected/BABEL-3066-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3066-vu-prepare.out
@@ -1,0 +1,5 @@
+CREATE TABLE babel_3066_vu_prepare_t1(col1 real);
+GO
+
+CREATE TABLE babel_3066_vu_prepare_t2(col1 numeric(30, 3));
+GO

--- a/test/JDBC/expected/BABEL-3066-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3066-vu-verify.out
@@ -1,0 +1,600 @@
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS value_casted_to_decimal_30_2;
+GO
+~~START~~
+real#!#numeric
+123456.25#!#123456.25
+~~END~~
+
+
+select cast(cast(123457.145637867 as real) as numeric (30, 20));
+GO
+~~START~~
+numeric
+123457.14843750000000000000
+~~END~~
+
+
+select cast((cast(123456.00 as real)) as numeric(30,2));
+GO
+~~START~~
+numeric
+123456.00
+~~END~~
+
+
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS real_casted_to_decimal_30_2;
+GO
+~~START~~
+real#!#numeric
+123456.25#!#123456.25
+~~END~~
+
+
+select CAST(CAST(123457.145637867 as real) as numeric (30, 20));
+GO
+~~START~~
+numeric
+123457.14843750000000000000
+~~END~~
+
+
+select CAST((CAST(123456.00 as real)) as numeric(30,2));
+GO
+~~START~~
+numeric
+123456.00
+~~END~~
+
+
+
+select CAST(CAST(123457.145637867 as real) as numeric (30, 0));
+GO
+~~START~~
+numeric
+123457
+~~END~~
+
+
+
+select CAST((CAST(123456.00 as real)) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+
+-- should throw error
+select CAST(CAST(123457.145637867 as real) as numeric (30, 38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The scale 38 for 'numeric' datatype must be within the range 0 to precision 30)~~
+
+
+-- Boundary real values
+SELECT CAST(CAST(3e+38 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(3e+38 as real) as numeric(38,0));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(3e+38 as real) as numeric(30,10));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+
+SELECT CAST(CAST(-3e+38 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(-3e+38 as real) as numeric(38,0));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(-3e+38 as real) as numeric(30,10));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(3e-38 as real) as numeric(38,38));
+GO
+~~START~~
+numeric
+3E-38
+~~END~~
+
+
+SELECT CAST(CAST(3e-38 as real) as numeric(38,0));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST(CAST(3e-38 as real) as numeric(30,10));
+GO
+~~START~~
+numeric
+0E-10
+~~END~~
+
+
+SELECT CAST(CAST(-3e-38 as real) as numeric(38,38));
+GO
+~~START~~
+numeric
+-3E-38
+~~END~~
+
+
+SELECT CAST(CAST(-3e-38 as real) as numeric(38,0));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST(CAST(-3e-38 as real) as numeric(30,10));
+GO
+~~START~~
+numeric
+0E-10
+~~END~~
+
+
+-- table insertion
+INSERT INTO babel_3066_vu_prepare_t1 VALUES (122.34562), (735412.97354), (-467822.56378), (-456.24516), (1234.465), ('inf'), ('-inf'), ('nan');
+GO
+~~ROW COUNT: 8~~
+
+INSERT INTO babel_3066_vu_prepare_t1 VALUES (123456789123456789123456789123456789.123456789);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT CAST(col1 as numeric(30,2)) as value_casted_to_decimal_30_2 from babel_3066_vu_prepare_t1;
+GO
+~~START~~
+numeric
+122.35
+735413.00
+-467822.56
+-456.25
+1234.46
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+SELECT CAST(col1 as numeric(30,20)) as value_casted_to_decimal_30_20 from babel_3066_vu_prepare_t1;
+GO
+~~START~~
+numeric
+122.34561920166015625000
+735413.00000000000000000000
+-467822.56250000000000000000
+-456.24514770507812500000
+1234.46496582031250000000
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+SELECT CAST(col1 as numeric(30,4)) as value_casted_to_decimal_30_4 from babel_3066_vu_prepare_t1;
+GO
+~~START~~
+numeric
+122.3456
+735413.0000
+-467822.5625
+-456.2451
+1234.4650
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+SELECT CAST(col1 as numeric(38,38)) as value_casted_to_decimal_38_38 from babel_3066_vu_prepare_t1;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+INSERT INTO babel_3066_vu_prepare_t2 values (CAST(1234.156 as real)), (CAST(-3256.55 as real)), (CAST(1234.6513 as real)), (CAST(1324567.45267781 as real)), (CAST(12.2 as real)), (CAST(122.34562 as real)), (CAST(735412.97354 as real));
+GO
+~~ROW COUNT: 7~~
+
+
+INSERT INTO babel_3066_vu_prepare_t2 values (123456789123456789123456789123456789.123456789);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT col1 from babel_3066_vu_prepare_t2;
+GO
+~~START~~
+numeric
+1234.156
+-3256.550
+1234.651
+1324567.500
+12.200
+122.346
+735413.000
+~~END~~
+
+
+select CAST(CAST(col1 AS real) AS decimal(30,2)) from babel_3066_vu_prepare_t2;
+GO
+~~START~~
+numeric
+1234.16
+-3256.55
+1234.65
+1324567.50
+12.20
+122.35
+735413.00
+~~END~~
+
+
+SELECT babel_3066_vu_prepare_t1.col1, babel_3066_vu_prepare_t2.col1 
+FROM babel_3066_vu_prepare_t1 JOIN babel_3066_vu_prepare_t2
+ON CAST (babel_3066_vu_prepare_t1.col1 as real) = CAST(CAST(babel_3066_vu_prepare_t2.col1 AS real) AS decimal(30,2));
+GO
+~~START~~
+real#!#numeric
+735413.0#!#735413.000
+~~END~~
+
+
+
+-- Directly cast to numeric 
+SELECT CAST(.12345678912345678912345678912345678912 as numeric(38,38));
+GO
+~~START~~
+numeric
+0.12345678912345678912345678912345678912
+~~END~~
+
+
+SELECT CAST(123456.789012 as numeric(38,0));
+GO
+~~START~~
+numeric
+123457
+~~END~~
+
+
+SELECT CAST(123456.489012 as numeric(38,0));
+GO
+~~START~~
+numeric
+123456
+~~END~~
+
+
+SELECT CAST(123456.789012 as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(.12345678 as numeric(1,0));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST(.12345678 as numeric(1,1));
+GO
+~~START~~
+numeric
+0.1
+~~END~~
+
+
+
+-- should throw error
+SELECT CAST(123.1234567891234567891234567891234567 as numeric(38,39));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The scale 39 for 'numeric' datatype must be within the range 0 to precision 38)~~
+
+
+SELECT CAST(123.1234567891234567891234567891234567 as numeric(39,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The size (39) given to the type 'numeric' exceeds the maximum allowed (38))~~
+
+
+SELECT CAST(.12345678 as numeric(0,1));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Specified column precision 0 for 'numeric' datatype must be within the range 1 to maximum precision(38))~~
+
+
+
+-- Cast expressions value with diff operators to numeric
+SELECT CAST((CAST(123.45628 as real) + cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+~~START~~
+numeric
+36915
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) + cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST((CAST(123.45628 as real) + cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+~~START~~
+numeric
+36914.9140625000
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) - cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+~~START~~
+numeric
+-36668
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) - cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST((CAST(123.45628 as real) - cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+~~START~~
+numeric
+-36668.0000000000
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) * cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+~~START~~
+numeric
+4542137
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) * cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST((CAST(123.45628 as real) * cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+~~START~~
+numeric
+4542136.5000000000
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) / cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) / cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+~~START~~
+numeric
+0.00335556920617818832397460937500000000
+~~END~~
+
+
+SELECT CAST((CAST(123.45628 as real) / cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+~~START~~
+numeric
+0.0033555692
+~~END~~
+
+
+-- Expression over casted value -> cast(x) + cast(y)
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+~~START~~
+numeric
+24931562
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+~~START~~
+numeric
+24931562.000000000000000
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+~~START~~
+numeric
+24931562.0000000000
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+~~START~~
+numeric
+0
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+~~START~~
+numeric
+155395695939961
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+SELECT CAST(CAST(CAST(CAST(12465781.46792 as real) as numeric(38,10)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,15)) as real) as numeric(38,6));
+GO
+~~START~~
+numeric
+155395691642880.000000
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+~~START~~
+numeric
+155395695939961.00000000000000000000
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+~~START~~
+numeric
+1.00000000000000000000
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+~~START~~
+numeric
+1.00000000000000000000
+~~END~~
+
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+~~START~~
+numeric
+1.00000000000000000000
+~~END~~
+

--- a/test/JDBC/expected/str-vu-verify.out
+++ b/test/JDBC/expected/str-vu-verify.out
@@ -29,7 +29,7 @@ SELECT * FROM str_vu_prepare_v5
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
-123.0#!#123.5#!#123.5#!#123.0#!#123.0#!#123.0#!#123.5#!#123.5#!#123.0#!#123.0#!#123.5#!#123.5#!#123.5#!#123.5
+123.0#!#123.5#!#123.4#!#123.0#!#123.0#!#123.0#!#123.5#!#123.5#!#123.0#!#123.0#!#123.5#!#123.5#!#123.5#!#123.5
 ~~END~~
 
 
@@ -197,7 +197,7 @@ EXEC str_vu_prepare_p5
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
-123.0#!#123.5#!#123.5#!#123.0#!#123.0#!#123.0#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5
+123.0#!#123.5#!#123.4#!#123.0#!#123.0#!#123.0#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5#!#123.5
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-3066-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-3066-vu-cleanup.sql
@@ -1,0 +1,5 @@
+DROP TABLE babel_3066_vu_prepare_t1;
+GO
+
+DROP TABLE babel_3066_vu_prepare_t2;
+GO

--- a/test/JDBC/input/BABEL-3066-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-3066-vu-prepare.sql
@@ -1,0 +1,5 @@
+CREATE TABLE babel_3066_vu_prepare_t1(col1 real);
+GO
+
+CREATE TABLE babel_3066_vu_prepare_t2(col1 numeric(30, 3));
+GO

--- a/test/JDBC/input/BABEL-3066-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3066-vu-verify.sql
@@ -1,0 +1,233 @@
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS value_casted_to_decimal_30_2;
+GO
+
+select cast(cast(123457.145637867 as real) as numeric (30, 20));
+GO
+
+select cast((cast(123456.00 as real)) as numeric(30,2));
+GO
+
+SELECT CAST(123456.25 AS real) AS value_as_real, CAST(CAST(123456.25 AS real) AS decimal(30,2)) AS real_casted_to_decimal_30_2;
+GO
+
+select CAST(CAST(123457.145637867 as real) as numeric (30, 20));
+GO
+
+select CAST((CAST(123456.00 as real)) as numeric(30,2));
+GO
+
+
+select CAST(CAST(123457.145637867 as real) as numeric (30, 0));
+GO
+
+
+select CAST((CAST(123456.00 as real)) as numeric(38,38));
+GO
+
+
+-- should throw error
+select CAST(CAST(123457.145637867 as real) as numeric (30, 38));
+GO
+
+-- Boundary real values
+SELECT CAST(CAST(3e+38 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(3e+38 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(3e+38 as real) as numeric(30,10));
+GO
+
+
+SELECT CAST(CAST(-3e+38 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(-3e+38 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(-3e+38 as real) as numeric(30,10));
+GO
+
+SELECT CAST(CAST(3e-38 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(3e-38 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(3e-38 as real) as numeric(30,10));
+GO
+
+SELECT CAST(CAST(-3e-38 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(-3e-38 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(-3e-38 as real) as numeric(30,10));
+GO
+
+-- table insertion
+INSERT INTO babel_3066_vu_prepare_t1 VALUES (122.34562), (735412.97354), (-467822.56378), (-456.24516), (1234.465), ('inf'), ('-inf'), ('nan');
+GO
+INSERT INTO babel_3066_vu_prepare_t1 VALUES (123456789123456789123456789123456789.123456789);
+GO
+
+SELECT CAST(col1 as numeric(30,2)) as value_casted_to_decimal_30_2 from babel_3066_vu_prepare_t1;
+GO
+SELECT CAST(col1 as numeric(30,20)) as value_casted_to_decimal_30_20 from babel_3066_vu_prepare_t1;
+GO
+SELECT CAST(col1 as numeric(30,4)) as value_casted_to_decimal_30_4 from babel_3066_vu_prepare_t1;
+GO
+SELECT CAST(col1 as numeric(38,38)) as value_casted_to_decimal_38_38 from babel_3066_vu_prepare_t1;
+GO
+
+INSERT INTO babel_3066_vu_prepare_t2 values (CAST(1234.156 as real)), (CAST(-3256.55 as real)), (CAST(1234.6513 as real)), (CAST(1324567.45267781 as real)), (CAST(12.2 as real)), (CAST(122.34562 as real)), (CAST(735412.97354 as real));
+GO
+
+INSERT INTO babel_3066_vu_prepare_t2 values (123456789123456789123456789123456789.123456789);
+GO
+
+SELECT col1 from babel_3066_vu_prepare_t2;
+GO
+
+select CAST(CAST(col1 AS real) AS decimal(30,2)) from babel_3066_vu_prepare_t2;
+GO
+
+SELECT babel_3066_vu_prepare_t1.col1, babel_3066_vu_prepare_t2.col1 
+FROM babel_3066_vu_prepare_t1 JOIN babel_3066_vu_prepare_t2
+ON CAST (babel_3066_vu_prepare_t1.col1 as real) = CAST(CAST(babel_3066_vu_prepare_t2.col1 AS real) AS decimal(30,2));
+GO
+
+-- Directly cast to numeric 
+
+SELECT CAST(.12345678912345678912345678912345678912 as numeric(38,38));
+GO
+
+SELECT CAST(123456.789012 as numeric(38,0));
+GO
+
+SELECT CAST(123456.489012 as numeric(38,0));
+GO
+
+SELECT CAST(123456.789012 as numeric(38,38));
+GO
+
+SELECT CAST(.12345678 as numeric(1,0));
+GO
+
+SELECT CAST(.12345678 as numeric(1,1));
+GO
+
+
+-- should throw error
+SELECT CAST(123.1234567891234567891234567891234567 as numeric(38,39));
+GO
+
+SELECT CAST(123.1234567891234567891234567891234567 as numeric(39,38));
+GO
+
+SELECT CAST(.12345678 as numeric(0,1));
+GO
+
+
+-- Cast expressions value with diff operators to numeric
+SELECT CAST((CAST(123.45628 as real) + cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+
+SELECT CAST((CAST(123.45628 as real) + cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+
+SELECT CAST((CAST(123.45628 as real) + cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+
+SELECT CAST((CAST(123.45628 as real) - cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+
+SELECT CAST((CAST(123.45628 as real) - cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+
+SELECT CAST((CAST(123.45628 as real) - cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+
+SELECT CAST((CAST(123.45628 as real) * cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+
+SELECT CAST((CAST(123.45628 as real) * cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+
+SELECT CAST((CAST(123.45628 as real) * cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+
+SELECT CAST((CAST(123.45628 as real) / cast(36791.45789926 as real)) as numeric(38, 0));
+GO
+
+SELECT CAST((CAST(123.45628 as real) / cast(36791.45789926 as real)) as numeric(38, 38));
+GO
+
+SELECT CAST((CAST(123.45628 as real) / cast(36791.45789926 as real)) as numeric(30, 10));
+GO
+
+-- Expression over casted value -> cast(x) + cast(y)
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) + CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) - CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+
+SELECT CAST(CAST(CAST(CAST(12465781.46792 as real) as numeric(38,10)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,15)) as real) as numeric(38,6));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) * CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,0));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,0)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,38)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,38));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,15));
+GO
+
+SELECT CAST(CAST(12465781.46792 as real) as numeric(38,10)) / CAST(CAST(12465781.4679213254 as real) as numeric(38,10));
+GO


### PR DESCRIPTION
### Description

Initially we were using "%.*g" to write to buffer. This can use scientific notation as well. Now, FLT_DIG decides the number of digits after decimal. The value of FLT_DIG is 6. Which simply means the precision is 6. That is the reason why we are not observing any digits after decimal if number of digits before decimal is >= 6. Added a new macro for TSQL dialect named BABEL_MAX_PRECISION which will allow to accept precision of 38.

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/169

### Issues Resolved

Task: BABEL-3066

3_X PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1680
 
### Check List

Signed-off-by: Shameem Ahmed [[shmeeh@amazon.com](mailto:shmeeh@amazon.com)]



### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).