### PR TITLE
Add collation when initialising scan keys for sys.varchar

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1110,7 +1110,7 @@ search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid, const char *logical_s
 		return NULL;
 
 	/* Search and drop the definition */
-	ScanKeyInit(&scanKey[0], 
+	ScanKeyInit(&scanKey[0],
 				Anum_bbf_view_def_dbid,
 				BTEqualStrategyNumber, F_INT2EQ,
 				Int16GetDatum(dbid));
@@ -2641,7 +2641,7 @@ rename_view_update_bbf_catalog(RenameStmt *stmt)
 
 	/* search for the row for update => build the key */
 	dbid = get_dbid_from_physical_schema_name(stmt->relation->schemaname, true);
-	ScanKeyInit(&key[0], 
+	ScanKeyInit(&key[0],
 				Anum_bbf_view_def_dbid,
 				BTEqualStrategyNumber, F_INT2EQ,
 				Int16GetDatum(dbid));

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1109,6 +1109,7 @@ search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid, const char *logical_s
 	if (!DbidIsValid(dbid) || logical_schema_name == NULL || view_name == NULL)
 		return NULL;
 
+
 	/* Search and drop the definition */
 	ScanKeyInit(&scanKey[0],
 				Anum_bbf_view_def_dbid,
@@ -1124,12 +1125,10 @@ search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid, const char *logical_s
 				BTEqualStrategyNumber, InvalidOid,
 				tsql_get_server_collation_oid_internal(false), F_TEXTEQ,
 				CStringGetTextDatum(view_name));
-	
 
 	scan = systable_beginscan(bbf_view_def_rel,
 							  get_bbf_view_def_idx_oid(),
 							  true, NULL, 3, scanKey);
-
 
 	scantup = systable_getnext(scan);
 	oldtup = heap_copytuple(scantup);
@@ -2635,7 +2634,6 @@ rename_view_update_bbf_catalog(RenameStmt *stmt)
 
 	/* open the catalog table */
 	bbf_view_def_rel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
-	
 	/* get the description of the table */
 	bbf_view_def_dsc = RelationGetDescr(bbf_view_def_rel);
 

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2657,7 +2657,7 @@ rename_view_update_bbf_catalog(RenameStmt *stmt)
 	ScanKeyEntryInitialize(&key[1], 0, Anum_bbf_view_def_schema_name,
 				BTEqualStrategyNumber, InvalidOid,
 				bbf_view_def_idx_rel->rd_indcollation[1], 
-				F_TEXTEQ,CStringGetTextDatum(logical_schema_name));
+				F_TEXTEQ, CStringGetTextDatum(logical_schema_name));
 	ScanKeyEntryInitialize(&key[2], 0,
 				Anum_bbf_view_def_object_name,
 				BTEqualStrategyNumber, InvalidOid,

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1903,8 +1903,7 @@ static char *
 get_fully_qualified_domain_name(char *netbios_domain)
 {
 	/* TODO: Add test cases for this mapping */
-	Relation	bbf_domain_mapping_rel,
-				bbf_domain_mapping_idx_rel;
+	Relation	bbf_domain_mapping_rel;
 	TupleDesc	dsc;
 	ScanKeyData scanKey;
 	SysScanDesc scan;
@@ -1912,7 +1911,6 @@ get_fully_qualified_domain_name(char *netbios_domain)
 	char	   *fq_domain_name;
 
 	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), RowShareLock);
-	bbf_domain_mapping_idx_rel = index_open(get_bbf_domain_mapping_idx_oid(), AccessShareLock);
 
 	dsc = RelationGetDescr(bbf_domain_mapping_rel);
 
@@ -1921,7 +1919,7 @@ get_fully_qualified_domain_name(char *netbios_domain)
 						   Anum_bbf_domain_mapping_netbios_domain_name,
 						   BTEqualStrategyNumber,
 						   InvalidOid,
-						   bbf_domain_mapping_idx_rel->rd_indcollation[0],
+						   tsql_get_server_collation_oid_internal(false),
 						   F_TEXTEQ,
 						   CStringGetTextDatum(netbios_domain));
 
@@ -1964,7 +1962,6 @@ get_fully_qualified_domain_name(char *netbios_domain)
 	}
 
 	systable_endscan(scan);
-	index_close(bbf_domain_mapping_idx_rel, AccessShareLock);
 	table_close(bbf_domain_mapping_rel, RowShareLock);
 
 	return fq_domain_name;
@@ -2161,8 +2158,7 @@ PG_FUNCTION_INFO_V1(babelfish_remove_domain_mapping_entry_internal);
 Datum
 babelfish_remove_domain_mapping_entry_internal(PG_FUNCTION_ARGS)
 {
-	Relation	bbf_domain_mapping_rel,
-				bbf_domain_mapping_idx_rel;
+	Relation	bbf_domain_mapping_rel;
 	ScanKeyData scanKey;
 	SysScanDesc scan;
 	HeapTuple	tuple;
@@ -2185,12 +2181,10 @@ babelfish_remove_domain_mapping_entry_internal(PG_FUNCTION_ARGS)
 
 	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), RowExclusiveLock);
 
-	bbf_domain_mapping_idx_rel = index_open(get_bbf_domain_mapping_idx_oid(), AccessShareLock);
-
 	ScanKeyEntryInitialize(&scanKey, 0,
 						   Anum_bbf_domain_mapping_netbios_domain_name,
 						   BTEqualStrategyNumber, InvalidOid,
-						   bbf_domain_mapping_idx_rel->rd_indcollation[0],
+						   tsql_get_server_collation_oid_internal(false),
 						   F_TEXTEQ, PG_GETARG_DATUM(0));
 
 	scan = systable_beginscan(bbf_domain_mapping_rel,
@@ -2214,7 +2208,6 @@ babelfish_remove_domain_mapping_entry_internal(PG_FUNCTION_ARGS)
 	}
 
 	systable_endscan(scan);
-	index_close(bbf_domain_mapping_idx_rel, AccessShareLock);
 	table_close(bbf_domain_mapping_rel, RowExclusiveLock);
 	return (Datum) 0;
 }

--- a/test/JDBC/expected/BABEL_4389.out
+++ b/test/JDBC/expected/BABEL_4389.out
@@ -1,0 +1,42 @@
+
+-- Failure of these indicates use of wrong collation
+-- when init scan keys
+CREATE VIEW BABEL4389V_1 as SELECT 1
+GO
+DROP VIEW BABEL4389V_1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+DROP VIEW BABEL4389V1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+sp_rename 'BABEL4389V1', 'BABEL4389V2', 'OBJECT'
+GO
+DROP VIEW BABEL4389V2
+GO
+
+SELECT object_name FROM sys.babelfish_view_def WHERE object_name IN ('BABEL4389V_1', 'BABEL4389V1', 'BABEL4389V2')
+GO
+~~START~~
+varchar
+~~END~~
+
+
+EXEC sys.babelfish_add_domain_mapping_entry 'BABEL4389D_1', 'CollationCheck'
+GO
+EXEC sys.babelfish_remove_domain_mapping_entry 'BABEL4389D_1'
+GO
+EXEC sys.babelfish_add_domain_mapping_entry 'BABEL4389D1', 'CollationCheck'
+GO
+EXEC sys.babelfish_remove_domain_mapping_entry 'BABEL4389D1'
+GO
+
+SELECT * FROM sys.babelfish_domain_mapping WHERE netbios_domain_name IN ('BABEL4389D1', 'BABEL4389D_1')
+GO
+~~START~~
+varchar#!#varchar
+~~END~~
+

--- a/test/JDBC/input/BABEL_4389.sql
+++ b/test/JDBC/input/BABEL_4389.sql
@@ -1,0 +1,34 @@
+-- Failure of these indicates use of wrong collation
+-- when init scan keys
+
+CREATE VIEW BABEL4389V_1 as SELECT 1
+GO
+DROP VIEW BABEL4389V_1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+DROP VIEW BABEL4389V1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+sp_rename 'BABEL4389V1', 'BABEL4389V2', 'OBJECT'
+GO
+DROP VIEW BABEL4389V2
+GO
+
+SELECT object_name FROM sys.babelfish_view_def WHERE object_name IN ('BABEL4389V_1', 'BABEL4389V1', 'BABEL4389V2')
+GO
+
+EXEC sys.babelfish_add_domain_mapping_entry 'BABEL4389D_1', 'CollationCheck'
+GO
+EXEC sys.babelfish_remove_domain_mapping_entry 'BABEL4389D_1'
+GO
+EXEC sys.babelfish_add_domain_mapping_entry 'BABEL4389D1', 'CollationCheck'
+GO
+EXEC sys.babelfish_remove_domain_mapping_entry 'BABEL4389D1'
+GO
+
+SELECT * FROM sys.babelfish_domain_mapping WHERE netbios_domain_name IN ('BABEL4389D1', 'BABEL4389D_1')
+GO


### PR DESCRIPTION
### Description
Orphan entries in tables uisng atleast one sys.varchar as a column.
Errors like : "duplcate key error" in view definition catalog table (sys.bablefish_view_def) and 
domain mapping entry corresponding to supplied argument could not be found" for domain 
mapping catalog (sys.babelfish_domain_mapping).

When we init scan keys without a collation, default collation "C" is used and hence comparison 
take place as per "C" collation whereas comparison as per server collation is expected. And 
hence index scan does not return the correct row.

We will now fetch the collation value from using tsql_get_server_collation_oid_internal(false) 
and forward it to the scan key init function (ScanKeyEntryInitialize()).

tables fixed - sys.bablefish_view_def, sys.babelfish_domain_mapping

Note - We will fix similar issue for other system catalog in subsequent changes.

Test Scenarios Covered -
We use cases which fail currently, that is using view/domain names with underscore character to force a situation which would fail if wrong collation is picked up when searching the index.

Task: BABEL-4389
Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).