### PR TITLE
Fix upgrade file changes for function COL_NAME()

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -893,22 +893,3 @@ ALTER FUNCTION sys.replace (in input_string text, in pattern text, in replacemen
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
-
--- Matches and returns column name of the corresponding table
-CREATE OR REPLACE FUNCTION sys.COL_NAME(IN table_id INT, IN column_id INT)
-RETURNS sys.SYSNAME AS $$
-    DECLARE
-        column_name TEXT;
-    BEGIN
-        SELECT attname INTO STRICT column_name 
-        FROM pg_attribute 
-        WHERE attrelid = table_id AND attnum = column_id AND attnum > 0;
-        
-        RETURN column_name::sys.SYSNAME;
-    EXCEPTION
-        WHEN OTHERS THEN
-            RETURN NULL;
-    END; 
-$$
-LANGUAGE plpgsql IMMUTABLE
-STRICT;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -44,3 +44,22 @@ DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
+
+-- Matches and returns column name of the corresponding table
+CREATE OR REPLACE FUNCTION sys.COL_NAME(IN table_id INT, IN column_id INT)
+RETURNS sys.SYSNAME AS $$
+    DECLARE
+        column_name TEXT;
+    BEGIN
+        SELECT attname INTO STRICT column_name 
+        FROM pg_attribute 
+        WHERE attrelid = table_id AND attnum = column_id AND attnum > 0;
+        
+        RETURN column_name::sys.SYSNAME;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN NULL;
+    END; 
+$$
+LANGUAGE plpgsql IMMUTABLE
+STRICT;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -42,6 +42,25 @@ LANGUAGE plpgsql;
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
 
+-- Matches and returns column name of the corresponding table
+CREATE OR REPLACE FUNCTION sys.COL_NAME(IN table_id INT, IN column_id INT)
+RETURNS sys.SYSNAME AS $$
+    DECLARE
+        column_name TEXT;
+    BEGIN
+        SELECT attname INTO STRICT column_name 
+        FROM pg_attribute 
+        WHERE attrelid = table_id AND attnum = column_id AND attnum > 0;
+        
+        RETURN column_name::sys.SYSNAME;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN NULL;
+    END; 
+$$
+LANGUAGE plpgsql IMMUTABLE
+STRICT;
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -63,22 +63,3 @@ STRICT;
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
-
--- Matches and returns column name of the corresponding table
-CREATE OR REPLACE FUNCTION sys.COL_NAME(IN table_id INT, IN column_id INT)
-RETURNS sys.SYSNAME AS $$
-    DECLARE
-        column_name TEXT;
-    BEGIN
-        SELECT attname INTO STRICT column_name 
-        FROM pg_attribute 
-        WHERE attrelid = table_id AND attnum = column_id AND attnum > 0;
-        
-        RETURN column_name::sys.SYSNAME;
-    EXCEPTION
-        WHEN OTHERS THEN
-            RETURN NULL;
-    END; 
-$$
-LANGUAGE plpgsql IMMUTABLE
-STRICT;


### PR DESCRIPTION
### Description

In the [PR-1703](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1703), the upgrade file changes were made in `3.2.0 -- 3.3.0` by mistake, corrected this by adding the changes in `3.3.0 -- 3.4.0`.

### Test Scenarios Covered ###

NA

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).