### PR TITLE
Fix sp_xxxextendedproperty() procedure's flakey behaviour

### DIFF
--- a/contrib/babelfishpg_tsql/src/extendedproperty.c
+++ b/contrib/babelfishpg_tsql/src/extendedproperty.c
@@ -264,7 +264,7 @@ sp_execextended_property(PG_FUNCTION_ARGS, ExtendedPropertyProc proc)
 	char 		*schema_name, *major_name, *minor_name, *var_object_name;
 	Oid			schema_id, owner_id;
 	Oid			db_owner, cur_user_id;
-	bool		is_dbo;
+	bool		is_dbo = false;
 	Relation	rel;
 	HeapTuple	tuple;
 	int			nkeys = 0;

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
@@ -1,8 +1,4 @@
--- psql
-
 -- tsql user=owner password=12345678
--- GRANT CREATE ON DATABASE jdbc_testdb TO babel_extended_properties_db_guest
--- GO
 USE babel_extended_properties_db
 GO
 
@@ -3359,4 +3355,3 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 ~~END~~
 
 
--- psql

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
@@ -1,8 +1,8 @@
 -- psql
-GRANT CREATE ON DATABASE jdbc_testdb TO babel_extended_properties_db_guest
-GO
 
 -- tsql user=owner password=12345678
+-- GRANT CREATE ON DATABASE jdbc_testdb TO babel_extended_properties_db_guest
+-- GO
 USE babel_extended_properties_db
 GO
 
@@ -3360,5 +3360,3 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 
 -- psql
-REVOKE CREATE ON DATABASE jdbc_testdb FROM babel_extended_properties_db_guest
-GO

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
@@ -1,3 +1,12 @@
+-- psql
+do
+$$ declare dbname text;
+begin
+    select setting from pg_settings where name like 'babelfishpg_tsql.database_name' into dbname;
+    EXECUTE 'GRANT CREATE ON DATABASE ' || quote_ident(dbname) || ' TO babel_extended_properties_db_guest';
+end $$;
+GO
+
 -- tsql user=owner password=12345678
 USE babel_extended_properties_db
 GO
@@ -3355,3 +3364,11 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 ~~END~~
 
 
+-- psql
+do
+$$ declare dbname text;
+begin
+    select setting from pg_settings where name like 'babelfishpg_tsql.database_name' into dbname;
+    EXECUTE 'REVOKE CREATE ON DATABASE ' || quote_ident(dbname) || ' FROM babel_extended_properties_db_guest';
+end $$;
+GO

--- a/test/JDBC/input/BABEL-EXTENDEDPROPERTY-v2-vu-verify.mix
+++ b/test/JDBC/input/BABEL-EXTENDEDPROPERTY-v2-vu-verify.mix
@@ -1,3 +1,12 @@
+-- psql
+do
+$$ declare dbname text;
+begin
+    select setting from pg_settings where name like 'babelfishpg_tsql.database_name' into dbname;
+    EXECUTE 'GRANT CREATE ON DATABASE ' || quote_ident(dbname) || ' TO babel_extended_properties_db_guest';
+end $$;
+GO
+
 -- tsql user=owner password=12345678
 USE babel_extended_properties_db
 GO
@@ -899,3 +908,11 @@ GO
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties
 GO
 
+-- psql
+do
+$$ declare dbname text;
+begin
+    select setting from pg_settings where name like 'babelfishpg_tsql.database_name' into dbname;
+    EXECUTE 'REVOKE CREATE ON DATABASE ' || quote_ident(dbname) || ' FROM babel_extended_properties_db_guest';
+end $$;
+GO

--- a/test/JDBC/input/BABEL-EXTENDEDPROPERTY-v2-vu-verify.mix
+++ b/test/JDBC/input/BABEL-EXTENDEDPROPERTY-v2-vu-verify.mix
@@ -1,7 +1,3 @@
--- psql
-GRANT CREATE ON DATABASE jdbc_testdb TO babel_extended_properties_db_guest
-GO
-
 -- tsql user=owner password=12345678
 USE babel_extended_properties_db
 GO
@@ -903,6 +899,3 @@ GO
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties
 GO
 
--- psql
-REVOKE CREATE ON DATABASE jdbc_testdb FROM babel_extended_properties_db_guest
-GO


### PR DESCRIPTION
### Description

This commit fixes sp_xxxextendedproperty()'s flakey behaviour when non-dbo user execute non-privileged operation. Since, is_dbo flag was uninitialized earlier, it was behaving non-deterministically allowing non-dbo user to execute non-privileged operation. It also improves BABEL-EXTENDEDPROPERTY-v2-vu-* test to consider physical babelfish database setting while granting the create privileges.

### Issues Resolved



### Test Scenarios Covered ###
* **Use case based -**
Existing test cases covers the same.

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).