### PR TITLE
Add null check in exec_eval_datum for table types (#1776)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -168,14 +168,14 @@ jobs:
         if: always() && steps.install-extensions.outcome == 'success' && steps.install-unix-odbc-driver.outcome=='success'
         run: |
           cd ~
-          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-12.01.0000.tar.gz
-          tar -zxvf psqlodbc-12.01.0000.tar.gz
-          cd psqlodbc-12.01.0000
+          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-16.00.0000.tar.gz
+          tar -zxvf psqlodbc-16.00.0000.tar.gz
+          cd psqlodbc-16.00.0000
           ./configure
           sudo make
           sudo make install
-          echo '[ODBC_Driver_12_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
-          echo 'Description=ODBC Driver 12 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo '[ODBC_Driver_16_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'Description=ODBC Driver 16 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'Driver=/usr/local/lib/psqlodbcw.so' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'UsageCount=1' | sudo tee -a /etc/odbcinst.ini > /dev/null
       
@@ -191,7 +191,7 @@ jobs:
             MSSQL_BABEL_DB_USER=jdbc_user \
             MSSQL_BABEL_DB_PASSWORD=12345678 \
             MSSQL_BABEL_DB_NAME=master \
-            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_12_for_PostgreSQL \
+            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_16_for_PostgreSQL \
             PSQL_BABEL_DB_SERVER=localhost \
             PSQL_BABEL_DB_PORT=5432 \
             PSQL_BABEL_DB_USER=jdbc_user \

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -58,14 +58,14 @@ jobs:
         if: steps.install-extensions.outcome == 'success' && steps.install-unix-odbc-driver.outcome=='success'
         run: |
           cd ~
-          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-12.01.0000.tar.gz
-          tar -zxvf psqlodbc-12.01.0000.tar.gz
-          cd psqlodbc-12.01.0000
+          wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-16.00.0000.tar.gz
+          tar -zxvf psqlodbc-16.00.0000.tar.gz
+          cd psqlodbc-16.00.0000
           ./configure
           sudo make
           sudo make install
-          echo '[ODBC_Driver_12_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
-          echo 'Description=ODBC Driver 12 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo '[ODBC_Driver_16_for_PostgreSQL]' | sudo tee -a /etc/odbcinst.ini > /dev/null
+          echo 'Description=ODBC Driver 16 for PostgreSQL Server' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'Driver=/usr/local/lib/psqlodbcw.so' | sudo tee -a /etc/odbcinst.ini > /dev/null
           echo 'UsageCount=1' | sudo tee -a /etc/odbcinst.ini > /dev/null
       
@@ -81,7 +81,7 @@ jobs:
             MSSQL_BABEL_DB_USER=jdbc_user \
             MSSQL_BABEL_DB_PASSWORD=12345678 \
             MSSQL_BABEL_DB_NAME=master \
-            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_12_for_PostgreSQL \
+            PSQL_ODBC_DRIVER_NAME=ODBC_Driver_16_for_PostgreSQL \
             PSQL_BABEL_DB_SERVER=localhost \
             PSQL_BABEL_DB_PORT=5432 \
             PSQL_BABEL_DB_USER=jdbc_user \

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -7,8 +7,8 @@ jobs:
       env:
       OLD_INSTALL_DIR: psql_source
       NEW_INSTALL_DIR: psql_target
-      ENGINE_BRANCH_FROM: BABEL_2_X_DEV__PG_14_X
-      EXTENSION_BRANCH_FROM: BABEL_2_X_DEV
+      ENGINE_BRANCH_FROM: BABEL_2_6_STABLE__PG_14_9
+      EXTENSION_BRANCH_FROM: BABEL_2_6_STABLE
 
     runs-on: ubuntu-20.04
     steps:

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -6947,7 +6947,7 @@ exec_eval_datum(PLtsql_execstate *estate,
 				*typeid = tbl->tbltypeid;
 				*typetypmod = -1;
 				*value = CStringGetDatum(tbl->tblname);
-				*isnull = false;
+				*isnull = !tbl->tblname ? true : false;
 				break;
 			}
 

--- a/test/JDBC/expected/table-variable-vu-cleanup.out
+++ b/test/JDBC/expected/table-variable-vu-cleanup.out
@@ -59,3 +59,13 @@ drop schema table_variable_vu_schema
 go
 drop function table_variable_vu_func2
 go
+
+-- BABEL-4337 - nested tv
+DROP FUNCTION tv_nested_func2
+GO
+
+DROP FUNCTION tv_nested_func1
+GO
+
+DROP TYPE tv_nested_type
+GO

--- a/test/JDBC/expected/table-variable-vu-prepare.out
+++ b/test/JDBC/expected/table-variable-vu-prepare.out
@@ -239,3 +239,11 @@ BEGIN
     RETURN
 END
 go
+
+-- BABEL-4337 - nested TV, null check in tblname
+CREATE TYPE tv_nested_type AS TABLE (a INT)
+GO
+CREATE FUNCTION tv_nested_func1 (@t tv_nested_type readonly) RETURNS @a TABLE (y INT) AS BEGIN; INSERT INTO @a SELECT x FROM @t; RETURN; END;
+GO
+CREATE FUNCTION tv_nested_func2 (@t tv_nested_type readonly) RETURNS @a TABLE (x INT) AS BEGIN; INSERT INTO @a SELECT y FROM tv_nested_func1(@t); RETURN; END;
+GO

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -263,3 +263,13 @@ bit
 1
 ~~END~~
 
+
+-- BABEL-4337 - check nested TV for null; should not crash but throw an error
+SELECT * FROM tv_nested_func2(NULL)
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: table variable underlying typename is NULL. refname: @t)~~
+

--- a/test/JDBC/input/table_variables/table-variable-vu-cleanup.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-cleanup.sql
@@ -59,3 +59,13 @@ drop schema table_variable_vu_schema
 go
 drop function table_variable_vu_func2
 go
+
+-- BABEL-4337 - nested tv
+DROP FUNCTION tv_nested_func2
+GO
+
+DROP FUNCTION tv_nested_func1
+GO
+
+DROP TYPE tv_nested_type
+GO

--- a/test/JDBC/input/table_variables/table-variable-vu-prepare.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-prepare.sql
@@ -225,3 +225,11 @@ BEGIN
     RETURN
 END
 go
+
+-- BABEL-4337 - nested TV, null check in tblname
+CREATE TYPE tv_nested_type AS TABLE (a INT)
+GO
+CREATE FUNCTION tv_nested_func1 (@t tv_nested_type readonly) RETURNS @a TABLE (y INT) AS BEGIN; INSERT INTO @a SELECT x FROM @t; RETURN; END;
+GO
+CREATE FUNCTION tv_nested_func2 (@t tv_nested_type readonly) RETURNS @a TABLE (x INT) AS BEGIN; INSERT INTO @a SELECT y FROM tv_nested_func1(@t); RETURN; END;
+GO

--- a/test/JDBC/input/table_variables/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-verify.sql
@@ -98,3 +98,7 @@ go
 select * from table_variable_vu_func2()
 select typbyval from pg_catalog.pg_type where typname like '@sometable_table_variable_vu_func2%';
 go
+
+-- BABEL-4337 - check nested TV for null; should not crash but throw an error
+SELECT * FROM tv_nested_func2(NULL)
+go


### PR DESCRIPTION
In cases of nested TVF, exec_eval_datum was returning an incorrect value of isnull for actual null values. We match the check in bbf_table_var_lookup to get the correct value.

Task: BABEL-4337

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).