### PR TITLE
Remove lineno definition from pl_comp.c

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -61,9 +61,6 @@ bool		pltsql_DumpExecTree = false;
 bool		pltsql_check_syntax = false;
 
 PLtsql_function *pltsql_curr_compile;
-int			pltsql_curr_compile_body_lineno;	/* lineno of
-												 * function/procedure body in
-												 * CREATE */
 
 /* A context appropriate for short-term allocs during compilation */
 MemoryContext pltsql_compile_tmp_cxt;


### PR DESCRIPTION
### Description

It seems that `pltsql_curr_compile_body_lineno` is defined in both `pl_comp.c` and `pl_comp-2.c`. I believe it can be safely dropped from the former one.

### Issues Resolved

#1978

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).