### PR TITLE
Support todatetimeoffset function

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -342,6 +342,157 @@ LANGUAGE plpgsql
 IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
+CREATE OR REPLACE FUNCTION sys.TODATETIMEOFFSET(IN input_expr PG_CATALOG.TEXT , IN tz_offset TEXT)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    v_string pg_catalog.text;
+    v_sign pg_catalog.text;
+    str_hr TEXT;
+    str_mi TEXT;
+    precision_str TEXT;
+    sign_flag INTEGER;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    v_precision INTEGER;
+    input_expr_datetime2 datetime2;
+BEGIN
+
+    BEGIN
+    input_expr_datetime2 := cast(input_expr as sys.datetime2);
+    exception
+        WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+    IF input_expr IS NULL or tz_offset IS NULL THEN 
+    RETURN NULL;
+    END IF;
+
+    IF tz_offset LIKE '+__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := 1;
+    ELSIF tz_offset LIKE '-__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := -1;
+    ELSE
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;   
+
+    BEGIN
+    v_hr := str_hr::INTEGER;
+    v_mi := str_mi ::INTEGER;
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END;
+
+    
+    if v_hr > 14 or (v_hr = 14 and v_mi > 0) THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    v_hr := v_hr * sign_flag;
+
+    v_string := CONCAT(input_expr_datetime2::pg_catalog.text , tz_offset);
+
+    BEGIN
+    RETURN cast(v_string as sys.datetimeoffset);
+    exception
+        WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION sys.TODATETIMEOFFSET(IN input_expr PG_CATALOG.TEXT , IN tz_offset anyelement)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    v_string pg_catalog.text;
+    v_sign pg_catalog.text;
+    hr INTEGER;
+    mi INTEGER;
+    tz_sign INTEGER;
+    tz_offset_smallint INTEGER;
+    input_expr_datetime2 datetime2;
+BEGIN
+
+        BEGIN
+        input_expr_datetime2:= cast(input_expr as sys.datetime2);
+        exception
+            WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+        END;
+
+
+        IF pg_typeof(tz_offset) NOT IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
+            'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype ,'varbinary'::regtype) THEN
+            RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+        END IF;
+
+        BEGIN
+        IF pg_typeof(tz_offset) NOT IN ('varbinary'::regtype) THEN
+            tz_offset := FLOOR(tz_offset);
+        END IF;
+        tz_offset_smallint := cast(tz_offset AS smallint);
+        exception
+            WHEN others THEN
+                RAISE USING MESSAGE := 'Arithmetic overflow error converting expression to data type smallint.';
+        END;
+
+        IF input_expr IS NULL THEN 
+            RETURN NULL;
+        END IF;
+    
+        IF tz_offset_smallint < 0 THEN
+            tz_sign := 1;
+        ELSE 
+            tz_sign := 0;
+        END IF;
+
+        IF tz_offset_smallint > 840 or tz_offset_smallint < -840  THEN
+            RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+        END IF;
+
+        hr := tz_offset_smallint / 60;
+        mi := tz_offset_smallint % 60;
+
+        v_sign := (
+        SELECT CASE
+            WHEN (tz_sign) = 1
+                THEN '-'
+            WHEN (tz_sign) = 0
+                THEN '+'    
+        END
+    );
+
+    
+        v_string := CONCAT(input_expr_datetime2::pg_catalog.text,v_sign,abs(hr)::SMALLINT::text,':',
+                                                          abs(mi)::SMALLINT::text);
+
+        BEGIN
+        RETURN cast(v_string as sys.datetimeoffset);
+        exception
+            WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+        END;
+    
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+
 CREATE OR REPLACE FUNCTION sys.datetime2fromparts(IN p_year TEXT,
                                                                 IN p_month TEXT,
                                                                 IN p_day TEXT,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.5.0--2.6.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.5.0--2.6.0.sql
@@ -79,6 +79,156 @@ $BODY$
 LANGUAGE plpgsql
 IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION sys.TODATETIMEOFFSET(IN input_expr PG_CATALOG.TEXT , IN tz_offset TEXT)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    v_string pg_catalog.text;
+    v_sign pg_catalog.text;
+    str_hr TEXT;
+    str_mi TEXT;
+    precision_str TEXT;
+    sign_flag INTEGER;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    v_precision INTEGER;
+    input_expr_datetime2 datetime2;
+BEGIN
+
+    BEGIN
+    input_expr_datetime2 := cast(input_expr as sys.datetime2);
+    exception
+        WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+    IF input_expr IS NULL or tz_offset IS NULL THEN 
+    RETURN NULL;
+    END IF;
+
+    IF tz_offset LIKE '+__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := 1;
+    ELSIF tz_offset LIKE '-__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := -1;
+    ELSE
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;   
+
+    BEGIN
+    v_hr := str_hr::INTEGER;
+    v_mi := str_mi ::INTEGER;
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END;
+
+    
+    if v_hr > 14 or (v_hr = 14 and v_mi > 0) THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    v_hr := v_hr * sign_flag;
+
+    v_string := CONCAT(input_expr_datetime2::pg_catalog.text , tz_offset);
+
+    BEGIN
+    RETURN cast(v_string as sys.datetimeoffset);
+    exception
+        WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION sys.TODATETIMEOFFSET(IN input_expr PG_CATALOG.TEXT , IN tz_offset anyelement)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    v_string pg_catalog.text;
+    v_sign pg_catalog.text;
+    hr INTEGER;
+    mi INTEGER;
+    tz_sign INTEGER;
+    tz_offset_smallint INTEGER;
+    input_expr_datetime2 datetime2;
+BEGIN
+
+        BEGIN
+        input_expr_datetime2:= cast(input_expr as sys.datetime2);
+        exception
+            WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+        END;
+
+
+        IF pg_typeof(tz_offset) NOT IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,'numeric'::regtype,
+            'float'::regtype, 'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype ,'varbinary'::regtype) THEN
+            RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+        END IF;
+
+        BEGIN
+        IF pg_typeof(tz_offset) NOT IN ('varbinary'::regtype) THEN
+            tz_offset := FLOOR(tz_offset);
+        END IF;
+        tz_offset_smallint := cast(tz_offset AS smallint);
+        exception
+            WHEN others THEN
+                RAISE USING MESSAGE := 'Arithmetic overflow error converting expression to data type smallint.';
+        END;
+
+        IF input_expr IS NULL THEN 
+            RETURN NULL;
+        END IF;
+    
+        IF tz_offset_smallint < 0 THEN
+            tz_sign := 1;
+        ELSE 
+            tz_sign := 0;
+        END IF;
+
+        IF tz_offset_smallint > 840 or tz_offset_smallint < -840  THEN
+            RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+        END IF;
+
+        hr := tz_offset_smallint / 60;
+        mi := tz_offset_smallint % 60;
+
+        v_sign := (
+        SELECT CASE
+            WHEN (tz_sign) = 1
+                THEN '-'
+            WHEN (tz_sign) = 0
+                THEN '+'    
+        END
+    );
+
+    
+        v_string := CONCAT(input_expr_datetime2::pg_catalog.text,v_sign,abs(hr)::SMALLINT::text,':',
+                                                          abs(mi)::SMALLINT::text);
+
+        BEGIN
+        RETURN cast(v_string as sys.datetimeoffset);
+        exception
+            WHEN others THEN
+                RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+        END;
+    
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
 CREATE OR REPLACE PROCEDURE sys.sp_describe_first_result_set (
 	"@tsql" sys.nvarchar(8000),
     "@params" sys.nvarchar(8000) = NULL, 

--- a/test/JDBC/expected/todatetimeoffset-dep-vu-cleanup.out
+++ b/test/JDBC/expected/todatetimeoffset-dep-vu-cleanup.out
@@ -1,0 +1,17 @@
+DROP VIEW todatetimeoffset_dep_vu_prepare_v1
+GO
+
+DROP VIEW todatetimeoffset_dep_vu_prepare_v2
+GO
+
+DROP PROCEDURE todatetimeoffset_dep_vu_prepare_p1
+GO
+
+DROP PROCEDURE todatetimeoffset_dep_vu_prepare_p2
+GO
+
+DROP FUNCTION todatetimeoffset_dep_vu_prepare_f1()
+GO
+
+DROP FUNCTION todatetimeoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/expected/todatetimeoffset-dep-vu-prepare.out
+++ b/test/JDBC/expected/todatetimeoffset-dep-vu-prepare.out
@@ -1,0 +1,25 @@
+CREATE VIEW todatetimeoffset_dep_vu_prepare_v1 as (Select todatetimeoffset('2000-04-22 16:2a:51.766890',340));
+GO
+
+CREATE VIEW todatetimeoffset_dep_vu_prepare_v2 as (Select todatetimeoffset('2000-04-22 16:23:51.766890','+13:00'));
+GO
+
+CREATE PROCEDURE  todatetimeoffset_dep_vu_prepare_p1 as (SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '-13:00'));
+GO
+
+CREATE PROCEDURE  todatetimeoffset_dep_vu_prepare_p2 as (Select todatetimeoffset('2000-04-22 16:23:51.766890',-234));
+GO
+
+CREATE FUNCTION todatetimeoffset_dep_vu_prepare_f1()
+RETURNS DATETIMEOFFSET AS
+BEGIN
+RETURN (Select todatetimeoffset('2000-0a-22 16:23:51.766890',-340));
+END
+GO
+
+CREATE FUNCTION todatetimeoffset_dep_vu_prepare_f2()
+RETURNS DATETIMEOFFSET as
+begin
+RETURN (Select todatetimeoffset('2000-04-22 16:23:5d.766890','+12:00'));
+END
+GO

--- a/test/JDBC/expected/todatetimeoffset-dep-vu-verify.out
+++ b/test/JDBC/expected/todatetimeoffset-dep-vu-verify.out
@@ -1,0 +1,48 @@
+SELECT * FROM todatetimeoffset_dep_vu_prepare_v1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+SELECT * FROM todatetimeoffset_dep_vu_prepare_v2
+GO
+~~START~~
+datetimeoffset
+2000-04-22 16:23:51.7668900 +13:00
+~~END~~
+
+
+EXEC todatetimeoffset_dep_vu_prepare_p1
+GO
+~~START~~
+datetimeoffset
+2023-08-08 16:06:45.0000000 -13:00
+~~END~~
+
+
+EXEC todatetimeoffset_dep_vu_prepare_p2
+GO
+~~START~~
+datetimeoffset
+2000-04-22 16:23:51.7668900 -03:54
+~~END~~
+
+
+SELECT todatetimeoffset_dep_vu_prepare_f1()
+GO
+~~START~~
+datetimeoffset
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+SELECT todatetimeoffset_dep_vu_prepare_f2()
+GO
+~~START~~
+datetimeoffset
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+

--- a/test/JDBC/expected/todatetimeoffset.out
+++ b/test/JDBC/expected/todatetimeoffset.out
@@ -1,0 +1,605 @@
+Select todatetimeoffset('0000-04-22 16:23:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('9999-04-22 16:23:51.766890','+12:00')
+GO
+~~START~~
+datetimeoffset
+9999-04-22 16:23:51.7668900 +12:00
+~~END~~
+
+
+Select todatetimeoffset('-1-04-22 16:23:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-0a-22 16:23:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('20sb-04-22 16:23:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-2c 16:23:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-22 1d:23:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-0a-22 16:2a:51.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-22 16:23:5d.766890','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-22 16:23:51.7668c0','+12:00') -- Wrong output , Need to fix BABEL-4328
+GO
+~~START~~
+datetimeoffset
+2000-04-22 16:23:51.7668000 +12:00
+~~END~~
+
+
+Select todatetimeoffset('2000-05-22 16:23:51.766890','+1d:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset('2000-04-22 16:23:51.766890','+12:0e')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset('1-04-22 16:23:51.766890','+12:00')
+GO
+~~START~~
+datetimeoffset
+2022-01-04 16:23:51.7668900 +12:00
+~~END~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45.3682170' as datetime2), '-13:00')
+GO
+~~START~~
+datetimeoffset
+2023-08-08 16:06:45.3682170 -13:00
+~~END~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '-13:00')
+GO
+~~START~~
+datetimeoffset
+2023-08-08 16:06:45.0000000 -13:00
+~~END~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08' as datetime2), '-13:00')
+GO
+~~START~~
+datetimeoffset
+2023-08-08 00:00:00.0000000 -13:00
+~~END~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '-15:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '+23:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset('2000-04-22 1d:23:51.766890',120)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-22 16:2a:51.766890',340)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-22 16:23:5d.766890',841)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('2000-04-22 16:23:51.7668c0',-342) -- Wrong output , Need to fix BABEL-4328
+GO
+~~START~~
+datetimeoffset
+2000-04-22 16:23:51.7668000 -05:42
+~~END~~
+
+
+Select todatetimeoffset('2000-05-22 16:23:51.766890',234)
+GO
+~~START~~
+datetimeoffset
+2000-05-22 16:23:51.7668900 +03:54
+~~END~~
+
+
+Select todatetimeoffset('2000-04-22 16:23:51.766890',345)
+GO
+~~START~~
+datetimeoffset
+2000-04-22 16:23:51.7668900 +05:45
+~~END~~
+
+
+Select todatetimeoffset('1-04-22 16:23:51.766890',-4556)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45.3682170' as datetime2), -345)
+GO
+~~START~~
+datetimeoffset
+2023-08-08 16:06:45.3682170 -05:45
+~~END~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), -234)
+GO
+~~START~~
+datetimeoffset
+2023-08-08 16:06:45.0000000 -03:54
+~~END~~
+
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08' as datetime2), 4556)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset('0001-01-00 00:00:00.00', '-10:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('0001-01-01 00:00:00.00', '+13:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('9999-12-31 23:59:59.59', '+12:00')
+GO
+~~START~~
+datetimeoffset
+9999-12-31 23:59:59.5900000 +12:00
+~~END~~
+
+
+Select todatetimeoffset('9999-12-31 23:59:59.59', '+12:00')
+GO
+~~START~~
+datetimeoffset
+9999-12-31 23:59:59.5900000 +12:00
+~~END~~
+
+
+Select todatetimeoffset('10000-12-31 23:59:59.59', '+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('9934-11-30 22:52:59.59', '+14:01')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset('9934-11-30 22:52:59.59', '-14:01')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2), '+12:00')
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.9980000 +12:00
+~~END~~
+
+
+DECLARE @test_date datetime;
+SET @test_date = '2022-12-11';
+Select todatetimeoffset(@test_date,'+12:00');
+GO
+~~START~~
+datetimeoffset
+2022-12-11 00:00:00.0000000 +12:00
+~~END~~
+
+
+DECLARE @test_date datetime2;
+SET @test_date = '2345-12-31 23:59:59.59';
+Select todatetimeoffset(@test_date,-120);
+GO
+~~START~~
+datetimeoffset
+2345-12-31 23:59:59.5900000 -02:00
+~~END~~
+
+
+Select todatetimeoffset(DATETIME2FROMPARTS(2011, 8, 15, 14, 23, 44, 5, 6 ), 300)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 14:23:44.0000050 +05:00
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), '+12:00')
+Go
+~~START~~
+datetimeoffset
+1900-05-06 13:59:30.0000000 +12:00
+~~END~~
+
+
+Select todatetimeoffset('0',120)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('0',0x23)
+Go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+DROP TABLE IF EXISTS tem
+GO
+Create table tem(a datetimeoffset)
+insert into tem (a) values(todatetimeoffset('2000-04-22 12:23:51.766890',120))
+Select * from tem
+Select todatetimeoffset(a,234) from tem
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+datetimeoffset
+2000-04-22 12:23:51.7668900 +02:00
+~~END~~
+
+~~START~~
+datetimeoffset
+2000-04-22 12:23:51.7668900 +03:54
+~~END~~
+
+
+Select todatetimeoffset('2030-05-06 13:59:29.998 ' ,'-08:00') + make_interval(1,0,3);
+GO
+~~START~~
+datetimeoffset
+2031-05-27 21:59:29.9980000 -08:00
+~~END~~
+
+
+Select todatetimeoffset('2030-05-06 13:59:29.998 ' ,'-08:00') - make_interval(1,0,3);
+GO
+~~START~~
+datetimeoffset
+2029-04-15 21:59:29.9980000 -08:00
+~~END~~
+
+
+Select todatetimeoffset('2345-12-31 23:59:59.59',NULL);
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select todatetimeoffset('2345-12-31 23:59:59.59','NULL');
+Go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset(NULL,'+12:00');
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select todatetimeoffset('NULL','+12:00');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('NULL',234);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset(NULL,234);
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select todatetimeoffset(NULL,'+12:000');
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select todatetimeoffset('NULL','+12:000');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('NULL',1233456777888);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset(NULL,1233456777888);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error converting expression to data type smallint.)~~
+
+
+Select todatetimeoffset('NULL','NULL')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset('NULL',NULL)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select todatetimeoffset(NULL,NULL)
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select todatetimeoffset(NULL,'NULL')
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 840)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.0500000 +14:00
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 841)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -841)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -840)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.0500000 -14:00
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 0x23)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.0500000 +00:35
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 234.49)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.0500000 +03:54
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 234.50)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.0500000 +03:54
+~~END~~
+
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 234.56)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:59:29.0500000 +03:54
+~~END~~
+
+
+Select todatetimeoffset('2001-04-22 ', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 00:00:00.0000000 +02:00
+~~END~~
+
+
+Select todatetimeoffset('2001-04-22 ', '+12:30')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 00:00:00.0000000 +12:30
+~~END~~
+
+
+Select todatetimeoffset('2001-04-22 17:34:56', -120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.0000000 -02:00
+~~END~~
+
+
+Select todatetimeoffset('2001-04-22 17:34:56', '-13:34')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.0000000 -13:34
+~~END~~
+
+
+Select todatetimeoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 0x23)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 14:30:00.5000000 +00:35
+~~END~~
+
+
+Select todatetimeoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), '-09:46')
+GO
+~~START~~
+datetimeoffset
+2011-08-15 14:30:00.5000000 -09:46
+~~END~~
+
+
+Select todatetimeoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 123/2*1.0)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 14:30:00.5000000 +01:01
+~~END~~
+
+
+Select todatetimeoffset('0001-01-01 00:00:01.00 +00:00',-743)
+GO
+~~START~~
+datetimeoffset
+0001-01-01 00:00:01.0000000 -12:23
+~~END~~
+
+
+Select todatetimeoffset('0001-01-01 00:00:00.00 +00:00',-743)
+GO
+~~START~~
+datetimeoffset
+0001-01-01 00:00:00.0000000 -12:23
+~~END~~
+
+
+Select todatetimeoffset('9999-12-31 23:12:00.123 +00:00',743)
+GO
+~~START~~
+datetimeoffset
+9999-12-31 23:12:00.1230000 +12:23
+~~END~~
+
+
+Select todatetimeoffset('10000-12-31 23:12:00.123 +00:00',743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+

--- a/test/JDBC/input/todatetimeoffset-dep-vu-cleanup.sql
+++ b/test/JDBC/input/todatetimeoffset-dep-vu-cleanup.sql
@@ -1,0 +1,17 @@
+DROP VIEW todatetimeoffset_dep_vu_prepare_v1
+GO
+
+DROP VIEW todatetimeoffset_dep_vu_prepare_v2
+GO
+
+DROP PROCEDURE todatetimeoffset_dep_vu_prepare_p1
+GO
+
+DROP PROCEDURE todatetimeoffset_dep_vu_prepare_p2
+GO
+
+DROP FUNCTION todatetimeoffset_dep_vu_prepare_f1()
+GO
+
+DROP FUNCTION todatetimeoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/input/todatetimeoffset-dep-vu-prepare.sql
+++ b/test/JDBC/input/todatetimeoffset-dep-vu-prepare.sql
@@ -1,0 +1,25 @@
+CREATE VIEW todatetimeoffset_dep_vu_prepare_v1 as (Select todatetimeoffset('2000-04-22 16:2a:51.766890',340));
+GO
+
+CREATE VIEW todatetimeoffset_dep_vu_prepare_v2 as (Select todatetimeoffset('2000-04-22 16:23:51.766890','+13:00'));
+GO
+
+CREATE PROCEDURE  todatetimeoffset_dep_vu_prepare_p1 as (SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '-13:00'));
+GO
+
+CREATE PROCEDURE  todatetimeoffset_dep_vu_prepare_p2 as (Select todatetimeoffset('2000-04-22 16:23:51.766890',-234));
+GO
+
+CREATE FUNCTION todatetimeoffset_dep_vu_prepare_f1()
+RETURNS DATETIMEOFFSET AS
+BEGIN
+RETURN (Select todatetimeoffset('2000-0a-22 16:23:51.766890',-340));
+END
+GO
+
+CREATE FUNCTION todatetimeoffset_dep_vu_prepare_f2()
+RETURNS DATETIMEOFFSET as
+begin
+RETURN (Select todatetimeoffset('2000-04-22 16:23:5d.766890','+12:00'));
+END
+GO

--- a/test/JDBC/input/todatetimeoffset-dep-vu-verify.sql
+++ b/test/JDBC/input/todatetimeoffset-dep-vu-verify.sql
@@ -1,0 +1,17 @@
+SELECT * FROM todatetimeoffset_dep_vu_prepare_v1
+GO
+
+SELECT * FROM todatetimeoffset_dep_vu_prepare_v2
+GO
+
+EXEC todatetimeoffset_dep_vu_prepare_p1
+GO
+
+EXEC todatetimeoffset_dep_vu_prepare_p2
+GO
+
+SELECT todatetimeoffset_dep_vu_prepare_f1()
+GO
+
+SELECT todatetimeoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/input/todatetimeoffset.sql
+++ b/test/JDBC/input/todatetimeoffset.sql
@@ -1,0 +1,243 @@
+Select todatetimeoffset('0000-04-22 16:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('9999-04-22 16:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('-1-04-22 16:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('2000-0a-22 16:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('20sb-04-22 16:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('2000-04-2c 16:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('2000-04-22 1d:23:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('2000-0a-22 16:2a:51.766890','+12:00')
+GO
+
+Select todatetimeoffset('2000-04-22 16:23:5d.766890','+12:00')
+GO
+
+Select todatetimeoffset('2000-04-22 16:23:51.7668c0','+12:00') -- Wrong output , Need to fix BABEL-4328
+GO
+
+Select todatetimeoffset('2000-05-22 16:23:51.766890','+1d:00')
+GO
+
+Select todatetimeoffset('2000-04-22 16:23:51.766890','+12:0e')
+GO
+
+Select todatetimeoffset('1-04-22 16:23:51.766890','+12:00')
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45.3682170' as datetime2), '-13:00')
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '-13:00')
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08' as datetime2), '-13:00')
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '-15:00')
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), '+23:00')
+GO
+
+Select todatetimeoffset('2000-04-22 1d:23:51.766890',120)
+GO
+
+Select todatetimeoffset('2000-04-22 16:2a:51.766890',340)
+GO
+
+Select todatetimeoffset('2000-04-22 16:23:5d.766890',841)
+GO
+
+Select todatetimeoffset('2000-04-22 16:23:51.7668c0',-342) -- Wrong output , Need to fix BABEL-4328
+GO
+
+Select todatetimeoffset('2000-05-22 16:23:51.766890',234)
+GO
+
+Select todatetimeoffset('2000-04-22 16:23:51.766890',345)
+GO
+
+Select todatetimeoffset('1-04-22 16:23:51.766890',-4556)
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45.3682170' as datetime2), -345)
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08 16:06:45' as datetime2), -234)
+GO
+
+SELECT TODATETIMEOFFSET(cast('2023-08-08' as datetime2), 4556)
+GO
+
+Select todatetimeoffset('0001-01-00 00:00:00.00', '-10:00')
+GO
+
+Select todatetimeoffset('0001-01-01 00:00:00.00', '+13:00')
+GO
+
+Select todatetimeoffset('9999-12-31 23:59:59.59', '+12:00')
+GO
+
+Select todatetimeoffset('9999-12-31 23:59:59.59', '+12:00')
+GO
+
+Select todatetimeoffset('10000-12-31 23:59:59.59', '+12:00')
+GO
+
+Select todatetimeoffset('9934-11-30 22:52:59.59', '+14:01')
+GO
+
+Select todatetimeoffset('9934-11-30 22:52:59.59', '-14:01')
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2), '+12:00')
+GO
+
+DECLARE @test_date datetime;
+SET @test_date = '2022-12-11';
+Select todatetimeoffset(@test_date,'+12:00');
+GO
+
+DECLARE @test_date datetime2;
+SET @test_date = '2345-12-31 23:59:59.59';
+Select todatetimeoffset(@test_date,-120);
+GO
+
+Select todatetimeoffset(DATETIME2FROMPARTS(2011, 8, 15, 14, 23, 44, 5, 6 ), 300)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), '+12:00')
+Go
+
+Select todatetimeoffset('0',120)
+GO
+
+Select todatetimeoffset('0',0x23)
+Go
+
+DROP TABLE IF EXISTS tem
+GO
+Create table tem(a datetimeoffset)
+insert into tem (a) values(todatetimeoffset('2000-04-22 12:23:51.766890',120))
+Select * from tem
+Select todatetimeoffset(a,234) from tem
+GO
+
+Select todatetimeoffset('2030-05-06 13:59:29.998 ' ,'-08:00') + make_interval(1,0,3);
+GO
+
+Select todatetimeoffset('2030-05-06 13:59:29.998 ' ,'-08:00') - make_interval(1,0,3);
+GO
+
+Select todatetimeoffset('2345-12-31 23:59:59.59',NULL);
+GO
+
+Select todatetimeoffset('2345-12-31 23:59:59.59','NULL');
+Go
+
+Select todatetimeoffset(NULL,'+12:00');
+GO
+
+Select todatetimeoffset('NULL','+12:00');
+GO
+
+Select todatetimeoffset('NULL',234);
+GO
+
+Select todatetimeoffset(NULL,234);
+GO
+
+Select todatetimeoffset(NULL,'+12:000');
+GO
+
+Select todatetimeoffset('NULL','+12:000');
+GO
+
+Select todatetimeoffset('NULL',1233456777888);
+GO
+
+Select todatetimeoffset(NULL,1233456777888);
+GO
+
+Select todatetimeoffset('NULL','NULL')
+GO
+
+Select todatetimeoffset('NULL',NULL)
+GO
+
+Select todatetimeoffset(NULL,NULL)
+GO
+
+Select todatetimeoffset(NULL,'NULL')
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 840)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 841)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -841)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -840)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 0x23)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 234.49)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 234.50)
+GO
+
+Select todatetimeoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2), 234.56)
+GO
+
+Select todatetimeoffset('2001-04-22 ', 120)
+GO
+
+Select todatetimeoffset('2001-04-22 ', '+12:30')
+GO
+
+Select todatetimeoffset('2001-04-22 17:34:56', -120)
+GO
+
+Select todatetimeoffset('2001-04-22 17:34:56', '-13:34')
+GO
+
+Select todatetimeoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 0x23)
+GO
+
+Select todatetimeoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), '-09:46')
+GO
+
+Select todatetimeoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 123/2*1.0)
+GO
+
+Select todatetimeoffset('0001-01-01 00:00:01.00 +00:00',-743)
+GO
+
+Select todatetimeoffset('0001-01-01 00:00:00.00 +00:00',-743)
+GO
+
+Select todatetimeoffset('9999-12-31 23:12:00.123 +00:00',743)
+GO
+
+Select todatetimeoffset('10000-12-31 23:12:00.123 +00:00',743)
+GO
+

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -36,6 +36,7 @@ TestUDD
 TestUniqueIdentifier
 TestVarChar
 TestXML
+<<<<<<< HEAD
 sys-assembly_types
 sys-database_mirroring
 sys-databases
@@ -152,6 +153,10 @@ insteadof_nested_trigger_inside_proc
 insteadof_nested_trigger_with_dml
 nested_trigger_inside_proc
 nested_trigger_with_dml
+=======
+timefromparts
+todatetimeoffset-dep
+>>>>>>> 422993b68 (Support todatetimeoffset function (#1697))
 triggers_with_transaction
 Test-sp_addrole
 Test-sp_addrolemember

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -36,7 +36,6 @@ TestUDD
 TestUniqueIdentifier
 TestVarChar
 TestXML
-<<<<<<< HEAD
 sys-assembly_types
 sys-database_mirroring
 sys-databases
@@ -153,10 +152,7 @@ insteadof_nested_trigger_inside_proc
 insteadof_nested_trigger_with_dml
 nested_trigger_inside_proc
 nested_trigger_with_dml
-=======
-timefromparts
 todatetimeoffset-dep
->>>>>>> 422993b68 (Support todatetimeoffset function (#1697))
 triggers_with_transaction
 Test-sp_addrole
 Test-sp_addrolemember


### PR DESCRIPTION
### Description

This function returns a datetimeoffset value that is translated from a datetime2 expression.

Example:-

```
SELECT TODATETIMEOFFSET(SYSDATETIME(), -120)
2023-08-03 10:26:35.5053494 -02:00

Select SYSDATETIME()
2023-08-03 10:27:07.3436982
```

Signed-off-by: Ashish Prasad [pashisht@amazon.com](mailto:pashisht@amazon.com)

### Conflict

- contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql (Resolved by adding the function to babelfishpg_tsql--2.5.0--2.6.0.sql )
- upgrade/latest/schedule (Resolved)

### Issues Resolved

BABEL-740

### Test Scenarios Covered ###

NOTE :-  There are issues with cast to datetimeoffset ,datetime2 datatype , filed a JIRA (BABEL-4328) , so there are some testcase which fail during cast to datetimeoffset which will also fail for the todatetimeoffset function.

* **Use case based -** Added


* **Boundary conditions -** Added


* **Arbitrary inputs -** Added


* **Negative test cases -** Added


* **Minor version upgrade tests -** Added


* **Major version upgrade tests -** Added


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).