### PR TITLE
BABEL-4411 set transaction isolation cmd change

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1206,6 +1206,7 @@ int			escape_hatch_ignore_dup_key = EH_STRICT;
 int			escape_hatch_rowversion = EH_STRICT;
 int			escape_hatch_showplan_all = EH_STRICT;
 int			escape_hatch_checkpoint = EH_IGNORE;
+int			escape_hatch_set_transaction_isolation_level = EH_STRICT;
 
 void
 define_escape_hatch_variables(void)
@@ -1541,6 +1542,17 @@ define_escape_hatch_variables(void)
 							 NULL,
 							 &escape_hatch_checkpoint,
 							 EH_IGNORE,
+							 escape_hatch_options,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+	
+	/* CHECKPOINT */
+	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_set_transaction_isolation_level",
+							 gettext_noop("escape hatch for SET TRANSACTION ISOLATION LEVEL"),
+							 NULL,
+							 &escape_hatch_set_transaction_isolation_level,
+							 EH_STRICT,
 							 escape_hatch_options,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1547,7 +1547,7 @@ define_escape_hatch_variables(void)
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);
 	
-	/* CHECKPOINT */
+	/* SET TRANSACTION ISOLATION */
 	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_set_transaction_isolation_level",
 							 gettext_noop("escape hatch for SET TRANSACTION ISOLATION LEVEL"),
 							 NULL,

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -980,6 +980,19 @@ is_batch_command(PLtsql_stmt *stmt)
 }
 
 static
+bool
+is_set_tran_isolation(PLtsql_stmt *stmt)
+{
+	if( stmt->cmd_type == PLTSQL_STMT_EXECSQL)
+	{
+		PLtsql_stmt_execsql	*execsql = (PLtsql_stmt_execsql *) stmt;
+		return execsql->is_set_tran_isolation;
+	}
+	else
+		return true;
+}
+
+static
 void
 record_error_state(PLtsql_execstate *estate)
 {
@@ -1192,7 +1205,7 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		 * savepoints and let the caller be responsible for handling the
 		 * error.
 		 */
-		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive())
+		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive() && !is_set_tran_isolation(stmt) )
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -986,10 +986,10 @@ is_set_tran_isolation(PLtsql_stmt *stmt)
 	if( stmt->cmd_type == PLTSQL_STMT_EXECSQL)
 	{
 		PLtsql_stmt_execsql	*execsql = (PLtsql_stmt_execsql *) stmt;
-		return execsql->is_set_tran_isolation;
+		if(execsql->is_set_tran_isolation)
+			return execsql->is_set_tran_isolation;
 	}
-	else
-		return true;
+	return false;
 }
 
 static

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1048,6 +1048,7 @@ typedef struct PLtsql_stmt_execsql
 	char	   *db_name;		/* db_name: only for cross db query */
 	bool		is_schema_specified;	/* is schema name specified? */
 	bool		is_create_view; /* CREATE VIEW? */
+	bool		is_set_tran_isolation; /* SET TRANSACTION ISOLATION*/
 	char	   *original_query; /* Only for batch level statement. */
 } PLtsql_stmt_execsql;
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4561,6 +4561,13 @@ makeSetStatement(TSqlParser::Set_statementContext *ctx, tsqlBuilder &builder)
 		}
 		else if (set_special_ctx->BABELFISH_STATISTICS() && set_special_ctx->PROFILE())
 			return makeSetExplainModeStatement(ctx, false);
+		else if(set_special_ctx->ISOLATION())
+		{
+			PLtsql_stmt_execsql *stmt = (PLtsql_stmt_execsql *) makeSQL(ctx);
+			stmt->is_set_tran_isolation = true;
+			attachPLtsql_fragment(ctx, (PLtsql_stmt *) stmt);
+			return (PLtsql_stmt *) stmt;
+		}
 		else
 			return makeSQL(ctx);
 	}

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -62,7 +62,6 @@ declare_escape_hatch(escape_hatch_session_settings);
 declare_escape_hatch(escape_hatch_ignore_dup_key);
 declare_escape_hatch(escape_hatch_rowversion);
 declare_escape_hatch(escape_hatch_checkpoint);
-declare_escape_hatch(escape_hatch_set_transaction_isolation_level);
 
 extern std::string getFullText(antlr4::ParserRuleContext *context);
 extern std::string stripQuoteFromId(TSqlParser::IdContext *context);

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -62,6 +62,7 @@ declare_escape_hatch(escape_hatch_session_settings);
 declare_escape_hatch(escape_hatch_ignore_dup_key);
 declare_escape_hatch(escape_hatch_rowversion);
 declare_escape_hatch(escape_hatch_checkpoint);
+declare_escape_hatch(escape_hatch_set_transaction_isolation_level);
 
 extern std::string getFullText(antlr4::ParserRuleContext *context);
 extern std::string stripQuoteFromId(TSqlParser::IdContext *context);

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2021,6 +2021,7 @@ babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch fo
 babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
 babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
 babelfishpg_tsql.escape_hatch_session_settings#!#strict#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_set_transaction_isolation_level#!#strict#!#escape hatch for SET TRANSACTION ISOLATION LEVEL
 babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
 babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
@@ -2086,6 +2087,7 @@ babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch fo
 babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
 babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
 babelfishpg_tsql.escape_hatch_session_settings#!#strict#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_set_transaction_isolation_level#!#strict#!#escape hatch for SET TRANSACTION ISOLATION LEVEL
 babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
 babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX
@@ -2132,6 +2134,7 @@ babelfishpg_tsql.escape_hatch_schemabinding_procedure#!#ignore#!#escape hatch fo
 babelfishpg_tsql.escape_hatch_schemabinding_trigger#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE TRIGGER
 babelfishpg_tsql.escape_hatch_schemabinding_view#!#ignore#!#escape hatch for SCHEMABINDING option in CREATE VIEW
 babelfishpg_tsql.escape_hatch_session_settings#!#strict#!#escape hatch for session settings
+babelfishpg_tsql.escape_hatch_set_transaction_isolation_level#!#strict#!#escape hatch for SET TRANSACTION ISOLATION LEVEL
 babelfishpg_tsql.escape_hatch_showplan_all#!#strict#!#escape hatch for SHOWPLAN_ALL and STATISTICS PROFILE
 babelfishpg_tsql.escape_hatch_storage_on_partition#!#strict#!#escape hatch for storage_on_partition option in CREATE/ALTER TABLE and CREATE INDEX
 babelfishpg_tsql.escape_hatch_storage_options#!#ignore#!#escape hatch for storage options option in CREATE/ALTER TABLE/INDEX

--- a/test/JDBC/expected/BABEL_4411.out
+++ b/test/JDBC/expected/BABEL_4411.out
@@ -1,0 +1,538 @@
+
+-- Escape hatch disabled
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+SELECT set_config('babelfishpg_tsql.escape_hatch_set_transaction_isolation_level', 'strict', false)
+GO
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+strict
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET TRANSACTION ISOLATION failed because of setting from invalid state, set escape hatch to silently ignore)~~
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET TRANSACTION ISOLATION failed because of setting from invalid state, set escape hatch to silently ignore)~~
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+ROLLBACK
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+BEGIN TRANSACTION
+GO
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+ROLLBACK
+GO
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SAVE TRANSACTION sp1
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET TRANSACTION ISOLATION failed because of setting from invalid state, set escape hatch to silently ignore)~~
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+BEGIN TRANSACTION
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+COMMIT
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+~~START~~
+text
+repeatable read
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+
+
+
+-- Escape hatch enabled
+SELECT set_config('babelfishpg_tsql.escape_hatch_set_transaction_isolation_level', 'ignore', false)
+GO
+~~START~~
+text
+ignore
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED 
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+ROLLBACK
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+
+~~START~~
+text
+read committed
+~~END~~
+

--- a/test/JDBC/expected/BABEL_4411.out
+++ b/test/JDBC/expected/BABEL_4411.out
@@ -536,3 +536,34 @@ text
 read committed
 ~~END~~
 
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SAVE TRANSACTION sp1
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+
+~~START~~
+text
+read uncommitted
+~~END~~
+

--- a/test/JDBC/expected/TestTransactionsSQLBatch.out
+++ b/test/JDBC/expected/TestTransactionsSQLBatch.out
@@ -2,6 +2,7 @@ create table TxnTable(c1 int);
 
 # Begin transaction -> commit transaction
 begin transaction;
+set transaction isolation level read committed;
 select @@trancount;
 ~~START~~
 int
@@ -15,7 +16,6 @@ int
 2
 ~~END~~
 
-set transaction isolation level read committed;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(1);
@@ -71,6 +71,7 @@ int
 
 # Begin tran -> rollback tran
 begin tran;
+set transaction isolation level read uncommitted;
 select @@trancount;
 ~~START~~
 int
@@ -78,7 +79,6 @@ int
 ~~END~~
 
 begin tran;
-set transaction isolation level read uncommitted;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(3);

--- a/test/JDBC/expected/babel_transaction.out
+++ b/test/JDBC/expected/babel_transaction.out
@@ -77,9 +77,9 @@ int
 
 -- Begin tran -> rollback tran
 begin tran;
+set transaction isolation level read uncommitted;
 select @@trancount;
 begin tran;
-set transaction isolation level read uncommitted;
 insert into TxnTable values(3);
 select @@trancount;
 rollback tran;

--- a/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
+++ b/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
@@ -2,7 +2,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_view
 GO
 ~~START~~
 int
-39
+40
 ~~END~~
 
 
@@ -10,7 +10,7 @@ EXEC sys_babelfish_configurations_view_vu_prepare_proc
 GO
 ~~START~~
 int
-39
+40
 ~~END~~
 
 
@@ -18,7 +18,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_func()
 GO
 ~~START~~
 int
-39
+40
 ~~END~~
 
 

--- a/test/JDBC/input/babel_transaction.sql
+++ b/test/JDBC/input/babel_transaction.sql
@@ -35,9 +35,9 @@ GO
 
 -- Begin tran -> rollback tran
 begin tran;
+set transaction isolation level read uncommitted;
 select @@trancount;
 begin tran;
-set transaction isolation level read uncommitted;
 insert into TxnTable values(3);
 select @@trancount;
 rollback tran;

--- a/test/JDBC/input/transactions/BABEL_4411.sql
+++ b/test/JDBC/input/transactions/BABEL_4411.sql
@@ -1,0 +1,129 @@
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+SELECT set_config('babelfishpg_tsql.escape_hatch_set_transaction_isolation_level', 'strict', false)
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+ROLLBACK
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+BEGIN TRANSACTION
+GO
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+ROLLBACK
+GO
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+BEGIN TRANSACTION
+GO
+SAVE TRANSACTION sp1
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+BEGIN TRANSACTION
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+

--- a/test/JDBC/input/transactions/BABEL_4411.sql
+++ b/test/JDBC/input/transactions/BABEL_4411.sql
@@ -1,3 +1,5 @@
+-- Escape hatch disabled
+
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED
 GO
 SELECT current_setting('transaction_isolation')
@@ -23,7 +25,7 @@ GO
 
 BEGIN TRANSACTION
 GO
-SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 GO
 SET TRANSACTION ISOLATION LEVEL SNAPSHOT
 GO
@@ -42,7 +44,7 @@ GO
 
 BEGIN TRANSACTION
 GO
-SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 GO
 SET TRANSACTION ISOLATION LEVEL SNAPSHOT
 GO
@@ -120,6 +122,24 @@ SELECT current_setting('default_transaction_isolation')
 GO
 COMMIT
 GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+COMMIT
+GO
 
 SELECT @@trancount
 SELECT current_setting('transaction_isolation')
@@ -127,3 +147,50 @@ SELECT current_setting('default_transaction_isolation')
 GO
 
 
+-- Escape hatch enabled
+
+SELECT set_config('babelfishpg_tsql.escape_hatch_set_transaction_isolation_level', 'ignore', false)
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED 
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO
+ROLLBACK
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO

--- a/test/JDBC/input/transactions/BABEL_4411.sql
+++ b/test/JDBC/input/transactions/BABEL_4411.sql
@@ -194,3 +194,19 @@ SELECT @@trancount
 SELECT current_setting('transaction_isolation')
 SELECT current_setting('default_transaction_isolation')
 GO
+
+BEGIN TRANSACTION
+GO
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+SAVE TRANSACTION sp1
+GO
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+GO

--- a/test/JDBC/input/transactions/TestTransactionsSQLBatch.txt
+++ b/test/JDBC/input/transactions/TestTransactionsSQLBatch.txt
@@ -2,10 +2,10 @@ create table TxnTable(c1 int);
 
 # Begin transaction -> commit transaction
 begin transaction;
+set transaction isolation level read committed;
 select @@trancount;
 begin transaction;
 select @@trancount;
-set transaction isolation level read committed;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(1);
@@ -29,9 +29,9 @@ select c1 from TxnTable;
 
 # Begin tran -> rollback tran
 begin tran;
+set transaction isolation level read uncommitted;
 select @@trancount;
 begin tran;
-set transaction isolation level read uncommitted;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(3);

--- a/test/dotnet/ExpectedOutput/TestSetTranIsolations.out
+++ b/test/dotnet/ExpectedOutput/TestSetTranIsolations.out
@@ -1,0 +1,89 @@
+#Q#SELECT set_config('babelfishpg_tsql.escape_hatch_set_transaction_isolation_level', 'strict', false)
+#D#text
+strict
+#Q#SELECT @@trancount
+#D#int
+0
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+read committed
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+read committed
+#Q#BEGIN TRAN
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+repeatable read
+#Q#COMMIT TRAN
+#Q#SELECT @@trancount
+#D#int
+0
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+repeatable read
+#Q#BEGIN TRAN
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+repeatable read
+#Q#ROLLBACK TRAN
+#Q#SELECT @@trancount
+#D#int
+0
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+read committed
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+read committed
+#Q#BEGIN TRAN
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+repeatable read
+#Q#SELECT @@trancount
+#D#int
+0
+#Q#SELECT current_setting('transaction_isolation')
+#D#text
+read committed
+#Q#SELECT current_setting('default_transaction_isolation')
+#D#text
+read committed

--- a/test/dotnet/input/Transaction/TestSetTranIsolations.txt
+++ b/test/dotnet/input/Transaction/TestSetTranIsolations.txt
@@ -1,0 +1,57 @@
+SELECT set_config('babelfishpg_tsql.escape_hatch_set_transaction_isolation_level', 'strict', false)
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+
+# SET TRAN ISOLATION INSIDE NESTED TRAN -> COMMIT -> COMMIT
+BEGIN TRAN
+txn#!#begin#!#isolation#!#ss
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+txn#!#commit
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+COMMIT TRAN
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+
+# RESET SESSION ISOLATION TO RC
+txn#!#begin#!#isolation#!#rc
+txn#!#commit
+
+# SET TRAN ISOLATION INSIDE NESTED TRAN -> COMMIT -> ROLLBACK
+BEGIN TRAN
+txn#!#begin#!#isolation#!#ss
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+txn#!#commit
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+ROLLBACK TRAN
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+
+
+# SET TRAN ISOLATION INSIDE NESTED TRAN -> COMMIT -> ROLLBACK
+BEGIN TRAN
+txn#!#begin#!#isolation#!#ss
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')
+txn#!#rollback
+
+
+SELECT @@trancount
+SELECT current_setting('transaction_isolation')
+SELECT current_setting('default_transaction_isolation')

--- a/test/python/expected/pyodbc/TestTransactionsSQLBatch.out
+++ b/test/python/expected/pyodbc/TestTransactionsSQLBatch.out
@@ -2,6 +2,7 @@ create table TxnTable(c1 int);
 
 # Begin transaction -> commit transaction
 begin transaction;
+set transaction isolation level read committed;
 select @@trancount;
 ~~START~~
 int
@@ -15,7 +16,6 @@ int
 2
 ~~END~~
 
-set transaction isolation level read committed;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(1);
@@ -71,6 +71,7 @@ int
 
 # Begin tran -> rollback tran
 begin tran;
+set transaction isolation level read uncommitted;
 select @@trancount;
 ~~START~~
 int
@@ -78,7 +79,6 @@ int
 ~~END~~
 
 begin tran;
-set transaction isolation level read uncommitted;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(3);

--- a/test/python/input/transactions/TestTransactionsSQLBatch.txt
+++ b/test/python/input/transactions/TestTransactionsSQLBatch.txt
@@ -2,10 +2,10 @@ create table TxnTable(c1 int);
 
 # Begin transaction -> commit transaction
 begin transaction;
+set transaction isolation level read committed;
 select @@trancount;
 begin transaction;
 select @@trancount;
-set transaction isolation level read committed;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(1);
@@ -29,9 +29,9 @@ select c1 from TxnTable;
 
 # Begin tran -> rollback tran
 begin tran;
+set transaction isolation level read uncommitted;
 select @@trancount;
 begin tran;
-set transaction isolation level read uncommitted;
 #show transaction_isolation;
 #show default_transaction_isolation;
 insert into TxnTable values(3);


### PR DESCRIPTION
### Description
Currently babelfish transactions start with session default isolation level. Users can not change this isolation level after transaction has started. On running the set transaction isolation inside a transaction, current transaction isolation does not change but all subsequent transaction will pick up this new isolation level.

Changes in this PR:

Allow changing the current transaction isolation level if no DML query has been run inside transaction.
Abort the transaction if set transaction isolation level is run after a DML query in a transaction block unless the new isolation level is same as current isolation level.
Introduce an escape hatch to ignore any invalid set transaction isolation level stmt so that transaction does not abort.

#### Engine Change:
Add check hook to guc default_transaction_isolation (all errors should be taken care here, that is assign hook should never fail)
If the conditions for setting isolation level are true returns true
If conditions are false and escape hatch is not set (strict - default value) - abort transaction with error
but if escape hatch is set to ignore for same situation - we simply ignore the set tran isolation command by setting the new isolation level to current isolation level. Which is apparently the same as ignoring the cmd.

#### Extension Change:
Introduce escape hatch for set transaction isolation 
New attribute in PLtsql_stmt_execsql structure. This attribute is needed to identify if the stmt is set transaction isolation during initialisation of internal savepoint and if set, we skip the internal save point for the current stmt.
This needs to be done since postgres does not allow setting isolation level inside a save point.

#### Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/217
#### Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1847

### Issues Resolved

BABEL-4411

#### Sign Off : Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
