### PR TITLE
fix varbinary to varchar and vice-versa conversion

### DIFF
--- a/contrib/babelfishpg_common/src/encoding/mb/conv.c
+++ b/contrib/babelfishpg_common/src/encoding/mb/conv.c
@@ -402,8 +402,8 @@ TsqlLocalToUtf(const unsigned char *iso, int len,
 		unsigned char b4 = 0;
 
 		/* "break" cases all represent errors */
-		if (*iso == '\0')
-			break;
+		// if (*iso == '\0')
+		// 	break;
 
 		if (!IS_HIGHBIT_SET(*iso))
 		{

--- a/test/JDBC/expected/BABEL-1940.out
+++ b/test/JDBC/expected/BABEL-1940.out
@@ -1,0 +1,217 @@
+SELECT CONVERT(VARCHAR(10), 0x123456789)
+GO
+~~START~~
+varchar
+#Eg‰
+~~END~~
+
+
+SELECT CONVERT(VARCHAR(10), 0x80)
+GO
+~~START~~
+varchar
+€
+~~END~~
+
+
+SELECT CONVERT(VARCHAR(10), 0xaaa)
+GO
+~~START~~
+varchar
+<newline>ª
+~~END~~
+
+
+SELECT CONVERT(VARCHAR(10), 0x330033)
+GO
+~~START~~
+varchar
+3
+~~END~~
+
+
+SELECT CONVERT(VARBINARY(10), 'ｳ')
+GO
+~~START~~
+varbinary
+3F
+~~END~~
+
+
+SELECT CONVERT(VARBINARY(10), 'ﾊﾟ')
+GO
+~~START~~
+varbinary
+3F3F
+~~END~~
+
+
+SELECT CONVERT(VARBINARY(10), 'A')
+GO
+~~START~~
+varbinary
+41
+~~END~~
+
+
+SELECT CONVERT(VARBINARY(10), 'ア')
+GO
+~~START~~
+varbinary
+3F
+~~END~~
+
+
+SELECT CONVERT(VARBINARY(10), 0x81)
+GO
+~~START~~
+varbinary
+81
+~~END~~
+
+
+SELECT CONVERT(VARBINARY(10), 0x330033)
+GO
+~~START~~
+varbinary
+330033
+~~END~~
+
+
+declare @key varchar(20) = 'part1'
+declare @email varchar(20) = 'part2'
+SELECT CONVERT(VARCHAR(10), HASHBYTES('SHA1', @key + LOWER(@email)))
+GO
+~~START~~
+varchar
+æ/fact¢+Ó
+~~END~~
+
+
+
+create table babel_1940_t1 (a varbinary(9))
+GO
+
+INSERT INTO babel_1940_t1 VALUES(0x80)
+INSERT INTO babel_1940_t1 VALUES(0xaaa)
+INSERT INTO babel_1940_t1 VALUES(0x123456789)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_1940_t1
+GO
+~~START~~
+varbinary
+80
+0AAA
+0123456789
+~~END~~
+
+
+SELECT CONVERT(VARCHAR(9), a) FROM babel_1940_t1
+GO
+~~START~~
+varchar
+€
+<newline>ª
+#Eg‰
+~~END~~
+
+
+SELECT CAST(a as VARCHAR(9)) FROM babel_1940_t1
+GO
+~~START~~
+varchar
+€
+<newline>ª
+#Eg‰
+~~END~~
+
+
+SELECT CAST(a as VARCHAR(10)) FROM babel_1940_t1
+GO
+~~START~~
+varchar
+€
+<newline>ª
+#Eg‰
+~~END~~
+
+
+
+create table babel_1940_t2(a varchar(10) collate japanese_cs_as);
+GO
+
+insert into babel_1940_t2 values ('ｳ'), ('C'), ('ﾊﾟ'), ('３'), ('c'), ('ｲ'), ('Ｃ'),('ﾊ'),('1'), 
+('ｱ'),('パ'), ('b'), ('2'), ('B'),('１'), ('Ａ'),('ア'),('A'), ('a'),('AbC'), ('aBc');
+GO
+~~ROW COUNT: 21~~
+
+
+SELECT CONVERT(varbinary(10), a) FROM babel_1940_t2
+GO
+~~START~~
+varbinary
+3F
+43
+3F3F
+3F
+63
+3F
+3F
+3F
+31
+3F
+3F
+62
+32
+42
+3F
+3F
+3F
+41
+61
+416243
+614263
+~~END~~
+
+
+SELECT CONVERT(varchar(10), CONVERT(varbinary(10), a)) FROM babel_1940_t2
+GO
+~~START~~
+varchar
+?
+C
+??
+?
+c
+?
+?
+?
+1
+?
+?
+b
+2
+B
+?
+?
+?
+A
+a
+AbC
+aBc
+~~END~~
+
+
+
+DROP TABLE babel_1940_t2
+GO
+
+DROP TABLE babel_1940_t1
+GO

--- a/test/JDBC/input/BABEL-1940.sql
+++ b/test/JDBC/input/BABEL-1940.sql
@@ -1,0 +1,76 @@
+SELECT CONVERT(VARCHAR(10), 0x123456789)
+GO
+
+SELECT CONVERT(VARCHAR(10), 0x80)
+GO
+
+SELECT CONVERT(VARCHAR(10), 0xaaa)
+GO
+
+SELECT CONVERT(VARCHAR(10), 0x330033)
+GO
+
+SELECT CONVERT(VARBINARY(10), 'ｳ')
+GO
+
+SELECT CONVERT(VARBINARY(10), 'ﾊﾟ')
+GO
+
+SELECT CONVERT(VARBINARY(10), 'A')
+GO
+
+SELECT CONVERT(VARBINARY(10), 'ア')
+GO
+
+SELECT CONVERT(VARBINARY(10), 0x81)
+GO
+
+SELECT CONVERT(VARBINARY(10), 0x330033)
+GO
+
+declare @key varchar(20) = 'part1'
+declare @email varchar(20) = 'part2'
+SELECT CONVERT(VARCHAR(10), HASHBYTES('SHA1', @key + LOWER(@email)))
+GO
+
+
+create table babel_1940_t1 (a varbinary(9))
+GO
+
+INSERT INTO babel_1940_t1 VALUES(0x80)
+INSERT INTO babel_1940_t1 VALUES(0xaaa)
+INSERT INTO babel_1940_t1 VALUES(0x123456789)
+GO
+
+SELECT * FROM babel_1940_t1
+GO
+
+SELECT CONVERT(VARCHAR(9), a) FROM babel_1940_t1
+GO
+
+SELECT CAST(a as VARCHAR(9)) FROM babel_1940_t1
+GO
+
+SELECT CAST(a as VARCHAR(10)) FROM babel_1940_t1
+GO
+
+
+create table babel_1940_t2(a varchar(10) collate japanese_cs_as);
+GO
+
+insert into babel_1940_t2 values ('ｳ'), ('C'), ('ﾊﾟ'), ('３'), ('c'), ('ｲ'), ('Ｃ'),('ﾊ'),('1'), 
+('ｱ'),('パ'), ('b'), ('2'), ('B'),('１'), ('Ａ'),('ア'),('A'), ('a'),('AbC'), ('aBc');
+GO
+
+SELECT CONVERT(varbinary(10), a) FROM babel_1940_t2
+GO
+
+SELECT CONVERT(varchar(10), CONVERT(varbinary(10), a)) FROM babel_1940_t2
+GO
+
+
+DROP TABLE babel_1940_t2
+GO
+
+DROP TABLE babel_1940_t1
+GO


### PR DESCRIPTION
### Description
fix varbinary to varchar and vice-versa conversion


### Issues Resolved
BABEL-1940

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).