### PR TITLE
Crash in Table Variable lookup after TVP execution via TDS RPC SPExecuteSQL

### DIFF
--- a/test/JDBC/expected/TestTvp.out
+++ b/test/JDBC/expected/TestTvp.out
@@ -1,0 +1,20 @@
+create type tableType as table (a int, b smallint)
+create type table_variable_vu_type as table (a text not null, b int primary key, c int, d int)
+create proc table_variable_vu_proc1 (@x table_variable_vu_type readonly) as begin	select tvp.b from @x tvp end
+prepst#!#Select * from ? #!#tvp|-|tableType|-|utils/tvp-dotnet.csv|-|utils/tvp-dotnet.csv
+~~START~~
+int#!#smallint
+1#!#1
+~~END~~
+
+declare @var1 table_variable_vu_type insert into @var1 values ('1', 2, 3, 4) exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+drop procedure table_variable_vu_proc1;
+drop type table_variable_vu_type;
+drop type tableType;

--- a/test/JDBC/input/datatypes/TestTvp.txt
+++ b/test/JDBC/input/datatypes/TestTvp.txt
@@ -1,0 +1,8 @@
+create type tableType as table (a int, b smallint)
+create type table_variable_vu_type as table (a text not null, b int primary key, c int, d int)
+create proc table_variable_vu_proc1 (@x table_variable_vu_type readonly) as begin	select tvp.b from @x tvp end
+prepst#!#Select * from @a #!#tvp|-|tableType|-|utils/tvp-dotnet.csv|-|utils/tvp-dotnet.csv
+declare @var1 table_variable_vu_type insert into @var1 values ('1', 2, 3, 4) exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
+drop procedure table_variable_vu_proc1;
+drop type table_variable_vu_type;
+drop type tableType;

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
@@ -16,6 +16,7 @@ import java.text.ParseException;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.nio.file.Paths;
 
 import static com.sqlsamples.HandleException.handleSQLExceptionWithFile;
 
@@ -148,7 +149,7 @@ public class JDBCPreparedStatement {
                     sqlxml.setString(parameter[2]);
                     pstmt.setSQLXML(j - 1, sqlxml);
                 } else if (parameter[0].equalsIgnoreCase("tvp")) {
-                    FileInputStream fstream = new FileInputStream(parameter[2]);
+                    FileInputStream fstream = new FileInputStream(Paths.get(Paths.get("").toAbsolutePath().toString(), parameter[2]).toString());
                     DataInputStream in = new DataInputStream(fstream);
                     BufferedReader br = new BufferedReader(new InputStreamReader(in));
 

--- a/test/JDBC/utils/tvp-dotnet.csv
+++ b/test/JDBC/utils/tvp-dotnet.csv
@@ -1,0 +1,2 @@
+a-int,b-smallint
+1,1


### PR DESCRIPTION
### Description
Earlier we were not reseting the tvp_lookup_list to NIL in SPExecuteSQL after usage and freeing it because of which any subsequent Table Variable lookup would try to lookup in this list which was freed and lead to a crash.
To fix this we set tvp_lookup_list as NIL at the start and at the end of SPExecuteSQL TDS RPC function. 


### Issues Resolved
BABEL-4463

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
X

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).