### PR TITLE
Support switchoffset function

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -821,6 +821,173 @@ EXCEPTION
         RAISE USING MESSAGE := 'Cannot construct data type smalldatetime, some of the arguments have values which are not valid.',
                     DETAIL := 'Possible use of incorrect value of date or time part (which lies outside of valid range).',
                     HINT := 'Check each input argument belongs to the valid range and try again.';
+
+CREATE OR REPLACE FUNCTION sys.SWITCHOFFSET(IN input_expr PG_CATALOG.TEXT,
+                                                               IN tz_offset PG_CATALOG.TEXT)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    p_year INTEGER;
+    p_month INTEGER;
+    p_day INTEGER;
+    p_hour INTEGER;
+    p_minute INTEGER;
+    p_seconds INTEGER;
+    p_nanosecond INTEGER;
+    p_tzoffset INTEGER;
+    f_tzoffset INTEGER;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+    offset_str PG_CATALOG.TEXT;
+    v_resdatetimeupdated TIMESTAMP WITHOUT TIME ZONE;
+    tzfm INTEGER;
+    str_hr PG_CATALOG.TEXT;
+    str_mi PG_CATALOG.TEXT;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    sign_flag INTEGER;
+    v_string datetimeoffset;
+BEGIN
+    IF tz_offset LIKE '+__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := 1;
+    ELSIF tz_offset LIKE '-__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := -1;
+    ELSE
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;
+
+    BEGIN
+    input_expr:= cast(input_expr AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END; 
+
+    BEGIN
+    v_hr := str_hr::INTEGER;
+    v_mi := str_mi::INTEGER;
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END;
+
+    if v_hr > 14 or v_hr < -14 or (v_hr = 14 and v_mi > 0) THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    tzfm := sign_flag*((v_hr*60)+v_mi);
+
+    p_year := sys.datepart('year',input_expr);
+    p_month := sys.datepart('month',input_expr);
+    p_day := sys.datepart('day',input_expr);
+    p_hour := sys.datepart('hour',input_expr::TIMESTAMP);
+    p_minute := sys.datepart('minute',input_expr);
+    p_seconds := sys.datepart('second',input_expr);
+    p_nanosecond := sys.datepart('nanosecond',input_expr);
+    p_tzoffset := -1*sys.datepart('tzoffset',input_expr);
+
+    
+
+    f_tzoffset := p_tzoffset + tzfm;
+    v_resdatetime := make_timestamp(p_year,p_month,p_day,p_hour,p_minute,p_seconds);
+    v_resdatetimeupdated := v_resdatetime + make_interval(mins => f_tzoffset);
+
+    v_string := CONCAT(v_resdatetimeupdated::pg_catalog.text,'.',p_nanosecond::text,tz_offset);
+    
+    BEGIN
+    RETURN cast(v_string AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+    
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION sys.SWITCHOFFSET(IN input_expr PG_CATALOG.TEXT,
+                                                               IN tz_offset anyelement)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    p_year INTEGER;
+    p_month INTEGER;
+    p_day INTEGER;
+    p_hour INTEGER;
+    p_minute INTEGER;
+    p_seconds INTEGER;
+    p_nanosecond INTEGER;
+    p_tzoffset INTEGER;
+    f_tzoffset INTEGER;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+    offset_str PG_CATALOG.TEXT;
+    v_resdatetimeupdated TIMESTAMP WITHOUT TIME ZONE;
+    tzfm INTEGER;
+    str_hr PG_CATALOG.TEXT;
+    str_mi PG_CATALOG.TEXT;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    sign_flag INTEGER;
+    v_string datetimeoffset;
+    v_sign PG_CATALOG.TEXT;
+BEGIN
+    
+    IF pg_typeof(tz_offset) <> 'integer'::regtype THEN
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;
+
+    BEGIN
+    input_expr:= cast(input_expr AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END; 
+
+    if tz_offset > 840 or tz_offset < -840 THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    v_hr := tz_offset/60;
+    v_mi := tz_offset%60;
+
+    p_year := sys.datepart('year',input_expr);
+    p_month := sys.datepart('month',input_expr);
+    p_day := sys.datepart('day',input_expr);
+    p_hour := sys.datepart('hour',input_expr::TIMESTAMP);
+    p_minute := sys.datepart('minute',input_expr);
+    p_seconds := sys.datepart('second',input_expr);
+    p_nanosecond := sys.datepart('nanosecond',input_expr);
+    p_tzoffset := -1*sys.datepart('tzoffset',input_expr);
+
+    v_sign := (
+        SELECT CASE
+            WHEN (tz_offset) >= 0
+                THEN '+'    
+            ELSE '-'
+        END
+    );
+
+    
+
+    f_tzoffset := p_tzoffset + tz_offset;
+    v_resdatetime := make_timestamp(p_year,p_month,p_day,p_hour,p_minute,p_seconds);
+    v_resdatetimeupdated := v_resdatetime + make_interval(mins => f_tzoffset);
+
+    v_string := CONCAT(v_resdatetimeupdated::pg_catalog.text,'.',p_nanosecond::text,v_sign,abs(v_hr)::TEXT,':',abs(v_mi)::TEXT);
+    
+    BEGIN
+    RETURN cast(v_string AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+    
 END;
 $BODY$
 LANGUAGE plpgsql

--- a/test/JDBC/expected/switchoffset-dep-vu-cleanup.out
+++ b/test/JDBC/expected/switchoffset-dep-vu-cleanup.out
@@ -1,0 +1,17 @@
+DROP VIEW switchoffset_dep_vu_prepare_v1
+GO
+
+DROP VIEW switchoffset_dep_vu_prepare_v2
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p1
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p2
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f1()
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/expected/switchoffset-dep-vu-prepare.out
+++ b/test/JDBC/expected/switchoffset-dep-vu-prepare.out
@@ -1,0 +1,25 @@
+CREATE VIEW switchoffset_dep_vu_prepare_v1 as (Select switchoffset('2000-04-22 16:2a:51.766890',340));
+GO
+
+CREATE VIEW switchoffset_dep_vu_prepare_v2 as (Select switchoffset('2000-04-22 ',345));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p1 as (SELECT switchoffset(cast('2023-08-08 16:06:45' as datetime2), '-13:00'));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p2 as (Select switchoffset('2000-04-22 16:23:51','+12:0e'));
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f1()
+RETURNS DATETIMEOFFSET AS
+BEGIN
+RETURN (Select switchoffset('2000-0a-22 ','+12:00'));
+END
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f2()
+RETURNS DATETIMEOFFSET as
+begin
+RETURN (Select switchoffset('2000-04-22 16:23:50.76689','+12:00'));
+END
+GO

--- a/test/JDBC/expected/switchoffset-dep-vu-verify.out
+++ b/test/JDBC/expected/switchoffset-dep-vu-verify.out
@@ -1,0 +1,46 @@
+SELECT * FROM switchoffset_dep_vu_prepare_v1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+SELECT * FROM switchoffset_dep_vu_prepare_v2
+GO
+~~START~~
+datetimeoffset
+2000-04-22 05:45:00.0000000 +05:45
+~~END~~
+
+
+EXEC switchoffset_dep_vu_prepare_p1
+GO
+~~START~~
+datetimeoffset
+2023-08-08 03:06:45.0000000 -13:00
+~~END~~
+
+
+EXEC switchoffset_dep_vu_prepare_p2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+SELECT switchoffset_dep_vu_prepare_f1()
+GO
+~~START~~
+datetimeoffset
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+SELECT switchoffset_dep_vu_prepare_f2()
+GO
+~~START~~
+datetimeoffset
+2000-04-23 04:23:50.7668900 +12:00
+~~END~~
+

--- a/test/JDBC/expected/switchoffset.out
+++ b/test/JDBC/expected/switchoffset.out
@@ -1,0 +1,112 @@
+Select switchoffset('2001-04-22 ', -120)
+GO
+~~START~~
+datetimeoffset
+2001-04-21 22:00:00.0000000 -02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 ', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 02:00:00.0000000 +02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 19:34:56.0000000 +02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 19:34:56.3450000 +02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 0)
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', -0)
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 0x12)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('2001-04-22 ', '+12:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 12:00:00.0000000 +12:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 ', '-12:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-21 12:00:00.0000000 -12:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56', '-12:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 05:34:56.0000000 -12:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-11:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 06:34:56.3450000 -11:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '+00:00')
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-00:00')
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 10:34:56.345', '-11:00')
+go
+~~START~~
+datetimeoffset
+2001-04-21 23:34:56.3450000 -11:00
+~~END~~
+
+
+

--- a/test/JDBC/input/switchoffset-dep-vu-cleanup.sql
+++ b/test/JDBC/input/switchoffset-dep-vu-cleanup.sql
@@ -1,0 +1,17 @@
+DROP VIEW switchoffset_dep_vu_prepare_v1
+GO
+
+DROP VIEW switchoffset_dep_vu_prepare_v2
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p1
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p2
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f1()
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/input/switchoffset-dep-vu-prepare.sql
+++ b/test/JDBC/input/switchoffset-dep-vu-prepare.sql
@@ -1,0 +1,25 @@
+CREATE VIEW switchoffset_dep_vu_prepare_v1 as (Select switchoffset('2000-04-22 16:2a:51.766890',340));
+GO
+
+CREATE VIEW switchoffset_dep_vu_prepare_v2 as (Select switchoffset('2000-04-22 ',345));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p1 as (SELECT switchoffset(cast('2023-08-08 16:06:45' as datetime2), '-13:00'));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p2 as (Select switchoffset('2000-04-22 16:23:51','+12:0e'));
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f1()
+RETURNS DATETIMEOFFSET AS
+BEGIN
+RETURN (Select switchoffset('2000-0a-22 ','+12:00'));
+END
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f2()
+RETURNS DATETIMEOFFSET as
+begin
+RETURN (Select switchoffset('2000-04-22 16:23:50.76689','+12:00'));
+END
+GO

--- a/test/JDBC/input/switchoffset-dep-vu-verify.sql
+++ b/test/JDBC/input/switchoffset-dep-vu-verify.sql
@@ -1,0 +1,17 @@
+SELECT * FROM switchoffset_dep_vu_prepare_v1
+GO
+
+SELECT * FROM switchoffset_dep_vu_prepare_v2
+GO
+
+EXEC switchoffset_dep_vu_prepare_p1
+GO
+
+EXEC switchoffset_dep_vu_prepare_p2
+GO
+
+SELECT switchoffset_dep_vu_prepare_f1()
+GO
+
+SELECT switchoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/input/switchoffset.sql
+++ b/test/JDBC/input/switchoffset.sql
@@ -1,0 +1,43 @@
+Select switchoffset('2001-04-22 ', -120)
+GO
+
+Select switchoffset('2001-04-22 ', 120)
+GO
+
+Select switchoffset('2001-04-22 17:34:56', 120)
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', 120)
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', 0)
+go
+
+Select switchoffset('2001-04-22 17:34:56.345', -0)
+go
+
+Select switchoffset('2001-04-22 17:34:56.345', 0x12)
+go
+
+Select switchoffset('2001-04-22 ', '+12:00')
+GO
+
+Select switchoffset('2001-04-22 ', '-12:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56', '-12:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '-11:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '+00:00')
+go
+
+Select switchoffset('2001-04-22 17:34:56.345', '-00:00')
+go
+
+Select switchoffset('2001-04-22 10:34:56.345', '-11:00')
+go
+
+

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -243,6 +243,7 @@ sp_describe_first_result_set
 sp_tablecollations
 smalldatetimefromparts-dep
 str
+switchoffset-dep
 sys-all_columns
 sys-all_columns-dep
 sys_all_objects


### PR DESCRIPTION
### Description
This function returns a datetimeoffset value that is changed from the stored time zone offset to a specified new time zone offset.

Example
```
SELECT TODATETIMEOFFSET(SYSDATETIME(), -120)
2023-08-03 10:26:35.5053494 -02:00

Select SYSDATETIME()
2023-08-03 10:27:07.3436982
```



### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).