### PR TITLE
Revert: Return syntax error for identity in select-into (#1763)

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -233,35 +233,8 @@ TsqlFunctionConvert(TypeName *typename, Node *arg, Node *style, bool try, int lo
 Node *
 TsqlFunctionIdentityInto(TypeName *typename, Node *seed, Node *increment, int location)
 {
-	Node *result;
-	List *args;
-	int32 typmod;
-	Oid type_oid;
-	Oid base_oid;
-	typenameTypeIdAndMod(NULL, typename, &type_oid, &typmod);
-	base_oid = getBaseType(type_oid);
-	switch (base_oid)
-	{
-		case INT2OID:
-			args = list_make3((Node *)makeIntConst((int)type_oid, location), seed, increment);
-			result = (Node *)makeFuncCall(TsqlSystemFuncName("identity_into_smallint"), args, COERCE_EXPLICIT_CALL, location);
-			break;
-		case INT4OID:
-			args = list_make3((Node *)makeIntConst((int)type_oid, location), seed, increment);
-			result = (Node *)makeFuncCall(TsqlSystemFuncName("identity_into_int"), args, COERCE_EXPLICIT_CALL, location);
-			break;
-		case INT8OID:
-		case NUMERICOID:
-			args = list_make3((Node *)makeIntConst((int)INT8OID, location), seed, increment); /* Used bigint internally for decimal and numeric as well*/
-			result = (Node *)makeFuncCall(TsqlSystemFuncName("identity_into_bigint"), args, COERCE_EXPLICIT_CALL, location);
-			break;
-		default:
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					errmsg("Parameter or variable '' has an invalid data type.")));
-			break;
-	}
-	return result;
+	ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR), errmsg("IDENTITY() function in SELECT INTO is not supported.")));
+	// Temporarily throw Syntax error instaed of reverting code until Select into identity function with order by is fixed 
 }
 
 /* TsqlFunctionParse -- Implements the PARSE and TRY_PARSE functions.

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1986,7 +1986,7 @@ public:
 	{
 		// if select doesnt contains into but it contains identity we should throw error
 		if(has_identity_function && !ctx->INTO()){
-			throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, "Incorrect syntax near ')'", getLineAndPos(ctx));
+			throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, "The IDENTITY function can only be used when the SELECT statement has an INTO clause.", getLineAndPos(ctx));
 		}
 		has_identity_function = false;
 		if (statementMutator)

--- a/test/JDBC/expected/BABEL_539-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_539-vu-cleanup.out
@@ -1,4 +1,4 @@
-DROP PROC babel_539_prepare_proc;
+DROP PROC IF EXISTS babel_539_prepare_proc;
 GO
 
 DROP TABLE IF EXISTS babel_539OldTable;

--- a/test/JDBC/expected/BABEL_539-vu-verify.out
+++ b/test/JDBC/expected/BABEL_539-vu-verify.out
@@ -1,14 +1,8 @@
 EXEC babel_539_prepare_proc
 GO
+~~ERROR (Code: 33557097)~~
 
-SELECT id_num, col1, name  FROM babel_539NewTable_proc ORDER BY id_num;
-GO
-~~START~~
-int#!#int#!#varchar
-1#!#10#!#user1
-3#!#20#!#user2
-5#!#30#!#user3
-~~END~~
+~~ERROR (Message: IDENTITY() function in SELECT INTO is not supported.)~~
 
 
 DROP TABLE IF EXISTS babel_539NewTable_proc;
@@ -17,359 +11,26 @@ GO
 DROP TABLE IF EXISTS babel_539NewTable1;
 GO
 
-SELECT col1, IDENTITY(int, 1,1) AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM babel_539NewTable1 ORDER BY id_num;
-GO
-~~START~~
-int#!#int
-1#!#10
-2#!#20
-3#!#30
-~~END~~
-
-
-DROP TABLE IF EXISTS babel_539NewTable1;
-GO
-
-SELECT col1, IDENTITY(int, 1) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num;
-GO
-~~START~~
-int#!#int
-1#!#10
-2#!#20
-3#!#30
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, IDENTITY(int) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT col1, id_num FROM #babel_539NewTable1 ORDER BY id_num;
-GO
-~~START~~
-int#!#int
-10#!#1
-20#!#2
-30#!#3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, id_num=IDENTITY(int, 1,100) INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num;
-GO
-~~START~~
-int#!#int
-1#!#10
-101#!#20
-201#!#30
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, [id_num]=IDENTITY(int, 1,1) INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int
-1#!#10
-2#!#20
-3#!#30
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, identity(int, 1,-100) AS [id_num] INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int
--199#!#30
--99#!#20
-1#!#10
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT *, identity(int) AS [id_num] INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int#!#varchar
-1#!#10#!#user1
-2#!#20#!#user2
-3#!#30#!#user3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
--- Self Join
-SELECT IDENTITY(int,1,1) AS id_num, ltable.col1 AS col1, ltable.name AS name INTO #babel_539NewTable1 
-FROM babel_539OldTable AS ltable JOIN babel_539OldTable AS rtable ON ltable.col1 <> rtable.col1 ORDER BY ltable.col1;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int#!#varchar
-1#!#10#!#user1
-2#!#10#!#user1
-3#!#20#!#user2
-4#!#20#!#user2
-5#!#30#!#user3
-6#!#30#!#user3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(bigint, 9223372036854775807, -1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-bigint#!#int#!#varchar
-9223372036854775805#!#30#!#user3
-9223372036854775806#!#20#!#user2
-9223372036854775807#!#10#!#user1
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(numeric, -9223372036854775806, +1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-bigint#!#int#!#varchar
--9223372036854775806#!#10#!#user1
--9223372036854775805#!#20#!#user2
--9223372036854775804#!#30#!#user3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(numeric(19,0), 9223372036854775807, -1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-bigint#!#int#!#varchar
-9223372036854775805#!#30#!#user3
-9223372036854775806#!#20#!#user2
-9223372036854775807#!#10#!#user1
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT distinct IDENTITY(numeric(19,0), 1, 1) as id_num, * into #babel_539NewTable1 from babel_539OldTable where 1=1;
-GO
-
-SELECT col1, name, id_num FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-~~START~~
-int#!#varchar#!#bigint
-10#!#user1#!#1
-20#!#user2#!#2
-30#!#user3#!#3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(int, -10, 1+1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: syntax error near 'identity')~~
-
-
-SELECT IDENTITY(int, 1, 1-2) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: syntax error near 'identity')~~
-
-
-SELECT col1, IDENTITY(char, 1,1) AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Parameter or variable '' has an invalid data type.)~~
-
-
-SELECT col1, IDENTITY(int, 1,1,1) AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: syntax error at or near ",")~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
--- impact to other similar queries and functions
--- normal create table cases
-CREATE TABLE babel_539OldTable2 (col1 int NOT NULL, name varchar(20), id_num INT IDENTITY(1, 2));
-GO
-
-INSERT INTO babel_539OldTable2 VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
-GO
-~~ROW COUNT: 3~~
-
-
-SELECT id_num, col1, name INTO babel_539NewTable2 FROM babel_539OldTable2 ORDER BY id_num;
-GO
-
-SELECT id_num, col1, name FROM babel_539NewTable2 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int#!#varchar
-1#!#10#!#user1
-3#!#20#!#user2
-5#!#30#!#user3
-~~END~~
-
-
-DROP TABLE IF EXISTS babel_539OldTable2;
-GO
-
-DROP TABLE IF EXISTS babel_539NewTable2;
-GO
-
--- create table as temp table
-CREATE TABLE #babel_539NewTable2 (col1 int, name varchar(20),  id_num int IDENTITY(-1, 2));
-GO
-
-INSERT INTO #babel_539NewTable2(col1, name) VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
-GO
-~~ROW COUNT: 3~~
-
-
-SELECT id_num, col1, name FROM #babel_539NewTable2 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int#!#varchar
--1#!#10#!#user1
-1#!#20#!#user2
-3#!#30#!#user3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable2;
-GO
-
-CREATE TABLE #babel_539NewTable2 (col1 int, name varchar(20) );
-GO
-
-SELECT col1, name FROM #babel_539NewTable2 ORDER BY col1; 
-GO
-~~START~~
-int#!#varchar
-~~END~~
-
-
--- try altering table and check other columns, sequence should drop and any constraints also
-ALTER TABLE #babel_539NewTable2 ADD id_num int IDENTITY(1, 1);
-GO
-
-INSERT INTO #babel_539NewTable2(col1, name) VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
-GO
-~~ROW COUNT: 3~~
-
-
-SELECT id_num, col1, name FROM #babel_539NewTable2 ORDER BY id_num; 
-GO
-~~START~~
-int#!#int#!#varchar
-1#!#10#!#user1
-2#!#20#!#user2
-3#!#30#!#user3
-~~END~~
-
-
-DROP TABLE IF EXISTS #babel_539NewTable2;
-GO
-
--- Two identity columns in a query
-SELECT col1, IDENTITY(int, 1,1) as id_num, IDENTITY(int, 1,1) as id_num2 INTO babel_539NewTable2 FROM babel_539OldTable;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Attempting to add multiple identity columns to table "babel_539newtable2" using the SELECT INTO statement.)~~
-
-
-SELECT col1, IDENTITY() AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: syntax error at or near ")")~~
-
-
 --calling internal function directly
-SELECT col1, IDENTITY_INTO(1, 1,1) as id_num INTO babel_539NewTempTable2 FROM babel_539OldTable;
+SELECT col1, IDENTITY_INTO_INT(23, 1,1) as id_num INTO babel_539NewTempTable2 FROM babel_539OldTable;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: function IDENTITY_INTO does not exist)~~
+~~ERROR (Message: function IDENTITY_INTO_INT does not exist)~~
 
 
 SELECT sys.IDENTITY(23, 1);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Incorrect syntax near ')')~~
+~~ERROR (Message: The IDENTITY function can only be used when the SELECT statement has an INTO clause.)~~
 
 
 SELECT IDENTITY(int, 21);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Incorrect syntax near ')')~~
-
-
-SELECT sys.IDENTITY_INTO(23, 1, 1);
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: function IDENTITY_INTO does not exist)~~
+~~ERROR (Message: The IDENTITY function can only be used when the SELECT statement has an INTO clause.)~~
 
 
 SELECT sys.identity_into_int(23, 1, 1);
@@ -386,6 +47,13 @@ GO
 ~~ERROR (Message: function IDENTITY_INTO_SMALLINT does not exist)~~
 
 
+SELECT sys.IDENTITY_INTO_INT(23, 1, 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function IDENTITY_INTO_INT does not exist)~~
+
+
 SELECT sys.IDENTITY_INTO_BIGINT(20, 1, 1);
 GO
 ~~ERROR (Code: 33557097)~~
@@ -393,9 +61,23 @@ GO
 ~~ERROR (Message: function IDENTITY_INTO_BIGINT does not exist)~~
 
 
-SELECT sys.IDENTITY_INTO_INT(23, 1, 1);
+SELECT col1, IDENTITY(int,1,1) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: function IDENTITY_INTO_INT does not exist)~~
+~~ERROR (Message: IDENTITY() function in SELECT INTO is not supported.)~~
+
+
+SELECT col1, IDENTITY(int, 1) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: IDENTITY() function in SELECT INTO is not supported.)~~
+
+
+SELECT col1, IDENTITY(int) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: IDENTITY() function in SELECT INTO is not supported.)~~
 

--- a/test/JDBC/input/BABEL_539-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL_539-vu-cleanup.sql
@@ -1,4 +1,4 @@
-DROP PROC babel_539_prepare_proc;
+DROP PROC IF EXISTS babel_539_prepare_proc;
 GO
 
 DROP TABLE IF EXISTS babel_539OldTable;

--- a/test/JDBC/input/BABEL_539-vu-verify.sql
+++ b/test/JDBC/input/BABEL_539-vu-verify.sql
@@ -1,201 +1,14 @@
 EXEC babel_539_prepare_proc
 GO
 
-SELECT id_num, col1, name  FROM babel_539NewTable_proc ORDER BY id_num;
-GO
-
 DROP TABLE IF EXISTS babel_539NewTable_proc;
 GO
 
 DROP TABLE IF EXISTS babel_539NewTable1;
 GO
 
-SELECT col1, IDENTITY(int, 1,1) AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM babel_539NewTable1 ORDER BY id_num;
-GO
-
-DROP TABLE IF EXISTS babel_539NewTable1;
-GO
-
-SELECT col1, IDENTITY(int, 1) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num;
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, IDENTITY(int) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT col1, id_num FROM #babel_539NewTable1 ORDER BY id_num;
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, id_num=IDENTITY(int, 1,100) INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num;
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, [id_num]=IDENTITY(int, 1,1) INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT col1, identity(int, 1,-100) AS [id_num] INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1 FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT *, identity(int) AS [id_num] INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
--- Self Join
-SELECT IDENTITY(int,1,1) AS id_num, ltable.col1 AS col1, ltable.name AS name INTO #babel_539NewTable1 
-FROM babel_539OldTable AS ltable JOIN babel_539OldTable AS rtable ON ltable.col1 <> rtable.col1 ORDER BY ltable.col1;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(bigint, 9223372036854775807, -1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(numeric, -9223372036854775806, +1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(numeric(19,0), 9223372036854775807, -1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT distinct IDENTITY(numeric(19,0), 1, 1) as id_num, * into #babel_539NewTable1 from babel_539OldTable where 1=1;
-GO
-
-SELECT col1, name, id_num FROM #babel_539NewTable1 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
-SELECT IDENTITY(int, -10, 1+1) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT IDENTITY(int, 1, 1-2) id_num, col1, name INTO #babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT col1, IDENTITY(char, 1,1) AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-SELECT col1, IDENTITY(int, 1,1,1) AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable1;
-GO
-
--- impact to other similar queries and functions
--- normal create table cases
-CREATE TABLE babel_539OldTable2 (col1 int NOT NULL, name varchar(20), id_num INT IDENTITY(1, 2));
-GO
-
-INSERT INTO babel_539OldTable2 VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
-GO
-
-SELECT id_num, col1, name INTO babel_539NewTable2 FROM babel_539OldTable2 ORDER BY id_num;
-GO
-
-SELECT id_num, col1, name FROM babel_539NewTable2 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS babel_539OldTable2;
-GO
-
-DROP TABLE IF EXISTS babel_539NewTable2;
-GO
-
--- create table as temp table
-CREATE TABLE #babel_539NewTable2 (col1 int, name varchar(20),  id_num int IDENTITY(-1, 2));
-GO
-
-INSERT INTO #babel_539NewTable2(col1, name) VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable2 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable2;
-GO
-
-CREATE TABLE #babel_539NewTable2 (col1 int, name varchar(20) );
-GO
-
-SELECT col1, name FROM #babel_539NewTable2 ORDER BY col1; 
-GO
-
--- try altering table and check other columns, sequence should drop and any constraints also
-ALTER TABLE #babel_539NewTable2 ADD id_num int IDENTITY(1, 1);
-GO
-
-INSERT INTO #babel_539NewTable2(col1, name) VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
-GO
-
-SELECT id_num, col1, name FROM #babel_539NewTable2 ORDER BY id_num; 
-GO
-
-DROP TABLE IF EXISTS #babel_539NewTable2;
-GO
-
--- Two identity columns in a query
-SELECT col1, IDENTITY(int, 1,1) as id_num, IDENTITY(int, 1,1) as id_num2 INTO babel_539NewTable2 FROM babel_539OldTable;
-GO
-
-SELECT col1, IDENTITY() AS id_num INTO babel_539NewTable1 FROM babel_539OldTable;
-GO
-
 --calling internal function directly
-SELECT col1, IDENTITY_INTO(1, 1,1) as id_num INTO babel_539NewTempTable2 FROM babel_539OldTable;
+SELECT col1, IDENTITY_INTO_INT(23, 1,1) as id_num INTO babel_539NewTempTable2 FROM babel_539OldTable;
 GO
 
 SELECT sys.IDENTITY(23, 1);
@@ -204,17 +17,23 @@ GO
 SELECT IDENTITY(int, 21);
 GO
 
-SELECT sys.IDENTITY_INTO(23, 1, 1);
-GO
-
 SELECT sys.identity_into_int(23, 1, 1);
 GO
 
 SELECT sys.IDENTITY_INTO_SMALLINT(21, 1, 1);
 GO
 
+SELECT sys.IDENTITY_INTO_INT(23, 1, 1);
+GO
+
 SELECT sys.IDENTITY_INTO_BIGINT(20, 1, 1);
 GO
 
-SELECT sys.IDENTITY_INTO_INT(23, 1, 1);
+SELECT col1, IDENTITY(int,1,1) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
+GO
+
+SELECT col1, IDENTITY(int, 1) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
+GO
+
+SELECT col1, IDENTITY(int) AS id_num INTO #babel_539NewTable1 FROM babel_539OldTable;
 GO


### PR DESCRIPTION
Need to do this because order by clause behavior is not as expected

Task: BABEL-539

### Description
Change for BABEL_3_3_STABLE

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).