### PR TITLE
Drop Table Variables even when AbortCurTransaction is true

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -10105,9 +10105,17 @@ pltsql_clean_table_variables(PLtsql_execstate *estate, PLtsql_function *func)
 	bool		old_pltsql_explain_only = pltsql_explain_only;
 	const char *query_fmt = "DROP TABLE %s";
 	const char *query;
+	bool old_abort_curr_txn = AbortCurTransaction;
 
 	PG_TRY();
 	{
+		/*
+		 * Temporarily set this to false to allow DROP to continue.
+		 * Othewise, DROP would not be allowed to acquire xlock on the
+		 * relation.
+		 */
+		AbortCurTransaction = false;
+
 		foreach(lc, func->table_varnos)
 		{
 			n = lfirst_int(lc);
@@ -10134,9 +10142,15 @@ pltsql_clean_table_variables(PLtsql_execstate *estate, PLtsql_function *func)
 				append_explain_info(NULL, query);
 			}
 		}
+
+		Assert(!AbortCurTransaction); /* engine should not change this value */
+		AbortCurTransaction = old_abort_curr_txn;
 	}
 	PG_CATCH();
 	{
+		Assert(!AbortCurTransaction); /* engine should not change this value */
+		AbortCurTransaction = old_abort_curr_txn;
+
 		pltsql_explain_only = old_pltsql_explain_only;	/* Recover EXPLAIN ONLY
 														 * mode */
 		PG_RE_THROW();

--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -459,13 +459,13 @@ GO
 
 
 -------------------------------------------------------------------------------
--- Cursor not explicitly closed 
+-- Cursor not explicitly closed
 -------------------------------------------------------------------------------
-DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
-DECLARE @v INT 
-DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE    
-OPEN CUR_NETWORK             
-FETCH NEXT  FROM CUR_NETWORK INTO @v      
+DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
+DECLARE @v INT
+DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE
+OPEN CUR_NETWORK
+FETCH NEXT  FROM CUR_NETWORK INTO @v
 GO
 
 select 123
@@ -476,16 +476,16 @@ int
 ~~END~~
 
 
-CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  () 
-RETURNS NVARCHAR(MAX) AS 
+
+CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
 BEGIN
-    DECLARE @TSQL NVARCHAR(MAX) 
-    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
+    DECLARE @TSQL NVARCHAR(MAX)
+    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
     DECLARE @STATION_INT INT     SET @TSQL = ''
-    DECLARE CUR_NETWORK CURSOR LOCAL FOR 
-        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK                
+    DECLARE CUR_NETWORK CURSOR LOCAL FOR
+        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK
     FETCH NEXT FROM CUR_NETWORK INTO @STATION_INT
-    
     RETURN @TSQL
 END
 GO
@@ -534,7 +534,7 @@ nvarchar
 ~~ERROR (Message: Throw error)~~
 
 
-DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery] 
+DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
 
@@ -568,4 +568,45 @@ nvarchar
 
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+
+EXECUTE usp_PopulateDiscount
+go
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "discount" does not exist)~~
+
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+
+exec test
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
 

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -461,13 +461,13 @@ GO
 
 
 -------------------------------------------------------------------------------
--- Cursor not explicitly closed 
+-- Cursor not explicitly closed
 -------------------------------------------------------------------------------
-DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
-DECLARE @v INT 
-DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE    
-OPEN CUR_NETWORK             
-FETCH NEXT  FROM CUR_NETWORK INTO @v      
+DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
+DECLARE @v INT
+DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE
+OPEN CUR_NETWORK
+FETCH NEXT  FROM CUR_NETWORK INTO @v
 GO
 
 select 123
@@ -478,16 +478,16 @@ int
 ~~END~~
 
 
-CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  () 
-RETURNS NVARCHAR(MAX) AS 
+
+CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
 BEGIN
-    DECLARE @TSQL NVARCHAR(MAX) 
-    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
+    DECLARE @TSQL NVARCHAR(MAX)
+    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
     DECLARE @STATION_INT INT     SET @TSQL = ''
-    DECLARE CUR_NETWORK CURSOR LOCAL FOR 
-        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK                
+    DECLARE CUR_NETWORK CURSOR LOCAL FOR
+        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK
     FETCH NEXT FROM CUR_NETWORK INTO @STATION_INT
-    
     RETURN @TSQL
 END
 GO
@@ -536,7 +536,7 @@ nvarchar
 ~~ERROR (Message: Throw error)~~
 
 
-DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery] 
+DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
 
@@ -570,4 +570,53 @@ nvarchar
 
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: function "usp_populatediscount" already exists with same argument types)~~
+
+
+EXECUTE usp_PopulateDiscount
+go
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "discount" does not exist)~~
+
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: function "test" already exists with same argument types)~~
+
+
+exec test
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
 

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -443,13 +443,13 @@ GO
 
 
 -------------------------------------------------------------------------------
--- Cursor not explicitly closed 
+-- Cursor not explicitly closed
 -------------------------------------------------------------------------------
-DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
-DECLARE @v INT 
-DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE    
-OPEN CUR_NETWORK             
-FETCH NEXT  FROM CUR_NETWORK INTO @v      
+DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
+DECLARE @v INT
+DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE
+OPEN CUR_NETWORK
+FETCH NEXT  FROM CUR_NETWORK INTO @v
 GO
 
 select 123
@@ -460,16 +460,16 @@ int
 ~~END~~
 
 
-CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  () 
-RETURNS NVARCHAR(MAX) AS 
+
+CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
 BEGIN
-    DECLARE @TSQL NVARCHAR(MAX) 
-    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
+    DECLARE @TSQL NVARCHAR(MAX)
+    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
     DECLARE @STATION_INT INT     SET @TSQL = ''
-    DECLARE CUR_NETWORK CURSOR LOCAL FOR 
-        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK                
+    DECLARE CUR_NETWORK CURSOR LOCAL FOR
+        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK
     FETCH NEXT FROM CUR_NETWORK INTO @STATION_INT
-    
     RETURN @TSQL
 END
 GO
@@ -518,7 +518,7 @@ nvarchar
 ~~ERROR (Message: Throw error)~~
 
 
-DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery] 
+DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
 
@@ -552,4 +552,53 @@ nvarchar
 
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
+
+
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: function "usp_populatediscount" already exists with same argument types)~~
+
+
+EXECUTE usp_PopulateDiscount
+go
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "discount" does not exist)~~
+
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: function "test" already exists with same argument types)~~
+
+
+exec test
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
 

--- a/test/JDBC/input/table_variables/table_variable_xact_errors.sql
+++ b/test/JDBC/input/table_variables/table_variable_xact_errors.sql
@@ -312,30 +312,30 @@ DROP TYPE typb
 GO
 
 -------------------------------------------------------------------------------
--- Cursor not explicitly closed 
+-- Cursor not explicitly closed
 -------------------------------------------------------------------------------
 
-DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
-DECLARE @v INT 
+DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
+DECLARE @v INT
 
-DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE    
-OPEN CUR_NETWORK             
-FETCH NEXT  FROM CUR_NETWORK INTO @v      
+DECLARE CUR_NETWORK CURSOR LOCAL FOR SELECT STATION_INT FROM @STATION_INTS_TABLE
+OPEN CUR_NETWORK
+FETCH NEXT  FROM CUR_NETWORK INTO @v
 GO
 
 select 123
 GO
 
-CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  () 
-RETURNS NVARCHAR(MAX) AS 
+CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
+RETURNS NVARCHAR(MAX) AS
 BEGIN
-    DECLARE @TSQL NVARCHAR(MAX) 
-    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)     
+    DECLARE @TSQL NVARCHAR(MAX)
+    DECLARE @STATION_INTS_TABLE TABLE (STATION_INT INT)
     DECLARE @STATION_INT INT     SET @TSQL = ''
-    DECLARE CUR_NETWORK CURSOR LOCAL FOR 
-        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK                
+    DECLARE CUR_NETWORK CURSOR LOCAL FOR
+        SELECT STATION_INT FROM @STATION_INTS_TABLE    OPEN CUR_NETWORK
     FETCH NEXT FROM CUR_NETWORK INTO @STATION_INT
-    
+
     RETURN @TSQL
 END
 GO
@@ -368,7 +368,7 @@ GO
 SELECT dbo.WOSQL_BuildRevenueDetailOLUQuery()
 GO
 
-DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery] 
+DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
 CREATE FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]  ()
@@ -397,3 +397,34 @@ GO
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+
+EXECUTE usp_PopulateDiscount
+go
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+
+exec test
+go


### PR DESCRIPTION
When there is an error, AbortCurTransaction could be set to true. During clean up phase, logic tries to drop table variables and as part of the drop, it acquires exclusive lock on the relation which eventually calls AssignTransactionId. This is not allowed in AssignTransactionId and error handling is not able to recover from there.

It has been decided to temporarily set AbortCurTransaction=false in clean up phase in order for drop to continue.


Task: BABEL-4336

### Description




### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).