### PR TITLE
Lookup for table in correct schema in set clause of update queries

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1437,13 +1437,28 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 		/* Get relid either by s.t or t */
 		if (schemaname && relname)
 		{
-			relid = RangeVarGetRelid(makeRangeVar(schemaname, relname, res->location),
+			/* Get physical schema name from logical schema name */
+			char *physical_schema_name = get_physical_schema_name(get_cur_db_name(), schemaname);
+			/* Get relid using physical schema name and relname */
+			relid = RangeVarGetRelid(makeRangeVar(physical_schema_name, relname, res->location),
 									 NoLock,
 									 true);
+			pfree(physical_schema_name);
 		}
 		else if (relname)
 		{
-			relid = RelnameGetRelid(relname);
+			/* 
+			 * In case of schema name is not specified, To get the relid of table
+			 * we will search for the table in schema of target relation.
+			 */
+			
+			/* Get physical schema name of target relation */
+			char *physical_schema_name = get_namespace_name(RelationGetNamespace(pstate->p_target_relation));
+			/* Get relid using physical schema name and relname */
+			relid = RangeVarGetRelid(makeRangeVar(physical_schema_name, relname, res->location),
+									 NoLock,
+									 true);
+			pfree(physical_schema_name);
 		}
 		targetRelid = RelationGetRelid(pstate->p_target_relation);
 		/* If relid matches or alias matches, try to resolve the qualifiers */

--- a/test/JDBC/expected/BABEL_4012.out
+++ b/test/JDBC/expected/BABEL_4012.out
@@ -1,0 +1,622 @@
+CREATE SCHEMA BABEL_4012_sch
+GO
+
+CREATE TABLE BABEL_4012_sch.table1(a int, b int);
+GO
+
+INSERT INTO BABEL_4012_sch.table1 VALUES(1,4), (1,5);
+GO
+~~ROW COUNT: 2~~
+
+
+-- WITH ALIAS
+-- without qouted identifier in alias
+-- with schema name in set and update
+UPDATE BABEL_4012_sch.table1 SET BABEL_4012_sch.table1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- with schema name in set and not in update
+UPDATE table1 SET BABEL_4012_sch.table1.a = 3 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- with schema name in set and alias in update
+UPDATE t1 SET BABEL_4012_sch.table1.a = 1 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- with schema name in update and not in set
+UPDATE BABEL_4012_sch.table1 SET table1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- without schema in update and set
+UPDATE table1 SET table1.a = 3 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- without schema name in set and alias in update
+UPDATE t1 SET table1.a = 1 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- using alias in set and schema in update
+UPDATE BABEL_4012_sch.table1 SET t1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- using alias in set and without schema in update
+UPDATE table1 SET t1.a = 3 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 1 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- WITH ALIAS
+-- with qouted identifier in alias
+-- with schema name in set and update
+UPDATE BABEL_4012_sch.table1 SET BABEL_4012_sch.table1.a = 3 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- with schema name in set and not in update
+UPDATE table1 SET BABEL_4012_sch.table1.a = 2 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- with schema name in set and alias in update
+UPDATE  "_t1 AbC か₰₨" SET BABEL_4012_sch.table1.a = 1 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- with schema name in update and not in set
+UPDATE BABEL_4012_sch.table1 SET table1.a = 3 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- without schema in update and set
+UPDATE table1 SET table1.a = 2 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- without schema name in set and alias in update
+UPDATE  "_t1 AbC か₰₨" SET table1.a = 1 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- using alias in set and schema in update
+UPDATE BABEL_4012_sch.table1 SET "_t1 AbC か₰₨".a = 3 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- using alias in set and without schema in update
+UPDATE table1 SET "_t1 AbC か₰₨".a = 2 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- using alias in set and update
+UPDATE "_t1 AbC か₰₨" SET "_t1 AbC か₰₨".a = 1 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- using alias in set and update
+UPDATE "_t1 AbC か₰₨" SET "_t1 AbC か₰₨".a = 2 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+
+
+
+
+-- WITHOUT ALIAS
+-- with schema name in set and update
+UPDATE BABEL_4012_sch.table1 SET BABEL_4012_sch.table1.a = 3 FROM BABEL_4012_sch.table1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- with schema name in set and not in update
+UPDATE table1 SET BABEL_4012_sch.table1.a = 1 FROM BABEL_4012_sch.table1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+1#!#4
+1#!#5
+~~END~~
+
+
+-- with schema name in update and not in set
+UPDATE BABEL_4012_sch.table1 SET table1.a = 2 FROM BABEL_4012_sch.table1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+2#!#4
+2#!#5
+~~END~~
+
+
+-- without schema in update and set
+UPDATE table1 SET table1.a = 3 FROM BABEL_4012_sch.table1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+~~START~~
+int#!#int
+3#!#4
+3#!#5
+~~END~~
+
+
+-- DEFAULT SCHEMA
+CREATE TABLE BABEL_4012_table2(a int, b int);
+GO
+
+INSERT INTO BABEL_4012_table2 VALUES(1,6), (1,7);
+GO
+~~ROW COUNT: 2~~
+
+
+-- WITH ALIAS
+-- with schema name in set and update
+-- error expected
+UPDATE dbo.BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The objects "master_dbo.babel_4012_table2" and "babel_4012_table2" in the FROM clause have the same exposed names. Use correlation names to distinguish them.)~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- with schema name in set and not in update
+UPDATE BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 3 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+3#!#6
+3#!#7
+~~END~~
+
+
+-- with schema name in set and alias in update
+UPDATE t1 SET dbo.BABEL_4012_table2.a = 1 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- with schema name in update and not in set
+-- error expected
+UPDATE dbo.BABEL_4012_table2 SET BABEL_4012_table2.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The objects "master_dbo.babel_4012_table2" and "babel_4012_table2" in the FROM clause have the same exposed names. Use correlation names to distinguish them.)~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- without schema in update and set
+UPDATE BABEL_4012_table2 SET BABEL_4012_table2.a = 3 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+3#!#6
+3#!#7
+~~END~~
+
+
+-- without schema name in set and alias in update
+UPDATE t1 SET BABEL_4012_table2.a = 1 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- using alias in set and schema in update
+-- error expected
+UPDATE dbo.BABEL_4012_table2 SET t1.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The objects "master_dbo.babel_4012_table2" and "babel_4012_table2" in the FROM clause have the same exposed names. Use correlation names to distinguish them.)~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- using alias in set and without schema in update
+UPDATE BABEL_4012_table2 SET t1.a = 3 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+3#!#6
+3#!#7
+~~END~~
+
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 1 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+2#!#6
+2#!#7
+~~END~~
+
+
+
+-- WITHOUT ALIAS
+-- with schema name in set and update
+UPDATE dbo.BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 3 FROM dbo.BABEL_4012_table2
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+3#!#6
+3#!#7
+~~END~~
+
+
+-- with schema name in set and not in update
+UPDATE BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 1 FROM dbo.BABEL_4012_table2
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+1#!#6
+1#!#7
+~~END~~
+
+
+-- with schema name in update and not in set
+UPDATE dbo.BABEL_4012_table2 SET BABEL_4012_table2.a = 2 FROM dbo.BABEL_4012_table2
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+2#!#6
+2#!#7
+~~END~~
+
+
+-- without schema in update and set
+UPDATE BABEL_4012_table2 SET BABEL_4012_table2.a = 3 FROM dbo.BABEL_4012_table2
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+~~START~~
+int#!#int
+3#!#6
+3#!#7
+~~END~~
+
+
+
+
+-- CLEAR
+DROP TABLE BABEL_4012_table2;
+GO
+
+DROP TABLE BABEL_4012_sch.table1;
+GO
+
+DROP SCHEMA BABEL_4012_sch;
+GO

--- a/test/JDBC/input/BABEL_4012.sql
+++ b/test/JDBC/input/BABEL_4012.sql
@@ -1,0 +1,308 @@
+CREATE SCHEMA BABEL_4012_sch
+GO
+
+CREATE TABLE BABEL_4012_sch.table1(a int, b int);
+GO
+
+INSERT INTO BABEL_4012_sch.table1 VALUES(1,4), (1,5);
+GO
+
+-- WITH ALIAS
+-- without qouted identifier in alias
+-- with schema name in set and update
+UPDATE BABEL_4012_sch.table1 SET BABEL_4012_sch.table1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in set and not in update
+UPDATE table1 SET BABEL_4012_sch.table1.a = 3 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in set and alias in update
+UPDATE t1 SET BABEL_4012_sch.table1.a = 1 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in update and not in set
+UPDATE BABEL_4012_sch.table1 SET table1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- without schema in update and set
+UPDATE table1 SET table1.a = 3 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- without schema name in set and alias in update
+UPDATE t1 SET table1.a = 1 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and schema in update
+UPDATE BABEL_4012_sch.table1 SET t1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and without schema in update
+UPDATE table1 SET t1.a = 3 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 1 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 2 FROM BABEL_4012_sch.table1 AS t1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- WITH ALIAS
+-- with qouted identifier in alias
+-- with schema name in set and update
+UPDATE BABEL_4012_sch.table1 SET BABEL_4012_sch.table1.a = 3 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in set and not in update
+UPDATE table1 SET BABEL_4012_sch.table1.a = 2 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in set and alias in update
+UPDATE  "_t1 AbC か₰₨" SET BABEL_4012_sch.table1.a = 1 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in update and not in set
+UPDATE BABEL_4012_sch.table1 SET table1.a = 3 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- without schema in update and set
+UPDATE table1 SET table1.a = 2 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- without schema name in set and alias in update
+UPDATE  "_t1 AbC か₰₨" SET table1.a = 1 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and schema in update
+UPDATE BABEL_4012_sch.table1 SET "_t1 AbC か₰₨".a = 3 FROM BABEL_4012_sch.table1 AS  "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and without schema in update
+UPDATE table1 SET "_t1 AbC か₰₨".a = 2 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and update
+UPDATE "_t1 AbC か₰₨" SET "_t1 AbC か₰₨".a = 1 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- using alias in set and update
+UPDATE "_t1 AbC か₰₨" SET "_t1 AbC か₰₨".a = 2 FROM BABEL_4012_sch.table1 AS "_t1 AbC か₰₨"
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+
+
+
+
+-- WITHOUT ALIAS
+-- with schema name in set and update
+UPDATE BABEL_4012_sch.table1 SET BABEL_4012_sch.table1.a = 3 FROM BABEL_4012_sch.table1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in set and not in update
+UPDATE table1 SET BABEL_4012_sch.table1.a = 1 FROM BABEL_4012_sch.table1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- with schema name in update and not in set
+UPDATE BABEL_4012_sch.table1 SET table1.a = 2 FROM BABEL_4012_sch.table1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- without schema in update and set
+UPDATE table1 SET table1.a = 3 FROM BABEL_4012_sch.table1
+GO
+
+SELECT * FROM BABEL_4012_sch.table1;
+GO
+
+-- DEFAULT SCHEMA
+CREATE TABLE BABEL_4012_table2(a int, b int);
+GO
+
+INSERT INTO BABEL_4012_table2 VALUES(1,6), (1,7);
+GO
+
+-- WITH ALIAS
+-- with schema name in set and update
+-- error expected
+UPDATE dbo.BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- with schema name in set and not in update
+UPDATE BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 3 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- with schema name in set and alias in update
+UPDATE t1 SET dbo.BABEL_4012_table2.a = 1 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- with schema name in update and not in set
+-- error expected
+UPDATE dbo.BABEL_4012_table2 SET BABEL_4012_table2.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- without schema in update and set
+UPDATE BABEL_4012_table2 SET BABEL_4012_table2.a = 3 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- without schema name in set and alias in update
+UPDATE t1 SET BABEL_4012_table2.a = 1 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- using alias in set and schema in update
+-- error expected
+UPDATE dbo.BABEL_4012_table2 SET t1.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- using alias in set and without schema in update
+UPDATE BABEL_4012_table2 SET t1.a = 3 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 1 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+-- using alias in set and update
+UPDATE t1 SET t1.a = 2 FROM BABEL_4012_table2 AS t1
+GO
+
+SELECT * FROM BABEL_4012_table2;
+GO
+
+
+-- WITHOUT ALIAS
+-- with schema name in set and update
+UPDATE dbo.BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 3 FROM dbo.BABEL_4012_table2
+GO
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+
+-- with schema name in set and not in update
+UPDATE BABEL_4012_table2 SET dbo.BABEL_4012_table2.a = 1 FROM dbo.BABEL_4012_table2
+GO
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+
+-- with schema name in update and not in set
+UPDATE dbo.BABEL_4012_table2 SET BABEL_4012_table2.a = 2 FROM dbo.BABEL_4012_table2
+GO
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+
+-- without schema in update and set
+UPDATE BABEL_4012_table2 SET BABEL_4012_table2.a = 3 FROM dbo.BABEL_4012_table2
+GO
+
+SELECT * FROM dbo.BABEL_4012_table2;
+GO
+
+
+
+-- CLEAR
+DROP TABLE BABEL_4012_table2;
+GO
+
+DROP TABLE BABEL_4012_sch.table1;
+GO
+
+DROP SCHEMA BABEL_4012_sch;
+GO


### PR DESCRIPTION
### Description
Earlier, We were getting error if we were using `table.column` with alias defined for table or `schema_name.table.column` in set clause of update queries. The error was getting raised in `transformUpdateTargetList` and it was due to mishandling of schema name to get relid of table in `pre_transform_target_entry` function, relid later get used to resolve the qualifiers. This commit fix following two cases:

1. In case of `schema_name.table.column` in set clause, we were trying to find the relid using logical schema name instead of physical schema name.
2. In case of `table.column` in set clause, when schema name is not specified, to get the relid of table we were looking into default schema while we should lookup for the table in schema of target relation.

3X PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1795

### Issues Resolved

Task: BABEL-4012

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).