### PR TITLE
Fix WAITFOR allow values of unrelated data type as input

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -280,25 +280,50 @@ CREATE OR REPLACE PROCEDURE sys.sp_testlinkedserver(IN "@servername" sys.sysname
 AS 'babelfishpg_tsql', 'sp_testlinkedserver_internal' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_testlinkedserver(IN sys.sysname) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.bbf_sleep_for(IN sleep_time DATETIME)
+CREATE OR REPLACE PROCEDURE sys.bbf_sleep_for(IN sleep_time sql_variant)
 AS $$
 DECLARE
   v TIME;
+  d DATETIME;
 BEGIN
-  v = CAST(sleep_time as TIME);
+  IF NOT (SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'varchar' 
+          OR SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'char'
+          OR SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'datetime') 
+      OR sleep_time IS NULL THEN
+    RAISE EXCEPTION 'Incorrect syntax near %', sleep_time;
+  ELSIF SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'varchar' THEN
+    d = CAST(sleep_time as DATETIME);
+    v = CAST(d as TIME);
+  ELSE
+    v = CAST(sleep_time as TIME);
+  END IF;
+
   PERFORM pg_sleep(extract(epoch from clock_timestamp() + v) -
                 extract(epoch from clock_timestamp()));
 END;
 $$ LANGUAGE plpgsql;
-GRANT EXECUTE ON PROCEDURE sys.bbf_sleep_for(IN sleep_time DATETIME) TO PUBLIC;
+GRANT EXECUTE ON PROCEDURE sys.bbf_sleep_for(IN sleep_time sql_variant) TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE sys.bbf_sleep_until(IN sleep_time DATETIME)
+CREATE OR REPLACE PROCEDURE sys.bbf_sleep_until(IN sleep_time sql_variant)
 AS $$
 DECLARE
   t TIME;
+  d DATETIME;
   target_timestamp TIMESTAMPTZ;
 BEGIN
-  t = CAST(sleep_time as TIME);
+  IF NOT (SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'varchar' 
+          OR SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'char'
+          OR SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'datetime'
+          ) 
+      OR sleep_time IS NULL THEN
+    RAISE EXCEPTION 'Incorrect syntax near %', sleep_time;
+  ELSIF SQL_VARIANT_PROPERTY(sleep_time, 'BaseType') = 'varchar' THEN
+    d = CAST(sleep_time as DATETIME);
+    t = CAST(d as TIME);
+  ELSE
+    t = CAST(sleep_time as TIME);
+  END IF;
+
   target_timestamp = current_date + t;
   IF target_timestamp < current_timestamp THEN
     target_timestamp = target_timestamp + '1 day';
@@ -307,7 +332,7 @@ BEGIN
                 extract(epoch from clock_timestamp()));
 END
 $$ LANGUAGE plpgsql;
-GRANT EXECUTE ON PROCEDURE sys.bbf_sleep_until(IN sleep_time DATETIME) TO PUBLIC;
+GRANT EXECUTE ON PROCEDURE sys.bbf_sleep_until(IN sleep_time sql_variant) TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_addextendedproperty
 (

--- a/test/JDBC/expected/waitfor-vu-verify.out
+++ b/test/JDBC/expected/waitfor-vu-verify.out
@@ -4,12 +4,64 @@ GO
 ~~ROW COUNT: 1~~
 
 
-WAITFOR DELAY '00:00:02'
-GO
-
 INSERT INTO Timecheck (NAME) values('b')
 GO
 ~~ROW COUNT: 1~~
+
+
+WAITFOR DELAY '00:00:01'
+GO
+
+-- Expect Fail with incorrect syntax 
+WAITFOR DELAY NULL
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near <NULL>)~~
+
+
+WAITFOR DELAY 0
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 0)~~
+
+
+WAITFOR DELAY 1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 1)~~
+
+
+WAITFOR DELAY 1000000
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 1000000)~~
+
+
+DECLARE @f float = 1.234
+WAITFOR DELAY @f
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 1.234)~~
+
+
+-- Expect fail but passed here, BABEL-4356
+WAITFOR DELAY '0::'
+GO
+
+WAITFOR DELAY '0:'
+GO
+
+-- Expect fail
+WAITFOR DELAY '19921:00:00'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: date/time field value out of range: "19921:00:00")~~
 
 
 -- Expect WAITFOR DELAY: Passed

--- a/test/JDBC/input/waitfor-vu-verify.sql
+++ b/test/JDBC/input/waitfor-vu-verify.sql
@@ -2,10 +2,38 @@
 INSERT INTO Timecheck (NAME) values('a')
 GO
 
-WAITFOR DELAY '00:00:02'
+INSERT INTO Timecheck (NAME) values('b')
 GO
 
-INSERT INTO Timecheck (NAME) values('b')
+WAITFOR DELAY '00:00:01'
+GO
+
+-- Expect Fail with incorrect syntax 
+WAITFOR DELAY NULL
+GO
+
+WAITFOR DELAY 0
+GO
+
+WAITFOR DELAY 1
+GO
+
+WAITFOR DELAY 1000000
+GO
+
+DECLARE @f float = 1.234
+WAITFOR DELAY @f
+GO
+
+-- Expect fail but passed here, BABEL-4356
+WAITFOR DELAY '0::'
+GO
+
+WAITFOR DELAY '0:'
+GO
+
+-- Expect fail
+WAITFOR DELAY '19921:00:00'
 GO
 
 -- Expect WAITFOR DELAY: Passed


### PR DESCRIPTION
### Description
Previously WAITFOR allows values of unrelated data type as input argument. And after implicit conversion, some values are be convert to datetime type and get executed. This commit added additional date type check in the procedure, restrict allowed datatype to only varchar/char/datatime.

### Issues Resolved
BABEL-122-fix
This commit fixed WAITFOR allow values of unrelated data type as input.

### Test Scenarios Covered ###
Added new test cases:
- int value as input 
- float value as input 
- null value as input


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).