### PR TITLE
Move parallel mode check logic into GUC's check_hook

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -99,6 +99,7 @@ extern bool pltsql_nocount;
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
 
+static bool check_identity_insert(const char *newal, void **extra, GucSource source);
 static void assign_identity_insert(const char *newval, void *extra);
 static void assign_textsize(int newval, void *extra);
 extern Datum init_collid_trans_tab(PG_FUNCTION_ARGS);
@@ -273,18 +274,15 @@ set_procid(Oid oid)
 	procid_var = oid;
 }
 
-static void
-assign_identity_insert(const char *newval, void *extra)
+static bool
+check_identity_insert(char** newval, void **extra, GucSource source)
 {
 	/*
 	 * Workers synchronize the parameter at the beginning of each parallel 
 	 * operation. Avoid performing parameter assignment uring parallel operation.
 	 */
-	if (IsParallelWorker())
+	if (IsParallelWorker() && !InitializingParallelWorker)
 	{
-		if (InitializingParallelWorker)
-			return;
-
         /*
          * A change other than during startup, for example due to a SET clause
          * attached to a function definition, should be rejected, as there is
@@ -292,8 +290,17 @@ assign_identity_insert(const char *newval, void *extra)
          */
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TRANSACTION_STATE),
-				 errmsg("cannot change identity_insert during a parallel operation")));
+				 errmsg("cannot change identity_insert during a parallel operation");
 	}
+
+	return true;
+}
+
+static void
+assign_identity_insert(const char *newval, void *extra)
+{
+	if (IsParallelWorker())
+		return;
 
 	if (strcmp(newval, "") != 0)
 	{
@@ -4084,7 +4091,7 @@ _PG_init(void)
 							   "",
 							   PGC_USERSET,
 							   GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-							   NULL,
+							   check_identity_insert,
 							   assign_identity_insert,
 							   NULL);
 


### PR DESCRIPTION
### Description

Previously the parallel mode check happens during GUC assignment for GUCs enable_pg_hint and identity_insert. This commit follows PG custom and moves the logic into the GUCs' check_hook function.

Task: BABEL-4419

### Tests
No new feature, existing tests are sufficient.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).