### PR TITLE
Make DBCC stmt in uppercase in error message for un-supported DBCC commands in babelfish. 

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1288,9 +1288,11 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDbcc_statement(TSqlParser:
 		}
 		else
 		{
+			std::string dbcc_cmd = ::getFullText(ctx->dbcc_command());
+			std::transform(dbcc_cmd.begin(), dbcc_cmd.end(), dbcc_cmd.begin(), ::toupper);
 			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED,
 				format_errmsg("DBCC %s is not currently supported in Babelfish",
-					::getFullText(ctx->dbcc_command()).c_str()), 
+					dbcc_cmd.c_str()), 
 						getLineAndPos(ctx->dbcc_command()));
 		}
 	}

--- a/test/JDBC/expected/BABEL-3201-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3201-vu-verify.out
@@ -318,6 +318,12 @@ GO
 
 ~~ERROR (Message: DBCC CHECKTABLE is not currently supported in Babelfish)~~
 
+DBCC checktable(babel_3201_t1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: DBCC CHECKTABLE is not currently supported in Babelfish)~~
+
 
 -- Invalid DBCC command
 DBCC FAKE_COMMAND(t1);

--- a/test/JDBC/input/BABEL-3201-vu-verify.mix
+++ b/test/JDBC/input/BABEL-3201-vu-verify.mix
@@ -180,6 +180,8 @@ GO
 -- Unsupported DBCC command
 DBCC CHECKTABLE(babel_3201_t1);
 GO
+DBCC checktable(babel_3201_t1);
+GO
 
 -- Invalid DBCC command
 DBCC FAKE_COMMAND(t1);


### PR DESCRIPTION
### Description
Make DBCC stmt in uppercase in error message for un-supported DBCC commands in babelfish. 

For query: 
```
dbcc traceon(3604)
GO

Before: 
DBCC traceon is not currently supported in Babelfish

After:
DBCC TRACEON is not currently supported in Babelfish
```

Signed-off-by: Sandeep Kumawat <skumwt@amazon.com>

### Issues Resolved
NO JIRA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).