### PR TITLE
[No jira] upgrade pg_hint_plan and fix the babel-3512 test case

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -59,7 +59,7 @@ runs:
         elif [[ ${{inputs.engine_branch}} != *"__PG_13_"* ]]; then
           cd ../..
           rm -rf pg_hint_plan
-          git clone --depth 1 --branch REL15_1_5_0 https://github.com/ossc-db/pg_hint_plan.git
+          git clone --depth 1 --branch REL15_1_5_1 https://github.com/ossc-db/pg_hint_plan.git
           cd pg_hint_plan
           export PATH=$HOME/${{ inputs.install_dir }}/bin:$PATH
           make

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -173,7 +173,7 @@ init_db() {
 init_pghint() {
     cd $1
     if [ ! -d "./pg_hint_plan" ]; then
-        git clone --depth 1 --branch REL14_1_4_0 https://github.com/ossc-db/pg_hint_plan.git
+        git clone --depth 1 --branch REL15_1_5_1 https://github.com/ossc-db/pg_hint_plan.git
     fi
     cd pg_hint_plan
     export PATH=$2/postgres/bin:$PATH

--- a/test/JDBC/expected/BABEL-3512.out
+++ b/test/JDBC/expected/BABEL-3512.out
@@ -285,6 +285,7 @@ WITH/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a1
 SET babelfish_showplan_all ON
 GO
 
+-- the purpose of babel_3512_t2_cte is to check the behavior for invalid hint 
 EXEC babel_3512_proc_6
 GO
 ~~START~~
@@ -295,8 +296,11 @@ Query Text: EXEC babel_3512_proc_6
         Index Cond: (b1 = 1)
         Filter: (c1 = 1)
   Query Text: WITH/*+ indexscan(babel_3512_t2 index_babel_3512_t2_b1babel_351ed65eb34ef55dec01b20e7fff9c5ca06) */ babel_3512_t2_cte (a1, b2, c2) as (SELECT * FROM babel_3512_t2                                    WHERE b2 = 1) SELECT * FROM babel_3512_t2_cte WHERE c2 = 1
-  ->  Seq Scan on babel_3512_t2
-        Filter: ((b2 = 1) AND (c2 = 1))
+  ->  Bitmap Heap Scan on babel_3512_t2
+        Recheck Cond: (b2 = 1)
+        Filter: (c2 = 1)
+        ->  Bitmap Index Scan on index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9
+              Index Cond: (b2 = 1)
 ~~END~~
 
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-3512.sql
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3512.sql
@@ -179,6 +179,7 @@ GO
 SET babelfish_showplan_all ON
 GO
 
+-- the purpose of babel_3512_t2_cte is to check the behavior for invalid hint 
 EXEC babel_3512_proc_6
 GO
 


### PR DESCRIPTION
upgrade pg_hint_plan and fix the babel-3512 test case
Signed-off-by: Zhibai Song <szh@amazon.com>

### Description

upgrade pg_hint_plan and fix the babel-3512 test case

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).