### PR TITLE
Create DB Performance improvements

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -309,6 +309,7 @@ getAvailDbid(void)
 		RangeVar	*sequence = makeRangeVarFromNameList(stringToQualifiedNameList("sys.babelfish_db_seq"));
 		Oid			seqid = RangeVarGetRelid(sequence, NoLock, false);
 
+		Assert(OidIsValid(seqid));
 		dbid = nextval_internal(seqid, false);
 		if (start == 0)
 			start = dbid;

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -306,7 +306,7 @@ getAvailDbid(void)
 
 	do
 	{
-		RangeVar   *sequence = makeRangeVarFromNameList(stringToQualifiedNameList("sys.babelfish_db_seq"));
+		RangeVar	*sequence = makeRangeVarFromNameList(stringToQualifiedNameList("sys.babelfish_db_seq"));
 		Oid			seqid = RangeVarGetRelid(sequence, NoLock, false);
 
 		dbid = nextval_internal(seqid, false);

--- a/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
+++ b/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
@@ -1,4 +1,4 @@
--- sla 10000
+-- sla 12000
 -- tsql
 CREATE DATABASE db1
 GO

--- a/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
+++ b/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
@@ -1,4 +1,4 @@
--- sla 12000
+-- sla 10000
 -- tsql
 CREATE DATABASE db1
 GO


### PR DESCRIPTION
### Description

In Multi DB mode, as the number of databases increases, so does the time to create the next new DB.
This is because we create three internal roles for each new DB and internally when run the DB subcommands, multiple calls to roles_is_member_of("sysadmin") is made. Now that output of this list contains all the three roles of every db created. This is the major reason for the perfomance degradation of CREATE DB command.

We fix this in three different places.

1. getAvailDbid - this functions makes a call to nextval function, which by default checks for current user's permission and makes a call to roles_is_member_of. Instead we could call the **nextval_internal** which is the same function but with the additional option of check permissions flag which we will set to false. To double check we can just ensure that the current user is "sysadmin" when getAvailDbid is called. (Currently we only call this when user is sysadmin)

2. Set temporary user when creating schema - when we create the dbo and guest schema for the new database, the create schema function fetches all the roles that current role is member of (recursively) to check if if current role can actually become the target schema owner role. To bypass this we can **assume the newdb_dbo role** when creating these schemas. In this case all the roles that newdb_dbo is member of will be fetched, but this list is much smaller than sysadmin.

3. Select best grantor - Select best grantor first fetches the roles_list that sysadmin is member of and then start checking for permissions. But sysadmin is always the first to be checked. That is sysadmin is always top of the roles_list. 
We can add a quick check to this. That is, first check if current role is sysadmin and can it give us all the permission needed. If yes, simply return. Note** This does not change any behaviour since this will anyway be done in the first loop after fetching roles_list. We are instead running the first loop before fetching the whole list.

4. Set newdb_dbo user when creating sysdatabases view in new db

| Create DB              | After | Before |
| :----------------: | :------: | :----: |
| DBs10        |   2ms  | 5ms |
| DBs500     |   3ms   | 163ms |
| DBs1000    |  4ms   | 740ms |
| DBs3000   |  9ms   | NA(~18secs) |

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/234
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1899

### Issues Resolved

[BABEL-3869](https://jira.rds.a2z.com/browse/BABEL-3869)


Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).