### PR TITLE
sp_executesql throws error when prefixed with dbo. or sys.

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4732,12 +4732,26 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 		int lineno = getLineNo(ctx);
 		int return_code_dno = -1;
 
+		std::string rewritten_name = "";
+		if (body->func_proc_name_server_database_schema())
+		{
+			// rewrite func/proc name if database/schema is omitted (i.e. EXEC ..proc1)
+			GetCtxFunc<TSqlParser::Func_proc_name_server_database_schemaContext *> getDatabase = [](TSqlParser::Func_proc_name_server_database_schemaContext *o) { return o->database; };
+			GetCtxFunc<TSqlParser::Func_proc_name_server_database_schemaContext *> getSchema = [](TSqlParser::Func_proc_name_server_database_schemaContext *o) { return o->schema; };
+			rewritten_name = rewrite_object_name_with_omitted_db_and_schema_name(body->func_proc_name_server_database_schema(), getDatabase, getSchema);
+		}
+
+		std::string name = (!rewritten_name.empty() ? rewritten_name : func_proc_name);
+		// Rewrite proc name to sp_* if the schema is "dbo" or "sys" and proc name starts with "sp_"
+		if ((pg_strncasecmp(name.c_str(), "dbo.sp_", 6) == 0) || (pg_strncasecmp(name.c_str(), "sys.sp_", 6) == 0))
+			name.erase(name.begin() + 0, name.begin() + 4);
+
+		if (is_sp_proc(name))
+			return makeSpStatement(name, func_proc_args, lineno, return_code_dno);
+
 		auto *localID = body->return_status ? body->LOCAL_ID()[0] : nullptr;
 		if (localID)
 			return_code_dno = getVarno(localID);
-
-		if (is_sp_proc(func_proc_name))
-			return makeSpStatement(func_proc_name, func_proc_args, lineno, return_code_dno);
 
 		PLtsql_stmt_exec *result = (PLtsql_stmt_exec *) palloc0(sizeof(*result));
 		result->cmd_type = PLTSQL_STMT_EXEC;
@@ -4775,20 +4789,7 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 			}
 		}
 
-		std::string rewritten_name = "";
-		if (body->func_proc_name_server_database_schema())
-		{
-			// rewrite func/proc name if database/schema is omitted (i.e. EXEC ..proc1)
-			GetCtxFunc<TSqlParser::Func_proc_name_server_database_schemaContext *> getDatabase = [](TSqlParser::Func_proc_name_server_database_schemaContext *o) { return o->database; };
-			GetCtxFunc<TSqlParser::Func_proc_name_server_database_schemaContext *> getSchema = [](TSqlParser::Func_proc_name_server_database_schemaContext *o) { return o->schema; };
-			rewritten_name = rewrite_object_name_with_omitted_db_and_schema_name(body->func_proc_name_server_database_schema(), getDatabase, getSchema);
-		}
-
 		std::stringstream ss;
-		std::string name = (!rewritten_name.empty() ? rewritten_name : func_proc_name);
-		// Rewrite proc name to sp_* if the schema is "dbo" and proc name starts with "sp_"
-		if (pg_strncasecmp(name.c_str(), "dbo.sp_", 6) == 0)
-			name.erase(name.begin() + 0, name.begin() + 4);
 		ss << "EXEC " << name;
 		if (func_proc_args)
 			ss << " " << ::getFullText(func_proc_args);
@@ -5202,6 +5203,11 @@ makeExecBodyBatch(TSqlParser::Execute_body_batchContext *ctx)
 	bool is_cross_db = false;
 	std::string db_name;
 	std::string func_proc_name = ::getFullText(ctx->func_proc_name_server_database_schema());
+
+	// Rewrite proc name to sp_* if the schema is "dbo" or "sys" and proc name starts with "sp_"
+	if ((pg_strncasecmp(func_proc_name.c_str(), "dbo.sp_", 6) == 0) || (pg_strncasecmp(func_proc_name.c_str(), "sys.sp_", 6) == 0))
+		func_proc_name.erase(func_proc_name.begin() + 0, func_proc_name.begin() + 4);
+
 	if (ctx->func_proc_name_server_database_schema()->database)
 	{
 		db_name = stripQuoteFromId(ctx->func_proc_name_server_database_schema()->database);
@@ -5252,9 +5258,6 @@ makeExecBodyBatch(TSqlParser::Execute_body_batchContext *ctx)
 	}
 
 	std::stringstream ss;
-	// Rewrite proc name to sp_* if the schema is "dbo" and proc name starts with "sp_"
-	if (pg_strncasecmp(func_proc_name.c_str(), "dbo.sp_", 6) == 0)
-		func_proc_name.erase(func_proc_name.begin() + 0, func_proc_name.begin() + 4);
 	ss << "EXEC " << func_proc_name;
 	if (func_proc_args)
 		ss << " " << ::getFullText(func_proc_args);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4746,12 +4746,12 @@ makeExecuteStatement(TSqlParser::Execute_statementContext *ctx)
 		if ((pg_strncasecmp(name.c_str(), "dbo.sp_", 6) == 0) || (pg_strncasecmp(name.c_str(), "sys.sp_", 6) == 0))
 			name.erase(name.begin() + 0, name.begin() + 4);
 
-		if (is_sp_proc(name))
-			return makeSpStatement(name, func_proc_args, lineno, return_code_dno);
-
 		auto *localID = body->return_status ? body->LOCAL_ID()[0] : nullptr;
 		if (localID)
 			return_code_dno = getVarno(localID);
+
+		if (is_sp_proc(name))
+			return makeSpStatement(name, func_proc_args, lineno, return_code_dno);
 
 		PLtsql_stmt_exec *result = (PLtsql_stmt_exec *) palloc0(sizeof(*result));
 		result->cmd_type = PLTSQL_STMT_EXEC;

--- a/test/JDBC/expected/TestSPExecutesql.out
+++ b/test/JDBC/expected/TestSPExecutesql.out
@@ -177,6 +177,48 @@ datetime#!#datetime
 ~~END~~
 
 
+/* 8. Prefixed with dbo.<> and sys.<> */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC dbo.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC sys.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+/* 9. With omitted database and schema name */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .dbo.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .sys.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
 /* Exceptions */
 /* 1. Wrong order of named/unnamed params */
 DECLARE @SQLString NVARCHAR(100);

--- a/test/JDBC/expected/TestSPExecutesql.out
+++ b/test/JDBC/expected/TestSPExecutesql.out
@@ -219,6 +219,16 @@ hello world
 ~~END~~
 
 
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC ..sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
 /* Exceptions */
 /* 1. Wrong order of named/unnamed params */
 DECLARE @SQLString NVARCHAR(100);

--- a/test/JDBC/input/storedProcedures/TestSPExecutesql.sql
+++ b/test/JDBC/input/storedProcedures/TestSPExecutesql.sql
@@ -118,6 +118,28 @@ EXEC sp_executesql @SQLString, @ParamDef, @a = @p1 OUT, @b = @p2 OUT;
 SELECT @p1, @p2;
 go
 
+/* 8. Prefixed with dbo.<> and sys.<> */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC dbo.sp_executesql @SQLString;
+go
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC sys.sp_executesql @SQLString;
+go
+
+/* 9. With omitted database and schema name */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .dbo.sp_executesql @SQLString;
+go
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .sys.sp_executesql @SQLString;
+go
+
 /* Exceptions */
 /* 1. Wrong order of named/unnamed params */
 DECLARE @SQLString NVARCHAR(100);

--- a/test/JDBC/input/storedProcedures/TestSPExecutesql.sql
+++ b/test/JDBC/input/storedProcedures/TestSPExecutesql.sql
@@ -140,6 +140,11 @@ SET @SQLString = N'SELECT N''hello world'';';
 EXEC .sys.sp_executesql @SQLString;
 go
 
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC ..sp_executesql @SQLString;
+go
+
 /* Exceptions */
 /* 1. Wrong order of named/unnamed params */
 DECLARE @SQLString NVARCHAR(100);


### PR DESCRIPTION
### Description

sp_executesql throws error when prefixed with dbo. or sys.

### Issues Resolved

1. Built-in stored procedures starting with sp_* should execute when prefixed with dbo. or sys.
2. These procedures should work even if the database/schema name is omitted

Task: BABEL-4345
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based - Added**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



