### PR TITLE
Improved memory management in the following BBF functions 

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -3129,7 +3129,8 @@ TdsSendTypeNumeric(FmgrInfo *finfo, Datum value, void *vMetaData)
 {
 	int			rc = EOF,
 				precision = 0,
-				scale = -1;
+				scale = -1,
+				outlen = 0;
 	uint8		sign = 1,
 				length = 0;
 	char	   *out,
@@ -3152,7 +3153,8 @@ TdsSendTypeNumeric(FmgrInfo *finfo, Datum value, void *vMetaData)
 	 * response string is formatted to obtain string representation of TDS
 	 * unsigned integer along with its precision and scale
 	 */
-	decString = (char *) palloc(sizeof(char) * (strlen(out) + 1));
+	outlen = strlen(out) + max_scale;
+	decString = (char *) palloc(sizeof(char) * (outlen + 1));
 	/* While there is still digit in out and we haven't reached max_scale */
 	while (*out && scale < max_scale)
 	{
@@ -3185,6 +3187,7 @@ TdsSendTypeNumeric(FmgrInfo *finfo, Datum value, void *vMetaData)
 		decString[precision++] = '0';
 	}
 	decString[precision] = '\0';
+	Assert(precision <= outlen);
 
 	if (precision > TDS_MAX_NUM_PRECISION ||
 		precision > max_precision)

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1666,7 +1666,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			/* Identifier is not truncated. */
 			else
 			{
-				memcpy(alias, original_name, alias_len);
+				memcpy(alias, original_name, actual_alias_len);
 			}
 			res->name = alias;
 		}

--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -1551,8 +1551,7 @@ pltsql_post_expand_star(ParseState *pstate, ColumnRef *cref, List *l)
 	Datum	   *optiondatums;
 	int			noptions,
 				i;
-	char	   *optstr,
-			   *bbf_original_name;
+	char	   *optstr;
 
 	foreach(li, l)
 	{
@@ -1605,9 +1604,7 @@ pltsql_post_expand_star(ParseState *pstate, ColumnRef *cref, List *l)
 				/*
 				 * We found the original name; rewrite it as bbf_original_name
 				 */
-				bbf_original_name = &optstr[18];
-				bbf_original_name[strlen(te->resname)] = '\0';
-				te->resname = pstrdup(bbf_original_name);
+				te->resname = pnstrdup((char *) &optstr[18], strlen(te->resname));
 				break;
 			}
 		}

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -797,6 +797,7 @@ get_original_login_name(char *login)
 	HeapTuple	tuple;
 	bool		isnull;
 	Datum		datum;
+	char 		*result = NULL;
 
 	relation = table_open(get_authid_login_ext_oid(), AccessShareLock);
 
@@ -823,10 +824,17 @@ get_original_login_name(char *login)
 	/* original login name should not be NULL. */
 	Assert(!isnull);
 
+	/*
+ 	* datum is a pointer to HeapTuple. On the other hand, HeapTuple
+ 	* is a pointer to a buffer page. We need to make a copy of that
+ 	* datum before closing the scan which releases the buffer.
+ 	*/
+	result = TextDatumGetCString(datum);
+
 	systable_endscan(scan);
 	table_close(relation, AccessShareLock);
 
-	return TextDatumGetCString(datum);
+	return result;
 }
 
 


### PR DESCRIPTION
I started running JDBC test with valgrind enabled. So far fixed a couple of minor and major issues.
I'd like to deliver some of them now. More information in Jira


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).