### PR TITLE
Default schema of guest user should be guest in sys.babelfish_authid_user_ext

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -657,5 +657,16 @@ $BODY$
 LANGUAGE plpgsql
 IMMUTABLE;
 
+-- This is a temporary procedure which is called during upgrade to create guest users
+-- for the user created databases if it doesn't have guest user already.
+CREATE OR REPLACE PROCEDURE sys.babelfish_update_user_catalog_for_guest_schema()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'update_user_catalog_for_guest_schema';
+
+CALL sys.babelfish_update_user_catalog_for_guest_schema();
+
+-- Drop this procedure after it gets executed once.
+DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest_schema();
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -657,8 +657,8 @@ $BODY$
 LANGUAGE plpgsql
 IMMUTABLE;
 
--- This is a temporary procedure which is called during upgrade to create guest users
--- for the user created databases if it doesn't have guest user already.
+-- This is a temporary procedure which is called during upgrade to update guest schema
+-- for the guest users in the already existing databases
 CREATE OR REPLACE PROCEDURE sys.babelfish_update_user_catalog_for_guest_schema()
 LANGUAGE C
 AS 'babelfishpg_tsql', 'update_user_catalog_for_guest_schema';

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1549,6 +1549,7 @@ static void init_catalog_data(void);
 static void get_catalog_info(Rule *rule);
 static void create_guest_role_for_db(const char *dbname);
 static char *get_db_owner_role_name(const char *dbname);
+static char alter_guest_schema_for_db(const char *dbname);
 
 /* Helper function Rename BBF catalog update*/
 static void rename_view_update_bbf_catalog(RenameStmt *stmt);
@@ -2532,7 +2533,7 @@ create_guest_role_for_db(const char *dbname)
 			CommandCounterIncrement();
 		}
 		set_cur_db(old_dbid, old_dbname);
-		add_to_bbf_authid_user_ext(guest, "guest", dbname, "guest", NULL, false, false, false);
+		add_to_bbf_authid_user_ext(guest, "guest", dbname, NULL, NULL, false, false, false);
 	}
 	PG_CATCH();
 	{
@@ -2796,4 +2797,89 @@ rename_procfunc_update_bbf_catalog(RenameStmt *stmt)
 
 	table_endscan(tblscan);
 	table_close(bbf_func_ext_rel, RowExclusiveLock);
+}
+
+PG_FUNCTION_INFO_V1(update_user_catalog_for_guest_schema);
+Datum
+update_user_catalog_for_guest_schema(PG_FUNCTION_ARGS)
+{
+	Relation	db_rel;
+	TableScanDesc scan;
+	HeapTuple	tuple;
+	bool		is_null;
+
+	db_rel = table_open(sysdatabases_oid, AccessShareLock);
+	scan = table_beginscan_catalog(db_rel, 0, NULL);
+	tuple = heap_getnext(scan, ForwardScanDirection);
+
+	while (HeapTupleIsValid(tuple))
+	{
+		Datum		db_name_datum = heap_getattr(tuple, Anum_sysdatabaese_name,
+												 db_rel->rd_att, &is_null);
+		const char *db_name = TextDatumGetCString(db_name_datum);
+
+		alter_guest_schema_for_db(db_name);
+		tuple = heap_getnext(scan, ForwardScanDirection);
+	}
+	table_endscan(scan);
+	table_close(db_rel, AccessShareLock);
+	PG_RETURN_INT32(0);
+}
+
+static void
+alter_guest_schema_for_db (const char *dbname)
+{
+	Relation	bbf_authid_user_ext_rel;
+	TupleDesc	bbf_authid_user_ext_dsc;
+	ScanKeyData key[2];
+	HeapTuple	usertuple;
+	HeapTuple	new_tuple;
+	TableScanDesc tblscan;
+	Datum		new_record_user_ext[BBF_AUTHID_USER_EXT_NUM_COLS];
+	bool		new_record_nulls_user_ext[BBF_AUTHID_USER_EXT_NUM_COLS];
+	bool		new_record_repl_user_ext[BBF_AUTHID_USER_EXT_NUM_COLS];
+
+	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
+										 RowExclusiveLock);
+	bbf_authid_user_ext_dsc = RelationGetDescr(bbf_authid_user_ext_rel);
+
+	/* Search and obtain the tuple based on the user name and db name */
+	ScanKeyInit(&key[0],
+				Anum_bbf_authid_user_ext_orig_username,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum("guest"));
+	ScanKeyInit(&key[1],
+				Anum_bbf_authid_user_ext_database_name,
+				BTEqualStrategyNumber, F_TEXTEQ,
+				CStringGetTextDatum(db_name));
+
+	tblscan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
+
+	/* Build a tuple to insert */
+	MemSet(new_record_user_ext, 0, sizeof(new_record_user_ext));
+	MemSet(new_record_nulls_user_ext, false, sizeof(new_record_nulls_user_ext));
+	MemSet(new_record_repl_user_ext, false, sizeof(new_record_repl_user_ext));
+
+	usertuple = heap_getnext(tblscan, ForwardScanDirection);
+
+	if (!HeapTupleIsValid(usertuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("Cannot find the user \"%s\", because it does not exist or you do not have permission.", user_name)));
+
+	new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("guest");
+	new_record_repl_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = true;
+
+	new_tuple = heap_modify_tuple(usertuple,
+								  bbf_authid_user_ext_dsc,
+								  new_record_user_ext,
+								  new_record_nulls_user_ext,
+								  new_record_repl_user_ext);
+
+	CatalogTupleUpdate(bbf_authid_user_ext_rel, &new_tuple->t_self, new_tuple);
+
+	heap_freetuple(new_tuple);
+
+	table_endscan(tblscan);
+	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
 }

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1549,7 +1549,7 @@ static void init_catalog_data(void);
 static void get_catalog_info(Rule *rule);
 static void create_guest_role_for_db(const char *dbname);
 static char *get_db_owner_role_name(const char *dbname);
-static char alter_guest_schema_for_db(const char *dbname);
+static void alter_guest_schema_for_db(const char *dbname);
 
 /* Helper function Rename BBF catalog update*/
 static void rename_view_update_bbf_catalog(RenameStmt *stmt);
@@ -2851,7 +2851,7 @@ alter_guest_schema_for_db (const char *dbname)
 	ScanKeyInit(&key[1],
 				Anum_bbf_authid_user_ext_database_name,
 				BTEqualStrategyNumber, F_TEXTEQ,
-				CStringGetTextDatum(db_name));
+				CStringGetTextDatum(dbname));
 
 	tblscan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
 
@@ -2861,15 +2861,13 @@ alter_guest_schema_for_db (const char *dbname)
 	MemSet(new_record_repl_user_ext, false, sizeof(new_record_repl_user_ext));
 
 	usertuple = heap_getnext(tblscan, ForwardScanDirection);
-
 	if (!HeapTupleIsValid(usertuple))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("Cannot find the user \"%s\", because it does not exist or you do not have permission.", user_name)));
+				 errmsg("tuple does not exist")));
 
 	new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("guest");
 	new_record_repl_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = true;
-
 	new_tuple = heap_modify_tuple(usertuple,
 								  bbf_authid_user_ext_dsc,
 								  new_record_user_ext,

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2864,7 +2864,7 @@ alter_guest_schema_for_db (const char *dbname)
 	if (!HeapTupleIsValid(usertuple))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("tuple does not exist")));
+				 errmsg("Cannot find the user \"guest\", because it does not exist or you do not have permission.")));
 
 	new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("guest");
 	new_record_repl_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = true;

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2532,7 +2532,7 @@ create_guest_role_for_db(const char *dbname)
 			CommandCounterIncrement();
 		}
 		set_cur_db(old_dbid, old_dbname);
-		add_to_bbf_authid_user_ext(guest, "guest", dbname, NULL, NULL, false, false, false);
+		add_to_bbf_authid_user_ext(guest, "guest", dbname, "guest", NULL, false, false, false);
 	}
 	PG_CATCH();
 	{

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -560,9 +560,9 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 			 * enabled by default
 			 */
 			if (strcmp(dbname, "master") == 0 || strcmp(dbname, "tempdb") == 0 || strcmp(dbname, "msdb") == 0)
-				add_to_bbf_authid_user_ext(guest, "guest", dbname, NULL, NULL, false, true, false);
+				add_to_bbf_authid_user_ext(guest, "guest", dbname, "guest", NULL, false, true, false);
 			else
-				add_to_bbf_authid_user_ext(guest, "guest", dbname, NULL, NULL, false, false, false);
+				add_to_bbf_authid_user_ext(guest, "guest", dbname, "guest", NULL, false, false, false);
 		}
 	}
 	PG_CATCH();

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1231,9 +1231,9 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 			 * enabled by default
 			 */
 			if (strcmp(db_name, "master") == 0 || strcmp(db_name, "tempdb") == 0 || strcmp(db_name, "msdb") == 0)
-				add_to_bbf_authid_user_ext(guest, "guest", db_name, "guest", NULL, false, true, false);
+				add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false, true, false);
 			else
-				add_to_bbf_authid_user_ext(guest, "guest", db_name, "guest", NULL, false, false, false);
+				add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false, false, false);
 		}
 
 		tuple = heap_getnext(scan, ForwardScanDirection);

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1104,12 +1104,7 @@ add_to_bbf_authid_user_ext(const char *user_name,
 	if (schema_name)
 		new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum(pstrdup(schema_name));
 	else
-	{
-		if (strcmp(orig_user_name, "guest") == 0)
-			new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum(pstrdup("guest"));
-		else
-			new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("");
-	}
+		new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("");
 	new_record_user_ext[USER_EXT_DEFAULT_LANGUAGE_NAME] = CStringGetTextDatum("English");
 	new_record_user_ext[USER_EXT_AUTHENTICATION_TYPE_DESC] = CStringGetTextDatum("");	/* placeholder */
 	if (has_dbaccess)

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1231,9 +1231,9 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 			 * enabled by default
 			 */
 			if (strcmp(db_name, "master") == 0 || strcmp(db_name, "tempdb") == 0 || strcmp(db_name, "msdb") == 0)
-				add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false, true, false);
+				add_to_bbf_authid_user_ext(guest, "guest", db_name, "guest", NULL, false, true, false);
 			else
-				add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false, false, false);
+				add_to_bbf_authid_user_ext(guest, "guest", db_name, "guest", NULL, false, false, false);
 		}
 
 		tuple = heap_getnext(scan, ForwardScanDirection);

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1104,7 +1104,12 @@ add_to_bbf_authid_user_ext(const char *user_name,
 	if (schema_name)
 		new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum(pstrdup(schema_name));
 	else
-		new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("");
+	{
+		if (strcmp(orig_user_name, "guest") == 0)
+			new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum(pstrdup("guest"));
+		else
+			new_record_user_ext[USER_EXT_DEFAULT_SCHEMA_NAME] = CStringGetTextDatum("");
+	}
 	new_record_user_ext[USER_EXT_DEFAULT_LANGUAGE_NAME] = CStringGetTextDatum("English");
 	new_record_user_ext[USER_EXT_AUTHENTICATION_TYPE_DESC] = CStringGetTextDatum("");	/* placeholder */
 	if (has_dbaccess)

--- a/test/JDBC/expected/BABEL-3637.out
+++ b/test/JDBC/expected/BABEL-3637.out
@@ -12,10 +12,6 @@ BEGIN
 	SELECT ServerRole, MemberName FROM @tmp_babel_3637;
 END
 GO
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: function "test_babel_3637_proc1" already exists with same argument types)~~
-
 
 CREATE PROC test_babel_3637_proc2 @rolename AS SYS.SYSNAME = NULL
 AS
@@ -25,10 +21,6 @@ BEGIN
 	SELECT UserName, RoleName, LoginName, DefDBName, DefSchemaName from @tmp_babel_3637;
 END
 GO
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: function "test_babel_3637_proc2" already exists with same argument types)~~
-
 
 CREATE LOGIN babel_3637_login1 WITH PASSWORD='12345678';
 GO

--- a/test/JDBC/expected/BABEL-3637.out
+++ b/test/JDBC/expected/BABEL-3637.out
@@ -12,6 +12,10 @@ BEGIN
 	SELECT ServerRole, MemberName FROM @tmp_babel_3637;
 END
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: function "test_babel_3637_proc1" already exists with same argument types)~~
+
 
 CREATE PROC test_babel_3637_proc2 @rolename AS SYS.SYSNAME = NULL
 AS
@@ -21,6 +25,10 @@ BEGIN
 	SELECT UserName, RoleName, LoginName, DefDBName, DefSchemaName from @tmp_babel_3637;
 END
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: function "test_babel_3637_proc2" already exists with same argument types)~~
+
 
 CREATE LOGIN babel_3637_login1 WITH PASSWORD='12345678';
 GO
@@ -43,7 +51,7 @@ GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -92,7 +100,7 @@ GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -117,7 +125,7 @@ GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -140,7 +148,7 @@ GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -162,7 +170,7 @@ GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -190,7 +198,7 @@ GO
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -219,7 +227,7 @@ GO
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -243,7 +251,7 @@ GO
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 
@@ -267,7 +275,7 @@ GO
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 babel_3637_login2#!#public#!#babel_3637_login2#!#master#!#dbo
 dbo#!#db_owner#!#jdbc_user#!#<NULL>#!#dbo
-guest#!#public#!#<NULL>#!#<NULL>#!#
+guest#!#public#!#<NULL>#!#<NULL>#!#guest
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -690,18 +690,18 @@ ORDER BY rolname;
 GO
 ~~START~~
 varchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar
-db1_guest#!#guest#!##!#db1#!#
+db1_guest#!#guest#!##!#db1#!#guest
 db_owner#!#db_owner#!##!#db1#!#
 dbo#!#dbo#!##!#db1#!#dbo
 master_db_owner#!#db_owner#!##!#master#!#
 master_dbo#!#dbo#!##!#master#!#dbo
-master_guest#!#guest#!##!#master#!#
+master_guest#!#guest#!##!#master#!#guest
 msdb_db_owner#!#db_owner#!##!#msdb#!#
 msdb_dbo#!#dbo#!##!#msdb#!#dbo
-msdb_guest#!#guest#!##!#msdb#!#
+msdb_guest#!#guest#!##!#msdb#!#guest
 tempdb_db_owner#!#db_owner#!##!#tempdb#!#
 tempdb_dbo#!#dbo#!##!#tempdb#!#dbo
-tempdb_guest#!#guest#!##!#tempdb#!#
+tempdb_guest#!#guest#!##!#tempdb#!#guest
 ~~END~~
 
 
@@ -865,13 +865,13 @@ GO
 varchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar
 master_db_owner#!#db_owner#!##!#master#!#
 master_dbo#!#dbo#!##!#master#!#dbo
-master_guest#!#guest#!##!#master#!#
+master_guest#!#guest#!##!#master#!#guest
 msdb_db_owner#!#db_owner#!##!#msdb#!#
 msdb_dbo#!#dbo#!##!#msdb#!#dbo
-msdb_guest#!#guest#!##!#msdb#!#
+msdb_guest#!#guest#!##!#msdb#!#guest
 tempdb_db_owner#!#db_owner#!##!#tempdb#!#
 tempdb_dbo#!#dbo#!##!#tempdb#!#dbo
-tempdb_guest#!#guest#!##!#tempdb#!#
+tempdb_guest#!#guest#!##!#tempdb#!#guest
 ~~END~~
 
 
@@ -935,19 +935,19 @@ GO
 varchar#!#varchar#!#nvarchar#!#nvarchar#!#nvarchar
 db1_db_owner#!##!#db_owner#!#db1#!#
 db1_dbo#!##!#dbo#!#db1#!#dbo
-db1_guest#!##!#guest#!#db1#!#
+db1_guest#!##!#guest#!#db1#!#guest
 db2_db_owner#!##!#db_owner#!#db2#!#
 db2_dbo#!##!#dbo#!#db2#!#dbo
-db2_guest#!##!#guest#!#db2#!#
+db2_guest#!##!#guest#!#db2#!#guest
 master_db_owner#!##!#db_owner#!#master#!#
 master_dbo#!##!#dbo#!#master#!#dbo
-master_guest#!##!#guest#!#master#!#
+master_guest#!##!#guest#!#master#!#guest
 msdb_db_owner#!##!#db_owner#!#msdb#!#
 msdb_dbo#!##!#dbo#!#msdb#!#dbo
-msdb_guest#!##!#guest#!#msdb#!#
+msdb_guest#!##!#guest#!#msdb#!#guest
 tempdb_db_owner#!##!#db_owner#!#tempdb#!#
 tempdb_dbo#!##!#dbo#!#tempdb#!#dbo
-tempdb_guest#!##!#guest#!#tempdb#!#
+tempdb_guest#!##!#guest#!#tempdb#!#guest
 ~~END~~
 
 
@@ -957,9 +957,9 @@ ORDER BY default_schema_name DESC, name;
 GO
 ~~START~~
 varchar#!#varchar
+guest#!#guest
 dbo#!#dbo
 db_owner#!#
-guest#!#
 INFORMATION_SCHEMA#!#<NULL>
 public#!#<NULL>
 sys#!#<NULL>
@@ -989,9 +989,9 @@ ORDER BY default_schema_name DESC, name;
 GO
 ~~START~~
 varchar#!#varchar
+guest#!#guest
 dbo#!#dbo
 db_owner#!#
-guest#!#
 INFORMATION_SCHEMA#!#<NULL>
 public#!#<NULL>
 sys#!#<NULL>
@@ -1127,16 +1127,16 @@ GO
 varchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar
 db2_db_owner#!#db_owner#!##!#db2#!#
 db2_dbo#!#dbo#!##!#db2#!#dbo
-db2_guest#!#guest#!##!#db2#!#
+db2_guest#!#guest#!##!#db2#!#guest
 master_db_owner#!#db_owner#!##!#master#!#
 master_dbo#!#dbo#!##!#master#!#dbo
-master_guest#!#guest#!##!#master#!#
+master_guest#!#guest#!##!#master#!#guest
 msdb_db_owner#!#db_owner#!##!#msdb#!#
 msdb_dbo#!#dbo#!##!#msdb#!#dbo
-msdb_guest#!#guest#!##!#msdb#!#
+msdb_guest#!#guest#!##!#msdb#!#guest
 tempdb_db_owner#!#db_owner#!##!#tempdb#!#
 tempdb_dbo#!#dbo#!##!#tempdb#!#dbo
-tempdb_guest#!#guest#!##!#tempdb#!#
+tempdb_guest#!#guest#!##!#tempdb#!#guest
 ~~END~~
 
 
@@ -1151,13 +1151,13 @@ GO
 varchar#!#nvarchar#!#varchar#!#nvarchar#!#nvarchar
 master_db_owner#!#db_owner#!##!#master#!#
 master_dbo#!#dbo#!##!#master#!#dbo
-master_guest#!#guest#!##!#master#!#
+master_guest#!#guest#!##!#master#!#guest
 msdb_db_owner#!#db_owner#!##!#msdb#!#
 msdb_dbo#!#dbo#!##!#msdb#!#dbo
-msdb_guest#!#guest#!##!#msdb#!#
+msdb_guest#!#guest#!##!#msdb#!#guest
 tempdb_db_owner#!#db_owner#!##!#tempdb#!#
 tempdb_dbo#!#dbo#!##!#tempdb#!#dbo
-tempdb_guest#!#guest#!##!#tempdb#!#
+tempdb_guest#!#guest#!##!#tempdb#!#guest
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -10,13 +10,13 @@ GO
 varchar#!#varchar#!#nvarchar#!#nvarchar#!#nvarchar
 master_db_owner#!##!#db_owner#!#master#!#
 master_dbo#!##!#dbo#!#master#!#dbo
-master_guest#!##!#guest#!#master#!#
+master_guest#!##!#guest#!#master#!#guest
 msdb_db_owner#!##!#db_owner#!#msdb#!#
 msdb_dbo#!##!#dbo#!#msdb#!#dbo
-msdb_guest#!##!#guest#!#msdb#!#
+msdb_guest#!##!#guest#!#msdb#!#guest
 tempdb_db_owner#!##!#db_owner#!#tempdb#!#
 tempdb_dbo#!##!#dbo#!#tempdb#!#dbo
-tempdb_guest#!##!#guest#!#tempdb#!#
+tempdb_guest#!##!#guest#!#tempdb#!#guest
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-USER.out
+++ b/test/JDBC/expected/BABEL-USER.out
@@ -49,18 +49,18 @@ ORDER BY rolname;
 GO
 ~~START~~
 varchar#!#varchar#!#nvarchar#!#nvarchar#!#nvarchar
-db1_guest#!##!#guest#!#db1#!#
+db1_guest#!##!#guest#!#db1#!#guest
 db_owner#!##!#db_owner#!#db1#!#
 dbo#!##!#dbo#!#db1#!#dbo
 master_db_owner#!##!#db_owner#!#master#!#
 master_dbo#!##!#dbo#!#master#!#dbo
-master_guest#!##!#guest#!#master#!#
+master_guest#!##!#guest#!#master#!#guest
 msdb_db_owner#!##!#db_owner#!#msdb#!#
 msdb_dbo#!##!#dbo#!#msdb#!#dbo
-msdb_guest#!##!#guest#!#msdb#!#
+msdb_guest#!##!#guest#!#msdb#!#guest
 tempdb_db_owner#!##!#db_owner#!#tempdb#!#
 tempdb_dbo#!##!#dbo#!#tempdb#!#dbo
-tempdb_guest#!##!#guest#!#tempdb#!#
+tempdb_guest#!##!#guest#!#tempdb#!#guest
 ~~END~~
 
 
@@ -70,9 +70,9 @@ ORDER BY default_schema_name DESC, name;
 GO
 ~~START~~
 varchar#!#varchar
+guest#!#guest
 dbo#!#dbo
 db_owner#!#
-guest#!#
 INFORMATION_SCHEMA#!#<NULL>
 public#!#<NULL>
 sys#!#<NULL>

--- a/test/JDBC/expected/Test-sp_helpuser-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_helpuser-vu-verify.out
@@ -19,7 +19,7 @@ GO
 ~~START~~
 varchar#!#varchar#!#int#!#varchar#!#varchar#!#nvarchar#!#int
 dbo#!#db_owner#!#1#!#<NULL>#!#dbo#!#dbo#!#1
-guest#!#public#!#0#!#<NULL>#!##!#guest#!#1
+guest#!#public#!#0#!#<NULL>#!#guest#!#guest#!#1
 ~~END~~
 
 

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -48,5 +48,6 @@ Unexpected drop found for procedure sys.babelfish_update_collation_to_default in
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.5.0--3.0.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.6.0--3.0.0.sql
 Unexpected drop found for procedure sys.babelfish_update_user_catalog_for_guest in file babelfishpg_tsql--2.2.0--2.3.0.sql
+Unexpected drop found for procedure sys.babelfish_update_user_catalog_for_guest_schema in file babelfishpg_tsql--3.3.0--3.4.0.sql
 Unexpected drop found for procedure sys.create_xp_qv_in_master_dbo in file babelfishpg_tsql--1.1.0--1.2.0.sql
 Unexpected drop found for procedure sys.sp_babelfish_grant_usage_to_all in file babelfishpg_tsql--1.1.0--1.2.0.sql


### PR DESCRIPTION
### Description

Default schema of guest user should be guest in sys.babelfish_authid_user_ext

### Issues Resolved


Task: <[BABEL-4409](https://jira.rds.a2z.com/browse/BABEL-4409)>
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes, already added.

* **Boundary conditions -** N/A

* **Arbitrary inputs -** N/A

* **Negative test cases -** N/A

* **Minor version upgrade tests -** Yes, already added.

* **Major version upgrade tests -** Yes, already added.

* **Performance tests -** N/A

* **Tooling impact -** N/A

* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).