### PR TITLE
Use sys cache for system extended catalog babelfish_namespace_ext

### DIFF
--- a/contrib/babelfishpg_tsql/src/schemacmds.c
+++ b/contrib/babelfishpg_tsql/src/schemacmds.c
@@ -83,7 +83,7 @@ del_ns_ext_info(const char *schemaname, bool missing_ok)
 				 errmsg("Could not drop schema created under PostgreSQL dialect: \"%s\"", schemaname)));
 		return;
 	}
-	
+
 	ReleaseSysCache(tuple);
 	CommandCounterIncrement();
 }
@@ -134,28 +134,13 @@ check_extra_schema_restrictions(Node *stmt)
 static bool
 has_ext_info(const char *schemaname)
 {
-	//Relation	rel;
 	HeapTuple	tuple;
-	//ScanKeyData scanKey;
-	//SysScanDesc scan;
 	bool		found = true;
 
-	//rel = table_open(namespace_ext_oid, AccessShareLock);
-	// ScanKeyInit(&scanKey,
-	// 			Anum_namespace_ext_namespace,
-	// 			BTEqualStrategyNumber, F_NAMEEQ,
-	// 			CStringGetDatum(schemaname));
-
-	// scan = systable_beginscan(rel, namespace_ext_idx_oid_oid, true,
-	// 						  NULL, 1, &scanKey);
-
-	//tuple = systable_getnext(scan);
 	tuple = SearchSysCache1(NAMESPACEEXTOID, CStringGetDatum(schemaname));
 	if (!HeapTupleIsValid(tuple))
 		found = false;
 
-	//systable_endscan(scan);
-	//table_close(rel, AccessShareLock);
 	ReleaseSysCache(tuple);
 	return found;
 }


### PR DESCRIPTION
### Description

Today, many helper routines such as `get_logical_schema_name`, `get_dbid_from_physical_schema_name`, `has_ext_info`, `del_ns_ext_info` perform heap scans on `babelfish_namespace_ext`, which can lead to slow performance. These routines are called internally for various utility operations like creating a database or using a database. As the size of the `babelfish_namespace_ext` catalog keeps increasing (as observed in BABEL-3869), the performance of these operations degrades. 

This PR includes changes that
Implemented a conversion of `babelfish_namespace_ext` to use the sys cache.
Modified the helper routines (`get_logical_schema_name`, `get_dbid_from_physical_schema_name`, `add_ns_ext_info`, `del_ns_ext_info` ) to utilize the sys cache for improved performance.

Engine PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/224

### Issues Resolved
[BABEL-4414](https://jira.rds.a2z.com/browse/BABEL-4414)

Signed-off-by: Sandeep Kumawat [skumwt@amazon.com](mailto:skumwt@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).