### PR TITLE
Automatically run ANALYZE after babelfish extension create/upgrade (#1922)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -166,6 +166,30 @@ BEGIN
 END
 $$;
 
+CREATE OR REPLACE PROCEDURE sys.analyze_babelfish_catalogs()
+LANGUAGE plpgsql
+AS $$ 
+DECLARE 
+	babelfish_catalog RECORD;
+	schema_name varchar = 'sys';
+	error_msg text;
+BEGIN
+	FOR babelfish_catalog IN (
+		SELECT relname as name from pg_class t 
+		INNER JOIN pg_namespace n on n.oid = t.relnamespace
+		WHERE t.relkind = 'r' and n.nspname = schema_name
+		)
+	LOOP
+		BEGIN
+			EXECUTE format('ANALYZE %I.%I', schema_name, babelfish_catalog.name);
+		EXCEPTION WHEN OTHERS THEN
+			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+			RAISE WARNING 'ANALYZE for babelfish catalog %.% failed with error: %s', schema_name, babelfish_catalog.name, error_msg;
+		END;
+	END LOOP;
+END;
+$$;
+
 CREATE OR REPLACE PROCEDURE initialize_babelfish ( sa_name VARCHAR(128) )
 LANGUAGE plpgsql
 AS $$
@@ -205,6 +229,8 @@ BEGIN
 	CALL sys.babel_initialize_logins('sysadmin');
 	CALL sys.babel_create_builtin_dbs(sa_name);
 	CALL sys.initialize_babel_extras();
+	-- run analyze for all babelfish catalog
+	CALL sys.analyze_babelfish_catalogs();
 END
 $$;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
@@ -1193,9 +1193,36 @@ WHERE CAST(t4."ORDINAL_POSITION" AS smallint) = ANY (t5.indkey)
     AND CAST(t4."ORDINAL_POSITION" AS smallint) = t5.indkey[seq];
 GRANT SELECT on sys.sp_statistics_view TO PUBLIC;
 
+CREATE OR REPLACE PROCEDURE sys.analyze_babelfish_catalogs()
+LANGUAGE plpgsql
+AS $$ 
+DECLARE 
+	babelfish_catalog RECORD;
+	schema_name varchar = 'sys';
+	error_msg text;
+BEGIN
+	FOR babelfish_catalog IN (
+		SELECT relname as name from pg_class t 
+		INNER JOIN pg_namespace n on n.oid = t.relnamespace
+		WHERE t.relkind = 'r' and n.nspname = schema_name
+		)
+	LOOP
+		BEGIN
+			EXECUTE format('ANALYZE %I.%I', schema_name, babelfish_catalog.name);
+		EXCEPTION WHEN OTHERS THEN
+			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+			RAISE WARNING 'ANALYZE for babelfish catalog %.% failed with error: %s', schema_name, babelfish_catalog.name, error_msg;
+		END;
+	END LOOP;
+END;
+$$;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
+
+-- After upgrade, always run analyze for all babelfish catalogs.
+CALL sys.analyze_babelfish_catalogs();
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/AUTO_ANALYZE-before-15-5-or-14-10-vu-prepare.out
+++ b/test/JDBC/expected/AUTO_ANALYZE-before-15-5-or-14-10-vu-prepare.out
@@ -1,0 +1,9 @@
+
+-- list all the babel catalogs that has been analyzed manually during extension create
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NOT NULL order by relname
+Go
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/expected/AUTO_ANALYZE-before-15-5-or-14-10-vu-verify.out
+++ b/test/JDBC/expected/AUTO_ANALYZE-before-15-5-or-14-10-vu-verify.out
@@ -1,0 +1,9 @@
+
+-- list all the babel catalogs that has not been analyzed manually during extension upgrade
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
+GO
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/expected/AUTO_ANALYZE-vu-prepare.out
+++ b/test/JDBC/expected/AUTO_ANALYZE-vu-prepare.out
@@ -1,0 +1,34 @@
+
+-- list all the babel catalogs that has not been analyzed manually during extension create
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
+Go
+~~START~~
+varchar
+~~END~~
+
+
+-- list all the babel catalogs that has been analyzed manually during extension create
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NOT NULL order by relname
+Go
+~~START~~
+varchar
+assemblies
+babelfish_authid_login_ext
+babelfish_authid_user_ext
+babelfish_configurations
+babelfish_domain_mapping
+babelfish_extended_properties
+babelfish_function_ext
+babelfish_helpcollation
+babelfish_namespace_ext
+babelfish_schema_permissions
+babelfish_server_options
+babelfish_sysdatabases
+babelfish_syslanguages
+babelfish_view_def
+service_settings
+spt_datatype_info_table
+versions
+~~END~~
+

--- a/test/JDBC/expected/AUTO_ANALYZE-vu-prepare.out
+++ b/test/JDBC/expected/AUTO_ANALYZE-vu-prepare.out
@@ -7,28 +7,3 @@ Go
 varchar
 ~~END~~
 
-
--- list all the babel catalogs that has been analyzed manually during extension create
-SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NOT NULL order by relname
-Go
-~~START~~
-varchar
-assemblies
-babelfish_authid_login_ext
-babelfish_authid_user_ext
-babelfish_configurations
-babelfish_domain_mapping
-babelfish_extended_properties
-babelfish_function_ext
-babelfish_helpcollation
-babelfish_namespace_ext
-babelfish_schema_permissions
-babelfish_server_options
-babelfish_sysdatabases
-babelfish_syslanguages
-babelfish_view_def
-service_settings
-spt_datatype_info_table
-versions
-~~END~~
-

--- a/test/JDBC/expected/AUTO_ANALYZE-vu-verify.out
+++ b/test/JDBC/expected/AUTO_ANALYZE-vu-verify.out
@@ -1,0 +1,9 @@
+
+-- list all the babel catalogs that has not been analyzed manually during extension upgrade
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
+GO
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/input/AUTO_ANALYZE-before-15-5-or-14-10-vu-prepare.sql
+++ b/test/JDBC/input/AUTO_ANALYZE-before-15-5-or-14-10-vu-prepare.sql
@@ -1,0 +1,5 @@
+
+-- list all the babel catalogs that has been analyzed manually during extension create
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NOT NULL order by relname
+Go

--- a/test/JDBC/input/AUTO_ANALYZE-before-15-5-or-14-10-vu-verify.sql
+++ b/test/JDBC/input/AUTO_ANALYZE-before-15-5-or-14-10-vu-verify.sql
@@ -1,0 +1,5 @@
+
+-- list all the babel catalogs that has not been analyzed manually during extension upgrade
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
+GO

--- a/test/JDBC/input/AUTO_ANALYZE-vu-prepare.sql
+++ b/test/JDBC/input/AUTO_ANALYZE-vu-prepare.sql
@@ -1,0 +1,9 @@
+
+-- list all the babel catalogs that has not been analyzed manually during extension create
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
+Go
+
+-- list all the babel catalogs that has been analyzed manually during extension create
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NOT NULL order by relname
+Go

--- a/test/JDBC/input/AUTO_ANALYZE-vu-prepare.sql
+++ b/test/JDBC/input/AUTO_ANALYZE-vu-prepare.sql
@@ -3,7 +3,3 @@
 -- will return NULL in this case
 SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
 Go
-
--- list all the babel catalogs that has been analyzed manually during extension create
-SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NOT NULL order by relname
-Go

--- a/test/JDBC/input/AUTO_ANALYZE-vu-verify.sql
+++ b/test/JDBC/input/AUTO_ANALYZE-vu-verify.sql
@@ -1,0 +1,5 @@
+
+-- list all the babel catalogs that has not been analyzed manually during extension upgrade
+-- will return NULL in this case
+SELECT relname FROM pg_stat_all_tables WHERE schemaname = 'sys' and last_analyze IS NULL order by relname
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -74,6 +74,8 @@ ignore#!#forjson-subquery-before-14_10-or-15_5-vu-cleanup
 ignore#!#forjson-datatypes-before-14_10-or-15_5-vu-prepare
 ignore#!#forjson-datatypes-before-14_10-or-15_5-vu-verify
 ignore#!#forjson-datatypes-before-14_10-or-15_5-vu-cleanup
+ignore#!#AUTO_ANALYZE-before-15-5-or-14-10-vu-prepare
+ignore#!#AUTO_ANALYZE-before-15-5-or-14-10-vu-verify
 
 # These tests are meant for upgrade scenario where source version is 13_X
 ignore#!#sys_database_principals_dep_for_13_x-vu-cleanup

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -202,3 +202,4 @@ BABEL-3938
 BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -253,3 +253,4 @@ BABEL-3938
 BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -314,3 +314,4 @@ BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -313,3 +313,4 @@ BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -313,3 +313,4 @@ BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -313,3 +313,4 @@ BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -326,3 +326,4 @@ BABEL-3215
 orderby-before-14_8-or-15_3
 BABEL_4330
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -338,3 +338,4 @@ orderby-before-14_8-or-15_3
 getdate
 BABEL_4330
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -364,3 +364,4 @@ BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
 BABEL_4330
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -406,3 +406,4 @@ BABEL-3215
 orderby
 getdate
 BABEL_4330
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -406,3 +406,4 @@ BABEL-3215
 orderby
 getdate
 BABEL_4330
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -410,3 +410,4 @@ sys-sql_expression_dependencies
 smalldatetimefromparts-dep
 BABEL_4330
 BABEL-4410
+AUTO_ANALYZE-before-15-5-or-14-10

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -413,3 +413,4 @@ smalldatetimefromparts-dep
 BABEL_4330
 Test_ISNULL
 BABEL-4410
+#AUTO_ANALYZE #uncomment this test when preparing for new minor version

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -66,6 +66,7 @@ Could not find tests for procedure babel_datatype_precedence_initializer
 Could not find tests for procedure initialize_babel_extras
 Could not find tests for procedure initialize_babelfish
 Could not find tests for procedure remove_babelfish
+Could not find tests for procedure sys.analyze_babelfish_catalogs
 Could not find tests for procedure sys.babel_drop_all_dbs
 Could not find tests for procedure sys.babel_drop_all_logins
 Could not find tests for procedure sys.babel_initialize_logins
@@ -186,6 +187,7 @@ Could not find upgrade tests for procedure babel_datatype_precedence_initializer
 Could not find upgrade tests for procedure initialize_babel_extras
 Could not find upgrade tests for procedure initialize_babelfish
 Could not find upgrade tests for procedure remove_babelfish
+Could not find upgrade tests for procedure sys.analyze_babelfish_catalogs
 Could not find upgrade tests for procedure sys.babel_drop_all_dbs
 Could not find upgrade tests for procedure sys.babel_drop_all_logins
 Could not find upgrade tests for procedure sys.babel_initialize_logins


### PR DESCRIPTION
### Description

Earlier, when having less than 50 schemas on the fresh instance causes the poor performance for problematic query when having large number of objects in database. In case of less than 50 schemas, sys.babelfish_namespace_ext catalog which stores the name of schema will have less than 50 rows which means autovacuum ANALYZE has never been run by PostgreSQL autovacuum daemon as the number of inserted rows doesn't exceeds the threshold criteria. Since the sys.babelfish_namespace_ext catalog has never been analyzed it leads bad query planning for large query. This commit add changes to automatically run ANALYZE after babelfish extension create/upgrade for all babelfish catalogs to avoid such issues in future.


Signed-off-by: Sumit Jaiswal sumiji@amazon.com



### Issues Resolved
Task: BABEL-4487


### Test Scenarios Covered ###
### Performance tests 
Execution time for Problematic query:
```
select count(*) from sys.tables AS tbl 
inner join sys.all_columns as clmns on clmns.object_id = tbl.object_id 
inner join sys.types as usrt on usrt.user_type_id = clmns.user_type_id;
```

Before ANALYZE: 29 min [query plan](https://explain.dalibo.com/plan/dd1e1g32d3b60e4h)
After ANALYZE: 2 sec [query plan](https://explain.dalibo.com/plan/gfdee3a342bb73b3)

### USE CASE BASED
Manually tested with creating table for which analyze will fail
```
jdbc_testdb=# call sys.analyze_babelfish_catalogs();
WARNING:  ANALYZE for babelfish catalog sys.test_table failed with error: data out of range for datetimes
CALL
```
Logs:
```
WARNING:  ANALYZE for babelfish catalog sys.test_table failed with error: data out of range for datetimes
CONTEXT:  PL/pgSQL function sys.analyze_babelfish_catalogs() line 17 at RAISE
```



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).