### PR TITLE
fixing column_id in view sys.index_columns

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1960,7 +1960,7 @@ GRANT SELECT ON sys.endpoints TO PUBLIC;
 create or replace view sys.index_columns
 as
 select i.indrelid::integer as object_id
-  , CAST(CASE WHEN i.indisclustered THEN 1 ELSE 1+row_number() OVER(PARTITION BY c.oid) END AS INTEGER) AS index_id
+  , imap.index_id
   , a.attrelid::integer as index_column_id
   , col.attnum::integer as column_id
   , a.attnum::sys.tinyint as key_ordinal
@@ -1972,6 +1972,7 @@ inner join pg_catalog.pg_attribute a on i.indexrelid = a.attrelid
 inner join pg_catalog.pg_attribute col on col.attname = a.attname and col.attrelid = i.indrelid
 inner join pg_class c on i.indrelid = c.oid
 inner join sys.schemas sch on sch.schema_id = c.relnamespace
+inner join (select indexrelid, CAST(CASE WHEN indisclustered THEN 1 ELSE 1+row_number() OVER(PARTITION BY indrelid) END AS INTEGER) AS index_id from pg_index) as imap on imap.indexrelid = i.indexrelid
 where has_schema_privilege(sch.schema_id, 'USAGE')
 and has_table_privilege(c.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
 GRANT SELECT ON sys.index_columns TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1962,13 +1962,14 @@ as
 select i.indrelid::integer as object_id
   , CAST(CASE WHEN i.indisclustered THEN 1 ELSE 1+row_number() OVER(PARTITION BY c.oid) END AS INTEGER) AS index_id
   , a.attrelid::integer as index_column_id
-  , a.attnum::integer as column_id
+  , col.attnum::integer as column_id
   , a.attnum::sys.tinyint as key_ordinal
   , 0::sys.tinyint as partition_ordinal
   , 0::sys.bit as is_descending_key
   , 1::sys.bit as is_included_column
 from pg_index as i
 inner join pg_catalog.pg_attribute a on i.indexrelid = a.attrelid
+inner join pg_catalog.pg_attribute col on col.attname = a.attname and col.attrelid = i.indrelid
 inner join pg_class c on i.indrelid = c.oid
 inner join sys.schemas sch on sch.schema_id = c.relnamespace
 where has_schema_privilege(sch.schema_id, 'USAGE')


### PR DESCRIPTION
### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

Using DBeaver to browse the database connecting with and SQL Server driver to an AWS Aurora instance with Babelfish enabled, I noticed that columns in indexed are always shown as the first columns in the table.

I finaly found that this is due to the query of the view sys.index_columns which use the attnum field from the table pg_attribute. But this table joined like it is currently give no information of the column id (or position) inside the table.

I added a extra join to pg_attribute to fix this (pull request will follow...)

### Issues Resolved

Issue #1791 

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).