### PR TITLE
fix crash in parallel query with enable_pg_hint 'on' 'server' in BABEL_2_3_STABLE

### DIFF
--- a/test/JDBC/expected/BABEL-4294-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4294-vu-cleanup.out
@@ -1,0 +1,9 @@
+
+-- Test to check if initialisation of Parallel Worker crash when babelfishpg_tsql.enable_pg_hint is set
+drop table babel_4294_t1;
+drop table babel_4294_t2;
+drop table babel_4294_t3;
+go
+
+drop table babel_4294_t4;
+go

--- a/test/JDBC/expected/BABEL-4294-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4294-vu-prepare.out
@@ -1,0 +1,20 @@
+
+-- Test to check if initialisation of Parallel Worker crash when babelfishpg_tsql.enable_pg_hint is set
+create table babel_4294_t1(id INT, val int);
+create table babel_4294_t2(babel_4294_t1_id INT, val int);
+create table babel_4294_t3(babel_4294_t1_id INT, val int);
+go
+
+insert into babel_4294_t1 values (1, 10), (2, 20), (3, 30);
+insert into babel_4294_t2 values (1, 11), (2, 12), (3, 13);
+insert into babel_4294_t3 values (1, 99), (2, 77), (3, 55);
+go
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+
+create table babel_4294_t4(id INT, val int);
+go

--- a/test/JDBC/expected/BABEL-4294-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4294-vu-verify.out
@@ -1,0 +1,56 @@
+
+-- Test to check if initialisation of Parallel Worker crash when babelfishpg_tsql.enable_pg_hint is set
+/*
+ * Set the enable_pg_hint, try to create parallel worker
+ */
+exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
+go
+
+select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
+inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
+inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
+GROUP BY babel_4294_t2.val
+UNION ALL
+select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
+inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
+inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
+GROUP BY babel_4294_t2.val
+go
+~~START~~
+int#!#int
+1#!#11
+1#!#13
+1#!#12
+1#!#11
+1#!#13
+1#!#12
+~~END~~
+
+
+-- Used force parallel mode to create a parallel worker
+select set_config('force_parallel_mode', '1', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+
+-- to check if parallel worker generated for following query, will crash or not
+select * from babel_4294_t4
+go
+~~START~~
+int#!#int
+~~END~~
+
+
+select set_config('force_parallel_mode', '0', false)
+go
+~~START~~
+text
+off
+~~END~~
+
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go

--- a/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-cleanup.sql
+++ b/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-cleanup.sql
@@ -1,0 +1,9 @@
+-- Test to check if initialisation of Parallel Worker crash when babelfishpg_tsql.enable_pg_hint is set
+
+drop table babel_4294_t1;
+drop table babel_4294_t2;
+drop table babel_4294_t3;
+go
+
+drop table babel_4294_t4;
+go

--- a/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-prepare.sql
+++ b/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-prepare.sql
@@ -1,0 +1,14 @@
+-- Test to check if initialisation of Parallel Worker crash when babelfishpg_tsql.enable_pg_hint is set
+
+create table babel_4294_t1(id INT, val int);
+create table babel_4294_t2(babel_4294_t1_id INT, val int);
+create table babel_4294_t3(babel_4294_t1_id INT, val int);
+go
+
+insert into babel_4294_t1 values (1, 10), (2, 20), (3, 30);
+insert into babel_4294_t2 values (1, 11), (2, 12), (3, 13);
+insert into babel_4294_t3 values (1, 99), (2, 77), (3, 55);
+go
+
+create table babel_4294_t4(id INT, val int);
+go

--- a/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-verify.sql
+++ b/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-verify.sql
@@ -1,0 +1,32 @@
+-- Test to check if initialisation of Parallel Worker crash when babelfishpg_tsql.enable_pg_hint is set
+/*
+ * Set the enable_pg_hint, try to create parallel worker
+ */
+
+exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
+go
+
+select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
+inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
+inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
+GROUP BY babel_4294_t2.val
+UNION ALL
+select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
+inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
+inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
+GROUP BY babel_4294_t2.val
+go
+
+-- Used force parallel mode to create a parallel worker
+select set_config('force_parallel_mode', '1', false)
+go
+
+-- to check if parallel worker generated for following query, will crash or not
+select * from babel_4294_t4
+go
+
+select set_config('force_parallel_mode', '0', false)
+go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go


### PR DESCRIPTION
### Description

Cherry Picked commit: fix crash in parallel query with enable_pg_hint 'on' 'server' (commit code: 5a16a95cddce1159f874655c5047b2c82147f7ef) from BABEL_3_X_DEV 

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved

BABEL-4294

### Test Scenarios Covered ###
* **Use case based -**
Added the new test

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).