### PR TITLE
Fix infinite recursion in yyfree

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/scan-tsql-epilogue.l.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/scan-tsql-epilogue.l.c
@@ -79,7 +79,7 @@ void
 void
 pgtsql_core_yyfree(void *ptr, core_yyscan_t yyscanner)
 {
-	pgtsql_core_yyfree(ptr, yyscanner);
+	core_yyfree(ptr, yyscanner);
 }
 
 #define core_yyset_extra pgtsql_core_yyset_extra


### PR DESCRIPTION
### Description

On newer versions of GCC the build is failing with `-Werror=infinite-recursion` warning:
```
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -ggdb -O0 -fno-omit-frame-pointer -g -Werror  -fstack-protector-strong -fcommon -Wno-error=format-security -Wno-error=maybe-uninitialized -ggdb -O0 -fno-omit-frame-pointer -fPIC -g -Werror  -fstack-protector-strong -fcommon -Wno-error=format-security -Wno-error=maybe-uninitialized -ggdb -O0 -fno-omit-frame-pointer -fPIC -I. -I/home/alex/projects/postgres/dev/postgresql_modified_for_babelfish/ -DFAULT_INJECTOR -I. -I./ -I/home/alex/projects/postgres/dist/include/server -I/home/alex/projects/postgres/dist/include/internal  -I -I/home/alex/projects/postgres/dev/postgresql_modified_for_babelfish/ -DFAULT_INJECTOR -I. -I./ -I/home/alex/projects/postgres/dist/include/server -I/home/alex/projects/postgres/dist/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2   -c -o src/backend_parser/scan-backend.o src/backend_parser/scan-backend.c
scan-tsql-epilogue.l.c: In function ‘pgtsql_core_yyfree’:
scan-tsql-epilogue.l.c:80:1: error: infinite recursion detected [-Werror=infinite-recursion]
scan-tsql-epilogue.l.c:82:2: note: recursive call
cc1: all warnings being treated as errors
make: *** [<builtin>: src/backend_parser/scan-backend.o] Error 1
```

`pgtsql_core_yyfree` function is [calling itself](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/8c5ca4839e0d7abf78e8952d9b08a6ea297195c3/contrib/babelfishpg_tsql/src/backend_parser/scan-tsql-epilogue.l.c#L82). This looks like an obvious typo as `core_yyfree` should be called instead.

In reality `pgtsql_core_yyfree` is never called because memory is allocated/deallocated with memory contexts. Still I suggest to fix this typo to allow successful compilation without specifying `-Wno-error=infinite-recursion`.

### Issues Resolved

#1849

### Test Scenarios Covered ###

The change does not affect the functionality because this call is never used.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).