### PR TITLE
Fixed crash exec_stmt_grantschema not able to handle non existing role

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3704,7 +3704,12 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 			rolname	= get_physical_user_name(dbname, grantee_name);
 			role_oid = get_role_oid(rolname, true);
 			grantee_is_db_owner = 0 == strncmp(grantee_name, get_owner_of_db(dbname), NAMEDATALEN);
-	
+
+
+			if (role_oid == InvalidOid)
+				ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", grantee_name)));
+
 			if (pg_namespace_ownercheck(schemaOid, role_oid) || is_member_of_role(role_oid, datdba) || grantee_is_db_owner)
 				ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -150,7 +150,7 @@ grant select on schema::babel_4344_s2 to jdbc_user; -- should fail
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+~~ERROR (Message: Cannot find the principal 'jdbc_user', because it does not exist or you do not have permission.)~~
 
 grant select on schema::babel_4344_s2 to guest; -- should pass 
 go


### PR DESCRIPTION
Task: BABEL-4536



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).