### PR TITLE
Fix the issue DISABLE trigger not work for instead of triggers

### DIFF
--- a/test/JDBC/expected/BABEL-3326-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3326-vu-cleanup.out
@@ -20,6 +20,24 @@ GO
 DROP TABLE babel_3326_Employees
 GO
 
+drop trigger babel_3326_t1_trigger
+GO
+
+drop trigger babel_3326_t2_trigger
+GO
+
+drop trigger babel_3326_t3_trigger
+GO
+
+drop table babel_3326_t1;
+GO
+
+drop table babel_3326_t2;
+GO
+
+drop table babel_3326_t3;
+GO
+
 DROP USER babel_3326_u1
 GO
 

--- a/test/JDBC/expected/BABEL-3326-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3326-vu-prepare.out
@@ -118,3 +118,41 @@ FOR INSERT
 AS
     SELECT 'Trigger db.TR_ins Invoked'
 GO
+
+create table babel_3326_t1 (a varchar)
+GO
+
+create trigger babel_3326_t1_trigger on babel_3326_t1 instead of insert as 
+begin
+    select count(*) from inserted;
+end;
+GO
+
+create table babel_3326_t2 (a varchar)
+GO
+
+insert into babel_3326_t2 values ('1');
+GO
+~~ROW COUNT: 1~~
+
+
+create trigger babel_3326_t2_trigger on babel_3326_t2 instead of delete as 
+begin
+    select count(*) from deleted;
+end;
+GO
+
+create table babel_3326_t3 (a varchar)
+GO
+
+insert into babel_3326_t3 values ('2');
+GO
+~~ROW COUNT: 1~~
+
+
+create trigger babel_3326_t3_trigger on babel_3326_t3 instead of update as 
+begin
+    select count(*) from deleted;
+    select count(*) from inserted;
+end;
+GO

--- a/test/JDBC/expected/BABEL-3326-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3326-vu-verify.out
@@ -1028,3 +1028,103 @@ GO
 
 ~~ERROR (Message: 'DDL trigger' is not currently supported in Babelfish.)~~
 
+
+-- The instead of trigger is on and there'll no rows will be inserted
+insert into babel_3326_t1 values ('1');
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+DISABLE trigger babel_3326_t1_trigger on babel_3326_t1
+GO
+
+insert into babel_3326_t1 values ('1');
+GO
+~~ROW COUNT: 1~~
+
+
+-- The instead of trigger is disabled and new rows are inserted into the table
+select * from babel_3326_t1;
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+delete from babel_3326_t2;
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+select * from babel_3326_t2;
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DISABLE trigger babel_3326_t2_trigger on babel_3326_t2
+GO
+
+delete from babel_3326_t2;
+GO
+~~ROW COUNT: 1~~
+
+
+select * from babel_3326_t2;
+GO
+~~START~~
+varchar
+~~END~~
+
+
+update babel_3326_t3 set a = '3';
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+select * from babel_3326_t3;
+GO
+~~START~~
+varchar
+2
+~~END~~
+
+
+DISABLE trigger babel_3326_t3_trigger on babel_3326_t3
+GO
+
+update babel_3326_t3 set a = '3';
+GO
+~~ROW COUNT: 1~~
+
+
+select * from babel_3326_t3;
+GO
+~~START~~
+varchar
+3
+~~END~~
+

--- a/test/JDBC/input/BABEL-3326-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-3326-vu-cleanup.mix
@@ -20,6 +20,24 @@ GO
 DROP TABLE babel_3326_Employees
 GO
 
+drop trigger babel_3326_t1_trigger
+GO
+
+drop trigger babel_3326_t2_trigger
+GO
+
+drop trigger babel_3326_t3_trigger
+GO
+
+drop table babel_3326_t1;
+GO
+
+drop table babel_3326_t2;
+GO
+
+drop table babel_3326_t3;
+GO
+
 DROP USER babel_3326_u1
 GO
 

--- a/test/JDBC/input/BABEL-3326-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-3326-vu-prepare.mix
@@ -114,3 +114,37 @@ FOR INSERT
 AS
     SELECT 'Trigger db.TR_ins Invoked'
 GO
+
+create table babel_3326_t1 (a varchar)
+GO
+
+create trigger babel_3326_t1_trigger on babel_3326_t1 instead of insert as 
+begin
+    select count(*) from inserted;
+end;
+GO
+
+create table babel_3326_t2 (a varchar)
+GO
+
+insert into babel_3326_t2 values ('1');
+GO
+
+create trigger babel_3326_t2_trigger on babel_3326_t2 instead of delete as 
+begin
+    select count(*) from deleted;
+end;
+GO
+
+create table babel_3326_t3 (a varchar)
+GO
+
+insert into babel_3326_t3 values ('2');
+GO
+
+create trigger babel_3326_t3_trigger on babel_3326_t3 instead of update as 
+begin
+    select count(*) from deleted;
+    select count(*) from inserted;
+end;
+GO

--- a/test/JDBC/input/BABEL-3326-vu-verify.mix
+++ b/test/JDBC/input/BABEL-3326-vu-verify.mix
@@ -581,3 +581,47 @@ GO
 
 ENABLE TRIGGER [TR_ins_안녕하세요_babel_3326_Employees], TR_upd_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz_babel_3326_Employees ON ALL SERVER
 GO
+
+-- The instead of trigger is on and there'll no rows will be inserted
+insert into babel_3326_t1 values ('1');
+GO
+
+DISABLE trigger babel_3326_t1_trigger on babel_3326_t1
+GO
+
+insert into babel_3326_t1 values ('1');
+GO
+
+-- The instead of trigger is disabled and new rows are inserted into the table
+select * from babel_3326_t1;
+GO
+
+delete from babel_3326_t2;
+GO
+
+select * from babel_3326_t2;
+GO
+
+DISABLE trigger babel_3326_t2_trigger on babel_3326_t2
+GO
+
+delete from babel_3326_t2;
+GO
+
+select * from babel_3326_t2;
+GO
+
+update babel_3326_t3 set a = '3';
+GO
+
+select * from babel_3326_t3;
+GO
+
+DISABLE trigger babel_3326_t3_trigger on babel_3326_t3
+GO
+
+update babel_3326_t3 set a = '3';
+GO
+
+select * from babel_3326_t3;
+GO


### PR DESCRIPTION
previously our support for ENABLE/DISABLE trigger syntax has a issue that it's not working for instead of triggers. This commit fix this issue.

Task: BABEL-3326

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).