### PR TITLE
Fix intermittent test failure in sp_enum_oledb_providers

### DIFF
--- a/test/JDBC/expected/sp_enum_oledb_providers.out
+++ b/test/JDBC/expected/sp_enum_oledb_providers.out
@@ -16,7 +16,26 @@ GO
 ~~ERROR (Message: Only members of the sysadmin role can execute this stored procedure.)~~
 
 
--- terminate-tsql-conn  user=linked_server_login    password=password
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'linked_server_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
 -- tsql
 DROP LOGIN linked_server_login
 GO

--- a/test/JDBC/input/sp_enum_oledb_providers.mix
+++ b/test/JDBC/input/sp_enum_oledb_providers.mix
@@ -12,7 +12,16 @@ GO
 EXEC sp_enum_oledb_providers
 GO
 
--- terminate-tsql-conn  user=linked_server_login    password=password
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'linked_server_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
 -- tsql
 DROP LOGIN linked_server_login
 GO


### PR DESCRIPTION
This commit fixes the flaky test failure of sp_enum_oledb_providers. Previously we were terminating the connection but the engine was not reflecting it immediately and so the consequent DROP LOGIN statement was failing intermittently. To fix this, we add a sleep of 1 second after terminating the connection.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).