### PR TITLE
Implemented fix for when column is enclosed in parens (round brackets) and single byte as well as multibyte table and column aliases.

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -102,7 +102,7 @@ static void pltsql_post_transform_table_definition(ParseState *pstate, RangeVar 
 static void pre_transform_target_entry(ResTarget *res, ParseState *pstate, ParseExprKind exprKind);
 static bool tle_name_comparison(const char *tlename, const char *identifier);
 static void resolve_target_list_unknowns(ParseState *pstate, List *targetlist);
-static inline bool is_identifier_char(char c);
+static inline bool is_identifier_char(unsigned char c);
 static int	find_attr_by_name_from_relation(Relation rd, const char *attname, bool sysColOK);
 static void modify_insert_stmt(InsertStmt *stmt, Oid relid);
 static void sort_nulls_first(SortGroupClause * sortcl, bool reverse);
@@ -1220,7 +1220,7 @@ resolve_target_list_unknowns(ParseState *pstate, List *targetlist)
 }
 
 static inline bool
-is_identifier_char(char c)
+is_identifier_char(unsigned char c)
 {
 	/* please see {tsql_ident_cont} in scan-tsql-decl.l */
 	bool		valid = ((c >= 'A' && c <= 'Z') ||
@@ -1382,6 +1382,8 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			char	*alias = palloc0(alias_len + 1);
 			const char	*original_name = NULL;
 			int		actual_alias_len = 0;
+			
+			/* To handle queries like SELECT ((<column_name>)) from <table_name> */
 			while(*colname_start == '(')
 			{
 				colname_start++;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -890,10 +890,13 @@ extract_identifier(const char *start)
 
 	bool		dq = false;
 	bool		sqb = false;
+	bool		sq = false;
+	bool		sb = false;
 	int			i = 0;
 	char	   *original_name = NULL;
 	bool		valid = false;
 	bool		found_escaped_in_dq = false;
+	bool		found_escaped_in_sq = false;
 
 	/* check identifier is delimited */
 	Assert(start);
@@ -901,6 +904,10 @@ extract_identifier(const char *start)
 		dq = true;
 	else if (start[0] == '[')
 		sqb = true;
+	else if (start[0] == '\'')
+		sq = true;
+	else if (start[0] == '(')
+		sb = true;
 	++i;						/* advance cursor by one. As it is already a
 								 * valid identiifer, its length should be
 								 * greater than 1 */
@@ -915,7 +922,7 @@ extract_identifier(const char *start)
 	{
 		char		c = start[i];
 
-		if (!dq && !sqb)		/* normal case */
+		if (!dq && !sqb && !sq && !sb)		/* normal case */
 		{
 			/* please see {tsql_ident_cont} in scan-tsql-decl.l */
 			valid = is_identifier_char(c);
@@ -972,6 +979,63 @@ extract_identifier(const char *start)
 				}
 			}
 		}
+		else if (sq)
+        {
+            /* please see xdinside in scan.l */
+            valid = (c != '\'');
+            if (!valid && start[i + 1] == '\'') /* escaped */
+            {
+                ++i;
+                ++i;            /* advance two characters */
+                found_escaped_in_sq = true;
+                continue;
+            }
+
+            if (!valid)
+            {
+                if (!found_escaped_in_sq)
+                {
+                    /* no escaped character. copy whole string at once */
+                    original_name = palloc(i);  /* exclude first/last single
+                                                 * quote */
+                    memcpy(original_name, start + 1, i - 1);
+                    original_name[i - 1] = '\0';
+                    return original_name;
+                }
+                else
+                {
+                    /*
+                     * there is escaped character. copy one by one to handle
+                     * escaped character
+                     */
+                    int         rcur = 1;   /* read-cursor */
+                    int         wcur = 0;   /* write-cursor */
+
+                    original_name = palloc(i);  /* exclude first/last single
+                                                 * quote */
+                    for (; rcur < i; ++rcur, ++wcur)
+                    {
+                        original_name[wcur] = start[rcur];
+                        if (start[rcur] == '\'')
+                            ++rcur; /* skip next character */
+                    }
+                    original_name[wcur] = '\0';
+                    return original_name;
+                }
+            }
+        }
+        else if (sb)
+        {
+            valid = (c != ')');
+            if (!valid)
+            {
+                original_name = palloc(i);  /* exclude first/last small
+                                             * bracket */
+                memcpy(original_name, start + 1, i - 1);
+                original_name[i - 1] = '\0';
+                return original_name;
+            }
+        }
 		else if (sqb)
 		{
 			/* please see xbrinside in scan-tsql-decl.l */
@@ -1330,105 +1394,34 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 		 */
 		if (alias_len > 0)
 		{
-			char	   *alias = palloc0(alias_len + 1);
-			bool		dq = *colname_start == '"';
-			bool		sqb = *colname_start == '[';
-			bool		sq = *colname_start == '\'';
-			bool		identifier_truncated = false;
-			const char *colname_end;
-			bool		enc_is_single_byte;
-			enc_is_single_byte = pg_database_encoding_max_length() == 1;
+			char    *alias = palloc0(alias_len + 1);
+            const char  *original_name = NULL;
+            int actual_alias_len = 0;
 
+            /* To extract the identifier name from the query.*/
+            original_name = extract_identifier(colname_start);
+            actual_alias_len = strlen(original_name);
 
-			if (dq || sqb)
-			{
-				return;
-			}
+            /* Maximum alias_len can be 63 after truncation. If alias_len is smaller than actual_alias_len,
+             * this means Identifier is truncated and it's last 32 bytes would be MD5 hash.
+             */
+            if(actual_alias_len > alias_len)
+            {
+                /* First 32 characters of original_name are assigned to alias. */
+                memcpy(alias, original_name, (alias_len - 32) );
+                /* Last 32 characters of identifier_name are assigned to alias, as actual alias is truncated. */
+                memcpy(alias + (alias_len) - 32,
+                identifier_name + (alias_len) - 32, 
+                32);
+                alias[alias_len+1] = '\0';
+            }
+            /* Identifier is not truncated. */
+            else
+            {
+                memcpy(alias, original_name, alias_len);
+            }
+            res->name = alias;
 
-			else
-			{
-				if(sq)
-				{
-					colname_start++;
-				}
-				/*
-				 * After truncation, minimum truncated length of alias can be 61
-				 * If length is less than 61, it means alias is not truncated.
-				 */
-				if(alias_len < 61)
-				{
-					memcpy(alias, colname_start, alias_len);
-				}
-				else
-				{
-					/*
-					 * For aliases whose length is between 61 to 63, the case of multibyte and single byte
-					 * characters are handled separately.
-					 * It is needed to check whether last 32 bytes are equal to identifier_name or not,
-					 * because last 32 bytes would be MD5 hash in case of truncated identifier and 
-					 * we can leverage the fact that MD5 hash would be different from original identifier.
-					 * If they are not equal, this means identifier_name is truncated.
-					 */
-					for(int x = alias_len - 32; x < alias_len; x++)
-					{
-						colname_end = colname_start + x;
-
-						/*
-						 * Check if colname_end is in upper case then does uppercase of identifier_name 
-						 * matches to colname_end or not in case of ascii values. 
-						 * If colname_end is in lowercase, then simply check colname_end is equals to 
-						 * identifier_name or not.
-						 */ 
-						if (*colname_end >= 'A' && *colname_end <= 'Z')
-						{
-							/* If original letter is in upper case then check it with upper case letter of identifier_name. */
-							if (!(*colname_end == identifier_name[x] + 'A' - 'a'))
-							{
-								identifier_truncated = true;
-								break;
-							}
-						}
-						else if(enc_is_single_byte && IS_HIGHBIT_SET(*colname_end) && isupper(*colname_end))
-						{
-							if (!(*colname_end == identifier_name[x] - 'A' + 'a'))
-							{
-								identifier_truncated = true;
-								break;
-							}
-						}
-						else
-						{
-							/* Original letter is already in lower case or it could be fractional byte of multibyte char. 
-							 * So it should match with original byte in either case.
-							 */
-							if(!(*colname_end == identifier_name[x]))
-							{
-								identifier_truncated = true;
-								break;
-							}
-						}
-					}
-					/* Identifier is not truncated. */
-					if(!(identifier_truncated))
-					{
-						memcpy(alias, colname_start, alias_len);
-					}
-
-					/* Identifier is truncated. */
-					else
-					{
-						/* First 32 characters of colname_start are assigned to alias. */
-						memcpy(alias, colname_start, (alias_len - 32) );
-						/* Last 32 characters of identifier_name are assigned to alias, as actual alias is truncated. */
-						memcpy(alias + (alias_len) - 32,
-						identifier_name + (alias_len) - 32, 
-						32);
-						alias[alias_len+1] = '\0';
-					}
-				}
-			}
-
-			res->name = alias;
 		}
 	}
 	/* Update table set qualified column name, resolve qualifiers here */

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1384,7 +1384,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			int		actual_alias_len = 0;
 			
 			/* To handle queries like SELECT ((<column_name>)) from <table_name> */
-			while(*colname_start == '(')
+			while(*colname_start == '(' || *colname_start == ' ')
 			{
 				colname_start++;
 			}

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -893,6 +893,7 @@ extract_identifier(const char *start)
 	bool		sq = false;
 	bool		sb = false;
 	int			i = 0;
+	int			count = 0;
 	char	   *original_name = NULL;
 	bool		valid = false;
 	bool		found_escaped_in_dq = false;
@@ -1026,13 +1027,19 @@ extract_identifier(const char *start)
         }
         else if (sb)
         {
-            valid = (c != ')');
+			while(start[i] == '(')
+			{
+				/*Count how many sb are in the name. */
+				count++;
+				i++;
+			}
+			valid = (c != ')');
             if (!valid)
             {
                 original_name = palloc(i);  /* exclude first/last small
                                              * bracket */
-                memcpy(original_name, start + 1, i - 1);
-                original_name[i - 1] = '\0';
+                memcpy(original_name, start + count + 1, i - count - 1);
+                original_name[i - count - 1] = '\0';
                 return original_name;
             }
         }

--- a/test/JDBC/expected/BABEL-4384-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4384-vu-cleanup.out
@@ -1,0 +1,30 @@
+-- tsql
+DROP VIEW babel_4384_v1;
+GO
+
+DROP VIEW babel_4384_v2;
+GO
+
+DROP VIEW babel_4384_v3;
+GO
+
+DROP VIEW babel_4384_v4;
+GO
+
+DROP VIEW babel_4384_v5;
+GO
+
+DROP VIEW babel_4384_v6;
+GO
+
+DROP VIEW babel_4384_v7;
+GO
+
+DROP table babel_4384_t1;
+GO
+
+DROP table babel_4384_t2;
+GO
+
+DROP table babel_4384_t3;
+GO

--- a/test/JDBC/expected/BABEL-4384-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4384-vu-prepare.out
@@ -1,0 +1,30 @@
+-- tsql
+CREATE TABLE babel_4384_t1(ABC INT, [DE.f] INT);
+GO
+
+CREATE VIEW babel_4384_v1 AS SELECT (ABC) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v2 AS SELECT (((ABC))) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v3 AS SELECT ( ( (ABC))) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v4 AS SELECT (( (ABC)) ) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v5 AS SELECT ( ( ([DE.f]))) FROM babel_4384_t1;
+GO
+
+CREATE TABLE babel_4384_t2(您对 INT);
+GO
+
+CREATE VIEW babel_4384_v6 AS SELECT ( ( (您对))) FROM babel_4384_t2;
+GO
+
+CREATE TABLE babel_4384_t3(您您对您对您对您对您对您对您对您对您对您您您 INT);
+GO
+
+CREATE VIEW babel_4384_v7 AS SELECT ( ( (您您对您对您对您对您对您对您对您对您对您您您))) FROM babel_4384_t3;
+GO

--- a/test/JDBC/expected/BABEL-4384-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4384-vu-verify.out
@@ -1,0 +1,62 @@
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v1';
+GO
+~~START~~
+text
+ SELECT babel_4384_t1.abc AS "ABC"<newline>   FROM master_dbo.babel_4384_t1;
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v2';
+GO
+~~START~~
+text
+ SELECT babel_4384_t1.abc AS "ABC"<newline>   FROM master_dbo.babel_4384_t1;
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v3';
+GO
+~~START~~
+text
+ SELECT babel_4384_t1.abc AS "ABC"<newline>   FROM master_dbo.babel_4384_t1;
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v4';
+GO
+~~START~~
+text
+ SELECT babel_4384_t1.abc AS "ABC"<newline>   FROM master_dbo.babel_4384_t1;
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v5';
+GO
+~~START~~
+text
+ SELECT babel_4384_t1."de.f" AS "DE.f"<newline>   FROM master_dbo.babel_4384_t1;
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v6';
+GO
+~~START~~
+text
+ SELECT babel_4384_t2."您对"<newline>   FROM master_dbo.babel_4384_t2;
+~~END~~
+
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v7';
+GO
+~~START~~
+text
+ SELECT babel_4384_t3."您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de"<newline>   FROM master_dbo.babel_4384_t3;
+~~END~~
+

--- a/test/JDBC/input/BABEL-4384-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-4384-vu-cleanup.mix
@@ -1,0 +1,30 @@
+-- tsql
+DROP VIEW babel_4384_v1;
+GO
+
+DROP VIEW babel_4384_v2;
+GO
+
+DROP VIEW babel_4384_v3;
+GO
+
+DROP VIEW babel_4384_v4;
+GO
+
+DROP VIEW babel_4384_v5;
+GO
+
+DROP VIEW babel_4384_v6;
+GO
+
+DROP VIEW babel_4384_v7;
+GO
+
+DROP table babel_4384_t1;
+GO
+
+DROP table babel_4384_t2;
+GO
+
+DROP table babel_4384_t3;
+GO

--- a/test/JDBC/input/BABEL-4384-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-4384-vu-prepare.mix
@@ -1,0 +1,30 @@
+-- tsql
+CREATE TABLE babel_4384_t1(ABC INT, [DE.f] INT);
+GO
+
+CREATE VIEW babel_4384_v1 AS SELECT (ABC) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v2 AS SELECT (((ABC))) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v3 AS SELECT ( ( (ABC))) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v4 AS SELECT (( (ABC)) ) FROM babel_4384_t1;
+GO
+
+CREATE VIEW babel_4384_v5 AS SELECT ( ( ([DE.f]))) FROM babel_4384_t1;
+GO
+
+CREATE TABLE babel_4384_t2(您对 INT);
+GO
+
+CREATE VIEW babel_4384_v6 AS SELECT ( ( (您对))) FROM babel_4384_t2;
+GO
+
+CREATE TABLE babel_4384_t3(您您对您对您对您对您对您对您对您对您对您您您 INT);
+GO
+
+CREATE VIEW babel_4384_v7 AS SELECT ( ( (您您对您对您对您对您对您对您对您对您对您您您))) FROM babel_4384_t3;
+GO

--- a/test/JDBC/input/BABEL-4384-vu-verify.mix
+++ b/test/JDBC/input/BABEL-4384-vu-verify.mix
@@ -1,0 +1,27 @@
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v1';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v2';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v3';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v4';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v5';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v6';
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'babel_4384_v7';
+GO


### PR DESCRIPTION
### Description

This pull request fix the issue when column name is enclosed in parens (round brackets) and no alias is specified. It also fix the implementation for column and table aliases contain both single byte and multibyte characters whose length less than or more than 64 bytes for 14.latest version.

**Issue 1:** Handling of column name when enclosed by any number of parens.
When column is enclosed in parens (round brackets) and no alias is specified, then the column name in result set is returned incorrectly. In such cases the actual column name should come, instead from first characters of query till length of column name. To resolve this issue I added a condition in [pre_transform_target_entry](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/babelfishpg_tsql/src/hooks.c#L1421) that will handle multiple levels of parens and spaces in-between parens.

**Issue 2:** Handle column and table aliases.
Column and table alias does not work when alias length is more than or equals to 64 bytes in case of multibyte aliases. When query select 1 as '您对“数据一览“中的车型，颜色，内饰，选装, '; executes through T-SQL endpoint, it causes client to hang and throws protocol error in TDS stream. The logic of pre_transform_target_entry was not handling the aliases contain multibyte characters whose length is more than 64 bytes accurately and overwriting the alias name in case of truncation. To address this problem, I redefined the function and implemented the conditions which will extract identifier name using extract_identifier() and handle both the case when aliases are not delimited as well as delimited with square bracket, single quotes and double quotes.

**Issue 3 :** Aliases with multibyte chars cause MVU failure.
When establishing a view of alias with multibyte chars through T-SQL endpoint and retrieving it's definition from PG end point, extra unreadable chars are appearing at the end of the alias and even we can not use this view through tsql endpoint as it throws protocol error in TDS stream. But while we use similar alias on PG end point, we are able to retrieve it's correct definition. This discrepancy in behaviour is causing MVU failure. After implementing the fix, the correct alias definition is obtained from the PG endpoint, which rectifies the issue.

### Issues Resolved
BABEL-4384
BABEL-4231

Signed-off-by: Riya Jain [riyaajn@amazon.com](mailto:riyaajn@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** Added test case from original bug.


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).