### PR TITLE
Cache sysadmin oid 

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -219,6 +219,7 @@ static table_variable_satisfies_vacuum_hook_type prev_table_variable_satisfies_v
 static table_variable_satisfies_vacuum_horizon_hook_type prev_table_variable_satisfies_vacuum_horizon = NULL;
 static drop_relation_refcnt_hook_type prev_drop_relation_refcnt_hook = NULL;
 static set_local_schema_for_func_hook_type prev_set_local_schema_for_func_hook = NULL;
+static bbf_get_sysadmin_oid_hook_type prev_bbf_get_sysadmin_oid_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -375,6 +376,9 @@ InstallExtendedHooks(void)
 
 	prev_set_local_schema_for_func_hook = set_local_schema_for_func_hook;
 	set_local_schema_for_func_hook = get_local_schema_for_bbf_functions;
+
+	prev_bbf_get_sysadmin_oid_hook = bbf_get_sysadmin_oid_hook;
+	bbf_get_sysadmin_oid_hook = get_sysadmin_oid;
 }
 
 void
@@ -435,6 +439,7 @@ UninstallExtendedHooks(void)
 	IsToastClassHook = PrevIsToastClassHook;
 	drop_relation_refcnt_hook = prev_drop_relation_refcnt_hook;
 	set_local_schema_for_func_hook = prev_set_local_schema_for_func_hook;
+	bbf_get_sysadmin_oid_hook = prev_bbf_get_sysadmin_oid_hook;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2045,6 +2045,7 @@ extern Oid	tsql_get_trigger_rel_oid(Oid object_id);
 extern bool pltsql_createFunction(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
                           ParamListInfo params);
 extern Oid get_sys_varcharoid(void);
+extern Oid get_sysadmin_oid(void);
 
 typedef struct
 {

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -46,6 +46,7 @@ extern bool restore_tsql_tabletype;
 
 /* To cache oid of sys.varchar */
 static Oid sys_varcharoid = InvalidOid;
+static Oid sysadmin_oid = InvalidOid;
 
 /*
  * Following the rule for locktag fields of advisory locks:
@@ -1716,6 +1717,14 @@ Oid get_sys_varcharoid(void)
 				 errmsg("Oid corresponding to sys.varchar datatype could not be found.")));
 	}
 	return sys_varcharoid;
+}
+
+Oid get_sysadmin_oid(void)
+{
+	if(!OidIsValid(sysadmin_oid))
+		sysadmin_oid = get_role_oid("sysadmin", true);
+	
+	return sysadmin_oid;
 }
 
 List

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1721,7 +1721,7 @@ Oid get_sys_varcharoid(void)
 
 Oid get_sysadmin_oid(void)
 {
-	if(!OidIsValid(sysadmin_oid))
+	if (!OidIsValid(sysadmin_oid))
 		sysadmin_oid = get_role_oid("sysadmin", true);
 	
 	return sysadmin_oid;


### PR DESCRIPTION
### Description

Continuation of the original PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1899

We cache the sysadmin role oid and expose it through a hook for engine code changes

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/234
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1899 
#### Extension PR: (cache sysadmin oid) https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1942

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).