### PR TITLE
Support switchoffset function (#1701)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -826,6 +826,248 @@ $BODY$
 LANGUAGE plpgsql
 IMMUTABLE;
 
+
+CREATE OR REPLACE FUNCTION sys.SWITCHOFFSET(IN input_expr PG_CATALOG.TEXT,
+                                                               IN tz_offset PG_CATALOG.TEXT)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    p_year INTEGER;
+    p_month INTEGER;
+    p_day INTEGER;
+    p_hour INTEGER;
+    p_minute INTEGER;
+    p_seconds INTEGER;
+    p_nanosecond PG_CATALOG.TEXT;
+    p_tzoffset INTEGER;
+    f_tzoffset INTEGER;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+    offset_str PG_CATALOG.TEXT;
+    v_resdatetimeupdated TIMESTAMP WITHOUT TIME ZONE;
+    tzfm INTEGER;
+    str_hr PG_CATALOG.TEXT;
+    str_mi PG_CATALOG.TEXT;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    sign_flag INTEGER;
+    v_string pg_catalog.text;
+    isoverflow pg_catalog.text;
+BEGIN
+
+    BEGIN
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+    if p_year <1 or p_year > 9999 THEN
+    RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END IF;
+
+
+    BEGIN
+    input_expr:= cast(input_expr AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END; 
+
+    IF input_expr IS NULL or tz_offset IS NULL THEN 
+    RETURN NULL;
+    END IF;
+
+
+    IF tz_offset LIKE '+__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := 1;
+    ELSIF tz_offset LIKE '-__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := -1;
+    ELSE
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;
+
+    
+
+    BEGIN
+    v_hr := str_hr::INTEGER;
+    v_mi := str_mi::INTEGER;
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END;
+
+    if v_hr > 14 or (v_hr = 14 and v_mi > 0) THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    tzfm := sign_flag*((v_hr*60)+v_mi);
+
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    p_month := date_part('month',input_expr::TIMESTAMP);
+    p_day := date_part('day',input_expr::TIMESTAMP);
+    p_hour := date_part('hour',input_expr::TIMESTAMP);
+    p_minute := date_part('minute',input_expr::TIMESTAMP);
+    p_seconds := TRUNC(date_part('second', input_expr::TIMESTAMP))::INTEGER;
+    p_tzoffset := -1*sys.babelfish_get_datetimeoffset_tzoffset(cast(input_expr as sys.datetimeoffset))::integer;
+
+    p_nanosecond := split_part(input_expr COLLATE "C",'.',2);
+    p_nanosecond := split_part(p_nanosecond COLLATE "C",' ',1);
+
+
+    f_tzoffset := p_tzoffset + tzfm;
+
+    v_resdatetime := make_timestamp(p_year,p_month,p_day,p_hour,p_minute,p_seconds);
+    v_resdatetimeupdated := v_resdatetime + make_interval(mins => f_tzoffset);
+
+    isoverflow := split_part(v_resdatetimeupdated::TEXT COLLATE "C",' ',3);
+
+    v_string := CONCAT(v_resdatetimeupdated::pg_catalog.text,'.',p_nanosecond::text,tz_offset);
+    p_year := split_part(v_string COLLATE "C",'-',1)::INTEGER;
+    
+
+    if p_year <1 or p_year > 9999 or isoverflow = 'BC' THEN
+    RAISE USING MESSAGE := 'The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.';
+    END IF;
+
+    BEGIN
+    RETURN cast(v_string AS sys.datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION sys.SWITCHOFFSET(IN input_expr PG_CATALOG.TEXT,
+                                                               IN tz_offset anyelement)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    p_year INTEGER;
+    p_month INTEGER;
+    p_day INTEGER;
+    p_hour INTEGER;
+    p_minute INTEGER;
+    p_seconds INTEGER;
+    p_nanosecond PG_CATALOG.TEXT;
+    p_tzoffset INTEGER;
+    f_tzoffset INTEGER;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+    offset_str PG_CATALOG.TEXT;
+    v_resdatetimeupdated TIMESTAMP WITHOUT TIME ZONE;
+    tzfm INTEGER;
+    str_hr PG_CATALOG.TEXT;
+    str_mi PG_CATALOG.TEXT;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    sign_flag INTEGER;
+    v_string pg_catalog.text;
+    v_sign PG_CATALOG.TEXT;
+    tz_offset_smallint smallint;
+    isoverflow pg_catalog.text;
+BEGIN
+
+    IF pg_typeof(tz_offset) NOT IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,
+    'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype,'varbinary'::regtype ) THEN
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;
+
+    BEGIN
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+    
+
+    if p_year <1 or p_year > 9999 THEN
+    RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END IF;
+
+    BEGIN
+    input_expr:= cast(input_expr AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+    BEGIN
+    IF pg_typeof(tz_offset) NOT IN ('varbinary'::regtype) THEN
+        tz_offset := FLOOR(tz_offset);
+    END IF;
+    tz_offset_smallint := cast(tz_offset AS smallint);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Arithmetic overflow error converting expression to data type smallint.';
+    END;  
+
+    IF input_expr IS NULL THEN 
+    RETURN NULL;
+    END IF;
+
+    if tz_offset_smallint > 840 or tz_offset_smallint < -840 THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    v_hr := tz_offset_smallint/60;
+    v_mi := tz_offset_smallint%60;
+    
+
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    p_month := date_part('month',input_expr::TIMESTAMP);
+    p_day := date_part('day',input_expr::TIMESTAMP);
+    p_hour := date_part('hour',input_expr::TIMESTAMP);
+    p_minute := date_part('minute',input_expr::TIMESTAMP);
+    p_seconds := TRUNC(date_part('second', input_expr::TIMESTAMP))::INTEGER;
+    p_tzoffset := -1*sys.babelfish_get_datetimeoffset_tzoffset(cast(input_expr as sys.datetimeoffset))::integer;
+
+    v_sign := (
+        SELECT CASE
+            WHEN (tz_offset_smallint) >= 0
+                THEN '+'    
+            ELSE '-'
+        END
+    );
+
+    p_nanosecond := split_part(input_expr COLLATE "C",'.',2);
+    p_nanosecond := split_part(p_nanosecond COLLATE "C",' ',1);
+
+    f_tzoffset := p_tzoffset + tz_offset_smallint;
+    v_resdatetime := make_timestamp(p_year,p_month,p_day,p_hour,p_minute,p_seconds);
+    v_resdatetimeupdated := v_resdatetime + make_interval(mins => f_tzoffset);
+
+    isoverflow := split_part(v_resdatetimeupdated::TEXT COLLATE "C",' ',3);
+
+    v_string := CONCAT(v_resdatetimeupdated::pg_catalog.text,'.',p_nanosecond::text,v_sign,abs(v_hr)::TEXT,':',abs(v_mi)::TEXT);
+
+    p_year := split_part(v_string COLLATE "C",'-',1)::INTEGER;
+
+    if p_year <1 or p_year > 9999 or isoverflow = 'BC' THEN
+    RAISE USING MESSAGE := 'The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.';
+    END IF;
+    
+
+    BEGIN
+    RETURN cast(v_string AS sys.datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
 -- Duplicate functions with arg TEXT since ANYELEMNT cannot handle type unknown.
 CREATE OR REPLACE FUNCTION sys.stuff(expr TEXT, start INTEGER, length INTEGER, replace_expr TEXT)
 RETURNS TEXT AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.5.0--2.6.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.5.0--2.6.0.sql
@@ -79,6 +79,247 @@ $BODY$
 LANGUAGE plpgsql
 IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION sys.SWITCHOFFSET(IN input_expr PG_CATALOG.TEXT,
+                                                               IN tz_offset PG_CATALOG.TEXT)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    p_year INTEGER;
+    p_month INTEGER;
+    p_day INTEGER;
+    p_hour INTEGER;
+    p_minute INTEGER;
+    p_seconds INTEGER;
+    p_nanosecond PG_CATALOG.TEXT;
+    p_tzoffset INTEGER;
+    f_tzoffset INTEGER;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+    offset_str PG_CATALOG.TEXT;
+    v_resdatetimeupdated TIMESTAMP WITHOUT TIME ZONE;
+    tzfm INTEGER;
+    str_hr PG_CATALOG.TEXT;
+    str_mi PG_CATALOG.TEXT;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    sign_flag INTEGER;
+    v_string pg_catalog.text;
+    isoverflow pg_catalog.text;
+BEGIN
+
+    BEGIN
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+    if p_year <1 or p_year > 9999 THEN
+    RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END IF;
+
+
+    BEGIN
+    input_expr:= cast(input_expr AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END; 
+
+    IF input_expr IS NULL or tz_offset IS NULL THEN 
+    RETURN NULL;
+    END IF;
+
+
+    IF tz_offset LIKE '+__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := 1;
+    ELSIF tz_offset LIKE '-__:__' THEN
+        str_hr := SUBSTRING(tz_offset,2,2);
+        str_mi := SUBSTRING(tz_offset,5,2);
+        sign_flag := -1;
+    ELSE
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;
+
+    
+
+    BEGIN
+    v_hr := str_hr::INTEGER;
+    v_mi := str_mi::INTEGER;
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END;
+
+    if v_hr > 14 or (v_hr = 14 and v_mi > 0) THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    tzfm := sign_flag*((v_hr*60)+v_mi);
+
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    p_month := date_part('month',input_expr::TIMESTAMP);
+    p_day := date_part('day',input_expr::TIMESTAMP);
+    p_hour := date_part('hour',input_expr::TIMESTAMP);
+    p_minute := date_part('minute',input_expr::TIMESTAMP);
+    p_seconds := TRUNC(date_part('second', input_expr::TIMESTAMP))::INTEGER;
+    p_tzoffset := -1*sys.babelfish_get_datetimeoffset_tzoffset(cast(input_expr as sys.datetimeoffset))::integer;
+
+    p_nanosecond := split_part(input_expr COLLATE "C",'.',2);
+    p_nanosecond := split_part(p_nanosecond COLLATE "C",' ',1);
+
+
+    f_tzoffset := p_tzoffset + tzfm;
+
+    v_resdatetime := make_timestamp(p_year,p_month,p_day,p_hour,p_minute,p_seconds);
+    v_resdatetimeupdated := v_resdatetime + make_interval(mins => f_tzoffset);
+
+    isoverflow := split_part(v_resdatetimeupdated::TEXT COLLATE "C",' ',3);
+
+    v_string := CONCAT(v_resdatetimeupdated::pg_catalog.text,'.',p_nanosecond::text,tz_offset);
+    p_year := split_part(v_string COLLATE "C",'-',1)::INTEGER;
+    
+
+    if p_year <1 or p_year > 9999 or isoverflow = 'BC' THEN
+    RAISE USING MESSAGE := 'The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.';
+    END IF;
+
+    BEGIN
+    RETURN cast(v_string AS sys.datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION sys.SWITCHOFFSET(IN input_expr PG_CATALOG.TEXT,
+                                                               IN tz_offset anyelement)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    p_year INTEGER;
+    p_month INTEGER;
+    p_day INTEGER;
+    p_hour INTEGER;
+    p_minute INTEGER;
+    p_seconds INTEGER;
+    p_nanosecond PG_CATALOG.TEXT;
+    p_tzoffset INTEGER;
+    f_tzoffset INTEGER;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+    offset_str PG_CATALOG.TEXT;
+    v_resdatetimeupdated TIMESTAMP WITHOUT TIME ZONE;
+    tzfm INTEGER;
+    str_hr PG_CATALOG.TEXT;
+    str_mi PG_CATALOG.TEXT;
+    v_hr INTEGER;
+    v_mi INTEGER;
+    sign_flag INTEGER;
+    v_string pg_catalog.text;
+    v_sign PG_CATALOG.TEXT;
+    tz_offset_smallint smallint;
+    isoverflow pg_catalog.text;
+BEGIN
+
+    IF pg_typeof(tz_offset) NOT IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,'sys.decimal'::regtype,
+    'numeric'::regtype, 'float'::regtype,'double precision'::regtype, 'real'::regtype, 'sys.money'::regtype,'sys.smallmoney'::regtype,'sys.bit'::regtype,'varbinary'::regtype ) THEN
+        RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF;
+
+    BEGIN
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+    
+
+    if p_year <1 or p_year > 9999 THEN
+    RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END IF;
+
+    BEGIN
+    input_expr:= cast(input_expr AS datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+    BEGIN
+    IF pg_typeof(tz_offset) NOT IN ('varbinary'::regtype) THEN
+        tz_offset := FLOOR(tz_offset);
+    END IF;
+    tz_offset_smallint := cast(tz_offset AS smallint);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Arithmetic overflow error converting expression to data type smallint.';
+    END;  
+
+    IF input_expr IS NULL THEN 
+    RETURN NULL;
+    END IF;
+
+    if tz_offset_smallint > 840 or tz_offset_smallint < -840 THEN
+       RAISE EXCEPTION 'The timezone provided to builtin function todatetimeoffset is invalid.';
+    END IF; 
+
+    v_hr := tz_offset_smallint/60;
+    v_mi := tz_offset_smallint%60;
+    
+
+    p_year := date_part('year',input_expr::TIMESTAMP);
+    p_month := date_part('month',input_expr::TIMESTAMP);
+    p_day := date_part('day',input_expr::TIMESTAMP);
+    p_hour := date_part('hour',input_expr::TIMESTAMP);
+    p_minute := date_part('minute',input_expr::TIMESTAMP);
+    p_seconds := TRUNC(date_part('second', input_expr::TIMESTAMP))::INTEGER;
+    p_tzoffset := -1*sys.babelfish_get_datetimeoffset_tzoffset(cast(input_expr as sys.datetimeoffset))::integer;
+
+    v_sign := (
+        SELECT CASE
+            WHEN (tz_offset_smallint) >= 0
+                THEN '+'    
+            ELSE '-'
+        END
+    );
+
+    p_nanosecond := split_part(input_expr COLLATE "C",'.',2);
+    p_nanosecond := split_part(p_nanosecond COLLATE "C",' ',1);
+
+    f_tzoffset := p_tzoffset + tz_offset_smallint;
+    v_resdatetime := make_timestamp(p_year,p_month,p_day,p_hour,p_minute,p_seconds);
+    v_resdatetimeupdated := v_resdatetime + make_interval(mins => f_tzoffset);
+
+    isoverflow := split_part(v_resdatetimeupdated::TEXT COLLATE "C",' ',3);
+
+    v_string := CONCAT(v_resdatetimeupdated::pg_catalog.text,'.',p_nanosecond::text,v_sign,abs(v_hr)::TEXT,':',abs(v_mi)::TEXT);
+
+    p_year := split_part(v_string COLLATE "C",'-',1)::INTEGER;
+
+    if p_year <1 or p_year > 9999 or isoverflow = 'BC' THEN
+    RAISE USING MESSAGE := 'The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.';
+    END IF;
+    
+
+    BEGIN
+    RETURN cast(v_string AS sys.datetimeoffset);
+    exception
+        WHEN others THEN
+            RAISE USING MESSAGE := 'Conversion failed when converting date and/or time from character string.';
+    END;
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE;
+
 CREATE OR REPLACE PROCEDURE sys.sp_describe_first_result_set (
 	"@tsql" sys.nvarchar(8000),
     "@params" sys.nvarchar(8000) = NULL, 

--- a/test/JDBC/expected/switchoffset-dep-vu-cleanup.out
+++ b/test/JDBC/expected/switchoffset-dep-vu-cleanup.out
@@ -1,0 +1,17 @@
+DROP VIEW switchoffset_dep_vu_prepare_v1
+GO
+
+DROP VIEW switchoffset_dep_vu_prepare_v2
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p1
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p2
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f1()
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/expected/switchoffset-dep-vu-prepare.out
+++ b/test/JDBC/expected/switchoffset-dep-vu-prepare.out
@@ -1,0 +1,25 @@
+CREATE VIEW switchoffset_dep_vu_prepare_v1 as (Select switchoffset('2000-04-22 16:2a:51.766890',340));
+GO
+
+CREATE VIEW switchoffset_dep_vu_prepare_v2 as (Select switchoffset('2000-04-22 ','+12:00'));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p1 as (SELECT switchoffset(cast('2023-08-08 16:06:45' as datetime2), '-13:00'));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p2 as (Select switchoffset('2000-04-22 16:23:51',120));
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f1()
+RETURNS DATETIMEOFFSET AS
+BEGIN
+RETURN (Select switchoffset('2000-0a-22 ','+12:00'));
+END
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f2()
+RETURNS DATETIMEOFFSET as
+begin
+RETURN (Select switchoffset('2000-04-22 16:23:50.76689',120));
+END
+GO

--- a/test/JDBC/expected/switchoffset-dep-vu-verify.out
+++ b/test/JDBC/expected/switchoffset-dep-vu-verify.out
@@ -1,0 +1,47 @@
+SELECT * FROM switchoffset_dep_vu_prepare_v1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+SELECT * FROM switchoffset_dep_vu_prepare_v2
+GO
+~~START~~
+datetimeoffset
+2000-04-22 12:00:00.0000000 +12:00
+~~END~~
+
+
+EXEC switchoffset_dep_vu_prepare_p1
+GO
+~~START~~
+datetimeoffset
+2023-08-08 03:06:45.0000000 -13:00
+~~END~~
+
+
+EXEC switchoffset_dep_vu_prepare_p2
+GO
+~~START~~
+datetimeoffset
+2000-04-22 18:23:51.0000000 +02:00
+~~END~~
+
+
+SELECT switchoffset_dep_vu_prepare_f1()
+GO
+~~START~~
+datetimeoffset
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+SELECT switchoffset_dep_vu_prepare_f2()
+GO
+~~START~~
+datetimeoffset
+2000-04-22 18:23:50.7668900 +02:00
+~~END~~
+

--- a/test/JDBC/expected/switchoffset.out
+++ b/test/JDBC/expected/switchoffset.out
@@ -1,0 +1,815 @@
+Select switchoffset('2001-04-22 ', -120)
+GO
+~~START~~
+datetimeoffset
+2001-04-21 22:00:00.0000000 -02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 ', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 02:00:00.0000000 +02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 19:34:56.0000000 +02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 120)
+GO
+~~START~~
+datetimeoffset
+2001-04-22 19:34:56.3450000 +02:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 0)
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', -0)
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('200a-0b-22 17:34:56.345', 1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 0x12)
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:52:56.3450000 +00:18
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', 'abcd')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('2001-04-22 ', '+12:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 12:00:00.0000000 +12:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 ', '-12:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-21 12:00:00.0000000 -12:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56', '-12:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 05:34:56.0000000 -12:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-11:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 06:34:56.3450000 -11:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '+00:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-00:00')
+go
+~~START~~
+datetimeoffset
+2001-04-22 17:34:56.3450000 +00:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 10:34:56.345', '-11:00')
+go
+~~START~~
+datetimeoffset
+2001-04-21 23:34:56.3450000 -11:00
+~~END~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-101:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-011:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('200a-0b-22 17:34:56.345', '-011:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '+14:01')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-14:01')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '-1a:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset('2001-04-22 17:34:56.345', '14:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+
+-- Currently these inputs are giving wrong output due to casting issues .(BABEL-4321) 
+Select switchoffset(convert(datetime,'2001-04-22'),'-13:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-21 11:00:00.0000000 -13:00
+~~END~~
+
+
+Select switchoffset(convert(date,'2001-04-22'),'-13:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-21 11:00:00.0000000 -13:00
+~~END~~
+
+
+Select switchoffset(convert(datetime2,'2001-04-22'),'-13:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-21 11:00:00.0000000 -13:00
+~~END~~
+
+
+Select switchoffset(convert(smalldatetime,'2001-04-22'),'-13:00')
+GO
+~~START~~
+datetimeoffset
+2001-04-21 11:00:00.0000000 -13:00
+~~END~~
+
+
+
+--
+Select switchoffset('0001-01-00 00:00:00.00', '-10:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('0001-01-01 00:00:00.00', '+13:00')
+GO
+~~START~~
+datetimeoffset
+0001-01-01 13:00:00.0000000 +13:00
+~~END~~
+
+
+Select switchoffset('9999-12-31 11:59:59.59', '+12:00')
+GO
+~~START~~
+datetimeoffset
+9999-12-31 23:59:59.5900000 +12:00
+~~END~~
+
+
+Select switchoffset('9999-12-31 24:59:59.59', 130)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('10000-12-31 23:59:59.59', 120)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 120)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 15:59:29.0500000 +02:00
+~~END~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), '+12:00')
+GO
+~~START~~
+datetimeoffset
+1900-05-07 01:59:29.0500000 +12:00
+~~END~~
+
+
+DECLARE @test_date datetime;
+SET @test_date = '2022-12-11';
+Select switchoffset(@test_date,'+12:00');
+GO
+~~START~~
+datetimeoffset
+2022-12-11 12:00:00.0000000 +12:00
+~~END~~
+
+
+DECLARE @test_date datetime2;
+SET @test_date = '2345-12-31 23:59:59.59';
+Select switchoffset(@test_date,-120);
+GO
+~~START~~
+datetimeoffset
+2345-12-31 21:59:59.5900000 -02:00
+~~END~~
+
+
+Select switchoffset(DATETIME2FROMPARTS(2011, 8, 15, 14, 23, 44, 5, 6 ), 300)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 19:23:44.0000050 +05:00
+~~END~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), '+12:00')
+Go
+~~START~~
+datetimeoffset
+1900-05-07 01:59:30.0000000 +12:00
+~~END~~
+
+
+Select switchoffset('0',120)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('0',0x23)
+Go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+DROP TABLE IF EXISTS tem
+GO
+Create table tem(a datetimeoffset)
+insert into tem (a) values(switchoffset('2000-04-22 12:23:51.766890',120))
+Select * from tem
+Select switchoffset(a,'+14:00') from tem;
+DROP TABLE IF EXISTS tem
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+datetimeoffset
+2000-04-22 14:23:51.7668900 +02:00
+~~END~~
+
+~~START~~
+datetimeoffset
+2000-04-23 02:23:51.7668900 +14:00
+~~END~~
+
+
+Select switchoffset('2030-05-06 13:59:29.998 ' ,'-08:00') + make_interval(1,0,3);
+GO
+~~START~~
+datetimeoffset
+2031-05-27 13:59:29.9980000 -08:00
+~~END~~
+
+
+Select switchoffset('2030-05-06 13:59:29.998 ' ,'-08:00') - make_interval(1,0,3);
+GO
+~~START~~
+datetimeoffset
+2029-04-15 13:59:29.9980000 -08:00
+~~END~~
+
+
+Select switchoffset('NULL','NULL')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('NULL',NULL)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset(NULL,NULL)
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select switchoffset(NULL,'NULL')
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), 0x23)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 14:34:30.0000000 +00:35
+~~END~~
+
+
+DECLARE @test_offset text;
+SET @test_offset = '-13:00';
+Select switchoffset('2345-12-31 23:59:59.59',@test_offset);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The text, ntext, and image data types are invalid for local variables.)~~
+
+
+DECLARE @test_offset1 float ;
+SET @test_offset1 = 23.567;
+Select switchoffset('2345-12-31 23:59:59.59',@test_offset1);
+GO
+~~START~~
+datetimeoffset
+2346-01-01 00:22:59.5900000 +00:23
+~~END~~
+
+
+DECLARE @test_offset1 decimal ;
+SET @test_offset1 = 23.567;
+Select switchoffset('2345-12-31 23:59:59.59',@test_offset1);
+GO
+~~START~~
+datetimeoffset
+2346-01-01 00:23:59.5900000 +00:24
+~~END~~
+
+
+Select switchoffset(CAST('1900-05-0x12 13:59:29.998 -8:00' AS datetime2(2)), 235.67)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type datetime2: "1900-05-0x12 13:59:29.998 -8:00")~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), 23647585)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error converting expression to data type smallint.)~~
+
+
+Select switchoffset('2345-12-31 23:59:59.59',23.567);
+GO
+~~START~~
+datetimeoffset
+2346-01-01 00:22:59.5900000 +00:23
+~~END~~
+
+
+Select switchoffset('2345-12-31 23:59:59.59',23.467);
+GO
+~~START~~
+datetimeoffset
+2346-01-01 00:22:59.5900000 +00:23
+~~END~~
+
+
+Select switchoffset('2345-12-31 23:59:59.59',cast(123 as bit));
+GO
+~~START~~
+datetimeoffset
+2346-01-01 00:00:59.5900000 +00:01
+~~END~~
+
+
+Select switchoffset('2345-12-31 23:59:59.59',NULL);
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select switchoffset('2345-12-31 23:59:59.59','NULL');
+Go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset(NULL,'+12:00');
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select switchoffset('NULL','+12:00');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('NULL',234);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset(NULL,234);
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select switchoffset(NULL,'+12:000');
+GO
+~~START~~
+datetimeoffset
+<NULL>
+~~END~~
+
+
+Select switchoffset('NULL','+12:000');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('NULL',1233456777888);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset(NULL,1233456777888);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error converting expression to data type smallint.)~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 840)
+GO
+~~START~~
+datetimeoffset
+1900-05-07 03:59:29.0500000 +14:00
+~~END~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 841)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -841)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function todatetimeoffset is invalid.)~~
+
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -840)
+GO
+~~START~~
+datetimeoffset
+1900-05-05 23:59:29.0500000 -14:00
+~~END~~
+
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 0x23)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 02:35:00.5000000 +00:35
+~~END~~
+
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 435.678999)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 09:15:00.5000000 +07:15
+~~END~~
+
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 43)
+GO
+~~START~~
+datetimeoffset
+2011-08-15 02:43:00.5000000 +00:43
+~~END~~
+
+
+Select switchoffset('1900-05-06 13:59:29.998 -8:00', '-12:00')
+GO
+~~START~~
+datetimeoffset
+1900-05-06 09:59:29.9980000 -12:00
+~~END~~
+
+
+Select switchoffset('1900-05-06 12:59:29.998 -00:00', '+12:00')
+GO
+~~START~~
+datetimeoffset
+1900-05-07 00:59:29.9980000 +12:00
+~~END~~
+
+
+Select switchoffset('1900-05-06 12:59:29.998 -02:00', 234)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 18:53:29.9980000 +03:54
+~~END~~
+
+
+Select switchoffset('1900-05-06 12:59:29.998 +10:00', -456)
+GO
+~~START~~
+datetimeoffset
+1900-05-05 19:23:29.9980000 -07:36
+~~END~~
+
+
+Select switchoffset('1900-05-06 12:59:29.998 -00:00', 0x12)
+GO
+~~START~~
+datetimeoffset
+1900-05-06 13:17:29.9980000 +00:18
+~~END~~
+
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(1, 1, 1, 4, 30, 00, 500, 12, 30, 3), '+00:43')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot construct data type datetimeoffset, some of the arguments have values which are not valid.)~~
+
+
+Select switchoffset('1-1-1 00:00:00.000 +12:00' , '+12:00')
+GO
+~~START~~
+datetimeoffset
+2001-01-01 00:00:00.0000000 +12:00
+~~END~~
+
+
+Select switchoffset('0001-1-1 00:00:00.000 +12:00' , '+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('0001-01-01 00:00:00.000 +12:00' , '+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('0002-01-01 00:00:00.000 +12:00' , '+12:43')
+GO
+~~START~~
+datetimeoffset
+0002-01-01 00:43:00.0000000 +12:43
+~~END~~
+
+
+Select switchoffset('10000-01-01 00:00:00.000 +12:00' , '+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('10000-01-01 00:00:00.123 +2:00','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.)~~
+
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00','+12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.)~~
+
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00','+12:00')
+GO
+~~START~~
+datetimeoffset
+0001-01-01 12:00:01.0000000 +12:00
+~~END~~
+
+
+Select switchoffset('0001-01-01 00:00:00.00 +00:00','+12:00')
+GO
+~~START~~
+datetimeoffset
+0001-01-01 12:00:00.0000000 +12:00
+~~END~~
+
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00','+12:00')
+GO
+~~START~~
+datetimeoffset
+0001-01-01 12:00:01.0000000 +12:00
+~~END~~
+
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(1, 1, 1, 4, 30, 00, 500, 12, 30, 3), 743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot construct data type datetimeoffset, some of the arguments have values which are not valid.)~~
+
+
+Select switchoffset('1-1-1 00:00:00.000 +12:00' , 743)
+GO
+~~START~~
+datetimeoffset
+2001-01-01 00:23:00.0000000 +12:23
+~~END~~
+
+
+Select switchoffset('0001-1-1 00:00:00.000 +12:00' , 743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('0001-01-01 00:00:00.000 +12:00' , 743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('0002-01-01 00:00:00.000 +12:00' , 743)
+GO
+~~START~~
+datetimeoffset
+0002-01-01 00:23:00.0000000 +12:23
+~~END~~
+
+
+Select switchoffset('10000-01-01 00:00:00.000 +12:00' , 743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('10000-01-01 00:00:00.123 +2:00', 743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
+
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00',743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.)~~
+
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00',743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.)~~
+
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00',743)
+GO
+~~START~~
+datetimeoffset
+0001-01-01 12:23:01.0000000 +12:23
+~~END~~
+
+
+Select switchoffset('0001-01-01 00:00:00.00 +00:00',743)
+GO
+~~START~~
+datetimeoffset
+0001-01-01 12:23:00.0000000 +12:23
+~~END~~
+
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00',743)
+GO
+~~START~~
+datetimeoffset
+0001-01-01 12:23:01.0000000 +12:23
+~~END~~
+
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00',-743)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.)~~
+
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00','-12:00')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The timezone provided to builtin function switchoffset would cause the datetimeoffset to overflow the range of valid date range in either UTC or local time.)~~
+

--- a/test/JDBC/input/switchoffset-dep-vu-cleanup.sql
+++ b/test/JDBC/input/switchoffset-dep-vu-cleanup.sql
@@ -1,0 +1,17 @@
+DROP VIEW switchoffset_dep_vu_prepare_v1
+GO
+
+DROP VIEW switchoffset_dep_vu_prepare_v2
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p1
+GO
+
+DROP PROCEDURE switchoffset_dep_vu_prepare_p2
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f1()
+GO
+
+DROP FUNCTION switchoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/input/switchoffset-dep-vu-prepare.sql
+++ b/test/JDBC/input/switchoffset-dep-vu-prepare.sql
@@ -1,0 +1,25 @@
+CREATE VIEW switchoffset_dep_vu_prepare_v1 as (Select switchoffset('2000-04-22 16:2a:51.766890',340));
+GO
+
+CREATE VIEW switchoffset_dep_vu_prepare_v2 as (Select switchoffset('2000-04-22 ','+12:00'));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p1 as (SELECT switchoffset(cast('2023-08-08 16:06:45' as datetime2), '-13:00'));
+GO
+
+CREATE PROCEDURE  switchoffset_dep_vu_prepare_p2 as (Select switchoffset('2000-04-22 16:23:51',120));
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f1()
+RETURNS DATETIMEOFFSET AS
+BEGIN
+RETURN (Select switchoffset('2000-0a-22 ','+12:00'));
+END
+GO
+
+CREATE FUNCTION switchoffset_dep_vu_prepare_f2()
+RETURNS DATETIMEOFFSET as
+begin
+RETURN (Select switchoffset('2000-04-22 16:23:50.76689',120));
+END
+GO

--- a/test/JDBC/input/switchoffset-dep-vu-verify.sql
+++ b/test/JDBC/input/switchoffset-dep-vu-verify.sql
@@ -1,0 +1,17 @@
+SELECT * FROM switchoffset_dep_vu_prepare_v1
+GO
+
+SELECT * FROM switchoffset_dep_vu_prepare_v2
+GO
+
+EXEC switchoffset_dep_vu_prepare_p1
+GO
+
+EXEC switchoffset_dep_vu_prepare_p2
+GO
+
+SELECT switchoffset_dep_vu_prepare_f1()
+GO
+
+SELECT switchoffset_dep_vu_prepare_f2()
+GO

--- a/test/JDBC/input/switchoffset.sql
+++ b/test/JDBC/input/switchoffset.sql
@@ -1,0 +1,331 @@
+Select switchoffset('2001-04-22 ', -120)
+GO
+
+Select switchoffset('2001-04-22 ', 120)
+GO
+
+Select switchoffset('2001-04-22 17:34:56', 120)
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', 120)
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', 0)
+go
+
+Select switchoffset('2001-04-22 17:34:56.345', -0)
+go
+
+Select switchoffset('200a-0b-22 17:34:56.345', 1)
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', 0x12)
+go
+
+Select switchoffset('2001-04-22 17:34:56.345', 'abcd')
+GO
+
+Select switchoffset('2001-04-22 ', '+12:00')
+GO
+
+Select switchoffset('2001-04-22 ', '-12:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56', '-12:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '-11:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '+00:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '-00:00')
+go
+
+Select switchoffset('2001-04-22 10:34:56.345', '-11:00')
+go
+
+Select switchoffset('2001-04-22 17:34:56.345', '-101:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '-011:00')
+GO
+
+Select switchoffset('200a-0b-22 17:34:56.345', '-011:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '+14:01')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '-14:01')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '-1a:00')
+GO
+
+Select switchoffset('2001-04-22 17:34:56.345', '14:00')
+GO
+
+-- Currently these inputs are giving wrong output due to casting issues .(BABEL-4321) 
+
+Select switchoffset(convert(datetime,'2001-04-22'),'-13:00')
+GO
+
+Select switchoffset(convert(date,'2001-04-22'),'-13:00')
+GO
+
+Select switchoffset(convert(datetime2,'2001-04-22'),'-13:00')
+GO
+
+Select switchoffset(convert(smalldatetime,'2001-04-22'),'-13:00')
+GO
+
+--
+
+Select switchoffset('0001-01-00 00:00:00.00', '-10:00')
+GO
+
+Select switchoffset('0001-01-01 00:00:00.00', '+13:00')
+GO
+
+Select switchoffset('9999-12-31 11:59:59.59', '+12:00')
+GO
+
+Select switchoffset('9999-12-31 24:59:59.59', 130)
+GO
+
+Select switchoffset('10000-12-31 23:59:59.59', 120)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 120)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), '+12:00')
+GO
+
+DECLARE @test_date datetime;
+SET @test_date = '2022-12-11';
+Select switchoffset(@test_date,'+12:00');
+GO
+
+DECLARE @test_date datetime2;
+SET @test_date = '2345-12-31 23:59:59.59';
+Select switchoffset(@test_date,-120);
+GO
+
+Select switchoffset(DATETIME2FROMPARTS(2011, 8, 15, 14, 23, 44, 5, 6 ), 300)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), '+12:00')
+Go
+
+Select switchoffset('0',120)
+GO
+
+Select switchoffset('0',0x23)
+Go
+
+DROP TABLE IF EXISTS tem
+GO
+Create table tem(a datetimeoffset)
+insert into tem (a) values(switchoffset('2000-04-22 12:23:51.766890',120))
+Select * from tem
+Select switchoffset(a,'+14:00') from tem;
+DROP TABLE IF EXISTS tem
+GO
+
+Select switchoffset('2030-05-06 13:59:29.998 ' ,'-08:00') + make_interval(1,0,3);
+GO
+
+Select switchoffset('2030-05-06 13:59:29.998 ' ,'-08:00') - make_interval(1,0,3);
+GO
+
+Select switchoffset('NULL','NULL')
+GO
+
+Select switchoffset('NULL',NULL)
+GO
+
+Select switchoffset(NULL,NULL)
+GO
+
+Select switchoffset(NULL,'NULL')
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), 0x23)
+GO
+
+DECLARE @test_offset text;
+SET @test_offset = '-13:00';
+Select switchoffset('2345-12-31 23:59:59.59',@test_offset);
+GO
+
+DECLARE @test_offset1 float ;
+SET @test_offset1 = 23.567;
+Select switchoffset('2345-12-31 23:59:59.59',@test_offset1);
+GO
+
+DECLARE @test_offset1 decimal ;
+SET @test_offset1 = 23.567;
+Select switchoffset('2345-12-31 23:59:59.59',@test_offset1);
+GO
+
+Select switchoffset(CAST('1900-05-0x12 13:59:29.998 -8:00' AS datetime2(2)), 235.67)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.998 -8:00' AS datetime2(2)), 23647585)
+GO
+
+Select switchoffset('2345-12-31 23:59:59.59',23.567);
+GO
+
+Select switchoffset('2345-12-31 23:59:59.59',23.467);
+GO
+
+Select switchoffset('2345-12-31 23:59:59.59',cast(123 as bit));
+GO
+
+Select switchoffset('2345-12-31 23:59:59.59',NULL);
+GO
+
+Select switchoffset('2345-12-31 23:59:59.59','NULL');
+Go
+
+Select switchoffset(NULL,'+12:00');
+GO
+
+Select switchoffset('NULL','+12:00');
+GO
+
+Select switchoffset('NULL',234);
+GO
+
+Select switchoffset(NULL,234);
+GO
+
+Select switchoffset(NULL,'+12:000');
+GO
+
+Select switchoffset('NULL','+12:000');
+GO
+
+Select switchoffset('NULL',1233456777888);
+GO
+
+Select switchoffset(NULL,1233456777888);
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 840)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), 841)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -841)
+GO
+
+Select switchoffset(CAST('1900-05-06 13:59:29.050 -8:00' AS datetime2(4)), -840)
+GO
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 0x23)
+GO
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 435.678999)
+GO
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(2011, 8, 15, 14, 30, 00, 500, 12, 30, 3), 43)
+GO
+
+Select switchoffset('1900-05-06 13:59:29.998 -8:00', '-12:00')
+GO
+
+Select switchoffset('1900-05-06 12:59:29.998 -00:00', '+12:00')
+GO
+
+Select switchoffset('1900-05-06 12:59:29.998 -02:00', 234)
+GO
+
+Select switchoffset('1900-05-06 12:59:29.998 +10:00', -456)
+GO
+
+Select switchoffset('1900-05-06 12:59:29.998 -00:00', 0x12)
+GO
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(1, 1, 1, 4, 30, 00, 500, 12, 30, 3), '+00:43')
+GO
+
+Select switchoffset('1-1-1 00:00:00.000 +12:00' , '+12:00')
+GO
+
+Select switchoffset('0001-1-1 00:00:00.000 +12:00' , '+12:00')
+GO
+
+Select switchoffset('0001-01-01 00:00:00.000 +12:00' , '+12:00')
+GO
+
+Select switchoffset('0002-01-01 00:00:00.000 +12:00' , '+12:43')
+GO
+
+Select switchoffset('10000-01-01 00:00:00.000 +12:00' , '+12:00')
+GO
+
+Select switchoffset('10000-01-01 00:00:00.123 +2:00','+12:00')
+GO
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00','+12:00')
+GO
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00','+12:00')
+GO
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00','+12:00')
+GO
+
+Select switchoffset('0001-01-01 00:00:00.00 +00:00','+12:00')
+GO
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00','+12:00')
+GO
+
+Select switchoffset(DATETIMEOFFSETFROMPARTS(1, 1, 1, 4, 30, 00, 500, 12, 30, 3), 743)
+GO
+
+Select switchoffset('1-1-1 00:00:00.000 +12:00' , 743)
+GO
+
+Select switchoffset('0001-1-1 00:00:00.000 +12:00' , 743)
+GO
+
+Select switchoffset('0001-01-01 00:00:00.000 +12:00' , 743)
+GO
+
+Select switchoffset('0002-01-01 00:00:00.000 +12:00' , 743)
+GO
+
+Select switchoffset('10000-01-01 00:00:00.000 +12:00' , 743)
+GO
+
+Select switchoffset('10000-01-01 00:00:00.123 +2:00', 743)
+GO
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00',743)
+GO
+
+Select switchoffset('9999-12-31 23:12:00.123 +00:00',743)
+GO
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00',743)
+GO
+
+Select switchoffset('0001-01-01 00:00:00.00 +00:00',743)
+GO
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00',743)
+GO
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00',-743)
+GO
+
+Select switchoffset('0001-01-01 00:00:01.00 +00:00','-12:00')
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -409,3 +409,4 @@ babel_varbinary_int4_div
 sys-sql_expression_dependencies
 smalldatetimefromparts-dep
 BABEL_4330
+switchoffset-dep


### PR DESCRIPTION
### Description
This function returns a datetimeoffset value that is changed from the stored time zone offset to a specified new time zone offset.

Example
```
Select switchoffset (CONVERT(datetimeoffset, GETDATE()), '-04:00');
 2023-08-03 06:05:07.4366667 -04:00

Select CONVERT(datetimeoffset, GETDATE());
 2023-08-03 10:05:49.1000000 +00:00
```

Signed-off-by: Ashish Prasad [pashisht@amazon.com](mailto:pashisht@amazon.com)

### Conflict

- contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql (Resolved by adding the function to babelfishpg_tsql--2.5.0--2.6.0.sql )
- upgrade/latest/schedule (Resolved)


### Issues Resolved

BABEL-744

### Test Scenarios Covered ###

NOTE :-  There are issues with cast to datetimeoffset datatype , filed a JIRA (BABEL-4328) , so there are some testcase which fail during cast to datetimeoffset which will also fail for the todatetimeoffset function.

* **Use case based -** Added


* **Boundary conditions -** Added


* **Arbitrary inputs -** Added


* **Negative test cases -** Added


* **Minor version upgrade tests -**  Added


* **Major version upgrade tests -** Added


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).