### PR TITLE
[TEST-ONLY] Disable pg_stat_statements.calls column testcase for GRANT/REVOKE

### DIFF
--- a/test/JDBC/expected/pg_stat_statements_tsql.out
+++ b/test/JDBC/expected/pg_stat_statements_tsql.out
@@ -305,7 +305,7 @@ int#!#char#!#varchar
 ~~END~~
 
 
-SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 and (query not like 'GRANT%' AND query not like 'REVOKE%') ORDER BY query COLLATE "C";
 go
 ~~START~~
 bit#!#text#!#bigint#!#bigint#!#bigint
@@ -316,15 +316,22 @@ bit#!#text#!#bigint#!#bigint#!#bigint
 1#!#CREATE TABLE pgss_test (a int, b char(20))#!#1#!#0#!#0
 1#!#CREATE TRIGGER pgss_trigger1 on [dbo].[pgss_test] for insert as<newline>PRINT 'after insert trigger called'#!#1#!#0#!#0
 1#!#DELETE FROM pgss_test WHERE a > $1#!#1#!#1#!#0
-1#!#GRANT INSERT, UPDATE, SELECT ON pgss_test TO pgss_test_role#!#1#!#0#!#0
 1#!#INSERT INTO pgss_test VALUES(generate_series($1, $2), $3, $4)#!#1#!#10#!#0
-1#!#REVOKE INSERT, UPDATE, SELECT ON pgss_test FROM pgss_test_role#!#1#!#0#!#0
 1#!#SELECT * FROM pgss_test#!#1#!#0#!#0
 1#!#SELECT * FROM pgss_test ORDER BY a#!#1#!#0#!#0
 1#!#SELECT * FROM pgss_test WHERE a IN ($1, $2, $3, $4, $5)#!#1#!#0#!#0
 1#!#SELECT toplevel, query from pg_stat_statements ORDER BY query COLLATE "C"#!#1#!#3#!#0
 1#!#TRUNCATE TABLE pgss_test#!#1#!#0#!#0
 1#!#UPDATE pgss_test SET b = $1 WHERE a > $2#!#1#!#3#!#0
+~~END~~
+
+
+SELECT toplevel, query, rows, plans from pg_stat_statements where queryid != 0 and (query like 'GRANT%' OR query like 'REVOKE%') ORDER BY query COLLATE "C";
+go
+~~START~~
+bit#!#text#!#bigint#!#bigint
+1#!#GRANT INSERT, UPDATE, SELECT ON pgss_test TO pgss_test_role#!#0#!#0
+1#!#REVOKE INSERT, UPDATE, SELECT ON pgss_test FROM pgss_test_role#!#0#!#0
 ~~END~~
 
 

--- a/test/JDBC/input/pg_stat_statements_tsql.mix
+++ b/test/JDBC/input/pg_stat_statements_tsql.mix
@@ -168,7 +168,10 @@ SELECT * FROM pgss_test ORDER BY a;
 SELECT * FROM pgss_test WHERE a IN (1, 2, 3, 4, 5);
 go
 
-SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 ORDER BY query COLLATE "C";
+SELECT toplevel, query, calls, rows, plans from pg_stat_statements where queryid != 0 and (query not like 'GRANT%' AND query not like 'REVOKE%') ORDER BY query COLLATE "C";
+go
+
+SELECT toplevel, query, rows, plans from pg_stat_statements where queryid != 0 and (query like 'GRANT%' OR query like 'REVOKE%') ORDER BY query COLLATE "C";
 go
 
 -- psql


### PR DESCRIPTION
This commit removes test case which validates calls columns value when GRANT/REVOKE with multiple permissions is executed. Test case will re-enabled with resolution of BABEL-4528.

### Issues Resolved



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).