### PR TITLE
Update psqlodbc driver used in github action

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -168,14 +168,14 @@ jobs:
         if: always() && steps.install-extensions.outcome == 'success' && steps.install-unix-odbc-driver.outcome=='success'
         run: |
           cd ~
-          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-12.01.0000.tar.gz
-          tar -zxvf psqlodbc-12.01.0000.tar.gz
-          cd psqlodbc-12.01.0000
+          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-16.00.0000.tar.gz
+          tar -zxvf psqlodbc-16.00.0000.tar.gz
+          cd psqlodbc-16.00.0000
           ./configure
           sudo make
           sudo make install
-          echo '[ODBC_Driver_12_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
-          echo 'Description=ODBC Driver 12 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo '[ODBC_Driver_16_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'Description=ODBC Driver 16 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'Driver=/usr/local/lib/psqlodbcw.so' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'UsageCount=1' | sudo tee -a /etc/odbcinst.ini > /dev/null
       
@@ -191,7 +191,7 @@ jobs:
             MSSQL_BABEL_DB_USER=jdbc_user \
             MSSQL_BABEL_DB_PASSWORD=12345678 \
             MSSQL_BABEL_DB_NAME=master \
-            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_12_for_PostgreSQL \
+            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_16_for_PostgreSQL \
             PSQL_BABEL_DB_SERVER=localhost \
             PSQL_BABEL_DB_PORT=5432 \
             PSQL_BABEL_DB_USER=jdbc_user \

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -58,14 +58,14 @@ jobs:
         if: steps.install-extensions.outcome == 'success' && steps.install-unix-odbc-driver.outcome=='success'
         run: |
           cd ~
-          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-12.01.0000.tar.gz
-          tar -zxvf psqlodbc-12.01.0000.tar.gz
-          cd psqlodbc-12.01.0000
+          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-16.00.0000.tar.gz
+          tar -zxvf psqlodbc-16.00.0000.tar.gz
+          cd psqlodbc-16.00.0000
           ./configure
           sudo make
           sudo make install
-          echo '[ODBC_Driver_12_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
-          echo 'Description=ODBC Driver 12 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo '[ODBC_Driver_16_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'Description=ODBC Driver 16 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'Driver=/usr/local/lib/psqlodbcw.so' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'UsageCount=1' | sudo tee -a /etc/odbcinst.ini > /dev/null
       
@@ -81,7 +81,7 @@ jobs:
             MSSQL_BABEL_DB_USER=jdbc_user \
             MSSQL_BABEL_DB_PASSWORD=12345678 \
             MSSQL_BABEL_DB_NAME=master \
-            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_12_for_PostgreSQL \
+            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_16_for_PostgreSQL \
             PSQL_BABEL_DB_SERVER=localhost \
             PSQL_BABEL_DB_PORT=5432 \
             PSQL_BABEL_DB_USER=jdbc_user \


### PR DESCRIPTION
### Description

This change updates psqlODBC used in github action to the latest version. This fixes build failures that recently started appearing in ODBC Tests workflow. See details in the linked issue.

### Issues Resolved

#1862

### Test Scenarios Covered ###

ODBC Tests github workflow.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).