### PR TITLE
Support error code 11506 in sp_describe_undeclared_parameters

### DIFF
--- a/contrib/babelfishpg_tds/error_mapping.txt
+++ b/contrib/babelfishpg_tds/error_mapping.txt
@@ -186,4 +186,4 @@ XX000 ERRCODE_INTERNAL_ERROR	"The table-valued parameter \"%s\" must be declared
 22008 ERRCODE_DATETIME_VALUE_OUT_OF_RANGE	"Adding a value to a \'%s\' column caused an overflow." SQL_ERROR_517 16
 42P01 ERRCODE_UNDEFINED_TABLE	"FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name."		SQL_ERROR_13600	16
 42P01 ERRCODE_FEATURE_NOT_SUPPORTED	"Values for json auto is not currently supported."		SQL_ERROR_13600	16
-
+22023 ERRCODE_INVALID_PARAMETER_VALUE "The parameter type could not be uniquely deduced." SQL_ERROR_11506 16

--- a/contrib/babelfishpg_tsql/src/err_handler.c
+++ b/contrib/babelfishpg_tsql/src/err_handler.c
@@ -137,6 +137,7 @@ is_ignorable_error(int pg_error_code, uint8_t override_flag)
 		case SQL_ERROR_535:
 		case SQL_ERROR_13600:
 		case SQL_ERROR_15003:
+		case SQL_ERROR_11506:
 			{
 				elog(DEBUG1, "TSQL TXN is_ignorable_error %d", latest_error_code);
 				return true;

--- a/contrib/babelfishpg_tsql/src/err_handler.h
+++ b/contrib/babelfishpg_tsql/src/err_handler.h
@@ -142,6 +142,7 @@ uint8_t		override_txn_behaviour(PLtsql_stmt *stmt);
 #define SQL_ERROR_10727 10727
 #define SQL_ERROR_10733 10733
 #define SQL_ERROR_10793 10793
+#define SQL_ERROR_11506 11506
 #define SQL_ERROR_11555 11555
 #define SQL_ERROR_11700 11700
 #define SQL_ERROR_11701 11701

--- a/test/JDBC/expected/BABEL-2408.out
+++ b/test/JDBC/expected/BABEL-2408.out
@@ -1,0 +1,44 @@
+sp_describe_undeclared_parameters N'SELECT @p1', NULL
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 11506)~~
+
+~~ERROR (Message: The parameter type could not be uniquely deduced.)~~
+
+
+sp_describe_undeclared_parameters N'SELECT @p1', 1
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "PROC")~~
+
+
+sp_describe_undeclared_parameters N'SELECT @p1', N'text_test'
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "PROC")~~
+
+
+sp_describe_undeclared_parameters N'SELECT * FROM t1'
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unsupported use case in sp_describe_undeclared_parameters)~~
+
+
+sp_describe_undeclared_parameters N'SELECT COUNT(*) FROM sys.assemblies'
+GO
+~~START~~
+int#!#varchar#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#int#!#int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unsupported use case in sp_describe_undeclared_parameters)~~
+

--- a/test/JDBC/expected/TestErrorHelperFunctions.out
+++ b/test/JDBC/expected/TestErrorHelperFunctions.out
@@ -209,6 +209,7 @@ XX000#!#The table-valued parameter "%s" must be declared with the READONLY optio
 22008#!#Adding a value to a '%s' column caused an overflow.#!##!#517
 42P01#!#FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.#!##!#13600
 42P01#!#Values for json auto is not currently supported.#!##!#13600
+22023#!#The parameter type could not be uniquely deduced.#!##!#11506
 ~~END~~
 
 

--- a/test/JDBC/expected/TestErrorHelperFunctionsUpgrade-vu-verify.out
+++ b/test/JDBC/expected/TestErrorHelperFunctionsUpgrade-vu-verify.out
@@ -117,6 +117,7 @@ int
 10727
 10733
 10793
+11506
 11555
 11700
 11701
@@ -317,6 +318,7 @@ int
 517
 13600
 13600
+11506
 ~~END~~
 
 
@@ -490,6 +492,7 @@ int
 517
 13600
 13600
+11506
 ~~END~~
 
 
@@ -497,6 +500,6 @@ EXEC TestErrorHelperFunctionsUpgrade_VU_PREPARE_PROC
 GO
 ~~START~~
 int
-166
+167
 ~~END~~
 

--- a/test/JDBC/input/BABEL-2408.sql
+++ b/test/JDBC/input/BABEL-2408.sql
@@ -1,0 +1,14 @@
+sp_describe_undeclared_parameters N'SELECT @p1', NULL
+GO
+
+sp_describe_undeclared_parameters N'SELECT @p1', 1
+GO
+
+sp_describe_undeclared_parameters N'SELECT @p1', N'text_test'
+GO
+
+sp_describe_undeclared_parameters N'SELECT * FROM t1'
+GO
+
+sp_describe_undeclared_parameters N'SELECT COUNT(*) FROM sys.assemblies'
+GO


### PR DESCRIPTION
### Description

Support error code 11506 in sp_describe_undeclared_parameters. In cases where a transaction block is supplied (such as with pyodbc driver), Babelfish would throw an unsupported error message. We map the supported error message to an expected value. 

### Issues Resolved

#1354 

### Test Scenarios Covered ###
Additional manual testing with the script provided. The result is as expected (transaction is not aborted, an error message is thrown)

```
$ python test.py 
None
success
```

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).