### PR TITLE
Add null check in exec_eval_datum for table types (#1776)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -6947,7 +6947,7 @@ exec_eval_datum(PLtsql_execstate *estate,
 				*typeid = tbl->tbltypeid;
 				*typetypmod = -1;
 				*value = CStringGetDatum(tbl->tblname);
-				*isnull = false;
+				*isnull = !tbl->tblname ? true : false;
 				break;
 			}
 

--- a/test/JDBC/expected/table-variable-vu-cleanup.out
+++ b/test/JDBC/expected/table-variable-vu-cleanup.out
@@ -59,3 +59,13 @@ drop schema table_variable_vu_schema
 go
 drop function table_variable_vu_func2
 go
+
+-- BABEL-4337 - nested tv
+DROP FUNCTION tv_nested_func2
+GO
+
+DROP FUNCTION tv_nested_func1
+GO
+
+DROP TYPE tv_nested_type
+GO

--- a/test/JDBC/expected/table-variable-vu-prepare.out
+++ b/test/JDBC/expected/table-variable-vu-prepare.out
@@ -239,3 +239,11 @@ BEGIN
     RETURN
 END
 go
+
+-- BABEL-4337 - nested TV, null check in tblname
+CREATE TYPE tv_nested_type AS TABLE (a INT)
+GO
+CREATE FUNCTION tv_nested_func1 (@t tv_nested_type readonly) RETURNS @a TABLE (y INT) AS BEGIN; INSERT INTO @a SELECT x FROM @t; RETURN; END;
+GO
+CREATE FUNCTION tv_nested_func2 (@t tv_nested_type readonly) RETURNS @a TABLE (x INT) AS BEGIN; INSERT INTO @a SELECT y FROM tv_nested_func1(@t); RETURN; END;
+GO

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -263,3 +263,13 @@ bit
 1
 ~~END~~
 
+
+-- BABEL-4337 - check nested TV for null; should not crash but throw an error
+SELECT * FROM tv_nested_func2(NULL)
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: table variable underlying typename is NULL. refname: @t)~~
+

--- a/test/JDBC/input/table_variables/table-variable-vu-cleanup.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-cleanup.sql
@@ -59,3 +59,13 @@ drop schema table_variable_vu_schema
 go
 drop function table_variable_vu_func2
 go
+
+-- BABEL-4337 - nested tv
+DROP FUNCTION tv_nested_func2
+GO
+
+DROP FUNCTION tv_nested_func1
+GO
+
+DROP TYPE tv_nested_type
+GO

--- a/test/JDBC/input/table_variables/table-variable-vu-prepare.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-prepare.sql
@@ -225,3 +225,11 @@ BEGIN
     RETURN
 END
 go
+
+-- BABEL-4337 - nested TV, null check in tblname
+CREATE TYPE tv_nested_type AS TABLE (a INT)
+GO
+CREATE FUNCTION tv_nested_func1 (@t tv_nested_type readonly) RETURNS @a TABLE (y INT) AS BEGIN; INSERT INTO @a SELECT x FROM @t; RETURN; END;
+GO
+CREATE FUNCTION tv_nested_func2 (@t tv_nested_type readonly) RETURNS @a TABLE (x INT) AS BEGIN; INSERT INTO @a SELECT y FROM tv_nested_func1(@t); RETURN; END;
+GO

--- a/test/JDBC/input/table_variables/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-verify.sql
@@ -98,3 +98,7 @@ go
 select * from table_variable_vu_func2()
 select typbyval from pg_catalog.pg_type where typname like '@sometable_table_variable_vu_func2%';
 go
+
+-- BABEL-4337 - check nested TV for null; should not crash but throw an error
+SELECT * FROM tv_nested_func2(NULL)
+go


### PR DESCRIPTION
In cases of nested TVF, exec_eval_datum was returning an incorrect value of isnull for actual null values. We match the check in bbf_table_var_lookup to get the correct value.

Task: BABEL-4337

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).