### PR TITLE
fix: add support to handle reapeatable read isolation level as snapshot isolation level tsql

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -4221,11 +4221,18 @@ tsql_IsolationLevelStr:
 				}
 			| REPEATABLE READ
 				{
-					TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_ISOLATION_LEVEL_REPEATABLE_READ);
-					ereport(ERROR,
+					if(pltsql_enable_snapshot_isolation_for_reapeatable_read == false){
+						TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_ISOLATION_LEVEL_REPEATABLE_READ);
+						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("REPEATABLE READ isolation level is not supported"),
+							errmsg("REPEATABLE READ isolation level is not supported, consider setting babelfishpg_tsql.enable_snapshot_isolation_for_reapeatable_read to on to enable snapshot isolation instead"),
 							parser_errposition(@1)));
+					}
+					else{
+						TSQLInstrumentation(INSTR_TSQL_ISOLATION_LEVEL_SNAPSHOT);
+						$$ = "repeatable read";
+					}
+
 				}
 			| SNAPSHOT
 				{

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -66,6 +66,7 @@ char	   *pltsql_host_release = NULL;
 char	   *pltsql_host_service_pack_level = NULL;
 
 bool		pltsql_enable_create_alter_view_from_pg = false;
+bool		pltsql_enable_snapshot_isolation_for_reapeatable_read = false;
 
 static const struct config_enum_entry explain_format_options[] = {
 	{"text", EXPLAIN_FORMAT_TEXT, false},
@@ -1147,6 +1148,15 @@ define_custom_variables(void)
 							 true,
 							 PGC_SUSET,
 							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_snapshot_isolation_for_reapeatable_read",
+							 gettext_noop("Enables isolation snapshot when asked for isolation level reapeatable read"),
+							 NULL,
+							 &pltsql_enable_snapshot_isolation_for_reapeatable_read,
+							 false,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE ,
 							 NULL, NULL, NULL);
 }
 

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -15,6 +15,7 @@ extern bool pltsql_enable_create_alter_view_from_pg;
 extern bool pltsql_enable_linked_servers;
 extern bool pltsql_allow_windows_login;
 extern char *pltsql_psql_logical_babelfish_db_name;
+extern bool pltsql_enable_snapshot_isolation_for_reapeatable_read;
 
 extern void define_custom_variables(void);
 extern void pltsql_validate_set_config_function(char *name, char *value);

--- a/test/python/expected/pyodbc/BABEL-4146.out
+++ b/test/python/expected/pyodbc/BABEL-4146.out
@@ -1,0 +1,162 @@
+
+starting permutation : { s1i s1c s2i s2c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+
+starting permutation : { s1i s2i s1c s2c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation : { s1i s2i s1c s2c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation : { s1i s2i s1c s2c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation : { s1i s2i s1c s2c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation : { s1i s2i s2c s1c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation : { s1i s2i s2c s1c }
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation : { s2i s1i s1c s2c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation : { s2i s1i s1c s2c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation : { s2i s1i s2c s1c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation : { s2i s1i s2c s1c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation : { s2i s1i s2c s1c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation : { s2i s1i s2c s1c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation : { s2i s2c s1i s1c }
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s1c: COMMIT;
+
+starting permutation : { s1t s1i s2i s2c s1s s1c }
+step s1t: Select current_setting('transaction_isolation');
+~~START~~
+str
+repeatable read
+~~END~~
+
+step s1i: INSERT INTO child VALUES (1, 1);
+~~ROW COUNT: 1~~
+
+step s2i: INSERT INTO child VALUES (2, 1);
+~~ROW COUNT: 1~~
+
+step s2c: COMMIT;
+step s1s: Select * from child;
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+step s1c: COMMIT;

--- a/test/python/input/isolation/BABEL-4146.spec
+++ b/test/python/input/isolation/BABEL-4146.spec
@@ -1,0 +1,49 @@
+setup
+{
+
+  CREATE TABLE parent (
+	parent_key	int		PRIMARY KEY,
+	aux			text	NOT NULL
+  );
+
+  CREATE TABLE child (
+	child_key	int		PRIMARY KEY,
+	parent_key	int		NOT NULL REFERENCES parent
+  );
+
+  INSERT INTO parent VALUES (1, 'foo');
+}
+
+teardown
+{
+  DROP TABLE parent, child;
+}
+
+session s1
+setup		{  select set_config('babelfishpg_tsql.enable_snapshot_isolation_for_reapeatable_read','on',false);
+  set transaction isolation level repeatable read; BEGIN TRAN; SET lock_timeout '500'; }
+step s1t { Select current_setting('transaction_isolation'); }
+step s1s { Select * from child; }
+step s1i	{ INSERT INTO child VALUES (1, 1); }
+step s1c	{ COMMIT; }
+
+session s2
+setup		{ BEGIN TRAN; SET lock_timeout '10000'; }
+step s2i	{ INSERT INTO child VALUES (2, 1); }
+step s2c	{ COMMIT; }
+
+permutation s1i s1c s2i s2c
+permutation s1i s2i s1c s2c
+permutation s1i s2i s1c s2c
+permutation s1i s2i s1c s2c
+permutation s1i s2i s1c s2c
+permutation s1i s2i s2c s1c
+permutation s1i s2i s2c s1c
+permutation s2i s1i s1c s2c
+permutation s2i s1i s1c s2c
+permutation s2i s1i s2c s1c
+permutation s2i s1i s2c s1c
+permutation s2i s1i s2c s1c
+permutation s2i s1i s2c s1c
+permutation s2i s2c s1i s1c
+permutation s1t s1i s2i s2c s1s s1c


### PR DESCRIPTION
### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. Added new GUC to allow support for repeatable read.
2. Repeatable read isolation level to be handled as snapshot isolation level.

### Issues Resolved

BABEL-4146

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).