### PR TITLE
Group mixed type failure test cases for parallel query. 

### DIFF
--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -80,7 +80,7 @@ ignore#!#BABEL-1444
 
 # ERROR CODE DIFFERENCE. 
 ignore#!#babel_datetime-vu-verify
-ignore#!#babel_datetime 
+ignore#!#babel_datetime
 ignore#!#BABEL-2812-vu-verify
 
 # "tds_fdw" does not exist
@@ -106,6 +106,7 @@ ignore#!#pgr_select_distinct
 
 # output difference
 ignore#!#sys-sp_pkeys-dep-vu-verify
+ignore#!#BABEL-SP_PKEYS
 
 #ignore#!#pg_stat_statements_tsql
 #ignore#!#sp_statistics_100
@@ -119,7 +120,6 @@ ignore#!#sys-sp_pkeys-dep-vu-verify
 #ignore#!#bbf_view_def
 #ignore#!#case_insensitive_collation-vu-prepare
 #ignore#!#case_insensitive_collation-vu-verify
-#ignore#!#BABEL-SP_PKEYS
 #ignore#!#BABEL-SP_STATISTICS
 #ignore#!#Test-sp_execute_postgresql
 #ignore#!#545_1

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -62,7 +62,7 @@ ignore#!#babel_index_nulls_order-vu-verify
 # Query Plan changed. (verified)
 ignore#!#BABEL-4264
 
-# Other or mixed issues
+# Other or mixed issues - JIRA-BABEL-4538
 # database "" does not exists. (calls is_member() functions)
 ignore#!#BABEL-1621
 # database "" does not exists. (calls schema_id())
@@ -76,12 +76,12 @@ ignore#!#BABEL-ROLE-MEMBER
 # current_setting('role') returns NULL.
 ignore#!#BABEL-1444
 
-# ERROR CODE DIFFERENCE. 
+# ERROR CODE DIFFERENCE.  JIRA-4539
 ignore#!#babel_datetime-vu-verify
 ignore#!#babel_datetime
 ignore#!#BABEL-2812-vu-verify
 
-# "tds_fdw" does not exist
+# "tds_fdw" does not exist - JIRA-4540
 ignore#!#BABEL-4168-vu-prepare
 ignore#!#BABEL-4168-vu-verify
 ignore#!#BABEL-4168-vu-cleanup
@@ -98,11 +98,11 @@ ignore#!#openquery-vu-prepare
 ignore#!#openquery-vu-verify
 ignore#!#openquery-vu-cleanup
 
-# relation "onek" does not exist
+# relation "onek" does not exist: JIRA-4541
 ignore#!#pgr_select
 ignore#!#pgr_select_distinct
 
-# output difference
+# output difference: JIRA-4542
 ignore#!#sys-sp_pkeys-dep-vu-verify
 ignore#!#BABEL-SP_PKEYS
 

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -65,12 +65,10 @@ ignore#!#BABEL-4264
 # Other or mixed issues
 # database "" does not exists. (calls is_member() functions)
 ignore#!#BABEL-1621
-
 # database "" does not exists. (calls schema_id())
 ignore#!#BABEL-741-vu-verify
 ignore#!#BABEL-2416
 ignore#!#BABEL-2833
-
 # database "" does not exists. (calls IS_ROLEMEMBER())
 ignore#!#BABEL-ROLE-MEMBER-vu-verify
 ignore#!#BABEL-ROLE-MEMBER
@@ -107,24 +105,6 @@ ignore#!#pgr_select_distinct
 # output difference
 ignore#!#sys-sp_pkeys-dep-vu-verify
 ignore#!#BABEL-SP_PKEYS
-
-#ignore#!#pg_stat_statements_tsql
-#ignore#!#sp_statistics_100
-#ignore#!#sys-sp_statistics_100-vu-prepare
-#ignore#!#sys-sp_statistics_100-vu-verify
-#ignore#!#sys-sp_statistics_100-vu-cleanup
-#ignore#!#sys-sp_statistics_100-dep-vu-verify
-#ignore#!#BABEL_4145
-#ignore#!#babel_extra_join_test_cases
-#ignore#!#babelfish_migration_mode-vu-verify
-#ignore#!#bbf_view_def
-#ignore#!#case_insensitive_collation-vu-prepare
-#ignore#!#case_insensitive_collation-vu-verify
-#ignore#!#BABEL-SP_STATISTICS
-#ignore#!#Test-sp_execute_postgresql
-#ignore#!#545_1
-#ignore#!#8107_1
-#ignore#!#8143_1
 
 # Test failures caused by babel_extra_join_test_cases_northwind failure
 ignore#!#babelfish_sysdatabases-vu-prepare

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -59,32 +59,34 @@ ignore#!#cast_eliminate-vu-verify
 # Query plan change (verified)
 # Need to design a way to allow expected parallel mode output to be accepted
 ignore#!#babel_index_nulls_order-vu-verify
+# Query Plan changed. (verified)
+ignore#!#BABEL-4264
 
 # Other or mixed issues
-ignore#!#545_1
-ignore#!#8107_1
-ignore#!#8143_1
-ignore#!#BABEL-741-vu-verify
-ignore#!#BABEL-1444
+# database "" does not exists. (calls is_member() functions)
 ignore#!#BABEL-1621
+
+# database "" does not exists. (calls schema_id())
+ignore#!#BABEL-741-vu-verify
 ignore#!#BABEL-2416
-ignore#!#BABEL-2812-vu-verify
 ignore#!#BABEL-2833
+
+# database "" does not exists. (calls IS_ROLEMEMBER())
+ignore#!#BABEL-ROLE-MEMBER-vu-verify
+ignore#!#BABEL-ROLE-MEMBER
+
+# current_setting('role') returns NULL.
+ignore#!#BABEL-1444
+
+# ERROR CODE DIFFERENCE. 
+ignore#!#babel_datetime-vu-verify
+ignore#!#babel_datetime 
+ignore#!#BABEL-2812-vu-verify
+
+# "tds_fdw" does not exist
 ignore#!#BABEL-4168-vu-prepare
 ignore#!#BABEL-4168-vu-verify
 ignore#!#BABEL-4168-vu-cleanup
-ignore#!#BABEL-ROLE-MEMBER-vu-verify
-ignore#!#BABEL-ROLE-MEMBER
-ignore#!#BABEL-SP_PKEYS
-ignore#!#BABEL-SP_STATISTICS
-ignore#!#Test-sp_execute_postgresql
-ignore#!#babel_datetime-vu-verify
-ignore#!#babel_datetime
-ignore#!#babel_extra_join_test_cases
-ignore#!#babelfish_migration_mode-vu-verify
-ignore#!#bbf_view_def
-ignore#!#case_insensitive_collation-vu-prepare
-ignore#!#case_insensitive_collation-vu-verify
 ignore#!#four-part-names-vu-prepare
 ignore#!#four-part-names-vu-verify
 ignore#!#four-part-names-vu-cleanup
@@ -97,17 +99,32 @@ ignore#!#linked_srv_4229-vu-cleanup
 ignore#!#openquery-vu-prepare
 ignore#!#openquery-vu-verify
 ignore#!#openquery-vu-cleanup
-ignore#!#pg_stat_statements_tsql
+
+# relation "onek" does not exist
 ignore#!#pgr_select
 ignore#!#pgr_select_distinct
-ignore#!#sp_statistics_100
+
+# output difference
 ignore#!#sys-sp_pkeys-dep-vu-verify
-ignore#!#sys-sp_statistics_100-vu-prepare
-ignore#!#sys-sp_statistics_100-vu-verify
-ignore#!#sys-sp_statistics_100-vu-cleanup
-ignore#!#sys-sp_statistics_100-dep-vu-verify
-ignore#!#BABEL-4264
-ignore#!#BABEL_4145
+
+#ignore#!#pg_stat_statements_tsql
+#ignore#!#sp_statistics_100
+#ignore#!#sys-sp_statistics_100-vu-prepare
+#ignore#!#sys-sp_statistics_100-vu-verify
+#ignore#!#sys-sp_statistics_100-vu-cleanup
+#ignore#!#sys-sp_statistics_100-dep-vu-verify
+#ignore#!#BABEL_4145
+#ignore#!#babel_extra_join_test_cases
+#ignore#!#babelfish_migration_mode-vu-verify
+#ignore#!#bbf_view_def
+#ignore#!#case_insensitive_collation-vu-prepare
+#ignore#!#case_insensitive_collation-vu-verify
+#ignore#!#BABEL-SP_PKEYS
+#ignore#!#BABEL-SP_STATISTICS
+#ignore#!#Test-sp_execute_postgresql
+#ignore#!#545_1
+#ignore#!#8107_1
+#ignore#!#8143_1
 
 # Test failures caused by babel_extra_join_test_cases_northwind failure
 ignore#!#babelfish_sysdatabases-vu-prepare


### PR DESCRIPTION
### Description

So there was a group of tests that were failing due to mixed reasons in case of parallel query mode. Classified them into categories and some of the test cases are no-more throwing error (maybe already got fixed no more reproducible) removed those from ignore file. 


### Issues Resolved
NO-JIRA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).