### PR TITLE
Fixed buffer overflow in babelfish_db_name()

### DIFF
--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -245,18 +245,21 @@ babelfish_db_name(PG_FUNCTION_ARGS)
 
 	if (dbid == 1)
 	{
-		dbname = palloc((strlen("master") + 1) * sizeof(char));
-		strncpy(dbname, "master", MAX_BBF_NAMEDATALEND);
+		int dbnamelen = strlen("master");
+		dbname = palloc0((dbnamelen + 1) * sizeof(char));
+		strncpy(dbname, "master", dbnamelen);
 	}
 	else if (dbid == 2)
 	{
-		dbname = palloc((strlen("tempdb") + 1) * sizeof(char));
-		strncpy(dbname, "tempdb", MAX_BBF_NAMEDATALEND);
+		int dbnamelen = strlen("tempdb");
+		dbname = palloc0((dbnamelen + 1) * sizeof(char));
+		strncpy(dbname, "tempdb", dbnamelen);
 	}
 	else if (dbid == 4)
 	{
-		dbname = palloc((strlen("msdb") + 1) * sizeof(char));
-		strncpy(dbname, "msdb", MAX_BBF_NAMEDATALEND);
+		int dbnamelen = strlen("msdb");
+		dbname = palloc0((dbnamelen + 1) * sizeof(char));
+		strncpy(dbname, "msdb", dbnamelen);
 	}
 	else
 		dbname = get_db_name(dbid);

--- a/test/JDBC/expected/BABEL-SESSION.out
+++ b/test/JDBC/expected/BABEL-SESSION.out
@@ -45,6 +45,40 @@ GO
 USE master;
 GO
 
+SELECT db_name();
+GO
+~~START~~
+nvarchar
+master
+~~END~~
+
+
+USE tempdb;
+GO
+
+SELECT db_name();
+GO
+~~START~~
+nvarchar
+tempdb
+~~END~~
+
+
+USE msdb;
+GO
+
+SELECT db_name();
+GO
+~~START~~
+nvarchar
+msdb
+~~END~~
+
+
+USE master;
+GO
+
+
 -- tsql user=r1 password=abc
 USE db1;
 GO

--- a/test/JDBC/input/BABEL-SESSION.mix
+++ b/test/JDBC/input/BABEL-SESSION.mix
@@ -41,6 +41,25 @@ GO
 USE master;
 GO
 
+SELECT db_name();
+GO
+
+USE tempdb;
+GO
+
+SELECT db_name();
+GO
+
+USE msdb;
+GO
+
+SELECT db_name();
+GO
+
+USE master;
+GO
+
+
 -- tsql user=r1 password=abc
 USE db1;
 GO


### PR DESCRIPTION
Allocates n bytes but writes more than n bytes.



### Description




### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).