### PR TITLE
Bug fixes and performance overhead reduction for GRANT .. ON SCHEMA

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -17,12 +17,12 @@ GRANT SELECT on sys.babelfish_sysdatabases TO PUBLIC;
 -- BABELFISH_SCHEMA_PERMISSIONS
 CREATE TABLE sys.babelfish_schema_permissions (
   dbid smallint NOT NULL,
-  schema_name NAME NOT NULL,
-  object_name NAME NOT NULL,
-  permission NAME NOT NULL,
-  grantee NAME NOT NULL,
-  object_type NAME,
-  PRIMARY KEY(dbid, schema_name, object_name, permission, grantee)
+  schema_name NAME NOT NULL COLLATE sys.database_default,
+  object_name NAME NOT NULL COLLATE sys.database_default,
+  permission SMALLINT,
+  grantee NAME NOT NULL COLLATE sys.database_default,
+  object_type NAME COLLATE sys.database_default,
+  PRIMARY KEY(dbid, schema_name, object_name, grantee)
 );
 
 -- BABELFISH_FUNCTION_EXT

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -890,14 +890,14 @@ $body$
 LANGUAGE plpgsql STABLE;
 
 -- BABELFISH_SCHEMA_PERMISSIONS
-CREATE TABLE IF NOT EXISTS sys.babelfish_schema_permissions (
+CREATE TABLE sys.babelfish_schema_permissions (
   dbid smallint NOT NULL,
-  schema_name NAME NOT NULL,
-  object_name NAME NOT NULL,
-  permission NAME NOT NULL,
-  grantee NAME NOT NULL,
-  object_type NAME,
-  PRIMARY KEY(dbid, schema_name, object_name, permission, grantee)
+  schema_name NAME NOT NULL COLLATE sys.database_default,
+  object_name NAME NOT NULL COLLATE sys.database_default,
+  permission SMALLINT,
+  grantee NAME NOT NULL COLLATE sys.database_default,
+  object_type NAME COLLATE sys.database_default,
+  PRIMARY KEY(dbid, schema_name, object_name, grantee)
 );
 
 create or replace function sys.babelfish_timezone_mapping(IN tmz text) returns text

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2832,7 +2832,7 @@ rename_procfunc_update_bbf_catalog(RenameStmt *stmt)
 void
 add_entry_to_bbf_schema(const char *schema_name,
 				const char *object_name,
-				const char *permission,
+				int16 permission,
 				const char *grantee,
 				const char *object_type)
 {
@@ -2855,7 +2855,7 @@ add_entry_to_bbf_schema(const char *schema_name,
 	new_record_bbf_schema[BBF_SCHEMA_PERMS_DBID] = Int16GetDatum(dbid);
 	new_record_bbf_schema[BBF_SCHEMA_PERMS_SCHEMA_NAME] = CStringGetDatum(pstrdup(schema_name));
 	new_record_bbf_schema[BBF_SCHEMA_PERMS_OBJECT_NAME] = CStringGetDatum(pstrdup(object_name));
-	new_record_bbf_schema[BBF_SCHEMA_PERMS_PERMISSION] = CStringGetDatum(pstrdup(permission));
+	new_record_bbf_schema[BBF_SCHEMA_PERMS_PERMISSION] = Int16GetDatum(permission);
 	new_record_bbf_schema[BBF_SCHEMA_PERMS_GRANTEE] = CStringGetDatum(pstrdup(grantee));
 	if (object_type != NULL)
 		new_record_bbf_schema[BBF_SCHEMA_PERMS_OBJECT_TYPE] = CStringGetDatum(pstrdup(object_type));
@@ -2876,16 +2876,148 @@ add_entry_to_bbf_schema(const char *schema_name,
 	CommandCounterIncrement();
 }
 
-/* Check if the catalog entry exists. */
-bool
-check_bbf_schema_for_entry(const char *schema_name,
-							const char *object_name,
-						   	const char *permission,
+/*get permission entry from catalog*/
+int16
+get_bbf_schema_privilege(const char *schema_name,
+ 							const char *object_name,
 							const char *grantee)
 {
 	Relation	bbf_schema_rel;
 	HeapTuple	tuple_bbf_schema;
-	ScanKeyData	key[5];
+	ScanKeyData	key[4];
+	TableScanDesc	scan;
+	int16	dbid = get_cur_db_id();
+	int16 permission = 0;
+
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									AccessShareLock);
+	ScanKeyInit(&key[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyInit(&key[1],
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(schema_name));
+	ScanKeyInit(&key[2],
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(object_name));
+	ScanKeyInit(&key[3],
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(grantee));
+
+	scan = table_beginscan_catalog(bbf_schema_rel, 4, key);
+	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
+	if (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		Form_bbf_schema_perms bbf_schema = (Form_bbf_schema_perms) GETSTRUCT(tuple_bbf_schema);
+		permission = bbf_schema->permission;
+	}
+
+	table_endscan(scan);
+	table_close(bbf_schema_rel, AccessShareLock);
+	return permission;
+}
+
+/*Update catalog entry*/
+void
+update_bbf_schema_entry(const char *schema_name,
+							const char *object_name,
+							int16 new_priv,
+							int16 old_priv,
+							const char *grantee,
+							const char *object_type,
+							bool is_grant)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	TupleDesc	bbf_schema_dsc;
+	HeapTuple	new_tuple;
+	ScanKeyData key[5];
+	TableScanDesc scan;
+	int16	dbid = get_cur_db_id();
+	int16 permission = 0;
+	Datum		new_record_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+	bool		new_record_nulls_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+	bool		new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+
+
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									RowExclusiveLock);
+
+	if(is_grant)
+	{
+		permission = new_priv | old_priv;
+	}
+	else
+	{
+		permission = ~new_priv & old_priv;
+	}
+	
+	if(permission == 0)
+	{
+		del_from_bbf_schema(schema_name, object_name, grantee);
+		return;
+	}
+	ScanKeyInit(&key[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyInit(&key[1],
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(schema_name));
+	ScanKeyInit(&key[2],
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(object_name));
+	ScanKeyInit(&key[3],
+				Anum_bbf_schema_perms_permission,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(old_priv));
+	ScanKeyInit(&key[4],
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(grantee));
+
+	scan = table_beginscan_catalog(bbf_schema_rel, 5, key);
+	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
+	bbf_schema_dsc = RelationGetDescr(bbf_schema_rel);
+	/* Build a tuple to insert */
+	MemSet(new_record_bbf_schema, 0, sizeof(new_record_bbf_schema));
+	MemSet(new_record_nulls_bbf_schema, false, sizeof(new_record_nulls_bbf_schema));
+	MemSet(new_record_repl_bbf_schema, false, sizeof(new_record_repl_bbf_schema));
+
+	new_record_bbf_schema[BBF_SCHEMA_PERMS_PERMISSION] = Int32GetDatum(permission);
+	new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_PERMISSION] = true;
+
+	new_tuple = heap_modify_tuple(tuple_bbf_schema,
+								  bbf_schema_dsc,
+								  new_record_bbf_schema,
+								  new_record_nulls_bbf_schema,
+								  new_record_repl_bbf_schema);
+
+	CatalogTupleUpdate(bbf_schema_rel, &new_tuple->t_self, new_tuple);
+
+	heap_freetuple(new_tuple);
+
+	table_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
+
+	CommandCounterIncrement();
+}
+
+/* Check if the catalog entry exists. */
+bool
+check_bbf_schema_for_entry(const char *schema_name,
+							const char *object_name,
+							const char *grantee)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	ScanKeyData	key[4];
 	TableScanDesc	scan;
 	bool	catalog_entry_exists = false;
 	int16	dbid = get_cur_db_id();
@@ -2905,15 +3037,11 @@ check_bbf_schema_for_entry(const char *schema_name,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(object_name));
 	ScanKeyInit(&key[3],
-				Anum_bbf_schema_perms_permission,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(permission));
-	ScanKeyInit(&key[4],
 				Anum_bbf_schema_perms_grantee,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(grantee));
 
-	scan = table_beginscan_catalog(bbf_schema_rel, 5, key);
+	scan = table_beginscan_catalog(bbf_schema_rel, 4, key);
 
 	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
 	if (HeapTupleIsValid(tuple_bbf_schema))
@@ -2927,14 +3055,14 @@ check_bbf_schema_for_entry(const char *schema_name,
 bool
 check_bbf_schema_for_schema(const char *schema_name,
 							const char *object_name,
-							const char *permission)
+							int16 permission)
 {
 	Relation	bbf_schema_rel;
 	HeapTuple	tuple_bbf_schema;
-	ScanKeyData key[4];
+	ScanKeyData key[3];
 	TableScanDesc scan;
-	bool		catalog_entry_exists = false;
 	int16	dbid = get_cur_db_id();
+	int16 priv = 0;
 
 	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
 									AccessShareLock);
@@ -2950,31 +3078,32 @@ check_bbf_schema_for_schema(const char *schema_name,
 				Anum_bbf_schema_perms_object_name,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(object_name));
-	ScanKeyInit(&key[3],
-				Anum_bbf_schema_perms_permission,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(permission));
 
-	scan = table_beginscan_catalog(bbf_schema_rel, 4, key);
+	scan = table_beginscan_catalog(bbf_schema_rel, 3, key);
 
 	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
-	if (HeapTupleIsValid(tuple_bbf_schema))
-		catalog_entry_exists = true;
+	while (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		Form_bbf_schema_perms schemaform;
+		schemaform = (Form_bbf_schema_perms) GETSTRUCT(tuple_bbf_schema);
+		priv = schemaform->permission;
 
+		if((permission & priv) == permission)
+			return true;
+	}
 	table_endscan(scan);
 	table_close(bbf_schema_rel, AccessShareLock);
-	return catalog_entry_exists;
+	return false;
 }
 
 void
 del_from_bbf_schema(const char *schema_name,
 				  const char *object_name,
-				  const char *permission,
 				  const char *grantee)
 {
 	Relation	bbf_schema_rel;
 	HeapTuple	tuple_bbf_schema;
-	ScanKeyData key[5];
+	ScanKeyData key[4];
 	TableScanDesc scan;
 	int16	dbid = get_cur_db_id();
 
@@ -2993,15 +3122,11 @@ del_from_bbf_schema(const char *schema_name,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(object_name));
 	ScanKeyInit(&key[3],
-				Anum_bbf_schema_perms_permission,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(permission));
-	ScanKeyInit(&key[4],
 				Anum_bbf_schema_perms_grantee,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(grantee));
 
-	scan = table_beginscan_catalog(bbf_schema_rel, 5, key);
+	scan = table_beginscan_catalog(bbf_schema_rel, 4, key);
 
 	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
 
@@ -3073,55 +3198,14 @@ clean_up_bbf_schema(const char *schema_name,
 	systable_endscan(scan);
 	table_close(bbf_schema_rel, RowExclusiveLock);
 }
-
-void
-grant_perms_to_objects_in_schema(const char *schema_name,
-				  const char *permission,
-				  const char *grantee)
+void grant_perms_to_each_obj(const char *db_name,
+					const char	*object_type,
+					const char *schema_name,
+					const char	*object_name,
+					const char *grantee,
+					const char *permission)
 {
-	TableScanDesc scan;
-	Relation	bbf_schema_rel;
-	HeapTuple	tuple_bbf_schema;
-	const char	*object_name;
-	const char	*object_type;
-	ScanKeyData scanKey[4];
-	int16		dbid = get_cur_db_id();
-	const char *db_name = get_cur_db_name();
-
-	/* Fetch the relation */
-	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
-									AccessShareLock);
-	ScanKeyInit(&scanKey[0],
-				Anum_bbf_schema_perms_dbid,
-				BTEqualStrategyNumber, F_INT2EQ,
-				Int16GetDatum(dbid));
-	ScanKeyInit(&scanKey[1],
-				Anum_bbf_schema_perms_schema_name,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(schema_name));
-	ScanKeyInit(&scanKey[2],
-				Anum_bbf_schema_perms_permission,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(permission));
-	ScanKeyInit(&scanKey[3],
-				Anum_bbf_schema_perms_grantee,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(grantee));
-
-	scan = table_beginscan_catalog(bbf_schema_rel, 4, scanKey);
-	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
-
-	while (HeapTupleIsValid(tuple_bbf_schema))
-	{
-		Form_bbf_schema_perms schemaform;
-		schemaform = (Form_bbf_schema_perms) GETSTRUCT(tuple_bbf_schema);
-		object_name = pstrdup(NameStr(schemaform->object_name));
-		object_type = pstrdup(NameStr(schemaform->object_type));
-
-		/* For each object, grant the permission explicitly. */
-		if (strcmp(object_name, "ALL") != 0)
-		{
-			StringInfoData	query;
+	StringInfoData	query;
 			char			*schema;
 			List			*res;
 			Node			*res_stmt;
@@ -3161,6 +3245,64 @@ grant_perms_to_objects_in_schema(const char *schema_name,
 
 			/* make sure later steps can see the object created here */
 			CommandCounterIncrement();
+}
+
+void
+grant_perms_to_objects_in_schema(const char *schema_name,
+				int16 priv,
+				const char *grantee)
+{
+	TableScanDesc scan;
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	const char	*object_name;
+	const char	*object_type;
+	ScanKeyData scanKey[3];
+	int16		dbid = get_cur_db_id();
+	const char *db_name = get_cur_db_name();
+	int16 permission = 0;
+
+	/* Fetch the relation */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									AccessShareLock);
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyInit(&scanKey[1],
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(schema_name));
+	ScanKeyInit(&scanKey[2],
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(grantee));
+
+	scan = table_beginscan_catalog(bbf_schema_rel, 3, scanKey);
+	tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
+
+	while (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		Form_bbf_schema_perms schemaform;
+		schemaform = (Form_bbf_schema_perms) GETSTRUCT(tuple_bbf_schema);
+		object_name = pstrdup(NameStr(schemaform->object_name));
+		object_type = pstrdup(NameStr(schemaform->object_type));
+		permission = (priv & (schemaform->permission));
+		/* For each object, grant the permission explicitly. */
+		if (strcmp(object_name, "ALL") != 0)
+		{
+			if((permission & 32) == 32)
+				grant_perms_to_each_obj(db_name, object_type, schema_name, object_name, grantee, "execute");
+			if((permission & 16) == 16)
+				grant_perms_to_each_obj(db_name, object_type, schema_name, object_name, grantee, "select");
+			if((permission & 8) == 8)
+				grant_perms_to_each_obj(db_name, object_type, schema_name, object_name, grantee, "insert");
+			if((permission & 4) == 4)
+				grant_perms_to_each_obj(db_name, object_type, schema_name, object_name, grantee, "update");
+			if((permission & 2) == 2)
+				grant_perms_to_each_obj(db_name, object_type, schema_name, object_name, grantee, "delete");
+			if((permission & 1) == 1)
+				grant_perms_to_each_obj(db_name, object_type, schema_name, object_name, grantee, "references");
 		}
 		tuple_bbf_schema = heap_getnext(scan, ForwardScanDirection);
 	}

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -310,7 +310,7 @@ typedef struct FormData_bbf_schema_perms
 	int16		dbid;
 	NameData	schema_name;
 	NameData	object_name;
-	NameData	permission;
+	int16		permission;
 	NameData	grantee;
 	NameData	object_type;
 } FormData_bbf_schema_perms;
@@ -319,30 +319,47 @@ typedef FormData_bbf_schema_perms *Form_bbf_schema_perms;
 
 extern void add_entry_to_bbf_schema(const char *schema_name,
 				  const char *object_name,
-				  const char *permission,
+				  int16 permission,
 				  const char *grantee,
 				  const char *object_type);
 
+extern int16 get_bbf_schema_privilege(const char *schema_name,
+ 							const char *object_name,
+							const char *grantee);
+
+extern void update_bbf_schema_entry(const char *schema_name,
+							const char *object_name,
+							int16 new_priv,
+							int16 old_priv,
+							const char *grantee,
+							const char *object_type,
+							bool is_grant);
+
 extern bool check_bbf_schema_for_entry(const char *schema_name,
 									   const char *object_name,
-									   const char *permission,
 									   const char *grantee);
 
 extern void del_from_bbf_schema(const char *schema_name,
 					  const char *object_name,
-					  const char *permission,
 					  const char *grantee);
 
 extern bool check_bbf_schema_for_schema(const char *schema_name,
 									   const char *object_name,
-									   const char *permission);
+									   int16 permission);
 
 extern void clean_up_bbf_schema(const char *schema_name,
 								const char *object_name,
 								bool is_schema);
 
+extern void grant_perms_to_each_obj(const char *db_name,
+					const char	*object_type,
+					const char *schema_name,
+					const char	*object_name,
+					const char *grantee,
+					const char *permission);
+
 extern void grant_perms_to_objects_in_schema(const char *schema_name,
-				  const char *permission,
+				  int16 permission,
 				  const char *grantee);
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -327,7 +327,7 @@ extern int16 get_bbf_schema_privilege(const char *schema_name,
  							const char *object_name,
 							const char *grantee);
 
-extern void update_bbf_schema_entry(const char *schema_name,
+extern void update_bbf_schema_privilege(const char *schema_name,
 							const char *object_name,
 							int16 new_priv,
 							int16 old_priv,

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3757,10 +3757,13 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 		char	*user = GetUserNameFromId(GetUserId(), false);
 		Oid	role_oid;
 		int16 old_priv = 0;
-		rolname	= get_physical_user_name(dbname, grantee_name);
+		if(strcmp(grantee_name, "public") != 0)
+			rolname	= get_physical_user_name(dbname, grantee_name);
+		else
+			rolname = "public";
 		role_oid = get_role_oid(rolname, true);
 
-		if (role_oid == InvalidOid)
+		if (strcmp(grantee_name, "public") != 0 && role_oid == InvalidOid)
 			ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", grantee_name)));
 

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -53,6 +53,7 @@ static int	exec_stmt_usedb_explain(PLtsql_execstate *estate, PLtsql_stmt_usedb *
 static int	exec_stmt_grantdb(PLtsql_execstate *estate, PLtsql_stmt_grantdb *stmt);
 static int	exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt);
 static int	exec_stmt_fulltextindex(PLtsql_execstate *estate, PLtsql_stmt_fulltextindex *stmt);
+static void exec_gen_grantschema(char *schema_name, char *rolname,  PLtsql_stmt_grantschema *stmt, char *priv_name);
 static int	exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *expr);
 static int	exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *expr);
 static int	exec_stmt_dbcc(PLtsql_execstate *estate, PLtsql_stmt_dbcc *stmt);
@@ -3661,11 +3662,43 @@ get_insert_bulk_kilobytes_per_batch()
 	return insert_bulk_kilobytes_per_batch;
 }
 
-static int
-exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
+void exec_gen_grantschema(char *schema_name, char *rolname,  PLtsql_stmt_grantschema *stmt, char *priv_name)
 {
 	List	   *parsetree_list;
 	ListCell   *parsetree_item;
+	parsetree_list = gen_grantschema_subcmds(schema_name, rolname, stmt->is_grant, stmt->with_grant_option, priv_name);
+				/* Run all subcommands */
+				foreach(parsetree_item, parsetree_list)
+				{
+					Node	   *stmt = ((RawStmt *) lfirst(parsetree_item))->stmt;
+					PlannedStmt *wrapper;
+
+					/* need to make a wrapper PlannedStmt */
+					wrapper = makeNode(PlannedStmt);
+					wrapper->commandType = CMD_UTILITY;
+					wrapper->canSetTag = false;
+					wrapper->utilityStmt = stmt;
+					wrapper->stmt_location = 0;
+					wrapper->stmt_len = 0;
+
+					/* do this step */
+					ProcessUtility(wrapper,
+								"(GRANT SCHEMA )",
+								false,
+								PROCESS_UTILITY_SUBCOMMAND,
+								NULL,
+								NULL,
+								None_Receiver,
+								NULL);
+
+					/* make sure later steps can see the object created here */
+					CommandCounterIncrement();
+				}
+}
+
+static int
+exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
+{
 	char	   *dbname = get_cur_db_name();
 	char	   *login = GetUserNameFromId(GetSessionUserId(), false);
 	bool		login_is_db_owner;
@@ -3673,8 +3706,26 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 	char		*rolname;
 	char		*schema_name;
 	ListCell   *lc;
-	ListCell	*lc1;
+	int16 privilege_maskInt = 0;
 	Oid 		schemaOid;
+
+	/* create integer bitmask for permissions*/
+	foreach(lc, stmt->privileges)
+	{
+		char	*priv_name = (char *) lfirst(lc);
+		if (!strcmp(priv_name,"execute"))
+			privilege_maskInt |= 32;
+		if (!strcmp(priv_name,"select"))
+			privilege_maskInt |= 16;
+		if (!strcmp(priv_name,"insert"))
+			privilege_maskInt |= 8;
+		if (!strcmp(priv_name,"update"))
+			privilege_maskInt |= 4;
+		if (!strcmp(priv_name,"delete"))
+			privilege_maskInt |= 2;
+		if (!strcmp(priv_name,"references"))
+			privilege_maskInt |= 1;
+	}
 
 	/*
 	 * If the login is not the db owner or the login is not the member of
@@ -3683,79 +3734,76 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 	login_is_db_owner = 0 == strncmp(login, get_owner_of_db(dbname), NAMEDATALEN);
 	datdba = get_role_oid("sysadmin", false);
 	schema_name = get_physical_schema_name(dbname, stmt->schema_name);
-	schemaOid = LookupExplicitNamespace(schema_name, true);
+	if(schema_name)
+	{
+		schemaOid = LookupExplicitNamespace(schema_name, true);
+	}
+	else
+	{
+		ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_SCHEMA),
+					 errmsg("An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as \"\" or [] are not allowed. Change the alias to a valid name.")));
+	}
 
 	if (!OidIsValid(schemaOid))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_SCHEMA),
 					 errmsg("schema \"%s\" does not exist",
 							schema_name)));
-	
-	if (!is_member_of_role(GetSessionUserId(), datdba) && !login_is_db_owner && !pg_namespace_ownercheck(schemaOid, GetUserId()))
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("Cannot find the schema \"%s\", because it does not exist or you do not have permission.", stmt->schema_name)));
 
-	foreach(lc1, stmt->privileges)
+	foreach(lc, stmt->grantees)
 	{
-		char	*priv_name = (char *) lfirst(lc1);
-		foreach(lc, stmt->grantees)
+		char		*grantee_name = (char *) lfirst(lc);
+		char	*user = GetUserNameFromId(GetUserId(), false);
+		Oid	role_oid;
+		int16 old_priv = 0;
+		rolname	= get_physical_user_name(dbname, grantee_name);
+		role_oid = get_role_oid(rolname, true);
+
+		if (role_oid == InvalidOid)
+			ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", grantee_name)));
+
+		if ((strcmp(rolname, user) == 0) || pg_namespace_ownercheck(schemaOid, role_oid) || is_member_of_role(role_oid, datdba))
+			ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					errmsg("Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.")));
+
+		if (!is_member_of_role(GetSessionUserId(), datdba) && !login_is_db_owner && !pg_namespace_ownercheck(schemaOid, GetUserId()))
+			ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("Cannot find the schema \"%s\", because it does not exist or you do not have permission.", stmt->schema_name)));
+
+		if((privilege_maskInt & 32) == 32)
+			exec_gen_grantschema(schema_name, rolname, stmt, "execute");
+		if((privilege_maskInt & 16) == 16)
+			exec_gen_grantschema(schema_name, rolname, stmt, "select");
+		if((privilege_maskInt & 8) == 8)
+			exec_gen_grantschema(schema_name, rolname, stmt, "insert");
+		if((privilege_maskInt & 4) == 4)
+			exec_gen_grantschema(schema_name, rolname, stmt, "update");
+		if((privilege_maskInt & 2) == 2)
+			exec_gen_grantschema(schema_name, rolname, stmt, "delete");
+		if((privilege_maskInt & 1) == 1)
+			exec_gen_grantschema(schema_name, rolname, stmt, "references");
+
+		/* Add entry for each grant statement. */
+		if (stmt->is_grant && !check_bbf_schema_for_entry(stmt->schema_name, "ALL", rolname))
+			add_entry_to_bbf_schema(stmt->schema_name, "ALL",  privilege_maskInt, rolname, NULL);
+		else if(stmt->is_grant)
 		{
-			char	   *grantee_name = (char *) lfirst(lc);
-			Oid	role_oid;
-			bool		grantee_is_db_owner;
-			rolname	= get_physical_user_name(dbname, grantee_name);
-			role_oid = get_role_oid(rolname, true);
-			grantee_is_db_owner = 0 == strncmp(grantee_name, get_owner_of_db(dbname), NAMEDATALEN);
-
-
-			if (role_oid == InvalidOid)
-				ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-					errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", grantee_name)));
-
-			if (pg_namespace_ownercheck(schemaOid, role_oid) || is_member_of_role(role_oid, datdba) || grantee_is_db_owner)
-				ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-					 errmsg("Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.")));
-
-			parsetree_list = gen_grantschema_subcmds(schema_name, rolname, stmt->is_grant, stmt->with_grant_option, priv_name);
-			/* Run all subcommands */
-			foreach(parsetree_item, parsetree_list)
-			{
-				Node	   *stmt = ((RawStmt *) lfirst(parsetree_item))->stmt;
-				PlannedStmt *wrapper;
-
-				/* need to make a wrapper PlannedStmt */
-				wrapper = makeNode(PlannedStmt);
-				wrapper->commandType = CMD_UTILITY;
-				wrapper->canSetTag = false;
-				wrapper->utilityStmt = stmt;
-				wrapper->stmt_location = 0;
-				wrapper->stmt_len = 0;
-
-				/* do this step */
-				ProcessUtility(wrapper,
-							"(GRANT SCHEMA )",
-							false,
-							PROCESS_UTILITY_SUBCOMMAND,
-							NULL,
-							NULL,
-							None_Receiver,
-							NULL);
-
-				/* make sure later steps can see the object created here */
-				CommandCounterIncrement();
-			}
-			/* Add entry for each grant statement. */
-			if (stmt->is_grant && !check_bbf_schema_for_entry(stmt->schema_name, "ALL", priv_name, rolname))
-				add_entry_to_bbf_schema(stmt->schema_name, "ALL", priv_name, rolname, NULL);
-			/* Remove entry for each revoke statement. */
-			if (!stmt->is_grant && check_bbf_schema_for_entry(stmt->schema_name, "ALL", priv_name, rolname))
-			{
-				/* If any object in the schema has the OBJECT level permission. Then, internally grant that permission back. */
-				grant_perms_to_objects_in_schema(stmt->schema_name, priv_name, rolname);
-				del_from_bbf_schema(stmt->schema_name, "ALL", priv_name, rolname);
-			}
+			int16 old_priv = get_bbf_schema_privilege(stmt->schema_name, "ALL", rolname);
+			if(old_priv!= privilege_maskInt || ((old_priv|privilege_maskInt) != old_priv))
+				update_bbf_schema_entry(stmt->schema_name, "ALL", privilege_maskInt, old_priv, rolname, NULL, stmt->is_grant);
+		}
+		/* Remove entry for each revoke statement. */
+		if (!stmt->is_grant && check_bbf_schema_for_entry(stmt->schema_name, "ALL", rolname))
+		{
+			/* If any object in the schema has the OBJECT level permission. Then, internally grant that permission back. */
+			grant_perms_to_objects_in_schema(stmt->schema_name, privilege_maskInt, rolname);
+			old_priv = get_bbf_schema_privilege(stmt->schema_name, "ALL", rolname);
+			if(old_priv!= privilege_maskInt || ((old_priv)&(~privilege_maskInt)) != old_priv)
+				update_bbf_schema_entry(stmt->schema_name, "ALL", privilege_maskInt, old_priv, rolname, NULL, stmt->is_grant);
 		}
 	}
 	return PLTSQL_RC_OK;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3608,6 +3608,25 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				GrantStmt *grant = (GrantStmt *) parsetree;
 				char	   *dbname = get_cur_db_name();
 				const char *current_user = GetUserNameFromId(GetUserId(), false);
+				int16 privilege_maskInt = 0;
+				ListCell   *lc1;
+				/* create integer bitmask for permissions*/
+						foreach(lc1, grant->privileges)
+						{
+							AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+							if (!strcmp(ap->priv_name,"execute"))
+								privilege_maskInt |= 32;
+							if (!strcmp(ap->priv_name,"select"))
+								privilege_maskInt |= 16;
+							if (!strcmp(ap->priv_name,"insert"))
+								privilege_maskInt |= 8;
+							if (!strcmp(ap->priv_name,"update"))
+								privilege_maskInt |= 4;
+							if (!strcmp(ap->priv_name,"delete"))
+								privilege_maskInt |= 2;
+							if (!strcmp(ap->priv_name,"references"))
+								privilege_maskInt |= 1;
+						}
 				/* Ignore when GRANT statement has no specific named object. */
 				if (sql_dialect != SQL_DIALECT_TSQL || grant->targtype != ACL_TARGET_OBJECT)
 					break;
@@ -3623,7 +3642,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						const char *logical_schema = NULL;
 						char	   *obj = rv->relname;
 						ListCell   *lc;
-						ListCell	*lc1;
 						const char *obj_type = "r";
 						if (rv->schemaname != NULL)
 							logical_schema = get_logical_schema_name(rv->schemaname, true);
@@ -3637,13 +3655,17 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								foreach(lc, grant->grantees)
 								{
 									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									int i = 0;
-									char *permissions[] = {"select", "insert", "update", "references", "delete"};
-									for(i = 0; i < 5; i++)
+									if((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logical_schema, obj,rol_spec->rolename))
 									{
-										if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logical_schema, obj, permissions[i], rol_spec->rolename))
-											add_entry_to_bbf_schema(logical_schema, obj, permissions[i], rol_spec->rolename, obj_type);
+										add_entry_to_bbf_schema(logical_schema, obj, 31, rol_spec->rolename, obj_type);
 									}
+									else if(rol_spec->rolename != NULL)
+									{
+										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
+										if(old_priv!= 31 || (old_priv|(31)) != old_priv)
+											update_bbf_schema_entry(logical_schema, obj, 31, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									}
+									
 								}
 								break;
 							}
@@ -3652,15 +3674,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								foreach(lc, grant->grantees)
 								{
 									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									int i = 0;
 									bool has_schema_perms = false;
-									char *permissions[] = {"select", "insert", "update", "references", "delete"};
-									for(i = 0; i < 5; i++)
+									if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logical_schema, "ALL", rol_spec->rolename) && !has_schema_perms)
+										has_schema_perms = true;
+									if((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
 									{
-										if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logical_schema, "ALL", permissions[i], rol_spec->rolename) && !has_schema_perms)
-											has_schema_perms = true;
-										if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logical_schema, obj, permissions[i], rol_spec->rolename))
-											del_from_bbf_schema(logical_schema, obj, permissions[i], rol_spec->rolename);
+										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
+										if(old_priv!= 31 || ((old_priv)&(~(31))) != old_priv)
+											update_bbf_schema_entry(logical_schema, obj, 31, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
 									}
 									if (has_schema_perms)
 										return;
@@ -3668,52 +3689,85 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								break;
 							}
 						}
-						foreach(lc1, grant->privileges)
+						
+						if (grant->is_grant)
 						{
-							AccessPriv *ap = (AccessPriv *) lfirst(lc1);
-							if (grant->is_grant)
-							{
-								/*
-								* 1. Execute the GRANT statement.
-								* 2. Add its corresponding entry in the catalog, if doesn't exist already.
-								* 3. Don't add an entry, if the permission is granted on column list.
-								*/
-								if (prev_ProcessUtility)
-									prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-										queryEnv, dest, qc);
-								else
-									standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-										queryEnv, dest, qc);
-								foreach(lc, grant->grantees)
-								{
-									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									if ((ap->cols == NULL) && (rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logical_schema, obj, ap->priv_name, rol_spec->rolename))
-										add_entry_to_bbf_schema(logical_schema, obj, ap->priv_name, rol_spec->rolename, obj_type);
-								}
-							}
+							/*
+							* 1. Execute the GRANT statement.
+							* 2. Add its corresponding entry in the catalog, if doesn't exist already.
+							* 3. Don't add an entry, if the permission is granted on column list.
+							*/
+							if (prev_ProcessUtility)
+								prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+									queryEnv, dest, qc);
 							else
+								standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+									queryEnv, dest, qc);
+							foreach(lc, grant->grantees)
 							{
-								foreach(lc, grant->grantees)
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+								bool flag = false;
+								foreach(lc1, grant->privileges)
 								{
-									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									/*
-									* 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists.
-									* 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
-									*/
-									if ((logical_schema != NULL) && (rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logical_schema, "ALL", ap->priv_name, rol_spec->rolename))
+									AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+									if(ap->cols != NULL)
 									{
-										if (prev_ProcessUtility)
-											prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-																queryEnv, dest, qc);
-										else
-											standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-																	queryEnv, dest, qc);
+										flag = true;
+										break;
 									}
-									if ((ap->cols == NULL) && (rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logical_schema, obj, ap->priv_name, rol_spec->rolename))
-										del_from_bbf_schema(logical_schema, obj, ap->priv_name, rol_spec->rolename);
+
+								}
+								if(flag)
+									break;
+								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
+									add_entry_to_bbf_schema(logical_schema, obj, privilege_maskInt, rol_spec->rolename, obj_type);
+								else if(rol_spec->rolename != NULL)
+								{
+									int16 old_priv = get_bbf_schema_privilege(logical_schema, obj, rol_spec->rolename);
+									if(old_priv!= privilege_maskInt || ((old_priv)|(privilege_maskInt)) != old_priv)
+										update_bbf_schema_entry(logical_schema, obj, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
 								}
 							}
 						}
+						else
+						{
+							foreach(lc, grant->grantees)
+							{
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+								bool flag = false;
+								/*
+								* 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists.
+								* 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
+								*/
+								if ((logical_schema != NULL) && (rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logical_schema, "ALL", rol_spec->rolename))
+								{
+									if (prev_ProcessUtility)
+										prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+															queryEnv, dest, qc);
+									else
+										standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+																queryEnv, dest, qc);
+								}
+								foreach(lc1, grant->privileges)
+								{
+									AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+									if(ap->cols != NULL)
+									{
+										flag = true;
+										break;
+									}
+
+								}
+								if(flag)
+									continue;
+								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
+									{
+										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
+										if(old_priv!= privilege_maskInt || ((old_priv)&(~(privilege_maskInt))) != old_priv)
+											update_bbf_schema_entry(logical_schema, obj, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									}
+							}
+						}					
 						return;
 					}
 				}
@@ -3721,7 +3775,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				{
 					ObjectWithArgs  *ob = (ObjectWithArgs *) linitial(grant->objects);
 					ListCell   *lc;
-					ListCell	*lc1;
 					const char *logicalschema = NULL;
 					char *funcname = NULL;
 					const char *obj_type = NULL;
@@ -3749,8 +3802,10 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					 */
 					if (pstmt->stmt_len == 0 && list_length(grant->privileges) == 0)
 					{
-						if(check_bbf_schema_for_schema(logicalschema, "ALL", "execute"))
+						if(check_bbf_schema_for_schema(logicalschema, "ALL", 32))
+						{
 							return;
+						}
 						break;
 					}
 					/* If ALL PRIVILEGES is granted/revoked. */
@@ -3761,8 +3816,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							foreach(lc, grant->grantees)
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logicalschema, funcname, "execute", rol_spec->rolename))
-									add_entry_to_bbf_schema(logicalschema, funcname, "execute", rol_spec->rolename, obj_type);
+								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+									add_entry_to_bbf_schema(logicalschema, funcname, 32, rol_spec->rolename, obj_type);
+								else if (rol_spec->rolename != NULL)
+								{
+									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
+									if(old_priv!= 32 || ((old_priv)|(32)) != old_priv)
+										update_bbf_schema_entry(logicalschema, funcname, 32, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+								}
 							}
 							break;
 						}
@@ -3772,19 +3833,21 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
 								bool has_schema_perms = false;
-								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logicalschema, "ALL", "execute", rol_spec->rolename) && !has_schema_perms)
+								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logicalschema, "ALL", rol_spec->rolename) && !has_schema_perms)
 									has_schema_perms = true;
-								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logicalschema, funcname, "execute", rol_spec->rolename))
-									del_from_bbf_schema(logicalschema, funcname, "execute", rol_spec->rolename);
+								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+								{
+									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname,rol_spec->rolename);
+									if(old_priv!= 32 || ((old_priv)&(~(32))) != old_priv)
+										update_bbf_schema_entry(logicalschema, funcname, 32, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+								}
 								if (has_schema_perms)
 									return;
 							}
 							break;
 						}
 					}
-					foreach(lc1, grant->privileges)
-					{
-						AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+					
 						if (grant->is_grant)
 						{
 							/* Execute the GRANT statement. */
@@ -3799,8 +3862,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
 								/* Don't store a row in catalog, if permission is granted for column */
-								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logicalschema, funcname, ap->priv_name, rol_spec->rolename))
-									add_entry_to_bbf_schema(logicalschema, funcname, ap->priv_name, rol_spec->rolename, obj_type);
+								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+									add_entry_to_bbf_schema(logicalschema, funcname, privilege_maskInt, rol_spec->rolename, obj_type);
+								else if(rol_spec->rolename != NULL)
+								{
+									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
+									if(old_priv!= privilege_maskInt || ((old_priv)|(privilege_maskInt)) != old_priv)
+										update_bbf_schema_entry(logicalschema, funcname, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+								}
 							}
 						}
 						else
@@ -3812,7 +3881,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								* 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists. 
 								* 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
 								*/
-								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logicalschema, "ALL", ap->priv_name, rol_spec->rolename))
+								if ((rol_spec->rolename != NULL) && !check_bbf_schema_for_entry(logicalschema, "ALL", rol_spec->rolename))
 								{
 									/* Execute REVOKE statement. */
 									if (prev_ProcessUtility)
@@ -3822,11 +3891,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 										standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 																queryEnv, dest, qc);
 								}
-								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logicalschema, funcname, ap->priv_name, rol_spec->rolename))
-									del_from_bbf_schema(logicalschema, funcname, ap->priv_name, rol_spec->rolename);
+								if ((rol_spec->rolename != NULL) && check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+								{
+									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
+									if(old_priv!= privilege_maskInt || ((old_priv)&(~(privilege_maskInt))) != old_priv)
+										update_bbf_schema_entry(logicalschema, funcname, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+								}
 							}
 						}
-					}
 					return;
 				}
 			}

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3608,25 +3608,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				GrantStmt *grant = (GrantStmt *) parsetree;
 				char	   *dbname = get_cur_db_name();
 				const char *current_user = GetUserNameFromId(GetUserId(), false);
-				int16 privilege_maskInt = 0;
+				int16 privilege_maskInt = create_privilege_bitmask(grant->privileges, false);
 				ListCell   *lc1;
-				/* create integer bitmask for permissions*/
-				foreach(lc1, grant->privileges)
-				{
-					AccessPriv *ap = (AccessPriv *) lfirst(lc1);
-					if (!strcmp(ap->priv_name,"execute"))
-						privilege_maskInt |= 32;
-					if (!strcmp(ap->priv_name,"select"))
-						privilege_maskInt |= 16;
-					if (!strcmp(ap->priv_name,"insert"))
-						privilege_maskInt |= 8;
-					if (!strcmp(ap->priv_name,"update"))
-						privilege_maskInt |= 4;
-					if (!strcmp(ap->priv_name,"delete"))
-						privilege_maskInt |= 2;
-					if (!strcmp(ap->priv_name,"references"))
-						privilege_maskInt |= 1;
-				}
+
 				/* Ignore when GRANT statement has no specific named object. */
 				if (sql_dialect != SQL_DIALECT_TSQL || grant->targtype != ACL_TARGET_OBJECT)
 					break;
@@ -3655,17 +3639,19 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								foreach(lc, grant->grantees)
 								{
 									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && !check_bbf_schema_for_entry(logical_schema, obj,rol_spec->rolename))
+									if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 									{
-										add_entry_to_bbf_schema(logical_schema, obj, 31, rol_spec->rolename, obj_type);
+										if (!check_bbf_schema_for_entry(logical_schema, obj,rol_spec->rolename))
+										{
+											add_entry_to_bbf_schema(logical_schema, obj, 31, rol_spec->rolename, obj_type);
+										}
+										else
+										{
+											int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
+											if(old_priv!= 31 || (old_priv|(31)) != old_priv)
+												update_bbf_schema_privilege(logical_schema, obj, 31, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+										}
 									}
-									else if(rol_spec->rolename != NULL && (strcmp(rol_spec->rolename, "public") != 0))
-									{
-										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
-										if(old_priv!= 31 || (old_priv|(31)) != old_priv)
-											update_bbf_schema_entry(logical_schema, obj, 31, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
-									}
-									
 								}
 								break;
 							}
@@ -3675,13 +3661,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								{
 									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
 									bool has_schema_perms = false;
-									if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && check_bbf_schema_for_entry(logical_schema, "ALL", rol_spec->rolename) && !has_schema_perms)
-										has_schema_perms = true;
-									if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
+									if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 									{
-										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
-										if(old_priv!= 31 || ((old_priv)&(~(31))) != old_priv)
-											update_bbf_schema_entry(logical_schema, obj, 31, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+										if (check_bbf_schema_for_entry(logical_schema, "ALL", rol_spec->rolename) && !has_schema_perms)
+											has_schema_perms = true;
+										if (check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
+										{
+											int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
+											if(old_priv!= 31 || ((old_priv)&(~(31))) != old_priv)
+												update_bbf_schema_privilege(logical_schema, obj, 31, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+										}
 									}
 									if (has_schema_perms)
 										return;
@@ -3689,7 +3678,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								break;
 							}
 						}
-						
 						if (grant->is_grant)
 						{
 							/*
@@ -3718,13 +3706,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								}
 								if(flag)
 									break;
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && !check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
-									add_entry_to_bbf_schema(logical_schema, obj, privilege_maskInt, rol_spec->rolename, obj_type);
-								else if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
+								if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 								{
-									int16 old_priv = get_bbf_schema_privilege(logical_schema, obj, rol_spec->rolename);
-									if(old_priv!= privilege_maskInt || ((old_priv)|(privilege_maskInt)) != old_priv)
-										update_bbf_schema_entry(logical_schema, obj, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									if (!check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
+										add_entry_to_bbf_schema(logical_schema, obj, privilege_maskInt, rol_spec->rolename, obj_type);
+									else
+									{
+										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj, rol_spec->rolename);
+										if(old_priv!= privilege_maskInt || ((old_priv)|(privilege_maskInt)) != old_priv)
+											update_bbf_schema_privilege(logical_schema, obj, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									}
 								}
 							}
 						}
@@ -3734,11 +3725,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
 								bool flag = false;
+								bool role_is_public = false;
+								if ((rol_spec->rolename == NULL) || (strcmp(rol_spec->rolename, "public") == 0))
+										role_is_public = true;
 								/*
-								* 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists.
-								* 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
-								*/
-								if ((logical_schema != NULL) && (rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && !check_bbf_schema_for_entry(logical_schema, "ALL", rol_spec->rolename))
+								 * 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists.
+								 * 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
+								 */
+								if ((logical_schema != NULL) && !role_is_public && !check_bbf_schema_for_entry(logical_schema, "ALL", rol_spec->rolename))
 								{
 									if (prev_ProcessUtility)
 										prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
@@ -3758,12 +3752,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								}
 								if(flag)
 									continue;
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
-									{
-										int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
-										if(old_priv!= privilege_maskInt || ((old_priv)&(~(privilege_maskInt))) != old_priv)
-											update_bbf_schema_entry(logical_schema, obj, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
-									}
+								if (!role_is_public && check_bbf_schema_for_entry(logical_schema, obj, rol_spec->rolename))
+								{
+									int16 old_priv = get_bbf_schema_privilege(logical_schema, obj,rol_spec->rolename);
+									if(old_priv!= privilege_maskInt || ((old_priv)&(~(privilege_maskInt))) != old_priv)
+										update_bbf_schema_privilege(logical_schema, obj, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+								}
 							}
 						}					
 						return;
@@ -3814,13 +3808,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							foreach(lc, grant->grantees)
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) &&  !check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
-									add_entry_to_bbf_schema(logicalschema, funcname, 32, rol_spec->rolename, obj_type);
-								else if (rol_spec->rolename != NULL && (strcmp(rol_spec->rolename, "public") != 0))
+								if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 								{
-									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
-									if(old_priv!= 32 || ((old_priv)|(32)) != old_priv)
-										update_bbf_schema_entry(logicalschema, funcname, 32, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									if (!check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+										add_entry_to_bbf_schema(logicalschema, funcname, 32, rol_spec->rolename, obj_type);
+									else
+									{
+										int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
+										if(old_priv!= 32 || ((old_priv)|(32)) != old_priv)
+											update_bbf_schema_privilege(logicalschema, funcname, 32, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									}
 								}
 							}
 							break;
@@ -3831,13 +3828,17 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
 								bool has_schema_perms = false;
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && check_bbf_schema_for_entry(logicalschema, "ALL", rol_spec->rolename) && !has_schema_perms)
-									has_schema_perms = true;
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+								if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 								{
-									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname,rol_spec->rolename);
-									if(old_priv!= 32 || ((old_priv)&(~(32))) != old_priv)
-										update_bbf_schema_entry(logicalschema, funcname, 32, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									if (check_bbf_schema_for_entry(logicalschema, "ALL", rol_spec->rolename) && !has_schema_perms)
+										has_schema_perms = true;
+
+									if (check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+									{
+										int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname,rol_spec->rolename);
+										if(old_priv!= 32 || ((old_priv)&(~(32))) != old_priv)
+											update_bbf_schema_privilege(logicalschema, funcname, 32, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+									}
 								}
 								if (has_schema_perms)
 									return;
@@ -3846,40 +3847,45 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 					}
 					
-						if (grant->is_grant)
+					if (grant->is_grant)
+					{
+						/* Execute the GRANT statement. */
+						if (prev_ProcessUtility)
+							prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+								queryEnv, dest, qc);
+						else
+							standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+								queryEnv, dest, qc);
+						/* Add entry to the catalog if it doesn't exist already. */
+						foreach(lc, grant->grantees)
 						{
-							/* Execute the GRANT statement. */
-							if (prev_ProcessUtility)
-								prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-									queryEnv, dest, qc);
-							else
-								standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-									queryEnv, dest, qc);
-							/* Add entry to the catalog if it doesn't exist already. */
-							foreach(lc, grant->grantees)
+							RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+							/* Don't store a row in catalog, if permission is granted for column */
+							if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 							{
-								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-								/* Don't store a row in catalog, if permission is granted for column */
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && !check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+								if (!check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
 									add_entry_to_bbf_schema(logicalschema, funcname, privilege_maskInt, rol_spec->rolename, obj_type);
-								else if((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
+								else
 								{
 									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
 									if(old_priv!= privilege_maskInt || ((old_priv)|(privilege_maskInt)) != old_priv)
-										update_bbf_schema_entry(logicalschema, funcname, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+										update_bbf_schema_privilege(logicalschema, funcname, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
 								}
 							}
 						}
-						else
+					}
+					else
+					{
+						foreach(lc, grant->grantees)
 						{
-							foreach(lc, grant->grantees)
+							RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+							/*
+							 * 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists.
+							 * 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
+							 */
+							if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0))
 							{
-								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-								/* 
-								* 1. If GRANT on schema does not exist, execute REVOKE statement and remove the catalog entry if exists. 
-								* 2. If GRANT on schema exist, only remove the entry from the catalog if exists.
-								*/
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && !check_bbf_schema_for_entry(logicalschema, "ALL", rol_spec->rolename))
+								if (!check_bbf_schema_for_entry(logicalschema, "ALL", rol_spec->rolename))
 								{
 									/* Execute REVOKE statement. */
 									if (prev_ProcessUtility)
@@ -3889,14 +3895,15 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 										standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 																queryEnv, dest, qc);
 								}
-								if ((rol_spec->rolename != NULL) && (strcmp(rol_spec->rolename, "public") != 0) && check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
+								if (check_bbf_schema_for_entry(logicalschema, funcname, rol_spec->rolename))
 								{
 									int16 old_priv = get_bbf_schema_privilege(logicalschema, funcname, rol_spec->rolename);
 									if(old_priv!= privilege_maskInt || ((old_priv)&(~(privilege_maskInt))) != old_priv)
-										update_bbf_schema_entry(logicalschema, funcname, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
+										update_bbf_schema_privilege(logicalschema, funcname, privilege_maskInt, old_priv, rol_spec->rolename, obj_type, grant->is_grant);
 								}
 							}
 						}
+					}
 					return;
 				}
 			}

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1914,6 +1914,14 @@ extern int	insert_bulk_rows_per_batch;
 extern int	insert_bulk_kilobytes_per_batch;
 extern bool insert_bulk_keep_nulls;
 
+/* Privilege Bits for GRANT SCHEMA */
+#define PRIVILEGE_EXECUTE 32
+#define PRIVILEGE_SELECT 16
+#define PRIVILEGE_INSERT 8
+#define PRIVILEGE_UPDATE 4
+#define PRIVILEGE_DELETE 2
+#define PRIVILEGE_REFERENCES 1
+
 /**********************************************************************
  * Function declarations
  **********************************************************************/
@@ -2119,6 +2127,7 @@ extern bool pltsql_createFunction(ParseState *pstate, PlannedStmt *pstmt, const 
                           ParamListInfo params);
 extern Oid get_sys_varcharoid(void);
 extern Oid get_sysadmin_oid(void);
+extern int16 create_privilege_bitmask(const List *l, bool grant_schema_stmt);
 
 typedef struct
 {

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -2000,3 +2000,35 @@ char
 		appendStringInfo(&query, "\"%s\".\"%s\"", schema_name, index_name);
 	return query.data;
 }
+
+/* Creates integer bitmask for permissions to be referenced in the catalog. */
+int16
+create_privilege_bitmask(const List *l, bool grant_schema_stmt)
+{
+	int16 privilege_maskInt = 0;
+	ListCell   *lc;
+	foreach(lc, l)
+	{
+		char	*priv_name;
+		if (grant_schema_stmt)
+			priv_name = (char *) lfirst(lc);
+		else
+		{
+			AccessPriv *ap = (AccessPriv *) lfirst(lc);
+			priv_name = ap->priv_name;
+		}
+		if (!strcmp(priv_name,"execute"))
+			privilege_maskInt |= PRIVILEGE_EXECUTE;
+		else if (!strcmp(priv_name,"select"))
+			privilege_maskInt |= PRIVILEGE_SELECT;
+		else if (!strcmp(priv_name,"insert"))
+			privilege_maskInt |= PRIVILEGE_INSERT;
+		else if (!strcmp(priv_name,"update"))
+			privilege_maskInt |= PRIVILEGE_UPDATE;
+		else if (!strcmp(priv_name,"delete"))
+			privilege_maskInt |= PRIVILEGE_DELETE;
+		else if (!strcmp(priv_name,"references"))
+			privilege_maskInt |= PRIVILEGE_REFERENCES;
+	}
+	return privilege_maskInt;
+}

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1037,6 +1037,10 @@ update_GrantStmt(Node *n, const char *object, const char *obj_schema, const char
 	if (grantee && stmt->grantees)
 	{
 		RoleSpec   *tmp = (RoleSpec *) llast(stmt->grantees);
+		if (strcmp(grantee, "public") == 0)
+		{
+			tmp->roletype = ROLESPEC_PUBLIC;
+		}
 		tmp->rolename = pstrdup(grantee);
 	}
 

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -25,6 +25,7 @@
 #include "parser/gramparse.h"
 #include "hooks.h"
 #include "tcop/utility.h"
+#include "session.h"
 
 #include "multidb.h"
 
@@ -1036,7 +1037,6 @@ update_GrantStmt(Node *n, const char *object, const char *obj_schema, const char
 	if (grantee && stmt->grantees)
 	{
 		RoleSpec   *tmp = (RoleSpec *) llast(stmt->grantees);
-
 		tmp->rolename = pstrdup(grantee);
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5527,6 +5527,11 @@ makeGrantdbStatement(TSqlParser::Security_statementContext *ctx)
 						char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
 						grantee_list = lappend(grantee_list, grantee_name);
 					}
+					if (prin->PUBLIC())
+					{
+						char *grantee_name = (char *)"public";
+						grantee_list = lappend(grantee_list, grantee_name);
+					}
 				}
 				result->grantees = grantee_list;
 				return (PLtsql_stmt *) result;
@@ -5553,6 +5558,11 @@ makeGrantdbStatement(TSqlParser::Security_statementContext *ctx)
 					{
 						std::string id_str = ::getFullText(prin->id());
 						char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
+						grantee_list = lappend(grantee_list, grantee_name);
+					}
+					if (prin->PUBLIC())
+					{
+						char *grantee_name = (char *)"public";
 						grantee_list = lappend(grantee_list, grantee_name);
 					}
 				}
@@ -5583,6 +5593,11 @@ makeGrantdbStatement(TSqlParser::Security_statementContext *ctx)
 				{
 					std::string id_str = ::getFullText(prin->id());
 					char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
+					grantee_list = lappend(grantee_list, grantee_name);
+				}
+				if (prin->PUBLIC())
+				{
+					char *grantee_name = (char *)"public";
 					grantee_list = lappend(grantee_list, grantee_name);
 				}
 			}
@@ -5635,6 +5650,11 @@ makeGrantdbStatement(TSqlParser::Security_statementContext *ctx)
 				{
 					std::string id_str = ::getFullText(prin->id());
 					char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
+					grantee_list = lappend(grantee_list, grantee_name);
+				}
+				if (prin->PUBLIC())
+				{
+					char *grantee_name = (char *)"public";
 					grantee_list = lappend(grantee_list, grantee_name);
 				}
 			}

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1704,7 +1704,8 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedGrantStmt(TSqlParser::Gran
 				continue;
 			else
 			{
-				unsupported_feature = "GRANT PERMISSION " + perm->getText();
+				unsupported_feature = "GRANT PERMISSION " + ::getFullText(single_perm);
+				std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 				handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(perm));
 			}
 		}
@@ -1719,6 +1720,7 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedGrantStmt(TSqlParser::Gran
 		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{
 			unsupported_feature = "GRANT ON " + obj_type->getText();
+			std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 			handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(obj_type));
 		}
 	}
@@ -1798,7 +1800,8 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Rev
 				continue;
 			else
 			{
-				unsupported_feature = "REVOKE PERMISSION " + perm->getText();
+				unsupported_feature = "REVOKE PERMISSION " + ::getFullText(single_perm);
+				std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 				handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(perm));
 			}
 		}
@@ -1813,6 +1816,7 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Rev
 		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{
 			unsupported_feature = "REVOKE ON " + obj_type->getText();
+			std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 			handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(obj_type));
 		}
 	}

--- a/test/JDBC/expected/BABEL-GRANT.out
+++ b/test/JDBC/expected/BABEL-GRANT.out
@@ -174,28 +174,56 @@ GO
 REVOKE SELECT ON SCHEMA::scm FROM guest;
 GO
 
-GRANT SHOWPLAN ON OBJECT::t1 TO guest;  -- unsupported permission
+GRANT showplan ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: 'GRANT PERMISSION SHOWPLAN' is not currently supported in Babelfish)~~
 
 
-REVOKE SHOWPLAN ON OBJECT::t2 TO alogin;  -- unsupported permission
+REVOKE showplan ON OBJECT::t2 TO alogin;  -- unsupported permission
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: 'REVOKE PERMISSION SHOWPLAN' is not currently supported in Babelfish)~~
 
 
-GRANT ALL ON SCHEMA::scm TO guest;  -- unsupported class
+GRANT create table ON OBJECT::t1 TO guest;  -- unsupported permission
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'GRANT PERMISSION CREATE TABLE' is not currently supported in Babelfish)~~
+
+
+REVOKE create table ON OBJECT::t2 TO alogin;  -- unsupported permission
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'REVOKE PERMISSION CREATE TABLE' is not currently supported in Babelfish)~~
+
+
+GRANT SELECT ON table::t1 TO guest; -- unsupported object
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'GRANT ON TABLE' is not currently supported in Babelfish)~~
+
+
+REVOKE SELECT ON table::t1 FROM guest; -- unsupported object
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'REVOKE ON TABLE' is not currently supported in Babelfish)~~
+
+
+GRANT ALL ON SCHEMA::scm TO guest;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The all permission has been deprecated and is not available for this class of entity.)~~
 
 
-REVOKE ALL ON SCHEMA::scm TO guest; -- unsupported class
+REVOKE ALL ON SCHEMA::scm TO guest;
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/BABEL-GRANT.out
+++ b/test/JDBC/expected/BABEL-GRANT.out
@@ -106,19 +106,19 @@ GO
 REVOKE ALL ON OBJECT::t1 TO guest;
 GO
 
-REVOKE ALL ON OBJECT::seq_tinyint FROM guest;
+REVOKE ALL ON OBJECT::seq_tinyint TO guest;
 GO
 
-REVOKE ALL ON OBJECT::my_view FROM guest;
+REVOKE ALL ON OBJECT::my_view TO guest;
 GO
 
-REVOKE ALL ON OBJECT::my_func FROM guest;
+REVOKE ALL ON OBJECT::my_func TO guest;
 GO
 
-REVOKE ALL ON OBJECT::my_proc FROM guest;
+REVOKE ALL ON OBJECT::my_proc TO guest;
 GO
 
-REVOKE ALL ON OBJECT::type_int FROM guest;
+REVOKE ALL ON OBJECT::type_int TO guest;
 GO
 
 REVOKE ALL ON OBJECT::my_func FROM PUBLIC;
@@ -133,7 +133,7 @@ GO
 GRANT SELECT ON t1 (a) TO guest;
 GO
 
-REVOKE SELECT ON t1 (a) FROM guest;
+REVOKE SELECT ON t1 (a) TO guest;
 GO
 
 GRANT SELECT (a) ON t1 TO guest WITH GRANT OPTION;
@@ -145,7 +145,7 @@ GO
 GRANT UPDATE ON t1 (a) TO guest;
 GO
 
-REVOKE UPDATE ON t1 (a) FROM guest;
+REVOKE UPDATE ON t1 (a) TO guest;
 GO
 
 GRANT UPDATE (a) ON t1 TO guest WITH GRANT OPTION;
@@ -181,7 +181,7 @@ GO
 ~~ERROR (Message: 'GRANT PERMISSION SHOWPLAN' is not currently supported in Babelfish)~~
 
 
-REVOKE showplan ON OBJECT::t2 FROM alogin;  -- unsupported permission
+REVOKE showplan ON OBJECT::t2 TO alogin;  -- unsupported permission
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -249,7 +249,7 @@ GO
 REVOKE EXECUTE ON my_func FROM PUBLIC;
 GO
 
-REVOKE ALL ON OBJECT::t1 FROM guest AS superuser;
+REVOKE ALL ON OBJECT::t1 TO guest AS superuser;
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/BABEL-GRANT.out
+++ b/test/JDBC/expected/BABEL-GRANT.out
@@ -106,19 +106,19 @@ GO
 REVOKE ALL ON OBJECT::t1 TO guest;
 GO
 
-REVOKE ALL ON OBJECT::seq_tinyint TO guest;
+REVOKE ALL ON OBJECT::seq_tinyint FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::my_view TO guest;
+REVOKE ALL ON OBJECT::my_view FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::my_func TO guest;
+REVOKE ALL ON OBJECT::my_func FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::my_proc TO guest;
+REVOKE ALL ON OBJECT::my_proc FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::type_int TO guest;
+REVOKE ALL ON OBJECT::type_int FROM guest;
 GO
 
 REVOKE ALL ON OBJECT::my_func FROM PUBLIC;
@@ -133,7 +133,7 @@ GO
 GRANT SELECT ON t1 (a) TO guest;
 GO
 
-REVOKE SELECT ON t1 (a) TO guest;
+REVOKE SELECT ON t1 (a) FROM guest;
 GO
 
 GRANT SELECT (a) ON t1 TO guest WITH GRANT OPTION;
@@ -145,7 +145,7 @@ GO
 GRANT UPDATE ON t1 (a) TO guest;
 GO
 
-REVOKE UPDATE ON t1 (a) TO guest;
+REVOKE UPDATE ON t1 (a) FROM guest;
 GO
 
 GRANT UPDATE (a) ON t1 TO guest WITH GRANT OPTION;
@@ -181,7 +181,7 @@ GO
 ~~ERROR (Message: 'GRANT PERMISSION SHOWPLAN' is not currently supported in Babelfish)~~
 
 
-REVOKE showplan ON OBJECT::t2 TO alogin;  -- unsupported permission
+REVOKE showplan ON OBJECT::t2 FROM alogin;  -- unsupported permission
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -195,7 +195,7 @@ GO
 ~~ERROR (Message: 'GRANT PERMISSION CREATE TABLE' is not currently supported in Babelfish)~~
 
 
-REVOKE create table ON OBJECT::t2 TO alogin;  -- unsupported permission
+REVOKE create table ON OBJECT::t2 FROM alogin;  -- unsupported permission
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -223,7 +223,7 @@ GO
 ~~ERROR (Message: The all permission has been deprecated and is not available for this class of entity.)~~
 
 
-REVOKE ALL ON SCHEMA::scm TO guest;
+REVOKE ALL ON SCHEMA::scm FROM guest;
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -249,7 +249,7 @@ GO
 REVOKE EXECUTE ON my_func FROM PUBLIC;
 GO
 
-REVOKE ALL ON OBJECT::t1 TO guest AS superuser;
+REVOKE ALL ON OBJECT::t1 FROM guest AS superuser;
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -135,7 +135,8 @@ grant execute on babel_4344_p1 to babel_4344_u1;
 go
 grant execute on babel_4344_s1.babel_4344_p1 to babel_4344_u1;
 go
-grant execute on babel_4344_f1 to babel_4344_u1;
+-- Mixed case
+grant Execute on Babel_4344_F1 to babel_4344_u1;
 go
 grant execute on babel_4344_s1.babel_4344_f1 to babel_4344_u1;
 go
@@ -154,6 +155,18 @@ go
 
 grant select on schema::babel_4344_s2 to guest; -- should pass 
 go
+grant select on schema::"" to guest; -- should fail 
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
+
+grant select on schema::[] to guest; -- should fail 
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
+
 
 -- tsql user=babel_4344_l1 password=12345678
 -- User has OBJECT privileges, should be accessible.
@@ -242,7 +255,7 @@ grant select on schema::babel_4344_s1 to babel_4344_u1; -- should fail
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot find the schema "babel_4344_s1", because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
 
 use master;
 go

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -51,10 +51,39 @@ go
 CREATE FUNCTION babel_4344_s1.babel_4344_f1() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
 go
 
+grant select on schema::babel_4344_s1 to public;
+go
+
 -- tsql user=babel_4344_l1 password=12345678 
 use babel_4344_d1;
 go
 
+-- User has select privileges, tables and views be accessible
+select * from babel_4344_s1.babel_4344_t1
+go
+~~START~~
+int
+~~END~~
+
+select * from babel_4344_s1.babel_4344_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+use master;
+go
+
+-- tsql
+use babel_4344_d1;
+go
+revoke select on schema::babel_4344_s1 from public;
+go
+
+-- tsql user=babel_4344_l1 password=12345678 
+use babel_4344_d1;
+go
 -- User doesn't have any privileges, objects should not be accessible
 select * from babel_4344_t1;
 go

--- a/test/JDBC/input/BABEL-GRANT.sql
+++ b/test/JDBC/input/BABEL-GRANT.sql
@@ -164,16 +164,28 @@ GO
 REVOKE SELECT ON SCHEMA::scm FROM guest;
 GO
 
-GRANT SHOWPLAN ON OBJECT::t1 TO guest;  -- unsupported permission
+GRANT showplan ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 
-REVOKE SHOWPLAN ON OBJECT::t2 TO alogin;  -- unsupported permission
+REVOKE showplan ON OBJECT::t2 TO alogin;  -- unsupported permission
 GO
 
-GRANT ALL ON SCHEMA::scm TO guest;  -- unsupported class
+GRANT create table ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 
-REVOKE ALL ON SCHEMA::scm TO guest; -- unsupported class
+REVOKE create table ON OBJECT::t2 TO alogin;  -- unsupported permission
+GO
+
+GRANT SELECT ON table::t1 TO guest; -- unsupported object
+GO
+
+REVOKE SELECT ON table::t1 FROM guest; -- unsupported object
+GO
+
+GRANT ALL ON SCHEMA::scm TO guest;
+GO
+
+REVOKE ALL ON SCHEMA::scm TO guest;
 GO
 
 GRANT ALL ON OBJECT::t1 TO guest WITH GRANT OPTION AS superuser;

--- a/test/JDBC/input/BABEL-GRANT.sql
+++ b/test/JDBC/input/BABEL-GRANT.sql
@@ -104,19 +104,19 @@ GO
 REVOKE ALL ON OBJECT::t1 TO guest;
 GO
 
-REVOKE ALL ON OBJECT::seq_tinyint FROM guest;
+REVOKE ALL ON OBJECT::seq_tinyint TO guest;
 GO
 
-REVOKE ALL ON OBJECT::my_view FROM guest;
+REVOKE ALL ON OBJECT::my_view TO guest;
 GO
 
-REVOKE ALL ON OBJECT::my_func FROM guest;
+REVOKE ALL ON OBJECT::my_func TO guest;
 GO
 
-REVOKE ALL ON OBJECT::my_proc FROM guest;
+REVOKE ALL ON OBJECT::my_proc TO guest;
 GO
 
-REVOKE ALL ON OBJECT::type_int FROM guest;
+REVOKE ALL ON OBJECT::type_int TO guest;
 GO
 
 REVOKE ALL ON OBJECT::my_func FROM PUBLIC;
@@ -131,7 +131,7 @@ GO
 GRANT SELECT ON t1 (a) TO guest;
 GO
 
-REVOKE SELECT ON t1 (a) FROM guest;
+REVOKE SELECT ON t1 (a) TO guest;
 GO
 
 GRANT SELECT (a) ON t1 TO guest WITH GRANT OPTION;
@@ -143,7 +143,7 @@ GO
 GRANT UPDATE ON t1 (a) TO guest;
 GO
 
-REVOKE UPDATE ON t1 (a) FROM guest;
+REVOKE UPDATE ON t1 (a) TO guest;
 GO
 
 GRANT UPDATE (a) ON t1 TO guest WITH GRANT OPTION;
@@ -167,7 +167,7 @@ GO
 GRANT showplan ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 
-REVOKE showplan ON OBJECT::t2 FROM alogin;  -- unsupported permission
+REVOKE showplan ON OBJECT::t2 TO alogin;  -- unsupported permission
 GO
 
 GRANT create table ON OBJECT::t1 TO guest;  -- unsupported permission
@@ -203,7 +203,7 @@ GO
 REVOKE EXECUTE ON my_func FROM PUBLIC;
 GO
 
-REVOKE ALL ON OBJECT::t1 FROM guest AS superuser;
+REVOKE ALL ON OBJECT::t1 TO guest AS superuser;
 GO
 
 ---

--- a/test/JDBC/input/BABEL-GRANT.sql
+++ b/test/JDBC/input/BABEL-GRANT.sql
@@ -104,19 +104,19 @@ GO
 REVOKE ALL ON OBJECT::t1 TO guest;
 GO
 
-REVOKE ALL ON OBJECT::seq_tinyint TO guest;
+REVOKE ALL ON OBJECT::seq_tinyint FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::my_view TO guest;
+REVOKE ALL ON OBJECT::my_view FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::my_func TO guest;
+REVOKE ALL ON OBJECT::my_func FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::my_proc TO guest;
+REVOKE ALL ON OBJECT::my_proc FROM guest;
 GO
 
-REVOKE ALL ON OBJECT::type_int TO guest;
+REVOKE ALL ON OBJECT::type_int FROM guest;
 GO
 
 REVOKE ALL ON OBJECT::my_func FROM PUBLIC;
@@ -131,7 +131,7 @@ GO
 GRANT SELECT ON t1 (a) TO guest;
 GO
 
-REVOKE SELECT ON t1 (a) TO guest;
+REVOKE SELECT ON t1 (a) FROM guest;
 GO
 
 GRANT SELECT (a) ON t1 TO guest WITH GRANT OPTION;
@@ -143,7 +143,7 @@ GO
 GRANT UPDATE ON t1 (a) TO guest;
 GO
 
-REVOKE UPDATE ON t1 (a) TO guest;
+REVOKE UPDATE ON t1 (a) FROM guest;
 GO
 
 GRANT UPDATE (a) ON t1 TO guest WITH GRANT OPTION;
@@ -167,13 +167,13 @@ GO
 GRANT showplan ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 
-REVOKE showplan ON OBJECT::t2 TO alogin;  -- unsupported permission
+REVOKE showplan ON OBJECT::t2 FROM alogin;  -- unsupported permission
 GO
 
 GRANT create table ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 
-REVOKE create table ON OBJECT::t2 TO alogin;  -- unsupported permission
+REVOKE create table ON OBJECT::t2 FROM alogin;  -- unsupported permission
 GO
 
 GRANT SELECT ON table::t1 TO guest; -- unsupported object
@@ -185,7 +185,7 @@ GO
 GRANT ALL ON SCHEMA::scm TO guest;
 GO
 
-REVOKE ALL ON SCHEMA::scm TO guest;
+REVOKE ALL ON SCHEMA::scm FROM guest;
 GO
 
 GRANT ALL ON OBJECT::t1 TO guest WITH GRANT OPTION AS superuser;
@@ -203,7 +203,7 @@ GO
 REVOKE EXECUTE ON my_func FROM PUBLIC;
 GO
 
-REVOKE ALL ON OBJECT::t1 TO guest AS superuser;
+REVOKE ALL ON OBJECT::t1 FROM guest AS superuser;
 GO
 
 ---

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -51,10 +51,30 @@ go
 CREATE FUNCTION babel_4344_s1.babel_4344_f1() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
 go
 
+grant select on schema::babel_4344_s1 to public;
+go
+
 -- tsql user=babel_4344_l1 password=12345678 
 use babel_4344_d1;
 go
 
+-- User has select privileges, tables and views be accessible
+select * from babel_4344_s1.babel_4344_t1
+go
+select * from babel_4344_s1.babel_4344_v1;
+go
+use master;
+go
+
+-- tsql
+use babel_4344_d1;
+go
+revoke select on schema::babel_4344_s1 from public;
+go
+
+-- tsql user=babel_4344_l1 password=12345678 
+use babel_4344_d1;
+go
 -- User doesn't have any privileges, objects should not be accessible
 select * from babel_4344_t1;
 go

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -99,7 +99,8 @@ grant execute on babel_4344_p1 to babel_4344_u1;
 go
 grant execute on babel_4344_s1.babel_4344_p1 to babel_4344_u1;
 go
-grant execute on babel_4344_f1 to babel_4344_u1;
+-- Mixed case
+grant Execute on Babel_4344_F1 to babel_4344_u1;
 go
 grant execute on babel_4344_s1.babel_4344_f1 to babel_4344_u1;
 go
@@ -109,6 +110,10 @@ go
 grant select on schema::babel_4344_s2 to jdbc_user; -- should fail
 go
 grant select on schema::babel_4344_s2 to guest; -- should pass 
+go
+grant select on schema::"" to guest; -- should fail 
+go
+grant select on schema::[] to guest; -- should fail 
 go
 
 -- tsql user=babel_4344_l1 password=12345678


### PR DESCRIPTION
### Description
Bug fixes and performance overhead reduction for GRANT .. ON SCHEMA

1. Server crash when using empty bracketed name.  `schema::[]`
2. Server crash when using empty quoted identifier. `schema::""`
3. When granting permission to yourself, we need a different error message.
4. Error message in not-supported multi-keyword permission should (i) be in uppercase (ii) have a space between keywords
5. Not-supported object type in error message should be in uppercase
6. Specified collation for column names using NAME datatype
7. Merged the permissions in a single column instead of having multiple rows for each permission.
8. GRANT ON SCHEMA:: TO PUBLIC does not take effect

### Issues Resolved
JIRA: BABEL-4344
Co-authored-by: Anju Bharti
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based - Added**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).