### PR TITLE
Test fixes for PG15.5 merge

### DIFF
--- a/test/JDBC/expected/TestRecreatedInnerProcedures.out
+++ b/test/JDBC/expected/TestRecreatedInnerProcedures.out
@@ -108,17 +108,15 @@ as
 insert into t1 values (1);
 go
 
--- This has failed since PG14.
 exec psql_outer_proc;
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Calling an inner procedure failed)~~
+~~ROW COUNT: 1~~
 
 select * from t1;
 go
 ~~START~~
 int
+1
 1
 ~~END~~
 
@@ -190,19 +188,13 @@ end;
 $$ LANGUAGE PLPGSQL;
 go
 
--- This has failed since PG14.
 call psql_outer_proc();
 go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Calling an inner procedure failed
-  Where: PL/pgSQL function psql_outer_proc() line 5 at RAISE
-    Server SQLState: P0001)~~
-
 select * from t1;
 go
 ~~START~~
 int4
+1
 1
 ~~END~~
 

--- a/test/JDBC/input/interoperability/TestRecreatedInnerProcedures.mix
+++ b/test/JDBC/input/interoperability/TestRecreatedInnerProcedures.mix
@@ -86,7 +86,6 @@ as
 insert into t1 values (1);
 go
 
--- This has failed since PG14.
 exec psql_outer_proc;
 go
 select * from t1;
@@ -146,7 +145,6 @@ end;
 $$ LANGUAGE PLPGSQL;
 go
 
--- This has failed since PG14.
 call psql_outer_proc();
 go
 select * from t1;


### PR DESCRIPTION
### Description
Seems like community has fixed a bug with procedure call 
due to which JDBC test case started passing. This commit
fixes the expected output file for it.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/251

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).