### PR TITLE
Support ALTER USER...WITH LOGIN

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -417,6 +417,17 @@ tsql_alter_user_options:
 									 (Node *)makeString($3),
 									 @1);
 				}
+			| TSQL_LOGIN '=' RoleId
+				{
+					RoleSpec	*login = makeRoleSpec(ROLESPEC_CSTRING, @1);
+					List		*rolelist;
+
+					login->rolename = pstrdup($3);
+					rolelist = list_make1(login);
+					$$ = makeDefElem("rolemembers",
+									 (Node *)rolelist,
+									 @1);
+				}
 		;
 
 tsql_AlterLoginStmt:

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -996,6 +996,54 @@ drop_all_logins(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(0);
 }
 
+static void
+verify_login_for_bbf_authid_user_ext(RoleSpec *login)
+{
+	Relation	bbf_authid_user_ext_rel;
+	HeapTuple	tuple_user_ext;
+	ScanKeyData key[2];
+	TableScanDesc scan;
+	const char *cur_db_owner;
+
+	if (login == NULL || !is_login_name(login->rolename))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("The login '%s' does not exist.", login->rolename)));
+
+	/* Fetch the relation */
+	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
+										 RowExclusiveLock);
+
+	/* Check for login to user uniqueness in the database */
+	login_name = (NameData *) palloc0(NAMEDATALEN);
+	snprintf(login_name->data, NAMEDATALEN, "%s", login->rolename);
+	ScanKeyInit(&key[0],
+				Anum_bbf_authid_user_ext_login_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				NameGetDatum(login_name));
+	ScanKeyInit(&key[1],
+				Anum_bbf_authid_user_ext_database_name,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum(get_cur_db_name()));
+
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
+
+	tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
+	if (tuple_user_ext != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_ROLE_SPECIFICATION),
+				 errmsg("Existing user already maps to login '%s' in current database.", login->rolename)));
+
+	table_endscan(scan);
+	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+
+	cur_db_owner = get_owner_of_db((const char *) get_cur_db_name());
+	if (strcmp(login_name_str, cur_db_owner) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_ROLE_SPECIFICATION),
+				 errmsg("The login already has an account under a different user name.")));
+}
+
 void
 add_to_bbf_authid_user_ext(const char *user_name,
 						   const char *orig_user_name,
@@ -1114,52 +1162,8 @@ create_bbf_authid_user_ext(CreateRoleStmt *stmt, bool has_schema, bool has_login
 
 	if (has_login)
 	{
-		Relation	bbf_authid_user_ext_rel;
-		HeapTuple	tuple_user_ext;
-		ScanKeyData key[2];
-		TableScanDesc scan;
-		const char *cur_db_owner;
-
-		if (login == NULL || !is_login_name(login->rolename))
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("The login '%s' does not exist.", login->rolename)));
-
-		/* Fetch the relation */
-		bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-											 RowExclusiveLock);
-
-		/* Check for login to user uniqueness in the database */
-		login_name = (NameData *) palloc0(NAMEDATALEN);
-		snprintf(login_name->data, NAMEDATALEN, "%s", login->rolename);
-		ScanKeyInit(&key[0],
-					Anum_bbf_authid_user_ext_login_name,
-					BTEqualStrategyNumber, F_NAMEEQ,
-					NameGetDatum(login_name));
-		ScanKeyInit(&key[1],
-					Anum_bbf_authid_user_ext_database_name,
-					BTEqualStrategyNumber, F_TEXTEQ,
-					CStringGetTextDatum(get_cur_db_name()));
-
-		scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
-
-		tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
-		if (tuple_user_ext != NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_ROLE_SPECIFICATION),
-					 errmsg("Existing user already maps to login '%s' in current database.", login->rolename)));
-
-		table_endscan(scan);
-		table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
-
+		verify_login_for_bbf_authid_user_ext(login);
 		login_name_str = login->rolename;
-		cur_db_owner = get_owner_of_db((const char *) get_cur_db_name());
-
-		if (strcmp(login_name_str, cur_db_owner) == 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_ROLE_SPECIFICATION),
-					 errmsg("The login already has an account under a different user name.")));
-
 	}
 
 	/* Add to the catalog table. Adds current database name by default */
@@ -1320,9 +1324,11 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 	SysScanDesc scan;
 	ListCell   *option;
 	NameData   *user_name;
+	RoleSpec   *login = NULL;
 	char	   *default_schema = NULL;
 	char	   *new_user_name = NULL;
 	char	   *physical_name = NULL;
+	char	   *login_name_str = NULL;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
@@ -1337,11 +1343,25 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 			if (defel->arg)
 				default_schema = strVal(defel->arg);
 		}
-		if (strcmp(defel->defname, "rename") == 0)
+		else if (strcmp(defel->defname, "rename") == 0)
 		{
 			if (defel->arg)
 				new_user_name = strVal(defel->arg);
 		}
+		else if (strcmp(defel->defname, "rolemembers") == 0)
+		{
+			List	   *rolemembers = NIL;
+
+			rolemembers = (List *) defel->arg;
+			login = (RoleSpec *) linitial(rolemembers);
+		}
+	}
+
+	if (login != NULL)
+	{
+		verify_login_for_bbf_authid_user_ext(login);
+		login_name_str = login->rolename;
+
 	}
 
 	/* Fetch the relation */
@@ -1398,6 +1418,12 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 		}
 		new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum(pstrdup(default_schema));
 		new_record_repl_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = true;
+	}
+
+	if (login_name_str)
+	{
+		new_record_user_ext[USER_EXT_LOGIN_NAME] = CStringGetDatum(pstrdup(login_name_str));
+		new_record_repl_user_ext[USER_EXT_LOGIN_NAME] = true;
 	}
 
 	new_tuple = heap_modify_tuple(tuple,

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1003,12 +1003,6 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitAlter_login(TSqlParser::Al
 
 antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::Ddl_statementContext *ctx)
 {
-	if (ctx->alter_user())
-	{
-		auto alter_user = ctx->alter_user();
-		if (alter_user->loginame)
-			handle(INSTR_UNSUPPORTED_TSQL_UNKNOWN_DDL, "ALTER USER WITH LOGIN",  getLineAndPos(ctx));
-	}
 	if (ctx->create_user())
 	{
 		auto create_user = ctx->create_user();

--- a/test/JDBC/expected/BABEL-2979.out
+++ b/test/JDBC/expected/BABEL-2979.out
@@ -1,6 +1,0 @@
-alter user john with login = smith
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: 'ALTER USER WITH LOGIN' is not currently supported in Babelfish)~~
-

--- a/test/JDBC/expected/BABEL-USER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-USER-vu-cleanup.out
@@ -18,3 +18,6 @@ GO
 
 DROP LOGIN babel_user_vu_prepare_test4
 GO
+
+DROP LOGIN babel_user_vu_prepare_test5
+GO

--- a/test/JDBC/expected/BABEL-USER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-USER-vu-cleanup.out
@@ -22,5 +22,5 @@ GO
 DROP LOGIN babel_user_vu_prepare_test5
 GO
 
-DROP LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO

--- a/test/JDBC/expected/BABEL-USER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-USER-vu-cleanup.out
@@ -21,3 +21,6 @@ GO
 
 DROP LOGIN babel_user_vu_prepare_test5
 GO
+
+DROP LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+GO

--- a/test/JDBC/expected/BABEL-USER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-USER-vu-prepare.out
@@ -10,6 +10,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test4 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
+GO
+
 CREATE PROC babel_user_vu_prepare_user_ext_proc AS
 BEGIN
 SELECT rolname, login_name, orig_username, database_name, default_schema_name

--- a/test/JDBC/expected/BABEL-USER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-USER-vu-prepare.out
@@ -13,7 +13,7 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
-CREATE LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
+CREATE LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
 GO
 
 CREATE PROC babel_user_vu_prepare_user_ext_proc AS

--- a/test/JDBC/expected/BABEL-USER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-USER-vu-prepare.out
@@ -13,6 +13,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
+GO
+
 CREATE PROC babel_user_vu_prepare_user_ext_proc AS
 BEGIN
 SELECT rolname, login_name, orig_username, database_name, default_schema_name

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -206,8 +206,8 @@ babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
 
 
 -- test ALTER USER...WITH LOGIN
--- login login name (63 character length name)
-ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+-- login login name (65 character length name)
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
 GO
 
 ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
@@ -274,6 +274,7 @@ SELECT rolname FROM pg_roles WHERE rolname LIKE '%babel_user_vu_prepare%' ORDER 
 GO
 ~~START~~
 varchar
+babel_user_vu_prepare_long_logief3e68adff43cde8ecb1392da470244f
 babel_user_vu_prepare_test1
 babel_user_vu_prepare_test2
 babel_user_vu_prepare_test3

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -203,6 +203,39 @@ babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
 ~~END~~
 
 
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
+GO
+
+EXEC babel_user_vu_prepare_user_ext_proc
+GO
+~~START~~
+varchar#!#varchar#!#nvarchar#!#nvarchar#!#nvarchar
+master_babel_user_vu_prepare_aacb2aa14e22b38c44e8614f1eae6949f8#!#babel_user_vu_prepare_test4#!#babel_user_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA#!#master#!#dbo
+master_babel_user_vu_prepare_test1_new#!#babel_user_vu_prepare_test1#!#babel_user_vu_prepare_test1_new#!#master#!#dbo
+master_babel_user_vu_prepare_test2#!#babel_user_vu_prepare_test2#!#babel_user_vu_prepare_test2#!#master#!#dbo
+master_babel_user_vu_prepare_test3#!#babel_user_vu_prepare_test5#!#babel_user_vu_prepare_test3#!#master#!#babel_user_vu_prepare_sch
+~~END~~
+
+
+EXEC babel_user_vu_prepare_db_principal_proc
+GO
+~~START~~
+varchar#!#varchar
+babel_user_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA#!#dbo
+babel_user_vu_prepare_test1_new#!#dbo
+babel_user_vu_prepare_test2#!#dbo
+babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
+~~END~~
+
+
+-- should fail
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Existing user already maps to login 'babel_user_vu_prepare_test1' in current database.)~~
+
+
 SELECT rolname FROM pg_roles WHERE rolname LIKE '%babel_user_vu_prepare%' ORDER BY rolname;
 GO
 ~~START~~
@@ -211,6 +244,7 @@ babel_user_vu_prepare_test1
 babel_user_vu_prepare_test2
 babel_user_vu_prepare_test3
 babel_user_vu_prepare_test4
+babel_user_vu_prepare_test5
 master_babel_user_vu_prepare_aacb2aa14e22b38c44e8614f1eae6949f8
 master_babel_user_vu_prepare_test1_new
 master_babel_user_vu_prepare_test2

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -1,3 +1,5 @@
+-- tsql
+
 SELECT rolname, login_name, orig_username, database_name, default_schema_name
 FROM sys.babelfish_authid_user_ext
 WHERE orig_username IN ('dbo', 'db_owner', 'guest')
@@ -203,6 +205,11 @@ babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
 ~~END~~
 
 
+-- test ALTER USER...WITH LOGIN
+-- login login name (63 character length name)
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+GO
+
 ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
 GO
 
@@ -228,12 +235,39 @@ babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
 ~~END~~
 
 
--- should fail
+-- tsql user=babel_user_vu_prepare_test5 password=abc
+SELECT CURRENT_USER;
+go
+~~START~~
+varchar
+babel_user_vu_prepare_test3
+~~END~~
+
+
+-- psql
+-- New login is now member of the user after ALTER
+SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+-- both of the commands below should fail
 ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test1;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Existing user already maps to login 'babel_user_vu_prepare_test1' in current database.)~~
+
+
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = jdbc_user;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The login already has an account under a different user name.)~~
 
 
 SELECT rolname FROM pg_roles WHERE rolname LIKE '%babel_user_vu_prepare%' ORDER BY rolname;

--- a/test/JDBC/expected/test_windows_alter_user-vu-verify.out
+++ b/test/JDBC/expected/test_windows_alter_user-vu-verify.out
@@ -33,19 +33,15 @@ master_alter_user_test#!#alter_user@BBF#!#dbo
 ~~END~~
 
 
--- negative test cases
 alter user alter_user_test with login = [bbf\alter_user2];
 GO
-~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ALTER USER WITH LOGIN' is not currently supported in Babelfish)~~
-
-
+-- negative test cases
 alter user alter_user_test with password = 123;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error near '123' at line 1 and character position 43)~~
+~~ERROR (Message: syntax error near '123' at line 2 and character position 43)~~
 
 
 alter user alter_user_test with default_language = English;

--- a/test/JDBC/input/BABEL-2979.sql
+++ b/test/JDBC/input/BABEL-2979.sql
@@ -1,2 +1,0 @@
-alter user john with login = smith
-GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
@@ -18,3 +18,6 @@ GO
 
 DROP LOGIN babel_user_vu_prepare_test4
 GO
+
+DROP LOGIN babel_user_vu_prepare_test5
+GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
@@ -22,5 +22,5 @@ GO
 DROP LOGIN babel_user_vu_prepare_test5
 GO
 
-DROP LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
@@ -21,3 +21,6 @@ GO
 
 DROP LOGIN babel_user_vu_prepare_test5
 GO
+
+DROP LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
@@ -10,6 +10,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test4 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
+GO
+
 CREATE PROC babel_user_vu_prepare_user_ext_proc AS
 BEGIN
 SELECT rolname, login_name, orig_username, database_name, default_schema_name

--- a/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
@@ -13,7 +13,7 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
-CREATE LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
+CREATE LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
 GO
 
 CREATE PROC babel_user_vu_prepare_user_ext_proc AS

--- a/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
@@ -13,6 +13,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
+GO
+
 CREATE PROC babel_user_vu_prepare_user_ext_proc AS
 BEGIN
 SELECT rolname, login_name, orig_username, database_name, default_schema_name

--- a/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
@@ -1,3 +1,5 @@
+-- tsql
+
 SELECT rolname, login_name, orig_username, database_name, default_schema_name
 FROM sys.babelfish_authid_user_ext
 WHERE orig_username IN ('dbo', 'db_owner', 'guest')
@@ -82,6 +84,11 @@ GO
 EXEC babel_user_vu_prepare_db_principal_proc
 GO
 
+-- test ALTER USER...WITH LOGIN
+-- login login name (63 character length name)
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+GO
+
 ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
 GO
 
@@ -91,8 +98,21 @@ GO
 EXEC babel_user_vu_prepare_db_principal_proc
 GO
 
--- should fail
+-- tsql user=babel_user_vu_prepare_test5 password=abc
+SELECT CURRENT_USER;
+go
+
+-- New login is now member of the user after ALTER
+-- psql
+SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+
+-- tsql
+-- both of the commands below should fail
 ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test1;
+GO
+
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = jdbc_user;
 GO
 
 SELECT rolname FROM pg_roles WHERE rolname LIKE '%babel_user_vu_prepare%' ORDER BY rolname;

--- a/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
@@ -85,8 +85,8 @@ EXEC babel_user_vu_prepare_db_principal_proc
 GO
 
 -- test ALTER USER...WITH LOGIN
--- login login name (63 character length name)
-ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_login_vu_prepare_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+-- login login name (65 character length name)
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
 GO
 
 ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;

--- a/test/JDBC/input/ownership/BABEL-USER-vu-verify.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-verify.sql
@@ -82,6 +82,19 @@ GO
 EXEC babel_user_vu_prepare_db_principal_proc
 GO
 
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
+GO
+
+EXEC babel_user_vu_prepare_user_ext_proc
+GO
+
+EXEC babel_user_vu_prepare_db_principal_proc
+GO
+
+-- should fail
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test1;
+GO
+
 SELECT rolname FROM pg_roles WHERE rolname LIKE '%babel_user_vu_prepare%' ORDER BY rolname;
 GO
 

--- a/test/JDBC/input/test_windows_alter_user-vu-verify.mix
+++ b/test/JDBC/input/test_windows_alter_user-vu-verify.mix
@@ -18,10 +18,10 @@ GO
 select rolname, login_name, default_schema_name from babelfish_authid_user_ext where rolname = 'master_alter_user_test';
 GO
 
--- negative test cases
 alter user alter_user_test with login = [bbf\alter_user2];
 GO
 
+-- negative test cases
 alter user alter_user_test with password = 123;
 GO
 


### PR DESCRIPTION
### Description
This commit adds support for  ALTER USER username WITH LOGIN = loginname,
which changes the mapping of a DB user (DB principal) to a login (server principal)
for the current database. 

Task: BABEL-2980
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
BABEL-USER-VU-* contains new test cases.

* **Boundary conditions -**
YES, i.e. long login name.

* **Arbitrary inputs -**


* **Negative test cases -**
YES

* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).