### PR TITLE
Restrict SELECT permission on sys.babelfish_extended_properties

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -636,7 +636,6 @@ CREATE TABLE sys.babelfish_extended_properties (
   value sys.sql_variant,
   PRIMARY KEY (dbid, type, schema_name, major_name, minor_name, name)
 );
-GRANT SELECT on sys.babelfish_extended_properties TO PUBLIC;
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_extended_properties', '');
 
 -- This view contains many outer joins that could potentially impair performance.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -208,7 +208,6 @@ CREATE TABLE sys.babelfish_extended_properties (
   value sys.sql_variant,
   PRIMARY KEY (dbid, type, schema_name, major_name, minor_name, name)
 );
-GRANT SELECT on sys.babelfish_extended_properties TO PUBLIC;
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_extended_properties', '');
 
 CREATE OR REPLACE VIEW sys.extended_properties

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-cleanup.out
@@ -26,7 +26,7 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 SELECT dbid, schema_name, major_name, minor_name, type, name, orig_name, value FROM sys.babelfish_extended_properties ORDER BY dbid, type, schema_name, major_name, minor_name, name
 GO
-~~START~~
-smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-v2-vu-verify.out
@@ -123,11 +123,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 before
-1#!##!##!##!#DATABASE#!#database property2#!#database property2#!#database property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'database property1', 'database property1 after'
@@ -156,11 +154,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!##!##!##!#DATABASE#!#database property2#!#database property2#!#database property2 after
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'database property2'
@@ -184,10 +180,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- schema
@@ -268,14 +263,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'schema property1', 'schema property1 after', 'schema', 'babel_extended_properties_schema1'
@@ -309,14 +299,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 after
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'schema property2', 'schema', 'BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name'
@@ -345,13 +330,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- table
@@ -459,19 +440,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table783e9cd01e68686d0d071a20f0d03eba#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table783e9cd01e68686d0d071a20f0d03eba#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'table property1', 'table property1 after', 'schema', 'babel_extended_properties_schema1', 'table', 'babel_extended_properties_table1'
@@ -515,19 +486,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property2#!#table property2#!#table property2 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table783e9cd01e68686d0d071a20f0d03eba#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table783e9cd01e68686d0d071a20f0d03eba#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'table property2', 'schema', 'babel_extended_properties_schema1', 'table', 'BABEL_extended_properties_table2'
@@ -564,17 +525,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table783e9cd01e68686d0d071a20f0d03eba#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP TABLE babel_extended_properties_schema1.BABEL_extended_properties_table3_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name
@@ -606,16 +559,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- table column
@@ -721,20 +667,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#long_long_long_long_long_long_l269ad0b8f4433298201fd6a8ca758a70#!#TABLE COLUMN#!#column property2 "{\)#!#COLUMN PROPERTY2 "{\)#!#COLUMN PROPERTY2 BEFORE "{\)   
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC sp_updateextendedproperty 'Column property1   ', 'column property1 after', 'Schema   ', 'Babel_extended_properties_schema1   ', 'Table', 'Babel_extended_properties_table1   ', 'Column   ', 'Id   '
@@ -772,20 +707,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#long_long_long_long_long_long_l269ad0b8f4433298201fd6a8ca758a70#!#TABLE COLUMN#!#column property2 "{\)#!#COLUMN PROPERTY2 "{\)#!#Column property2 after   
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC sp_dropextendedproperty 'Column property2 "{\)     ', 'Schema   ', 'Babel_extended_properties_schema1   ', 'Table   ', 'Babel_extended_properties_table2   ', 'Column   ', 'long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name   '
@@ -819,19 +743,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- view
@@ -939,23 +853,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'view property1', 'view property1 after', 'schema', 'babel_extended_properties_schema1', 'view', 'babel_extended_properties_view1'
@@ -998,23 +898,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property2#!#view property2#!#view property2 after
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'view property2', 'schema', 'babel_extended_properties_schema1', 'view', 'babel_extended_properties_view2'
@@ -1052,22 +938,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- sequence
@@ -1179,26 +1052,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'sequence property1', 'sequence property1 after', 'schema', 'babel_extended_properties_schema1', 'sequence', 'babel_extended_properties_seq1'
@@ -1244,26 +1100,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'sequence property2', 'schema', 'babel_extended_properties_schema1', 'sequence', 'babel_extended_properties_seq2'
@@ -1304,25 +1143,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- procedure
@@ -1448,29 +1271,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'procedure property1', 'procedure property1 after', 'schema', 'babel_extended_properties_schema1', 'procedure', 'babel_extended_properties_proc1'
@@ -1519,29 +1322,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'procedure property2', 'schema', 'babel_extended_properties_schema1', 'procedure', 'babel_extended_properties_proc2'
@@ -1585,28 +1368,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- function
@@ -1738,32 +1502,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'function property1', 'function property1 after', 'schema', 'babel_extended_properties_schema1', 'function', 'babel_extended_properties_func1'
@@ -1815,32 +1556,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'function property2', 'schema', 'babel_extended_properties_schema1', 'function', 'babel_extended_properties_func2'
@@ -1887,31 +1605,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- type
@@ -2043,35 +1739,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property2#!#type property2#!#12345678
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_updateextendedproperty 'type property1', 'type property1 after', 'schema', 'babel_extended_properties_schema1', 'type', 'babel_extended_properties_type1'
@@ -2126,35 +1796,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property2#!#type property2#!#87654321
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 EXEC babel_sp_dropextendedproperty 'type property2', 'schema', 'babel_extended_properties_schema1', 'type', 'babel_extended_properties_type2'
@@ -2204,34 +1848,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- sp_rename
@@ -2305,34 +1924,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func2#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 sp_rename 'babel_extended_properties_schema1.babel_extended_properties_func2', 'babel_extended_properties_func3', 'OBJECT'
@@ -2372,34 +1966,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc2#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 sp_rename 'babel_extended_properties_schema1.babel_extended_properties_proc2', 'babel_extended_properties_proc3', 'OBJECT'
@@ -2439,34 +2008,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq2#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 sp_rename 'babel_extended_properties_schema1.babel_extended_properties_seq2', 'babel_extended_properties_seq3', 'OBJECT'
@@ -2506,34 +2050,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view2#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 sp_rename 'babel_extended_properties_schema1.babel_extended_properties_view2', 'babel_extended_properties_view3', 'OBJECT'
@@ -2573,34 +2092,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 sp_rename 'babel_extended_properties_schema1.BABEL_extended_properties_table2.Id', 'id1', 'COLUMN'
@@ -2640,34 +2134,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table2#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 sp_rename 'babel_extended_properties_schema1.BABEL_extended_properties_table2', 'babel_extended_properties_table3', 'OBJECT'
@@ -2707,34 +2176,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type2#!##!#TYPE#!#type property1#!#type property1#!#type property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- drop object
@@ -2807,33 +2251,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func3#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP FUNCTION babel_extended_properties_schema1.babel_extended_properties_func3
@@ -2871,32 +2291,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc3#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP PROCEDURE babel_extended_properties_schema1.babel_extended_properties_proc3
@@ -2933,31 +2330,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq3#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP SEQUENCE babel_extended_properties_schema1.babel_extended_properties_seq3
@@ -2993,30 +2368,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view3#!##!#VIEW#!#view property1#!#view property1#!#view property1 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP VIEW babel_extended_properties_schema1.babel_extended_properties_view3
@@ -3051,29 +2405,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!#id1#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 ALTER TABLE babel_extended_properties_schema1.babel_extended_properties_table3 DROP id1
@@ -3107,28 +2441,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table3#!##!#TABLE#!#table property1#!#table property1#!#table property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP TABLE babel_extended_properties_schema1.babel_extended_properties_table3
@@ -3161,27 +2476,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 DROP SCHEMA BABEL_extended_properties_schema2_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name
@@ -3213,26 +2510,9 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 
 EXEC babel_babelfish_extended_properties_proc
 GO
-~~START~~
-int#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#sql_variant
-1#!##!##!##!#DATABASE#!#database property1#!#database property1#!#database property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property1#!#function property1#!#function property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_func1#!##!#FUNCTION#!#function property2#!#function property2#!#function property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property1#!#procedure property1#!#procedure property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_proc1#!##!#PROCEDURE#!#procedure property2#!#procedure property2#!#procedure property2 before
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property1#!#schema property1#!#schema property1 after
-1#!#babel_extended_properties_schema1#!##!##!#SCHEMA#!#schema property2#!#schema property2#!#schema property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property1#!#sequence property1#!#sequence property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_seq1#!##!#SEQUENCE#!#sequence property2#!#sequence property2#!#sequence property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property1#!#table property1#!#table property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!##!#TABLE#!#table property2#!#table property2#!#table property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#id#!#TABLE COLUMN#!#column property1#!#column property1#!#column property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_table1#!#name#!#TABLE COLUMN#!#column property2#!#column property2#!#column property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property1#!#type property1#!#type property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_type1#!##!#TYPE#!#type property2#!#type property2#!#type property2 before
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property1#!#view property1#!#view property1 after
-1#!#babel_extended_properties_schema1#!#babel_extended_properties_view1#!##!#VIEW#!#view property2#!#view property2#!#view property2 before
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- tsql user=normal_user password=12345678
@@ -3362,6 +2642,13 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 3#!#SCHEMA#!#1#!#0#!#schema property1#!#schema property1 after
 3#!#SCHEMA#!#1#!#0#!#schema property2#!#schema property2 before
 ~~END~~
+
+
+select * from sys.babelfish_extended_properties;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babelfish_extended_properties)~~
 
 
 -- psql

--- a/test/JDBC/input/BABEL-EXTENDEDPROPERTY-v2-vu-verify.mix
+++ b/test/JDBC/input/BABEL-EXTENDEDPROPERTY-v2-vu-verify.mix
@@ -908,6 +908,9 @@ GO
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties
 GO
 
+select * from sys.babelfish_extended_properties;
+go
+
 -- psql
 do
 $$ declare dbname text;


### PR DESCRIPTION
**Description**

In order to avoid leakage of metadata, the SELECT permission on sys.babelfish_extended_properties should not be granted PUBLIC. This commit fixes above leak by removing grant statement allowing select on sys.babelfish_extended_properties to public from the babelfish SQL scripts.

Task: BABEL-4350
Authored-by: Anju Bharti [abanju@amazon.com](mailto:abanju@amazon.com)
Signed-off-by: Anju Bharti [abanju@amazon.com](mailto:abanju@amazon.com)

**Issues Resolved**
JIRA BABEL-4350
the permission on sys.babelfish_extended_properties granted SELECT to PUBLIC

Check List
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).