### PR TITLE
Change error message for unsupported DBCC commands in babelfish. 

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1270,7 +1270,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDbcc_statement(TSqlParser:
 		else
 		{
 			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED,
-				format_errmsg("DBCC %s is not yet supported in Babelfish",
+				format_errmsg("DBCC %s is not currently supported in Babelfish",
 					::getFullText(ctx->dbcc_command()).c_str()), 
 						getLineAndPos(ctx->dbcc_command()));
 		}

--- a/test/JDBC/expected/BABEL-3201-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3201-vu-verify.out
@@ -316,7 +316,7 @@ DBCC CHECKTABLE(babel_3201_t1);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: DBCC CHECKTABLE is not yet supported in Babelfish)~~
+~~ERROR (Message: DBCC CHECKTABLE is not currently supported in Babelfish)~~
 
 
 -- Invalid DBCC command

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2537,7 +2537,7 @@ DBCC CLONEDATABASE (d12608, d12608_clone);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: DBCC CLONEDATABASE is not yet supported in Babelfish)~~
+~~ERROR (Message: DBCC CLONEDATABASE is not currently supported in Babelfish)~~
 
 DROP DATABASE d12608;
 GO


### PR DESCRIPTION
### Description

This PR fixes Error message for unsupported DBCC commands in babelfish. 

### Issues Resolved
NO JIRA

Signed-off-by: Sandeep Kumawat <skumwt@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).