### PR TITLE
Rewrite  sysutcdatetime and getutcdate functions in C

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -147,6 +147,8 @@ PG_FUNCTION_INFO_V1(object_schema_name);
 PG_FUNCTION_INFO_V1(parsename);
 PG_FUNCTION_INFO_V1(pg_extension_config_remove);
 PG_FUNCTION_INFO_V1(objectproperty_internal);
+PG_FUNCTION_INFO_V1(sysutcdatetime);
+PG_FUNCTION_INFO_V1(getutcdate);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -238,6 +240,20 @@ version(PG_FUNCTION_ARGS)
 	info = (*common_utility_plugin_ptr->tsql_varchar_input) (temp.data, temp.len, -1);
 	pfree(temp.data);
 	PG_RETURN_VARCHAR_P(info);
+}
+
+Datum sysutcdatetime(PG_FUNCTION_ARGS)
+{
+    PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamptz_zone,CStringGetTextDatum("UTC"),
+                                                            PointerGetDatum(GetCurrentStatementStartTimestamp())));
+    
+}
+
+Datum getutcdate(PG_FUNCTION_ARGS)
+{
+    PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamp_trunc,CStringGetTextDatum("millisecond"),DirectFunctionCall2(timestamptz_zone,CStringGetTextDatum("UTC"),
+                                                            PointerGetDatum(GetCurrentStatementStartTimestamp()))));
+    
 }
 
 void *

--- a/contrib/babelfishpg_tsql/sql/sys.sql
+++ b/contrib/babelfishpg_tsql/sql/sys.sql
@@ -13,7 +13,7 @@ GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.sysutcdatetime() returns sys.datetime2
 AS 'babelfishpg_tsql', 'sysutcdatetime'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C STABLE;
 
 CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
     AS $$select date_trunc('millisecond', statement_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
@@ -22,7 +22,7 @@ GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
 
 create or replace function sys.getutcdate() returns sys.datetime
 AS 'babelfishpg_tsql', 'getutcdate'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C STABLE;
 
 
 CREATE FUNCTION sys.isnull(text,text) RETURNS text AS $$

--- a/contrib/babelfishpg_tsql/sql/sys.sql
+++ b/contrib/babelfishpg_tsql/sql/sys.sql
@@ -11,21 +11,18 @@ CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
 GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 
 
-CREATE OR REPLACE FUNCTION sys.sysutcdatetime() RETURNS sys.datetime2
-    AS $$select (statement_timestamp()::text::datetime2 AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime2;$$
-    LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.sysutcdatetime() TO PUBLIC;
-
+CREATE OR REPLACE FUNCTION sys.sysutcdatetime() returns sys.datetime2
+AS 'babelfishpg_tsql', 'sysutcdatetime'
+LANGUAGE C IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
     AS $$select date_trunc('millisecond', statement_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
     LANGUAGE SQL STABLE;
 GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
 
-CREATE OR REPLACE FUNCTION sys.getutcdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', ((statement_timestamp()::text::datetime2 AT TIME ZONE 'UTC'::pg_catalog.text)::pg_catalog.text::pg_catalog.TIMESTAMP))::sys.datetime;$$
-    LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.getutcdate() TO PUBLIC;
+create or replace function sys.getutcdate() returns sys.datetime
+AS 'babelfishpg_tsql', 'getutcdate'
+LANGUAGE C IMMUTABLE;
 
 
 CREATE FUNCTION sys.isnull(text,text) RETURNS text AS $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -875,15 +875,13 @@ END;
 $BODY$
 LANGUAGE 'plpgsql' STABLE;
 
-CREATE OR REPLACE FUNCTION sys.sysutcdatetime() RETURNS sys.datetime2
-    AS $$select (statement_timestamp()::text::datetime2 AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime2;$$
-    LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.sysutcdatetime() TO PUBLIC;
+CREATE OR REPLACE FUNCTION sys.sysutcdatetime() returns sys.datetime2
+AS 'babelfishpg_tsql', 'sysutcdatetime'
+LANGUAGE C IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION sys.getutcdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', ((statement_timestamp()::text::datetime2 AT TIME ZONE 'UTC'::pg_catalog.text)::pg_catalog.text::pg_catalog.TIMESTAMP))::sys.datetime;$$
-    LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.getutcdate() TO PUBLIC;
+create or replace function sys.getutcdate() returns sys.datetime
+AS 'babelfishpg_tsql', 'getutcdate'
+LANGUAGE C IMMUTABLE;
 
 -- internal helper function for date_bucket().
 CREATE OR REPLACE FUNCTION sys.date_bucket_internal_helper(IN datepart PG_CATALOG.TEXT, IN number INTEGER, IN check_date boolean, IN origin boolean, IN date ANYELEMENT default NULL) RETURNS boolean 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -877,11 +877,11 @@ LANGUAGE 'plpgsql' STABLE;
 
 CREATE OR REPLACE FUNCTION sys.sysutcdatetime() returns sys.datetime2
 AS 'babelfishpg_tsql', 'sysutcdatetime'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C STABLE;
 
 create or replace function sys.getutcdate() returns sys.datetime
 AS 'babelfishpg_tsql', 'getutcdate'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C STABLE;
 
 -- internal helper function for date_bucket().
 CREATE OR REPLACE FUNCTION sys.date_bucket_internal_helper(IN datepart PG_CATALOG.TEXT, IN number INTEGER, IN check_date boolean, IN origin boolean, IN date ANYELEMENT default NULL) RETURNS boolean 

--- a/test/JDBC/input/getdate-vu-verify.sql
+++ b/test/JDBC/input/getdate-vu-verify.sql
@@ -1,4 +1,3 @@
--- sla 50000
 exec sysdatetime_dep_proc
 go
 


### PR DESCRIPTION
### Description

Before introduction of AT TIME ZONE function , sysutcdatetime and getutcdate were using postgres AT TIME ZONE function 
but after introduction our AT TIME ZONE there was degradation of performance as AT TIME ZONE calls a plpgsql function (sys.timezone) as data given below .
So now we re-write the above functions as C functions which calls the postgres AT TIME ZONE function which improves the performance.

Performance (getdate test file) :-
Before AT TIME ZONE was introduced :- 8 seconds
After AT TIME ZONE was introduced :- 18 seconds
Now with AT TIME ZONE still present :- 5 seconds

### Issues Resolved

BABEL-986 (AT TIME ZONE)

### Test Scenarios Covered ###
(Tests are already present)
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).