### PR TITLE
Fix memory leak in FOR XML code

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -225,6 +225,7 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 		}
 	}
 	appendStringInfoString(state, "/>");
+	ReleaseTupleDesc(tupdesc);
 }
 
 /*
@@ -301,6 +302,7 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 	}
 	else if (element_name[0] != '\0')
 		appendStringInfo(state, "</%s>", element_name);
+	ReleaseTupleDesc(tupdesc);
 }
 
 static void


### PR DESCRIPTION
Add a call to ReleaseTupleDesc at the end of tsql_row_to_xml_raw() and tsql_row_to_xml_path() to prevent a memory leak.

### Description

The code that evaluated each row during execution of FOR XML did not properly release the tupdesc. This would lead to hanging on queries of extremely large tables.

### Issues Resolved

BABEL-4355

### Test Scenarios Covered ###
N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).