### PR TITLE
Re-enable test blocked due to BABEL-4423 (when parallel query enforced)

### DIFF
--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -332,9 +332,6 @@ ignore#!#babel_table_type
 # BABEL-4422
 ignore#!#babel_money
 
-# BABEL-4423
-ignore#!#BABEL-IDENTITY
-
 # BABEL-4424
 ignore#!#TestDecimal
 ignore#!#TestNumeric


### PR DESCRIPTION
### Description

Test BABEL-IDENTITY was blocked for parallel query execution workflow because some crash. Re-enabling this test because
problematic crash is resolved/no more able to reproduce.

Task: BABEL-4423
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).