### PR TITLE
Support the function COL_NAME()

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -3527,3 +3527,22 @@ CREATE OR REPLACE FUNCTION sys.fn_listextendedproperty
 RETURNS SETOF RECORD
 AS 'babelfishpg_tsql' LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.fn_listextendedproperty TO PUBLIC;
+
+-- Matches and returns column name of the corresponding table
+CREATE OR REPLACE FUNCTION sys.COL_NAME(IN table_id INT, IN column_id INT)
+RETURNS sys.SYSNAME AS $$
+    DECLARE
+        column_name TEXT;
+    BEGIN
+        SELECT attname INTO STRICT column_name 
+        FROM pg_attribute 
+        WHERE attrelid = table_id AND attnum = column_id AND attnum > 0;
+        
+        RETURN column_name::sys.SYSNAME;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN NULL;
+    END; 
+$$
+LANGUAGE plpgsql IMMUTABLE
+STRICT;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -894,3 +894,22 @@ ALTER FUNCTION sys.replace (in input_string text, in pattern text, in replacemen
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
+
+-- Matches and returns column name of the corresponding table
+CREATE OR REPLACE FUNCTION sys.COL_NAME(IN table_id INT, IN column_id INT)
+RETURNS sys.SYSNAME AS $$
+    DECLARE
+        column_name TEXT;
+    BEGIN
+        SELECT attname INTO STRICT column_name 
+        FROM pg_attribute 
+        WHERE attrelid = table_id AND attnum = column_id AND attnum > 0;
+        
+        RETURN column_name::sys.SYSNAME;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN NULL;
+    END; 
+$$
+LANGUAGE plpgsql IMMUTABLE
+STRICT;

--- a/test/JDBC/expected/BABEL_COL_NAME-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_COL_NAME-vu-cleanup.out
@@ -1,0 +1,36 @@
+USE babel_3172_test_db;
+GO
+
+DROP TABLE IF EXISTS sys_column_name_vu_t_column_name;
+GO
+
+DROP TABLE IF EXISTS sys_col_name_test_schema.test_table;
+GO
+
+DROP SCHEMA IF EXISTS sys_col_name_test_schema;
+GO
+
+USE master;
+GO
+
+DROP DATABASE IF EXISTS babel_3172_test_db;
+GO
+
+-- Drop views
+DROP VIEW IF EXISTS col_name_prepare_v1;
+DROP VIEW IF EXISTS col_name_prepare_v2;
+DROP VIEW IF EXISTS col_name_prepare_v3;
+DROP VIEW IF EXISTS col_name_prepare_v4;
+GO
+
+-- Drop procedures
+DROP PROCEDURE IF EXISTS col_name_prepare_p1;
+DROP PROCEDURE IF EXISTS col_name_prepare_p2;
+DROP PROCEDURE IF EXISTS col_name_prepare_p3;
+DROP PROCEDURE IF EXISTS col_name_prepare_p4;
+GO
+
+-- Drop functions
+DROP FUNCTION IF EXISTS col_name_prepare_f1();
+DROP FUNCTION IF EXISTS col_name_prepare_f2();
+GO

--- a/test/JDBC/expected/BABEL_COL_NAME-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_COL_NAME-vu-prepare.out
@@ -1,0 +1,66 @@
+CREATE DATABASE babel_3172_test_db;
+GO
+
+USE babel_3172_test_db;
+GO
+
+CREATE TABLE sys_column_name_vu_t_column_name(
+    id int,
+    names char
+)
+GO
+
+CREATE SCHEMA sys_col_name_test_schema;
+GO
+
+CREATE TABLE sys_col_name_test_schema.test_table(
+    firstName varchar(30)
+)
+GO
+
+CREATE VIEW col_name_prepare_v1 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), 1))
+GO
+
+-- Invalid column, should return NULL
+CREATE VIEW col_name_prepare_v2 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), 3))
+GO
+
+-- Invalid table, should return NULL
+CREATE VIEW col_name_prepare_v3 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name_invalid')) AS INT), 1))
+GO
+
+-- Invalid column, should return NULL
+CREATE VIEW col_name_prepare_v4 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), NULL))
+GO
+
+-- Invalid table, should return NULL
+CREATE PROCEDURE col_name_prepare_p1 AS (SELECT COL_NAME(NULL, 1));
+GO
+
+-- Invalid column, should return NULL
+CREATE PROCEDURE col_name_prepare_p2 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), -1))
+GO
+
+-- Invalid table, should return NULL
+CREATE PROCEDURE col_name_prepare_p3 AS (SELECT COL_NAME(-1, 1))
+GO
+
+-- Invalid table and column, should return NULL
+CREATE PROCEDURE col_name_prepare_p4 AS (SELECT COL_NAME(-1, -1))
+GO
+
+-- Invalid column, should return NULL
+CREATE FUNCTION col_name_prepare_f1()
+RETURNS sys.SYSNAME AS
+BEGIN
+RETURN (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), 'invalid test expression'))
+END
+GO
+
+-- Invalid table, should return NULL
+CREATE FUNCTION col_name_prepare_f2()
+RETURNS sys.SYSNAME AS
+BEGIN
+RETURN (SELECT COL_NAME('invalid test expression', 1))
+END
+GO

--- a/test/JDBC/expected/BABEL_COL_NAME-vu-verify.out
+++ b/test/JDBC/expected/BABEL_COL_NAME-vu-verify.out
@@ -1,0 +1,137 @@
+USE babel_3172_test_db;
+GO
+
+SELECT * FROM col_name_prepare_v1;
+GO
+~~START~~
+varchar
+id
+~~END~~
+
+
+SELECT * FROM col_name_prepare_v2;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+SELECT * FROM col_name_prepare_v3;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+SELECT * FROM col_name_prepare_v4;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+EXEC col_name_prepare_p1;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+EXEC col_name_prepare_p2;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+EXEC col_name_prepare_p3;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+EXEC col_name_prepare_p4;
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+SELECT col_name_prepare_f1();
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "invalid test expression")~~
+
+
+SELECT col_name_prepare_f2();
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "invalid test expression")~~
+
+
+SELECT * FROM COL_NAME(NULL, NULL);
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+
+DECLARE @table_id INT = (SELECT OBJECT_ID('sys_col_name_test_schema.test_table'));
+SELECT * FROM COL_NAME(@table_id, 1);
+GO
+~~START~~
+varchar
+firstname
+~~END~~
+
+
+SELECT * FROM COL_NAME('0x1A', 3);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "0x1A")~~
+
+
+SELECT * FROM COL_NAME(7, 'column_name');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "column_name")~~
+
+
+SELECT * FROM COL_NAME('0x2F', 'another_column');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "0x2F")~~
+
+
+SELECT * FROM COL_NAME('0xAB', '0x8C');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "0xAB")~~
+
+
+SELECT * FROM COL_NAME('sample_table', 'some_column');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "sample_table")~~
+

--- a/test/JDBC/input/BABEL_COL_NAME-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL_COL_NAME-vu-cleanup.sql
@@ -1,0 +1,36 @@
+USE babel_3172_test_db;
+GO
+
+DROP TABLE IF EXISTS sys_column_name_vu_t_column_name;
+GO
+
+DROP TABLE IF EXISTS sys_col_name_test_schema.test_table;
+GO
+
+DROP SCHEMA IF EXISTS sys_col_name_test_schema;
+GO
+
+USE master;
+GO
+
+DROP DATABASE IF EXISTS babel_3172_test_db;
+GO
+
+-- Drop views
+DROP VIEW IF EXISTS col_name_prepare_v1;
+DROP VIEW IF EXISTS col_name_prepare_v2;
+DROP VIEW IF EXISTS col_name_prepare_v3;
+DROP VIEW IF EXISTS col_name_prepare_v4;
+GO
+
+-- Drop procedures
+DROP PROCEDURE IF EXISTS col_name_prepare_p1;
+DROP PROCEDURE IF EXISTS col_name_prepare_p2;
+DROP PROCEDURE IF EXISTS col_name_prepare_p3;
+DROP PROCEDURE IF EXISTS col_name_prepare_p4;
+GO
+
+-- Drop functions
+DROP FUNCTION IF EXISTS col_name_prepare_f1();
+DROP FUNCTION IF EXISTS col_name_prepare_f2();
+GO

--- a/test/JDBC/input/BABEL_COL_NAME-vu-prepare.sql
+++ b/test/JDBC/input/BABEL_COL_NAME-vu-prepare.sql
@@ -1,0 +1,66 @@
+CREATE DATABASE babel_3172_test_db;
+GO
+
+USE babel_3172_test_db;
+GO
+
+CREATE TABLE sys_column_name_vu_t_column_name(
+    id int,
+    names char
+)
+GO
+
+CREATE SCHEMA sys_col_name_test_schema;
+GO
+
+CREATE TABLE sys_col_name_test_schema.test_table(
+    firstName varchar(30)
+)
+GO
+
+CREATE VIEW col_name_prepare_v1 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), 1))
+GO
+
+-- Invalid column, should return NULL
+CREATE VIEW col_name_prepare_v2 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), 3))
+GO
+
+-- Invalid table, should return NULL
+CREATE VIEW col_name_prepare_v3 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name_invalid')) AS INT), 1))
+GO
+
+-- Invalid column, should return NULL
+CREATE VIEW col_name_prepare_v4 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), NULL))
+GO
+
+-- Invalid table, should return NULL
+CREATE PROCEDURE col_name_prepare_p1 AS (SELECT COL_NAME(NULL, 1));
+GO
+
+-- Invalid column, should return NULL
+CREATE PROCEDURE col_name_prepare_p2 AS (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), -1))
+GO
+
+-- Invalid table, should return NULL
+CREATE PROCEDURE col_name_prepare_p3 AS (SELECT COL_NAME(-1, 1))
+GO
+
+-- Invalid table and column, should return NULL
+CREATE PROCEDURE col_name_prepare_p4 AS (SELECT COL_NAME(-1, -1))
+GO
+
+-- Invalid column, should return NULL
+CREATE FUNCTION col_name_prepare_f1()
+RETURNS sys.SYSNAME AS
+BEGIN
+RETURN (SELECT COL_NAME(CAST((SELECT OBJECT_ID('sys_column_name_vu_t_column_name')) AS INT), 'invalid test expression'))
+END
+GO
+
+-- Invalid table, should return NULL
+CREATE FUNCTION col_name_prepare_f2()
+RETURNS sys.SYSNAME AS
+BEGIN
+RETURN (SELECT COL_NAME('invalid test expression', 1))
+END
+GO

--- a/test/JDBC/input/BABEL_COL_NAME-vu-verify.sql
+++ b/test/JDBC/input/BABEL_COL_NAME-vu-verify.sql
@@ -1,0 +1,55 @@
+USE babel_3172_test_db;
+GO
+
+SELECT * FROM col_name_prepare_v1;
+GO
+
+SELECT * FROM col_name_prepare_v2;
+GO
+
+SELECT * FROM col_name_prepare_v3;
+GO
+
+SELECT * FROM col_name_prepare_v4;
+GO
+
+EXEC col_name_prepare_p1;
+GO
+
+EXEC col_name_prepare_p2;
+GO
+
+EXEC col_name_prepare_p3;
+GO
+
+EXEC col_name_prepare_p4;
+GO
+
+SELECT col_name_prepare_f1();
+GO
+
+SELECT col_name_prepare_f2();
+GO
+
+SELECT * FROM COL_NAME(NULL, NULL);
+GO
+
+DECLARE @table_id INT = (SELECT OBJECT_ID('sys_col_name_test_schema.test_table'));
+
+SELECT * FROM COL_NAME(@table_id, 1);
+GO
+
+SELECT * FROM COL_NAME('0x1A', 3);
+GO
+
+SELECT * FROM COL_NAME(7, 'column_name');
+GO
+
+SELECT * FROM COL_NAME('0x2F', 'another_column');
+GO
+
+SELECT * FROM COL_NAME('0xAB', '0x8C');
+GO
+
+SELECT * FROM COL_NAME('sample_table', 'some_column');
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -147,6 +147,7 @@ babelfish_sysdatabases
 babel_function_string
 BABEL_GRANT_CONNECT
 babel_isnumeric
+BABEL_COL_NAME
 BABEL-LOGIN
 BABEL-LOGIN-USER-EXT
 BABEL-NEXT-VALUE-FOR


### PR DESCRIPTION
### Description

Implement a function COL_NAME(table_id, column_id) which returns the Transact-SQL column name that corresponds to the provided column ID within the specified table.

For example:

Input-
CREATE TABLE test_table(c1 int);
GO
SELECT COL_NAME(OBJECT_ID('test_table'), 1);
GO

Output-
c1

Signed-off-by: Roshan Kanwar [rskanwar@amazon.com](mailto:rskanwar@amazon.com)

### Issues Resolved

BABEL-3172

### Test Scenarios Covered ###
* **Use case based -** Added use case based tests in JDBC framework


* **Boundary conditions -** Added edge cases where table_id and column_id both can be invalid or NULL


* **Arbitrary inputs -** Added cases for string/expression input


* **Negative test cases -** Added test cases where table_id and column_id will be negative


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).