### PR TITLE
sp_executesql throws error when prefixed with dbo. or sys. (#1811)

### DIFF
--- a/test/JDBC/expected/TestSPExecutesql.out
+++ b/test/JDBC/expected/TestSPExecutesql.out
@@ -177,6 +177,58 @@ datetime#!#datetime
 ~~END~~
 
 
+/* 8. Prefixed with dbo.<> and sys.<> */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC dbo.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC sys.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+/* 9. With omitted database and schema name */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .dbo.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .sys.sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC ..sp_executesql @SQLString;
+go
+~~START~~
+nvarchar
+hello world
+~~END~~
+
+
 /* Exceptions */
 /* 1. Wrong order of named/unnamed params */
 DECLARE @SQLString NVARCHAR(100);

--- a/test/JDBC/input/storedProcedures/TestSPExecutesql.sql
+++ b/test/JDBC/input/storedProcedures/TestSPExecutesql.sql
@@ -118,6 +118,33 @@ EXEC sp_executesql @SQLString, @ParamDef, @a = @p1 OUT, @b = @p2 OUT;
 SELECT @p1, @p2;
 go
 
+/* 8. Prefixed with dbo.<> and sys.<> */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC dbo.sp_executesql @SQLString;
+go
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC sys.sp_executesql @SQLString;
+go
+
+/* 9. With omitted database and schema name */
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .dbo.sp_executesql @SQLString;
+go
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC .sys.sp_executesql @SQLString;
+go
+
+DECLARE @SQLString NVARCHAR(100);
+SET @SQLString = N'SELECT N''hello world'';';
+EXEC ..sp_executesql @SQLString;
+go
+
 /* Exceptions */
 /* 1. Wrong order of named/unnamed params */
 DECLARE @SQLString NVARCHAR(100);


### PR DESCRIPTION


### Description

sp_executesql throws error when prefixed with dbo. or sys.

### Issues Resolved


1. Built-in stored procedures starting with sp_* should execute when prefixed with dbo. or sys.

2. These procedures should work even if the database/schema name is omitted

Task: BABEL-4345


### Test Scenarios Covered ###
* **Use case based - Added**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**
