### PR TITLE
Handle build failures in is_ms_shipped function

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2699,7 +2699,8 @@ bool is_ms_shipped(char *object_name, int type, Oid schema_id)
 	 */
 	for (i = 0; i < num_all_db_objects; i++)
 	{
-		char		*tempnspname;
+		char		*tempnspname = NULL;
+		bool		isNull = false;
 
 		if (is_ms_shipped)
 			break;
@@ -2716,7 +2717,7 @@ bool is_ms_shipped(char *object_name, int type, Oid schema_id)
 
 		while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 		{
-			datum = heap_getattr(tuple, Anum_namespace_ext_namespace, dsc, NULL);
+			datum = heap_getattr(tuple, Anum_namespace_ext_namespace, dsc, &isNull);
 			tempnspname = TextDatumGetCString(datum);
 			if (pg_strcasecmp(namespace_name, tempnspname) == 0)
 			{

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2623,7 +2623,7 @@ bool is_ms_shipped(char *object_name, int type, Oid schema_id)
 {
 	int	i = 0;
 	bool	is_ms_shipped = false;
-	char	*namespace_name;
+	char	*namespace_name = NULL;
 	/*
 	 * This array contains information of objects that reside in a schema in one specfic database.
 	 * For example, 'master_dbo' schema can only exist in the 'master' database.


### PR DESCRIPTION
### Description

Currently in is_ms_shipped function, we are using tempnspname variable which is not initialised. It might cause an issue while trying to free (pfree()) the variable.

### Issues Resolved

BABEL-4317

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).