### PR TITLE
Rewrite GETDATE, SYSDATETIME and SYSDATETIMEOFFSET functions in C language

### DIFF
--- a/contrib/babelfishpg_common/src/babelfishpg_common.c
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.c
@@ -18,6 +18,7 @@
 #include "sqlvariant.h"
 #include "typecode.h"
 #include "varchar.h"
+#include "datetimeoffset.h"
 
 common_utility_plugin common_utility_plugin_var = {NULL};
 static common_utility_plugin *get_common_utility_plugin(void);
@@ -189,6 +190,7 @@ get_common_utility_plugin(void)
 		common_utility_plugin_var.is_tsql_rowversion_or_timestamp_datatype = &is_tsql_rowversion_or_timestamp_datatype;
 		common_utility_plugin_var.datetime_in_str = &datetime_in_str;
 		common_utility_plugin_var.datetime2sqlvariant = &datetime2sqlvariant;
+		common_utility_plugin_var.timestamp_datetimeoffset = &timestamp_datetimeoffset;
 		common_utility_plugin_var.tinyint2sqlvariant = &tinyint2sqlvariant;
 		common_utility_plugin_var.translate_pg_type_to_tsql = &translate_pg_type_to_tsql;
 		common_utility_plugin_var.get_tsql_datatype_oid = &get_tsql_datatype_oid;

--- a/contrib/babelfishpg_common/src/babelfishpg_common.h
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.h
@@ -53,6 +53,7 @@ typedef struct common_utility_plugin
 	bool		(*is_tsql_rowversion_or_timestamp_datatype) (Oid oid);
 	Datum		(*datetime_in_str) (char *str);
 	Datum		(*datetime2sqlvariant) (PG_FUNCTION_ARGS);
+	Datum		(*timestamp_datetimeoffset) (PG_FUNCTION_ARGS);
 	Datum		(*tinyint2sqlvariant) (PG_FUNCTION_ARGS);
 	Datum		(*translate_pg_type_to_tsql) (PG_FUNCTION_ARGS);
 	Oid		(*get_tsql_datatype_oid) (char *type_name);

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -15,6 +15,7 @@
 #include "utils/timestamp.h"
 
 #include "fmgr.h"
+#include "access/xact.h"
 #include "miscadmin.h"
 #include "datetimeoffset.h"
 #include "datetime.h"
@@ -61,6 +62,7 @@ PG_FUNCTION_INFO_V1(datetimeoffset_datetime);
 PG_FUNCTION_INFO_V1(datetime2_datetimeoffset);
 PG_FUNCTION_INFO_V1(datetimeoffset_datetime2);
 PG_FUNCTION_INFO_V1(datetimeoffset_scale);
+PG_FUNCTION_INFO_V1(sysdatetimeoffset);
 
 PG_FUNCTION_INFO_V1(get_datetimeoffset_tzoffset_internal);
 
@@ -831,4 +833,13 @@ EncodeDatetimeoffsetTimezone(char *str, int tz, int style)
 	tmp = pg_ultostr_zeropad(tmp, min, 2);
 
 	*tmp = '\0';
+}
+
+
+Datum sysdatetimeoffset(PG_FUNCTION_ARGS)
+{
+	
+
+	PG_RETURN_DATETIMEOFFSET((DirectFunctionCall1(timestamp_datetimeoffset,
+													PointerGetDatum(GetCurrentStatementStartTimestamp()))));
 }

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -48,6 +48,7 @@ PG_FUNCTION_INFO_V1(datetimeoffset_mi);
 PG_FUNCTION_INFO_V1(datetimeoffset_hash);
 PG_FUNCTION_INFO_V1(datetimeoffset_hash_extended);
 
+PG_FUNCTION_INFO_V1(timestamp_datetimeoffset);
 PG_FUNCTION_INFO_V1(datetimeoffset_timestamp);
 PG_FUNCTION_INFO_V1(date_datetimeoffset);
 PG_FUNCTION_INFO_V1(datetimeoffset_date);

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -15,7 +15,6 @@
 #include "utils/timestamp.h"
 
 #include "fmgr.h"
-#include "access/xact.h"
 #include "miscadmin.h"
 #include "datetimeoffset.h"
 #include "datetime.h"
@@ -49,7 +48,6 @@ PG_FUNCTION_INFO_V1(datetimeoffset_mi);
 PG_FUNCTION_INFO_V1(datetimeoffset_hash);
 PG_FUNCTION_INFO_V1(datetimeoffset_hash_extended);
 
-PG_FUNCTION_INFO_V1(timestamp_datetimeoffset);
 PG_FUNCTION_INFO_V1(datetimeoffset_timestamp);
 PG_FUNCTION_INFO_V1(date_datetimeoffset);
 PG_FUNCTION_INFO_V1(datetimeoffset_date);
@@ -833,6 +831,3 @@ EncodeDatetimeoffsetTimezone(char *str, int tz, int style)
 
 	*tmp = '\0';
 }
-
-
-

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -62,7 +62,6 @@ PG_FUNCTION_INFO_V1(datetimeoffset_datetime);
 PG_FUNCTION_INFO_V1(datetime2_datetimeoffset);
 PG_FUNCTION_INFO_V1(datetimeoffset_datetime2);
 PG_FUNCTION_INFO_V1(datetimeoffset_scale);
-PG_FUNCTION_INFO_V1(sysdatetimeoffset);
 
 PG_FUNCTION_INFO_V1(get_datetimeoffset_tzoffset_internal);
 
@@ -836,10 +835,4 @@ EncodeDatetimeoffsetTimezone(char *str, int tz, int style)
 }
 
 
-Datum sysdatetimeoffset(PG_FUNCTION_ARGS)
-{
-	
 
-	PG_RETURN_DATETIMEOFFSET((DirectFunctionCall1(timestamp_datetimeoffset,
-							PointerGetDatum(GetCurrentStatementStartTimestamp()))));
-}

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -841,5 +841,5 @@ Datum sysdatetimeoffset(PG_FUNCTION_ARGS)
 	
 
 	PG_RETURN_DATETIMEOFFSET((DirectFunctionCall1(timestamp_datetimeoffset,
-													PointerGetDatum(GetCurrentStatementStartTimestamp()))));
+							PointerGetDatum(GetCurrentStatementStartTimestamp()))));
 }

--- a/contrib/babelfishpg_common/src/datetimeoffset.h
+++ b/contrib/babelfishpg_common/src/datetimeoffset.h
@@ -23,6 +23,7 @@ extern void AdjustTimestampForSmallDatetime(Timestamp *time);
 extern void CheckSmalldatetimeRange(const Timestamp time);
 extern void CheckDatetimeRange(const Timestamp time);
 extern void CheckDatetime2Range(const Timestamp time);
+extern Datum timestamp_datetimeoffset(PG_FUNCTION_ARGS);
 typedef struct tsql_datetimeoffset
 {
 	int64		tsql_ts;

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -55,6 +55,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_constraint.h"
+#include "../../babelfishpg_common/src/datetimeoffset.h"
 
 #define TSQL_STAT_GET_ACTIVITY_COLS 26
 #define SP_DATATYPE_INFO_HELPER_COLS 23
@@ -158,6 +159,7 @@ PG_FUNCTION_INFO_V1(getutcdate);
 PG_FUNCTION_INFO_V1(babelfish_concat_wrapper);
 PG_FUNCTION_INFO_V1(getdate_internal);
 PG_FUNCTION_INFO_V1(sysdatetime);
+PG_FUNCTION_INFO_V1(sysdatetimeoffset);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -399,6 +401,14 @@ Datum getdate_internal(PG_FUNCTION_ARGS)
 Datum sysdatetime(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_TIMESTAMPTZ(GetCurrentStatementStartTimestamp());
+}
+
+Datum sysdatetimeoffset(PG_FUNCTION_ARGS)
+{
+	
+
+	PG_RETURN_DATETIMEOFFSET((DirectFunctionCall1(timestamp_datetimeoffset,
+							PointerGetDatum(GetCurrentStatementStartTimestamp()))));
 }
 
 void *

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -392,7 +392,7 @@ Datum getutcdate(PG_FUNCTION_ARGS)
 Datum getdate_internal(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamp_trunc,CStringGetTextDatum("millisecond"),
-											PointerGetDatum(GetCurrentStatementStartTimestamp())));
+						PointerGetDatum(GetCurrentStatementStartTimestamp())));
 	
 }
 

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -55,7 +55,6 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_constraint.h"
-#include "../../babelfishpg_common/src/datetimeoffset.h"
 
 #define TSQL_STAT_GET_ACTIVITY_COLS 26
 #define SP_DATATYPE_INFO_HELPER_COLS 23
@@ -407,7 +406,7 @@ Datum sysdatetimeoffset(PG_FUNCTION_ARGS)
 {
 	
 
-	PG_RETURN_DATETIMEOFFSET((DirectFunctionCall1(timestamp_datetimeoffset,
+	PG_RETURN_POINTER((DirectFunctionCall1(common_utility_plugin_ptr->timestamp_datetimeoffset,
 							PointerGetDatum(GetCurrentStatementStartTimestamp()))));
 }
 

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -156,6 +156,8 @@ PG_FUNCTION_INFO_V1(objectproperty_internal);
 PG_FUNCTION_INFO_V1(sysutcdatetime);
 PG_FUNCTION_INFO_V1(getutcdate);
 PG_FUNCTION_INFO_V1(babelfish_concat_wrapper);
+PG_FUNCTION_INFO_V1(getdate_internal);
+PG_FUNCTION_INFO_V1(sysdatetime);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -385,6 +387,18 @@ Datum getutcdate(PG_FUNCTION_ARGS)
     PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamp_trunc,CStringGetTextDatum("millisecond"),DirectFunctionCall2(timestamptz_zone,CStringGetTextDatum("UTC"),
                                                             PointerGetDatum(GetCurrentStatementStartTimestamp()))));
     
+}
+
+Datum getdate_internal(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamp_trunc,CStringGetTextDatum("millisecond"),
+											PointerGetDatum(GetCurrentStatementStartTimestamp())));
+	
+}
+
+Datum sysdatetime(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TIMESTAMPTZ(GetCurrentStatementStartTimestamp());
 }
 
 void *

--- a/contrib/babelfishpg_tsql/sql/sys.sql
+++ b/contrib/babelfishpg_tsql/sql/sys.sql
@@ -5,7 +5,7 @@ LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
-AS 'babelfishpg_common', 'sysdatetimeoffset'
+AS 'babelfishpg_tsql', 'sysdatetimeoffset'
 LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/sys.sql
+++ b/contrib/babelfishpg_tsql/sql/sys.sql
@@ -1,13 +1,12 @@
 /* Built in functions */
 CREATE OR REPLACE FUNCTION sys.sysdatetime() RETURNS datetime2
-    AS $$select statement_timestamp()::datetime2;$$
-    LANGUAGE SQL;
+AS 'babelfishpg_tsql', 'sysdatetime'
+LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
-    -- Casting to text as there are not type cast function from timestamptz to datetimeoffset
-    AS $$select cast(cast(statement_timestamp() as text) as sys.datetimeoffset);$$
-    LANGUAGE SQL STABLE;
+AS 'babelfishpg_common', 'sysdatetimeoffset'
+LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 
 
@@ -16,8 +15,8 @@ AS 'babelfishpg_tsql', 'sysutcdatetime'
 LANGUAGE C STABLE;
 
 CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', statement_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
-    LANGUAGE SQL STABLE;
+AS 'babelfishpg_tsql', 'getdate_internal'
+LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
 
 create or replace function sys.getutcdate() returns sys.datetime

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -4276,7 +4276,7 @@ LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
-AS 'babelfishpg_common', 'sysdatetimeoffset'
+AS 'babelfishpg_tsql', 'sysdatetimeoffset'
 LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -4218,10 +4218,6 @@ RETURNS setof record
 AS 'babelfishpg_tsql', 'bbf_pivot'
 LANGUAGE C STABLE;
 
--- Drops the temporary procedure used by the upgrade script.
--- Please have this be one of the last statements executed in this upgrade script.
-DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
-
 CREATE OR REPLACE VIEW sys.babelfish_configurations_view as
     SELECT * 
     FROM pg_catalog.pg_settings 
@@ -4231,11 +4227,7 @@ CREATE OR REPLACE VIEW sys.babelfish_configurations_view as
           name collate "C" like 'babelfishpg_tsql.isolation_level_%';
 GRANT SELECT on sys.babelfish_configurations_view TO PUBLIC;
 
--- After upgrade, always run analyze for all babelfish catalogs.
-CALL sys.analyze_babelfish_catalogs();
 
--- Reset search_path to not affect any subsequent scripts
-SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
 
 -- Change the owner of the current database.
 -- This is a wrapper around ALTER AUTHORIZATION ON DATABASE::
@@ -4287,3 +4279,13 @@ CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
 AS 'babelfishpg_common', 'sysdatetimeoffset'
 LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
+
+-- After upgrade, always run analyze for all babelfish catalogs.
+CALL sys.analyze_babelfish_catalogs();
+
+-- Reset search_path to not affect any subsequent scripts
+SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -4273,3 +4273,17 @@ END
 $$;
 GRANT EXECUTE ON PROCEDURE sys.sp_changedbowner(IN sys.sysname, IN sys.VARCHAR(5)) TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
+AS 'babelfishpg_tsql', 'getdate_internal'
+LANGUAGE C STABLE;
+GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.sysdatetime() RETURNS datetime2
+AS 'babelfishpg_tsql', 'sysdatetime'
+LANGUAGE C STABLE;
+GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
+AS 'babelfishpg_common', 'sysdatetimeoffset'
+LANGUAGE C STABLE;
+GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -319,14 +319,6 @@ ignore#!#TestDecimal
 ignore#!#TestNumeric
 ignore#!#numericOverflow
 
-# BABEL-4425 - Taking too much time to run.
-ignore#!#getdate-vu-prepare
-ignore#!#getdate-vu-verify
-ignore#!#getdate-vu-cleanup
-ignore#!#getdatetest
-ignore#!#TestDatetime-numeric-representation-vu-prepare
-ignore#!#TestDatetime-numeric-representation-vu-verify
-
 # Taking too much time to complete. (TIME-OUT FAILURES)
 ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-verify
 ignore#!#BABEL-SP_COLUMNS_MANAGED-dep-vu-verify

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -335,3 +335,5 @@ ignore#!#TestSimpleErrors
 ignore#!#ISC-Views
 ignore#!#TestSimpleErrorsWithXactAbort
 ignore#!#BABEL-2513
+ignore#!#TestDatetime-numeric-representation-vu-prepare
+ignore#!#TestDatetime-numeric-representation-vu-verify


### PR DESCRIPTION
### Description
When parallel query is enabled, functions getdate, sysdatetime and sysdatetimoeoffset was performing exceptionally slow. This commit rewrite those function in C language to have better performance.

Signed-off-by: Sumit Jaiswal sumiji@amazon.com

### Issues Resolved

Task: BABEL-4425


Performance test:
Overall execution time(in ms) for 1000 function call when parallel query is enabled.


| Functions | Before | After |
|--------|--------|--------|
| getdate | 79036 | 374 |
| sysdatetime | 582 | 571 |
| sysdatetimoeoffset | 658 | 508 |  

### Test Scenarios Covered ###
* **Use case based -** tests are already present in `getdate-vu-*`


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**



* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).