### PR TITLE
Babel should not allow VIEW in OUTPUT INTO clause

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2324,10 +2324,19 @@ modify_insert_stmt(InsertStmt *stmt, Oid relid)
 	HeapTuple	tuple;
 	List	   *insert_col_list = NIL,
 			   *temp_col_list;
+	char		relkind = get_rel_relkind(relid);
 
 	if (!output_into_insert_transformation)
+	{
+		if(relkind == RELKIND_VIEW || relkind == RELKIND_MATVIEW)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("The target '%s' of the OUTPUT INTO clause cannot be a view or common table expression.", stmt->relation->relname)));
+		}
 		return;
-
+	}
+		
 	if (stmt->cols != NIL)
 		return;
 

--- a/test/JDBC/expected/BABEL-2144-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-2144-vu-cleanup.out
@@ -1,0 +1,6 @@
+drop VIEW babel_2144_vu_prepare_v1;
+go
+drop table babel_2144_vu_prepare_t1;
+go
+drop table babel_2144_vu_prepare_t2;
+go

--- a/test/JDBC/expected/BABEL-2144-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-2144-vu-prepare.out
@@ -1,0 +1,25 @@
+create table babel_2144_vu_prepare_t1(c1 int, c2 int);
+go
+create table babel_2144_vu_prepare_t2(c1 int, c2 int);
+go
+insert into babel_2144_vu_prepare_t1 values (12,15);
+go
+~~ROW COUNT: 1~~
+
+insert into babel_2144_vu_prepare_t1 values (0,0);
+go
+~~ROW COUNT: 1~~
+
+insert into babel_2144_vu_prepare_t2 values (13,16);
+go
+~~ROW COUNT: 1~~
+
+insert into babel_2144_vu_prepare_t2 values (0,0);
+go
+~~ROW COUNT: 1~~
+
+CREATE VIEW babel_2144_vu_prepare_v1 AS SELECT * FROM babel_2144_vu_prepare_t2 WHERE c2 > 10;
+go
+
+
+

--- a/test/JDBC/expected/BABEL-2144-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2144-vu-verify.out
@@ -1,0 +1,69 @@
+UPDATE babel_2144_vu_prepare_t1 SET c1 = 23 OUTPUT INSERTED.c2, 22 INTO babel_2144_vu_prepare_v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The target 'babel_2144_vu_prepare_v1' of the OUTPUT INTO clause cannot be a view or common table expression.)~~
+
+UPDATE babel_2144_vu_prepare_t2 SET c1 = 0 OUTPUT INSERTED.c2, 22 INTO babel_2144_vu_prepare_v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The target 'babel_2144_vu_prepare_v1' of the OUTPUT INTO clause cannot be a view or common table expression.)~~
+
+UPDATE babel_2144_vu_prepare_t2 SET c1 = 23 OUTPUT INSERTED.c2, 22 INTO babel_2144_vu_prepare_t2;
+go
+~~ROW COUNT: 2~~
+
+UPDATE babel_2144_vu_prepare_t2 SET c1 = 0 OUTPUT INSERTED.c1, 33 INTO babel_2144_vu_prepare_t2;
+go
+~~ROW COUNT: 4~~
+
+UPDATE babel_2144_vu_prepare_t1 SET c1 = 1 OUTPUT INSERTED.c2, 11 INTO babel_2144_vu_prepare_t1;
+go
+~~ROW COUNT: 2~~
+
+UPDATE babel_2144_vu_prepare_t1 SET c1 = 2 OUTPUT INSERTED.c1, 1 INTO babel_2144_vu_prepare_t2;
+go
+~~ROW COUNT: 4~~
+
+select * from babel_2144_vu_prepare_t1;
+go
+~~START~~
+int#!#int
+2#!#15
+2#!#11
+2#!#0
+2#!#11
+~~END~~
+
+select * from babel_2144_vu_prepare_t2;
+go
+~~START~~
+int#!#int
+0#!#16
+0#!#33
+0#!#22
+0#!#33
+0#!#0
+0#!#33
+0#!#22
+0#!#33
+2#!#1
+2#!#1
+2#!#1
+2#!#1
+~~END~~
+
+select * from babel_2144_vu_prepare_v1;
+go
+~~START~~
+int#!#int
+0#!#16
+0#!#33
+0#!#22
+0#!#33
+0#!#33
+0#!#22
+0#!#33
+~~END~~
+

--- a/test/JDBC/input/BABEL-2144-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-2144-vu-cleanup.sql
@@ -1,0 +1,6 @@
+drop VIEW babel_2144_vu_prepare_v1;
+go
+drop table babel_2144_vu_prepare_t1;
+go
+drop table babel_2144_vu_prepare_t2;
+go

--- a/test/JDBC/input/BABEL-2144-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-2144-vu-prepare.sql
@@ -1,0 +1,17 @@
+create table babel_2144_vu_prepare_t1(c1 int, c2 int);
+go
+create table babel_2144_vu_prepare_t2(c1 int, c2 int);
+go
+insert into babel_2144_vu_prepare_t1 values (12,15);
+go
+insert into babel_2144_vu_prepare_t1 values (0,0);
+go
+insert into babel_2144_vu_prepare_t2 values (13,16);
+go
+insert into babel_2144_vu_prepare_t2 values (0,0);
+go
+CREATE VIEW babel_2144_vu_prepare_v1 AS SELECT * FROM babel_2144_vu_prepare_t2 WHERE c2 > 10;
+go
+
+
+

--- a/test/JDBC/input/BABEL-2144-vu-verify.sql
+++ b/test/JDBC/input/BABEL-2144-vu-verify.sql
@@ -1,0 +1,18 @@
+UPDATE babel_2144_vu_prepare_t1 SET c1 = 23 OUTPUT INSERTED.c2, 22 INTO babel_2144_vu_prepare_v1;
+go
+UPDATE babel_2144_vu_prepare_t2 SET c1 = 0 OUTPUT INSERTED.c2, 22 INTO babel_2144_vu_prepare_v1;
+go
+UPDATE babel_2144_vu_prepare_t2 SET c1 = 23 OUTPUT INSERTED.c2, 22 INTO babel_2144_vu_prepare_t2;
+go
+UPDATE babel_2144_vu_prepare_t2 SET c1 = 0 OUTPUT INSERTED.c1, 33 INTO babel_2144_vu_prepare_t2;
+go
+UPDATE babel_2144_vu_prepare_t1 SET c1 = 1 OUTPUT INSERTED.c2, 11 INTO babel_2144_vu_prepare_t1;
+go
+UPDATE babel_2144_vu_prepare_t1 SET c1 = 2 OUTPUT INSERTED.c1, 1 INTO babel_2144_vu_prepare_t2;
+go
+select * from babel_2144_vu_prepare_t1;
+go
+select * from babel_2144_vu_prepare_t2;
+go
+select * from babel_2144_vu_prepare_v1;
+go


### PR DESCRIPTION
### Description

when query `UPDATE table1 SET c1 = 23 OUTPUT INSERTED.c2, 22 INTO view1` executes on babelfish, it executes without throwing any error. Ideally it should throw error. So, to fix this, the `relkind` is fetched using `relid` and then added condition to check whether this relation is view or not. And error is thrown in this if block.
This PR contains the changes for VIEW relation only, for common table expression babel does not support the syntax right now. 



### Issues Resolved

BABEL-2144

### Test Scenarios Covered ###
* **Use case based -**
Added

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).