### PR TITLE
Improve defensive code for crash in AtEOXact_Parallel

### DIFF
--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -298,21 +298,10 @@ ignore#!#test_windows_login-vu-prepare
 ignore#!#test_windows_login-vu-verify
 ignore#!#test_windows_login-vu-cleanup
 
-# JIRA - BABEL-4419
-ignore#!#BABEL-1056
-ignore#!#BABEL-GUC-PLAN
-ignore#!#BABEL-3092
-ignore#!#BABEL-COLUMN-CONSTRAINT
-ignore#!#BABEL-1251-vu-verify
-ignore#!#BABEL-1251
-
 # JIRA - BABEL-4421
 ignore#!#Test-sp_addrolemember-dep-vu-verify
 ignore#!#Test-sp_droprolemember-dep-vu-verify
 ignore#!#babel_table_type
-
-# BABEL-4423
-ignore#!#BABEL-IDENTITY
 
 # BABEL-4424
 ignore#!#TestDecimal


### PR DESCRIPTION
### Description

Setting GUC during parallel operation will cause GUC inconsistency because there is no way to sync the GUC value among parallel workers.

The crash is previously fixed by BABEL-4393 and BABEL-4420. This commit improves the defensive code and only allows setting insert_identity during parallel operation initialization.

### Issues Resolved
BABEL-4340/4419/4423

### Test Scenarios Covered

Existing JDBC tests are sufficient.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).