### PR TITLE
Handle different behavior with escape char('\') for BBF

### DIFF
--- a/test/JDBC/expected/BABEL-4046-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4046-vu-prepare.out
@@ -41,7 +41,7 @@ select * from t join t_babel4046 on a like b;
 GO
 
 CREATE VIEW babel4046_2 as
-select * from t join t_babel4046 on a like 'aa%';
+select * from t join t_babel4046 on a like 'aa%' order by 1 offset 0 ROWS;;
 GO
 
 CREATE TABLE [dbo].[t3](

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -25,8 +25,8 @@ GO
 ~~START~~
 varchar#!#varchar
 aaa#!#a%
-AAA#!#a%
 aaa#!#A%
+AAA#!#a%
 AAA#!#A%
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -25,8 +25,8 @@ GO
 ~~START~~
 varchar#!#varchar
 aaa#!#a%
-aaa#!#A%
 AAA#!#a%
+aaa#!#A%
 AAA#!#A%
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-4270-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4270-vu-cleanup.out
@@ -1,0 +1,17 @@
+use babel_4270
+go
+
+drop procedure BABEL_4270_test_default_escape
+go
+
+drop function BABEL_4270_abc
+go
+
+drop table t
+go
+
+use master
+go
+
+drop database babel_4270
+go

--- a/test/JDBC/expected/BABEL-4270-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4270-vu-prepare.out
@@ -1,0 +1,83 @@
+create database babel_4270
+go
+use babel_4270
+go
+
+create table t ( a varchar(30));
+go
+insert into t values ('0');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('4270');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('0.599');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc_d_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('bbc_d_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('xbc_f_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abcdde');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc\_d\_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc\_d_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc\ad\c');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc\cd\_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc\xFEcd\_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abc\xFFcd\_');
+go
+~~ROW COUNT: 1~~
+
+insert into t values ('abcxFFcd\_');
+go
+~~ROW COUNT: 1~~
+
+
+create function BABEL_4270_abc()
+returns varchar(20)
+as
+    begin
+        return 'abc\xFE%'
+    end
+go
+
+
+create procedure BABEL_4270_test_default_escape
+as
+    begin
+        select * from t where a like 'abc\%'
+    end
+go

--- a/test/JDBC/expected/BABEL-4270-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4270-vu-verify.out
@@ -295,16 +295,18 @@ abcxFFcd\_
 ~~END~~
 
 
-
 -- like pattern from a function (babelfish bug, tsql have output while bbf doesn't)
 select * from t where a like BABEL_4270_abc();
--- like pattern from a non-varchar pattern
-select * from t where a like 0
 go
 ~~START~~
 varchar
+abc\xFEcd\_
 ~~END~~
 
+
+-- like pattern from a non-varchar pattern
+select * from t where a like 0
+go
 ~~START~~
 varchar
 0

--- a/test/JDBC/expected/BABEL-4270-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4270-vu-verify.out
@@ -1,0 +1,572 @@
+use babel_4270
+go
+
+-- check test list
+select * from t
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like expression without escape clause
+select * from t where a like 'abc'
+go
+~~START~~
+varchar
+abc
+~~END~~
+
+select * from t where a like 'ab_'
+go
+~~START~~
+varchar
+abc
+~~END~~
+
+select * from t where a like 'abc%'
+go
+~~START~~
+varchar
+abc
+abc_d_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+select * from t where a like 'abd'
+go
+~~START~~
+varchar
+~~END~~
+
+select * from t where a like 'abd_'
+go
+~~START~~
+varchar
+~~END~~
+
+select * from t where a like 'abc%'
+go
+~~START~~
+varchar
+abc
+abc_d_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+select * from t where a like '[a-z]bc%'
+go
+~~START~~
+varchar
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like expression with postgres default escape character '\'
+select * from t where a like 'abc\%'
+go
+~~START~~
+varchar
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+~~END~~
+
+select * from t where a like 'abc\_d\_'
+go
+~~START~~
+varchar
+abc\_d\_
+abc\ad\c
+abc\cd\_
+~~END~~
+
+
+-- not like expression with postgres default escape character '\'
+select * from t where a not like 'abc\%'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abcxFFcd\_
+~~END~~
+
+select * from t where a not like 'abc\_d\_'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like expression that pattern has default invalid UTF-8 character ‘\xFE’
+select * from t where a like 'abc\xFEcd\_'
+go
+~~START~~
+varchar
+abc\xFEcd\_
+~~END~~
+
+select * from t where a like 'abc\xFE%'
+go
+~~START~~
+varchar
+abc\xFEcd\_
+~~END~~
+
+
+-- not like expression that pattern has default invalid UTF-8 character ‘\xFE’
+select * from t where a not like 'abc\xFEcd\_'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+select * from t where a not like 'abc\xFE%'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like pattern from result of a select clause
+select * from t where a like (select 'abc\xFE%')
+go
+~~START~~
+varchar
+abc\xFEcd\_
+~~END~~
+
+select * from t where a like (select * from t where a like (select 'abc\xFE%'))
+go
+~~START~~
+varchar
+abc\xFEcd\_
+~~END~~
+
+
+-- not like pattern from result of a select clause
+select * from t where a not like (select 'abc\xFE%')
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+select * from t where a not like (select * from t where a like (select 'abc\xFE%'))
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like pattern from a variable ?
+declare @f varchar(20) = 'abc%'
+select * from t where a like @f
+go
+~~START~~
+varchar
+abc
+abc_d_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+
+-- like pattern from a function (babelfish bug, tsql have output while bbf doesn't)
+select * from t where a like BABEL_4270_abc();
+-- like pattern from a non-varchar pattern
+select * from t where a like 0
+go
+~~START~~
+varchar
+~~END~~
+
+~~START~~
+varchar
+0
+~~END~~
+
+select * from t where a like 4270
+go
+~~START~~
+varchar
+4270
+~~END~~
+
+select * from t where a like 4272
+go
+~~START~~
+varchar
+~~END~~
+
+select * from t where a like 0.599
+go
+~~START~~
+varchar
+0.599
+~~END~~
+
+
+-- like expression with escape clause
+select * from t where a like 'abcc_%' escape 'c'
+go
+~~START~~
+varchar
+abc_d_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+select * from t where a not like 'abcc_%' escape 'c'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+bbc_d_
+xbc_f_
+~~END~~
+
+
+-- like, escape clause with special escape clause
+select * from t where a like 'abc\_%' escape '\'
+go
+~~START~~
+varchar
+abc_d_
+~~END~~
+
+select * from t where a like 'abc\\xFE_d\_' escape '\xFE'
+go
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+select * from t where a like 'abc_\__%' escape '_'
+go
+~~START~~
+varchar
+abc\_d\_
+abc\_d_
+~~END~~
+
+
+-- not like, escape clause of special escape clause
+select * from t where a not like 'abc\_%' escape '\'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+select * from t where a not like 'abc\\xFE_d\_' escape '\xFE'
+go
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+select * from t where a not like 'abc_\__%' escape '_'
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like, escape character is from result of a select clause
+select * from t where a like 'abc\_%' escape (select '\')
+go
+~~START~~
+varchar
+abc_d_
+~~END~~
+
+
+select * from t where a not like 'abc\\xFE_d\_' escape ( select'\xFE')
+go
+~~START~~
+varchar
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+select * from t where a not like 'abc_\__%' escape (select '_')
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+abc_d_
+bbc_d_
+xbc_f_
+abcdde
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+-- like, escape character is from a variable
+declare @f varchar(20) = '\xFE'
+select * from t where a like 'abc\\xFE_d\_' escape @f
+go
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+declare @f varchar(20) = '\'
+select * from t where a like 'abc\_%' escape @f
+go
+~~START~~
+varchar
+abc_d_
+~~END~~
+
+
+-- like pattern and escape character both come from a variable
+declare @f varchar(20) = '\'
+declare @d varchar(20) = 'abc\_%'
+select * from t where a like @d escape @f
+go
+~~START~~
+varchar
+abc_d_
+~~END~~
+
+
+declare @f varchar(20) = '\xFE'
+declare @d varchar(20) = 'abc\\xFE_d\_'
+select * from t where a like @d escape @f
+go
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+-- not like pattern and escape character both come from a variable
+declare @f varchar(20) = '\'
+declare @d varchar(20) = 'abc\_%'
+select * from t where a not like @d escape @f
+go
+~~START~~
+varchar
+0
+4270
+0.599
+abc
+bbc_d_
+xbc_f_
+abcdde
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+abcxFFcd\_
+~~END~~
+
+
+declare @f varchar(20) = '\xFE'
+declare @d varchar(20) = 'abc\\xFE_d\_'
+select * from t where a not like @d escape @f
+go
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+-- like, escape character is from a non-varchar value
+select * from t where a like 'abc0\0_%' escape 0
+go
+~~START~~
+varchar
+abc\_d\_
+abc\_d_
+~~END~~
+
+
+-- like, escape character is from a non-varchar value
+select * from t where a like 'abc0\0_%' escape 0.5
+go
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+-- like expression with default escape '\' in a procedure
+exec BABEL_4270_test_default_escape
+go
+~~START~~
+varchar
+abc\_d\_
+abc\_d_
+abc\ad\c
+abc\cd\_
+abc\xFEcd\_
+abc\xFFcd\_
+~~END~~
+

--- a/test/JDBC/expected/babel_collection.out
+++ b/test/JDBC/expected/babel_collection.out
@@ -306,8 +306,8 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE '\%ones'
-Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=3 width=32)
-  Filter: ((c1)::text = '%ones'::text COLLATE "default")
+Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
+  Filter: (((c1)::text ~~* '\%ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -317,8 +317,8 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE '\_ones'
-Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=3 width=32)
-  Filter: ((c1)::text = '_ones'::text COLLATE "default")
+Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
+  Filter: (((c1)::text ~~* '\_ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 

--- a/test/JDBC/expected/like_expression.out
+++ b/test/JDBC/expected/like_expression.out
@@ -1214,7 +1214,6 @@ select 1 where '_ab' like '\_ab'          -- no row, but returns 1  in BBF , BAB
 GO
 ~~START~~
 int
-1
 ~~END~~
 
 
@@ -1222,7 +1221,6 @@ select 1 where '%AAABBB%' like '\%AAA%'   -- no row, but returns 1  in BBF , BAB
 go
 ~~START~~
 int
-1
 ~~END~~
 
 
@@ -1258,7 +1256,6 @@ select 1 where 'AB[C]D' LIKE 'AB\[C]D' ESCAPE '\'  -- 1
 GO
 ~~START~~
 int
-1
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/input/BABEL-4046-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4046-vu-prepare.sql
@@ -29,7 +29,7 @@ select * from t join t_babel4046 on a like b;
 GO
 
 CREATE VIEW babel4046_2 as
-select * from t join t_babel4046 on a like 'aa%';
+select * from t join t_babel4046 on a like 'aa%' order by 1 offset 0 ROWS;;
 GO
 
 CREATE TABLE [dbo].[t3](

--- a/test/JDBC/input/BABEL-4270-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4270-vu-cleanup.sql
@@ -1,0 +1,17 @@
+use babel_4270
+go
+
+drop procedure BABEL_4270_test_default_escape
+go
+
+drop function BABEL_4270_abc
+go
+
+drop table t
+go
+
+use master
+go
+
+drop database babel_4270
+go

--- a/test/JDBC/input/BABEL-4270-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4270-vu-prepare.sql
@@ -1,0 +1,53 @@
+create database babel_4270
+go
+use babel_4270
+go
+
+create table t ( a varchar(30));
+go
+insert into t values ('0');
+go
+insert into t values ('4270');
+go
+insert into t values ('0.599');
+go
+insert into t values ('abc');
+go
+insert into t values ('abc_d_');
+go
+insert into t values ('bbc_d_');
+go
+insert into t values ('xbc_f_');
+go
+insert into t values ('abcdde');
+go
+insert into t values ('abc\_d\_');
+go
+insert into t values ('abc\_d_');
+go
+insert into t values ('abc\ad\c');
+go
+insert into t values ('abc\cd\_');
+go
+insert into t values ('abc\xFEcd\_');
+go
+insert into t values ('abc\xFFcd\_');
+go
+insert into t values ('abcxFFcd\_');
+go
+
+create function BABEL_4270_abc()
+returns varchar(20)
+as
+    begin
+        return 'abc\xFE%'
+    end
+go
+
+
+create procedure BABEL_4270_test_default_escape
+as
+    begin
+        select * from t where a like 'abc\%'
+    end
+go

--- a/test/JDBC/input/BABEL-4270-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4270-vu-verify.sql
@@ -64,6 +64,7 @@ go
 
 -- like pattern from a function (babelfish bug, tsql have output while bbf doesn't)
 select * from t where a like BABEL_4270_abc();
+go
 
 -- like pattern from a non-varchar pattern
 select * from t where a like 0

--- a/test/JDBC/input/BABEL-4270-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4270-vu-verify.sql
@@ -1,0 +1,151 @@
+use babel_4270
+go
+
+-- check test list
+select * from t
+go
+
+-- like expression without escape clause
+select * from t where a like 'abc'
+go
+select * from t where a like 'ab_'
+go
+select * from t where a like 'abc%'
+go
+select * from t where a like 'abd'
+go
+select * from t where a like 'abd_'
+go
+select * from t where a like 'abc%'
+go
+select * from t where a like '[a-z]bc%'
+go
+
+-- like expression with postgres default escape character '\'
+select * from t where a like 'abc\%'
+go
+select * from t where a like 'abc\_d\_'
+go
+
+-- not like expression with postgres default escape character '\'
+select * from t where a not like 'abc\%'
+go
+select * from t where a not like 'abc\_d\_'
+go
+
+-- like expression that pattern has default invalid UTF-8 character ‘\xFE’
+select * from t where a like 'abc\xFEcd\_'
+go
+select * from t where a like 'abc\xFE%'
+go
+
+-- not like expression that pattern has default invalid UTF-8 character ‘\xFE’
+select * from t where a not like 'abc\xFEcd\_'
+go
+select * from t where a not like 'abc\xFE%'
+go
+
+-- like pattern from result of a select clause
+select * from t where a like (select 'abc\xFE%')
+go
+select * from t where a like (select * from t where a like (select 'abc\xFE%'))
+go
+
+-- not like pattern from result of a select clause
+select * from t where a not like (select 'abc\xFE%')
+go
+select * from t where a not like (select * from t where a like (select 'abc\xFE%'))
+go
+
+-- like pattern from a variable ?
+declare @f varchar(20) = 'abc%'
+select * from t where a like @f
+go
+
+-- like pattern from a function (babelfish bug, tsql have output while bbf doesn't)
+select * from t where a like BABEL_4270_abc();
+
+-- like pattern from a non-varchar pattern
+select * from t where a like 0
+go
+select * from t where a like 4270
+go
+select * from t where a like 4272
+go
+select * from t where a like 0.599
+go
+
+-- like expression with escape clause
+select * from t where a like 'abcc_%' escape 'c'
+go
+select * from t where a not like 'abcc_%' escape 'c'
+go
+
+-- like, escape clause with special escape clause
+select * from t where a like 'abc\_%' escape '\'
+go
+select * from t where a like 'abc\\xFE_d\_' escape '\xFE'
+go
+select * from t where a like 'abc_\__%' escape '_'
+go
+
+-- not like, escape clause of special escape clause
+select * from t where a not like 'abc\_%' escape '\'
+go
+select * from t where a not like 'abc\\xFE_d\_' escape '\xFE'
+go
+select * from t where a not like 'abc_\__%' escape '_'
+go
+
+-- like, escape character is from result of a select clause
+select * from t where a like 'abc\_%' escape (select '\')
+go
+
+select * from t where a not like 'abc\\xFE_d\_' escape ( select'\xFE')
+go
+
+select * from t where a not like 'abc_\__%' escape (select '_')
+go
+
+-- like, escape character is from a variable
+declare @f varchar(20) = '\xFE'
+select * from t where a like 'abc\\xFE_d\_' escape @f
+go
+
+declare @f varchar(20) = '\'
+select * from t where a like 'abc\_%' escape @f
+go
+
+-- like pattern and escape character both come from a variable
+declare @f varchar(20) = '\'
+declare @d varchar(20) = 'abc\_%'
+select * from t where a like @d escape @f
+go
+
+declare @f varchar(20) = '\xFE'
+declare @d varchar(20) = 'abc\\xFE_d\_'
+select * from t where a like @d escape @f
+go
+
+-- not like pattern and escape character both come from a variable
+declare @f varchar(20) = '\'
+declare @d varchar(20) = 'abc\_%'
+select * from t where a not like @d escape @f
+go
+
+declare @f varchar(20) = '\xFE'
+declare @d varchar(20) = 'abc\\xFE_d\_'
+select * from t where a not like @d escape @f
+go
+
+-- like, escape character is from a non-varchar value
+select * from t where a like 'abc0\0_%' escape 0
+go
+
+-- like, escape character is from a non-varchar value
+select * from t where a like 'abc0\0_%' escape 0.5
+go
+
+-- like expression with default escape '\' in a procedure
+exec BABEL_4270_test_default_escape
+go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -454,3 +454,4 @@ sp_who
 BABEL_4330
 kill
 Test_ISNULL
+BABEL-4270


### PR DESCRIPTION
### Description

Postgres uses escape clause with empty string to turn off default escape. Since TSQL does not allow empty string as a valid escape pattern. We use non-UTF8 character in escape clause as a flag and reuse the code logic of escape clause with empty string to disable default escape character ’\‘. 

### Issues Resolved
Solved behavior difference when using '\' in like clause in babelfish
Task: BABEL-4270

### Test Scenarios Covered ###
like expression without escape clause

1. regular like expression
2. like expression that pattern has default escape character ‘\’ 
3. like expression that pattern has default invalid UTF-8 character ‘\xFE’
4. like pattern from result of a select clause
    1. select result with ‘\’
    2. select result with ‘\xFE’
5. like pattern from a variable/function call
6. like expression with non-varchar pattern

like expression with escape clause

1. regular like expression with escape clause
    1. with any escape charcter 
2.  like expression with special escape clause
    1. ‘\’
    2. ‘\xFE’ 
3. expect escape all ‘\’ rather than ‘\xFE’
4. should we expect user to escape this character? *‘0xFE’ is an non-UTF-8 Character
5. like pattern from result of a select clause?
6. like pattern not from a variable and escape character from a variable
7. like pattern from a variable and escape character from a variable
8. like pattern from a variable and escape character from a function
9. like pattern from a variable and escape character from a non-varchar value 

like expression within a procedure




### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).