### PR TITLE
Address sp_who test failure where an unexpected PG connection shows up

### DIFF
--- a/test/JDBC/input/sp_who-vu-verify.mix
+++ b/test/JDBC/input/sp_who-vu-verify.mix
@@ -1,4 +1,4 @@
--- sla 100000
+-- sla 1000000
 /* tests for sp_babelfish_autoformat */
 sp_babelfish_autoformat 't_sp_who'
 go


### PR DESCRIPTION
### Description

Address failure of one of the sp_who JDBC tests due to an unexpected PG connection showing up in sysprocesses

### Issues Resolved

- Take a copy of sysprocesses just once
- Allow for 10x longer test execution time since sometimes it times out

### Test Scenarios Covered ###

- No changes to test cases.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).