### PR TITLE
Fixed Assertion during CREATE TABLE with TIMESTAMP and PKEY (ASC)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -990,8 +990,18 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 									{
 										foreach(lc, (List *) c->keys)
 										{
-											char	*colname = strVal(lfirst(lc));
-											int		 colname_len = strlen(colname);
+											char	*colname = NULL;
+											int		 colname_len = 0;
+
+											/* T-SQL Parser might have directly prepared IndexElem instead of String*/
+											if (nodeTag(lfirst(lc)) == T_IndexElem) {
+												IndexElem *ie = (IndexElem *) lfirst(lc);
+												colname = ie->name;
+												colname_len = strlen(colname);
+											} else {
+												colname = strVal(lfirst(lc));
+												colname_len = strlen(colname);
+											}
 
 											foreach(elements, stmt->tableElts)
 											{
@@ -1481,8 +1491,16 @@ validate_rowversion_table_constraint(Constraint *c, char *rowversion_column_name
 
 	foreach(lc, colnames)
 	{
-		char	   *colname = strVal(lfirst(lc));
-		bool		found = false;
+		char *colname = NULL;
+		bool found = false;
+
+		/* T-SQL Parser might have directly prepared IndexElem instead of String*/
+		if (nodeTag(lfirst(lc)) == T_IndexElem) {
+			IndexElem *ie = (IndexElem *) lfirst(lc);
+			colname = ie->name;
+		} else {
+			colname = strVal(lfirst(lc));
+		}
 
 		if (strlen(colname) == rv_colname_len)
 		{

--- a/test/JDBC/expected/BABEL-1524.out
+++ b/test/JDBC/expected/BABEL-1524.out
@@ -333,5 +333,14 @@ ok
 drop table t1;
 go
 
+-- Test BABEL-4433
+CREATE TABLE t( c timestamp NOT NULL, PRIMARY KEY ( [ID] ASC))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "id" named in key does not exist)~~
+
+
+
 EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'strict';
 go

--- a/test/JDBC/expected/BABEL-CREATE-TABLE.out
+++ b/test/JDBC/expected/BABEL-CREATE-TABLE.out
@@ -1,0 +1,111 @@
+
+-- BABEL-4433: Crashes during CREATE TABLE with ASC/DESC Keys
+-- This should fail with collation error but it should not crash
+CREATE TABLE [Babel4433Table1](
+        [Id] [uniqueidentifier] NOT NULL,
+        [SequenceId] [bigint] IDENTITY(1,1) NOT NULL,
+        [PanelId] [uniqueidentifier] NOT NULL,
+        [Name] [nvarchar](400) COLLATE Latin1_General_100_CI_AS_SC NULL,
+ CONSTRAINT [PK_Babel4433Table1] PRIMARY KEY CLUSTERED
+(
+        [Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [UC_Babel4433Table1_SequenceId] UNIQUE NONCLUSTERED
+(
+        [SequenceId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: collation "latin1_general_100_ci_as_sc" for encoding "UTF8" does not exist)~~
+
+
+
+-----------------------------------------------------------------------
+CREATE TABLE [Babel4433Table2](
+        [col1] [int] IDENTITY(1,1) NOT NULL,
+        [col2] [nvarchar](64) NOT NULL,
+        [col3] [int] NOT NULL,
+        [col4] [int] NOT NULL,
+ CONSTRAINT [PK_Babel4433Table2] PRIMARY KEY CLUSTERED
+(
+        [col1]
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [IX_Babel4433Table2] UNIQUE NONCLUSTERED
+(
+        [col2] ,
+        [col3] DESC,
+        [col4]
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+DROP TABLE [Babel4433Table2]
+GO
+
+
+-----------------------------------------------------------------------
+CREATE TABLE [Babel4433Table3](
+        [ID] [int] IDENTITY(1,1) NOT NULL,
+        [Userid] [varchar](50) NOT NULL,
+ CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED
+(
+        [ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [Unique_Key_Userid] UNIQUE NONCLUSTERED
+(
+        [Userid] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+go
+
+DROP TABLE [Babel4433Table3]
+GO
+
+
+-----------------------------------------------------------------------
+CREATE TABLE [Babel4433Table4](
+        [ContainerID] [int] IDENTITY(1,1) NOT NULL,
+        [ContentIdentifier] [varchar](100) NOT NULL,
+ CONSTRAINT [PK_Babel4433Table3] PRIMARY KEY CLUSTERED
+(
+        [ContainerID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [NC_Container__ContentIdentifier_UIX1] UNIQUE NONCLUSTERED
+(
+        [ContentIdentifier] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+go
+
+DROP TABLE [Babel4433Table4]
+GO
+
+
+-----------------------------------------------------------------------
+-- This should fail because schema does not exist but it should not crash
+CREATE TABLE [Dummy].[Babel4433Table5](
+        [ProcessID] [int] NOT NULL,
+        [Ordinal] [int] NOT NULL,
+        [StageKey] [varchar](64) NOT NULL,
+ CONSTRAINT [PK_Babel4433Table5] PRIMARY KEY CLUSTERED
+(
+        [ProcessID] ASC,
+        [Ordinal] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [AK_ProcessStage] UNIQUE NONCLUSTERED
+(
+        [ProcessID] ASC,
+        [StageKey] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_dummy" does not exist)~~
+
+
+
+
+

--- a/test/JDBC/expected/BABEL-guest.out
+++ b/test/JDBC/expected/BABEL-guest.out
@@ -10,7 +10,7 @@ GO
 CREATE TABLE babel_2571_table1(a int, b int)
 GO
 
-CREATE LOGIN babel_2571_login1 WITH password='123'
+CREATE LOGIN babel_2571_login1 WITH password='12345678'
 GO
 
 CREATE DATABASE babel_2571_db1
@@ -52,7 +52,7 @@ tempdb_guest
 ~~END~~
 
 
--- tsql         user=babel_2571_login1 password=123
+-- tsql         user=babel_2571_login1 password=12345678
 -- Login as guest to show default schema is guest
 SELECT schema_name()
 GO

--- a/test/JDBC/input/BABEL-1524.sql
+++ b/test/JDBC/input/BABEL-1524.sql
@@ -218,5 +218,10 @@ go
 drop table t1;
 go
 
+-- Test BABEL-4433
+CREATE TABLE t( c timestamp NOT NULL, PRIMARY KEY ( [ID] ASC))
+GO
+
+
 EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'strict';
 go

--- a/test/JDBC/input/BABEL-CREATE-TABLE.sql
+++ b/test/JDBC/input/BABEL-CREATE-TABLE.sql
@@ -1,0 +1,104 @@
+-- BABEL-4433: Crashes during CREATE TABLE with ASC/DESC Keys
+
+-- This should fail with collation error but it should not crash
+CREATE TABLE [Babel4433Table1](
+        [Id] [uniqueidentifier] NOT NULL,
+        [SequenceId] [bigint] IDENTITY(1,1) NOT NULL,
+        [PanelId] [uniqueidentifier] NOT NULL,
+        [Name] [nvarchar](400) COLLATE Latin1_General_100_CI_AS_SC NULL,
+ CONSTRAINT [PK_Babel4433Table1] PRIMARY KEY CLUSTERED
+(
+        [Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [UC_Babel4433Table1_SequenceId] UNIQUE NONCLUSTERED
+(
+        [SequenceId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+-----------------------------------------------------------------------
+
+CREATE TABLE [Babel4433Table2](
+        [col1] [int] IDENTITY(1,1) NOT NULL,
+        [col2] [nvarchar](64) NOT NULL,
+        [col3] [int] NOT NULL,
+        [col4] [int] NOT NULL,
+ CONSTRAINT [PK_Babel4433Table2] PRIMARY KEY CLUSTERED
+(
+        [col1]
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [IX_Babel4433Table2] UNIQUE NONCLUSTERED
+(
+        [col2] ,
+        [col3] DESC,
+        [col4]
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+DROP TABLE [Babel4433Table2]
+GO
+
+-----------------------------------------------------------------------
+
+CREATE TABLE [Babel4433Table3](
+        [ID] [int] IDENTITY(1,1) NOT NULL,
+        [Userid] [varchar](50) NOT NULL,
+ CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED
+(
+        [ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [Unique_Key_Userid] UNIQUE NONCLUSTERED
+(
+        [Userid] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+go
+
+DROP TABLE [Babel4433Table3]
+GO
+
+-----------------------------------------------------------------------
+
+CREATE TABLE [Babel4433Table4](
+        [ContainerID] [int] IDENTITY(1,1) NOT NULL,
+        [ContentIdentifier] [varchar](100) NOT NULL,
+ CONSTRAINT [PK_Babel4433Table3] PRIMARY KEY CLUSTERED
+(
+        [ContainerID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [NC_Container__ContentIdentifier_UIX1] UNIQUE NONCLUSTERED
+(
+        [ContentIdentifier] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+go
+
+DROP TABLE [Babel4433Table4]
+GO
+
+-----------------------------------------------------------------------
+
+-- This should fail because schema does not exist but it should not crash
+CREATE TABLE [Dummy].[Babel4433Table5](
+        [ProcessID] [int] NOT NULL,
+        [Ordinal] [int] NOT NULL,
+        [StageKey] [varchar](64) NOT NULL,
+ CONSTRAINT [PK_Babel4433Table5] PRIMARY KEY CLUSTERED
+(
+        [ProcessID] ASC,
+        [Ordinal] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [AK_ProcessStage] UNIQUE NONCLUSTERED
+(
+        [ProcessID] ASC,
+        [StageKey] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+-----------------------------------------------------------------------
+
+
+

--- a/test/JDBC/input/ownership/BABEL-guest.mix
+++ b/test/JDBC/input/ownership/BABEL-guest.mix
@@ -10,7 +10,7 @@ GO
 CREATE TABLE babel_2571_table1(a int, b int)
 GO
 
-CREATE LOGIN babel_2571_login1 WITH password='123'
+CREATE LOGIN babel_2571_login1 WITH password='12345678'
 GO
 
 CREATE DATABASE babel_2571_db1
@@ -35,7 +35,7 @@ SELECT nspname FROM sys.babelfish_namespace_ext ORDER BY nspname
 GO
 
 -- Login as guest to show default schema is guest
--- tsql         user=babel_2571_login1 password=123
+-- tsql         user=babel_2571_login1 password=12345678
 SELECT schema_name()
 GO
 


### PR DESCRIPTION
Assertion happens because strVal enforces String type starting in Rel15. BBF could enter this code in either String type or IndexElem type. BBF code should check what type similar to other logic in similar functions such as in transformIndexConstraint() or is_nullable_constraint()

For instance in `transformIndexConstraint()`

```
           /* T-SQL parser might have directly prepared indexElem */
            if (nodeTag(lfirst(lc)) == T_IndexElem) {
                IndexElem * i = (IndexElem *) lfirst(lc);
                key = i->name;
            }
            else
                key = strVal(lfirst(lc));
```

Task: BABEL-4433

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).