### PR TITLE
Fixed error: “lost connection to parallel worker” when running parallel query

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/err_handler.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/err_handler.c
@@ -195,8 +195,12 @@ get_tsql_error_details(ErrorData *edata,
 
 		/* Possible infinite loop of errors. Do not touch it further. */
 		if (!error_stack_full())
+		{
+			HOLD_INTERRUPTS();
 			elog(LOG, "Unmapped error found. Code: %d, Message: %s, File: %s, Line: %d, Context: %s",
 				 edata->sqlerrcode, edata->message, edata->filename, edata->lineno, error_context);
+			RESUME_INTERRUPTS();
+		}
 
 		return false;
 	}
@@ -267,8 +271,12 @@ get_tsql_error_details(ErrorData *edata,
 
 			/* Possible infinite loop of errors. Do not touch it further. */	
 			if (!error_stack_full())
+			{
+				HOLD_INTERRUPTS();
 				elog(LOG, "Unmapped error found. Code: %d, Message: %s, File: %s, Line: %d, Context: %s",
 					 edata->sqlerrcode, edata->message, edata->filename, edata->lineno, error_context);
+				RESUME_INTERRUPTS();
+			}
 
 			*tsql_error_code = ERRCODE_PLTSQL_ERROR_NOT_MAPPED;
 			*tsql_error_severity = 16;
@@ -301,7 +309,9 @@ emit_tds_log(ErrorData *edata)
 
 	if (edata->elevel < ERROR)
 	{
+		HOLD_INTERRUPTS();
 		elog(DEBUG5, "suppressing informational client message < ERROR");
+		RESUME_INTERRUPTS();
 
 		/* reset the flag */
 		tds_disable_error_log_hook = false;
@@ -356,9 +366,11 @@ emit_tds_log(ErrorData *edata)
 		/* Log the internal error message */
 		ErrorData  *next_edata;
 
+		HOLD_INTERRUPTS();
 		next_edata = CopyErrorData();
 		elog(LOG, "internal error occurred: %s", next_edata->message);
 		FreeErrorData(next_edata);
+		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -990,6 +990,7 @@ ProcessBCPRequest(TDSRequest request)
 				int			ret;
 
 				HOLD_CANCEL_INTERRUPTS();
+				HOLD_INTERRUPTS();
 
 				/*
 				 * Discard remaining TDS_BULK_LOAD packets only if End of
@@ -1014,6 +1015,7 @@ ProcessBCPRequest(TDSRequest request)
 									req->rowCount, req->colCount),
 							 errhidestmt(true)));
 
+				RESUME_INTERRUPTS();
 				PG_RE_THROW();
 			}
 			PG_END_TRY();

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -550,6 +550,7 @@ SPExecuteSQL(TDSRequestSP req)
 	}
 	PG_CATCH();
 	{
+		HOLD_INTERRUPTS();
 		if (TDS_DEBUG_ENABLED(TDS_DEBUG2))
 			ereport(LOG,
 					(errmsg("sp_executesql statement: %s", s.data),
@@ -557,6 +558,7 @@ SPExecuteSQL(TDSRequestSP req)
 					 errdetail_params(req->nTotalParams)));
 
 		TDSStatementExceptionCallback(NULL, NULL, false);
+		RESUME_INTERRUPTS();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -749,6 +751,7 @@ SPExecute(TDSRequestSP req)
 	}
 	PG_CATCH();
 	{
+		HOLD_INTERRUPTS();
 		if (TDS_DEBUG_ENABLED(TDS_DEBUG2))
 			ereport(LOG,
 					(errmsg("sp_execute handle: %d", req->handle),
@@ -757,6 +760,7 @@ SPExecute(TDSRequestSP req)
 
 		TDSStatementExceptionCallback(NULL, NULL, false);
 		tvp_lookup_list = NIL;
+		RESUME_INTERRUPTS();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -871,6 +875,7 @@ SPPrepExec(TDSRequestSP req)
 	}
 	PG_CATCH();
 	{
+		HOLD_INTERRUPTS();
 		if (TDS_DEBUG_ENABLED(TDS_DEBUG2))
 			ereport(LOG,
 					(errmsg("sp_prepexec handle: %d, "
@@ -880,6 +885,7 @@ SPPrepExec(TDSRequestSP req)
 
 		TDSStatementExceptionCallback(NULL, NULL, false);
 		tvp_lookup_list = NIL;
+		RESUME_INTERRUPTS();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -1099,6 +1105,7 @@ SPCustomType(TDSRequestSP req)
 	}
 	PG_CATCH();
 	{
+		HOLD_INTERRUPTS();
 		if (TDS_DEBUG_ENABLED(TDS_DEBUG2))
 			ereport(LOG,
 					(errmsg("stored procedure: %s", req->name.data),
@@ -1107,6 +1114,7 @@ SPCustomType(TDSRequestSP req)
 
 		tvp_lookup_list = NIL;
 
+		RESUME_INTERRUPTS();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssqlbatch.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssqlbatch.c
@@ -94,9 +94,13 @@ ExecuteSQLBatch(char *query)
 	PG_CATCH();
 	{
 		if (TDS_DEBUG_ENABLED(TDS_DEBUG2))
+		{
+			HOLD_INTERRUPTS();
 			ereport(LOG,
 					(errmsg("sql_batch statement: %s", query),
 					 errhidestmt(true)));
+			RESUME_INTERRUPTS();
+		}
 
 		PG_RE_THROW();
 	}

--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -1589,9 +1589,11 @@ pltsql_post_expand_star(ParseState *pstate, ColumnRef *cref, List *l)
 		}
 		PG_CATCH();
 		{
+			HOLD_INTERRUPTS();
 			elog(LOG, "Cache lookup failed in pltsql_post_expand_star for attribute %d of relation %u",
 				 attnum, relid);
 			attopts = (Datum) 0;
+			RESUME_INTERRUPTS();
 		}
 		PG_END_TRY();
 		if (!attopts)

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -110,11 +110,13 @@ BulkCopy(BulkCopyStmt *stmt, uint64 *processed)
 	}
 	PG_CATCH();
 	{
+		HOLD_INTERRUPTS();
 		/* For exact row which caused error, we have BulkCopyErrorCallback. */
 		elog(WARNING, "Error while executing Bulk Copy. Error occured while processing at "
 			 "implicit Batch number: %d, Rows inserted in total: %ld", stmt->cur_batch_num, stmt->rows_processed);
 		if (rel != NULL)
 			table_close(rel, NoLock);
+		RESUME_INTERRUPTS();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -451,13 +451,18 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 			PG_CATCH();
 			{
 				query = psprintf("DROP VIEW %s", sp_describe_first_result_set_view_name);
+				HOLD_INTERRUPTS();
 
 				if ((rc = SPI_execute(query, false, 1)) < 0)
+				{
+					RESUME_INTERRUPTS();
 					elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
+				}
 
 				pfree(query);
 				pfree(sp_describe_first_result_set_view_name);
 				SPI_finish();
+				RESUME_INTERRUPTS();
 				PG_RE_THROW();
 			}
 			PG_END_TRY();


### PR DESCRIPTION
As per coding convention of Postgresql, One should not use elog/ereport with any level of log when error report cycle is in progress. Use of such elog may run into various error particularly when error being processed is reported from parallel worker. This may even run into crashes during cleanup.

In Babelfish, we are using such elog to report log/debug without holding interrupt inside error report cycle which is leading to error like “lost connection to parallel worker”. This commit aim to fix such issue by appropriately holding/resuming interrupts during error report cycle.

Task: BABEL-4393
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).