### PR TITLE
Fix default behaviour of extension creation using sp_execute_postgresql procedure in all the database

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1696,10 +1696,9 @@ sp_execute_postgresql(PG_FUNCTION_ARGS)
 				}
 
 				SetCurrentRoleId(GetSessionUserId(), false);
-				SetConfigOption("search_path",
-								new_path,
-								PGC_SUSET,
-								PGC_S_DATABASE_USER);
+				set_config_option("search_path", new_path,
+								   PGC_USERSET, PGC_S_SESSION,
+								   GUC_ACTION_SAVE, true, 0, false);
 
 				foreach(lc, crstmt->options)
 				{
@@ -1810,10 +1809,9 @@ sp_execute_postgresql(PG_FUNCTION_ARGS)
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		SetConfigOption("search_path",
-					saved_path,
-					PGC_SUSET,
-					PGC_S_DATABASE_USER);
+		set_config_option("search_path", saved_path,
+						  PGC_USERSET, PGC_S_SESSION,
+						  GUC_ACTION_SAVE, true, 0, false);
 		SetCurrentRoleId(current_user_id, false);
 
 	}

--- a/test/JDBC/expected/Test-sp_execute_postgresql.out
+++ b/test/JDBC/expected/Test-sp_execute_postgresql.out
@@ -263,6 +263,33 @@ go
 exec sp_execute_postgresql 'drop extension pg_stat_statements';
 go
 
+-- try extension creation after switching database context
+create database sp_exec_psql_db1;
+go
+
+use sp_exec_psql_db1;
+go
+
+exec sp_execute_postgresql 'create extension pg_stat_statements;';
+go
+
+select nsp.nspname from pg_extension ext join pg_namespace nsp on ext.extnamespace=nsp.oid where ext.extname = 'pg_stat_statements';
+go
+~~START~~
+varchar
+public
+~~END~~
+
+
+exec sp_execute_postgresql 'drop extension pg_stat_statements;';
+go
+
+use master;
+go
+
+drop database sp_exec_psql_db1;
+go
+
 -- cascade not supported yet, it will throw error
 exec sp_execute_postgresql 'create extension pg_stat_statements with cascade';
 go

--- a/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_execute_postgresql.mix
@@ -152,6 +152,28 @@ go
 exec sp_execute_postgresql 'drop extension pg_stat_statements';
 go
 
+-- try extension creation after switching database context
+create database sp_exec_psql_db1;
+go
+
+use sp_exec_psql_db1;
+go
+
+exec sp_execute_postgresql 'create extension pg_stat_statements;';
+go
+
+select nsp.nspname from pg_extension ext join pg_namespace nsp on ext.extnamespace=nsp.oid where ext.extname = 'pg_stat_statements';
+go
+
+exec sp_execute_postgresql 'drop extension pg_stat_statements;';
+go
+
+use master;
+go
+
+drop database sp_exec_psql_db1;
+go
+
 -- cascade not supported yet, it will throw error
 exec sp_execute_postgresql 'create extension pg_stat_statements with cascade';
 go


### PR DESCRIPTION
### Description

Previously, When extensions are created using sp_execute_postgresql procedure after switching to different database context, they were created in the dbo instead of public schema because search_path was not getting updated. The reason was GUC context flag PGC_SUSET was passed while setting the search_path instead of PGC_USERSET.

This commit fixes above issue by changing GUC context flag from PGC_SUSET to PGC_USERSET.

Task: BABEL-4301

### Issues Resolved

BABEL-4301

### Test Scenarios Covered ###
* **Use case based -**
Failing scenario covered

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).