### PR TITLE
Handle different behavior with like escape null and like escape ' '

### DIFF
--- a/test/JDBC/expected/BABEL-4271.out
+++ b/test/JDBC/expected/BABEL-4271.out
@@ -1,0 +1,79 @@
+--Queries that cover the empty escape string case 
+select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE ''
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+select 1 where 'cbc' LIKE '[c-a]bc' ESCAPE ''
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+select 1 where 'abc' LIKE '[0-a]bc' ESCAPE ''
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+select 1 where 'abc' LIKE '[abc]bc' ESCAPE ''
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+select 1 where 'abc' LIKE '[a-c]bc' ESCAPE ''
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+select 1 where 'bbc' LIKE '[a-c]bc' ESCAPE ''
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+--Queries that cover the ESCAPE null case (ESCAPE null means no ESCAPE char used)
+select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE null
+go
+~~START~~
+int
+1
+~~END~~
+
+select 1 where 'cbc' LIKE '[c-a]bc' ESCAPE null
+go
+~~START~~
+int
+~~END~~
+
+select 1 where 'abc' LIKE '[0-a]bc' ESCAPE null
+go
+~~START~~
+int
+1
+~~END~~
+
+select 1 where 'abc' LIKE '[abc]bc' ESCAPE null
+go
+~~START~~
+int
+1
+~~END~~
+
+select 1 where 'abc' LIKE '[a-c]bc' ESCAPE null
+go
+~~START~~
+int
+1
+~~END~~
+
+select 1 where 'bbc' LIKE '[a-c]bc' ESCAPE null
+go
+~~START~~
+int
+1
+~~END~~
+

--- a/test/JDBC/expected/like_expression.out
+++ b/test/JDBC/expected/like_expression.out
@@ -1339,10 +1339,9 @@ int
  
 select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE ''  -- should raise error , BABEL-4271
 go
-~~START~~
-int
-1
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
 
 select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE 'xy'  -- raise error
 go

--- a/test/JDBC/input/BABEL-4271.sql
+++ b/test/JDBC/input/BABEL-4271.sql
@@ -1,0 +1,26 @@
+--Queries that cover the empty escape string case 
+select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE ''
+go
+select 1 where 'cbc' LIKE '[c-a]bc' ESCAPE ''
+go
+select 1 where 'abc' LIKE '[0-a]bc' ESCAPE ''
+go
+select 1 where 'abc' LIKE '[abc]bc' ESCAPE ''
+go
+select 1 where 'abc' LIKE '[a-c]bc' ESCAPE ''
+go
+select 1 where 'bbc' LIKE '[a-c]bc' ESCAPE ''
+go
+--Queries that cover the ESCAPE null case (ESCAPE null means no ESCAPE char used)
+select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE null
+go
+select 1 where 'cbc' LIKE '[c-a]bc' ESCAPE null
+go
+select 1 where 'abc' LIKE '[0-a]bc' ESCAPE null
+go
+select 1 where 'abc' LIKE '[abc]bc' ESCAPE null
+go
+select 1 where 'abc' LIKE '[a-c]bc' ESCAPE null
+go
+select 1 where 'bbc' LIKE '[a-c]bc' ESCAPE null
+go


### PR DESCRIPTION
### Description

This PR adds the test cases for the following changes in `postgresql_modified_for_babelfish`:-

When query select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE '' executes on babelfish, it should return an error as expected according to SQL server. But it was not throwing error, this is actually there was no condition added to return error in case of empty ESCAPE char. So i added a condition to return error for this case.
Another query is select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE null. This should return 1 row as expected SQL server behaviour and before this fix, this query returned 0 row on execution on babelfish. So i added one condition to capture this case and revert the behaviour as expected. (Behaviour same as no ESCAPE char used - as per Rob's comment on Jira).


### Issues Resolved

BABEL-4271

### Test Scenarios Covered ###
* **Use case based -**
Added test cases for both the queries mentioned in JIRA

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).