### PR TITLE
Make FORMAT(), format_numeric() and format_datetime() function PARALLEL UNSAFE

### DIFF
--- a/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
+++ b/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
@@ -58,11 +58,11 @@ AS 'babelfishpg_tsql', 'formatmessage' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION sys.formatmessage(IN VARCHAR, VARIADIC "any") TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.format_datetime(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '') RETURNS sys.nvarchar
-AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.format_datetime(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.format_numeric(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '', IN e_position INT DEFAULT -1) RETURNS sys.nvarchar
-AS 'babelfishpg_tsql', 'format_numeric' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+AS 'babelfishpg_tsql', 'format_numeric' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.format_numeric(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR, IN INT) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.FORMAT(IN arg anyelement, IN p_format_pattern NVARCHAR, IN p_culture VARCHAR default 'en-us')
@@ -123,7 +123,7 @@ EXCEPTION
 					HINT := 'Convert it to valid datatype and try again.';
 END;
 $BODY$
-LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.FORMAT(IN anyelement, IN NVARCHAR, IN VARCHAR) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.STR(IN float_expression NUMERIC, IN length INTEGER DEFAULT 10, IN decimal_point INTEGER DEFAULT 0) RETURNS VARCHAR 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
@@ -1193,6 +1193,75 @@ WHERE CAST(t4."ORDINAL_POSITION" AS smallint) = ANY (t5.indkey)
     AND CAST(t4."ORDINAL_POSITION" AS smallint) = t5.indkey[seq];
 GRANT SELECT on sys.sp_statistics_view TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.format_datetime(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '') RETURNS sys.nvarchar
+AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
+GRANT EXECUTE ON FUNCTION sys.format_datetime(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR) TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.format_numeric(IN value anyelement, IN format_pattern NVARCHAR,IN culture VARCHAR,  IN data_type VARCHAR DEFAULT '', IN e_position INT DEFAULT -1) RETURNS sys.nvarchar
+AS 'babelfishpg_tsql', 'format_numeric' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
+GRANT EXECUTE ON FUNCTION sys.format_numeric(IN anyelement, IN NVARCHAR, IN VARCHAR, IN VARCHAR, IN INT) TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.FORMAT(IN arg anyelement, IN p_format_pattern NVARCHAR, IN p_culture VARCHAR default 'en-us')
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+DECLARE
+    arg_type regtype;
+    v_temp_integer INTEGER;
+BEGIN
+    arg_type := pg_typeof(arg);
+
+    CASE
+        WHEN arg_type IN ('time'::regtype ) THEN
+            RETURN sys.format_datetime(arg, p_format_pattern, p_culture, 'time');
+
+        WHEN arg_type IN ('date'::regtype, 'sys.datetime'::regtype, 'sys.smalldatetime'::regtype, 'sys.datetime2'::regtype ) THEN
+            RETURN sys.format_datetime(arg::timestamp, p_format_pattern, p_culture);
+
+        WHEN arg_type IN ('sys.tinyint'::regtype) THEN
+            RETURN sys.format_numeric(arg::SMALLINT, p_format_pattern, p_culture, 'tinyint');
+
+        WHEN arg_type IN ('smallint'::regtype) THEN
+            RETURN sys.format_numeric(arg::SMALLINT, p_format_pattern, p_culture, 'smallint');
+
+        WHEN arg_type IN ('integer'::regtype) THEN
+            RETURN sys.format_numeric(arg, p_format_pattern, p_culture, 'integer');
+
+         WHEN arg_type IN ('bigint'::regtype) THEN
+            RETURN sys.format_numeric(arg, p_format_pattern, p_culture, 'bigint');
+
+        WHEN arg_type IN ('numeric'::regtype) THEN
+            RETURN sys.format_numeric(arg, p_format_pattern, p_culture, 'numeric');
+
+        WHEN arg_type IN ('sys.decimal'::regtype) THEN
+            RETURN sys.format_numeric(arg::numeric, p_format_pattern, p_culture, 'numeric');
+
+        WHEN arg_type IN ('real'::regtype) THEN
+            IF(p_format_pattern LIKE 'R%') THEN
+                v_temp_integer := length(nullif((regexp_matches(arg::real::text, '(?<=\d*\.).*(?=[eE].*)')::text[])[1], ''));
+            ELSE v_temp_integer:= -1;
+            END IF;
+
+            RETURN sys.format_numeric(arg, p_format_pattern, p_culture, 'real', v_temp_integer);
+
+        WHEN arg_type IN ('float'::regtype) THEN
+            RETURN sys.format_numeric(arg, p_format_pattern, p_culture, 'float');
+
+        WHEN pg_typeof(arg) IN ('sys.smallmoney'::regtype, 'sys.money'::regtype) THEN
+            RETURN sys.format_numeric(arg::numeric, p_format_pattern, p_culture, 'numeric');
+        ELSE
+            RAISE datatype_mismatch;
+        END CASE;
+EXCEPTION
+	WHEN datatype_mismatch THEN
+		RAISE USING MESSAGE := format('Argument data type % is invalid for argument 1 of format function.', pg_typeof(arg)),
+					DETAIL := 'Invalid datatype.',
+					HINT := 'Convert it to valid datatype and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE;
+GRANT EXECUTE ON FUNCTION sys.FORMAT(IN anyelement, IN NVARCHAR, IN VARCHAR) TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);


### PR DESCRIPTION
### Description

In FORMAT() function we do the following operations which makes it PARALLEL UNSAFE : 
1. [EXCEPTION](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql#L119) statement is being used which will create a subtransaction. Subtransactions can not be started during a parallel operation.
2. FORMAT() is internally calling format_numeric() and format_datetime() functions where we modify some GUCs like [extra_float_digits](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_3_X_DEV/contrib/babelfishpg_tsql/src/format.c#L214C23-L214C41). We can not modify GUCs during a parallel operation.

This change makes the functions FORMAT(), format_numeric() and format_datetime() PARALLEL UNSAFE.

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)


### Issues Resolved

BABEL-4394

### Test Scenarios Covered ###
* **Use case based -** Tests for format() function are already written in `babel_format_standard_date_time` , `babel_format_standard_numeric` and `format-vu-*`


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** `format-vu-*`


* **Major version upgrade tests -** `format-vu-*`


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).