### PR TITLE
Add collation when initialising scan keys for sys.varchar (#1832)

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1076,14 +1076,14 @@ search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid, const char *logical_s
 				BTEqualStrategyNumber, F_INT2EQ,
 				Int16GetDatum(dbid));
 
-	ScanKeyInit(&scanKey[1],
-				Anum_bbf_view_def_schema_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
+	ScanKeyEntryInitialize(&scanKey[1], 0, Anum_bbf_view_def_schema_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false), F_TEXTEQ,
 				CStringGetTextDatum(logical_schema_name));
 
-	ScanKeyInit(&scanKey[2],
-				Anum_bbf_view_def_object_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
+	ScanKeyEntryInitialize(&scanKey[2], 0, Anum_bbf_view_def_object_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false), F_TEXTEQ,
 				CStringGetTextDatum(view_name));
 
 	scan = systable_beginscan(bbf_view_def_rel,
@@ -2418,8 +2418,7 @@ rename_view_update_bbf_catalog(RenameStmt *stmt)
 
 	// open the catalog table
 	bbf_view_def_rel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
-
-	// get the description of the table
+	/* get the description of the table */
 	bbf_view_def_dsc = RelationGetDescr(bbf_view_def_rel);
 
 	// search for the row for update => build the key
@@ -2429,14 +2428,15 @@ rename_view_update_bbf_catalog(RenameStmt *stmt)
 				BTEqualStrategyNumber, F_INT2EQ,
 				Int16GetDatum(dbid));
 	logical_schema_name = get_logical_schema_name(stmt->relation->schemaname, true);
-	ScanKeyInit(&key[1],
-				Anum_bbf_view_def_schema_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
-				CStringGetTextDatum(logical_schema_name));
-	ScanKeyInit(&key[2],
+	ScanKeyEntryInitialize(&key[1], 0, Anum_bbf_view_def_schema_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false), 
+				F_TEXTEQ, CStringGetTextDatum(logical_schema_name));
+	ScanKeyEntryInitialize(&key[2], 0,
 				Anum_bbf_view_def_object_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
-				CStringGetTextDatum(stmt->relation->relname));
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ, CStringGetTextDatum(stmt->relation->relname));
 
 	// scan
 	tblscan = table_beginscan_catalog(bbf_view_def_rel, 3, key);

--- a/test/JDBC/expected/BABEL_4389.out
+++ b/test/JDBC/expected/BABEL_4389.out
@@ -1,0 +1,27 @@
+
+-- Failure of these indicates use of wrong collation
+-- when init scan keys
+CREATE VIEW BABEL4389V_1 as SELECT 1
+GO
+DROP VIEW BABEL4389V_1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+DROP VIEW BABEL4389V1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+sp_rename 'BABEL4389V1', 'BABEL4389V2', 'OBJECT'
+GO
+DROP VIEW BABEL4389V2
+GO
+
+SELECT object_name FROM sys.babelfish_view_def WHERE object_name IN ('BABEL4389V_1', 'BABEL4389V1', 'BABEL4389V2')
+GO
+~~START~~
+varchar
+~~END~~
+
+

--- a/test/JDBC/input/BABEL_4389.sql
+++ b/test/JDBC/input/BABEL_4389.sql
@@ -1,0 +1,23 @@
+-- Failure of these indicates use of wrong collation
+-- when init scan keys
+
+CREATE VIEW BABEL4389V_1 as SELECT 1
+GO
+DROP VIEW BABEL4389V_1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+DROP VIEW BABEL4389V1
+GO
+
+CREATE VIEW BABEL4389V1 as SELECT 1
+GO
+sp_rename 'BABEL4389V1', 'BABEL4389V2', 'OBJECT'
+GO
+DROP VIEW BABEL4389V2
+GO
+
+SELECT object_name FROM sys.babelfish_view_def WHERE object_name IN ('BABEL4389V_1', 'BABEL4389V1', 'BABEL4389V2')
+GO
+


### PR DESCRIPTION
### Description

Orphan entries in tables uisng atleast one sys.varchar as a column. Errors like : "duplcate key error" in view definition catalog table (sys.bablefish_view_def).

When we init scan keys without a collation, default collation "C" is used and hence comparison take place as per "C" collation whereas comparison as per server collation is expected. And hence index scan does not return the correct row.

We will now fetch the collation value from using tsql_get_server_collation_oid_internal(false) and forward it to the scan key init function (ScanKeyEntryInitialize()).

tables fixed - sys.bablefish_view_def

Test Scenarios Covered -
We use cases which fail currently, that is using view/domain names with underscore character to force a situation which would fail if wrong collation is picked up when searching the index.

Task: BABEL-4389
Signed-off-by: Tanzeel Khan tzlkhan@amazon.com


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).