### PR TITLE
Fix a crash in bbf_ExecDropStmt

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5907,7 +5907,8 @@ bbf_ExecDropStmt(DropStmt *stmt)
 			schema_oid = get_object_namespace(&address);
 			if (OidIsValid(schema_oid))
 				schema_name = get_namespace_name(schema_oid);
-			logicalschema = get_logical_schema_name(schema_name, true);
+			if (schema_name != NULL)
+				logicalschema = get_logical_schema_name(schema_name, true);
 
 			if (schema_name && major_name)
 			{
@@ -5978,7 +5979,8 @@ bbf_ExecDropStmt(DropStmt *stmt)
 			schema_oid = get_object_namespace(&address);
 			if (OidIsValid(schema_oid))
 				schema_name = get_namespace_name(schema_oid);
-			logicalschema = get_logical_schema_name(schema_name, true);
+			if (schema_name != NULL)
+				logicalschema = get_logical_schema_name(schema_name, true);
 
 			if (schema_name && major_name)
 			{


### PR DESCRIPTION
### Description

Fix a crash in bbf_ExecDropStmt where schema_name was NULL and get_logical_schema_name() was called with NULL schema_name.

Signed-off-by: Shalini Lohia <lshalini@amazon.com>
### Issues Resolved
[no jira]
[List any issues this PR will resolve]

### Test Scenarios Covered ###

* **Use case based - Tested locally, there was no crash for BABEL-1636 with the change**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).