### PR TITLE
Used sysadmin query in place of superuser query in server_principals testfile

### DIFF
--- a/test/JDBC/expected/sys-server_principals-vu-cleanup.out
+++ b/test/JDBC/expected/sys-server_principals-vu-cleanup.out
@@ -2,10 +2,8 @@
 DROP LOGIN sys_server_principals_vu_login_without_sa
 GO
 
--- psql
-ALTER USER sys_server_principals_vu_login_with_sa WITH NOSUPERUSER
+ALTER ROLE sysadmin drop member sys_server_principals_vu_login_with_sa
 GO
 
--- tsql
 DROP LOGIN sys_server_principals_vu_login_with_sa
 GO

--- a/test/JDBC/expected/sys-server_principals-vu-cleanup.out
+++ b/test/JDBC/expected/sys-server_principals-vu-cleanup.out
@@ -2,8 +2,5 @@
 DROP LOGIN sys_server_principals_vu_login_without_sa
 GO
 
-ALTER ROLE sysadmin drop member sys_server_principals_vu_login_with_sa
-GO
-
 DROP LOGIN sys_server_principals_vu_login_with_sa
 GO

--- a/test/JDBC/expected/sys-server_principals-vu-prepare.out
+++ b/test/JDBC/expected/sys-server_principals-vu-prepare.out
@@ -4,6 +4,3 @@ GO
 
 CREATE LOGIN sys_server_principals_vu_login_with_sa with password = '123'
 GO
-
-ALTER ROLE sysadmin add member sys_server_principals_vu_login_with_sa
-GO

--- a/test/JDBC/expected/sys-server_principals-vu-prepare.out
+++ b/test/JDBC/expected/sys-server_principals-vu-prepare.out
@@ -5,6 +5,5 @@ GO
 CREATE LOGIN sys_server_principals_vu_login_with_sa with password = '123'
 GO
 
--- psql
-ALTER USER sys_server_principals_vu_login_with_sa WITH SUPERUSER
+ALTER ROLE sysadmin add member sys_server_principals_vu_login_with_sa
 GO

--- a/test/JDBC/expected/sys-server_principals-vu-verify.out
+++ b/test/JDBC/expected/sys-server_principals-vu-verify.out
@@ -1,4 +1,7 @@
 -- tsql
+ALTER ROLE sysadmin add member sys_server_principals_vu_login_with_sa
+GO
+
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.server_principals');
 GO
 ~~START~~
@@ -77,3 +80,7 @@ sys_server_principals_vu_login_with_sa#!#S#!#SQL_LOGIN#!#master#!#English#!#-1#!
 sys_server_principals_vu_login_without_sa#!#S#!#SQL_LOGIN#!#master#!#English#!#-1#!#-1#!#0
 ~~END~~
 
+
+--tsql
+ALTER ROLE sysadmin drop member sys_server_principals_vu_login_with_sa
+GO

--- a/test/JDBC/input/sys-server_principals-vu-cleanup.mix
+++ b/test/JDBC/input/sys-server_principals-vu-cleanup.mix
@@ -2,10 +2,8 @@
 DROP LOGIN sys_server_principals_vu_login_without_sa
 GO
 
--- psql
-ALTER USER sys_server_principals_vu_login_with_sa WITH NOSUPERUSER
+ALTER ROLE sysadmin drop member sys_server_principals_vu_login_with_sa
 GO
 
--- tsql
 DROP LOGIN sys_server_principals_vu_login_with_sa
 GO

--- a/test/JDBC/input/sys-server_principals-vu-cleanup.mix
+++ b/test/JDBC/input/sys-server_principals-vu-cleanup.mix
@@ -2,8 +2,5 @@
 DROP LOGIN sys_server_principals_vu_login_without_sa
 GO
 
-ALTER ROLE sysadmin drop member sys_server_principals_vu_login_with_sa
-GO
-
 DROP LOGIN sys_server_principals_vu_login_with_sa
 GO

--- a/test/JDBC/input/sys-server_principals-vu-prepare.mix
+++ b/test/JDBC/input/sys-server_principals-vu-prepare.mix
@@ -4,6 +4,3 @@ GO
 
 CREATE LOGIN sys_server_principals_vu_login_with_sa with password = '123'
 GO
-
-ALTER ROLE sysadmin add member sys_server_principals_vu_login_with_sa
-GO

--- a/test/JDBC/input/sys-server_principals-vu-prepare.mix
+++ b/test/JDBC/input/sys-server_principals-vu-prepare.mix
@@ -5,6 +5,5 @@ GO
 CREATE LOGIN sys_server_principals_vu_login_with_sa with password = '123'
 GO
 
--- psql
-ALTER USER sys_server_principals_vu_login_with_sa WITH SUPERUSER
+ALTER ROLE sysadmin add member sys_server_principals_vu_login_with_sa
 GO

--- a/test/JDBC/input/sys-server_principals-vu-verify.mix
+++ b/test/JDBC/input/sys-server_principals-vu-verify.mix
@@ -1,4 +1,7 @@
 -- tsql
+ALTER ROLE sysadmin add member sys_server_principals_vu_login_with_sa
+GO
+
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.server_principals');
 GO
 
@@ -38,4 +41,8 @@ GO
 
 SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id, is_fixed_role
 FROM sys.server_principals name WHERE name like 'sys_server_principals_vu_login%' ORDER BY name;
+GO
+
+--tsql
+ALTER ROLE sysadmin drop member sys_server_principals_vu_login_with_sa
 GO


### PR DESCRIPTION
**Description**

Fixed test failures Major Version Upgrade Tests and JDBC test which was because superuser command is not working so instead used sysadmin to add logins as the member of the sysadmin.

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -** modified the existing test with correct query


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).