### PR TITLE
Rename Babelfish C functions which have same name in engine to avoid crashes

### DIFF
--- a/contrib/babelfishpg_common/src/encoding/encoding.h
+++ b/contrib/babelfishpg_common/src/encoding/encoding.h
@@ -20,14 +20,14 @@ extern int	TsqlLocalToUtf(const unsigned char *iso, int len,
 						   int encoding);
 
 /* Functions in src/encoding/mb/conversion_procs */
-extern int	utf8_to_win(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	utf8_to_big5(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	utf8_to_gbk(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	utf8_to_uhc(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	utf8_to_sjis(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_utf8_to_win(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_utf8_to_big5(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_utf8_to_gbk(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_utf8_to_uhc(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_utf8_to_sjis(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
 
-extern int	win_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	big5_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len);
-extern int	gbk_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	uhc_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
-extern int	sjis_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_win_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_big5_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len);
+extern int	tsql_gbk_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_uhc_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);
+extern int	tsql_sjis_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *result, int len);

--- a/contrib/babelfishpg_common/src/encoding/encoding_utils.c
+++ b/contrib/babelfishpg_common/src/encoding/encoding_utils.c
@@ -101,19 +101,19 @@ do_encoding_conversion(unsigned char *src, int len,
 		switch (dest_encoding)
 		{
 			case PG_BIG5:
-				*encodedByteLen = utf8_to_big5(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_utf8_to_big5(src_encoding, dest_encoding, src, result, len);
 				break;
 			case PG_GBK:
-				*encodedByteLen = utf8_to_gbk(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_utf8_to_gbk(src_encoding, dest_encoding, src, result, len);
 				break;
 			case PG_UHC:
-				*encodedByteLen = utf8_to_uhc(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_utf8_to_uhc(src_encoding, dest_encoding, src, result, len);
 				break;
 			case PG_SJIS:
-				*encodedByteLen = utf8_to_sjis(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_utf8_to_sjis(src_encoding, dest_encoding, src, result, len);
 				break;
 			default:
-				*encodedByteLen = utf8_to_win(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_utf8_to_win(src_encoding, dest_encoding, src, result, len);
 				break;
 		}
 	}
@@ -122,19 +122,19 @@ do_encoding_conversion(unsigned char *src, int len,
 		switch (src_encoding)
 		{
 			case PG_BIG5:
-				*encodedByteLen = big5_to_utf8(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_big5_to_utf8(src_encoding, dest_encoding, src, result, len);
 				break;
 			case PG_GBK:
-				*encodedByteLen = gbk_to_utf8(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_gbk_to_utf8(src_encoding, dest_encoding, src, result, len);
 				break;
 			case PG_UHC:
-				*encodedByteLen = uhc_to_utf8(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_uhc_to_utf8(src_encoding, dest_encoding, src, result, len);
 				break;
 			case PG_SJIS:
-				*encodedByteLen = sjis_to_utf8(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_sjis_to_utf8(src_encoding, dest_encoding, src, result, len);
 				break;
 			default:
-				*encodedByteLen = win_to_utf8(src_encoding, dest_encoding, src, result, len);
+				*encodedByteLen = tsql_win_to_utf8(src_encoding, dest_encoding, src, result, len);
 				break;
 		}
 	}

--- a/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_big5/utf8_and_big5.c
+++ b/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_big5/utf8_and_big5.c
@@ -7,7 +7,7 @@
 #include "src/encoding/encoding.h"
 
 /* ----------
- * utf8_to_big5:
+ * tsql_utf8_to_big5:
  *		src_encoding,	-- source encoding id
  *		dest_encoding,	-- destination encoding id
  *		src,			-- source string (null terminated C string)
@@ -17,7 +17,7 @@
  * ----------
  */
 int
-utf8_to_big5(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_utf8_to_big5(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlUtfToLocal(src, len, dest,
 						  &big5_from_unicode_tree,
@@ -27,7 +27,7 @@ utf8_to_big5(int src_encoding, int dest_encoding, const unsigned char *src, unsi
 }
 
 int
-big5_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_big5_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlLocalToUtf(src, len, dest,
 						  &big5_to_unicode_tree,

--- a/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_gbk/utf8_and_gbk.c
+++ b/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_gbk/utf8_and_gbk.c
@@ -7,7 +7,7 @@
 #include "src/encoding/encoding.h"
 
 /* ----------
- * utf8_to_gbk:
+ * tsql_utf8_to_gbk:
  *		src_encoding,	-- source encoding id
  *		dest_encoding,	-- destination encoding id
  *		src,			-- source string (null terminated C string)
@@ -17,7 +17,7 @@
  * ----------
  */
 int
-utf8_to_gbk(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_utf8_to_gbk(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlUtfToLocal(src, len, dest,
 						  &gbk_from_unicode_tree,
@@ -27,7 +27,7 @@ utf8_to_gbk(int src_encoding, int dest_encoding, const unsigned char *src, unsig
 }
 
 int
-gbk_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_gbk_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlLocalToUtf(src, len, dest,
 						  &gbk_to_unicode_tree,

--- a/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_sjis/utf8_and_sjis.c
+++ b/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_sjis/utf8_and_sjis.c
@@ -7,7 +7,7 @@
 #include "src/encoding/encoding.h"
 
 /* ----------
- * utf8_to_sjis:
+ * tsql_utf8_to_sjis:
  *		src_encoding,	-- source encoding id
  *		dest_encoding,	-- destination encoding id
  *		src,			-- source string (null terminated C string)
@@ -17,7 +17,7 @@
  * ----------
  */
 int
-utf8_to_sjis(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_utf8_to_sjis(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlUtfToLocal(src, len, dest,
 						  &sjis_from_unicode_tree,
@@ -27,7 +27,7 @@ utf8_to_sjis(int src_encoding, int dest_encoding, const unsigned char *src, unsi
 }
 
 int
-sjis_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_sjis_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlLocalToUtf(src, len, dest,
 						  &sjis_to_unicode_tree,

--- a/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_uhc/utf8_and_uhc.c
+++ b/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_uhc/utf8_and_uhc.c
@@ -7,7 +7,7 @@
 #include "src/encoding/encoding.h"
 
 /* ----------
- * utf8_to_uhc:
+ * tsql_utf8_to_uhc:
  *		src_encoding,	-- source encoding id
  *		dest_encoding,	-- destination encoding id
  *		src,			-- source string (null terminated C string)
@@ -17,7 +17,7 @@
  * ----------
  */
 int
-utf8_to_uhc(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_utf8_to_uhc(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlUtfToLocal(src, len, dest,
 						  &uhc_from_unicode_tree,
@@ -27,7 +27,7 @@ utf8_to_uhc(int src_encoding, int dest_encoding, const unsigned char *src, unsig
 }
 
 int
-uhc_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_uhc_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	return TsqlLocalToUtf(src, len, dest,
 						  &uhc_to_unicode_tree,

--- a/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_win/utf8_and_win.c
+++ b/contrib/babelfishpg_common/src/encoding/mb/conversion_procs/utf8_and_win/utf8_and_win.c
@@ -48,7 +48,7 @@ static const pg_conv_map maps[] = {
 };
 
 /* ----------
- * utf8_to_win:
+ * tsql_utf8_to_win:
  *		src_encoding,	-- source encoding id
  *		dest_encoding,	-- destination encoding id
  *		src,			-- source string (null terminated C string)
@@ -58,7 +58,7 @@ static const pg_conv_map maps[] = {
  * ----------
  */
 int
-utf8_to_win(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_utf8_to_win(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	int			i;
 
@@ -83,7 +83,7 @@ utf8_to_win(int src_encoding, int dest_encoding, const unsigned char *src, unsig
 }
 
 int
-win_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
+tsql_win_to_utf8(int src_encoding, int dest_encoding, const unsigned char *src, unsigned char *dest, int len)
 {
 	int			i;
 

--- a/test/JDBC/expected/BABEL-4342.out
+++ b/test/JDBC/expected/BABEL-4342.out
@@ -1,0 +1,58 @@
+-- psql
+CREATE PROCEDURE sys.babel_4342_proc1() 
+LANGUAGE 'pltsql' AS $$
+BEGIN 
+DECLARE @objtype sys.VARCHAR(2)
+SELECT @objtype = type COLLATE DATABASE_DEFAULT FROM sys.sysobjects WHERE id = 1 
+END 
+$$;
+GO
+
+CREATE OR REPLACE PROCEDURE sys.babel_4342_proc2()
+LANGUAGE 'pltsql'
+AS $$
+BEGIN
+DECLARE @objtype sys.VARCHAR(2)
+SELECT @objtype = type FROM sys.sysobjects WHERE id = 1
+END
+$$;
+GO
+
+CREATE OR REPLACE PROCEDURE sys.babel_4342_proc3()
+LANGUAGE 'pltsql'
+AS $$
+BEGIN
+DECLARE @objtype VARCHAR(2)
+SELECT @objtype = type FROM sys.sysobjects WHERE id = 1
+END
+$$;
+GO
+
+CALL sys.babel_4342_proc1();
+GO
+
+CALL sys.babel_4342_proc2();
+GO
+
+CALL sys.babel_4342_proc3();
+GO
+
+-- tsql
+EXEC sys.babel_4342_proc1;
+GO
+
+EXEC sys.babel_4342_proc2;
+GO
+
+EXEC sys.babel_4342_proc3;
+GO
+
+-- psql 
+DROP PROCEDURE sys.babel_4342_proc1;
+GO
+
+DROP PROCEDURE sys.babel_4342_proc2;
+GO
+
+DROP PROCEDURE sys.babel_4342_proc3;
+GO

--- a/test/JDBC/input/BABEL-4342.mix
+++ b/test/JDBC/input/BABEL-4342.mix
@@ -1,0 +1,58 @@
+-- psql
+CREATE PROCEDURE sys.babel_4342_proc1() 
+LANGUAGE 'pltsql' AS $$
+BEGIN 
+DECLARE @objtype sys.VARCHAR(2)
+SELECT @objtype = type COLLATE DATABASE_DEFAULT FROM sys.sysobjects WHERE id = 1 
+END 
+$$;
+GO
+
+CREATE OR REPLACE PROCEDURE sys.babel_4342_proc2()
+LANGUAGE 'pltsql'
+AS $$
+BEGIN
+DECLARE @objtype sys.VARCHAR(2)
+SELECT @objtype = type FROM sys.sysobjects WHERE id = 1
+END
+$$;
+GO
+
+CREATE OR REPLACE PROCEDURE sys.babel_4342_proc3()
+LANGUAGE 'pltsql'
+AS $$
+BEGIN
+DECLARE @objtype VARCHAR(2)
+SELECT @objtype = type FROM sys.sysobjects WHERE id = 1
+END
+$$;
+GO
+
+CALL sys.babel_4342_proc1();
+GO
+
+CALL sys.babel_4342_proc2();
+GO
+
+CALL sys.babel_4342_proc3();
+GO
+
+-- tsql
+EXEC sys.babel_4342_proc1;
+GO
+
+EXEC sys.babel_4342_proc2;
+GO
+
+EXEC sys.babel_4342_proc3;
+GO
+
+-- psql 
+DROP PROCEDURE sys.babel_4342_proc1;
+GO
+
+DROP PROCEDURE sys.babel_4342_proc2;
+GO
+
+DROP PROCEDURE sys.babel_4342_proc3;
+GO


### PR DESCRIPTION
### Description
Earlier, Some T-SQL procedure crashes the PG server when executed from PSQL endpoint. It was happening because of having same function name used in Babelfish and engine code, so when we were executing from PSQL endpoint it was picking up the wrong function which resulted into crash. This commit renames all such functions to avoid server crashes.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

3X PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1746
### Issues Resolved

Task: BABEL-4342

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).