### PR TITLE
Rewrite GETDATE, SYSDATETIME, SYSDATETIMEOFFSET, SYSUTCDATETIME and GETUTCDATE functions in C language

### DIFF
--- a/contrib/babelfishpg_common/src/babelfishpg_common.c
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.c
@@ -19,6 +19,7 @@
 #include "sqlvariant.h"
 #include "typecode.h"
 #include "varchar.h"
+#include "datetimeoffset.h"
 
 common_utility_plugin common_utility_plugin_var = {NULL};
 static common_utility_plugin *get_common_utility_plugin(void);
@@ -179,6 +180,7 @@ get_common_utility_plugin(void)
 		common_utility_plugin_var.is_tsql_rowversion_or_timestamp_datatype = &is_tsql_rowversion_or_timestamp_datatype;
 		common_utility_plugin_var.datetime_in_str = &datetime_in_str;
 		common_utility_plugin_var.datetime2sqlvariant = &datetime2sqlvariant;
+		common_utility_plugin_var.timestamp_datetimeoffset = &timestamp_datetimeoffset;
 		common_utility_plugin_var.tinyint2sqlvariant = &tinyint2sqlvariant;
 		common_utility_plugin_var.translate_pg_type_to_tsql = &translate_pg_type_to_tsql;
 		common_utility_plugin_var.TdsGetPGbaseType = &TdsGetPGbaseType;

--- a/contrib/babelfishpg_common/src/babelfishpg_common.h
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.h
@@ -51,6 +51,7 @@ typedef struct common_utility_plugin
 	bool		(*is_tsql_rowversion_or_timestamp_datatype) (Oid oid);
 	Datum		(*datetime_in_str) (char *str);
 	Datum		(*datetime2sqlvariant) (PG_FUNCTION_ARGS);
+	Datum		(*timestamp_datetimeoffset) (PG_FUNCTION_ARGS);
 	Datum		(*tinyint2sqlvariant) (PG_FUNCTION_ARGS);
 	Datum		(*translate_pg_type_to_tsql) (PG_FUNCTION_ARGS);
 	void		(*TdsGetPGbaseType) (uint8 variantBaseType, int *pgBaseType, int tempLen,

--- a/contrib/babelfishpg_common/src/datetimeoffset.h
+++ b/contrib/babelfishpg_common/src/datetimeoffset.h
@@ -23,6 +23,7 @@ extern void AdjustTimestampForSmallDatetime(Timestamp *time);
 extern void CheckSmalldatetimeRange(const Timestamp time);
 extern void CheckDatetimeRange(const Timestamp time);
 extern void CheckDatetime2Range(const Timestamp time);
+extern Datum timestamp_datetimeoffset(PG_FUNCTION_ARGS);
 typedef struct tsql_datetimeoffset
 {
 	int64		tsql_ts;

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -131,6 +131,11 @@ PG_FUNCTION_INFO_V1(numeric_degrees);
 PG_FUNCTION_INFO_V1(numeric_radians);
 PG_FUNCTION_INFO_V1(object_schema_name);
 PG_FUNCTION_INFO_V1(objectproperty_internal);
+PG_FUNCTION_INFO_V1(sysutcdatetime);
+PG_FUNCTION_INFO_V1(getutcdate);
+PG_FUNCTION_INFO_V1(getdate_internal);
+PG_FUNCTION_INFO_V1(sysdatetime);
+PG_FUNCTION_INFO_V1(sysdatetimeoffset);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -219,6 +224,40 @@ version(PG_FUNCTION_ARGS)
 	info = (*common_utility_plugin_ptr->tsql_varchar_input) (temp.data, temp.len, -1);
 	pfree(temp.data);
 	PG_RETURN_VARCHAR_P(info);
+}
+
+Datum sysutcdatetime(PG_FUNCTION_ARGS)
+{
+    PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamptz_zone,CStringGetTextDatum("UTC"),
+                                                            PointerGetDatum(GetCurrentStatementStartTimestamp())));
+    
+}
+
+Datum getutcdate(PG_FUNCTION_ARGS)
+{
+    PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamp_trunc,CStringGetTextDatum("millisecond"),DirectFunctionCall2(timestamptz_zone,CStringGetTextDatum("UTC"),
+                                                            PointerGetDatum(GetCurrentStatementStartTimestamp()))));
+    
+}
+
+Datum getdate_internal(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TIMESTAMP(DirectFunctionCall2(timestamp_trunc,CStringGetTextDatum("millisecond"),
+						PointerGetDatum(GetCurrentStatementStartTimestamp())));
+	
+}
+
+Datum sysdatetime(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TIMESTAMPTZ(GetCurrentStatementStartTimestamp());
+}
+
+Datum sysdatetimeoffset(PG_FUNCTION_ARGS)
+{
+	
+
+	PG_RETURN_POINTER((DirectFunctionCall1(common_utility_plugin_ptr->timestamp_datetimeoffset,
+							PointerGetDatum(GetCurrentStatementStartTimestamp()))));
 }
 
 void *

--- a/contrib/babelfishpg_tsql/sql/sys.sql
+++ b/contrib/babelfishpg_tsql/sql/sys.sql
@@ -1,31 +1,27 @@
 /* Built in functions */
 CREATE OR REPLACE FUNCTION sys.sysdatetime() RETURNS datetime2
-    AS $$select statement_timestamp()::datetime2;$$
-    LANGUAGE SQL;
+AS 'babelfishpg_tsql', 'sysdatetime'
+LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
-    -- Casting to text as there are not type cast function from timestamptz to datetimeoffset
-    AS $$select cast(cast(statement_timestamp() as text) as sys.datetimeoffset);$$
-    LANGUAGE SQL STABLE;
+AS 'babelfishpg_tsql', 'sysdatetimeoffset'
+LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
 
 
-CREATE OR REPLACE FUNCTION sys.sysutcdatetime() RETURNS sys.datetime2
-    AS $$select (statement_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime2;$$
-    LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.sysutcdatetime() TO PUBLIC;
-
+CREATE OR REPLACE FUNCTION sys.sysutcdatetime() returns sys.datetime2
+AS 'babelfishpg_tsql', 'sysutcdatetime'
+LANGUAGE C STABLE;
 
 CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', statement_timestamp()::pg_catalog.timestamp)::sys.datetime;$$
-    LANGUAGE SQL STABLE;
+AS 'babelfishpg_tsql', 'getdate_internal'
+LANGUAGE C STABLE;
 GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
 
-CREATE OR REPLACE FUNCTION sys.getutcdate() RETURNS sys.datetime
-    AS $$select date_trunc('millisecond', statement_timestamp() AT TIME ZONE 'UTC'::pg_catalog.text)::sys.datetime;$$
-    LANGUAGE SQL STABLE;
-GRANT EXECUTE ON FUNCTION sys.getutcdate() TO PUBLIC;
+create or replace function sys.getutcdate() returns sys.datetime
+AS 'babelfishpg_tsql', 'getutcdate'
+LANGUAGE C STABLE;
 
 
 CREATE FUNCTION sys.isnull(text,text) RETURNS text AS $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
@@ -1778,6 +1778,29 @@ SELECT
 WHERE FALSE;
 GRANT SELECT ON sys.database_permissions TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.sysutcdatetime() returns sys.datetime2
+AS 'babelfishpg_tsql', 'sysutcdatetime'
+LANGUAGE C STABLE;
+
+create or replace function sys.getutcdate() returns sys.datetime
+AS 'babelfishpg_tsql', 'getutcdate'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION sys.getdate() RETURNS sys.datetime
+AS 'babelfishpg_tsql', 'getdate_internal'
+LANGUAGE C STABLE;
+GRANT EXECUTE ON FUNCTION sys.getdate() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.sysdatetime() RETURNS datetime2
+AS 'babelfishpg_tsql', 'sysdatetime'
+LANGUAGE C STABLE;
+GRANT EXECUTE ON FUNCTION sys.sysdatetime() TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.sysdatetimeoffset() RETURNS sys.datetimeoffset
+AS 'babelfishpg_tsql', 'sysdatetimeoffset'
+LANGUAGE C STABLE;
+GRANT EXECUTE ON FUNCTION sys.sysdatetimeoffset() TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -318,14 +318,6 @@ ignore#!#TestDecimal
 ignore#!#TestNumeric
 ignore#!#numericOverflow
 
-# BABEL-4425 - Taking too much time to run.
-ignore#!#getdate-vu-prepare
-ignore#!#getdate-vu-verify
-ignore#!#getdate-vu-cleanup
-ignore#!#getdatetest
-ignore#!#TestDatetime-numeric-representation-vu-prepare
-ignore#!#TestDatetime-numeric-representation-vu-verify
-
 # Taking too much time to complete. (TIME-OUT FAILURES)
 ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-verify
 ignore#!#BABEL-SP_COLUMNS_MANAGED-dep-vu-verify
@@ -423,3 +415,5 @@ ignore#!#Test-sp_rename-dep-vu-cleanup
 # TIME-OUT
 ignore#!#TestSimpleErrorsWithImplicitTran
 ignore#!#babel_cursor
+ignore#!#TestDatetime-numeric-representation-vu-prepare
+ignore#!#TestDatetime-numeric-representation-vu-verify


### PR DESCRIPTION

### Description

When parallel query is enabled, functions getdate, sysdatetime, sysdatetimoeoffset, sysutcdatetime and getutcdate was performing exceptionally slow. This commit rewrite those function in C language to have better performance.

Authored-by: Sumit Jaiswal <sumiji@amazon.com>
Co-Authored-by: Ashish Prasad <pashisht@amazon.com>
Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

cherry-picked https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1908/ and https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2000
### Issues Resolved

Task: BABEL-4425


Performance test:
Overall execution time(in ms) for 1000 function call when parallel query is enabled.


| Functions | Before | After |
|--------|--------|--------|
| getdate | 79036 | 374 |
| sysdatetime | 582 | 571 |
| sysdatetimoeoffset | 658 | 508 |  

### Test Scenarios Covered ###
* **Use case based -** tests are already present in `getdate-vu-*`


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**



* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).