### PR TITLE
Fix code coverage github action

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: '0 0 * * *'  # runs every midnight
   workflow_dispatch:
-  push:
 
 jobs:
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 0 * * *'  # runs every midnight
   workflow_dispatch:
+  push:
 
 jobs:
 
@@ -103,7 +104,7 @@ jobs:
 
       - name: Run JDBC Tests
         id: jdbc
-        if: always() && steps.build-postgis-extension.outcome == 'success'
+        if: always() && steps.install-extensions.outcome == 'success'
         timeout-minutes: 60
         run: |
           export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
@@ -113,7 +114,7 @@ jobs:
         
       - name: Install MSSQL Tools
         id: install-mssql-tools
-        if: always() && steps.install-mssql-tools.outcome == 'success'
+        if: always() && steps.install-extensions.outcome == 'success'
         run: |
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list


### PR DESCRIPTION
### Description

Previously the JDBC tests were not running in the code coverage action
in BABEL_2_X_DEV branch because the step would run only if PostGIS
extension build was successful which would always be false because we do
not build the PostGIS extension in BABEL_2_X_DEV. Fixed this by making
the JDBC tests run if the Babelfish extensions are installed correctly.

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).