### PR TITLE
Fixed "database "" does not exist" error in parallel worker

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -17,6 +17,7 @@
 
 #include "access/attnum.h"
 #include "access/htup_details.h"
+#include "access/parallel.h"
 #include "access/table.h"
 #include "catalog/heap.h"
 #include "catalog/indexing.h"
@@ -259,6 +260,9 @@ set_procid(Oid oid)
 static void
 assign_identity_insert(const char *newval, void *extra)
 {
+	if (IsParallelWorker())
+		return;
+
 	if (strcmp(newval, "") != 0)
 	{
 		List	   *elemlist;


### PR DESCRIPTION
Error "database "" does not exist" is being throw from Parallel worker during initialisation of GUC space. As matter of fact, we should not care to restore the value of babelfishpg_tsql.identity_insert because value of the same would not be used in parallel worker execution. Hence, this commit avoids assigning babelfishpg_tsql.identity_insert inside parallel worker.

Note on test: Given JDBC test cases are sufficient but currently parallel worker is running into other crashes or issues so we can not really show tests here. Have tested this changes locally.

Task: BABEL-4420
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).