### PR TITLE
fix crash in fixeddecimalaggstateserialize and fixeddecimalaggstatedeserialize for parallel queries

### DIFF
--- a/contrib/babelfishpg_money/fixeddecimal.c
+++ b/contrib/babelfishpg_money/fixeddecimal.c
@@ -2981,7 +2981,10 @@ fixeddecimalaggstateserialize(PG_FUNCTION_ARGS)
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
-	state = (FixedDecimalAggState *) PG_GETARG_POINTER(0);
+	state = PG_ARGISNULL(0) ? NULL : (FixedDecimalAggState *) PG_GETARG_POINTER(0);
+
+	if (state == NULL)
+		PG_RETURN_NULL();
 
 	pq_begintypsend(&buf);
 
@@ -3006,7 +3009,10 @@ fixeddecimalaggstatedeserialize(PG_FUNCTION_ARGS)
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
-	sstate = PG_GETARG_BYTEA_P(0);
+	sstate = PG_ARGISNULL(0) ? NULL : PG_GETARG_BYTEA_P(0);
+
+	if (sstate == NULL)
+		PG_RETURN_NULL();
 
 	/*
 	 * Copy the bytea into a StringInfo so that we can "receive" it using the

--- a/contrib/babelfishpg_money/fixeddecimal.c
+++ b/contrib/babelfishpg_money/fixeddecimal.c
@@ -2981,10 +2981,10 @@ fixeddecimalaggstateserialize(PG_FUNCTION_ARGS)
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
-	state = PG_ARGISNULL(0) ? NULL : (FixedDecimalAggState *) PG_GETARG_POINTER(0);
-
-	if (state == NULL)
+	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
+
+	state = (FixedDecimalAggState *) PG_GETARG_POINTER(0);
 
 	pq_begintypsend(&buf);
 
@@ -3009,10 +3009,10 @@ fixeddecimalaggstatedeserialize(PG_FUNCTION_ARGS)
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
-	sstate = PG_ARGISNULL(0) ? NULL : PG_GETARG_BYTEA_P(0);
-
-	if (sstate == NULL)
+	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
+
+	sstate = PG_GETARG_BYTEA_P(0);
 
 	/*
 	 * Copy the bytea into a StringInfo so that we can "receive" it using the

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -114,3 +114,89 @@ GO
 DROP TABLE t_babel4261;
 GO
 
+
+
+CREATE TABLE t2_babel4261 (a money);
+GO
+
+BEGIN TRAN BABEL4261_T2; 
+GO
+
+ALTER TABLE t2_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+GO
+
+-- The third parameter is true to set config back to default after transaction is committed
+SELECT set_config('force_parallel_mode', '1', true)
+SELECT set_config('parallel_setup_cost', '0', true)
+SELECT set_config('parallel_tuple_cost', '0', true)
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+
+--- INSERT SOME data into t2_babel4261
+INSERT t2_babel4261 SELECT 0.4245*10000
+INSERT t2_babel4261 SELECT 0.5234*10000
+INSERT t2_babel4261 SELECT 0.1113*10000
+INSERT t2_babel4261 SELECT 0.6732*10000
+INSERT t2_babel4261 SELECT 0.3467*10000
+INSERT t2_babel4261 SELECT 0.5213*10000
+INSERT t2_babel4261 SELECT 0.9893*10000
+INSERT t2_babel4261 SELECT 0.6034*10000
+INSERT t2_babel4261 SELECT 0.3334*10000
+INSERT t2_babel4261 SELECT 0.8888*10000
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT sum(a) FROM t2_babel4261
+SELECT sum(a) FROM t2_babel4261   -- should not crash
+GO
+~~START~~
+money
+54153.0000
+~~END~~
+
+~~START~~
+money
+54153.0000
+~~END~~
+
+
+-- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
+COMMIT TRAN BABEL4261_T2;
+GO
+
+DROP TABLE t2_babel4261;
+GO
+

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -51,3 +51,44 @@ GO
 DROP TABLE t_babel4261;
 GO
 
+
+
+CREATE TABLE t2_babel4261 (a money);
+GO
+
+BEGIN TRAN BABEL4261_T2; 
+GO
+
+ALTER TABLE t2_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+GO
+
+-- The third parameter is true to set config back to default after transaction is committed
+SELECT set_config('force_parallel_mode', '1', true)
+SELECT set_config('parallel_setup_cost', '0', true)
+SELECT set_config('parallel_tuple_cost', '0', true)
+GO
+
+--- INSERT SOME data into t2_babel4261
+INSERT t2_babel4261 SELECT 0.4245*10000
+INSERT t2_babel4261 SELECT 0.5234*10000
+INSERT t2_babel4261 SELECT 0.1113*10000
+INSERT t2_babel4261 SELECT 0.6732*10000
+INSERT t2_babel4261 SELECT 0.3467*10000
+INSERT t2_babel4261 SELECT 0.5213*10000
+INSERT t2_babel4261 SELECT 0.9893*10000
+INSERT t2_babel4261 SELECT 0.6034*10000
+INSERT t2_babel4261 SELECT 0.3334*10000
+INSERT t2_babel4261 SELECT 0.8888*10000
+GO
+
+SELECT sum(a) FROM t2_babel4261
+SELECT sum(a) FROM t2_babel4261   -- should not crash
+GO
+
+-- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
+COMMIT TRAN BABEL4261_T2;
+GO
+
+DROP TABLE t2_babel4261;
+GO
+

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -307,9 +307,6 @@ ignore#!#Test-sp_addrolemember-dep-vu-verify
 ignore#!#Test-sp_droprolemember-dep-vu-verify
 ignore#!#babel_table_type
 
-# BABEL-4422
-ignore#!#babel_money
-
 # BABEL-4423
 ignore#!#BABEL-IDENTITY
 


### PR DESCRIPTION
### Description
In parallel query context, variables `state` and `sstate` can be `NULL` in functions `fixeddecimalaggstateserialize` and `fixeddecimalaggstatedeserialize` respectively. This scenario was not handled properly in functions `fixeddecimalaggstateserialize` and `fixeddecimalaggstatedeserialize`. This PR adds a check in these functions which will handle this `NULL` value scenario.

Also removed `babel_money` test from `parallel_query_jdbc_schedule` file, as the crash will be resolved by this PR.

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-4261

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).