### PR TITLE
fix crash in fixeddecimalaggstateserialize and fixeddecimalaggstatedeserialize for parallel queries

### DIFF
--- a/contrib/babelfishpg_money/fixeddecimal.c
+++ b/contrib/babelfishpg_money/fixeddecimal.c
@@ -2984,6 +2984,9 @@ fixeddecimalaggstateserialize(PG_FUNCTION_ARGS)
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
 	state = (FixedDecimalAggState *) PG_GETARG_POINTER(0);
 
 	pq_begintypsend(&buf);
@@ -3008,6 +3011,9 @@ fixeddecimalaggstatedeserialize(PG_FUNCTION_ARGS)
 
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "aggregate function called in non-aggregate context");
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
 
 	sstate = PG_GETARG_BYTEA_P(0);
 

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -1,10 +1,128 @@
-CREATE TABLE t1_babel4261 (a money);
+BEGIN TRAN BABEL4261_T1; 
 GO
 
-BEGIN TRAN BABEL4261_T1;
+CREATE TABLE t_babel4261 (a int, b int);
 GO
 
-ALTER TABLE t1_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+-- The third parameter is true to set config back to default after transaction is committed
+select set_config('parallel_setup_cost', 0, true);
+select set_config('parallel_tuple_cost', 0, true);
+select set_config('min_parallel_table_scan_size', 0, true);
+GO
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+
+
+-- show explicitly this is a parallel query plan
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL ON
+GO
+
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+~~START~~
+text
+Query Text: select a, count(*) from t_babel4261 group by a order by 2
+Sort
+  Sort Key: (count(*)) NULLS FIRST
+  ->  Finalize HashAggregate
+        Group Key: a
+        ->  Gather
+              Workers Planned: 2
+              ->  Partial HashAggregate
+                    Group Key: a
+                    ->  Parallel Seq Scan on t_babel4261
+~~END~~
+
+
+-- set configurations back
+SET BABELFISH_SHOWPLAN_ALL OFF
+GO
+
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
+COMMIT TRAN BABEL4261_T1;
+GO
+
+
+DROP TABLE t_babel4261;
+GO
+
+
+
+CREATE TABLE t2_babel4261 (a money);
+GO
+
+BEGIN TRAN BABEL4261_T2; 
+GO
+
+ALTER TABLE t2_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
 GO
 
 -- The third parameter is true to set config back to default after transaction is committed
@@ -28,17 +146,17 @@ text
 ~~END~~
 
 
---- INSERT SOME data into t1_babel4261
-INSERT t1_babel4261 SELECT 0.4245*10000
-INSERT t1_babel4261 SELECT 0.5234*10000
-INSERT t1_babel4261 SELECT 0.1113*10000
-INSERT t1_babel4261 SELECT 0.6732*10000
-INSERT t1_babel4261 SELECT 0.3467*10000
-INSERT t1_babel4261 SELECT 0.5213*10000
-INSERT t1_babel4261 SELECT 0.9893*10000
-INSERT t1_babel4261 SELECT 0.6034*10000
-INSERT t1_babel4261 SELECT 0.3334*10000
-INSERT t1_babel4261 SELECT 0.8888*10000
+--- INSERT SOME data into t2_babel4261
+INSERT t2_babel4261 SELECT 0.4245*10000
+INSERT t2_babel4261 SELECT 0.5234*10000
+INSERT t2_babel4261 SELECT 0.1113*10000
+INSERT t2_babel4261 SELECT 0.6732*10000
+INSERT t2_babel4261 SELECT 0.3467*10000
+INSERT t2_babel4261 SELECT 0.5213*10000
+INSERT t2_babel4261 SELECT 0.9893*10000
+INSERT t2_babel4261 SELECT 0.6034*10000
+INSERT t2_babel4261 SELECT 0.3334*10000
+INSERT t2_babel4261 SELECT 0.8888*10000
 GO
 ~~ROW COUNT: 1~~
 
@@ -61,8 +179,8 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT sum(a) FROM t1_babel4261
-SELECT sum(a) FROM t1_babel4261   -- should not crash
+SELECT sum(a) FROM t2_babel4261
+SELECT sum(a) FROM t2_babel4261   -- should not crash
 GO
 ~~START~~
 money
@@ -76,9 +194,8 @@ money
 
 
 -- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
-COMMIT TRAN BABEL4261_T1;
+COMMIT TRAN BABEL4261_T2;
 GO
 
-DROP TABLE t1_babel4261;
+DROP TABLE t2_babel4261;
 GO
-

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -1,0 +1,84 @@
+CREATE TABLE t1_babel4261 (a money);
+GO
+
+BEGIN TRAN BABEL4261_T1;
+GO
+
+ALTER TABLE t1_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+GO
+
+-- The third parameter is true to set config back to default after transaction is committed
+SELECT set_config('force_parallel_mode', '1', true)
+SELECT set_config('parallel_setup_cost', '0', true)
+SELECT set_config('parallel_tuple_cost', '0', true)
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+
+--- INSERT SOME data into t1_babel4261
+INSERT t1_babel4261 SELECT 0.4245*10000
+INSERT t1_babel4261 SELECT 0.5234*10000
+INSERT t1_babel4261 SELECT 0.1113*10000
+INSERT t1_babel4261 SELECT 0.6732*10000
+INSERT t1_babel4261 SELECT 0.3467*10000
+INSERT t1_babel4261 SELECT 0.5213*10000
+INSERT t1_babel4261 SELECT 0.9893*10000
+INSERT t1_babel4261 SELECT 0.6034*10000
+INSERT t1_babel4261 SELECT 0.3334*10000
+INSERT t1_babel4261 SELECT 0.8888*10000
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT sum(a) FROM t1_babel4261
+SELECT sum(a) FROM t1_babel4261   -- should not crash
+GO
+~~START~~
+money
+54153.0000
+~~END~~
+
+~~START~~
+money
+54153.0000
+~~END~~
+
+
+-- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
+COMMIT TRAN BABEL4261_T1;
+GO
+
+DROP TABLE t1_babel4261;
+GO
+

--- a/test/JDBC/expected/BABEL-4261.out
+++ b/test/JDBC/expected/BABEL-4261.out
@@ -1,128 +1,10 @@
-BEGIN TRAN BABEL4261_T1; 
+CREATE TABLE t1_babel4261 (a money);
 GO
 
-CREATE TABLE t_babel4261 (a int, b int);
+BEGIN TRAN BABEL4261_T1;
 GO
 
--- The third parameter is true to set config back to default after transaction is committed
-select set_config('parallel_setup_cost', 0, true);
-select set_config('parallel_tuple_cost', 0, true);
-select set_config('min_parallel_table_scan_size', 0, true);
-GO
-~~START~~
-text
-0
-~~END~~
-
-~~START~~
-text
-0
-~~END~~
-
-~~START~~
-text
-0
-~~END~~
-
-
-
--- show explicitly this is a parallel query plan
-select set_config('babelfishpg_tsql.explain_timing', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
-select set_config('babelfishpg_tsql.explain_summary', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
-SET BABELFISH_SHOWPLAN_ALL ON
-GO
-
-select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
-GO
-~~START~~
-text
-Query Text: select a, count(*) from t_babel4261 group by a order by 2
-Sort
-  Sort Key: (count(*)) NULLS FIRST
-  ->  Finalize HashAggregate
-        Group Key: a
-        ->  Gather
-              Workers Planned: 2
-              ->  Partial HashAggregate
-                    Group Key: a
-                    ->  Parallel Seq Scan on t_babel4261
-~~END~~
-
-
--- set configurations back
-SET BABELFISH_SHOWPLAN_ALL OFF
-GO
-
-select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
-GO
-~~START~~
-int#!#int
-~~END~~
-
-
-select set_config('babelfishpg_tsql.explain_timing', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
-select set_config('babelfishpg_tsql.explain_summary', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
--- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
-COMMIT TRAN BABEL4261_T1;
-GO
-
-
-DROP TABLE t_babel4261;
-GO
-
-
-
-CREATE TABLE t2_babel4261 (a money);
-GO
-
-BEGIN TRAN BABEL4261_T2; 
-GO
-
-ALTER TABLE t2_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+ALTER TABLE t1_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
 GO
 
 -- The third parameter is true to set config back to default after transaction is committed
@@ -146,17 +28,17 @@ text
 ~~END~~
 
 
---- INSERT SOME data into t2_babel4261
-INSERT t2_babel4261 SELECT 0.4245*10000
-INSERT t2_babel4261 SELECT 0.5234*10000
-INSERT t2_babel4261 SELECT 0.1113*10000
-INSERT t2_babel4261 SELECT 0.6732*10000
-INSERT t2_babel4261 SELECT 0.3467*10000
-INSERT t2_babel4261 SELECT 0.5213*10000
-INSERT t2_babel4261 SELECT 0.9893*10000
-INSERT t2_babel4261 SELECT 0.6034*10000
-INSERT t2_babel4261 SELECT 0.3334*10000
-INSERT t2_babel4261 SELECT 0.8888*10000
+--- INSERT SOME data into t1_babel4261
+INSERT t1_babel4261 SELECT 0.4245*10000
+INSERT t1_babel4261 SELECT 0.5234*10000
+INSERT t1_babel4261 SELECT 0.1113*10000
+INSERT t1_babel4261 SELECT 0.6732*10000
+INSERT t1_babel4261 SELECT 0.3467*10000
+INSERT t1_babel4261 SELECT 0.5213*10000
+INSERT t1_babel4261 SELECT 0.9893*10000
+INSERT t1_babel4261 SELECT 0.6034*10000
+INSERT t1_babel4261 SELECT 0.3334*10000
+INSERT t1_babel4261 SELECT 0.8888*10000
 GO
 ~~ROW COUNT: 1~~
 
@@ -179,8 +61,8 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT sum(a) FROM t2_babel4261
-SELECT sum(a) FROM t2_babel4261   -- should not crash
+SELECT sum(a) FROM t1_babel4261
+SELECT sum(a) FROM t1_babel4261   -- should not crash
 GO
 ~~START~~
 money
@@ -194,8 +76,9 @@ money
 
 
 -- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
-COMMIT TRAN BABEL4261_T2;
+COMMIT TRAN BABEL4261_T1;
 GO
 
-DROP TABLE t2_babel4261;
+DROP TABLE t1_babel4261;
 GO
+

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -1,65 +1,10 @@
-BEGIN TRAN BABEL4261_T1; 
+CREATE TABLE t1_babel4261 (a money);
 GO
 
-CREATE TABLE t_babel4261 (a int, b int);
+BEGIN TRAN BABEL4261_T1;
 GO
 
--- The third parameter is true to set config back to default after transaction is committed
-select set_config('parallel_setup_cost', 0, true);
-select set_config('parallel_tuple_cost', 0, true);
-select set_config('min_parallel_table_scan_size', 0, true);
-GO
-
-
--- show explicitly this is a parallel query plan
-select set_config('babelfishpg_tsql.explain_timing', 'off', false);
-GO
-
-select set_config('babelfishpg_tsql.explain_summary', 'off', false);
-GO
-
-SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false);
-GO
-
-SET BABELFISH_SHOWPLAN_ALL ON
-GO
-
-select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
-GO
-
--- set configurations back
-SET BABELFISH_SHOWPLAN_ALL OFF
-GO
-
-select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
-GO
-
-select set_config('babelfishpg_tsql.explain_timing', 'on', false);
-GO
-
-select set_config('babelfishpg_tsql.explain_summary', 'on', false);
-GO
-
-SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false);
-GO
-
--- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
-COMMIT TRAN BABEL4261_T1;
-GO
-
-
-DROP TABLE t_babel4261;
-GO
-
-
-
-CREATE TABLE t2_babel4261 (a money);
-GO
-
-BEGIN TRAN BABEL4261_T2; 
-GO
-
-ALTER TABLE t2_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+ALTER TABLE t1_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
 GO
 
 -- The third parameter is true to set config back to default after transaction is committed
@@ -68,26 +13,27 @@ SELECT set_config('parallel_setup_cost', '0', true)
 SELECT set_config('parallel_tuple_cost', '0', true)
 GO
 
---- INSERT SOME data into t2_babel4261
-INSERT t2_babel4261 SELECT 0.4245*10000
-INSERT t2_babel4261 SELECT 0.5234*10000
-INSERT t2_babel4261 SELECT 0.1113*10000
-INSERT t2_babel4261 SELECT 0.6732*10000
-INSERT t2_babel4261 SELECT 0.3467*10000
-INSERT t2_babel4261 SELECT 0.5213*10000
-INSERT t2_babel4261 SELECT 0.9893*10000
-INSERT t2_babel4261 SELECT 0.6034*10000
-INSERT t2_babel4261 SELECT 0.3334*10000
-INSERT t2_babel4261 SELECT 0.8888*10000
+--- INSERT SOME data into t1_babel4261
+INSERT t1_babel4261 SELECT 0.4245*10000
+INSERT t1_babel4261 SELECT 0.5234*10000
+INSERT t1_babel4261 SELECT 0.1113*10000
+INSERT t1_babel4261 SELECT 0.6732*10000
+INSERT t1_babel4261 SELECT 0.3467*10000
+INSERT t1_babel4261 SELECT 0.5213*10000
+INSERT t1_babel4261 SELECT 0.9893*10000
+INSERT t1_babel4261 SELECT 0.6034*10000
+INSERT t1_babel4261 SELECT 0.3334*10000
+INSERT t1_babel4261 SELECT 0.8888*10000
 GO
 
-SELECT sum(a) FROM t2_babel4261
-SELECT sum(a) FROM t2_babel4261   -- should not crash
+SELECT sum(a) FROM t1_babel4261
+SELECT sum(a) FROM t1_babel4261   -- should not crash
 GO
 
 -- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
-COMMIT TRAN BABEL4261_T2;
+COMMIT TRAN BABEL4261_T1;
 GO
 
-DROP TABLE t2_babel4261;
+DROP TABLE t1_babel4261;
 GO
+

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -1,0 +1,39 @@
+CREATE TABLE t1_babel4261 (a money);
+GO
+
+BEGIN TRAN BABEL4261_T1;
+GO
+
+ALTER TABLE t1_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+GO
+
+-- The third parameter is true to set config back to default after transaction is committed
+SELECT set_config('force_parallel_mode', '1', true)
+SELECT set_config('parallel_setup_cost', '0', true)
+SELECT set_config('parallel_tuple_cost', '0', true)
+GO
+
+--- INSERT SOME data into t1_babel4261
+INSERT t1_babel4261 SELECT 0.4245*10000
+INSERT t1_babel4261 SELECT 0.5234*10000
+INSERT t1_babel4261 SELECT 0.1113*10000
+INSERT t1_babel4261 SELECT 0.6732*10000
+INSERT t1_babel4261 SELECT 0.3467*10000
+INSERT t1_babel4261 SELECT 0.5213*10000
+INSERT t1_babel4261 SELECT 0.9893*10000
+INSERT t1_babel4261 SELECT 0.6034*10000
+INSERT t1_babel4261 SELECT 0.3334*10000
+INSERT t1_babel4261 SELECT 0.8888*10000
+GO
+
+SELECT sum(a) FROM t1_babel4261
+SELECT sum(a) FROM t1_babel4261   -- should not crash
+GO
+
+-- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
+COMMIT TRAN BABEL4261_T1;
+GO
+
+DROP TABLE t1_babel4261;
+GO
+

--- a/test/JDBC/input/BABEL-4261.sql
+++ b/test/JDBC/input/BABEL-4261.sql
@@ -1,10 +1,65 @@
-CREATE TABLE t1_babel4261 (a money);
+BEGIN TRAN BABEL4261_T1; 
 GO
 
-BEGIN TRAN BABEL4261_T1;
+CREATE TABLE t_babel4261 (a int, b int);
 GO
 
-ALTER TABLE t1_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
+-- The third parameter is true to set config back to default after transaction is committed
+select set_config('parallel_setup_cost', 0, true);
+select set_config('parallel_tuple_cost', 0, true);
+select set_config('min_parallel_table_scan_size', 0, true);
+GO
+
+
+-- show explicitly this is a parallel query plan
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false);
+GO
+
+SET BABELFISH_SHOWPLAN_ALL ON
+GO
+
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+
+-- set configurations back
+SET BABELFISH_SHOWPLAN_ALL OFF
+GO
+
+select a, count(*) from t_babel4261 group by a order by 2; -- should not crash
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false);
+GO
+
+-- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
+COMMIT TRAN BABEL4261_T1;
+GO
+
+
+DROP TABLE t_babel4261;
+GO
+
+
+
+CREATE TABLE t2_babel4261 (a money);
+GO
+
+BEGIN TRAN BABEL4261_T2; 
+GO
+
+ALTER TABLE t2_babel4261 SET (parallel_workers = 16);  -- note: this is PG syntax, not T-SQL
 GO
 
 -- The third parameter is true to set config back to default after transaction is committed
@@ -13,27 +68,26 @@ SELECT set_config('parallel_setup_cost', '0', true)
 SELECT set_config('parallel_tuple_cost', '0', true)
 GO
 
---- INSERT SOME data into t1_babel4261
-INSERT t1_babel4261 SELECT 0.4245*10000
-INSERT t1_babel4261 SELECT 0.5234*10000
-INSERT t1_babel4261 SELECT 0.1113*10000
-INSERT t1_babel4261 SELECT 0.6732*10000
-INSERT t1_babel4261 SELECT 0.3467*10000
-INSERT t1_babel4261 SELECT 0.5213*10000
-INSERT t1_babel4261 SELECT 0.9893*10000
-INSERT t1_babel4261 SELECT 0.6034*10000
-INSERT t1_babel4261 SELECT 0.3334*10000
-INSERT t1_babel4261 SELECT 0.8888*10000
+--- INSERT SOME data into t2_babel4261
+INSERT t2_babel4261 SELECT 0.4245*10000
+INSERT t2_babel4261 SELECT 0.5234*10000
+INSERT t2_babel4261 SELECT 0.1113*10000
+INSERT t2_babel4261 SELECT 0.6732*10000
+INSERT t2_babel4261 SELECT 0.3467*10000
+INSERT t2_babel4261 SELECT 0.5213*10000
+INSERT t2_babel4261 SELECT 0.9893*10000
+INSERT t2_babel4261 SELECT 0.6034*10000
+INSERT t2_babel4261 SELECT 0.3334*10000
+INSERT t2_babel4261 SELECT 0.8888*10000
 GO
 
-SELECT sum(a) FROM t1_babel4261
-SELECT sum(a) FROM t1_babel4261   -- should not crash
+SELECT sum(a) FROM t2_babel4261
+SELECT sum(a) FROM t2_babel4261   -- should not crash
 GO
 
 -- Commiting sets force_parallel_mode, parallel_setup_cost, parallel_tuple_cost back to default
-COMMIT TRAN BABEL4261_T1;
+COMMIT TRAN BABEL4261_T2;
 GO
 
-DROP TABLE t1_babel4261;
+DROP TABLE t2_babel4261;
 GO
-

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -307,9 +307,6 @@ ignore#!#Test-sp_addrolemember-dep-vu-verify
 ignore#!#Test-sp_droprolemember-dep-vu-verify
 ignore#!#babel_table_type
 
-# BABEL-4422
-ignore#!#babel_money
-
 # BABEL-4423
 ignore#!#BABEL-IDENTITY
 

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -420,8 +420,3 @@ ignore#!#Test-sp_rename-dep-vu-cleanup
 # TIME-OUT
 ignore#!#TestSimpleErrorsWithImplicitTran
 ignore#!#babel_cursor
-
-# Crashing
-ignore#!#sys-server_principals-vu-prepare
-ignore#!#sys-server_principals-vu-verify
-ignore#!#sys-server_principals-vu-cleanup

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -420,3 +420,8 @@ ignore#!#Test-sp_rename-dep-vu-cleanup
 # TIME-OUT
 ignore#!#TestSimpleErrorsWithImplicitTran
 ignore#!#babel_cursor
+
+# Crashing
+ignore#!#sys-server_principals-vu-prepare
+ignore#!#sys-server_principals-vu-verify
+ignore#!#sys-server_principals-vu-cleanup


### PR DESCRIPTION
### Description
In parallel query context, variables `state` and `sstate` can be `NULL` in functions `fixeddecimalaggstateserialize` and `fixeddecimalaggstatedeserialize` respectively. This scenario was not handled properly in functions `fixeddecimalaggstateserialize` and `fixeddecimalaggstatedeserialize`. This PR adds a check in these functions which will handle this `NULL` value scenario.

Also removed babel_money test from parallel_query_jdbc_schedule file, as the crash will be resolved by this PR.

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-4261

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).