### PR TITLE
Make FORMAT(), format_numeric() and format_datetime() function PARALLEL UNSAFE

### DIFF
--- a/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
+++ b/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
@@ -62,7 +62,7 @@ AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION sys.format_datetime(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.format_numeric(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '', IN e_position INT DEFAULT -1) RETURNS sys.nvarchar
-AS 'babelfishpg_tsql', 'format_numeric' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+AS 'babelfishpg_tsql', 'format_numeric' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.format_numeric(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR, IN INT) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.FORMAT(IN arg anyelement, IN p_format_pattern NVARCHAR, IN p_culture VARCHAR default 'en-us')
@@ -123,7 +123,7 @@ EXCEPTION
 					HINT := 'Convert it to valid datatype and try again.';
 END;
 $BODY$
-LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.FORMAT(IN anyelement, IN NVARCHAR, IN VARCHAR) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.STR(IN float_expression NUMERIC, IN length INTEGER DEFAULT 10, IN decimal_point INTEGER DEFAULT 0) RETURNS VARCHAR 

--- a/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
+++ b/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
@@ -58,7 +58,7 @@ AS 'babelfishpg_tsql', 'formatmessage' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION sys.formatmessage(IN VARCHAR, VARIADIC "any") TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.format_datetime(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '') RETURNS sys.nvarchar
-AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.format_datetime(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.format_numeric(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '', IN e_position INT DEFAULT -1) RETURNS sys.nvarchar

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -2520,6 +2520,10 @@ CALL sys.babelfish_update_user_catalog_for_guest_schema();
 -- Drop this procedure after it gets executed once.
 DROP PROCEDURE sys.babelfish_update_user_catalog_for_guest_schema();
 
+CREATE OR REPLACE FUNCTION sys.format_datetime(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '') RETURNS sys.nvarchar
+AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
+GRANT EXECUTE ON FUNCTION sys.format_datetime(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR) TO PUBLIC;
+
 CREATE OR REPLACE FUNCTION sys.format_numeric(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '', IN e_position INT DEFAULT -1) RETURNS sys.nvarchar
 AS 'babelfishpg_tsql', 'format_numeric' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.format_numeric(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR, IN INT) TO PUBLIC;

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -33,11 +33,6 @@ ignore#!#sys-eomonth-vu-verify
 ignore#!#babel_datetime2
 ignore#!#babel_collation
 
-# Group 2: cannot start subtransactions during a parallel operation BABEL-4394
-ignore#!#babel_format_standard_date_time
-ignore#!#babel_format_standard_numeric
-ignore#!#format-vu-verify
-
 # Group 3: “could not access file "pg_hint_plan": No such file or directory" BABEL-4395
 ignore#!#BABEL-3291
 ignore#!#BABEL-3292


### PR DESCRIPTION
### Description

In FORMAT() function we do the following operations which makes it PARALLEL UNSAFE : 
1. [EXCEPTION](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql#L119) statement is being used which will create a subtransaction. Subtransactions can not be started during a parallel operation.
2. FORMAT() is internally calling format_numeric() and format_datetime() functions where we modify some GUCs like [extra_float_digits](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/babelfishpg_tsql/src/format.c#L214C23-L214C41). We can not modify GUCs during a parallel operation.

This change makes the functions FORMAT(), format_numeric() and format_datetime() PARALLEL UNSAFE.

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)


### Issues Resolved

BABEL-4394

### Test Scenarios Covered ###
* **Use case based -** Tests for format() function are already written in `babel_format_standard_date_time` , `babel_format_standard_numeric` and `format-vu-*`


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** `format-vu-*`


* **Major version upgrade tests -** `format-vu-*`


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).