### PR TITLE
Define spatial types using PostGIS functions

### DIFF
--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -18,6 +18,14 @@ ifdef PREV_EXTVERSION
 DATA = sql/$(EXTENSION)--$(PREV_EXTVERSION).sql
 endif
 
+# preprocessor check for postgis file
+# LIB = $$libdir/postgis-3.so 
+
+# ifneq($(wildcard $($libdir/postgis-3)),)
+# PG_CPPFLAGS = -DPOSTGIS_INCLUDED
+# CFLAGS = -DPOSTGIS_INCLUDED
+# endif
+
 DATA_built = \
     $(EXTENSION).control \
     sql/$(EXTENSION)--$(EXTVERSION).sql
@@ -78,13 +86,6 @@ include $(PGXS)
 
 ifeq ($(GE91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(UPGRADES)
-endif
-
-#preprocessor check for postgis file
-LIB = $$libdir/postgis-3.so 
-
-ifneq($(wildcard $(LIB)),)
-PG_CPPFLAGS = -DPOSTGIS_INCLUDED
 endif
 
 $(EXTENSION).control: $(EXTENSION).control.in

--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -80,6 +80,13 @@ ifeq ($(GE91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(UPGRADES)
 endif
 
+#preprocessor check for postgis file
+LIB = $$libdir/postgis-3.so 
+
+ifneq($(wildcard $(LIB)),)
+PG_CPPFLAGS = -DPOSTGIS_INCLUDED
+endif
+
 $(EXTENSION).control: $(EXTENSION).control.in
 	cat $< \
 		| sed -e 's|@EXTVERSION@|$(EXTVERSION)|g' \

--- a/contrib/babelfishpg_common/sql/babelfishpg_common.in
+++ b/contrib/babelfishpg_common/sql/babelfishpg_common.in
@@ -29,11 +29,8 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 #include "string_operators.sql"
 #include "coerce.sql"
 #include "rowversion.sql"
-#ifdef POSTGIS_INCLUDED
-#include "geometry.sql"
-#include "geography.sql"
-#endif
-
+//#include "geometry.sql"
+//#include "geography.sql"
 
 #include "utils.sql"
 

--- a/contrib/babelfishpg_common/sql/babelfishpg_common.in
+++ b/contrib/babelfishpg_common/sql/babelfishpg_common.in
@@ -29,6 +29,11 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 #include "string_operators.sql"
 #include "coerce.sql"
 #include "rowversion.sql"
+#ifdef POSTGIS_INCLUDED
+#include "geometry.sql"
+#include "geography.sql"
+#endif
+
 
 #include "utils.sql"
 

--- a/contrib/babelfishpg_common/sql/babelfishpg_common.in
+++ b/contrib/babelfishpg_common/sql/babelfishpg_common.in
@@ -29,8 +29,8 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 #include "string_operators.sql"
 #include "coerce.sql"
 #include "rowversion.sql"
-//#include "geometry.sql"
-//#include "geography.sql"
+#include "geometry.sql"
+#include "geography.sql"
 
 #include "utils.sql"
 

--- a/contrib/babelfishpg_common/sql/geography.sql
+++ b/contrib/babelfishpg_common/sql/geography.sql
@@ -1,0 +1,109 @@
+CREATE OR REPLACE FUNCTION sys.geographyin(cstring, oid, integer)
+    RETURNS sys.GEOGRAPHY
+    AS '$libdir/postgis-3','geography_in'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geographyout(sys.GEOGRAPHY)
+    RETURNS cstring
+    AS '$libdir/postgis-3','geography_out'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geographytypmodin(cstring[])
+    RETURNS integer
+    AS '$libdir/postgis-3','geometry_typmod_in'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geographytypmodout(integer)
+    RETURNS cstring
+    AS '$libdir/postgis-3','postgis_typmod_out'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geographyrecv(internal, oid, integer)
+    RETURNS sys.GEOGRAPHY
+    AS '$libdir/postgis-3','geography_recv'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE; 
+
+CREATE OR REPLACE FUNCTION sys.geographysend(sys.GEOGRAPHY)
+    RETURNS bytea
+    AS '$libdir/postgis-3','geography_send'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geographyanalyze(internal)
+    RETURNS bool
+    AS '$libdir/postgis-3','gserialized_analyze_nd'
+    LANGUAGE 'c' VOLATILE STRICT;  
+
+
+CREATE TYPE sys.GEOGRAPHY (
+    INTERNALLENGTH = variable,
+	INPUT          = sys.geographyin,
+    OUTPUT         = sys.geographyout,
+    RECEIVE        = sys.geographyrecv,
+    SEND           = sys.geographysend,
+    TYPMOD_IN      = sys.geographytypmodin,
+    TYPMOD_OUT     = sys.geographytypmodout,
+    DELIMITER      = ':', 
+    ANALYZE        = sys.geographyanalyze,
+    STORAGE        = main, 
+    ALIGNMENT      = double
+);
+
+CREATE OR REPLACE FUNCTION sys.GEOGRAPHY(sys.GEOGRAPHY, integer, boolean)
+	RETURNS sys.GEOGRAPHY
+	AS '$libdir/postgis-3','geography_enforce_typmod'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (sys.GEOGRAPHY AS sys.GEOGRAPHY) WITH FUNCTION sys.GEOGRAPHY(sys.GEOGRAPHY, integer, boolean) AS IMPLICIT;
+
+CREATE OR REPLACE FUNCTION sys.GEOGRAPHY(bytea)
+	RETURNS sys.GEOGRAPHY
+	AS '$libdir/postgis-3','geography_from_binary'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.bytea(sys.GEOGRAPHY)
+	RETURNS bytea
+	AS '$libdir/postgis-3','LWGEOM_to_bytea'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (bytea AS sys.GEOGRAPHY) WITH FUNCTION sys.GEOGRAPHY(bytea) AS IMPLICIT;
+CREATE CAST (sys.GEOGRAPHY AS bytea) WITH FUNCTION sys.bytea(sys.GEOGRAPHY) AS IMPLICIT;
+
+CREATE OR REPLACE FUNCTION sys.GEOGRAPHY(sys.GEOMETRY)
+	RETURNS sys.GEOGRAPHY
+	AS '$libdir/postgis-3','geography_from_geometry'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (sys.GEOMETRY AS sys.GEOGRAPHY) WITH FUNCTION sys.GEOGRAPHY(sys.GEOMETRY) AS IMPLICIT;
+
+CREATE OR REPLACE FUNCTION sys.GEOMETRY(sys.GEOGRAPHY)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','geometry_from_geography'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (sys.GEOGRAPHY AS sys.GEOMETRY) WITH FUNCTION sys.GEOMETRY(sys.GEOGRAPHY) ;
+
+CREATE OR REPLACE FUNCTION sys.STAsText(sys.GEOGRAPHY)
+	RETURNS TEXT
+	AS '$libdir/postgis-3','LWGEOM_asText'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE; 
+
+CREATE OR REPLACE FUNCTION sys.STAsBinary(sys.GEOGRAPHY)
+	RETURNS bytea
+	AS '$libdir/postgis-3','LWGEOM_asBinary'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
+
+-- Minimum distance. 2D only.
+CREATE OR REPLACE FUNCTION sys.STDistance(geog1 sys.GEOGRAPHY, geog2 sys.GEOGRAPHY)
+	RETURNS float8
+	AS '$libdir/postgis-3', 'ST_Distance'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.long(sys.GEOGRAPHY)
+	RETURNS float8
+	AS '$libdir/postgis-3','LWGEOM_x_point'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.lat(sys.GEOGRAPHY)
+	RETURNS float8
+	AS '$libdir/postgis-3','LWGEOM_y_point'
+	LANGUAGE 'c' IMMUTABLE STRICT;  

--- a/contrib/babelfishpg_common/sql/geometry.sql
+++ b/contrib/babelfishpg_common/sql/geometry.sql
@@ -1,0 +1,141 @@
+CREATE OR REPLACE FUNCTION sys.geometryin(cstring)
+    RETURNS sys.GEOMETRY
+    AS '$libdir/postgis-3', 'LWGEOM_in'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geometryout(sys.GEOMETRY)
+	RETURNS cstring
+	AS '$libdir/postgis-3','LWGEOM_out'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geometrytypmodin(cstring[])
+	RETURNS integer
+	AS '$libdir/postgis-3','geometry_typmod_in'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geometrytypmodout(integer)
+	RETURNS cstring
+	AS '$libdir/postgis-3','postgis_typmod_out'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geometryanalyze(internal)
+	RETURNS bool
+	AS '$libdir/postgis-3', 'gserialized_analyze_nd'
+	LANGUAGE 'c' VOLATILE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.geometryrecv(internal)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','LWGEOM_recv'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.geometrysend(sys.GEOMETRY)
+	RETURNS bytea
+	AS '$libdir/postgis-3','LWGEOM_send'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE TYPE sys.GEOMETRY (
+	INTERNALLENGTH = variable,
+	INPUT = sys.geometryin,
+	OUTPUT = sys.geometryout,
+	SEND = sys.geometrysend,
+	RECEIVE = sys.geometryrecv,
+	TYPMOD_IN = sys.geometrytypmodin,
+	TYPMOD_OUT = sys.geometrytypmodout,
+	DELIMITER = ':',
+	ALIGNMENT = double,
+	ANALYZE = sys.geometryanalyze,
+	STORAGE = main
+);
+
+
+CREATE OR REPLACE FUNCTION sys.GEOMETRY(sys.GEOMETRY, integer, boolean)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','geometry_enforce_typmod'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (sys.GEOMETRY AS sys.GEOMETRY) WITH FUNCTION sys.GEOMETRY(sys.GEOMETRY, integer, boolean) AS IMPLICIT;
+
+CREATE OR REPLACE FUNCTION sys.GEOMETRY(point)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','point_to_geometry'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.point(sys.GEOMETRY)
+	RETURNS point
+	AS '$libdir/postgis-3','geometry_to_point'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (sys.GEOMETRY AS point) WITH FUNCTION sys.point(sys.GEOMETRY);
+CREATE CAST (point AS sys.GEOMETRY) WITH FUNCTION sys.GEOMETRY(point);
+
+CREATE OR REPLACE FUNCTION sys.stgeomfromtext(text)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','LWGEOM_from_text'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.stgeomfromtext(text,integer)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','LWGEOM_from_text'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.STAsText(sys.GEOMETRY)
+	RETURNS TEXT
+	AS '$libdir/postgis-3','LWGEOM_asText'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE; 
+
+CREATE OR REPLACE FUNCTION sys.text(sys.GEOMETRY)
+	RETURNS text
+	AS '$libdir/postgis-3','LWGEOM_to_text'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.GEOMETRY(bytea)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','LWGEOM_from_bytea'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.bytea(sys.GEOMETRY)
+	RETURNS bytea
+	AS '$libdir/postgis-3','LWGEOM_to_bytea'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.GEOMETRY(text)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','parse_WKT_lwgeom'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (text AS sys.GEOMETRY) WITH FUNCTION sys.GEOMETRY(text) AS IMPLICIT;
+CREATE CAST (sys.GEOMETRY AS text) WITH FUNCTION sys.text(sys.GEOMETRY) AS IMPLICIT;
+CREATE CAST (bytea AS sys.GEOMETRY) WITH FUNCTION sys.GEOMETRY(bytea) AS IMPLICIT;
+CREATE CAST (sys.GEOMETRY AS bytea) WITH FUNCTION sys.bytea(sys.GEOMETRY) AS IMPLICIT;
+
+-- Availability: 3.2.0 current supported in APG
+CREATE OR REPLACE FUNCTION sys.Point(float8, float8, srid integer)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3', 'ST_Point'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE; 
+
+CREATE OR REPLACE FUNCTION sys.STAsBinary(sys.GEOMETRY)
+	RETURNS bytea
+	AS '$libdir/postgis-3','LWGEOM_asBinary'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.STPointFromText(text, integer)
+	RETURNS sys.GEOMETRY
+	AS '$libdir/postgis-3','LWGEOM_from_text'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Minimum distance. 2D only.
+CREATE OR REPLACE FUNCTION sys.STDistance(geom1 sys.GEOMETRY, geom2 sys.GEOMETRY)
+	RETURNS float8
+	AS '$libdir/postgis-3', 'ST_Distance'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.long(sys.GEOMETRY)
+	RETURNS float8
+	AS '$libdir/postgis-3','LWGEOM_x_point'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.lat(sys.GEOMETRY)
+	RETURNS float8
+	AS '$libdir/postgis-3','LWGEOM_y_point'
+	LANGUAGE 'c' IMMUTABLE STRICT;

--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -3397,6 +3397,7 @@ expression
     | DEFAULT                                                                   #default_expr
     | case_expression                                                           #case_expr
     | hierarchyid_coloncolon_methods                                            #hierarchyid_coloncolon
+    | spatial_coloncolon_methods                                                #spatial_coloncolon
     | over_clause                                                               #over_clause_expr
     | odbc_literal                                                              #odbc_literal_expr
     | DOLLAR_ACTION                                                             #dollar_action_expr
@@ -3814,6 +3815,10 @@ hierarchyid_methods
 hierarchyid_coloncolon_methods
     : id colon_colon  method=(GETROOT | PARSE) LR_BRACKET expression? RR_BRACKET
     ;
+
+spatial_coloncolon_methods
+    : data_type colon_colon function_call
+    ; 
 
 // this is no longer used:
 xml_data_type_methods

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -955,6 +955,18 @@ public:
 			rewritten_query_fragment.emplace(std::make_pair(ctx->start->getStartIndex(), std::make_pair(::getFullText(ctx), rewritten_name)));
 		if (pltsql_enable_tsql_information_schema && !rewritten_schema_name.empty())
 			rewritten_query_fragment.emplace(std::make_pair(ctx->schema->start->getStartIndex(), std::make_pair(::getFullText(ctx->schema), rewritten_schema_name)));
+		
+		#ifndef POSTGIS_INCLUDED
+		if(!ctx->id().empty() && ctx->id()[0]->id().size() == 2)
+		{
+			TSqlParser::IdContext *idctx = ctx->id()[0];
+			if(idctx->id()[0] && idctx->colon_colon() && idctx->id()[1])
+			{
+				rewritten_query_fragment.emplace(std::make_pair(idctx->start->getStartIndex(), std::make_pair(::getFullText(idctx->id()[0]), ""))); 
+				rewritten_query_fragment.emplace(std::make_pair(idctx->colon_colon()->start->getStartIndex(), std::make_pair(::getFullText(idctx->colon_colon()), "")));			
+			}
+		}
+		#endif
 
 		// don't need to call does_object_name_need_delimiter() because problematic keywords are already allowed as function name
 	}
@@ -2175,6 +2187,22 @@ public:
 	// "char" is a data type name in PostgreSQL
 
 	TSqlParser::IdContext *proc = ctx->procedure;
+
+	#ifndef POSTGIS_INCLUDED
+	if(!ctx->id().empty() && ctx->id()[0]->id().size() == 2)
+	{
+		TSqlParser::IdContext *idctx = ctx->id()[0];
+		if(idctx->id()[0] && idctx->colon_colon() && idctx->id()[1])
+		{
+			// Replace id()[0] and colon_colon with blank spaces of the same length
+            std::string idText = idctx->id()[0]->getText();
+            std::string colonText = idctx->colon_colon()->getText();
+            std::string blankSpaces(idText.size() + colonText.size(), ' ');
+            
+            stream.setText(idctx->id()[0]->start->getStartIndex(), blankSpaces.c_str());
+		}
+	}
+	#endif
 
 	// if the func name contains colon_colon, it must begin with it. see grammar
     if (ctx->colon_colon())

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -956,7 +956,8 @@ public:
 		if (pltsql_enable_tsql_information_schema && !rewritten_schema_name.empty())
 			rewritten_query_fragment.emplace(std::make_pair(ctx->schema->start->getStartIndex(), std::make_pair(::getFullText(ctx->schema), rewritten_schema_name)));
 		
-		#ifndef POSTGIS_INCLUDED
+		//#ifndef POSTGIS_INCLUDED
+		/*
 		if(!ctx->id().empty() && ctx->id()[0]->id().size() == 2)
 		{
 			TSqlParser::IdContext *idctx = ctx->id()[0];
@@ -966,7 +967,8 @@ public:
 				rewritten_query_fragment.emplace(std::make_pair(idctx->colon_colon()->start->getStartIndex(), std::make_pair(::getFullText(idctx->colon_colon()), "")));			
 			}
 		}
-		#endif
+		*/
+		//#endif
 
 		// don't need to call does_object_name_need_delimiter() because problematic keywords are already allowed as function name
 	}
@@ -2188,7 +2190,8 @@ public:
 
 	TSqlParser::IdContext *proc = ctx->procedure;
 
-	#ifndef POSTGIS_INCLUDED
+	//#ifndef POSTGIS_INCLUDED
+	/*
 	if(!ctx->id().empty() && ctx->id()[0]->id().size() == 2)
 	{
 		TSqlParser::IdContext *idctx = ctx->id()[0];
@@ -2202,7 +2205,8 @@ public:
             stream.setText(idctx->id()[0]->start->getStartIndex(), blankSpaces.c_str());
 		}
 	}
-	#endif
+	*/
+	//#endif
 
 	// if the func name contains colon_colon, it must begin with it. see grammar
     if (ctx->colon_colon())

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -957,7 +957,6 @@ public:
 			rewritten_query_fragment.emplace(std::make_pair(ctx->schema->start->getStartIndex(), std::make_pair(::getFullText(ctx->schema), rewritten_schema_name)));
 		
 		//#ifndef POSTGIS_INCLUDED
-		/*
 		if(!ctx->id().empty() && ctx->id()[0]->id().size() == 2)
 		{
 			TSqlParser::IdContext *idctx = ctx->id()[0];
@@ -967,7 +966,6 @@ public:
 				rewritten_query_fragment.emplace(std::make_pair(idctx->colon_colon()->start->getStartIndex(), std::make_pair(::getFullText(idctx->colon_colon()), "")));			
 			}
 		}
-		*/
 		//#endif
 
 		// don't need to call does_object_name_need_delimiter() because problematic keywords are already allowed as function name
@@ -2191,7 +2189,6 @@ public:
 	TSqlParser::IdContext *proc = ctx->procedure;
 
 	//#ifndef POSTGIS_INCLUDED
-	/*
 	if(!ctx->id().empty() && ctx->id()[0]->id().size() == 2)
 	{
 		TSqlParser::IdContext *idctx = ctx->id()[0];
@@ -2205,7 +2202,6 @@ public:
             stream.setText(idctx->id()[0]->start->getStartIndex(), blankSpaces.c_str());
 		}
 	}
-	*/
 	//#endif
 
 	// if the func name contains colon_colon, it must begin with it. see grammar

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -211,7 +211,9 @@ protected:
 		antlrcpp::Any visitXml_exist_call(TSqlParser::Xml_exist_callContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_XML_EXIST, "XML EXIST", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitXml_modify_call(TSqlParser::Xml_modify_callContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_XML_MODIFY, "XML MODIFY", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitHierarchyid_methods(TSqlParser::Hierarchyid_methodsContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_HIERARCHYID_METHOD, "HIERARCHYID methods", getLineAndPos(ctx)); return visitChildren(ctx); }
+		#ifndef POSTGIS_INCLUDED
 		antlrcpp::Any visitSpatial_methods(TSqlParser::Spatial_methodsContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_SPATIAL_METHOD, "spatial methods", getLineAndPos(ctx)); return visitChildren(ctx); }
+		#endif
 
 		// built-in functions
 		antlrcpp::Any visitBif_cast_parse(TSqlParser::Bif_cast_parseContext *ctx) override;
@@ -1438,10 +1440,12 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitData_type(TSqlParser::Data
 			}
 			else if (pg_strcasecmp("hierarchyid", name.c_str()) == 0)
 				handle(INSTR_TSQL_HIERARCHYID_DATATYPE, "HIERARCHYID datatype", getLineAndPos(ctx));
+			#ifndef POSTGIS_INCLUDED
 			else if (pg_strcasecmp("geography", name.c_str()) == 0)
 				handle(INSTR_TSQL_GEOGRAPHY_DATATYPE, "GEOGRAPHY datatype", getLineAndPos(ctx));
 			else if (pg_strcasecmp("geometry", name.c_str()) == 0)
 				handle(INSTR_TSQL_GEOMETRY_DATATYPE, "GEOMETRY datatype", getLineAndPos(ctx));
+			#endif
 		}
 	}
 	if (ctx->NATIONAL())

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -211,9 +211,9 @@ protected:
 		antlrcpp::Any visitXml_exist_call(TSqlParser::Xml_exist_callContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_XML_EXIST, "XML EXIST", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitXml_modify_call(TSqlParser::Xml_modify_callContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_XML_MODIFY, "XML MODIFY", getLineAndPos(ctx)); return visitChildren(ctx); }
 		antlrcpp::Any visitHierarchyid_methods(TSqlParser::Hierarchyid_methodsContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_HIERARCHYID_METHOD, "HIERARCHYID methods", getLineAndPos(ctx)); return visitChildren(ctx); }
-		#ifndef POSTGIS_INCLUDED
-		antlrcpp::Any visitSpatial_methods(TSqlParser::Spatial_methodsContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_SPATIAL_METHOD, "spatial methods", getLineAndPos(ctx)); return visitChildren(ctx); }
-		#endif
+		//#ifndef POSTGIS_INCLUDED
+		//antlrcpp::Any visitSpatial_methods(TSqlParser::Spatial_methodsContext *ctx) override { handle(INSTR_UNSUPPORTED_TSQL_SPATIAL_METHOD, "spatial methods", getLineAndPos(ctx)); return visitChildren(ctx); }
+		//#endif
 
 		// built-in functions
 		antlrcpp::Any visitBif_cast_parse(TSqlParser::Bif_cast_parseContext *ctx) override;
@@ -1440,12 +1440,12 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitData_type(TSqlParser::Data
 			}
 			else if (pg_strcasecmp("hierarchyid", name.c_str()) == 0)
 				handle(INSTR_TSQL_HIERARCHYID_DATATYPE, "HIERARCHYID datatype", getLineAndPos(ctx));
-			#ifndef POSTGIS_INCLUDED
-			else if (pg_strcasecmp("geography", name.c_str()) == 0)
-				handle(INSTR_TSQL_GEOGRAPHY_DATATYPE, "GEOGRAPHY datatype", getLineAndPos(ctx));
-			else if (pg_strcasecmp("geometry", name.c_str()) == 0)
-				handle(INSTR_TSQL_GEOMETRY_DATATYPE, "GEOMETRY datatype", getLineAndPos(ctx));
-			#endif
+			//#ifndef POSTGIS_INCLUDED
+			//else if (pg_strcasecmp("geography", name.c_str()) == 0)
+			//	handle(INSTR_TSQL_GEOGRAPHY_DATATYPE, "GEOGRAPHY datatype", getLineAndPos(ctx));
+			//else if (pg_strcasecmp("geometry", name.c_str()) == 0)
+			//	handle(INSTR_TSQL_GEOMETRY_DATATYPE, "GEOMETRY datatype", getLineAndPos(ctx));
+			//#endif
 		}
 	}
 	if (ctx->NATIONAL())


### PR DESCRIPTION
Currently Babelfish does not support spatial types, with this change Geometry and Geography are defined using PostGIS functionality. Contains the following definitions and functionalities:

[Geography variable]
[Geography column]
[Geometry variable]
[Geometry column]
Spatial type modifier [Point]
Spatial method [.Lat]
Spatial method [.Long]
Spatial support method [STGeomFromText]
Spatial support method [STPointFromText]
Spatial support method [.STDistance]
Spatial support method .STAsText
Spatial support method .STAsBinary
as well as modifications to the antlr parser in order to support the scope parameter (::)

Check List
 Commits are signed per the DCO using --signoff
By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).