### PR TITLE
Fix: Modify config user based on role for testing

### DIFF
--- a/test/JDBC/expected/BABEL-2170-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2170-vu-verify.out
@@ -484,11 +484,27 @@ DROP TRIGGER IF EXISTS babel_2170_vu_employees_view_iot_txn_delete;
 GO
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
+-- Set current_user for testing db mode
+IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
+BEGIN
+	WITH SET_CTE
+	AS
+	(SELECT set_config('role', 'jdbc_user', false))
+	SELECT NULL
+	FROM SET_CTE
+END
+ELSE
+BEGIN
+	WITH SET_CTE
+	AS
+	(SELECT set_config('role', 'babeltestuser', false))
+	SELECT NULL
+	FROM SET_CTE
+END
 GO
 ~~START~~
-text
-jdbc_user
+int
+<NULL>
 ~~END~~
 
 

--- a/test/JDBC/input/triggers/BABEL-2170-vu-verify.sql
+++ b/test/JDBC/input/triggers/BABEL-2170-vu-verify.sql
@@ -254,7 +254,23 @@ DROP TRIGGER IF EXISTS babel_2170_vu_employees_view_iot_txn_delete;
 GO
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
+-- Set current_user for testing db mode
+IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
+BEGIN
+	WITH SET_CTE
+	AS
+	(SELECT set_config('role', 'jdbc_user', false))
+	SELECT NULL
+	FROM SET_CTE
+END
+ELSE
+BEGIN
+	WITH SET_CTE
+	AS
+	(SELECT set_config('role', 'babeltestuser', false))
+	SELECT NULL
+	FROM SET_CTE
+END
 GO
 
 SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);


### PR DESCRIPTION
Task: BABEL-2170

### Description
Modify a test case for testing multi-db mode so that role is picked based on environment.
Can be. a jdbc_user or babeltestuser

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).