### PR TITLE
Release syscache entries in objectproperty_internal function

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2827,6 +2827,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 
 					table_close(depRel, RowExclusiveLock);
 				}
+				ReleaseSysCache(tp);
 			}
 			/*
 			 * If the object is not of Table type (TT), it should be user defined table (U)
@@ -2838,6 +2839,8 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 			type = OBJECT_TYPE_VIEW;
 		else if (pg_class->relkind == 's')
 			type = OBJECT_TYPE_SEQUENCE_OBJECT;
+
+		ReleaseSysCache(tuple);
 	}
 	/* pg_proc */
 	if (!schema_id)
@@ -2884,6 +2887,8 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 								type = OBJECT_TYPE_TSQL_TABLE_VALUED_FUNCTION;
 							else
 								type = OBJECT_TYPE_TSQL_INLINE_TABLE_VALUED_FUNCTION;
+
+							ReleaseSysCache(tp);
 						}
 					}
 					else
@@ -2892,6 +2897,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 					pfree(temp);
 				}
 			}
+			ReleaseSysCache(tuple);
 		}
 	}
 	/* pg_attrdef */
@@ -2990,6 +2996,8 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 			 */
 			else if (con->contype == 'c' && con->conrelid != 0)
 				type = OBJECT_TYPE_CHECK_CONSTRAINT;
+			
+			ReleaseSysCache(tuple);
 		}
 	}
 


### PR DESCRIPTION
### Description

Currently, some of the syscache entries are not being released in objectproperty_internal function. This change releases the syscahce entries.




### Issues Resolved

BABEL-4317

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).