### PR TITLE
Modify babel_cursor test to match SQL Server usage

### DIFF
--- a/test/JDBC/expected/babel_cursor.out
+++ b/test/JDBC/expected/babel_cursor.out
@@ -17,14 +17,16 @@ GO
 
 
 
-CREATE PROCEDURE babel_fetch_cursor_helper_int_proc(@cur CURSOR, @num_fetch int)
+CREATE PROCEDURE babel_cursor_proc(@num_fetch int)
 AS
 BEGIN
 	DECLARE @var_i int;
 	DECLARE @cnt int = 0;
+	DECLARE cur CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i
+	OPEN cur
 	WHILE @cnt < @num_fetch
 	  BEGIN
-		FETCH FROM @cur INTO @var_i
+		FETCH FROM cur INTO @var_i
 		SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
 		IF @@FETCH_STATUS <> 0
 		BREAK
@@ -33,114 +35,12 @@ BEGIN
 		SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
 		SET @cnt = @cnt + 1
 	  END
+	
+	CLOSE cur
 END;
 GO
 
-
-CREATE PROCEDURE babel_fetch_cursor_helper_char_proc(@cur CURSOR, @num_fetch int)
-AS
-BEGIN
-	DECLARE @var_c varchar(100);
-	DECLARE @cnt int = 0;
-	WHILE @cnt < @num_fetch
-	BEGIN
-		FETCH FROM @cur INTO @var_c
-		SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
-		IF @@FETCH_STATUS <> 0
-			BREAK
-		SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
-		IF (@var_c IS NULL)
-			SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
-		SET @cnt = @cnt + 1
-	END
-END;
-GO
-
-
-
-CREATE PROCEDURE babel_cursor_proc
-AS
-BEGIN
-	DECLARE @var_a int;
-	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	OPEN cur_a;
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-	CLOSE cur_a;
-END;
-GO
-
-EXEC babel_cursor_proc;
-GO
-~~START~~
-varchar
-@@fetch_status: 0
-~~END~~
-
-~~START~~
-varchar
-<NULL>
-~~END~~
-
-~~START~~
-varchar
-@var_i is null: true
-~~END~~
-
-~~START~~
-varchar
-@@fetch_status: 0
-~~END~~
-
-~~START~~
-varchar
-@var_i: 1
-~~END~~
-
-~~START~~
-varchar
-@@fetch_status: 0
-~~END~~
-
-~~START~~
-varchar
-@var_i: 2
-~~END~~
-
-~~START~~
-varchar
-@@fetch_status: 0
-~~END~~
-
-~~START~~
-varchar
-@var_i: 3
-~~END~~
-
-~~START~~
-varchar
-@@fetch_status: 0
-~~END~~
-
-~~START~~
-varchar
-@var_i: 4
-~~END~~
-
-
-
-
-CREATE PROCEDURE babel_cursor_no_semi_proc
-AS
-BEGIN
-	DECLARE @var_a int
-	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i
-	OPEN cur_a
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-	CLOSE cur_a
-END;
-GO
-
-EXEC babel_cursor_no_semi_proc;
+EXEC babel_cursor_proc 5;
 GO
 ~~START~~
 varchar
@@ -211,8 +111,6 @@ GO
 ~~ERROR (Message: "cur_a" is not a known variable)~~
 
 
-
-
 -- no cursor cur_b (in CLOSE)
 CREATE PROCEDURE babel_invalid_cursor_proc_2
 AS
@@ -221,7 +119,6 @@ BEGIN
 	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	OPEN cur_a;
 	FETCH NEXT FROM cur_a INTO @var_a;
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	CLOSE cur_b;
 END;
 GO
@@ -244,8 +141,6 @@ GO
 ~~ERROR (Message: variable "@var_a" must be of type cursor or refcursor)~~
 
 
-
-
 -- CLOSE with non-cursor var
 CREATE PROCEDURE babel_invalid_cursor_proc_4
 AS
@@ -254,7 +149,6 @@ BEGIN
 	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	OPEN cur_a;
 	FETCH NEXT FROM cur_a INTO @var_a;
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	CLOSE @var_a;
 END;
 GO
@@ -281,8 +175,6 @@ GO
 ~~ERROR (Message: 'GLOBAL CURSOR' is not currently supported in Babelfish)~~
 
 
-
-
 -- global cursor is not supported yet (CLOSE)
 CREATE PROCEDURE babel_cursor_global_close_proc
 AS
@@ -291,7 +183,6 @@ BEGIN
 	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	OPEN cur_a;
 	FETCH NEXT FROM cur_a INTO @var_a;
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	CLOSE GLOBAL cur_a;
 END;
 GO
@@ -847,9 +738,20 @@ CREATE PROCEDURE babel_local_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a;
 END;
 GO
@@ -868,7 +770,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i is null: true
+@var_a is null: true
 ~~END~~
 
 ~~START~~
@@ -878,7 +780,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -888,7 +790,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~START~~
@@ -898,7 +800,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 3
+@var_a: 3
 ~~END~~
 
 ~~START~~
@@ -908,7 +810,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 4
+@var_a: 4
 ~~END~~
 
 
@@ -918,9 +820,20 @@ CREATE PROCEDURE babel_forward_only_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR FORWARD_ONLY FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 3;
+	  WHILE @cnt < 3
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  -- error
 	  FETCH PRIOR FROM cur_a INTO @var_a;
 	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10));
@@ -943,7 +856,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i is null: true
+@var_a is null: true
 ~~END~~
 
 ~~START~~
@@ -953,7 +866,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -963,7 +876,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~
@@ -977,9 +890,20 @@ CREATE PROCEDURE babel_scroll_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR SCROLL FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 3;
+	  WHILE @cnt < 3
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  FETCH PRIOR FROM cur_a INTO @var_a;
 	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10));
 	  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100));
@@ -1001,7 +925,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i is null: true
+@var_a is null: true
 ~~END~~
 
 ~~START~~
@@ -1011,7 +935,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -1021,7 +945,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~START~~
@@ -1041,9 +965,20 @@ CREATE PROCEDURE babel_static_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR STATIC FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a;
 END;
 GO
@@ -1062,7 +997,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i is null: true
+@var_a is null: true
 ~~END~~
 
 ~~START~~
@@ -1072,7 +1007,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -1082,7 +1017,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~START~~
@@ -1092,7 +1027,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 3
+@var_a: 3
 ~~END~~
 
 ~~START~~
@@ -1102,10 +1037,8 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 4
+@var_a: 4
 ~~END~~
-
-
 
 
 CREATE PROCEDURE babel_keyset_cursor_proc
@@ -1114,15 +1047,12 @@ BEGIN
 	  DECLARE @var_a int;
 	  DECLARE cur_a CURSOR KEYSET FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	  CLOSE cur_a;
 END;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: 'KEYSET CURSOR' is not currently supported in Babelfish)~~
-
-
 
 
 
@@ -1134,7 +1064,6 @@ BEGIN
 	  DECLARE @var_a int;
 	  DECLARE cur_a CURSOR DYNAMIC FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	  CLOSE cur_a;
 END;
 GO
@@ -1152,9 +1081,20 @@ CREATE PROCEDURE babel_fast_forward_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a;
 END;
 GO
@@ -1173,7 +1113,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i is null: true
+@var_a is null: true
 ~~END~~
 
 ~~START~~
@@ -1183,7 +1123,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -1193,7 +1133,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~START~~
@@ -1203,7 +1143,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 3
+@var_a: 3
 ~~END~~
 
 ~~START~~
@@ -1213,7 +1153,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 4
+@var_a: 4
 ~~END~~
 
 
@@ -1223,10 +1163,21 @@ CREATE PROCEDURE babel_read_only_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR READ_ONLY FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	-- TODO: currently READ_ONLY is ignored. read-only cursor is updatable.
 	-- UPDATE babel_cursor_t1 SET i = i+1 WHERE CURRENT OF cur_a;
 	  CLOSE cur_a;
@@ -1242,7 +1193,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -1252,7 +1203,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~START~~
@@ -1262,7 +1213,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 3
+@var_a: 3
 ~~END~~
 
 ~~START~~
@@ -1272,15 +1223,13 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 4
+@var_a: 4
 ~~END~~
 
 ~~START~~
 varchar
 @@fetch_status: -1
 ~~END~~
-
-
 
 
 CREATE PROCEDURE babel_scroll_locks_cursor_proc
@@ -1290,15 +1239,12 @@ BEGIN
 	  DECLARE cur_a CURSOR SCROLL_LOCKS FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	  CLOSE cur_a;
 END;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: 'SCROLL_LOCKS' is not currently supported in Babelfish)~~
-
-
 
 
 
@@ -1311,7 +1257,6 @@ BEGIN
 	  DECLARE cur_a CURSOR OPTIMISTIC FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
 	  CLOSE cur_a;
 END;
 GO
@@ -1517,10 +1462,21 @@ CREATE PROCEDURE babel_cursor_fetch_failure_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  SET @var_a = 1;
 	  FETCH NEXT FROM cur_a INTO @var_a;
 	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10));
@@ -1537,7 +1493,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 1
+@var_a: 1
 ~~END~~
 
 ~~START~~
@@ -1547,7 +1503,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 2
+@var_a: 2
 ~~END~~
 
 ~~START~~
@@ -1557,7 +1513,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 3
+@var_a: 3
 ~~END~~
 
 ~~START~~
@@ -1567,7 +1523,7 @@ varchar
 
 ~~START~~
 varchar
-@var_i: 4
+@var_a: 4
 ~~END~~
 
 ~~START~~
@@ -1609,15 +1565,37 @@ AS
 BEGIN
 	  DECLARE @var_i int;
 	  DECLARE @var_c varchar(10)
+	  DECLARE @cnt int = 0;
 	  DECLARE @cur_a CURSOR;
 	  SET @cur_a = CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  DEALLOCATE @cur_a;
 	  -- set another cursor for the same curvar
 	  SET @cur_a = CURSOR FOR SELECT c FROM babel_cursor_t1 ORDER BY i;
+	  SET @cnt = 0;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_c
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+		  IF (@var_c IS NULL)
+		  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE @cur_a;
 END;
 GO
@@ -1746,15 +1724,37 @@ AS
 BEGIN
 	  DECLARE @var_i int;
 	  DECLARE @var_c varchar(10)
+	  DECLARE @cnt int = 0;
 	  DECLARE @cur_a CURSOR;
 	  SET @cur_a = CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  DEALLOCATE @cur_a;
 	  -- set another cursor for the same curvar
 	  SET @cur_a = CURSOR SCROLL FOR SELECT c FROM babel_cursor_t1 ORDER BY c;
+	  SET @cnt = 0;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_c
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+		  IF (@var_c IS NULL)
+		  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE @cur_a;
 END;
 GO
@@ -1885,11 +1885,25 @@ BEGIN
 	  DECLARE @cur_a CURSOR;
 	  SET @cur_a = CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_i
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+	  IF (@var_i IS NULL)
+	  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 	  -- set another cursor for the same curvar without deallocate
 	  SET @cur_a = CURSOR SCROLL FOR SELECT c FROM babel_cursor_t1 ORDER BY c;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_c
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+	  IF (@var_c IS NULL)
+	  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 	  CLOSE @cur_a;
 END;
 GO
@@ -1941,7 +1955,14 @@ BEGIN
 	  -- set another cursor for the same curvar without deallocate
 	  SET @cur_a = CURSOR SCROLL FOR SELECT c FROM babel_cursor_t1;
 	  OPEN @cur_a;
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_c
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+	  IF (@var_c IS NULL)
+	  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 	  CLOSE @cur_a;
 END;
 GO
@@ -1985,7 +2006,14 @@ BEGIN
 	  SET @cur_a = CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1;
 	  OPEN @cur_a;
 	  FETCH NEXT FROM @cur_a INTO @var_i;
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_i
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+	  IF (@var_i IS NULL)
+	  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 	  DEALLOCATE @cur_a;
 	  DEALLOCATE @cur_a;
 END;
@@ -2760,15 +2788,38 @@ varchar
 CREATE PROCEDURE babel_cursor_redecl_proc
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a
 	  DEALLOCATE cur_a
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
+	  SET @cnt = 0
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a
 	  DEALLOCATE cur_a
 END;
@@ -2892,14 +2943,25 @@ varchar
 CREATE PROCEDURE babel_cursor_redecl_not_deallocd_proc_1
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 	  CLOSE cur_a
 END;
 GO
@@ -2975,7 +3037,6 @@ BEGIN
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 END;
 GO
 
@@ -2993,7 +3054,6 @@ BEGIN
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 END;
 GO
 
@@ -3007,16 +3067,40 @@ GO
 CREATE PROCEDURE babel_cursor_redecl_goto_proc
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  GOTO label1
 	label2:
+	  SET @cnt = 0
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  GOTO label3
 	label1:
+	  SET @cnt = 0
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  DEALLOCATE cur_a
 	  GOTO label2
 	label3:
@@ -3139,18 +3223,29 @@ varchar
 CREATE PROCEDURE babel_cursor_redecl_goto_proc_2
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  GOTO label1
 	label2:
 	  -- error is expected here because cur_a in label1 is not dealloc'd
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 	  DEALLOCATE cur_a
 	  GOTO label3
 	label1:
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  GOTO label2
 	label3:
 END
@@ -3216,284 +3311,6 @@ varchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: cursor cur_a already exists)~~
-
-
-
-
-CREATE PROCEDURE babel_print_sp_cursor_list(@cur CURSOR)
-AS
-BEGIN
-	  DECLARE @refname VARCHAR(200);
-	  DECLARE @curname VARCHAR(200);
-	  DECLARE @scope INT;
-	  DECLARE @status INT;
-	  DECLARE @model INT;
-	  DECLARE @concurrency INT;
-	  DECLARE @scrollable INT;
-	  DECLARE @open_status INT;
-	  DECLARE @cursor_rows DECIMAL(10,0);
-	  DECLARE @fetch_status INT;
-	  DECLARE @column_count INT;
-	  DECLARE @row_count DECIMAL(10,0);
-	  DECLARE @last_operation INT;
-	  FETCH FROM @cur INTO @refname, @curname, @scope, @status, @model, @concurrency, @scrollable, @open_status, @cursor_rows, @fetch_status, @column_count, @row_count, @last_operation;
-	  WHILE @@FETCH_STATUS = 0
-	  BEGIN
-		SELECT '(sp_cursor_list out) @refname: ' + @refname + ', @curname: ' + @curname + ', @scope: ' + cast(@scope as VARCHAR(10)) + ', @model: ' + cast(@model as varchar(10)) + ', @concurrency: ' + cast(@concurrency as varchar(10)) + ', @scrollable: ' + cast(@scrollable as varchar(10)) + ', @open_status: ' + cast(@open_status as varchar(10)) + ', @cursor_rows: ' + cast(@cursor_rows as varchar(10)) + ', @fetch_status: ' + cast(@fetch_status as varchar(10)) + ', @column_count: ' + cast(@column_count as varchar(10)) + ', @row_count: ' + cast(@row_count as varchar(10)) + ', @last_operation ' + cast(@last_operation as varchar(10));
-		FETCH FROM @cur INTO @refname, @curname, @scope, @status, @model, @concurrency, @scrollable, @open_status, @cursor_rows, @fetch_status, @column_count, @row_count, @last_operation;
-	  END
-	  CLOSE @cur;
-	  DEALLOCATE @cur;
-END
-GO
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-CREATE PROCEDURE babel_sp_cursor_list_proc
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE @var_a int;
-	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE cur_b CURSOR FOR SELECT i+1 FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE @refcur_b CURSOR;
-	  DECLARE @refcur_c CURSOR;
-	  SELECT '== AFTER DECLARE ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  SET @refcur_b = cur_b;
-	  SET @refcur_c = CURSOR FOR SELECT i+2 FROM babel_cursor_t1 ORDER BY i;
-	  SELECT '== AFTER SET ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  OPEN cur_a;
-	  OPEN @refcur_b;
-	  OPEN @refcur_c;
-	  SELECT '== AFTER OPEN ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  FETCH NEXT FROM cur_a INTO @var_a;
-	  FETCH NEXT FROM @refcur_b INTO @var_a;
-	  FETCH NEXT FROM @refcur_c INTO @var_a;
-	  SELECT '== AFTER FETCH ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  CLOSE cur_a;
-	  CLOSE @refcur_b;
-	  CLOSE @refcur_c;
-	  SELECT '== AFTER CLOSE ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  DEALLOCATE cur_a;
-	  DEALLOCATE @refcur_b;
-	  DEALLOCATE @refcur_c;
-	  SELECT '== AFTER DEALLOCATE ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-END;
-GO
-
-EXEC babel_sp_cursor_list_proc;
-GO
-~~START~~
-varchar
-== AFTER DECLARE ==
-~~END~~
-
-~~START~~
-varchar
-(sp_cursor_list out) @refname: cur_a, @curname: cur_a, @scope: 1, @model: 1, @concurrency: 1, @scrollable: 1, @open_status: 0, @cursor_rows: 0, @fetch_status: -9, @column_count: -1, @row_count: 0, @last_operation 0
-~~END~~
-
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cursor "<unnamed portal 376>" does not exist)~~
-
-
-
-
-CREATE PROCEDURE babel_sp_cursor_list_nested_proc_2
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE cur_a CURSOR FOR SELECT * FROM babel_cursor_t1 ORDER BY c;
-	  OPEN cur_a;
-	  SELECT '== in the nested proc ==';
-	  EXEC sp_cursor_list @report_cur OUT, 3;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-END;
-GO
-
-
-
-
-
-
-CREATE PROCEDURE babel_sp_cursor_list_nested_proc
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE @var_a INT;
-	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE @refcur_a CURSOR;
-	  SET @refcur_a = cur_a;
-	  OPEN cur_a;
-	  FETCH NEXT FROM @refcur_a INTO @var_a;
-	  SELECT '== before calling nested proc ==';
-	  EXEC sp_cursor_list @report_cur OUT, 3;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC babel_sp_cursor_list_nested_proc_2;
-	  SELECT '== after calling nested proc ==';
-	  EXEC sp_cursor_list @report_cur OUT, 3;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-END;
-GO
-
-EXEC babel_sp_cursor_list_nested_proc;
-GO
-~~START~~
-varchar
-== before calling nested proc ==
-~~END~~
-
-~~START~~
-varchar
-(sp_cursor_list out) @refname: cur_a, @curname: cur_a, @scope: 1, @model: 1, @concurrency: 1, @scrollable: 1, @open_status: 1, @cursor_rows: -1, @fetch_status: 0, @column_count: 1, @row_count: 1, @last_operation 2
-~~END~~
-
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cursor "<unnamed portal 379>" does not exist)~~
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-CREATE PROCEDURE babel_sp_describe_cursor_proc
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE @var_a int;
-	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE cur_b CURSOR FOR SELECT i+1 FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE @refcur_b CURSOR;
-	  DECLARE @refcur_c CURSOR;
-	  SELECT '== AFTER DECLARE ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  SET @refcur_b = cur_b;
-	  SET @refcur_c = CURSOR FOR SELECT i+2 FROM babel_cursor_t1 ORDER BY i;
-	  SELECT '== AFTER SET ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  OPEN cur_a;
-	  OPEN @refcur_b;
-	  OPEN @refcur_c;
-	  SELECT '== AFTER OPEN ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  FETCH NEXT FROM cur_a INTO @var_a;
-	  FETCH NEXT FROM @refcur_b INTO @var_a;
-	  FETCH NEXT FROM @refcur_c INTO @var_a;
-	  SELECT '== AFTER FETCH ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  SELECT '== BEGIN (call with invalid argument) =='
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', '@refcur_not_exsits';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_not_exsits';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  SELECT '== END (call with invalid argument) =='
-	  CLOSE cur_a;
-	  CLOSE @refcur_b;
-	  CLOSE @refcur_c;
-	  SELECT '== AFTER CLOSE ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  DEALLOCATE cur_a;
-	  DEALLOCATE @refcur_b;
-	  DEALLOCATE @refcur_c;
-	  SELECT '== AFTER DEALLOCATE ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-END;
-GO
-
-EXEC babel_sp_describe_cursor_proc;
-GO
-~~START~~
-varchar
-== AFTER DECLARE ==
-~~END~~
-
-~~START~~
-varchar
-(sp_cursor_list out) @refname: cur_a, @curname: cur_a, @scope: 1, @model: 1, @concurrency: 1, @scrollable: 1, @open_status: 0, @cursor_rows: 0, @fetch_status: -9, @column_count: -1, @row_count: 0, @last_operation 0
-~~END~~
-
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cursor "<unnamed portal 382>" does not exist)~~
 
 
 CREATE PROCEDURE babel_same_cursor_name_proc(@opt int)
@@ -3959,13 +3776,13 @@ EXEC babel_sp_cursor_fetch_proc 2, 0, 1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 EXEC babel_sp_cursor_close_proc;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 
 EXEC babel_sp_cursor_execute_proc;
@@ -3978,13 +3795,13 @@ EXEC babel_sp_cursor_fetch_proc 2, 0, 4;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 EXEC babel_sp_cursor_close_proc;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 
 EXEC babel_sp_cursor_unprepare_proc;
@@ -4009,13 +3826,13 @@ EXEC babel_sp_cursor_fetch_proc 2, 0, 1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 EXEC babel_sp_cursor_close_proc;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 
 EXEC babel_sp_cursor_execute_proc;
@@ -4028,7 +3845,7 @@ EXEC babel_sp_cursor_fetch_proc 2, 0, 6;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cursor "180150062" does not exist)~~
+~~ERROR (Message: cursor "180150054" does not exist)~~
 
 
 EXEC babel_sp_cursor_unprepare_proc;
@@ -4269,7 +4086,6 @@ varchar
 
 
 DROP PROCEDURE babel_cursor_proc;
-DROP PROCEDURE babel_cursor_no_semi_proc;
 DROP PROCEDURE babel_cursor_double_precision_proc;
 DROP PROCEDURE babel_cursor_varchar_proc;
 DROP PROCEDURE babel_cursor_uniqueidentifier_proc;
@@ -4309,13 +4125,6 @@ DROP PROCEDURE babel_cursor_redecl_not_deallocd_proc_2;
 DROP PROCEDURE babel_cursor_redecl_not_deallocd_proc_3;
 DROP PROCEDURE babel_cursor_redecl_goto_proc;
 DROP PROCEDURE babel_cursor_redecl_goto_proc_2;
-DROP PROCEDURE babel_fetch_cursor_helper_int_proc;
-DROP PROCEDURE babel_fetch_cursor_helper_char_proc;
-DROP PROCEDURE babel_sp_cursor_list_proc;
-DROP PROCEDURE babel_sp_cursor_list_nested_proc_2;
-DROP PROCEDURE babel_sp_cursor_list_nested_proc;
-DROP PROCEDURE babel_sp_describe_cursor_proc;
-DROP PROCEDURE babel_print_sp_cursor_list;
 DROP PROCEDURE babel_same_cursor_name_proc;
 DROP PROCEDURE babel_cursor_rows_proc;
 DROP PROCEDURE babel_sp_cursor_proc;

--- a/test/JDBC/input/babel_cursor.sql
+++ b/test/JDBC/input/babel_cursor.sql
@@ -7,15 +7,17 @@ INSERT INTO babel_cursor_t1 VALUES (4, 4444.4444, 'dddddd', '4E984725-C51C-4BF4-
 INSERT INTO babel_cursor_t1 VALUES (NULL, NULL, NULL, NULL, NULL);
 GO
 
-CREATE PROCEDURE babel_fetch_cursor_helper_int_proc(@cur CURSOR, @num_fetch int)
+CREATE PROCEDURE babel_cursor_proc(@num_fetch int)
 AS
 BEGIN
 	DECLARE @var_i int;
 	DECLARE @cnt int = 0;
+	DECLARE cur CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i
+	OPEN cur
 
 	WHILE @cnt < @num_fetch
 	  BEGIN
-		FETCH FROM @cur INTO @var_i
+		FETCH FROM cur INTO @var_i
 		SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
 		IF @@FETCH_STATUS <> 0
 		BREAK
@@ -24,59 +26,12 @@ BEGIN
 		SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
 		SET @cnt = @cnt + 1
 	  END
+	
+	CLOSE cur
 END;
 GO
 
-CREATE PROCEDURE babel_fetch_cursor_helper_char_proc(@cur CURSOR, @num_fetch int)
-AS
-BEGIN
-	DECLARE @var_c varchar(100);
-	DECLARE @cnt int = 0;
-
-	WHILE @cnt < @num_fetch
-	BEGIN
-		FETCH FROM @cur INTO @var_c
-		SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
-		IF @@FETCH_STATUS <> 0
-			BREAK
-		SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
-		IF (@var_c IS NULL)
-			SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
-		SET @cnt = @cnt + 1
-	END
-END;
-GO
-
-CREATE PROCEDURE babel_cursor_proc
-AS
-BEGIN
-	DECLARE @var_a int;
-	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	OPEN cur_a;
-
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
-	CLOSE cur_a;
-END;
-GO
-
-EXEC babel_cursor_proc;
-GO
-
-CREATE PROCEDURE babel_cursor_no_semi_proc
-AS
-BEGIN
-	DECLARE @var_a int
-	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i
-	OPEN cur_a
-
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
-	CLOSE cur_a
-END;
-GO
-
-EXEC babel_cursor_no_semi_proc;
+EXEC babel_cursor_proc 5;
 GO
 
 -- no cursor cur_a (in OPEN)
@@ -96,9 +51,6 @@ BEGIN
 	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	OPEN cur_a;
 	FETCH NEXT FROM cur_a INTO @var_a;
-
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	CLOSE cur_b;
 END;
 GO
@@ -121,9 +73,6 @@ BEGIN
 	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	OPEN cur_a;
 	FETCH NEXT FROM cur_a INTO @var_a;
-
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	CLOSE @var_a;
 END;
 GO
@@ -150,9 +99,6 @@ BEGIN
 	DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	OPEN cur_a;
 	FETCH NEXT FROM cur_a INTO @var_a;
-
-	EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	CLOSE GLOBAL cur_a;
 END;
 GO
@@ -348,10 +294,21 @@ CREATE PROCEDURE babel_local_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  CLOSE cur_a;
 END;
@@ -364,10 +321,21 @@ CREATE PROCEDURE babel_forward_only_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR FORWARD_ONLY FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 3;
+	  WHILE @cnt < 3
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  -- error
 	  FETCH PRIOR FROM cur_a INTO @var_a;
@@ -384,10 +352,21 @@ CREATE PROCEDURE babel_scroll_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR SCROLL FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 3;
+	  WHILE @cnt < 3
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  FETCH PRIOR FROM cur_a INTO @var_a;
 	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10));
@@ -403,10 +382,21 @@ CREATE PROCEDURE babel_static_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR STATIC FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  CLOSE cur_a;
 END;
@@ -421,9 +411,6 @@ BEGIN
 	  DECLARE @var_a int;
 	  DECLARE cur_a CURSOR KEYSET FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	  CLOSE cur_a;
 END;
 GO
@@ -437,9 +424,6 @@ BEGIN
 	  DECLARE @var_a int;
 	  DECLARE cur_a CURSOR DYNAMIC FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
-
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	  CLOSE cur_a;
 END;
 GO
@@ -451,10 +435,21 @@ CREATE PROCEDURE babel_fast_forward_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  CLOSE cur_a;
 END;
@@ -467,11 +462,22 @@ CREATE PROCEDURE babel_read_only_cursor_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR READ_ONLY FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	-- TODO: currently READ_ONLY is ignored. read-only cursor is updatable.
 	-- UPDATE babel_cursor_t1 SET i = i+1 WHERE CURRENT OF cur_a;
@@ -489,9 +495,6 @@ BEGIN
 	  DECLARE cur_a CURSOR SCROLL_LOCKS FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
-
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	  CLOSE cur_a;
 END;
 GO
@@ -506,9 +509,6 @@ BEGIN
 	  DECLARE cur_a CURSOR OPTIMISTIC FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
-
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
-
 	  CLOSE cur_a;
 END;
 GO
@@ -588,11 +588,22 @@ CREATE PROCEDURE babel_cursor_fetch_failure_proc
 AS
 BEGIN
 	  DECLARE @var_a int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN cur_a;
 	  FETCH NEXT FROM cur_a INTO @var_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_a
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_a: ' + CAST(@var_a AS VARCHAR(100))
+		  IF (@var_a IS NULL)
+		  SELECT '@var_a is null: ' + CAST((case when @var_a is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  SET @var_a = 1;
 	  FETCH NEXT FROM cur_a INTO @var_a;
@@ -622,20 +633,42 @@ AS
 BEGIN
 	  DECLARE @var_i int;
 	  DECLARE @var_c varchar(10)
+	  DECLARE @cnt int = 0;
 	  DECLARE @cur_a CURSOR;
 
 	  SET @cur_a = CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  DEALLOCATE @cur_a;
 
 	  -- set another cursor for the same curvar
 	  SET @cur_a = CURSOR FOR SELECT c FROM babel_cursor_t1 ORDER BY i;
+	  SET @cnt = 0;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_c
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+		  IF (@var_c IS NULL)
+		  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  CLOSE @cur_a;
 END;
@@ -649,20 +682,42 @@ AS
 BEGIN
 	  DECLARE @var_i int;
 	  DECLARE @var_c varchar(10)
+	  DECLARE @cnt int = 0;
 	  DECLARE @cur_a CURSOR;
 
 	  SET @cur_a = CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  DEALLOCATE @cur_a;
 
 	  -- set another cursor for the same curvar
 	  SET @cur_a = CURSOR SCROLL FOR SELECT c FROM babel_cursor_t1 ORDER BY c;
+	  SET @cnt = 0;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 5;
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM @cur_a INTO @var_c
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+		  IF (@var_c IS NULL)
+		  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 
 	  CLOSE @cur_a;
 END;
@@ -681,13 +736,27 @@ BEGIN
 	  SET @cur_a = CURSOR FAST_FORWARD FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_i
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+	  IF (@var_i IS NULL)
+	  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 
 	  -- set another cursor for the same curvar without deallocate
 	  SET @cur_a = CURSOR SCROLL FOR SELECT c FROM babel_cursor_t1 ORDER BY c;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_c
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+	  IF (@var_c IS NULL)
+	  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 
 	  CLOSE @cur_a;
 END;
@@ -709,7 +778,14 @@ BEGIN
 	  SET @cur_a = CURSOR SCROLL FOR SELECT c FROM babel_cursor_t1;
 	  OPEN @cur_a;
 
-	  EXEC babel_fetch_cursor_helper_char_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_c
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_c: ' + CAST(@var_c AS VARCHAR(100))
+	  IF (@var_c IS NULL)
+	  SELECT '@var_c is null: ' + CAST((case when @var_c is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 
 	  CLOSE @cur_a;
 END;
@@ -739,7 +815,14 @@ BEGIN
 	  OPEN @cur_a;
 	  FETCH NEXT FROM @cur_a INTO @var_i;
 
-	  EXEC babel_fetch_cursor_helper_int_proc @cur_a, 1;
+	  FETCH FROM @cur_a INTO @var_i
+	  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+	  IF @@FETCH_STATUS = 0
+	  BEGIN
+	  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+	  IF (@var_i IS NULL)
+	  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+	  END
 
 	  DEALLOCATE @cur_a;
 	  DEALLOCATE @cur_a;
@@ -1150,16 +1233,39 @@ GO
 CREATE PROCEDURE babel_cursor_redecl_proc
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a
 	  DEALLOCATE cur_a
 
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
+	  SET @cnt = 0
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a
 	  DEALLOCATE cur_a
 END;
@@ -1172,15 +1278,26 @@ GO
 CREATE PROCEDURE babel_cursor_redecl_not_deallocd_proc_1
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  CLOSE cur_a
 
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 	  CLOSE cur_a
 END;
 GO
@@ -1197,7 +1314,6 @@ BEGIN
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 END;
 GO
 
@@ -1211,7 +1327,6 @@ BEGIN
 	  -- redeclare with different definition
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 END;
 GO
 
@@ -1221,16 +1336,40 @@ GO
 CREATE PROCEDURE babel_cursor_redecl_goto_proc
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  GOTO label1
 	label2:
+	  SET @cnt = 0
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  GOTO label3
 	label1:
+	  SET @cnt = 0
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  DEALLOCATE cur_a
 	  GOTO label2
 	label3:
@@ -1243,260 +1382,35 @@ GO
 CREATE PROCEDURE babel_cursor_redecl_goto_proc_2
 AS
 BEGIN
+	  DECLARE @var_i int;
+	  DECLARE @cnt int = 0;
 	  GOTO label1
 	label2:
 	  -- error is expected here because cur_a in label1 is not dealloc'd
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i+100 from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
 	  DEALLOCATE cur_a
 	  GOTO label3
 	label1:
 	  DECLARE cur_a CURSOR LOCAL FOR SELECT i from babel_cursor_t1
 	  OPEN cur_a
-	  EXEC babel_fetch_cursor_helper_int_proc cur_a, 5
+	  WHILE @cnt < 5
+	    BEGIN
+		  FETCH FROM cur_a INTO @var_i
+		  SELECT '@@fetch_status: ' + CAST(@@fetch_status AS VARCHAR(10))
+		  IF @@FETCH_STATUS <> 0
+		  BREAK
+		  SELECT '@var_i: ' + CAST(@var_i AS VARCHAR(100))
+		  IF (@var_i IS NULL)
+		  SELECT '@var_i is null: ' + CAST((case when @var_i is null then 'true' else 'false' end) AS VARCHAR(100))
+		  SET @cnt = @cnt + 1
+		END
 	  GOTO label2
 	label3:
 END
 GO
 
 EXEC babel_cursor_redecl_goto_proc_2
-GO
-
-CREATE PROCEDURE babel_print_sp_cursor_list(@cur CURSOR)
-AS
-BEGIN
-	  DECLARE @refname VARCHAR(200);
-	  DECLARE @curname VARCHAR(200);
-	  DECLARE @scope INT;
-	  DECLARE @status INT;
-	  DECLARE @model INT;
-	  DECLARE @concurrency INT;
-	  DECLARE @scrollable INT;
-	  DECLARE @open_status INT;
-	  DECLARE @cursor_rows DECIMAL(10,0);
-	  DECLARE @fetch_status INT;
-	  DECLARE @column_count INT;
-	  DECLARE @row_count DECIMAL(10,0);
-	  DECLARE @last_operation INT;
-
-	  FETCH FROM @cur INTO @refname, @curname, @scope, @status, @model, @concurrency, @scrollable, @open_status, @cursor_rows, @fetch_status, @column_count, @row_count, @last_operation;
-	  WHILE @@FETCH_STATUS = 0
-	  BEGIN
-		SELECT '(sp_cursor_list out) @refname: ' + @refname + ', @curname: ' + @curname + ', @scope: ' + cast(@scope as VARCHAR(10)) + ', @model: ' + cast(@model as varchar(10)) + ', @concurrency: ' + cast(@concurrency as varchar(10)) + ', @scrollable: ' + cast(@scrollable as varchar(10)) + ', @open_status: ' + cast(@open_status as varchar(10)) + ', @cursor_rows: ' + cast(@cursor_rows as varchar(10)) + ', @fetch_status: ' + cast(@fetch_status as varchar(10)) + ', @column_count: ' + cast(@column_count as varchar(10)) + ', @row_count: ' + cast(@row_count as varchar(10)) + ', @last_operation ' + cast(@last_operation as varchar(10));
-		FETCH FROM @cur INTO @refname, @curname, @scope, @status, @model, @concurrency, @scrollable, @open_status, @cursor_rows, @fetch_status, @column_count, @row_count, @last_operation;
-	  END
-
-	  CLOSE @cur;
-	  DEALLOCATE @cur;
-END
-GO
-
-
-CREATE PROCEDURE babel_sp_cursor_list_proc
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE @var_a int;
-
-	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE cur_b CURSOR FOR SELECT i+1 FROM babel_cursor_t1 ORDER BY i;
-
-	  DECLARE @refcur_b CURSOR;
-	  DECLARE @refcur_c CURSOR;
-
-	  SELECT '== AFTER DECLARE ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  SET @refcur_b = cur_b;
-	  SET @refcur_c = CURSOR FOR SELECT i+2 FROM babel_cursor_t1 ORDER BY i;
-
-	  SELECT '== AFTER SET ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  OPEN cur_a;
-	  OPEN @refcur_b;
-	  OPEN @refcur_c;
-
-	  SELECT '== AFTER OPEN ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  FETCH NEXT FROM cur_a INTO @var_a;
-	  FETCH NEXT FROM @refcur_b INTO @var_a;
-	  FETCH NEXT FROM @refcur_c INTO @var_a;
-
-	  SELECT '== AFTER FETCH ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  CLOSE cur_a;
-	  CLOSE @refcur_b;
-	  CLOSE @refcur_c;
-
-	  SELECT '== AFTER CLOSE ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  DEALLOCATE cur_a;
-	  DEALLOCATE @refcur_b;
-	  DEALLOCATE @refcur_c;
-
-	  SELECT '== AFTER DEALLOCATE ==';
-	  EXEC sp_cursor_list @report_cur OUT, 1;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-END;
-GO
-
-EXEC babel_sp_cursor_list_proc;
-GO
-
-CREATE PROCEDURE babel_sp_cursor_list_nested_proc_2
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE cur_a CURSOR FOR SELECT * FROM babel_cursor_t1 ORDER BY c;
-	  OPEN cur_a;
-
-	  SELECT '== in the nested proc ==';
-	  EXEC sp_cursor_list @report_cur OUT, 3;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-END;
-GO
-
-CREATE PROCEDURE babel_sp_cursor_list_nested_proc
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE @var_a INT;
-	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE @refcur_a CURSOR;
-
-	  SET @refcur_a = cur_a;
-
-	  OPEN cur_a;
-	  FETCH NEXT FROM @refcur_a INTO @var_a;
-
-	  SELECT '== before calling nested proc ==';
-	  EXEC sp_cursor_list @report_cur OUT, 3;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  EXEC babel_sp_cursor_list_nested_proc_2;
-
-	  SELECT '== after calling nested proc ==';
-	  EXEC sp_cursor_list @report_cur OUT, 3;
-	  EXEC babel_print_sp_cursor_list @report_cur;
-END;
-GO
-
-EXEC babel_sp_cursor_list_nested_proc;
-GO
-
-CREATE PROCEDURE babel_sp_describe_cursor_proc
-AS
-BEGIN
-	  DECLARE @report_cur CURSOR;
-	  DECLARE @var_a int;
-
-	  DECLARE cur_a CURSOR FOR SELECT i FROM babel_cursor_t1 ORDER BY i;
-	  DECLARE cur_b CURSOR FOR SELECT i+1 FROM babel_cursor_t1 ORDER BY i;
-
-	  DECLARE @refcur_b CURSOR;
-	  DECLARE @refcur_c CURSOR;
-
-	  SELECT '== AFTER DECLARE ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  SET @refcur_b = cur_b;
-	  SET @refcur_c = CURSOR FOR SELECT i+2 FROM babel_cursor_t1 ORDER BY i;
-
-	  SELECT '== AFTER SET ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  OPEN cur_a;
-	  OPEN @refcur_b;
-	  OPEN @refcur_c;
-
-	  SELECT '== AFTER OPEN ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  FETCH NEXT FROM cur_a INTO @var_a;
-	  FETCH NEXT FROM @refcur_b INTO @var_a;
-	  FETCH NEXT FROM @refcur_c INTO @var_a;
-
-	  SELECT '== AFTER FETCH ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  SELECT '== BEGIN (call with invalid argument) =='
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', '@refcur_not_exsits';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_not_exsits';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  SELECT '== END (call with invalid argument) =='
-
-	  CLOSE cur_a;
-	  CLOSE @refcur_b;
-	  CLOSE @refcur_c;
-
-	  SELECT '== AFTER CLOSE ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-	  DEALLOCATE cur_a;
-	  DEALLOCATE @refcur_b;
-	  DEALLOCATE @refcur_c;
-
-	  SELECT '== AFTER DEALLOCATE ==';
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_a';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'local', 'cur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_b';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-	  EXEC sp_describe_cursor @report_cur OUT, 'variable', '@refcur_c';
-	  EXEC babel_print_sp_cursor_list @report_cur;
-
-END;
-GO
-
-EXEC babel_sp_describe_cursor_proc;
 GO
 
 CREATE PROCEDURE babel_same_cursor_name_proc(@opt int)
@@ -1922,7 +1836,6 @@ EXEC babel_943_proc
 GO
 
 DROP PROCEDURE babel_cursor_proc;
-DROP PROCEDURE babel_cursor_no_semi_proc;
 DROP PROCEDURE babel_cursor_double_precision_proc;
 DROP PROCEDURE babel_cursor_varchar_proc;
 DROP PROCEDURE babel_cursor_uniqueidentifier_proc;
@@ -1962,13 +1875,6 @@ DROP PROCEDURE babel_cursor_redecl_not_deallocd_proc_2;
 DROP PROCEDURE babel_cursor_redecl_not_deallocd_proc_3;
 DROP PROCEDURE babel_cursor_redecl_goto_proc;
 DROP PROCEDURE babel_cursor_redecl_goto_proc_2;
-DROP PROCEDURE babel_fetch_cursor_helper_int_proc;
-DROP PROCEDURE babel_fetch_cursor_helper_char_proc;
-DROP PROCEDURE babel_sp_cursor_list_proc;
-DROP PROCEDURE babel_sp_cursor_list_nested_proc_2;
-DROP PROCEDURE babel_sp_cursor_list_nested_proc;
-DROP PROCEDURE babel_sp_describe_cursor_proc;
-DROP PROCEDURE babel_print_sp_cursor_list;
 DROP PROCEDURE babel_same_cursor_name_proc;
 DROP PROCEDURE babel_cursor_rows_proc;
 DROP PROCEDURE babel_sp_cursor_proc;

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -143,9 +143,3 @@ ignore#!#load_road
 ignore#!#load_tenk
 ignore#!#load_stud_emp
 ignore#!#load_student
-
-# This test case has implemented cursor functionality which SQL Server does not even support
-# When fixing unquoted string parameters in BABEL-334, this test now fails, but it should never 
-# really have succeeded in the first place, so disabling the test for now
-ignore#!#babel_cursor
-

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -66,6 +66,8 @@ Could not find tests for procedure sys.babel_drop_all_dbs
 Could not find tests for procedure sys.babel_drop_all_logins
 Could not find tests for procedure sys.babel_initialize_logins
 Could not find tests for procedure sys.printarg
+Could not find tests for procedure sys.sp_cursor_list
+Could not find tests for procedure sys.sp_describe_cursor
 Could not find tests for table sys.babelfish_helpcollation
 Could not find tests for table sys.babelfish_syslanguages
 Could not find tests for table sys.service_settings


### PR DESCRIPTION
### Description

Babelfish cursor has the following problems:
1. In SQL Server, cursor can only be a procedure argument of type VARYING OUTPUT, and cannot be an INPUT. However both are allowed in Babelfish.
2. In current Babelfish, when cursor is used as a VARYING OUTPUT argument, it is not behaving the same as SQL Server. This issue is tracked in BABEL-3350.

Due to the above reasons, rewrote/removed some test cases in babel_cursor.sql test to match SQL Server usage. Output has been verified against SQL Server test result. For the same reason, `sp_cursor_list` and `sp_describe_cursor` usage does not match SQL Server behavior either, removing related tests till BABEL-3350 is fixed.

Task: BABEL-4391
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).