### PR TITLE
insert varchar column mismatch through INSERT INTO EXEC into a table

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -165,6 +165,9 @@ static bool bbf_check_rowcount_hook(int es_processed);
 
 static char *get_local_schema_for_bbf_functions(Oid proc_nsp_oid);
 extern bool called_from_tsql_insert_exec();
+extern Datum pltsql_exec_tsql_cast_value(Datum value, bool *isnull,
+							 Oid valtype, int32 valtypmod,
+							 Oid reqtype, int32 reqtypmod);
 
 /*****************************************
  * 			Replication Hooks
@@ -233,6 +236,7 @@ static bbf_get_sysadmin_oid_hook_type prev_bbf_get_sysadmin_oid_hook = NULL;
 /* TODO: do we need to use variable to store hook value before transfrom pivot? No other function uses the same hook, should be redundant */
 static transform_pivot_clause_hook_type pre_transform_pivot_clause_hook = NULL;
 static called_from_tsql_insert_exec_hook_type pre_called_from_tsql_insert_exec_hook = NULL;
+static exec_tsql_cast_value_hook_type pre_exec_tsql_cast_value_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -401,6 +405,9 @@ InstallExtendedHooks(void)
 
 	pre_called_from_tsql_insert_exec_hook = called_from_tsql_insert_exec_hook;
 	called_from_tsql_insert_exec_hook = called_from_tsql_insert_exec;
+
+	pre_exec_tsql_cast_value_hook = exec_tsql_cast_value_hook;
+	exec_tsql_cast_value_hook = pltsql_exec_tsql_cast_value;
 }
 
 void

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -164,6 +164,7 @@ static bool plsql_TriggerRecursiveCheck(ResultRelInfo *resultRelInfo);
 static bool bbf_check_rowcount_hook(int es_processed);
 
 static char *get_local_schema_for_bbf_functions(Oid proc_nsp_oid);
+extern bool called_from_tsql_insert_exec();
 
 /*****************************************
  * 			Replication Hooks
@@ -231,6 +232,7 @@ static set_local_schema_for_func_hook_type prev_set_local_schema_for_func_hook =
 static bbf_get_sysadmin_oid_hook_type prev_bbf_get_sysadmin_oid_hook = NULL;
 /* TODO: do we need to use variable to store hook value before transfrom pivot? No other function uses the same hook, should be redundant */
 static transform_pivot_clause_hook_type pre_transform_pivot_clause_hook = NULL;
+static called_from_tsql_insert_exec_hook_type pre_called_from_tsql_insert_exec_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -396,6 +398,9 @@ InstallExtendedHooks(void)
 
 	prev_optimize_explicit_cast_hook = optimize_explicit_cast_hook;
 	optimize_explicit_cast_hook = optimize_explicit_cast;
+
+	pre_called_from_tsql_insert_exec_hook = called_from_tsql_insert_exec_hook;
+	called_from_tsql_insert_exec_hook = called_from_tsql_insert_exec;
 }
 
 void
@@ -459,6 +464,7 @@ UninstallExtendedHooks(void)
 	bbf_get_sysadmin_oid_hook = prev_bbf_get_sysadmin_oid_hook;
 	transform_pivot_clause_hook = pre_transform_pivot_clause_hook;
 	optimize_explicit_cast_hook = prev_optimize_explicit_cast_hook;
+	called_from_tsql_insert_exec_hook = pre_called_from_tsql_insert_exec_hook;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -429,6 +429,9 @@ static Datum exec_cast_value(PLtsql_execstate *estate,
 							 Datum value, bool *isnull,
 							 Oid valtype, int32 valtypmod,
 							 Oid reqtype, int32 reqtypmod);
+Datum pltsql_exec_tsql_cast_value(Datum value, bool *isnull,
+							 Oid valtype, int32 valtypmod,
+							 Oid reqtype, int32 reqtypmod);
 static pltsql_CastHashEntry *get_cast_hashentry(PLtsql_execstate *estate,
 												Oid srctype, int32 srctypmod,
 												Oid dsttype, int32 dsttypmod);
@@ -10383,4 +10386,14 @@ char *
 get_original_query_string(void)
 {
 	return original_query_string;
+}
+
+Datum pltsql_exec_tsql_cast_value(Datum value, bool *isnull,
+							 Oid valtype, int32 valtypmod,
+							 Oid reqtype, int32 reqtypmod)
+{
+	return exec_cast_value(get_current_tsql_estate(), 
+					value, isnull,
+					valtype, valtypmod,
+					reqtype, reqtypmod);
 }

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4347,7 +4347,6 @@ pltsql_estate_setup(PLtsql_execstate *estate,
 	estate->insert_exec = (func->fn_prokind == PROKIND_PROCEDURE ||
 						   strcmp(func->fn_signature, "inline_code_block") == 0)
 		&& rsi;
-	
 	estate->pivot_number = 0;
 	estate->pivot_parsetree_list = NIL;
 	

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4783,6 +4783,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 		rsinfo.isDone = ExprSingleResult;
 		rsinfo.setResult = NULL;
 		rsinfo.setDesc = NULL;
+		ReleaseTupleDesc(reldesc);
 	}
 
 	/* And run the function */
@@ -4849,6 +4850,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 			dest->receiveSlot(slot, dest);
 			ExecClearTuple(slot);
 		}
+		ReleaseTupleDesc(rsinfo.expectedDesc);
 		ExecDropSingleTupleTableSlot(slot);
 	}
 

--- a/test/JDBC/expected/BABEL-2999-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-2999-vu-cleanup.out
@@ -1,0 +1,29 @@
+drop table if exists t2_BABEL2999;
+GO
+
+drop table t1_BABEL2999;
+GO
+
+drop table t3_BABEL2999;
+GO
+
+drop table t3_BABEL2999_2;
+GO
+
+drop procedure p1_BABEL2999;
+GO
+
+drop procedure p2_BABEL2999
+GO
+
+drop procedure p3_BABEL2999
+GO
+
+drop table t4_BABEL2999;
+GO
+
+drop table t5_BABEL2999;
+GO
+
+drop table t6_BABEL2999
+GO

--- a/test/JDBC/expected/BABEL-2999-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-2999-vu-prepare.out
@@ -1,0 +1,32 @@
+drop table if exists t1_BABEL2999;
+GO
+
+create table t1_BABEL2999(b varchar(10));
+GO
+
+create table t2_BABEL2999(b int);
+GO
+
+create table t3_BABEL2999(b varchar);
+GO
+
+create procedure p1_BABEL2999 as select 'abc';
+GO
+
+create procedure p2_BABEL2999 as select 555;
+GO
+
+create table t3_BABEL2999_2(a int, b datetime, c varchar(20))
+GO
+
+create procedure p3_BABEL2999 as select '123', 123, 123;
+GO
+
+create table t4_BABEL2999( a binary(30), b varbinary(30), c varchar(30), d datetime, e smalldatetime)
+GO
+
+create table t5_BABEL2999( a decimal, b numeric)
+GO
+
+create table t6_BABEL2999( a int, b tinyint, c smallint)
+GO

--- a/test/JDBC/expected/BABEL-2999-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2999-vu-verify.out
@@ -141,18 +141,18 @@ int#!#datetime#!#varchar
 ~~END~~
 
 
-insert into t3_BABEL_2999_2 exec('select ''123''');
+insert into t3_BABEL2999_2 exec('select ''123''');
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "t3_babel_2999_2" does not exist)~~
+~~ERROR (Message: structure of query does not match function result type)~~
 
 
-insert into t3_BABEL_2999_2 exec('select 123, 123');
+insert into t3_BABEL2999_2 exec('select 123, 123');
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "t3_babel_2999_2" does not exist)~~
+~~ERROR (Message: structure of query does not match function result type)~~
 
 
 insert into t4_BABEL2999 exec('select 123, 123, 123, 123, 123')
@@ -213,4 +213,15 @@ GO
 insert into t6_BABEL2999 exec('select c,b,a from t6_BABEL2999')
 GO
 ~~ROW COUNT: 2~~
+
+
+select * from t6_BABEL2999
+GO
+~~START~~
+int#!#tinyint#!#smallint
+1#!#2#!#3
+1#!#2#!#3
+3#!#2#!#1
+3#!#2#!#1
+~~END~~
 

--- a/test/JDBC/expected/BABEL-2999-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2999-vu-verify.out
@@ -1,0 +1,216 @@
+insert into t1_BABEL2999 exec('Select ''5''');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t1_BABEL2999 exec('Select 5');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t1_BABEL2999 exec('Select ''5''');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t1_BABEL2999 exec('Select ''hello''');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t1_BABEL2999 exec('SELECT ''helloworld''');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t1_BABEL2999 exec('SELECT ''helloworldhello''');
+GO
+~~ERROR (Code: 8152)~~
+
+~~ERROR (Message: value too long for type character varying(10))~~
+
+
+select b from t1_BABEL2999 order by b;
+GO
+~~START~~
+varchar
+5
+5
+5
+hello
+helloworld
+~~END~~
+
+
+insert into t2_BABEL2999 exec('Select ''5'''); -- varchar to int
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t2_BABEL2999 exec('Select 5');  -- int to int
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t2_BABEL2999 SELECT '5'; 
+GO
+~~ROW COUNT: 1~~
+
+
+select b from t2_BABEL2999 order by b;
+GO
+~~START~~
+int
+5
+5
+5
+~~END~~
+
+
+insert into t3_BABEL2999 exec('Select ''5''');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t3_BABEL2999 exec('Select 5');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t3_BABEL2999 exec('Select ''5''');
+GO
+~~ROW COUNT: 1~~
+
+
+select b from t3_BABEL2999 order by b;
+GO
+~~START~~
+varchar
+5
+5
+5
+~~END~~
+
+
+delete from t1_BABEL2999
+GO
+~~ROW COUNT: 5~~
+
+
+insert into t1_BABEL2999 exec p1_BABEL2999;
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t1_BABEL2999 exec('exec p1_BABEL2999');
+GO
+~~ROW COUNT: 1~~
+
+
+select * from  t1_BABEL2999;
+GO
+~~START~~
+varchar
+abc
+abc
+~~END~~
+
+
+insert t3_BABEL2999_2 exec('select ''123'', 123, 123');
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t3_BABEL2999_2 exec p3_BABEL2999
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t3_BABEL2999_2 select '123', 123, 123
+GO
+~~ROW COUNT: 1~~
+
+
+select * from t3_BABEL2999_2;
+GO
+~~START~~
+int#!#datetime#!#varchar
+123#!#1900-05-04 00:00:00.0#!#123
+123#!#1900-05-04 00:00:00.0#!#123
+123#!#1900-05-04 00:00:00.0#!#123
+~~END~~
+
+
+insert into t3_BABEL_2999_2 exec('select ''123''');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "t3_babel_2999_2" does not exist)~~
+
+
+insert into t3_BABEL_2999_2 exec('select 123, 123');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "t3_babel_2999_2" does not exist)~~
+
+
+insert into t4_BABEL2999 exec('select 123, 123, 123, 123, 123')
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t4_BABEL2999 exec('select cast(123 as binary), cast(123 as varbinary), 123, cast(123 as datetime), cast(123 as smalldatetime)')
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t4_BABEL2999 select 123, 123, 123, 123, 123
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t4_BABEL2999 exec('select ''123'', ''123'', ''123'', ''123'', ''123''');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Implicit conversion from data type varchar to binary is not allowed. Use the CONVERT function to run this query.)~~
+
+
+select * from t4_BABEL2999
+GO
+~~START~~
+binary#!#varbinary#!#varchar#!#datetime#!#smalldatetime
+00000000000000000000000000000000000000000000000000000000007B#!#0000007B#!#123#!#1900-05-04 00:00:00.0#!#1900-05-04 00:00:00.0
+00000000000000000000000000000000000000000000000000000000007B#!#0000007B#!#123#!#1900-05-04 00:00:00.0#!#1900-05-04 00:00:00.0
+00000000000000000000000000000000000000000000000000000000007B#!#0000007B#!#123#!#1900-05-04 00:00:00.0#!#1900-05-04 00:00:00.0
+~~END~~
+
+
+insert into t5_BABEL2999 exec('select ''1.234'', ''33.33''');
+GO
+~~ROW COUNT: 1~~
+
+
+select * from t5_BABEL2999
+GO
+~~START~~
+numeric#!#numeric
+1#!#33
+~~END~~
+
+
+insert into t6_BABEL2999 exec('select 1,2,3')
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t6_BABEL2999 exec('select ''1'',''2'',''3''')
+GO
+~~ROW COUNT: 1~~
+
+
+insert into t6_BABEL2999 exec('select c,b,a from t6_BABEL2999')
+GO
+~~ROW COUNT: 2~~
+

--- a/test/JDBC/input/BABEL-2999-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-2999-vu-cleanup.sql
@@ -1,0 +1,29 @@
+drop table if exists t2_BABEL2999;
+GO
+
+drop table t1_BABEL2999;
+GO
+
+drop table t3_BABEL2999;
+GO
+
+drop table t3_BABEL2999_2;
+GO
+
+drop procedure p1_BABEL2999;
+GO
+
+drop procedure p2_BABEL2999
+GO
+
+drop procedure p3_BABEL2999
+GO
+
+drop table t4_BABEL2999;
+GO
+
+drop table t5_BABEL2999;
+GO
+
+drop table t6_BABEL2999
+GO

--- a/test/JDBC/input/BABEL-2999-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-2999-vu-prepare.sql
@@ -1,0 +1,32 @@
+drop table if exists t1_BABEL2999;
+GO
+
+create table t1_BABEL2999(b varchar(10));
+GO
+
+create table t2_BABEL2999(b int);
+GO
+
+create table t3_BABEL2999(b varchar);
+GO
+
+create procedure p1_BABEL2999 as select 'abc';
+GO
+
+create procedure p2_BABEL2999 as select 555;
+GO
+
+create table t3_BABEL2999_2(a int, b datetime, c varchar(20))
+GO
+
+create procedure p3_BABEL2999 as select '123', 123, 123;
+GO
+
+create table t4_BABEL2999( a binary(30), b varbinary(30), c varchar(30), d datetime, e smalldatetime)
+GO
+
+create table t5_BABEL2999( a decimal, b numeric)
+GO
+
+create table t6_BABEL2999( a int, b tinyint, c smallint)
+GO

--- a/test/JDBC/input/BABEL-2999-vu-verify.sql
+++ b/test/JDBC/input/BABEL-2999-vu-verify.sql
@@ -67,10 +67,10 @@ GO
 select * from t3_BABEL2999_2;
 GO
 
-insert into t3_BABEL_2999_2 exec('select ''123''');
+insert into t3_BABEL2999_2 exec('select ''123''');
 GO
 
-insert into t3_BABEL_2999_2 exec('select 123, 123');
+insert into t3_BABEL2999_2 exec('select 123, 123');
 GO
 
 insert into t4_BABEL2999 exec('select 123, 123, 123, 123, 123')
@@ -101,4 +101,7 @@ insert into t6_BABEL2999 exec('select ''1'',''2'',''3''')
 GO
 
 insert into t6_BABEL2999 exec('select c,b,a from t6_BABEL2999')
+GO
+
+select * from t6_BABEL2999
 GO

--- a/test/JDBC/input/BABEL-2999-vu-verify.sql
+++ b/test/JDBC/input/BABEL-2999-vu-verify.sql
@@ -1,0 +1,104 @@
+insert into t1_BABEL2999 exec('Select ''5''');
+GO
+
+insert into t1_BABEL2999 exec('Select 5');
+GO
+
+insert into t1_BABEL2999 exec('Select ''5''');
+GO
+
+insert into t1_BABEL2999 exec('Select ''hello''');
+GO
+
+insert into t1_BABEL2999 exec('SELECT ''helloworld''');
+GO
+
+insert into t1_BABEL2999 exec('SELECT ''helloworldhello''');
+GO
+
+select b from t1_BABEL2999 order by b;
+GO
+
+insert into t2_BABEL2999 exec('Select ''5'''); -- varchar to int
+GO
+
+insert into t2_BABEL2999 exec('Select 5');  -- int to int
+GO
+
+insert into t2_BABEL2999 SELECT '5'; 
+GO
+
+select b from t2_BABEL2999 order by b;
+GO
+
+insert into t3_BABEL2999 exec('Select ''5''');
+GO
+
+insert into t3_BABEL2999 exec('Select 5');
+GO
+
+insert into t3_BABEL2999 exec('Select ''5''');
+GO
+
+select b from t3_BABEL2999 order by b;
+GO
+
+delete from t1_BABEL2999
+GO
+
+insert into t1_BABEL2999 exec p1_BABEL2999;
+GO
+
+insert into t1_BABEL2999 exec('exec p1_BABEL2999');
+GO
+
+select * from  t1_BABEL2999;
+GO
+
+insert t3_BABEL2999_2 exec('select ''123'', 123, 123');
+GO
+
+insert into t3_BABEL2999_2 exec p3_BABEL2999
+GO
+
+insert into t3_BABEL2999_2 select '123', 123, 123
+GO
+
+select * from t3_BABEL2999_2;
+GO
+
+insert into t3_BABEL_2999_2 exec('select ''123''');
+GO
+
+insert into t3_BABEL_2999_2 exec('select 123, 123');
+GO
+
+insert into t4_BABEL2999 exec('select 123, 123, 123, 123, 123')
+GO
+
+insert into t4_BABEL2999 exec('select cast(123 as binary), cast(123 as varbinary), 123, cast(123 as datetime), cast(123 as smalldatetime)')
+GO
+
+insert into t4_BABEL2999 select 123, 123, 123, 123, 123
+GO
+
+insert into t4_BABEL2999 exec('select ''123'', ''123'', ''123'', ''123'', ''123''');
+GO
+
+select * from t4_BABEL2999
+GO
+
+insert into t5_BABEL2999 exec('select ''1.234'', ''33.33''');
+GO
+
+select * from t5_BABEL2999
+GO
+
+insert into t6_BABEL2999 exec('select 1,2,3')
+GO
+
+insert into t6_BABEL2999 exec('select ''1'',''2'',''3''')
+GO
+
+insert into t6_BABEL2999 exec('select c,b,a from t6_BABEL2999')
+GO

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -220,3 +220,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -273,3 +273,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -328,3 +328,4 @@ GRANT_SCHEMA
 AUTO_ANALYZE-before-15-5-or-14-10
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -321,3 +321,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -321,3 +321,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -325,3 +325,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -417,3 +417,4 @@ BABEL-3326
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -343,3 +343,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -358,3 +358,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -393,3 +393,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -413,3 +413,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -412,3 +412,4 @@ default_params
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -414,3 +414,4 @@ default_params
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -391,3 +391,4 @@ default_params
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -422,3 +422,4 @@ default_params
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -443,3 +443,4 @@ default_params
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -456,3 +456,4 @@ default_params
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
+BABEL-2999

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -488,3 +488,4 @@ pivot
 cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order
+BABEL-2999


### PR DESCRIPTION
Previously insert exec impl didn't consider the type cast during execution, this fix has add a implicit type cast between insert execution and exec execution if the type is mismatched.

Task: BABEL-2999

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).