### PR TITLE
Fixed handling of input arguments for ISNULL()

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -3,7 +3,7 @@ inputs:
   engine_branch:
     description: 'Engine Branch'
     required: no
-    default: 'latest'
+    default: 'jira-babel-971'
   install_dir:
     description: 'Engine install directory'
     required: no
@@ -23,14 +23,14 @@ runs:
         
         if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
           if [[ ${{inputs.engine_branch}} == "latest" ]]; then
-            ENGINE_BRANCH=$GITHUB_HEAD_REF
+            ENGINE_BRANCH='jira-babel-971'
           else
             ENGINE_BRANCH=${{inputs.engine_branch}}
           fi            
           REPOSITORY_OWNER=$HEAD_OWNER
         else
           if [[ ${{inputs.engine_branch}} == "latest" ]]; then
-            ENGINE_BRANCH=$GITHUB_REF_NAME
+            ENGINE_BRANCH='jira-babel-971'
           else
             ENGINE_BRANCH=${{inputs.engine_branch}}
           fi

--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -3,7 +3,7 @@ inputs:
   engine_branch:
     description: 'Engine Branch'
     required: no
-    default: 'jira-babel-971'
+    default: 'latest'
   install_dir:
     description: 'Engine install directory'
     required: no
@@ -23,14 +23,14 @@ runs:
         
         if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
           if [[ ${{inputs.engine_branch}} == "latest" ]]; then
-            ENGINE_BRANCH='jira-babel-971'
+            ENGINE_BRANCH=$GITHUB_HEAD_REF
           else
             ENGINE_BRANCH=${{inputs.engine_branch}}
           fi            
           REPOSITORY_OWNER=$HEAD_OWNER
         else
           if [[ ${{inputs.engine_branch}} == "latest" ]]; then
-            ENGINE_BRANCH='jira-babel-971'
+            ENGINE_BRANCH=$GITHUB_REF_NAME
           else
             ENGINE_BRANCH=${{inputs.engine_branch}}
           fi

--- a/.github/scripts/clone_engine_repo
+++ b/.github/scripts/clone_engine_repo
@@ -78,6 +78,10 @@ else
             BRANCH_OPTION=''
         fi
     fi
+    if [ "$BRANCH" = "jira-babel-971" ]; then
+        BASE_URL=https://github.com/amazon-aurora/postgresql_modified_for_babelfish
+        BRANCH_OPTION="--branch $BRANCH"
+    fi
 fi
 GIT_URL=${BASE_URL}.git
 

--- a/.github/scripts/clone_engine_repo
+++ b/.github/scripts/clone_engine_repo
@@ -78,10 +78,6 @@ else
             BRANCH_OPTION=''
         fi
     fi
-    if [ "$BRANCH" = "jira-babel-971" ]; then
-        BASE_URL=https://github.com/amazon-aurora/postgresql_modified_for_babelfish
-        BRANCH_OPTION="--branch $BRANCH"
-    fi
 fi
 GIT_URL=${BASE_URL}.git
 

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1571,8 +1571,7 @@ sp_datatype_info_helper(PG_FUNCTION_ARGS)
 	MemoryContext per_query_ctx;
 	MemoryContext oldcontext;
 	int			i;
-	Oid			nspoid = get_namespace_oid("sys", false);
-	Oid			sys_varcharoid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("varchar"), ObjectIdGetDatum(nspoid));
+	Oid			sys_varcharoid = get_sys_varcharoid();
 	Oid			colloid = tsql_get_server_collation_oid_internal(false);
 
 	/* check to see if caller supports us returning a tuplestore */

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -127,18 +127,7 @@ static void insert_pltsql_function_defaults(HeapTuple func_tuple, List *defaults
 static int	print_pltsql_function_arguments(StringInfo buf, HeapTuple proctup, bool print_table_args, bool print_defaults);
 static void pltsql_GetNewObjectId(VariableCache variableCache);
 static void pltsql_validate_var_datatype_scale(const TypeName *typeName, Type typ);
-<<<<<<< HEAD
-=======
-static bool pltsql_bbfCustomProcessUtility(ParseState *pstate,
-									  PlannedStmt *pstmt,
-									  const char *queryString,
-									  ProcessUtilityContext context,
-									  ParamListInfo params, QueryCompletion *qc);
-static void pltsql_bbfSelectIntoAddIdentity(IntoClause *into,  List *tableElts);
-extern void pltsql_bbfSelectIntoUtility(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, 
-					QueryEnvironment *queryEnv, ParamListInfo params, QueryCompletion *qc);
 static Oid select_common_type_for_isnull(ParseState *pstate, List *exprs);
->>>>>>> a011dec44 (Fixed handling of input arguments for ISNULL() (#1709))
 
 /*****************************************
  * 			Executor Hooks

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2011,6 +2011,7 @@ extern void remove_trailing_spaces(char *name);
 extern Oid	tsql_get_proc_nsp_oid(Oid object_id);
 extern Oid	tsql_get_constraint_nsp_oid(Oid object_id, Oid user_id);
 extern Oid	tsql_get_trigger_rel_oid(Oid object_id);
+extern Oid get_sys_varcharoid(void);
 
 typedef struct
 {

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -845,8 +845,7 @@ tsql_func_select_candidate(int nargs,
 	if (unknowns_resolved)
 	{
 		Oid		   *new_input_typeids = palloc(nargs * sizeof(Oid));
-		Oid			nspoid = get_namespace_oid("sys", false);
-		Oid			sys_varcharoid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("varchar"), ObjectIdGetDatum(nspoid));
+		Oid			sys_varcharoid = get_sys_varcharoid();
 
 		/*
 		 * For unknown literals, try the following orders: varchar -> text ->

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -35,18 +35,9 @@ bool		is_tsql_any_char_datatype(Oid oid); /* sys.char / sys.nchar /
 												 * sys.varchar / sys.nvarchar */
 bool		is_tsql_text_ntext_or_image_datatype(Oid oid);
 
-<<<<<<< HEAD
-=======
-bool
-pltsql_createFunction(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
-                          ParamListInfo params);
-
-extern bool restore_tsql_tabletype;
-
 /* To cache oid of sys.varchar */
 static Oid sys_varcharoid = InvalidOid;
 
->>>>>>> a011dec44 (Fixed handling of input arguments for ISNULL() (#1709))
 /*
  * Following the rule for locktag fields of advisory locks:
  *	field1: MyDatabaseId ... ensures locks are local to each database

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -35,6 +35,18 @@ bool		is_tsql_any_char_datatype(Oid oid); /* sys.char / sys.nchar /
 												 * sys.varchar / sys.nvarchar */
 bool		is_tsql_text_ntext_or_image_datatype(Oid oid);
 
+<<<<<<< HEAD
+=======
+bool
+pltsql_createFunction(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
+                          ParamListInfo params);
+
+extern bool restore_tsql_tabletype;
+
+/* To cache oid of sys.varchar */
+static Oid sys_varcharoid = InvalidOid;
+
+>>>>>>> a011dec44 (Fixed handling of input arguments for ISNULL() (#1709))
 /*
  * Following the rule for locktag fields of advisory locks:
  *	field1: MyDatabaseId ... ensures locks are local to each database
@@ -1322,4 +1334,22 @@ tsql_get_trigger_rel_oid(Oid object_id)
 	systable_endscan(tgscan);
 	table_close(tgrel, AccessShareLock);
 	return tgrelid;
+}
+
+Oid get_sys_varcharoid(void)
+{
+	Oid sys_oid;
+	if (OidIsValid(sys_varcharoid))
+	{
+		return sys_varcharoid;
+	}
+	sys_oid = get_namespace_oid("sys", false);
+	sys_varcharoid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("varchar"), ObjectIdGetDatum(sys_oid));
+	if (!OidIsValid(sys_varcharoid))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("Oid corresponding to sys.varchar datatype could not be found.")));
+	}
+	return sys_varcharoid;
 }

--- a/test/JDBC/expected/14_6__preparation__Test_ISNULL-vu-prepare.out
+++ b/test/JDBC/expected/14_6__preparation__Test_ISNULL-vu-prepare.out
@@ -1,0 +1,76 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "Unassigned")~~
+
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/expected/14_9__preparation__Test_ISNULL-vu-prepare.out
+++ b/test/JDBC/expected/14_9__preparation__Test_ISNULL-vu-prepare.out
@@ -1,0 +1,76 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "Unassigned")~~
+
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/expected/15_2__preparation__Test_ISNULL-vu-prepare.out
+++ b/test/JDBC/expected/15_2__preparation__Test_ISNULL-vu-prepare.out
@@ -1,0 +1,76 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "Unassigned")~~
+
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/expected/15_4__preparation__Test_ISNULL-vu-prepare.out
+++ b/test/JDBC/expected/15_4__preparation__Test_ISNULL-vu-prepare.out
@@ -1,0 +1,76 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "Unassigned")~~
+
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/expected/BABEL-2089.out
+++ b/test/JDBC/expected/BABEL-2089.out
@@ -369,7 +369,7 @@ go
 select * from babel_2089_OpsDbView
 go
 ~~START~~
-int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#datetime#!#datetime#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#nvarchar#!#int#!#int#!#nvarchar#!#int#!#int#!#int#!#int#!#varchar#!#datetime2#!#int#!#int#!#int#!#int#!#int#!#datetime2#!#int#!#varchar#!#varchar#!#int#!#varchar#!#int#!#varchar
+int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#datetime#!#datetime#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#nvarchar#!#int#!#int#!#nvarchar#!#int#!#int#!#int#!#int#!#varchar#!#datetime2#!#int#!#int#!#int#!#int#!#int#!#datetime2#!#int#!#varchar#!#varchar#!#int#!#nvarchar#!#int#!#varchar
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-3943.out
+++ b/test/JDBC/expected/BABEL-3943.out
@@ -16,11 +16,48 @@ GO
 
 
 -- tsql
+-- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
 GO
 ~~START~~
 numeric
+0.000000
+~~END~~
+
+
+-- TODO: Fix BABEL-4359
+SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1 AND   [owner_amounts].[tax] is not null
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+-- TODO: Fix BABEL-4359
+SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+-- TODO: Fix BABEL-4359
+SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1 AND   [owner_amounts].[tax] is not null
+GO
+~~START~~
+numeric
 0E-8
+~~END~~
+
+
+-- TODO: Fix BABEL-4359
+SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1
+GO
+~~START~~
+numeric
+0.000000
 ~~END~~
 
 
@@ -28,9 +65,8 @@ SELECT sum([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and
 GO
 ~~START~~
 numeric
-0E-8
+0.000000
 ~~END~~
-
 
 
 --cleanup

--- a/test/JDBC/expected/BABEL-4327.out
+++ b/test/JDBC/expected/BABEL-4327.out
@@ -1,0 +1,84 @@
+CREATE TABLE [dbo].[test_babel_4327_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id]));
+GO
+
+-- should be sys.varchar
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_babel_4327_table'
+	)
+);
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+INSERT INTO [dbo].[test_babel_4327_table]([my_varchar_data])VALUES ('1');
+INSERT INTO [dbo].[test_babel_4327_table]([my_varchar_data])VALUES ('HELLO');
+INSERT INTO [dbo].[test_babel_4327_table]([my_varchar_data])VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_babel_4327_table];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+<NULL>#!#Unassigned#!#HELLO#!#Unassigned#!#
+<NULL>#!#Unassigned#!#Unassigned#!#Unassigned#!#
+~~END~~
+
+
+select * from [dbo].[test_babel_4327_table] where ISNULL([my_varchar_data], [id]) = 'HELLO';
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+2#!#HELLO#!#HELLO
+~~END~~
+
+
+select * from [dbo].[test_babel_4327_table] where [my_computed_column] = 'HELLO';
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+2#!#HELLO#!#HELLO
+~~END~~
+
+
+select * from [dbo].[test_babel_4327_table] where ISNULL([my_varchar_data], [id]) = 'HeLLO';
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+2#!#HELLO#!#HELLO
+~~END~~
+
+
+select * from [dbo].[test_babel_4327_table] where [my_computed_column] = 'HeLLO';
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+2#!#HELLO#!#HELLO
+~~END~~
+
+
+DROP TABLE [dbo].[test_babel_4327_table];
+GO

--- a/test/JDBC/expected/Test_ISNULL-vu-cleanup.out
+++ b/test/JDBC/expected/Test_ISNULL-vu-cleanup.out
@@ -1,0 +1,35 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view6]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/expected/Test_ISNULL-vu-prepare.out
+++ b/test/JDBC/expected/Test_ISNULL-vu-prepare.out
@@ -1,0 +1,72 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/expected/Test_ISNULL-vu-verify.out
+++ b/test/JDBC/expected/Test_ISNULL-vu-verify.out
@@ -1,0 +1,204 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select * from [dbo].[test_isnull_table]
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+1#!#1#!#1
+2#!#<NULL>#!#2
+~~END~~
+
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+<NULL>#!#Unassigned#!#Unassigned#!#Unassigned#!#
+~~END~~
+
+
+select * from [dbo].[test_isnull_view];
+GO
+~~START~~
+varchar
+1
+2
+~~END~~
+
+
+select * from [dbo].[test_isnull_view1];
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view2];
+GO
+~~START~~
+bigint#!#varchar#!#varchar
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view3];
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from [dbo].[test_isnull_view4];
+GO
+~~START~~
+varchar
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view5];
+GO
+~~START~~
+varchar
+1
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view6];
+GO
+~~START~~
+varchar
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view7];
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view6'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select [dbo].[test_isnull_func1]();
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+exec [dbo].[test_isnull_proc1];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+~~END~~
+

--- a/test/JDBC/expected/latest__verification_cleanup__14_6__Test_ISNULL-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_6__Test_ISNULL-vu-cleanup.out
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/expected/latest__verification_cleanup__14_6__Test_ISNULL-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_6__Test_ISNULL-vu-verify.out
@@ -1,0 +1,181 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+bigint
+~~END~~
+
+
+select * from [dbo].[test_isnull_table]
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+2#!#<NULL>#!#2
+~~END~~
+
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+<NULL>#!#Unassigned#!#Unassigned#!#Unassigned#!#
+~~END~~
+
+
+select * from [dbo].[test_isnull_view];
+GO
+~~START~~
+bigint
+1
+2
+~~END~~
+
+
+select * from [dbo].[test_isnull_view1];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view2];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view3];
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from [dbo].[test_isnull_view4];
+GO
+~~START~~
+text
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view5];
+GO
+~~START~~
+varchar
+1
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view7];
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+text
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select [dbo].[test_isnull_func1]();
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+exec [dbo].[test_isnull_proc1];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+~~END~~
+

--- a/test/JDBC/expected/latest__verification_cleanup__14_9__Test_ISNULL-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_9__Test_ISNULL-vu-cleanup.out
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/expected/latest__verification_cleanup__14_9__Test_ISNULL-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_9__Test_ISNULL-vu-verify.out
@@ -1,0 +1,181 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+bigint
+~~END~~
+
+
+select * from [dbo].[test_isnull_table]
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+2#!#<NULL>#!#2
+~~END~~
+
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+<NULL>#!#Unassigned#!#Unassigned#!#Unassigned#!#
+~~END~~
+
+
+select * from [dbo].[test_isnull_view];
+GO
+~~START~~
+bigint
+1
+2
+~~END~~
+
+
+select * from [dbo].[test_isnull_view1];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view2];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view3];
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from [dbo].[test_isnull_view4];
+GO
+~~START~~
+text
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view5];
+GO
+~~START~~
+varchar
+1
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view7];
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+text
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select [dbo].[test_isnull_func1]();
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+exec [dbo].[test_isnull_proc1];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+~~END~~
+

--- a/test/JDBC/expected/latest__verification_cleanup__15_2__Test_ISNULL-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__15_2__Test_ISNULL-vu-cleanup.out
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/expected/latest__verification_cleanup__15_2__Test_ISNULL-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__15_2__Test_ISNULL-vu-verify.out
@@ -1,0 +1,181 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+bigint
+~~END~~
+
+
+select * from [dbo].[test_isnull_table]
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+2#!#<NULL>#!#2
+~~END~~
+
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+<NULL>#!#Unassigned#!#Unassigned#!#Unassigned#!#
+~~END~~
+
+
+select * from [dbo].[test_isnull_view];
+GO
+~~START~~
+bigint
+1
+2
+~~END~~
+
+
+select * from [dbo].[test_isnull_view1];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view2];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view3];
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from [dbo].[test_isnull_view4];
+GO
+~~START~~
+text
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view5];
+GO
+~~START~~
+varchar
+1
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view7];
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+text
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select [dbo].[test_isnull_func1]();
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+exec [dbo].[test_isnull_proc1];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+~~END~~
+

--- a/test/JDBC/expected/latest__verification_cleanup__15_4__Test_ISNULL-vu-cleanup.out
+++ b/test/JDBC/expected/latest__verification_cleanup__15_4__Test_ISNULL-vu-cleanup.out
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/expected/latest__verification_cleanup__15_4__Test_ISNULL-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__15_4__Test_ISNULL-vu-verify.out
@@ -1,0 +1,181 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+bigint
+~~END~~
+
+
+select * from [dbo].[test_isnull_table]
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+2#!#<NULL>#!#2
+~~END~~
+
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+<NULL>#!#Unassigned#!#Unassigned#!#Unassigned#!#
+~~END~~
+
+
+select * from [dbo].[test_isnull_view];
+GO
+~~START~~
+bigint
+1
+2
+~~END~~
+
+
+select * from [dbo].[test_isnull_view1];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view2];
+GO
+~~START~~
+bigint#!#varchar#!#bigint
+1#!#1#!#1
+~~END~~
+
+
+select * from [dbo].[test_isnull_view3];
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from [dbo].[test_isnull_view4];
+GO
+~~START~~
+text
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view5];
+GO
+~~START~~
+varchar
+1
+Unassigned
+~~END~~
+
+
+select * from [dbo].[test_isnull_view7];
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+text
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+varchar
+~~END~~
+
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+~~START~~
+text
+int
+~~END~~
+
+
+select [dbo].[test_isnull_func1]();
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
+exec [dbo].[test_isnull_proc1];
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#varchar
+<NULL>#!#Unassigned#!#1#!#Unassigned#!#
+~~END~~
+

--- a/test/JDBC/input/BABEL-3943.mix
+++ b/test/JDBC/input/BABEL-3943.mix
@@ -14,12 +14,28 @@ select 0,1,862 from generate_series(1,200000);
 GO
 
 -- tsql
+-- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
+GO
+
+-- TODO: Fix BABEL-4359
+SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1 AND   [owner_amounts].[tax] is not null
+GO
+
+-- TODO: Fix BABEL-4359
+SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1
+GO
+
+-- TODO: Fix BABEL-4359
+SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1 AND   [owner_amounts].[tax] is not null
+GO
+
+-- TODO: Fix BABEL-4359
+SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1
 GO
 
 SELECT sum([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
 GO
-
 
 --cleanup
 drop table owner_amounts

--- a/test/JDBC/input/BABEL-4327.sql
+++ b/test/JDBC/input/BABEL-4327.sql
@@ -1,0 +1,46 @@
+CREATE TABLE [dbo].[test_babel_4327_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id]));
+GO
+
+-- should be sys.varchar
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_babel_4327_table'
+	)
+);
+GO
+
+INSERT INTO [dbo].[test_babel_4327_table]([my_varchar_data])VALUES ('1');
+INSERT INTO [dbo].[test_babel_4327_table]([my_varchar_data])VALUES ('HELLO');
+INSERT INTO [dbo].[test_babel_4327_table]([my_varchar_data])VALUES (NULL);
+GO
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_babel_4327_table];
+GO
+
+select * from [dbo].[test_babel_4327_table] where ISNULL([my_varchar_data], [id]) = 'HELLO';
+GO
+
+select * from [dbo].[test_babel_4327_table] where [my_computed_column] = 'HELLO';
+GO
+
+select * from [dbo].[test_babel_4327_table] where ISNULL([my_varchar_data], [id]) = 'HeLLO';
+GO
+
+select * from [dbo].[test_babel_4327_table] where [my_computed_column] = 'HeLLO';
+GO
+
+DROP TABLE [dbo].[test_babel_4327_table];
+GO

--- a/test/JDBC/input/Test_ISNULL-vu-cleanup.sql
+++ b/test/JDBC/input/Test_ISNULL-vu-cleanup.sql
@@ -1,0 +1,35 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view6]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/input/Test_ISNULL-vu-prepare.sql
+++ b/test/JDBC/input/Test_ISNULL-vu-prepare.sql
@@ -1,0 +1,68 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/input/Test_ISNULL-vu-verify.sql
+++ b/test/JDBC/input/Test_ISNULL-vu-verify.sql
@@ -1,0 +1,105 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+
+select * from [dbo].[test_isnull_table]
+GO
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+
+select * from [dbo].[test_isnull_view];
+GO
+
+select * from [dbo].[test_isnull_view1];
+GO
+
+select * from [dbo].[test_isnull_view2];
+GO
+
+select * from [dbo].[test_isnull_view3];
+GO
+
+select * from [dbo].[test_isnull_view4];
+GO
+
+select * from [dbo].[test_isnull_view5];
+GO
+
+select * from [dbo].[test_isnull_view6];
+GO
+
+select * from [dbo].[test_isnull_view7];
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view6'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+
+select [dbo].[test_isnull_func1]();
+GO
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+
+exec [dbo].[test_isnull_proc1];
+GO

--- a/test/JDBC/upgrade/14_6/preparation/Test_ISNULL-vu-prepare.sql
+++ b/test/JDBC/upgrade/14_6/preparation/Test_ISNULL-vu-prepare.sql
@@ -1,0 +1,68 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/upgrade/14_9/preparation/Test_ISNULL-vu-prepare.sql
+++ b/test/JDBC/upgrade/14_9/preparation/Test_ISNULL-vu-prepare.sql
@@ -1,0 +1,68 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/upgrade/15_2/preparation/Test_ISNULL-vu-prepare.sql
+++ b/test/JDBC/upgrade/15_2/preparation/Test_ISNULL-vu-prepare.sql
@@ -1,0 +1,68 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/upgrade/15_4/preparation/Test_ISNULL-vu-prepare.sql
+++ b/test/JDBC/upgrade/15_4/preparation/Test_ISNULL-vu-prepare.sql
@@ -1,0 +1,68 @@
+CREATE TABLE [dbo].[test_isnull_table](
+       [id] [bigint] IDENTITY(1,1) NOT NULL,
+       [my_varchar_data] [varchar](20) NULL,
+       [my_computed_column] AS isnull([my_varchar_data],[id])) 
+GO
+
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES ('1')
+INSERT INTO [dbo].[test_isnull_table]([my_varchar_data])VALUES (NULL)
+GO
+
+create view [dbo].[test_isnull_view] as select isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view1] as select * from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view2] as select * from [dbo].[test_isnull_table] where isnull(NULL,[id]) = 1;
+GO
+
+create view [dbo].[test_isnull_view3] as
+select ISNULL(NULL, NULL);
+GO
+
+create view [dbo].[test_isnull_view4] as
+select ISNULL(NULL, 'Unassigned');
+GO
+
+create view [dbo].[test_isnull_view5] as
+select
+  ISNULL([my_varchar_data], 'Unassigned')
+from [dbo].[test_isnull_table];
+GO
+
+create view [dbo].[test_isnull_view6] as
+select ISNULL('Unassigned', 1);
+GO
+
+create view [dbo].[test_isnull_view7] as
+select ISNULL ('', 5);
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func1]()
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT
+    SELECT @ans= isnull([my_varchar_data],[id]) from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1
+    RETURN @ans
+END
+GO
+
+CREATE FUNCTION [dbo].[test_isnull_func2](@in1 varchar(20), @in2 bigint)
+RETURNS BIGINT AS
+BEGIN
+    DECLARE @ans BIGINT = isnull(@in1, @in2) 
+	RETURN @ans
+END
+GO
+
+CREATE PROCEDURE [dbo].[test_isnull_proc1]
+AS
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table] where isnull([my_varchar_data],[id]) = 1;
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -409,3 +409,4 @@ babel_varbinary_int4_div
 sys-sql_expression_dependencies
 smalldatetimefromparts-dep
 BABEL_4330
+Test_ISNULL

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_6/Test_ISNULL-vu-cleanup.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_6/Test_ISNULL-vu-cleanup.sql
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_6/Test_ISNULL-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_6/Test_ISNULL-vu-verify.sql
@@ -1,0 +1,92 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+
+select * from [dbo].[test_isnull_table]
+GO
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+
+select * from [dbo].[test_isnull_view];
+GO
+
+select * from [dbo].[test_isnull_view1];
+GO
+
+select * from [dbo].[test_isnull_view2];
+GO
+
+select * from [dbo].[test_isnull_view3];
+GO
+
+select * from [dbo].[test_isnull_view4];
+GO
+
+select * from [dbo].[test_isnull_view5];
+GO
+
+select * from [dbo].[test_isnull_view7];
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+
+select [dbo].[test_isnull_func1]();
+GO
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+
+exec [dbo].[test_isnull_proc1];
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_9/Test_ISNULL-vu-cleanup.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_9/Test_ISNULL-vu-cleanup.sql
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_9/Test_ISNULL-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_9/Test_ISNULL-vu-verify.sql
@@ -1,0 +1,92 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+
+select * from [dbo].[test_isnull_table]
+GO
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+
+select * from [dbo].[test_isnull_view];
+GO
+
+select * from [dbo].[test_isnull_view1];
+GO
+
+select * from [dbo].[test_isnull_view2];
+GO
+
+select * from [dbo].[test_isnull_view3];
+GO
+
+select * from [dbo].[test_isnull_view4];
+GO
+
+select * from [dbo].[test_isnull_view5];
+GO
+
+select * from [dbo].[test_isnull_view7];
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+
+select [dbo].[test_isnull_func1]();
+GO
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+
+exec [dbo].[test_isnull_proc1];
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/15_2/Test_ISNULL-vu-cleanup.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/15_2/Test_ISNULL-vu-cleanup.sql
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/15_2/Test_ISNULL-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/15_2/Test_ISNULL-vu-verify.sql
@@ -1,0 +1,92 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+
+select * from [dbo].[test_isnull_table]
+GO
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+
+select * from [dbo].[test_isnull_view];
+GO
+
+select * from [dbo].[test_isnull_view1];
+GO
+
+select * from [dbo].[test_isnull_view2];
+GO
+
+select * from [dbo].[test_isnull_view3];
+GO
+
+select * from [dbo].[test_isnull_view4];
+GO
+
+select * from [dbo].[test_isnull_view5];
+GO
+
+select * from [dbo].[test_isnull_view7];
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+
+select [dbo].[test_isnull_func1]();
+GO
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+
+exec [dbo].[test_isnull_proc1];
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/15_4/Test_ISNULL-vu-cleanup.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/15_4/Test_ISNULL-vu-cleanup.sql
@@ -1,0 +1,32 @@
+DROP FUNCTION [dbo].[test_isnull_func1];
+GO
+
+DROP FUNCTION [dbo].[test_isnull_func2];
+GO
+
+DROP PROCEDURE [dbo].[test_isnull_proc1];
+GO
+
+DROP VIEW [dbo].[test_isnull_view]
+GO
+
+DROP VIEW [dbo].[test_isnull_view1]
+GO
+
+DROP VIEW [dbo].[test_isnull_view2]
+GO
+
+DROP VIEW [dbo].[test_isnull_view3]
+GO
+
+DROP VIEW [dbo].[test_isnull_view4]
+GO
+
+DROP VIEW [dbo].[test_isnull_view5]
+GO
+
+DROP VIEW [dbo].[test_isnull_view7]
+GO
+
+DROP TABLE [dbo].[test_isnull_table]
+GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/15_4/Test_ISNULL-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/15_4/Test_ISNULL-vu-verify.sql
@@ -1,0 +1,92 @@
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+    name = 'my_computed_column' and 
+	object_id = 
+	(
+	  select object_id from sys.tables where name = 'test_isnull_table'
+	)
+) and is_user_defined = 0;
+GO
+
+select * from [dbo].[test_isnull_table]
+GO
+
+select
+  ISNULL(NULL, NULL),
+  ISNULL(NULL, 'Unassigned'),
+  ISNULL([my_varchar_data], 'Unassigned'),
+  ISNULL('Unassigned', 1),
+  ISNULL ('', 5)
+from [dbo].[test_isnull_table];
+GO
+
+select * from [dbo].[test_isnull_view];
+GO
+
+select * from [dbo].[test_isnull_view1];
+GO
+
+select * from [dbo].[test_isnull_view2];
+GO
+
+select * from [dbo].[test_isnull_view3];
+GO
+
+select * from [dbo].[test_isnull_view4];
+GO
+
+select * from [dbo].[test_isnull_view5];
+GO
+
+select * from [dbo].[test_isnull_view7];
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view3'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view4'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view5'
+	)
+) and is_user_defined = 0;
+GO
+
+select name from sys.types where system_type_id = 
+(
+  select system_type_id from sys.columns where 
+	object_id = 
+	(
+	  select object_id from sys.views where name = 'test_isnull_view7'
+	)
+) and is_user_defined = 0;
+GO
+
+select [dbo].[test_isnull_func1]();
+GO
+
+select [dbo].[test_isnull_func2]('1', 1);
+GO
+
+exec [dbo].[test_isnull_proc1];
+GO


### PR DESCRIPTION
Previously, we were handling ISNULL using COALESCE semantics which is not right thing to do because return datatype of T-SQL ISNULL function is not same as COALESCE in all the cases. So this commit fixes this issue by appropriately implementing hook to select the common type, select_common_type_hook_type. Logic to select common type or return type is very straight forward and described below:

1. If first argument is literal NULL then return the data type of second argument.
2. If second argument is also literal NULL then return INT.

There could be major version upgrade due to this change. Have opened BABEL-4263 internally to handle it when we support major version upgrade from version 15 to version 16.

Task: BABEL-917
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).