### PR TITLE
Implemented blocking of UNIQUE constraint/index on nullable column consistently

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1558,6 +1558,10 @@ has_unique_nullable_constraint(ColumnDef *column)
 	return is_unique & !is_notnull;
 }
 
+/* has_nullable_constraint
+ *		Given a Column definition
+ *		return true if column does not have any NOT NULL constraint else false
+ */
 static bool
 has_nullable_constraint(ColumnDef *column)
 {
@@ -1581,6 +1585,10 @@ has_nullable_constraint(ColumnDef *column)
 	return !is_notnull;
 }
 
+/* is_nullable_constraint
+ *		Given a Constraint
+ *		return true if atleast one of the attribute in the constraint is nullable else false
+ */
 static bool
 is_nullable_constraint(Constraint *cst, Oid rel_oid)
 {
@@ -1647,6 +1655,10 @@ get_attnotnull(Oid relid, AttrNumber attnum)
 	return false;
 }
 
+/* is_nullable_index
+ *		Given an Index Statement
+ *		return true if atleast one of the attribute in the index is nullable else false
+ */
 static bool
 is_nullable_index(IndexStmt *stmt)
 {

--- a/test/JDBC/expected/BABEL-2619-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-2619-vu-cleanup.out
@@ -1,0 +1,11 @@
+drop table if exists babel_2619_t1
+drop table if exists babel_2619_t2
+drop table if exists babel_2619_t3
+drop table if exists babel_2619_t4
+drop table if exists babel_2619_t5_1
+drop table if exists babel_2619_t5_2
+drop table if exists babel_2619_t5_3
+drop table if exists babel_2619_t6_1
+drop table if exists babel_2619_t6_2
+drop table if exists babel_2619_t6_3
+go

--- a/test/JDBC/expected/BABEL-2619-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-2619-vu-prepare.out
@@ -1,0 +1,11 @@
+create table babel_2619_t1(a int not null, b int null)
+create table babel_2619_t2(a int not null, b int null)
+create table babel_2619_t3(a int not null, b int null)
+create table babel_2619_t4(a int not null, b int null)
+create table babel_2619_t5_1(a int not null, b int null)
+create table babel_2619_t5_2(a int not null, b int null)
+create table babel_2619_t5_3(a int not null, b int null)
+create table babel_2619_t6_1(a int not null, b int null)
+create table babel_2619_t6_2(a int not null, b int null)
+create table babel_2619_t6_3(a int not null, b int null)
+go

--- a/test/JDBC/expected/BABEL-2619-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2619-vu-verify.out
@@ -1,0 +1,193 @@
+
+-- Tests to check whether error will be raised in case of creation of unique constraint/index on nullable column
+-- Test 1: trying to create unique constraint on nullable and non null columns 
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+create table babel_2619_v_t1(a int null, b int null unique, c int not null)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+create table babel_2619_v_t2(a int null, b int not null unique, c int not null)
+go
+
+create table babel_2619_v_t3(a int null, b int unique, c int not null)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+create table babel_2619_v_t4(a int null, b int not null, unique(a))
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+create table babel_2619_v_t5(a int null, b int not null, unique(b))
+go
+
+create table babel_2619_v_t6(a int not null, b int null, c int not null, unique(a, b, c))
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+create table babel_2619_v_t7(a int not null, b int null, c int not null, unique(a, c))
+go
+
+drop table if exists babel_2619_v_t1;
+drop table if exists babel_2619_v_t2;
+drop table if exists babel_2619_v_t3;
+drop table if exists babel_2619_v_t4;
+drop table if exists babel_2619_v_t5;
+drop table if exists babel_2619_v_t6;
+drop table if exists babel_2619_v_t7;
+go
+
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+create table babel_2619_v_t8(a int null, b int null unique, c int not null)
+go
+
+create table babel_2619_v_t9(a int null, b int not null unique, c int not null)
+go
+
+create table babel_2619_v_t10(a int null, b int unique, c int not null)
+go
+
+create table babel_2619_v_t11(a int null, b int not null, unique(a))
+go
+
+create table babel_2619_v_t12(a int null, b int not null, unique(b))
+go
+
+create table babel_2619_v_t13(a int not null, b int null, c int not null, unique(a, b, c))
+go
+
+create table babel_2619_v_t14(a int not null, b int null, c int not null, unique(a, c))
+go
+
+drop table if exists babel_2619_v_t8;
+drop table if exists babel_2619_v_t9;
+drop table if exists babel_2619_v_t10;
+drop table if exists babel_2619_v_t11;
+drop table if exists babel_2619_v_t12;
+drop table if exists babel_2619_v_t13;
+drop table if exists babel_2619_v_t14;
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go
+
+-- Test 2: trying to creating unique index on nullable and non null columns
+-- Table definition: babel_2619_t1(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+create unique index ix1 on babel_2619_t1(a)
+go
+
+create unique index ix2 on babel_2619_t1(b)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE index is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+create unique index ix3 on babel_2619_t1(a,b)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE index is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+-- Table definition: babel_2619_t2(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+create unique index ix1 on babel_2619_t2(a)
+go
+
+create unique index ix2 on babel_2619_t2(b)
+go
+
+create unique index ix3 on babel_2619_t2(a,b)
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go
+
+
+-- Test 3: trying to alter table to add a column with unique contraint on nullable and non null columns
+-- Table definition: babel_2619_t3(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+alter table babel_2619_t3 add col_c int null unique;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+alter table babel_2619_t3 add col_d int not null unique;
+go
+
+-- Table definition: babel_2619_t4(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+alter table babel_2619_t4 add col_c int null unique;
+go
+
+alter table babel_2619_t4 add col_d int not null unique;
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go
+
+
+-- Test 4: trying to alter table to add unique contraint on nullable and non null columns
+-- Table definition: babel_2619_t5_1(a int not null, b int null),
+-- babel_2619_t5_2(a int not null, b int null),
+-- babel_2619_t5_3(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+alter table babel_2619_t5_1 add constraint uq_a unique (a);
+go
+
+alter table babel_2619_t5_2 add constraint uq_b unique (b);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+alter table babel_2619_t5_3 add constraint uq_ab unique (a, b);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore or add a NOT NULL constraint)~~
+
+
+-- Table definition: babel_2619_t6_1(a int not null, b int null),
+-- babel_2619_t6_2(a int not null, b int null),
+-- babel_2619_t6_3(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+alter table babel_2619_t6_1 add constraint uq_a unique (a);
+go
+
+alter table babel_2619_t6_2 add constraint uq_b unique (b);
+go
+
+alter table babel_2619_t6_3 add constraint uq_ab unique (a, b);
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go

--- a/test/JDBC/expected/BABEL-SP_SPECIAL_COLUMNS-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-SP_SPECIAL_COLUMNS-vu-prepare.out
@@ -131,10 +131,10 @@ GO
 
 CREATE TABLE dbo.tidentityintbigmulti (
     data_type_test CHAR(50) NULL
-    , test_scenario CHAR(60) NULL
+    , test_scenario CHAR(60) NOT NULL
     , value_test BIGINT IDENTITY (202202081842, 100 ) NOT NULL
     , inserted_dt DATETIME DEFAULT GETDATE()
-    , user_login CHAR(255) DEFAULT CURRENT_USER
+    , user_login CHAR(255) DEFAULT CURRENT_USER NOT NULL
 )
 GO
 CREATE UNIQUE NONCLUSTERED INDEX dbo_tidentityintbigmulti_value_test ON dbo.tidentityintbigmulti (user_login ASC, value_test ASC, test_scenario ASC);

--- a/test/JDBC/expected/BABEL-SP_SPECIAL_COLUMNS.out
+++ b/test/JDBC/expected/BABEL-SP_SPECIAL_COLUMNS.out
@@ -614,10 +614,10 @@ smallint#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint
 
 CREATE TABLE dbo.tidentityintbigmulti (
     data_type_test CHAR(50) NULL
-    , test_scenario CHAR(60) NULL
-    , value_test BIGINT IDENTITY (202202081842, 100 ) NOT NULL
+    , test_scenario CHAR(60) NOT NULL   -- Used for unique index
+    , value_test BIGINT IDENTITY (202202081842, 100 ) NOT NULL  -- Used for unique index
     , inserted_dt DATETIME DEFAULT GETDATE()
-    , user_login CHAR(255) DEFAULT CURRENT_USER
+    , user_login CHAR(255) DEFAULT CURRENT_USER NOT NULL    -- Used for unique index
 )
 GO
 CREATE UNIQUE NONCLUSTERED INDEX dbo_tidentityintbigmulti_value_test ON dbo.tidentityintbigmulti (user_login ASC, value_test ASC, test_scenario ASC);

--- a/test/JDBC/expected/babel_ddl.out
+++ b/test/JDBC/expected/babel_ddl.out
@@ -12,9 +12,9 @@ create table t2 ( a int, b int, primary key nonclustered (a));
 GO
 create table t3 ( a int, b int, primary key clustered (a));
 GO
-create table t4 ( a int, b int, unique nonclustered (a));
+create table t4 ( a int not null, b int, unique nonclustered (a));
 GO
-create table t5 ( a int, b int, unique clustered (a));
+create table t5 ( a int not null, b int, unique clustered (a));
 GO
 
 create table t6 ( a int primary key nonclustered, b int);
@@ -81,9 +81,9 @@ create table t17(a int, primary key clustered (a) on [PRIMARY]);
 GO
 create table t18(a int, primary key clustered (a) on [PRIMARY]);
 GO
-create table t19(a int, unique clustered (a) on [PRIMARY]);
+create table t19(a int not null, unique clustered (a) on [PRIMARY]);
 GO
-create table t20(a int, unique clustered (a) on [PRIMARY]);
+create table t20(a int not null, unique clustered (a) on [PRIMARY]);
 GO
 
 -- ALTER TABLE ... ADD [CONSTRAINT ...] DEFAULT ... FOR ...

--- a/test/JDBC/expected/constraint_column_usage.out
+++ b/test/JDBC/expected/constraint_column_usage.out
@@ -52,7 +52,7 @@ nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-create table constraint_column_usage_tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
+create table constraint_column_usage_tbl6 (arg12 int, arg13 int not null, UNIQUE(arg13));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;

--- a/test/JDBC/input/BABEL-2619-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-2619-vu-cleanup.sql
@@ -1,0 +1,11 @@
+drop table if exists babel_2619_t1
+drop table if exists babel_2619_t2
+drop table if exists babel_2619_t3
+drop table if exists babel_2619_t4
+drop table if exists babel_2619_t5_1
+drop table if exists babel_2619_t5_2
+drop table if exists babel_2619_t5_3
+drop table if exists babel_2619_t6_1
+drop table if exists babel_2619_t6_2
+drop table if exists babel_2619_t6_3
+go

--- a/test/JDBC/input/BABEL-2619-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-2619-vu-prepare.sql
@@ -1,0 +1,11 @@
+create table babel_2619_t1(a int not null, b int null)
+create table babel_2619_t2(a int not null, b int null)
+create table babel_2619_t3(a int not null, b int null)
+create table babel_2619_t4(a int not null, b int null)
+create table babel_2619_t5_1(a int not null, b int null)
+create table babel_2619_t5_2(a int not null, b int null)
+create table babel_2619_t5_3(a int not null, b int null)
+create table babel_2619_t6_1(a int not null, b int null)
+create table babel_2619_t6_2(a int not null, b int null)
+create table babel_2619_t6_3(a int not null, b int null)
+go

--- a/test/JDBC/input/BABEL-2619-vu-verify.sql
+++ b/test/JDBC/input/BABEL-2619-vu-verify.sql
@@ -1,0 +1,157 @@
+-- Tests to check whether error will be raised in case of creation of unique constraint/index on nullable column
+
+-- Test 1: trying to create unique constraint on nullable and non null columns 
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+create table babel_2619_v_t1(a int null, b int null unique, c int not null)
+go
+
+create table babel_2619_v_t2(a int null, b int not null unique, c int not null)
+go
+
+create table babel_2619_v_t3(a int null, b int unique, c int not null)
+go
+
+create table babel_2619_v_t4(a int null, b int not null, unique(a))
+go
+
+create table babel_2619_v_t5(a int null, b int not null, unique(b))
+go
+
+create table babel_2619_v_t6(a int not null, b int null, c int not null, unique(a, b, c))
+go
+
+create table babel_2619_v_t7(a int not null, b int null, c int not null, unique(a, c))
+go
+
+drop table if exists babel_2619_v_t1;
+drop table if exists babel_2619_v_t2;
+drop table if exists babel_2619_v_t3;
+drop table if exists babel_2619_v_t4;
+drop table if exists babel_2619_v_t5;
+drop table if exists babel_2619_v_t6;
+drop table if exists babel_2619_v_t7;
+go
+
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+create table babel_2619_v_t8(a int null, b int null unique, c int not null)
+go
+
+create table babel_2619_v_t9(a int null, b int not null unique, c int not null)
+go
+
+create table babel_2619_v_t10(a int null, b int unique, c int not null)
+go
+
+create table babel_2619_v_t11(a int null, b int not null, unique(a))
+go
+
+create table babel_2619_v_t12(a int null, b int not null, unique(b))
+go
+
+create table babel_2619_v_t13(a int not null, b int null, c int not null, unique(a, b, c))
+go
+
+create table babel_2619_v_t14(a int not null, b int null, c int not null, unique(a, c))
+go
+
+drop table if exists babel_2619_v_t8;
+drop table if exists babel_2619_v_t9;
+drop table if exists babel_2619_v_t10;
+drop table if exists babel_2619_v_t11;
+drop table if exists babel_2619_v_t12;
+drop table if exists babel_2619_v_t13;
+drop table if exists babel_2619_v_t14;
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go
+
+-- Test 2: trying to creating unique index on nullable and non null columns
+-- Table definition: babel_2619_t1(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+create unique index ix1 on babel_2619_t1(a)
+go
+
+create unique index ix2 on babel_2619_t1(b)
+go
+
+create unique index ix3 on babel_2619_t1(a,b)
+go
+
+-- Table definition: babel_2619_t2(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+create unique index ix1 on babel_2619_t2(a)
+go
+
+create unique index ix2 on babel_2619_t2(b)
+go
+
+create unique index ix3 on babel_2619_t2(a,b)
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go
+
+
+-- Test 3: trying to alter table to add a column with unique contraint on nullable and non null columns
+-- Table definition: babel_2619_t3(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+alter table babel_2619_t3 add col_c int null unique;
+go
+
+alter table babel_2619_t3 add col_d int not null unique;
+go
+
+-- Table definition: babel_2619_t4(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+alter table babel_2619_t4 add col_c int null unique;
+go
+
+alter table babel_2619_t4 add col_d int not null unique;
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go
+
+
+-- Test 4: trying to alter table to add unique contraint on nullable and non null columns
+-- Table definition: babel_2619_t5_1(a int not null, b int null),
+-- babel_2619_t5_2(a int not null, b int null),
+-- babel_2619_t5_3(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to STRICT (Default value)
+alter table babel_2619_t5_1 add constraint uq_a unique (a);
+go
+
+alter table babel_2619_t5_2 add constraint uq_b unique (b);
+go
+
+alter table babel_2619_t5_3 add constraint uq_ab unique (a, b);
+go
+
+-- Table definition: babel_2619_t6_1(a int not null, b int null),
+-- babel_2619_t6_2(a int not null, b int null),
+-- babel_2619_t6_3(a int not null, b int null)
+-- when babelfishpg_tsql.escape_hatch_unique_constraint is set to IGNORE
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+go
+
+alter table babel_2619_t6_1 add constraint uq_a unique (a);
+go
+
+alter table babel_2619_t6_2 add constraint uq_b unique (b);
+go
+
+alter table babel_2619_t6_3 add constraint uq_ab unique (a, b);
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';
+go

--- a/test/JDBC/input/BABEL-SP_SPECIAL_COLUMNS-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-SP_SPECIAL_COLUMNS-vu-prepare.sql
@@ -131,10 +131,10 @@ GO
 
 CREATE TABLE dbo.tidentityintbigmulti (
     data_type_test CHAR(50) NULL
-    , test_scenario CHAR(60) NULL
+    , test_scenario CHAR(60) NOT NULL
     , value_test BIGINT IDENTITY (202202081842, 100 ) NOT NULL
     , inserted_dt DATETIME DEFAULT GETDATE()
-    , user_login CHAR(255) DEFAULT CURRENT_USER
+    , user_login CHAR(255) DEFAULT CURRENT_USER NOT NULL
 )
 GO
 CREATE UNIQUE NONCLUSTERED INDEX dbo_tidentityintbigmulti_value_test ON dbo.tidentityintbigmulti (user_login ASC, value_test ASC, test_scenario ASC);

--- a/test/JDBC/input/BABEL-SP_SPECIAL_COLUMNS.sql
+++ b/test/JDBC/input/BABEL-SP_SPECIAL_COLUMNS.sql
@@ -291,10 +291,10 @@ GO
 
 CREATE TABLE dbo.tidentityintbigmulti (
     data_type_test CHAR(50) NULL
-    , test_scenario CHAR(60) NULL
-    , value_test BIGINT IDENTITY (202202081842, 100 ) NOT NULL
+    , test_scenario CHAR(60) NOT NULL   -- Used for unique index
+    , value_test BIGINT IDENTITY (202202081842, 100 ) NOT NULL  -- Used for unique index
     , inserted_dt DATETIME DEFAULT GETDATE()
-    , user_login CHAR(255) DEFAULT CURRENT_USER
+    , user_login CHAR(255) DEFAULT CURRENT_USER NOT NULL    -- Used for unique index
 )
 GO
 CREATE UNIQUE NONCLUSTERED INDEX dbo_tidentityintbigmulti_value_test ON dbo.tidentityintbigmulti (user_login ASC, value_test ASC, test_scenario ASC);

--- a/test/JDBC/input/babel_ddl.sql
+++ b/test/JDBC/input/babel_ddl.sql
@@ -12,9 +12,9 @@ create table t2 ( a int, b int, primary key nonclustered (a));
 GO
 create table t3 ( a int, b int, primary key clustered (a));
 GO
-create table t4 ( a int, b int, unique nonclustered (a));
+create table t4 ( a int not null, b int, unique nonclustered (a));
 GO
-create table t5 ( a int, b int, unique clustered (a));
+create table t5 ( a int not null, b int, unique clustered (a));
 GO
 
 create table t6 ( a int primary key nonclustered, b int);
@@ -65,9 +65,9 @@ create table t17(a int, primary key clustered (a) on [PRIMARY]);
 GO
 create table t18(a int, primary key clustered (a) on [PRIMARY]);
 GO
-create table t19(a int, unique clustered (a) on [PRIMARY]);
+create table t19(a int not null, unique clustered (a) on [PRIMARY]);
 GO
-create table t20(a int, unique clustered (a) on [PRIMARY]);
+create table t20(a int not null, unique clustered (a) on [PRIMARY]);
 GO
 
 -- ALTER TABLE ... ADD [CONSTRAINT ...] DEFAULT ... FOR ...

--- a/test/JDBC/input/constraint_column_usage.mix
+++ b/test/JDBC/input/constraint_column_usage.mix
@@ -35,7 +35,7 @@ go
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;
 go
 
-create table constraint_column_usage_tbl6 (arg12 int, arg13 int, UNIQUE(arg13));
+create table constraint_column_usage_tbl6 (arg12 int, arg13 int not null, UNIQUE(arg13));
 go
 
 SELECT * FROM information_schema.CONSTRAINT_COLUMN_USAGE WHERE TABLE_NAME NOT LIKE 'sys%' ORDER BY COLUMN_NAME;

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -335,3 +335,4 @@ timefromparts
 triggers_with_transaction
 BABEL-4046
 BABEL_4330
+BABEL-2619

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -350,3 +350,4 @@ triggers_with_transaction
 BABEL-4046
 getdate
 BABEL_4330
+BABEL-2619

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -384,3 +384,4 @@ triggers_with_transaction
 BABEL-4046
 getdate
 BABEL_4330
+BABEL-2619

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -407,3 +407,4 @@ datetimeoffset-timezone-before-15_3
 BABEL-4046
 getdate
 BABEL_4330
+BABEL-2619

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -405,3 +405,4 @@ datetimeoffset-timezone-before-15_3
 BABEL-4046
 getdate
 BABEL_4330
+BABEL-2619

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -406,3 +406,4 @@ orderby
 BABEL-4046
 getdate
 BABEL_4330
+BABEL-2619

--- a/test/odbc/psqlodbc/test/bytea.cpp
+++ b/test/odbc/psqlodbc/test/bytea.cpp
@@ -259,7 +259,7 @@ TEST_F(PSQL_DataTypes_ByteA, Table_Composite_Keys) {
 TEST_F(PSQL_DataTypes_ByteA, Table_Unique_Constraint) {
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_NAME}
+    {COL2_NAME, DATATYPE_NAME + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  

--- a/test/odbc/psqlodbc/test/char.cpp
+++ b/test/odbc/psqlodbc/test/char.cpp
@@ -628,18 +628,18 @@ TEST_F(PSQL_DataTypes_Char, Table_Unique_Constraint) {
 
   const vector<pair<string, string>> TABLE_COLUMNS_1 = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_1}
+    {COL2_NAME, DATATYPE_1 + " NOT NULL"}
   };
 
   const vector<pair<string, string>> TABLE_COLUMNS_20 = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_20}
+    {COL2_NAME, DATATYPE_20 + " NOT NULL"}
   };
 
   // Maximum allowed for PG connection is 2704
   const vector<pair<string, string>> TABLE_COLUMNS_2704 = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE + "(2704)"}
+    {COL2_NAME, DATATYPE + "(2704) NOT NULL"}
   };
 
   const vector<string> INSERTED_VALUES_1 = {

--- a/test/odbc/psqlodbc/test/date.cpp
+++ b/test/odbc/psqlodbc/test/date.cpp
@@ -279,7 +279,7 @@ TEST_F(PSQL_DataTypes_Date, Table_Composite_Keys) {
 TEST_F(PSQL_DataTypes_Date, Table_Unique_Constraint) {
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_NAME}
+    {COL2_NAME, DATATYPE_NAME + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  

--- a/test/odbc/psqlodbc/test/decimal.cpp
+++ b/test/odbc/psqlodbc/test/decimal.cpp
@@ -382,7 +382,7 @@ TEST_F(PSQL_DataTypes_Decimal, Table_Unique_Constraints) {
   const string COL2_NAME = COL_NAMES[PK_INDEX];
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, COL_TYPES[PK_INDEX]}
+    {COL2_NAME, COL_TYPES[PK_INDEX] + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  

--- a/test/odbc/psqlodbc/test/numeric.cpp
+++ b/test/odbc/psqlodbc/test/numeric.cpp
@@ -382,7 +382,7 @@ TEST_F(PSQL_DataTypes_Numeric, Table_Unique_Constraints) {
   const string COL2_NAME = COL_NAMES[PK_INDEX];
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, COL_TYPES[PK_INDEX]}
+    {COL2_NAME, COL_TYPES[PK_INDEX] + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  

--- a/test/odbc/psqlodbc/test/smallint.cpp
+++ b/test/odbc/psqlodbc/test/smallint.cpp
@@ -333,7 +333,7 @@ TEST_F(PSQL_DataTypes_SmallInt, Table_Unique_Constraint) {
 
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_NAME}
+    {COL2_NAME, DATATYPE_NAME + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  

--- a/test/odbc/psqlodbc/test/sql_variant.cpp
+++ b/test/odbc/psqlodbc/test/sql_variant.cpp
@@ -451,7 +451,7 @@ TEST_F(PSQL_DataTypes_Sql_Variant, Table_Composite_Keys) {
 TEST_F(PSQL_DataTypes_Sql_Variant, Table_Unique_Constraint) {
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_NAME}
+    {COL2_NAME, DATATYPE_NAME + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  

--- a/test/odbc/psqlodbc/test/text.cpp
+++ b/test/odbc/psqlodbc/test/text.cpp
@@ -261,6 +261,11 @@ TEST_F(PSQL_DataTypes_Text, Table_Unique_Constraint) {
   const string SCHEMA_NAME = PG_TABLE_NAME.substr(0, PG_TABLE_NAME.find('.'));
   const string BBF_SCHEMA_NAME = SCHEMA_NAME.substr(SCHEMA_NAME.find('_') + 1, SCHEMA_NAME.length());
 
+  const vector<pair<string, string>> TABLE_COLUMNS = {
+    {COL1_NAME, " int PRIMARY KEY"},
+    {COL2_NAME, DATATYPE + " NOT NULL"}
+  };
+
   const vector<string> UNIQUE_COLUMNS = {
     COL2_NAME
   };

--- a/test/odbc/psqlodbc/test/time.cpp
+++ b/test/odbc/psqlodbc/test/time.cpp
@@ -320,7 +320,7 @@ TEST_F(PSQL_DataTypes_Time, Table_Composite_Keys) {
 TEST_F(PSQL_DataTypes_Time, Table_Unique_Constraint) {
   const vector<pair<string, string>> TABLE_COLUMNS = {
     {COL1_NAME, "INT"},
-    {COL2_NAME, DATATYPE_NAME}
+    {COL2_NAME, DATATYPE_NAME + " NOT NULL"}
   };
 
   const string TABLE_NAME = PG_TABLE_NAME.substr(PG_TABLE_NAME.find('.') + 1, PG_TABLE_NAME.length());  


### PR DESCRIPTION
### Description

Blocking of UNIQUE constraint/index on nullable column was not implemented consistently. This PR will cover all the different ways to add unique constraint/index on nullable column and will block those statements by giving error. This blocking of such statements will only happen when babelfishpg_tsql.escape_hatch_unique_constraint is not set to ignore.

Updated some test files in which statements trying to create unique index/constraint on nullable columns, as the changes contained in this PR will raise an error for such statements.

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-2619

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).