### PR TITLE
Added the fix for column and table aliases contain single and multibyte characters.

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1275,7 +1275,7 @@ find_attr_by_name_from_relation(Relation rd, const char *attname, bool sysColOK)
 
 static void
 pre_transform_target_entry(ResTarget *res, ParseState *pstate,
-						ParseExprKind exprKind)
+							ParseExprKind exprKind)
 {
 	if (prev_pre_transform_target_entry_hook)
 		(*prev_pre_transform_target_entry_hook) (res, pstate, exprKind);
@@ -1321,7 +1321,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 		/*
 		 * Case 1 : Handle both singlebyte and multibyte aliases when delimited by 
 		 * square bracket(sqb) and double quoutes(dq).
-		 * For instance, queries like : SELECT 1 AS '您对“数据一览“中的车型，颜色，内饰，选装, ';
+		 * For instance, queries like : SELECT 1 AS "您对“数据一览“中的车型，颜色，内饰，选选装";
 		 * Case 2 : Preserve the case of aliases with ascii characters when there is no sqb and dq.
 		 * For instance, queries like: SELECT 1 AS ABCD;
 		 * Case 3 : Handle both singlebyte and multibyte aliases whose length is

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1326,7 +1326,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 		 * For instance, queries like: SELECT 1 AS ABCD;
 		 * Case 3 : Handle both singlebyte and multibyte aliases whose length is
 		 * more than or equals to 63 when not delimited by sqb and dq.
-		 * For instance, queries like : SELECT 1 AS 您对您对您对您对您对您对您对您对您对您对您对您对您对;
+		 * For example, queries like : SELECT 1 AS 您对您对您对您对您对您对您对您对您对您对您对您对您对;
 		 */
 		if (alias_len > 0)
 		{

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1317,72 +1317,64 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			alias_len = strlen(res->name);
 			colname_start = pstate->p_sourcetext + res->name_location;
 		}
-
 		if (alias_len > 0)
-		{
-			char	   *alias = palloc0(alias_len + 1);
-			bool		dq = *colname_start == '"';
-			bool		sqb = *colname_start == '[';
-			bool		sq = *colname_start == '\'';
-			int			a = 0;
-			const char *colname_end;
-			bool		closing_quote_reached = false;
+        {
+            char       *alias = palloc0(alias_len + 1);
+            bool        dq = *colname_start == '"';
+            bool        sqb = *colname_start == '[';
+            bool        sq = *colname_start == '\'';
+            bool        identifier_truncated;
+            const char *colname_end;
 
-			if (dq || sqb || sq)
-			{
-				colname_start++;
-			}
+            if (dq || sqb)
+            {
+                memcpy(alias, identifier_name, alias_len);
+            }
+            else
+            {
+                if(sq)
+                {
+                    colname_start++;
+                }
+                /*
+                * After truncation, maximum truncated length of alias can be 60
+                * If length is less than 60, it means alias is not truncated
+                */
+                if(alias_len < 60){
+                    memcpy(alias, colname_start, alias_len);
+                }
+                else
+                {
+                    /*
+                    * To check whether last 32 bytes are equal to identifier_name or not.
+                    * If they are not equal, this means identifier_name is truncated
+                    */
 
-			if (dq || sq)
-			{
-
-				for (colname_end = colname_start; a < alias_len; colname_end++)
-				{
-					if (dq && *colname_end == '"')
-					{
-						if ((*(++colname_end) != '"'))
-						{
-							closing_quote_reached = true;
-							break;	/* end of dbl-quoted identifier */
-						}
-					}
-					else if (sq && *colname_end == '\'')
-					{
-						if ((*(++colname_end) != '\''))
-						{
-							closing_quote_reached = true;
-							break;	/* end of single-quoted identifier */
-						}
-					}
-
-					alias[a++] = *colname_end;
-				}
-
-				/* Assert(a == alias_len); */
-			}
-			else
-			{
-				colname_end = colname_start + alias_len;
-				memcpy(alias, colname_start, alias_len);
-			}
-
-			/*
-			 * If the end of the string is a uniquifier, then copy the
-			 * uniquifier into the last 32 characters of the alias
-			 */
-			if (alias_len == NAMEDATALEN - 1 &&
-				(((sq || dq) && !closing_quote_reached) ||
-				 is_identifier_char(*colname_end)))
-
-			{
-				memcpy(alias + (NAMEDATALEN - 1) - 32,
-					   identifier_name + (NAMEDATALEN - 1) - 32,
-					   32);
-				alias[NAMEDATALEN] = '\0';
-			}
-
-			res->name = alias;
-		}
+                    for(int x = alias_len - 32; x < alias_len; x++){
+                        colname_end = colname_start + x;
+                        if((*colname_end == identifier_name[x] || *colname_end == toupper(identifier_name[x])))
+                        {
+                            identifier_truncated = false;
+                        }
+                        else
+                        {
+                            identifier_truncated = true;
+                            memcpy(alias, colname_start, (alias_len - 32) );
+                            memcpy(alias + (alias_len + 1 - 1) - 32,
+                            identifier_name + (alias_len + 1 - 1) - 32, 
+                            32);
+                            alias[alias_len+1] = '\0';
+                            break;
+                        }   
+                    }
+                    /* Idenfier is not truncated */
+                    if(!(identifier_truncated)){
+                        memcpy(alias, colname_start, alias_len);
+                    }
+                }
+            }
+            res->name = alias;
+        }		
 	}
 	/* Update table set qualified column name, resolve qualifiers here */
 	else if (exprKind == EXPR_KIND_UPDATE_SOURCE && res->indirection)

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1275,7 +1275,7 @@ find_attr_by_name_from_relation(Relation rd, const char *attname, bool sysColOK)
 
 static void
 pre_transform_target_entry(ResTarget *res, ParseState *pstate,
-							ParseExprKind exprKind)
+						   ParseExprKind exprKind)
 {
 	if (prev_pre_transform_target_entry_hook)
 		(*prev_pre_transform_target_entry_hook) (res, pstate, exprKind);
@@ -1330,13 +1330,13 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 		 */
 		if (alias_len > 0)
 		{
-			char       *alias = palloc0(alias_len + 1);
-			bool        dq = *colname_start == '"';
-			bool        sqb = *colname_start == '[';
-			bool        sq = *colname_start == '\'';
-			bool        identifier_truncated;
+			char	   *alias = palloc0(alias_len + 1);
+			bool		dq = *colname_start == '"';
+			bool		sqb = *colname_start == '[';
+			bool		sq = *colname_start == '\'';
+			bool		identifier_truncated;
 			const char *colname_end;
-			bool        enc_is_single_byte;
+			bool		enc_is_single_byte;
 			enc_is_single_byte = pg_database_encoding_max_length() == 1;
 
 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1352,17 +1352,17 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 					colname_start++;
 				}
 				/*
-				 * After truncation, maximum truncated length of alias can be 60
-				 * If length is less than 60, it means alias is not truncated.
+				 * After truncation, minimum truncated length of alias can be 61
+				 * If length is less than 61, it means alias is not truncated.
 				 */
-				if(alias_len < 60)
+				if(alias_len < 61)
 				{
 					memcpy(alias, colname_start, alias_len);
 				}
 				else
 				{
 					/*
-					 * For aliases whose length is between 60 to 63, the case of multibyte and single byte
+					 * For aliases whose length is between 61 to 63, the case of multibyte and single byte
 					 * characters are handled separately.
 					 * It is needed to check whether last 32 bytes are equal to identifier_name or not,
 					 * because last 32 bytes would be MD5 hash in case of truncated identifier and 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1334,7 +1334,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			bool		dq = *colname_start == '"';
 			bool		sqb = *colname_start == '[';
 			bool		sq = *colname_start == '\'';
-			bool		identifier_truncated;
+			bool		identifier_truncated = false;
 			const char *colname_end;
 			bool		enc_is_single_byte;
 			enc_is_single_byte = pg_database_encoding_max_length() == 1;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1362,7 +1362,9 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
                     /*
                      * For aliases whose length is between 60 to 63, the case of multibyte and single byte
                      * characters are handled separately.
-                     * It is needed to check whether last 32 bytes are equal to identifier_name or not.
+                     * It is needed to check whether last 32 bytes are equal to identifier_name or not,
+					 * because last 32 bytes would be MD5 hash in case of truncated identifier and 
+					 * we can leverage the fact that MD5 hash would be different from original identifier.
                      * If they are not equal, this means identifier_name is truncated.
                      */
                     for(int x = alias_len - 32; x < alias_len; x++){
@@ -1376,6 +1378,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
                          */ 
                         if (*colname_end >= 'A' && *colname_end <= 'Z')
                         {
+							/* If original letter is in upper case then check it with upper case letter of identifier_name.*/
                             if (!(*colname_end == identifier_name[x] + 'A' - 'a'))
                             {
                                 identifier_truncated = true;
@@ -1392,6 +1395,9 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
                         }
                         else
                         {
+							/* Original letter is already in lower case or it could be fractional byte of multibyte char. 
+							 * So it should match with original byte in either case.
+							 */
                             if(!(*colname_end == identifier_name[x]))
                             {
                                 identifier_truncated = true;

--- a/test/JDBC/expected/BABEL-4231-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4231-vu-cleanup.out
@@ -1,0 +1,151 @@
+-- tsql
+DROP VIEW view_babel_4231_1;
+GO
+
+DROP VIEW view_babel_4231_2;
+GO
+
+DROP VIEW view_babel_4231_3;
+GO
+
+DROP VIEW view_babel_4231_4;
+GO
+
+DROP VIEW view_babel_4231_5;
+GO
+
+DROP VIEW view_babel_4231_6;
+GO
+
+DROP VIEW view_babel_4231_7;
+GO
+
+DROP VIEW view_babel_4231_8;
+GO
+
+DROP VIEW view_babel_4231_9;
+GO
+
+DROP VIEW view_babel_4231_10;
+GO
+
+DROP VIEW view_babel_4231_11;
+GO
+
+DROP VIEW view_babel_4231_12;
+GO
+
+DROP VIEW view_babel_4231_13;
+GO
+
+DROP VIEW view_babel_4231_14;
+GO
+
+DROP VIEW view_babel_4231_15;
+GO
+
+DROP VIEW view_babel_4231_16;
+GO
+
+DROP VIEW view_babel_4231_17;
+GO
+
+DROP VIEW view_babel_4231_18;
+GO
+
+DROP VIEW view_babel_4231_19;
+GO
+DROP TABLE table1_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_20;
+GO
+DROP TABLE table2_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_21;
+GO
+DROP TABLE table3_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_22;
+GO
+DROP TABLE table4_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_23;
+GO
+DROP TABLE table5_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_24;
+GO
+DROP TABLE table6_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_25;
+GO
+DROP TABLE table7_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_26;
+GO
+DROP TABLE table8_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_27;
+GO
+DROP TABLE table9_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_28;
+GO
+DROP TABLE table10_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_29;
+GO
+DROP TABLE table11_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_30;
+GO
+DROP TABLE table12_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_31;
+GO
+DROP TABLE table13_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_32;
+GO
+DROP TABLE table14_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_33;
+GO
+DROP TABLE table15_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_34;
+GO
+DROP TABLE table16_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_35;
+GO
+DROP TABLE table17_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_36;
+GO
+
+DROP VIEW view_babel_4231_37;
+GO
+
+DROP VIEW view_babel_4231_38;
+GO
+
+DROP VIEW view_babel_4231_39;
+GO

--- a/test/JDBC/expected/BABEL-4231-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4231-vu-cleanup.out
@@ -149,3 +149,8 @@ GO
 
 DROP VIEW view_babel_4231_39;
 GO
+
+DROP VIEW view_babel_4231_40;
+GO
+DROP TABLE table18_babel_4231;
+GO

--- a/test/JDBC/expected/BABEL-4231-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4231-vu-prepare.out
@@ -1,0 +1,258 @@
+-- tsql
+-- column aliases with english characters whose length is less than 64
+CREATE VIEW view_babel_4231_1 AS SELECT 1 AS "AbcdE";
+GO
+
+-- tsql
+-- column aliases with english characters whose length is more than or equals 64
+CREATE VIEW view_babel_4231_2 AS SELECT 1 AS "AbnkxalnclKSNcfjNAJCb jdsb;FCBouiwehyriuoqjhINCKSJBDCJS csjkndbcjsdbcjsNDJFKWcdE";
+GO
+
+-- tsql
+-- column aliases with english characters whose length is more than or equals 64
+CREATE VIEW view_babel_4231_3 AS SELECT 1 AS [AbnkxalnclKSNcfjNAJCb jdsb;FCBouiwehyriuoqjhINCKSJBDCJS csjkndbcjsdbcjsND];
+GO
+
+
+-- tsql
+-- column aliases with chinese characters whose length is less than 64
+CREATE VIEW view_babel_4231_4 AS SELECT 1 AS "您对“数";
+GO
+
+
+-- tsql
+-- column aliases with chinese characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_5 AS SELECT 1 AS "您对“数据一览“中的车型，颜色，内饰，选装, ";
+GO
+
+
+-- tsql
+-- column aliases with chinese characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_6 AS SELECT 1 AS [您对“数据一览“中的车型，颜色，内饰，选装, ];
+GO
+
+
+-- tsql
+-- column aliases with japanese characters whose length is less than 64
+CREATE VIEW view_babel_4231_7 AS SELECT 1 AS " ぁ あ ";
+GO
+
+
+-- tsql
+-- column aliases with japanese characters whose length is less than 64
+CREATE VIEW view_babel_4231_8 AS SELECT 1 AS [ぁ あ ];
+GO
+
+
+-- tsql
+-- column aliases with japanese characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_9 AS SELECT 1 AS " ぁ あ ぃ い ぅ う ぇ え ぉ せ ぜ す じ し ざ さ ゑ ス ウ ゎ ぺ";
+GO
+
+-- tsql
+-- column aliases with korean characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_10 AS SELECT 1 AS "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎㅏ ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ";
+GO
+
+
+-- tsql
+-- column aliases with korean characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_11 AS SELECT 1 AS [ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎㅏ ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ];
+GO
+
+
+-- tsql
+-- column aliases with korean characters whose length is less than 64
+CREATE VIEW view_babel_4231_12 AS SELECT 1 AS "ㄴ ㄷ ㄹ ㅁ";
+GO
+
+
+-- tsql
+-- column aliases with arabic characters whose length is less than 64
+CREATE VIEW view_babel_4231_13 AS SELECT 1 AS "خ	ذ	ض	ظ";
+GO
+
+
+-- tsql
+-- column aliases with arabic characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_14 AS SELECT 1 AS "ج	د	ه	و	ز	ح	ط	ي	ك	ل	م	ن	س	ع	ف	ص	ق	ر	ش	ت	ث	خ	ذ	ض	ظ	غ";
+GO
+
+
+-- tsql
+-- column aliases with polish characters whose length is less than 64
+CREATE VIEW view_babel_4231_15 AS SELECT 1 AS [ĄĆĘŁŃÓŚŹŻąćęłńóśź];
+GO
+
+
+-- tsql
+-- column aliases with polish characters whose length is less than 64
+CREATE VIEW view_babel_4231_16 AS SELECT 1 AS "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+GO
+
+
+-- tsql
+-- column aliases with greek characters whose length is less than 64
+CREATE VIEW view_babel_4231_17 AS SELECT 1 AS "αΒβΓγΔδΕε";
+GO
+
+
+-- tsql
+-- column aliases with greek characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_18 AS SELECT 1 AS "αΒβΓγΔδΕεΖζ ΗηΘΙιΚ κ, Λ λ, Μ μ, Ν ν, Ξ ξ, Ο ο, Π π, Ρ ρ, Σ σ/ς, Τ τ, Υ υ, Φ φ, Χ χ, Ψ ψ";
+GO
+
+
+-- tsql
+-- table aliases with english characters whose length is less than 64
+CREATE TABLE table1_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_19 AS SELECT * FROM table1_babel_4231 as "abndand_dkandf""";
+GO
+
+
+-- tsql
+-- table aliases with english characters whose length is more than or equals 64
+CREATE TABLE table2_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_20 AS SELECT * FROM table2_babel_4231 AS "AbnkxalnclKSNcfjNAJCb jdsb;FCBouiwehyriuoqjhINCKSJBDCJS csjkndbcjsdbcjsNDJFKWcdE";
+GO
+
+
+-- tsql
+-- table aliases with chinese characters whose length is less than 64
+CREATE TABLE table3_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_21 AS SELECT * FROM table3_babel_4231 AS "您对数";
+GO
+
+
+-- tsql
+-- table aliases with chinese characters whose length is less than 64
+CREATE TABLE table4_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_22 AS SELECT * FROM table4_babel_4231 AS [您对数];
+GO
+
+
+-- tsql
+-- table aliases with chinese characters whose length is greater than or equals to 64
+CREATE TABLE table5_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_23 AS SELECT * FROM table5_babel_4231 AS "您对“数据一览“中的车型，颜色，内饰，选装";
+GO
+
+
+-- tsql
+-- table aliases with japanese characters whose length is less than 64
+CREATE TABLE table6_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_24 AS SELECT * FROM table6_babel_4231 AS " ぁ あ";
+GO
+
+
+-- tsql
+-- table aliases with japanese characters whose length is more than or equals to 64
+CREATE TABLE table7_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_25 AS SELECT * FROM table7_babel_4231 AS "ぁ あ ぃ い ぅ う ぇ え ぉ せ ぜ す じ し ざ さ ゑ ス ウ ゎ ぺ";
+GO
+
+
+-- tsql
+-- table aliases with japanese characters whose length is more than or equals to 64
+CREATE TABLE table8_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_26 AS SELECT * FROM table8_babel_4231 AS [ぁ あ ぃ い ぅ う ぇ え ぉ せ ぜ す じ し ざ さ ゑ ス ウ ゎ ぺ];
+GO
+
+
+-- tsql
+-- table aliases with korean characters whose length is less than 64
+CREATE TABLE table9_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_27 AS SELECT * FROM table9_babel_4231 AS "ㄱ ㄴ ㄷ ㄹ";
+GO
+
+
+-- tsql
+-- table aliases with korean characters whose length is less than 64
+CREATE TABLE table10_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_28 AS SELECT * FROM table10_babel_4231 AS [ㄱ ㄴ ㄷ ㄹ];
+GO
+
+
+-- tsql
+-- table aliases with korean characters whose length is more than or equals to 64
+CREATE TABLE table11_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_29 AS SELECT * FROM table11_babel_4231 AS "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎㅏ ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ";
+GO
+
+-- tsql
+-- table aliases with arabic characters whose length is less than 64
+CREATE TABLE table12_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_30 AS SELECT * FROM table12_babel_4231 AS "خ	ذ	ض	ظ";
+GO
+
+
+-- tsql
+-- table aliases with arabic characters whose length is more than or equals to 64
+CREATE TABLE table13_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_31 AS SELECT * FROM table13_babel_4231 AS "ج	د	ه	و	ز	ح	ط	ي	ك	ل	م	ن	س	ع	ف	ص	ق	ر	ش	ت	ث	خ	ذ	ض	ظ	غ";
+GO
+
+
+-- tsql
+-- table aliases with polish characters whose length is less than 64
+CREATE TABLE table14_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_32 AS SELECT * FROM table14_babel_4231 AS "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+GO
+
+
+-- tsql
+-- table aliases with greek characters whose length is less than 64
+CREATE TABLE table15_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_33 AS SELECT * FROM table15_babel_4231 AS "αΒβΓγΔδΕε";
+GO
+
+
+-- tsql
+-- table aliases with greek characters whose length is less than 64
+CREATE TABLE table16_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_34 AS SELECT * FROM table16_babel_4231 AS [αΒβΓγΔδΕε];
+GO
+
+
+-- tsql
+-- table aliases with greek characters whose length is more than or equals to 64
+CREATE TABLE table17_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_35 AS SELECT * FROM table17_babel_4231 AS "αΒβΓγΔδΕεΖζ ΗηΘΙιΚ κ, Λ λ, Μ μ, Ν ν, Ξ ξ, Ο ο, Π π, Ρ ρ, Σ σ/ς, Τ τ, Υ υ, Φ φ, Χ χ, Ψ ψ";
+GO
+
+-- tsql
+-- table aliases which are not delimited by double quote, square bracket and length is less than 64
+CREATE VIEW view_babel_4231_36 AS SELECT 1 AS ABCD;
+GO
+
+-- tsql
+-- table aliases with single byte characters which are not delimited by double quote, square bracket and length is more than or equals to 64
+CREATE VIEW view_babel_4231_37 AS SELECT 1 AS ABCDbdjaBFWFGRUWlgrefwfiwuegfdvfwefgvggfedfudywtitewutgfdWUIF;
+GO
+
+-- tsql
+-- table aliases with single byte characters which are delimited by single quote and length is more than or equals to 64
+CREATE VIEW view_babel_4231_38 AS SELECT 1 AS 'ABCDbdjaBFWFGRUWlgrefwfiwuegfdvfwefgvggfedfudywtitewutgfdWUIF';
+GO
+
+-- tsql
+-- table aliases with single byte characters which are delimited by single quote and length is less than 64
+CREATE VIEW view_babel_4231_39 AS SELECT 1 AS N'ANfjws';
+GO

--- a/test/JDBC/expected/BABEL-4231-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4231-vu-prepare.out
@@ -256,3 +256,10 @@ GO
 -- table aliases with single byte characters which are delimited by single quote and length is less than 64
 CREATE VIEW view_babel_4231_39 AS SELECT 1 AS N'ANfjws';
 GO
+
+-- tsql
+-- table aliases with chinese characters whose length is more than or equals to 64
+CREATE TABLE table18_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_40 AS SELECT 您您对您对您对您对您对您对您对您对您对您您您.* FROM table18_babel_4231 AS 您您对您对您对您对您对您对您对您对您对您您您;
+GO

--- a/test/JDBC/expected/BABEL-4231-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4231-vu-verify.out
@@ -1,0 +1,350 @@
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_1';
+GO
+~~START~~
+text
+ SELECT 1 AS "AbcdE";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_2';
+GO
+~~START~~
+text
+ SELECT 1 AS "AbnkxalnclKSNcfjNAJCb jdsb;FCBo3230b498a93d3d3c201b75df000f7422";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_3';
+GO
+~~START~~
+text
+ SELECT 1 AS "AbnkxalnclKSNcfjNAJCb jdsb;FCBo98276e81604b6c8f5b25ae3f87180e62";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_4';
+GO
+~~START~~
+text
+ SELECT 1 AS "您对“数";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_5';
+GO
+~~START~~
+text
+ SELECT 1 AS "您对“数据一览“中的f14d4ea72c5ab09dd327efc75f66d708";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_6';
+GO
+~~START~~
+text
+ SELECT 1 AS "您对“数据一览“中的f14d4ea72c5ab09dd327efc75f66d708";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_7';
+GO
+~~START~~
+text
+ SELECT 1 AS " ぁ あ ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_8';
+GO
+~~START~~
+text
+ SELECT 1 AS "ぁ あ ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_9';
+GO
+~~START~~
+text
+ SELECT 1 AS " ぁ あ ぃ い ぅ う ぇ 837c554dda804e3ffe7d700d76c55bc0";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_10';
+GO
+~~START~~
+text
+ SELECT 1 AS "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ8522e1e3c9eb50a92076a5c0c105a0d6";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_11';
+GO
+~~START~~
+text
+ SELECT 1 AS "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ8522e1e3c9eb50a92076a5c0c105a0d6";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_12';
+GO
+~~START~~
+text
+ SELECT 1 AS "ㄴ ㄷ ㄹ ㅁ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_13';
+GO
+~~START~~
+text
+ SELECT 1 AS "خ	ذ	ض	ظ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_14';
+GO
+~~START~~
+text
+ SELECT 1 AS "ج	د	ه	و	ز	ح	ط	ي	ك	ل	17a5c50aadee4e5fc6ccb1f1f70dd4f8";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_15';
+GO
+~~START~~
+text
+ SELECT 1 AS "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_16';
+GO
+~~START~~
+text
+ SELECT 1 AS "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_17';
+GO
+~~START~~
+text
+ SELECT 1 AS "αΒβΓγΔδΕε";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_18';
+GO
+~~START~~
+text
+ SELECT 1 AS "αΒβΓγΔδΕεΖζ ΗηΘΙc65025c8691f705f084f6d40aa6e076c";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_19';
+GO
+~~START~~
+text
+ SELECT "abndand_dkandf""".a,<newline>    "abndand_dkandf""".b<newline>   FROM master_dbo.table1_babel_4231 "abndand_dkandf""";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_20';
+GO
+~~START~~
+text
+ SELECT "abnkxalnclksncfjnajcb jdsb;fcbo3230b498a93d3d3c201b75df000f7422".a,<newline>    "abnkxalnclksncfjnajcb jdsb;fcbo3230b498a93d3d3c201b75df000f7422".b<newline>   FROM master_dbo.table2_babel_4231 "abnkxalnclksncfjnajcb jdsb;fcbo3230b498a93d3d3c201b75df000f7422";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_21';
+GO
+~~START~~
+text
+ SELECT "您对数".a,<newline>    "您对数".b<newline>   FROM master_dbo.table3_babel_4231 "您对数";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_22';
+GO
+~~START~~
+text
+ SELECT "您对数".a,<newline>    "您对数".b<newline>   FROM master_dbo.table4_babel_4231 "您对数";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_23';
+GO
+~~START~~
+text
+ SELECT "您对“数据一览“中的车型，颜色，内饰，选装".a,<newline>    "您对“数据一览“中的车型，颜色，内饰，选装".b<newline>   FROM master_dbo.table5_babel_4231 "您对“数据一览“中的车型，颜色，内饰，选装";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_24';
+GO
+~~START~~
+text
+ SELECT " ぁ あ".a,<newline>    " ぁ あ".b<newline>   FROM master_dbo.table6_babel_4231 " ぁ あ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_25';
+GO
+~~START~~
+text
+ SELECT "ぁ あ ぃ い ぅ う ぇ え0ee571349edc4237ec58683730cf1445".a,<newline>    "ぁ あ ぃ い ぅ う ぇ え0ee571349edc4237ec58683730cf1445".b<newline>   FROM master_dbo.table7_babel_4231 "ぁ あ ぃ い ぅ う ぇ え0ee571349edc4237ec58683730cf1445";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_26';
+GO
+~~START~~
+text
+ SELECT "ぁ あ ぃ い ぅ う ぇ え0ee571349edc4237ec58683730cf1445".a,<newline>    "ぁ あ ぃ い ぅ う ぇ え0ee571349edc4237ec58683730cf1445".b<newline>   FROM master_dbo.table8_babel_4231 "ぁ あ ぃ い ぅ う ぇ え0ee571349edc4237ec58683730cf1445";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_27';
+GO
+~~START~~
+text
+ SELECT "ㄱ ㄴ ㄷ ㄹ".a,<newline>    "ㄱ ㄴ ㄷ ㄹ".b<newline>   FROM master_dbo.table9_babel_4231 "ㄱ ㄴ ㄷ ㄹ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_28';
+GO
+~~START~~
+text
+ SELECT "ㄱ ㄴ ㄷ ㄹ".a,<newline>    "ㄱ ㄴ ㄷ ㄹ".b<newline>   FROM master_dbo.table10_babel_4231 "ㄱ ㄴ ㄷ ㄹ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_29';
+GO
+~~START~~
+text
+ SELECT "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ8522e1e3c9eb50a92076a5c0c105a0d6".a,<newline>    "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ8522e1e3c9eb50a92076a5c0c105a0d6".b<newline>   FROM master_dbo.table11_babel_4231 "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ8522e1e3c9eb50a92076a5c0c105a0d6";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_30';
+GO
+~~START~~
+text
+ SELECT "خ	ذ	ض	ظ".a,<newline>    "خ	ذ	ض	ظ".b<newline>   FROM master_dbo.table12_babel_4231 "خ	ذ	ض	ظ";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_31';
+GO
+~~START~~
+text
+ SELECT "ج	د	ه	و	ز	ح	ط	ي	ك	ل	17a5c50aadee4e5fc6ccb1f1f70dd4f8".a,<newline>    "ج	د	ه	و	ز	ح	ط	ي	ك	ل	17a5c50aadee4e5fc6ccb1f1f70dd4f8".b<newline>   FROM master_dbo.table13_babel_4231 "ج	د	ه	و	ز	ح	ط	ي	ك	ل	17a5c50aadee4e5fc6ccb1f1f70dd4f8";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_32';
+GO
+~~START~~
+text
+ SELECT "ĄĆĘŁŃÓŚŹŻąćęłńóśź".a,<newline>    "ĄĆĘŁŃÓŚŹŻąćęłńóśź".b<newline>   FROM master_dbo.table14_babel_4231 "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_33';
+GO
+~~START~~
+text
+ SELECT "αΒβΓγΔδΕε".a,<newline>    "αΒβΓγΔδΕε".b<newline>   FROM master_dbo.table15_babel_4231 "αΒβΓγΔδΕε";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_34';
+GO
+~~START~~
+text
+ SELECT "αΒβΓγΔδΕε".a,<newline>    "αΒβΓγΔδΕε".b<newline>   FROM master_dbo.table16_babel_4231 "αΒβΓγΔδΕε";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_35';
+GO
+~~START~~
+text
+ SELECT "αΒβΓγΔδΕεΖζ ΗηΘΙc65025c8691f705f084f6d40aa6e076c".a,<newline>    "αΒβΓγΔδΕεΖζ ΗηΘΙc65025c8691f705f084f6d40aa6e076c".b<newline>   FROM master_dbo.table17_babel_4231 "αΒβΓγΔδΕεΖζ ΗηΘΙc65025c8691f705f084f6d40aa6e076c";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_36';
+GO
+~~START~~
+text
+ SELECT 1 AS "ABCD";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_37';
+GO
+~~START~~
+text
+ SELECT 1 AS "ABCDbdjaBFWFGRUWlgrefwfiwuegfdvfwefgvggfedfudywtitewutgfdWUIF";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_38';
+GO
+~~START~~
+text
+ SELECT 1 AS "ABCDbdjaBFWFGRUWlgrefwfiwuegfdvfwefgvggfedfudywtitewutgfdWUIF";
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_39';
+GO
+~~START~~
+text
+ SELECT 1 AS "ANfjws";
+~~END~~
+

--- a/test/JDBC/expected/BABEL-4231-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4231-vu-verify.out
@@ -348,3 +348,12 @@ text
  SELECT 1 AS "ANfjws";
 ~~END~~
 
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_40';
+GO
+~~START~~
+text
+ SELECT "您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de".a,<newline>    "您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de".b<newline>   FROM master_dbo.table18_babel_4231 "您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de";
+~~END~~
+

--- a/test/JDBC/input/BABEL-4231-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-4231-vu-cleanup.mix
@@ -1,0 +1,151 @@
+-- tsql
+DROP VIEW view_babel_4231_1;
+GO
+
+DROP VIEW view_babel_4231_2;
+GO
+
+DROP VIEW view_babel_4231_3;
+GO
+
+DROP VIEW view_babel_4231_4;
+GO
+
+DROP VIEW view_babel_4231_5;
+GO
+
+DROP VIEW view_babel_4231_6;
+GO
+
+DROP VIEW view_babel_4231_7;
+GO
+
+DROP VIEW view_babel_4231_8;
+GO
+
+DROP VIEW view_babel_4231_9;
+GO
+
+DROP VIEW view_babel_4231_10;
+GO
+
+DROP VIEW view_babel_4231_11;
+GO
+
+DROP VIEW view_babel_4231_12;
+GO
+
+DROP VIEW view_babel_4231_13;
+GO
+
+DROP VIEW view_babel_4231_14;
+GO
+
+DROP VIEW view_babel_4231_15;
+GO
+
+DROP VIEW view_babel_4231_16;
+GO
+
+DROP VIEW view_babel_4231_17;
+GO
+
+DROP VIEW view_babel_4231_18;
+GO
+
+DROP VIEW view_babel_4231_19;
+GO
+DROP TABLE table1_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_20;
+GO
+DROP TABLE table2_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_21;
+GO
+DROP TABLE table3_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_22;
+GO
+DROP TABLE table4_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_23;
+GO
+DROP TABLE table5_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_24;
+GO
+DROP TABLE table6_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_25;
+GO
+DROP TABLE table7_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_26;
+GO
+DROP TABLE table8_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_27;
+GO
+DROP TABLE table9_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_28;
+GO
+DROP TABLE table10_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_29;
+GO
+DROP TABLE table11_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_30;
+GO
+DROP TABLE table12_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_31;
+GO
+DROP TABLE table13_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_32;
+GO
+DROP TABLE table14_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_33;
+GO
+DROP TABLE table15_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_34;
+GO
+DROP TABLE table16_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_35;
+GO
+DROP TABLE table17_babel_4231;
+GO
+
+DROP VIEW view_babel_4231_36;
+GO
+
+DROP VIEW view_babel_4231_37;
+GO
+
+DROP VIEW view_babel_4231_38;
+GO
+
+DROP VIEW view_babel_4231_39;
+GO

--- a/test/JDBC/input/BABEL-4231-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-4231-vu-cleanup.mix
@@ -149,3 +149,8 @@ GO
 
 DROP VIEW view_babel_4231_39;
 GO
+
+DROP VIEW view_babel_4231_40;
+GO
+DROP TABLE table18_babel_4231;
+GO

--- a/test/JDBC/input/BABEL-4231-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-4231-vu-prepare.mix
@@ -1,0 +1,258 @@
+-- tsql
+-- column aliases with english characters whose length is less than 64
+CREATE VIEW view_babel_4231_1 AS SELECT 1 AS "AbcdE";
+GO
+
+-- tsql
+-- column aliases with english characters whose length is more than or equals 64
+CREATE VIEW view_babel_4231_2 AS SELECT 1 AS "AbnkxalnclKSNcfjNAJCb jdsb;FCBouiwehyriuoqjhINCKSJBDCJS csjkndbcjsdbcjsNDJFKWcdE";
+GO
+
+-- tsql
+-- column aliases with english characters whose length is more than or equals 64
+CREATE VIEW view_babel_4231_3 AS SELECT 1 AS [AbnkxalnclKSNcfjNAJCb jdsb;FCBouiwehyriuoqjhINCKSJBDCJS csjkndbcjsdbcjsND];
+GO
+
+
+-- tsql
+-- column aliases with chinese characters whose length is less than 64
+CREATE VIEW view_babel_4231_4 AS SELECT 1 AS "您对“数";
+GO
+
+
+-- tsql
+-- column aliases with chinese characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_5 AS SELECT 1 AS "您对“数据一览“中的车型，颜色，内饰，选装, ";
+GO
+
+
+-- tsql
+-- column aliases with chinese characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_6 AS SELECT 1 AS [您对“数据一览“中的车型，颜色，内饰，选装, ];
+GO
+
+
+-- tsql
+-- column aliases with japanese characters whose length is less than 64
+CREATE VIEW view_babel_4231_7 AS SELECT 1 AS " ぁ あ ";
+GO
+
+
+-- tsql
+-- column aliases with japanese characters whose length is less than 64
+CREATE VIEW view_babel_4231_8 AS SELECT 1 AS [ぁ あ ];
+GO
+
+
+-- tsql
+-- column aliases with japanese characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_9 AS SELECT 1 AS " ぁ あ ぃ い ぅ う ぇ え ぉ せ ぜ す じ し ざ さ ゑ ス ウ ゎ ぺ";
+GO
+
+-- tsql
+-- column aliases with korean characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_10 AS SELECT 1 AS "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎㅏ ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ";
+GO
+
+
+-- tsql
+-- column aliases with korean characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_11 AS SELECT 1 AS [ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎㅏ ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ];
+GO
+
+
+-- tsql
+-- column aliases with korean characters whose length is less than 64
+CREATE VIEW view_babel_4231_12 AS SELECT 1 AS "ㄴ ㄷ ㄹ ㅁ";
+GO
+
+
+-- tsql
+-- column aliases with arabic characters whose length is less than 64
+CREATE VIEW view_babel_4231_13 AS SELECT 1 AS "خ	ذ	ض	ظ";
+GO
+
+
+-- tsql
+-- column aliases with arabic characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_14 AS SELECT 1 AS "ج	د	ه	و	ز	ح	ط	ي	ك	ل	م	ن	س	ع	ف	ص	ق	ر	ش	ت	ث	خ	ذ	ض	ظ	غ";
+GO
+
+
+-- tsql
+-- column aliases with polish characters whose length is less than 64
+CREATE VIEW view_babel_4231_15 AS SELECT 1 AS [ĄĆĘŁŃÓŚŹŻąćęłńóśź];
+GO
+
+
+-- tsql
+-- column aliases with polish characters whose length is less than 64
+CREATE VIEW view_babel_4231_16 AS SELECT 1 AS "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+GO
+
+
+-- tsql
+-- column aliases with greek characters whose length is less than 64
+CREATE VIEW view_babel_4231_17 AS SELECT 1 AS "αΒβΓγΔδΕε";
+GO
+
+
+-- tsql
+-- column aliases with greek characters whose length is greater than or equals to 64
+CREATE VIEW view_babel_4231_18 AS SELECT 1 AS "αΒβΓγΔδΕεΖζ ΗηΘΙιΚ κ, Λ λ, Μ μ, Ν ν, Ξ ξ, Ο ο, Π π, Ρ ρ, Σ σ/ς, Τ τ, Υ υ, Φ φ, Χ χ, Ψ ψ";
+GO
+
+
+-- tsql
+-- table aliases with english characters whose length is less than 64
+CREATE TABLE table1_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_19 AS SELECT * FROM table1_babel_4231 as "abndand_dkandf""";
+GO
+
+
+-- tsql
+-- table aliases with english characters whose length is more than or equals 64
+CREATE TABLE table2_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_20 AS SELECT * FROM table2_babel_4231 AS "AbnkxalnclKSNcfjNAJCb jdsb;FCBouiwehyriuoqjhINCKSJBDCJS csjkndbcjsdbcjsNDJFKWcdE";
+GO
+
+
+-- tsql
+-- table aliases with chinese characters whose length is less than 64
+CREATE TABLE table3_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_21 AS SELECT * FROM table3_babel_4231 AS "您对数";
+GO
+
+
+-- tsql
+-- table aliases with chinese characters whose length is less than 64
+CREATE TABLE table4_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_22 AS SELECT * FROM table4_babel_4231 AS [您对数];
+GO
+
+
+-- tsql
+-- table aliases with chinese characters whose length is greater than or equals to 64
+CREATE TABLE table5_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_23 AS SELECT * FROM table5_babel_4231 AS "您对“数据一览“中的车型，颜色，内饰，选装";
+GO
+
+
+-- tsql
+-- table aliases with japanese characters whose length is less than 64
+CREATE TABLE table6_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_24 AS SELECT * FROM table6_babel_4231 AS " ぁ あ";
+GO
+
+
+-- tsql
+-- table aliases with japanese characters whose length is more than or equals to 64
+CREATE TABLE table7_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_25 AS SELECT * FROM table7_babel_4231 AS "ぁ あ ぃ い ぅ う ぇ え ぉ せ ぜ す じ し ざ さ ゑ ス ウ ゎ ぺ";
+GO
+
+
+-- tsql
+-- table aliases with japanese characters whose length is more than or equals to 64
+CREATE TABLE table8_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_26 AS SELECT * FROM table8_babel_4231 AS [ぁ あ ぃ い ぅ う ぇ え ぉ せ ぜ す じ し ざ さ ゑ ス ウ ゎ ぺ];
+GO
+
+
+-- tsql
+-- table aliases with korean characters whose length is less than 64
+CREATE TABLE table9_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_27 AS SELECT * FROM table9_babel_4231 AS "ㄱ ㄴ ㄷ ㄹ";
+GO
+
+
+-- tsql
+-- table aliases with korean characters whose length is less than 64
+CREATE TABLE table10_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_28 AS SELECT * FROM table10_babel_4231 AS [ㄱ ㄴ ㄷ ㄹ];
+GO
+
+
+-- tsql
+-- table aliases with korean characters whose length is more than or equals to 64
+CREATE TABLE table11_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_29 AS SELECT * FROM table11_babel_4231 AS "ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎㅏ ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ";
+GO
+
+-- tsql
+-- table aliases with arabic characters whose length is less than 64
+CREATE TABLE table12_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_30 AS SELECT * FROM table12_babel_4231 AS "خ	ذ	ض	ظ";
+GO
+
+
+-- tsql
+-- table aliases with arabic characters whose length is more than or equals to 64
+CREATE TABLE table13_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_31 AS SELECT * FROM table13_babel_4231 AS "ج	د	ه	و	ز	ح	ط	ي	ك	ل	م	ن	س	ع	ف	ص	ق	ر	ش	ت	ث	خ	ذ	ض	ظ	غ";
+GO
+
+
+-- tsql
+-- table aliases with polish characters whose length is less than 64
+CREATE TABLE table14_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_32 AS SELECT * FROM table14_babel_4231 AS "ĄĆĘŁŃÓŚŹŻąćęłńóśź";
+GO
+
+
+-- tsql
+-- table aliases with greek characters whose length is less than 64
+CREATE TABLE table15_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_33 AS SELECT * FROM table15_babel_4231 AS "αΒβΓγΔδΕε";
+GO
+
+
+-- tsql
+-- table aliases with greek characters whose length is less than 64
+CREATE TABLE table16_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_34 AS SELECT * FROM table16_babel_4231 AS [αΒβΓγΔδΕε];
+GO
+
+
+-- tsql
+-- table aliases with greek characters whose length is more than or equals to 64
+CREATE TABLE table17_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_35 AS SELECT * FROM table17_babel_4231 AS "αΒβΓγΔδΕεΖζ ΗηΘΙιΚ κ, Λ λ, Μ μ, Ν ν, Ξ ξ, Ο ο, Π π, Ρ ρ, Σ σ/ς, Τ τ, Υ υ, Φ φ, Χ χ, Ψ ψ";
+GO
+
+-- tsql
+-- table aliases which are not delimited by double quote, square bracket and length is less than 64
+CREATE VIEW view_babel_4231_36 AS SELECT 1 AS ABCD;
+GO
+
+-- tsql
+-- table aliases with single byte characters which are not delimited by double quote, square bracket and length is more than or equals to 64
+CREATE VIEW view_babel_4231_37 AS SELECT 1 AS ABCDbdjaBFWFGRUWlgrefwfiwuegfdvfwefgvggfedfudywtitewutgfdWUIF;
+GO
+
+-- tsql
+-- table aliases with single byte characters which are delimited by single quote and length is more than or equals to 64
+CREATE VIEW view_babel_4231_38 AS SELECT 1 AS 'ABCDbdjaBFWFGRUWlgrefwfiwuegfdvfwefgvggfedfudywtitewutgfdWUIF';
+GO
+
+-- tsql
+-- table aliases with single byte characters which are delimited by single quote and length is less than 64
+CREATE VIEW view_babel_4231_39 AS SELECT 1 AS N'ANfjws';
+GO

--- a/test/JDBC/input/BABEL-4231-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-4231-vu-prepare.mix
@@ -256,3 +256,10 @@ GO
 -- table aliases with single byte characters which are delimited by single quote and length is less than 64
 CREATE VIEW view_babel_4231_39 AS SELECT 1 AS N'ANfjws';
 GO
+
+-- tsql
+-- table aliases with chinese characters whose length is more than or equals to 64
+CREATE TABLE table18_babel_4231(a INT , b INT);
+GO
+CREATE VIEW view_babel_4231_40 AS SELECT 您您对您对您对您对您对您对您对您对您对您您您.* FROM table18_babel_4231 AS 您您对您对您对您对您对您对您对您对您对您您您;
+GO

--- a/test/JDBC/input/BABEL-4231-vu-verify.mix
+++ b/test/JDBC/input/BABEL-4231-vu-verify.mix
@@ -153,3 +153,7 @@ GO
 -- psql
 SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_39';
 GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_40';
+GO

--- a/test/JDBC/input/BABEL-4231-vu-verify.mix
+++ b/test/JDBC/input/BABEL-4231-vu-verify.mix
@@ -1,0 +1,155 @@
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_1';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_2';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_3';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_4';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_5';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_6';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_7';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_8';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_9';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_10';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_11';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_12';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_13';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_14';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_15';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_16';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_17';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_18';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_19';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_20';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_21';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_22';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_23';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_24';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_25';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_26';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_27';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_28';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_29';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_30';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_31';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_32';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_33';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_34';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_35';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_36';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_37';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_38';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'view_babel_4231_39';
+GO


### PR DESCRIPTION
### Description

This pull request fixed the implementation for **column** and **table aliases** contain both single byte and multibyte characters whose length is more than 64 bytes for 14.latest version.

**Issue 1 :** Handle column and table aliases.
Column alias does not work when alias length is more than or equals to 64 bytes in case of multibyte aliases. When query select 1  as '您对“数据一览“中的车型，颜色，内饰，选装, '; executes through T-SQL endpoint, it causes client to hang and throws protocol error in TDS stream. The logic of [pre_transform_target_entry](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/babelfishpg_tsql/src/hooks.c#L1501C1-L1501C1) was not handling the aliases contain multibyte characters whose length is more than 64 bytes accurately and overwriting the alias name in case of truncation. To address this problem, I redefined the function and implemented the conditions which will handle aliases delimited with square bracket and double quotes separately with other aliases. In other aliases, I added the conditions which will handle both truncated and untruncated aliases separately.

**Issue 2 :** Aliases with multibyte chars cause MVU failure.
When establishing a view of alias with multibyte chars through T-SQL endpoint and retrieving it's definition from PG end point, extra unreadable chars are appearing at the end of the alias and even we can not use this view through tsql endpoint as it throws protocol error in TDS stream. But while we use similar alias on PG end point, we are able to retrieve it's correct definition. This discrepancy in behaviour is causing MVU failure. After implementing a fix, the correct alias definition is obtained from the PG endpoint, which rectifies the issue.

### Issues Resolved

BABEL-4231

Signed-off-by: Riya Jain <riyaajn@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).