### PR TITLE
Fixed CFL statement to rewrite search_condition appropriately

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -172,7 +172,6 @@ static std::string delimit_identifier(TSqlParser::IdContext *id);
 static bool does_msg_exceeds_params_limit(const std::string& msg);
 static std::string getProcNameFromExecParam(TSqlParser::Execute_parameterContext *exParamCtx);
 static ANTLR_result antlr_parse_query(const char *sourceText, bool useSSLParsing);
-
 /*
  * Structure / Utility function for general purpose of query string modification
  *
@@ -1874,6 +1873,37 @@ public:
 	void enterExecute_body_batch(TSqlParser::Execute_body_batchContext *ctx) override
 	{
 		graft(makeExecBodyBatch(ctx), peekContainer());
+	}
+
+	PLtsql_expr *rewrite_if_condition(TSqlParser::Search_conditionContext *ctx)
+	{
+		PLtsql_expr *expr = makeTsqlExpr(ctx, false);
+		PLtsql_expr_query_mutator mutator(expr, ctx);
+		add_rewritten_query_fragment_to_mutator(&mutator);
+		mutator.run();
+		clear_rewritten_query_fragment();
+
+		/* Now we can prepend SELECT to rewritten search_condition */
+		expr->query = strdup((std::string("SELECT ") + std::string(expr->query)).c_str());
+		return expr;
+	}
+
+	void exitSearch_condition(TSqlParser::Search_conditionContext *ctx) override
+	{
+		if (!ctx->parent || !ctx->parent->parent)
+			return;
+
+		if (((TSqlParser::Cfl_statementContext *) ctx->parent->parent)->if_statement())
+		{
+
+			PLtsql_stmt_if *fragment = (PLtsql_stmt_if *) getPLtsql_fragment(ctx->parent->parent);
+			fragment->cond = rewrite_if_condition(ctx);
+		}
+		else if (((TSqlParser::Cfl_statementContext *) ctx->parent->parent)->while_statement())
+		{
+			PLtsql_stmt_while *fragment = (PLtsql_stmt_while *) getPLtsql_fragment(ctx->parent->parent);
+			fragment->cond = rewrite_if_condition(ctx);
+		}
 	}
 };
 
@@ -3756,10 +3786,13 @@ makeIfStmt(TSqlParser::If_statementContext *ctx)
 
 	result->cmd_type = PLTSQL_STMT_IF;
 	result->lineno = getLineNo(ctx);
-	result->cond = makeTsqlExpr(ctx->search_condition(), true);
 
-	// Note that we record the then_body and the else_body
-	// in exitIf_statement()
+	/*
+	 * Note that 
+	 * 1/ We fill in result->cond during exitIf_statement so that search_condition would have
+	 *    been rewritten at that point. 
+	 * 2/ We record the then_body and the else_body in exitIf_statement().
+	 */
 
 	return result;
 }
@@ -3897,10 +3930,10 @@ void *
 makeWhileStmt(TSqlParser::While_statementContext *ctx)
 {
 	PLtsql_stmt_while *result = (PLtsql_stmt_while *) palloc0(sizeof(*result));
-
 	result->cmd_type = PLTSQL_STMT_WHILE;
-	result->cond = makeTsqlExpr(ctx->search_condition(), true);
-	
+
+	/* We will populate result->cond during exitSearch_condition() */
+
 	return result;
 }
 

--- a/test/JDBC/expected/BABEL_4320.out
+++ b/test/JDBC/expected/BABEL_4320.out
@@ -1,0 +1,142 @@
+-- dummy test to check if schema is being rewritten
+IF (EXISTS (select * from information_schema.test))
+BEGIN
+    SELECT 1
+END;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.test" does not exist)~~
+
+
+WHILE (select avg(a) from information_schema.test group by b) < 300
+BEGIN
+    SELECT 1
+END;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.test" does not exist)~~
+
+
+SELECT 
+CASE 
+	WHEN (EXISTS (SELECT * FROM INFORMATION_SCHEMA.test)) THEN 'TRUE'
+	ELSE 'FALSE'
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "information_schema_tsql.test" does not exist)~~
+
+
+-- regular test cases
+CREATE TABLE [dbo].[My_Table_4320](
+    [My_ID] [varchar](3) NOT NULL,
+    [My_Column] [varchar](250) NOT NULL
+)
+go
+
+IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320'))
+BEGIN
+    SELECT 'TABLE EXISTS - THIS IS CORRECT'
+END
+ELSE
+BEGIN
+    SELECT 'TABLE NOT EXISTS - THIS IS WRONG, BECAUSE IT DOES EXIST'
+END
+GO
+~~START~~
+varchar
+TABLE EXISTS - THIS IS CORRECT
+~~END~~
+
+
+WHILE (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320'))
+BEGIN
+    SELECT 'TABLE EXISTS - THIS IS CORRECT';
+    break;
+END
+GO
+~~START~~
+varchar
+TABLE EXISTS - THIS IS CORRECT
+~~END~~
+
+
+IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320'))
+BEGIN
+    SELECT 'TABLE NOT EXISTS - THIS IS WRONG, BECAUSE IT DOES EXIST'
+END
+ELSE
+BEGIN
+    SELECT 'TABLE EXISTS - THIS IS CORRECT'
+END
+GO
+~~START~~
+varchar
+TABLE EXISTS - THIS IS CORRECT
+~~END~~
+
+
+SELECT 
+CASE 
+	WHEN (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_43201')) THEN 'TABLE EXISTS'
+	ELSE 'TABLE DOES NOT EXIST'
+END
+GO
+~~START~~
+text
+TABLE DOES NOT EXIST
+~~END~~
+
+
+SELECT CASE
+ WHEN (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320') = 1 THEN 'TABLE EXISTS'
+ ELSE 'TABEL DOES NOT EXIST'
+END;
+GO
+~~START~~
+text
+TABLE EXISTS
+~~END~~
+
+
+-- table identifier truncation
+CREATE TABLE ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue (a int)
+go
+
+IF (NOT EXISTS(select * from ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue))
+BEGIN
+    SELECT 'Expected result'
+END
+GO
+~~START~~
+varchar
+Expected result
+~~END~~
+
+
+-- table and column name truncation
+CREATE TABLE jakldnhjcDhdeuqpdkancjdtueqjanckdalejnxutuwmxdjajcneiqmalnfenirlenlaplqirncsrju (ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue int)
+GO
+
+IF (NOT EXISTS(select ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue from jakldnhjcDhdeuqpdkancjdtueqjanckdalejnxutuwmxdjajcneiqmalnfenirlenlaplqirncsrju))
+BEGIN
+    SELECT 'Expected result'
+END
+GO
+~~START~~
+varchar
+Expected result
+~~END~~
+
+
+DROP TABLE jakldnhjcDhdeuqpdkancjdtueqjanckdalejnxutuwmxdjajcneiqmalnfenirlenlaplqirncsrju;
+GO
+
+DROP TABLE ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue;
+GO
+
+DROP TABLE [dbo].[My_Table_4320];
+GO

--- a/test/JDBC/input/BABEL_4320.sql
+++ b/test/JDBC/input/BABEL_4320.sql
@@ -1,0 +1,95 @@
+-- dummy test to check if schema is being rewritten
+IF (EXISTS (select * from information_schema.test))
+BEGIN
+    SELECT 1
+END;
+GO
+
+WHILE (select avg(a) from information_schema.test group by b) < 300
+BEGIN
+    SELECT 1
+END;
+GO
+
+SELECT 
+CASE 
+	WHEN (EXISTS (SELECT * FROM INFORMATION_SCHEMA.test)) THEN 'TRUE'
+	ELSE 'FALSE'
+END
+GO
+
+-- regular test cases
+CREATE TABLE [dbo].[My_Table_4320](
+    [My_ID] [varchar](3) NOT NULL,
+    [My_Column] [varchar](250) NOT NULL
+)
+go
+
+IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320'))
+BEGIN
+    SELECT 'TABLE EXISTS - THIS IS CORRECT'
+END
+ELSE
+BEGIN
+    SELECT 'TABLE NOT EXISTS - THIS IS WRONG, BECAUSE IT DOES EXIST'
+END
+GO
+
+WHILE (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320'))
+BEGIN
+    SELECT 'TABLE EXISTS - THIS IS CORRECT';
+    break;
+END
+GO
+
+IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320'))
+BEGIN
+    SELECT 'TABLE NOT EXISTS - THIS IS WRONG, BECAUSE IT DOES EXIST'
+END
+ELSE
+BEGIN
+    SELECT 'TABLE EXISTS - THIS IS CORRECT'
+END
+GO
+
+SELECT 
+CASE 
+	WHEN (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_43201')) THEN 'TABLE EXISTS'
+	ELSE 'TABLE DOES NOT EXIST'
+END
+GO
+
+SELECT CASE
+ WHEN (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'My_Table_4320') = 1 THEN 'TABLE EXISTS'
+ ELSE 'TABEL DOES NOT EXIST'
+END;
+GO
+
+-- table identifier truncation
+CREATE TABLE ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue (a int)
+go
+
+IF (NOT EXISTS(select * from ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue))
+BEGIN
+    SELECT 'Expected result'
+END
+GO
+
+-- table and column name truncation
+CREATE TABLE jakldnhjcDhdeuqpdkancjdtueqjanckdalejnxutuwmxdjajcneiqmalnfenirlenlaplqirncsrju (ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue int)
+GO
+
+IF (NOT EXISTS(select ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue from jakldnhjcDhdeuqpdkancjdtueqjanckdalejnxutuwmxdjajcneiqmalnfenirlenlaplqirncsrju))
+BEGIN
+    SELECT 'Expected result'
+END
+GO
+
+DROP TABLE jakldnhjcDhdeuqpdkancjdtueqjanckdalejnxutuwmxdjajcneiqmalnfenirlenlaplqirncsrju;
+GO
+
+DROP TABLE ncHdbdnjcnkejnjkcnreunjaknsaowlmfkrngvurtkanajhruddhbcmiuqwpalkdmfhcnbxndwue;
+GO
+
+DROP TABLE [dbo].[My_Table_4320];
+GO


### PR DESCRIPTION
Previously, we were not transforming search_condition to rewrite object names, for example, Any reference to INFORMATION_SCHEMA should get translated to INFORMATION_SCHEMA_TSQL. This commit fixes that issue by rewriting search_condition in exitSearch_condition even appropriately.

Task: BABEL-4320
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).