### PR TITLE
sqlcmd hangs for select query with null XML values (#1591)

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2597,7 +2597,6 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 							break;
 						case TDS_TYPE_CHAR:
 						case TDS_TYPE_NCHAR:
-						case TDS_TYPE_XML:
 						case TDS_TYPE_BINARY:
 
 							/*
@@ -2605,6 +2604,14 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 							 * (CHARBIN_NULL) to indicate NULL
 							 */
 							simpleRowSize += 2;
+							break;
+						case TDS_TYPE_XML:
+							/*
+							 * To send NULL,we have to
+							 * indicate it using 0xffffffffffffffff
+							 * (PLP_NULL)
+							 */
+							simpleRowSize += 8;
 							break;
 						case TDS_TYPE_SQLVARIANT:
 
@@ -2627,7 +2634,7 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 			}
 		}
 
-		if (nullMapSize < simpleRowSize)
+		if (nullMapSize <= simpleRowSize)
 		{
 			rowToken = TDS_TOKEN_NBCROW;
 		}
@@ -2710,7 +2717,6 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 						break;
 					case TDS_TYPE_CHAR:
 					case TDS_TYPE_NCHAR:
-					case TDS_TYPE_XML:
 					case TDS_TYPE_BINARY:
 
 						/*
@@ -2718,6 +2724,14 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 						 * we need to send 0xffff (CHARBIN_NULL)
 						 */
 						TdsPutInt16LE(0xffff);
+						break;
+					case TDS_TYPE_XML:
+
+						/*
+						 * In case of TDS version lower than or equal to 7.3A,
+						 * we need to send 0xffffffffffffffff (PLP_NULL)
+						 */
+						TdsPutUInt64LE(0xffffffffffffffff);
 						break;
 					case TDS_TYPE_SQLVARIANT:
 

--- a/test/JDBC/expected/TestXML.out
+++ b/test/JDBC/expected/TestXML.out
@@ -27,3 +27,28 @@ xml
 ~~END~~
 
 DROP TABLE XML_dt;
+
+CREATE TABLE [dbo].[notification_definition]([id] [bigint] NOT NULL,[name_tx] [nvarchar](200) NOT NULL,[description_tx] [nvarchar](max) NULL,[schedule_xml] [xml] NULL,[default_sender_tx] [nvarchar](200) NULL,[lock_id] [tinyint] NOT NULL,[settings_xml] [xml] NULL,[agency_id] [bigint] NULL)
+INSERT [dbo].[NOTIFICATION_DEFINITION] VALUES (13, N'INTRA_MSG', N'Intra-System Message', NULL, N'donotreply_OPMQA@ospreycompliancesuite.com', 63,N'<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG<MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars<VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>', 1)
+~~ROW COUNT: 1~~
+
+SELECT ID,NAME_TX,LOCK_ID,DESCRIPTION_TX,N'' as emptystring, SCHEDULE_XML,DEFAULT_SENDER_TX,SETTINGS_XML,AGENCY_ID FROM NOTIFICATION_DEFINITION
+~~START~~
+bigint#!#nvarchar#!#tinyint#!#nvarchar#!#nvarchar#!#xml#!#nvarchar#!#xml#!#bigint
+13#!#INTRA_MSG#!#63#!#Intra-System Message#!##!#<NULL>#!#donotreply_OPMQA@ospreycompliancesuite.com#!#<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG<MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars<VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>#!#1
+~~END~~
+
+DROP TABLE [dbo].[notification_definition];
+
+CREATE TABLE [dbo].[notification_definition]([id] [bigint] NOT NULL,[name_tx] [nvarchar](200) NOT NULL,[description_tx] [nvarchar](max) NULL,[schedule_xml] [xml] NULL,[default_sender_tx] [nvarchar](200) NULL,[lock_id] [tinyint] NOT NULL,[settings_xml] [xml] NULL,[agency_id] [bigint] NULL)
+prepst#!# INSERT [dbo].[NOTIFICATION_DEFINITION] VALUES(?, ?, ?, ?, ?, ?, ?, ?) #!#bigint|-|a|-|13#!#nvarchar|-|b|-|INTRA_MSG#!#nvarchar|-|c|-|Intra-System Message#!#XML|-|d|-|NULL#!#nvarchar|-|e|-|donotreply_OPMQA#!#tinyint|-|f|-|63#!#XML|-|g|-|<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG</MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars</VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>#!#bigint|-|h|-|1
+~~ROW COUNT: 1~~
+
+#INSERT [dbo].[NOTIFICATION_DEFINITION] VALUES (13, N'INTRA_MSG', N'Intra-System Message', NULL, N'donotreply_OPMQA@ospreycompliancesuite.com', 63,N'<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG<MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars<VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>', 1)
+SELECT ID,NAME_TX,LOCK_ID,DESCRIPTION_TX,N'' as emptystring, SCHEDULE_XML,DEFAULT_SENDER_TX,SETTINGS_XML,AGENCY_ID FROM NOTIFICATION_DEFINITION
+~~START~~
+bigint#!#nvarchar#!#tinyint#!#nvarchar#!#nvarchar#!#xml#!#nvarchar#!#xml#!#bigint
+13#!#INTRA_MSG#!#63#!#Intra-System Message#!##!#NULL#!#donotreply_OPMQA#!#<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG</MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars</VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>#!#1
+~~END~~
+
+DROP TABLE [dbo].[notification_definition];

--- a/test/JDBC/input/datatypes/TestXML.txt
+++ b/test/JDBC/input/datatypes/TestXML.txt
@@ -9,3 +9,14 @@ INSERT INTO XML_dt values(NULL)
 INSERT INTO XML_dt values(<contact><name>Contact Name 2</name><phone>YYY-YYY-YYYY</phone>)
 SELECT * FROM XML_dt;
 DROP TABLE XML_dt;
+
+CREATE TABLE [dbo].[notification_definition]([id] [bigint] NOT NULL,[name_tx] [nvarchar](200) NOT NULL,[description_tx] [nvarchar](max) NULL,[schedule_xml] [xml] NULL,[default_sender_tx] [nvarchar](200) NULL,[lock_id] [tinyint] NOT NULL,[settings_xml] [xml] NULL,[agency_id] [bigint] NULL)
+INSERT [dbo].[NOTIFICATION_DEFINITION] VALUES (13, N'INTRA_MSG', N'Intra-System Message', NULL, N'donotreply_OPMQA@ospreycompliancesuite.com', 63,N'<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG<MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars<VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>', 1)
+SELECT ID,NAME_TX,LOCK_ID,DESCRIPTION_TX,N'' as emptystring, SCHEDULE_XML,DEFAULT_SENDER_TX,SETTINGS_XML,AGENCY_ID FROM NOTIFICATION_DEFINITION
+DROP TABLE [dbo].[notification_definition];
+
+CREATE TABLE [dbo].[notification_definition]([id] [bigint] NOT NULL,[name_tx] [nvarchar](200) NOT NULL,[description_tx] [nvarchar](max) NULL,[schedule_xml] [xml] NULL,[default_sender_tx] [nvarchar](200) NULL,[lock_id] [tinyint] NOT NULL,[settings_xml] [xml] NULL,[agency_id] [bigint] NULL)
+prepst#!# INSERT [dbo].[NOTIFICATION_DEFINITION] VALUES(@a, @b, @c, @d, @e, @f, @g, @h) #!#bigint|-|a|-|13#!#nvarchar|-|b|-|INTRA_MSG#!#nvarchar|-|c|-|Intra-System Message#!#XML|-|d|-|NULL#!#nvarchar|-|e|-|donotreply_OPMQA#!#tinyint|-|f|-|63#!#XML|-|g|-|<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG</MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars</VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>#!#bigint|-|h|-|1
+#INSERT [dbo].[NOTIFICATION_DEFINITION] VALUES (13, N'INTRA_MSG', N'Intra-System Message', NULL, N'donotreply_OPMQA@ospreycompliancesuite.com', 63,N'<Settings><SubjectTemplateTypeCd>NTF_SUB_INTRA_MSG</SubjectTemplateTypeCd><MessageTemplateTypeCd>NTF_MSG_INTRA_MSG<MessageTemplateTypeCd><VariableRefDomainName>PolicyDocumentTemplateVars<VariableRefDomainName><ProcessDefinitionId>11</ProcessDefinitionId></Settings>', 1)
+SELECT ID,NAME_TX,LOCK_ID,DESCRIPTION_TX,N'' as emptystring, SCHEDULE_XML,DEFAULT_SENDER_TX,SETTINGS_XML,AGENCY_ID FROM NOTIFICATION_DEFINITION
+DROP TABLE [dbo].[notification_definition];


### PR DESCRIPTION
Description
Previously the sqlcmd hangs for select query which has null XML value. This commit fixes by sending NbcRowToken when nullMapSize and simpleRowSize are equal. And for older clients of TDS 7.2 where NbcRowToken doesn't exist, sending PLP_NULL(0xffffffffffffffff) specially for variables of type XML.

Issues Resolved
BABEL-4196

Test Scenarios Covered
Use case based - Added select queries which contain NULL xml. Inserted values through INSERT command and through prep-exec.

Boundary conditions -

Arbitrary inputs - Inserted NULL and some value for XML variables.

Negative test cases - N/A

Minor version upgrade tests - N/A

Major version upgrade tests - N/A

Performance tests -

Tooling impact -

Client tests -
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).