### PR TITLE
Fix for the crash in pre_transform_target_entry

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1645,7 +1645,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			 * Case 3: Handle the case when column name is delimited with sqb. When number of sqb
 			 * are zero, it means we are out of sqb.
 			 */
-			if(res->location != 0 && (list_length(cref->fields) > 1 &&
+			else if(res->location != 0 && (list_length(cref->fields) > 1 &&
 				IsA(llast(cref->fields), String)))
 			{
 				identifier_name = strVal(llast(cref->fields));

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1606,7 +1606,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 	if (exprKind == EXPR_KIND_SELECT_TARGET)
 	{
 		int			alias_len = 0;
-		const char *colname_start;
+		const char *colname_start = NULL;
 		const char *identifier_name = NULL;
 		int			open_square_bracket = 0;
 		int			double_quotes = 0;

--- a/test/JDBC/expected/BABEL-4484-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4484-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP TABLE test_babel_4484_t1;
+GO
+
+DROP TABLE test_babel_4484_t2;
+GO
+
+DROP TABLE test_babel_4484_t3;
+GO

--- a/test/JDBC/expected/BABEL-4484-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4484-vu-prepare.out
@@ -1,0 +1,8 @@
+CREATE TABLE test_babel_4484_t1(ABC int, ced varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t2(ABC int, 您您 varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t3(ABC int, 您您对您对您对您对您对您对您对您对您对您您您 int);
+GO

--- a/test/JDBC/expected/BABEL-4484-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4484-vu-verify.out
@@ -1,0 +1,28 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+DELETE test_babel_4484_t1 OUTPUT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO
+~~START~~
+varchar
+~~END~~
+
+
+DELETE test_babel_4484_t2 OUTPUT test_babel_4484_t2.您您 FROM test_babel_4484_t2 INNER JOIN test_babel_4484_t3 ON test_babel_4484_t2.ABC = test_babel_4484_t3.ABC WHERE test_babel_4484_t2.ABC = 1;
+GO
+~~START~~
+varchar
+~~END~~
+
+
+SELECT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/input/BABEL-4484-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4484-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP TABLE test_babel_4484_t1;
+GO
+
+DROP TABLE test_babel_4484_t2;
+GO
+
+DROP TABLE test_babel_4484_t3;
+GO

--- a/test/JDBC/input/BABEL-4484-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4484-vu-prepare.sql
@@ -1,0 +1,8 @@
+CREATE TABLE test_babel_4484_t1(ABC int, ced varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t2(ABC int, 您您 varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t3(ABC int, 您您对您对您对您对您对您对您对您对您对您您您 int);
+GO

--- a/test/JDBC/input/BABEL-4484-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4484-vu-verify.sql
@@ -1,0 +1,11 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false);
+GO
+
+DELETE test_babel_4484_t1 OUTPUT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO
+
+DELETE test_babel_4484_t2 OUTPUT test_babel_4484_t2.您您 FROM test_babel_4484_t2 INNER JOIN test_babel_4484_t3 ON test_babel_4484_t2.ABC = test_babel_4484_t3.ABC WHERE test_babel_4484_t2.ABC = 1;
+GO
+
+SELECT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -473,3 +473,4 @@ sys_asymmetric_keys
 sys_certificates
 sys_database_permissions
 BABEL-4279
+BABEL-4484


### PR DESCRIPTION
### Description

This pull request fix the crash is `pre_transform_target_entry` for queries that involves DELETE ... OUTPUT with JOIN statement. 

**Issue:**
For the delete queries with join statement, somehow the `res->location` is not processed correctly. This causes server to crash as the value of `last_dot` pointer has never been computed. I implemented a check which first computed whether the `res->location` is correct or not and then further proceed with the code.


### Issues Resolved

BABEL-4484

Signed-off-by: Riya Jain [riyaajn@amazon.com](mailto:riyaajn@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).