### PR TITLE
Added tests for temp object drop order

### DIFF
--- a/test/JDBC/expected/BABEL-3168-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3168-vu-cleanup.out
@@ -1,0 +1,14 @@
+drop procedure p3168
+go
+
+drop procedure p3168_2
+go
+
+drop procedure p3168_3
+go
+
+drop procedure p3168_4
+go
+
+drop type typ3168
+go

--- a/test/JDBC/expected/BABEL-3168-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3168-vu-prepare.out
@@ -1,0 +1,25 @@
+create procedure p3168 as begin
+create table #t (id int identity(1,1))
+end
+go
+
+create procedure p3168_2 as begin
+create table #t (id int identity primary key)
+create index i on #t(id)
+end
+go
+
+create procedure p3168_3 as begin
+create table #t (id int)
+create index i on #t(id)
+end
+go
+
+create type typ3168 from int
+go
+
+create procedure p3168_4 as begin
+create table #t(id typ3168 primary key)
+create index i on #t(id)
+end
+go

--- a/test/JDBC/expected/BABEL-3168-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3168-vu-verify.out
@@ -1,0 +1,12 @@
+exec p3168
+go
+
+exec p3168_2
+go
+
+exec p3168_3
+go
+
+exec p3168_4
+go
+

--- a/test/JDBC/input/BABEL-3168-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-3168-vu-cleanup.sql
@@ -1,0 +1,14 @@
+drop procedure p3168
+go
+
+drop procedure p3168_2
+go
+
+drop procedure p3168_3
+go
+
+drop procedure p3168_4
+go
+
+drop type typ3168
+go

--- a/test/JDBC/input/BABEL-3168-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-3168-vu-prepare.sql
@@ -1,0 +1,25 @@
+create procedure p3168 as begin
+create table #t (id int identity(1,1))
+end
+go
+
+create procedure p3168_2 as begin
+create table #t (id int identity primary key)
+create index i on #t(id)
+end
+go
+
+create procedure p3168_3 as begin
+create table #t (id int)
+create index i on #t(id)
+end
+go
+
+create type typ3168 from int
+go
+
+create procedure p3168_4 as begin
+create table #t(id typ3168 primary key)
+create index i on #t(id)
+end
+go

--- a/test/JDBC/input/BABEL-3168-vu-verify.sql
+++ b/test/JDBC/input/BABEL-3168-vu-verify.sql
@@ -1,0 +1,12 @@
+exec p3168
+go
+
+exec p3168_2
+go
+
+exec p3168_3
+go
+
+exec p3168_4
+go
+


### PR DESCRIPTION
### Description

Adding unit tests for https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/168

Sort ENR, similar to findDependentObjects, before deletion. This avoids situations where ENR objects are cleaned up in the wrong order, which will throw an error in some cases. For example, in this case: 

```
1> create procedure p
2> as
3> begin
4>      create table #t (id int identity(1,1))
5>      --drop table #t  -- when uncommenting this line, no error is raised
6> end
7> go
1>
2> exec p
3> go
Msg 3723, Level 16, State 1, Server BABELFISH, Line 1
cannot drop sequence "#t_id_seq" because column id of table "#t" requires it
```

An error is thrown due to ENRDropTempTables attempting to drop the sequence #t_id_seq before dropping table #t. In findDependentObjects, dependent objects are sorted into a stable visitation order, so we should do the same in ENRDropTempTables. 

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).