### PR TITLE
Fix backward scan flag for parallel queries 

### DIFF
--- a/test/JDBC/expected/BABEL-4281.out
+++ b/test/JDBC/expected/BABEL-4281.out
@@ -1,0 +1,104 @@
+BEGIN TRAN BABEL4281_T1; 
+GO
+
+CREATE TABLE t_babel4281 (a int, b int);
+GO
+
+-- The third parameter is true to set config back to default after transaction is committed
+select set_config('parallel_setup_cost', 0, true);
+select set_config('parallel_tuple_cost', 0, true);
+select set_config('min_parallel_table_scan_size', 0, true);
+GO
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+~~START~~
+text
+0
+~~END~~
+
+
+
+-- show explicitly this is a parallel query plan
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
+select a, count(*) from t_babel4281 group by a order by 2; -- should not crash
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~START~~
+text
+Query Text: select a, count(*) from t_babel4281 group by a order by 2
+Sort  (cost=38.27..38.77 rows=200 width=8) (actual rows=0 loops=1)
+  Sort Key: (count(*)) NULLS FIRST
+  Sort Method: quicksort  Memory: 25kB
+  ->  Finalize HashAggregate  (cost=28.13..30.63 rows=200 width=8) (actual rows=0 loops=1)
+        Group Key: a
+        Batches: 1  Memory Usage: 40kB
+        ->  Gather  (cost=24.13..26.13 rows=400 width=12) (actual rows=0 loops=1)
+              Workers Planned: 2
+              Workers Launched: 2
+              ->  Partial HashAggregate  (cost=24.13..26.13 rows=200 width=12) (actual rows=0 loops=3)
+                    Group Key: a
+                    Batches: 1  Memory Usage: 40kB
+                    Worker 0:  Batches: 1  Memory Usage: 40kB
+                    Worker 1:  Batches: 1  Memory Usage: 40kB
+                    ->  Parallel Seq Scan on t_babel4281  (cost=0.00..19.42 rows=942 width=4) (actual rows=0 loops=3)
+~~END~~
+
+
+
+-- set configurations back
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
+COMMIT TRAN BABEL4281_T1;
+GO
+
+
+DROP TABLE t_babel4281;
+GO
+

--- a/test/JDBC/expected/BABEL-4281.out
+++ b/test/JDBC/expected/BABEL-4281.out
@@ -43,6 +43,14 @@ off
 ~~END~~
 
 
+select set_config('babelfishpg_tsql.explain_costs', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE ON
 GO
 
@@ -55,21 +63,21 @@ int#!#int
 ~~START~~
 text
 Query Text: select a, count(*) from t_babel4281 group by a order by 2
-Sort  (cost=38.27..38.77 rows=200 width=8) (actual rows=0 loops=1)
+Sort (actual rows=0 loops=1)
   Sort Key: (count(*)) NULLS FIRST
   Sort Method: quicksort  Memory: 25kB
-  ->  Finalize HashAggregate  (cost=28.13..30.63 rows=200 width=8) (actual rows=0 loops=1)
+  ->  Finalize HashAggregate (actual rows=0 loops=1)
         Group Key: a
         Batches: 1  Memory Usage: 40kB
-        ->  Gather  (cost=24.13..26.13 rows=400 width=12) (actual rows=0 loops=1)
+        ->  Gather (actual rows=0 loops=1)
               Workers Planned: 2
               Workers Launched: 2
-              ->  Partial HashAggregate  (cost=24.13..26.13 rows=200 width=12) (actual rows=0 loops=3)
+              ->  Partial HashAggregate (actual rows=0 loops=3)
                     Group Key: a
                     Batches: 1  Memory Usage: 40kB
                     Worker 0:  Batches: 1  Memory Usage: 40kB
                     Worker 1:  Batches: 1  Memory Usage: 40kB
-                    ->  Parallel Seq Scan on t_babel4281  (cost=0.00..19.42 rows=942 width=4) (actual rows=0 loops=3)
+                    ->  Parallel Seq Scan on t_babel4281 (actual rows=0 loops=3)
 ~~END~~
 
 
@@ -87,6 +95,14 @@ on
 
 
 select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_costs', 'on', false);
 GO
 ~~START~~
 text

--- a/test/JDBC/input/BABEL-4281.sql
+++ b/test/JDBC/input/BABEL-4281.sql
@@ -18,6 +18,9 @@ GO
 select set_config('babelfishpg_tsql.explain_summary', 'off', false);
 GO
 
+select set_config('babelfishpg_tsql.explain_costs', 'off', false);
+GO
+
 SET BABELFISH_STATISTICS PROFILE ON
 GO
 
@@ -33,6 +36,9 @@ select set_config('babelfishpg_tsql.explain_timing', 'on', false);
 GO
 
 select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_costs', 'on', false);
 GO
 
 -- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default

--- a/test/JDBC/input/BABEL-4281.sql
+++ b/test/JDBC/input/BABEL-4281.sql
@@ -1,0 +1,45 @@
+BEGIN TRAN BABEL4281_T1; 
+GO
+
+CREATE TABLE t_babel4281 (a int, b int);
+GO
+
+-- The third parameter is true to set config back to default after transaction is committed
+select set_config('parallel_setup_cost', 0, true);
+select set_config('parallel_tuple_cost', 0, true);
+select set_config('min_parallel_table_scan_size', 0, true);
+GO
+
+
+-- show explicitly this is a parallel query plan
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
+select a, count(*) from t_babel4281 group by a order by 2; -- should not crash
+GO
+
+
+-- set configurations back
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+
+-- Commiting sets parallel_setup_cost, parallel_tuple_cost, min_parallel_table_scan_size back to default
+COMMIT TRAN BABEL4281_T1;
+GO
+
+
+DROP TABLE t_babel4281;
+GO
+

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -51,7 +51,7 @@ ignore#!#BABEL-3248
 ignore#!#BABEL-3295
 ignore#!#BABEL-3513-vu-prepare
 ignore#!#BABEL-3513-vu-verify
-ignore#!#BABEL-4261
+ignore#!#BABEL-4281
 ignore#!#babel_collection
 ignore#!#binary-index-vu-verify
 ignore#!#pgr_select_into


### PR DESCRIPTION
### Description
Currently there is a bug in Babelfish that allows the backward scan flag to be set for parallel queries. However, backward scans cannot be parallelized. This bug results in assertion failures in the Postgres engine and leads Babelfish queries to crash.

Cherry-picked from [PR-1604](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1604)
Engine PR: [PR-253](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/253)


Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-4281

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).