### PR TITLE
Fix the issue of preserving case of column names in SELECT corrname.colname and Fix the issue of preserving case of column names in SELECT corrname.colname.

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1384,7 +1384,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 				alias_len = strlen(identifier_name);
 				colname_start = pstate->p_sourcetext + res->location;
 				last_dot = colname_start;
-				while(true)
+				while(*colname_start != '\0')
 				{	
 					if(open_square_bracket == 0 && *colname_start == '"')
 					{
@@ -1445,7 +1445,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 			int		actual_alias_len = 0;
 			
 			/* To handle queries like SELECT ((<column_name>)) from <table_name> */
-			while(*colname_start == '(' || scanner_isspace(*colname_start))
+			while(*colname_start != '\0' && (*colname_start == '(' || scanner_isspace(*colname_start)))
 			{
 				colname_start++;
 			}

--- a/test/JDBC/expected/BABEL-4279-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4279-vu-cleanup.out
@@ -1,0 +1,60 @@
+-- tsql
+DROP VIEW test_babel_4279_v1;
+GO
+
+DROP VIEW test_babel_4279_v2;
+GO
+
+DROP VIEW test_babel_4279_v3;
+GO
+
+DROP TABLE test_babel_4279_t1;
+GO
+
+USE [test_babel_4279_d.1];
+GO
+
+DROP VIEW test_babel_4279_sv1;
+GO
+
+DROP TABLE test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+DROP SCHEMA test_babel_4279_s1;
+GO
+
+USE MASTER;
+GO
+
+DROP DATABASE [test_babel_4279_d.1];
+GO
+
+DROP VIEW test_babel_4279_v4;
+GO
+
+DROP VIEW test_babel_4279_v5;
+GO
+
+DROP TABLE test_babel_4279_t2;
+GO
+
+DROP VIEW test_babel_4279_v6;
+GO
+
+DROP TABLE "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+DROP SCHEMA "tngdf'";
+GO
+
+DROP VIEW test_babel_4279_v7;
+GO
+
+DROP TABLE test_babel_4279_t3;
+GO
+
+DROP VIEW test_babel_4279_v8;
+GO
+
+DROP TABLE test_babel_4279_t4;
+GO

--- a/test/JDBC/expected/BABEL-4279-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4279-vu-prepare.out
@@ -1,0 +1,60 @@
+-- tsql
+CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_v1 AS SELECT test_babel_4279_t1.[ABC.nfds] from test_babel_4279_t1;
+GO
+
+CREATE VIEW test_babel_4279_v2 AS SELECT [test_babel_4279_t1].[ABC.nfds] ,test_babel_4279_t1.[DEf.j] from test_babel_4279_t1;
+GO
+
+CREATE DATABASE [test_babel_4279_d.1];
+GO
+
+USE [test_babel_4279_d.1];
+GO
+
+CREATE SCHEMA test_babel_4279_s1;
+GO
+
+CREATE TABLE test_babel_4279_s1.test_babel_4279_st1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_sv1 AS SELECT [test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+USE MASTER
+GO
+
+CREATE VIEW test_babel_4279_v3 AS SELECT [test_babel_4279_d.1].[test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from [test_babel_4279_d.1].[test_babel_4279_s1].[test_babel_4279_st1];
+GO
+
+CREATE TABLE test_babel_4279_t2(您您对您对您对您对您对您对您对您对您对您您您 INT, 对您对您对您对您对您对您对您 INT);
+GO
+
+CREATE VIEW test_babel_4279_v4 AS SELECT test_babel_4279_t2.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2;
+GO
+
+CREATE VIEW test_babel_4279_v5 AS SELECT ぁあ.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2 AS ぁあ;
+GO
+
+CREATE SCHEMA "tngdf'";
+GO
+
+CREATE TABLE "tngdf'".[sc,sdg"fdsngjds']("AB[C" INT);
+GO
+
+CREATE VIEW test_babel_4279_v6 AS SELECT "tngdf'".[sc,sdg"fdsngjds']."AB[C" from "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+CREATE TABLE test_babel_4279_t3(ABCD INT);
+GO
+
+CREATE VIEW test_babel_4279_v7 AS SELECT  test_babel_4279_t3.ABCD FROM test_babel_4279_t3;
+GO
+
+CREATE TABLE test_babel_4279_t4([ぁあ'"] INT);
+GO
+
+CREATE VIEW test_babel_4279_v8 AS SELECT test_babel_4279_t4.[ぁあ'"] FROM test_babel_4279_t4;
+GO

--- a/test/JDBC/expected/BABEL-4279-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4279-vu-verify.out
@@ -1,0 +1,72 @@
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v1';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t1."abc.nfds" AS "ABC.nfds"<newline>   FROM master_dbo.test_babel_4279_t1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v2';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t1."abc.nfds" AS "ABC.nfds",<newline>    test_babel_4279_t1."def.j" AS "DEf.j"<newline>   FROM master_dbo.test_babel_4279_t1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_sv1';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM "test_babel_4279_d.1_test_babel_4279_s1".test_babel_4279_st1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v3';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM "test_babel_4279_d.1_test_babel_4279_s1".test_babel_4279_st1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v4';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t2."您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de"<newline>   FROM master_dbo.test_babel_4279_t2;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v5';
+GO
+~~START~~
+text
+ SELECT "ぁあ"."您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de"<newline>   FROM master_dbo.test_babel_4279_t2 "ぁあ";
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v6';
+GO
+~~START~~
+text
+ SELECT "sc,sdg""fdsngjds'"."ab[c" AS "AB[C"<newline>   FROM "master_tngdf'"."sc,sdg""fdsngjds'";
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v7';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t3.abcd AS "ABCD"<newline>   FROM master_dbo.test_babel_4279_t3;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v8';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t4."ぁあ'"""<newline>   FROM master_dbo.test_babel_4279_t4;
+~~END~~
+

--- a/test/JDBC/expected/BABEL-4279.out
+++ b/test/JDBC/expected/BABEL-4279.out
@@ -1,0 +1,194 @@
+-- tsql
+CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_v1 AS SELECT test_babel_4279_t1.[ABC.nfds] from test_babel_4279_t1;
+GO
+
+CREATE VIEW test_babel_4279_v2 AS SELECT [test_babel_4279_t1].[ABC.nfds] ,test_babel_4279_t1.[DEf.j] from test_babel_4279_t1;
+GO
+
+CREATE DATABASE ["test_babel_4279_d.1"];
+GO
+
+USE ["test_babel_4279_d.1"];
+GO
+
+CREATE SCHEMA test_babel_4279_s1;
+GO
+
+CREATE TABLE test_babel_4279_s1.test_babel_4279_st1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_sv1 AS SELECT [test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+USE MASTER
+GO
+
+CREATE VIEW test_babel_4279_v3 AS SELECT ["test_babel_4279_d.1"].[test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from ["test_babel_4279_d.1"].[test_babel_4279_s1].[test_babel_4279_st1];
+GO
+
+CREATE TABLE test_babel_4279_t2(您您对您对您对您对您对您对您对您对您对您您您 INT, 对您对您对您对您对您对您对您 INT);
+GO
+
+CREATE VIEW test_babel_4279_v4 AS SELECT test_babel_4279_t2.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2;
+GO
+
+CREATE VIEW test_babel_4279_v5 AS SELECT ぁあ.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2 AS ぁあ;
+GO
+
+CREATE SCHEMA "tngdf'";
+GO
+
+CREATE TABLE "tngdf'".[sc,sdg"fdsngjds']("AB[C" INT);
+GO
+
+CREATE VIEW test_babel_4279_v6 AS SELECT "tngdf'".[sc,sdg"fdsngjds']."AB[C" from "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+CREATE TABLE test_babel_4279_t3(ABCD INT);
+GO
+
+CREATE VIEW test_babel_4279_v7 AS SELECT  test_babel_4279_t3.ABCD FROM test_babel_4279_t3;
+GO
+
+CREATE TABLE test_babel_4279_t4([ぁあ'"] INT);
+GO
+
+CREATE VIEW test_babel_4279_v8 AS SELECT test_babel_4279_t4.[ぁあ'"] FROM test_babel_4279_t4;
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v1';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t1."abc.nfds" AS "ABC.nfds"<newline>   FROM master_dbo.test_babel_4279_t1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v2';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t1."abc.nfds" AS "ABC.nfds",<newline>    test_babel_4279_t1."def.j" AS "DEf.j"<newline>   FROM master_dbo.test_babel_4279_t1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_sv1';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v3';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v4';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t2."您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de"<newline>   FROM master_dbo.test_babel_4279_t2;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v5';
+GO
+~~START~~
+text
+ SELECT "ぁあ"."您您对您对您对您对您d60211ff7d947ff09db87babbf0cb9de"<newline>   FROM master_dbo.test_babel_4279_t2 "ぁあ";
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v6';
+GO
+~~START~~
+text
+ SELECT "sc,sdg""fdsngjds'"."ab[c" AS "AB[C"<newline>   FROM "master_tngdf'"."sc,sdg""fdsngjds'";
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v7';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t3.abcd AS "ABCD"<newline>   FROM master_dbo.test_babel_4279_t3;
+~~END~~
+
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v8';
+GO
+~~START~~
+text
+ SELECT test_babel_4279_t4."ぁあ'"""<newline>   FROM master_dbo.test_babel_4279_t4;
+~~END~~
+
+
+-- tsql
+DROP VIEW test_babel_4279_v1;
+GO
+
+DROP VIEW test_babel_4279_v2;
+GO
+
+DROP VIEW test_babel_4279_v3;
+GO
+
+DROP TABLE test_babel_4279_t1;
+GO
+
+USE ["test_babel_4279_d.1"];
+GO
+
+DROP VIEW test_babel_4279_sv1;
+GO
+
+DROP TABLE test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+DROP SCHEMA test_babel_4279_s1;
+GO
+
+USE MASTER;
+GO
+
+DROP DATABASE ["test_babel_4279_d.1"];
+GO
+
+DROP VIEW test_babel_4279_v4;
+GO
+
+DROP VIEW test_babel_4279_v5;
+GO
+
+DROP TABLE test_babel_4279_t2;
+GO
+
+DROP VIEW test_babel_4279_v6;
+GO
+
+DROP TABLE "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+DROP SCHEMA "tngdf'";
+GO
+
+DROP VIEW test_babel_4279_v7;
+GO
+
+DROP TABLE test_babel_4279_t3;
+GO
+
+DROP VIEW test_babel_4279_v8;
+GO
+
+DROP TABLE test_babel_4279_t4;
+GO

--- a/test/JDBC/expected/BABEL-4484-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4484-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP TABLE test_babel_4484_t1;
+GO
+
+DROP TABLE test_babel_4484_t2;
+GO
+
+DROP TABLE test_babel_4484_t3;
+GO

--- a/test/JDBC/expected/BABEL-4484-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4484-vu-prepare.out
@@ -1,0 +1,8 @@
+CREATE TABLE test_babel_4484_t1(ABC int, ced varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t2(ABC int, 您您 varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t3(ABC int, 您您对您对您对您对您对您对您对您对您对您您您 int);
+GO

--- a/test/JDBC/expected/BABEL-4484-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4484-vu-verify.out
@@ -1,0 +1,28 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+DELETE test_babel_4484_t1 OUTPUT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO
+~~START~~
+varchar
+~~END~~
+
+
+DELETE test_babel_4484_t2 OUTPUT test_babel_4484_t2.您您 FROM test_babel_4484_t2 INNER JOIN test_babel_4484_t3 ON test_babel_4484_t2.ABC = test_babel_4484_t3.ABC WHERE test_babel_4484_t2.ABC = 1;
+GO
+~~START~~
+varchar
+~~END~~
+
+
+SELECT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/input/BABEL-4279-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4279-vu-cleanup.sql
@@ -1,0 +1,60 @@
+-- tsql
+DROP VIEW test_babel_4279_v1;
+GO
+
+DROP VIEW test_babel_4279_v2;
+GO
+
+DROP VIEW test_babel_4279_v3;
+GO
+
+DROP TABLE test_babel_4279_t1;
+GO
+
+USE [test_babel_4279_d.1];
+GO
+
+DROP VIEW test_babel_4279_sv1;
+GO
+
+DROP TABLE test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+DROP SCHEMA test_babel_4279_s1;
+GO
+
+USE MASTER;
+GO
+
+DROP DATABASE [test_babel_4279_d.1];
+GO
+
+DROP VIEW test_babel_4279_v4;
+GO
+
+DROP VIEW test_babel_4279_v5;
+GO
+
+DROP TABLE test_babel_4279_t2;
+GO
+
+DROP VIEW test_babel_4279_v6;
+GO
+
+DROP TABLE "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+DROP SCHEMA "tngdf'";
+GO
+
+DROP VIEW test_babel_4279_v7;
+GO
+
+DROP TABLE test_babel_4279_t3;
+GO
+
+DROP VIEW test_babel_4279_v8;
+GO
+
+DROP TABLE test_babel_4279_t4;
+GO

--- a/test/JDBC/input/BABEL-4279-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4279-vu-prepare.sql
@@ -1,0 +1,60 @@
+-- tsql
+CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_v1 AS SELECT test_babel_4279_t1.[ABC.nfds] from test_babel_4279_t1;
+GO
+
+CREATE VIEW test_babel_4279_v2 AS SELECT [test_babel_4279_t1].[ABC.nfds] ,test_babel_4279_t1.[DEf.j] from test_babel_4279_t1;
+GO
+
+CREATE DATABASE [test_babel_4279_d.1];
+GO
+
+USE [test_babel_4279_d.1];
+GO
+
+CREATE SCHEMA test_babel_4279_s1;
+GO
+
+CREATE TABLE test_babel_4279_s1.test_babel_4279_st1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_sv1 AS SELECT [test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+USE MASTER
+GO
+
+CREATE VIEW test_babel_4279_v3 AS SELECT [test_babel_4279_d.1].[test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from [test_babel_4279_d.1].[test_babel_4279_s1].[test_babel_4279_st1];
+GO
+
+CREATE TABLE test_babel_4279_t2(您您对您对您对您对您对您对您对您对您对您您您 INT, 对您对您对您对您对您对您对您 INT);
+GO
+
+CREATE VIEW test_babel_4279_v4 AS SELECT test_babel_4279_t2.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2;
+GO
+
+CREATE VIEW test_babel_4279_v5 AS SELECT ぁあ.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2 AS ぁあ;
+GO
+
+CREATE SCHEMA "tngdf'";
+GO
+
+CREATE TABLE "tngdf'".[sc,sdg"fdsngjds']("AB[C" INT);
+GO
+
+CREATE VIEW test_babel_4279_v6 AS SELECT "tngdf'".[sc,sdg"fdsngjds']."AB[C" from "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+CREATE TABLE test_babel_4279_t3(ABCD INT);
+GO
+
+CREATE VIEW test_babel_4279_v7 AS SELECT  test_babel_4279_t3.ABCD FROM test_babel_4279_t3;
+GO
+
+CREATE TABLE test_babel_4279_t4([ぁあ'"] INT);
+GO
+
+CREATE VIEW test_babel_4279_v8 AS SELECT test_babel_4279_t4.[ぁあ'"] FROM test_babel_4279_t4;
+GO

--- a/test/JDBC/input/BABEL-4279-vu-verify.mix
+++ b/test/JDBC/input/BABEL-4279-vu-verify.mix
@@ -1,0 +1,27 @@
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v1';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v2';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_sv1';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v3';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v4';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v5';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v6';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v7';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v8';
+GO

--- a/test/JDBC/input/BABEL-4279.mix
+++ b/test/JDBC/input/BABEL-4279.mix
@@ -1,0 +1,149 @@
+-- tsql
+CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_v1 AS SELECT test_babel_4279_t1.[ABC.nfds] from test_babel_4279_t1;
+GO
+
+CREATE VIEW test_babel_4279_v2 AS SELECT [test_babel_4279_t1].[ABC.nfds] ,test_babel_4279_t1.[DEf.j] from test_babel_4279_t1;
+GO
+
+CREATE DATABASE ["test_babel_4279_d.1"];
+GO
+
+USE ["test_babel_4279_d.1"];
+GO
+
+CREATE SCHEMA test_babel_4279_s1;
+GO
+
+CREATE TABLE test_babel_4279_s1.test_babel_4279_st1([ABC.nfds] INT, [DEf.j] INT);
+GO
+
+CREATE VIEW test_babel_4279_sv1 AS SELECT [test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+USE MASTER
+GO
+
+CREATE VIEW test_babel_4279_v3 AS SELECT ["test_babel_4279_d.1"].[test_babel_4279_s1].[test_babel_4279_st1].[ABC.nfds] from ["test_babel_4279_d.1"].[test_babel_4279_s1].[test_babel_4279_st1];
+GO
+
+CREATE TABLE test_babel_4279_t2(您您对您对您对您对您对您对您对您对您对您您您 INT, 对您对您对您对您对您对您对您 INT);
+GO
+
+CREATE VIEW test_babel_4279_v4 AS SELECT test_babel_4279_t2.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2;
+GO
+
+CREATE VIEW test_babel_4279_v5 AS SELECT ぁあ.[您您对您对您对您对您对您对您对您对您对您您您] from test_babel_4279_t2 AS ぁあ;
+GO
+
+CREATE SCHEMA "tngdf'";
+GO
+
+CREATE TABLE "tngdf'".[sc,sdg"fdsngjds']("AB[C" INT);
+GO
+
+CREATE VIEW test_babel_4279_v6 AS SELECT "tngdf'".[sc,sdg"fdsngjds']."AB[C" from "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+CREATE TABLE test_babel_4279_t3(ABCD INT);
+GO
+
+CREATE VIEW test_babel_4279_v7 AS SELECT  test_babel_4279_t3.ABCD FROM test_babel_4279_t3;
+GO
+
+CREATE TABLE test_babel_4279_t4([ぁあ'"] INT);
+GO
+
+CREATE VIEW test_babel_4279_v8 AS SELECT test_babel_4279_t4.[ぁあ'"] FROM test_babel_4279_t4;
+GO
+
+-- psql
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v1';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v2';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_sv1';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v3';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v4';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v5';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v6';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v7';
+GO
+
+SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_babel_4279_v8';
+GO
+
+-- tsql
+DROP VIEW test_babel_4279_v1;
+GO
+
+DROP VIEW test_babel_4279_v2;
+GO
+
+DROP VIEW test_babel_4279_v3;
+GO
+
+DROP TABLE test_babel_4279_t1;
+GO
+
+USE ["test_babel_4279_d.1"];
+GO
+
+DROP VIEW test_babel_4279_sv1;
+GO
+
+DROP TABLE test_babel_4279_s1.test_babel_4279_st1;
+GO
+
+DROP SCHEMA test_babel_4279_s1;
+GO
+
+USE MASTER;
+GO
+
+DROP DATABASE ["test_babel_4279_d.1"];
+GO
+
+DROP VIEW test_babel_4279_v4;
+GO
+
+DROP VIEW test_babel_4279_v5;
+GO
+
+DROP TABLE test_babel_4279_t2;
+GO
+
+DROP VIEW test_babel_4279_v6;
+GO
+
+DROP TABLE "tngdf'".[sc,sdg"fdsngjds'];
+GO
+
+DROP SCHEMA "tngdf'";
+GO
+
+DROP VIEW test_babel_4279_v7;
+GO
+
+DROP TABLE test_babel_4279_t3;
+GO
+
+DROP VIEW test_babel_4279_v8;
+GO
+
+DROP TABLE test_babel_4279_t4;
+GO

--- a/test/JDBC/input/BABEL-4484-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4484-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP TABLE test_babel_4484_t1;
+GO
+
+DROP TABLE test_babel_4484_t2;
+GO
+
+DROP TABLE test_babel_4484_t3;
+GO

--- a/test/JDBC/input/BABEL-4484-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4484-vu-prepare.sql
@@ -1,0 +1,8 @@
+CREATE TABLE test_babel_4484_t1(ABC int, ced varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t2(ABC int, 您您 varchar(10));
+GO
+
+CREATE TABLE test_babel_4484_t3(ABC int, 您您对您对您对您对您对您对您对您对您对您您您 int);
+GO

--- a/test/JDBC/input/BABEL-4484-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4484-vu-verify.sql
@@ -1,0 +1,11 @@
+SELECT set_config('babelfishpg_tsql.enable_sll_parse_mode', 'true', false);
+GO
+
+DELETE test_babel_4484_t1 OUTPUT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO
+
+DELETE test_babel_4484_t2 OUTPUT test_babel_4484_t2.您您 FROM test_babel_4484_t2 INNER JOIN test_babel_4484_t3 ON test_babel_4484_t2.ABC = test_babel_4484_t3.ABC WHERE test_babel_4484_t2.ABC = 1;
+GO
+
+SELECT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -128,3 +128,8 @@ ignore#!#BABEL-4078-before-14_8-or-15_3-vu-cleanup
 ignore#!#orderby-before-14_8-or-15_3-vu-prepare
 ignore#!#orderby-before-14_8-or-15_3-vu-verify
 ignore#!#orderby-before-14_8-or-15_3-vu-cleanup
+
+# These tests are running in multidb mode in upgrade and singledb mode in JDBC
+ignore#!#BABEL-4279-vu-prepare
+ignore#!#BABEL-4279-vu-verify
+ignore#!#BABEL-4279-vu-cleanup

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -413,5 +413,3 @@ smalldatetimefromparts-dep
 BABEL_4330
 Test_ISNULL
 BABEL-4410
-BABEL-4279
-BABEL-4484

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -413,3 +413,5 @@ smalldatetimefromparts-dep
 BABEL_4330
 Test_ISNULL
 BABEL-4410
+BABEL-4279
+BABEL-4484


### PR DESCRIPTION
### Description

This pull request fix preserving the original case spelling of column names while selecting named column with a correlation name. It also fix the crash is pre_transform_target_entry for queries that involves DELETE ... OUTPUT with JOIN statement.

**Issue 1:**
When selecting named column with a correlation name, the lowercase spelling is always returned. The case of column name is not preserved. For instance, `select ABC from table`, here ABC is the column name. In this case column name becomes downcased. To address this issue, I've made some code modifications to ensure that the column name is handled correctly, whether it's truncated or its case needs to be preserved.

**Issue 2:**
For the delete queries with join statement, somehow the `res->location` is not processed correctly. This causes server to crash as the value of `last_dot` pointer has never been computed. I implemented a check which first computed whether the `res->location` is correct or not and then further proceed with the code.


### Issues Resolved

BABEL-4279
BABEL-4484

Signed-off-by: Riya Jain [riyaajn@amazon.com](mailto:riyaajn@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** Added test case from original bug.


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).