### PR TITLE
Properly handle space in pre_transform_target_entry

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1411,7 +1411,7 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 					 * If there is no open sqb, there are even no. of sq or dq and colname_start is at
 					 * space or comma, it means colname_start is at the end of column name.
 					 */
-					else if(open_square_bracket == 0 && double_quotes % 2 == 0 && (*colname_start == ' ' || *colname_start == ','))
+					else if(open_square_bracket == 0 && double_quotes % 2 == 0 && (scanner_isspace(*colname_start) || *colname_start == ','))
 					{
 						last_dot++;
 						colname_start = last_dot;

--- a/test/JDBC/expected/BABEL-4279.out
+++ b/test/JDBC/expected/BABEL-4279.out
@@ -192,3 +192,46 @@ GO
 
 DROP TABLE test_babel_4279_t4;
 GO
+
+CREATE TABLE t2(c int)
+GO
+
+CREATE TABLE t1(c int)
+GO
+
+-- should not crash when column followed by '\n'|'\t' etc.
+CREATE VIEW v
+AS
+SELECT t1.c
+FROM	dbo.t2 INNER JOIN t1  
+ON t2.c = t1.c
+GO
+
+DROP VIEW v
+GO
+
+DROP TABLE t2
+GO
+
+DROP TABLE t1
+GO
+
+CREATE TABLE t3(RecordEntryId bigint NOT NULL)	
+GO
+
+CREATE FUNCTION tvf_t3(@UserId BIGINT)
+RETURNS TABLE
+AS
+RETURN 
+(
+select	rp.RecordEntryId
+from	dbo.t3 rp
+)
+GO
+
+DROP FUNCTION tvf_t3
+GO
+
+DROP TABLE t3
+GO
+

--- a/test/JDBC/input/BABEL-4279.mix
+++ b/test/JDBC/input/BABEL-4279.mix
@@ -147,3 +147,46 @@ GO
 
 DROP TABLE test_babel_4279_t4;
 GO
+
+CREATE TABLE t2(c int)
+GO
+
+CREATE TABLE t1(c int)
+GO
+
+-- should not crash when column followed by '\n'|'\t' etc.
+CREATE VIEW v
+AS
+SELECT t1.c
+FROM	dbo.t2 INNER JOIN t1  
+ON t2.c = t1.c
+GO
+
+DROP VIEW v
+GO
+
+DROP TABLE t2
+GO
+
+DROP TABLE t1
+GO
+
+CREATE TABLE t3(RecordEntryId bigint NOT NULL)	
+GO
+
+CREATE FUNCTION tvf_t3(@UserId BIGINT)
+RETURNS TABLE
+AS
+RETURN 
+(
+select	rp.RecordEntryId
+from	dbo.t3 rp
+)
+GO
+
+DROP FUNCTION tvf_t3
+GO
+
+DROP TABLE t3
+GO
+


### PR DESCRIPTION
Old code is not able to identify newline, tab and other characters causing parsing of target column names to fail.

Task: BABEL-4522


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).