### PR TITLE
Fix test output plan verification with SHOWPLAN_ALL (2_X)

### DIFF
--- a/test/JDBC/expected/BABEL-4281.out
+++ b/test/JDBC/expected/BABEL-4281.out
@@ -51,40 +51,37 @@ off
 ~~END~~
 
 
-SET BABELFISH_STATISTICS PROFILE ON
+SET BABELFISH_SHOWPLAN_ALL ON
 GO
 
+select a, count(*) from t_babel4281 group by a order by 2; -- should not crash
+GO
+~~START~~
+text
+Query Text: select a, count(*) from t_babel4281 group by a order by 2
+Sort
+  Sort Key: (count(*)) NULLS FIRST
+  ->  Finalize HashAggregate
+        Group Key: a
+        ->  Gather
+              Workers Planned: 2
+              ->  Partial HashAggregate
+                    Group Key: a
+                    ->  Parallel Seq Scan on t_babel4281
+~~END~~
+
+
+-- set configurations back
+SET BABELFISH_SHOWPLAN_ALL OFF
+GO
+
+-- Verify Output
 select a, count(*) from t_babel4281 group by a order by 2; -- should not crash
 GO
 ~~START~~
 int#!#int
 ~~END~~
 
-~~START~~
-text
-Query Text: select a, count(*) from t_babel4281 group by a order by 2
-Sort (actual rows=0 loops=1)
-  Sort Key: (count(*)) NULLS FIRST
-  Sort Method: quicksort  Memory: 25kB
-  ->  Finalize HashAggregate (actual rows=0 loops=1)
-        Group Key: a
-        Batches: 1  Memory Usage: 40kB
-        ->  Gather (actual rows=0 loops=1)
-              Workers Planned: 2
-              Workers Launched: 2
-              ->  Partial HashAggregate (actual rows=0 loops=3)
-                    Group Key: a
-                    Batches: 1  Memory Usage: 40kB
-                    Worker 0:  Batches: 1  Memory Usage: 40kB
-                    Worker 1:  Batches: 1  Memory Usage: 40kB
-                    ->  Parallel Seq Scan on t_babel4281 (actual rows=0 loops=3)
-~~END~~
-
-
-
--- set configurations back
-SET BABELFISH_STATISTICS PROFILE OFF
-GO
 
 select set_config('babelfishpg_tsql.explain_timing', 'on', false);
 GO

--- a/test/JDBC/input/BABEL-4281.sql
+++ b/test/JDBC/input/BABEL-4281.sql
@@ -21,15 +21,18 @@ GO
 select set_config('babelfishpg_tsql.explain_costs', 'off', false);
 GO
 
-SET BABELFISH_STATISTICS PROFILE ON
+SET BABELFISH_SHOWPLAN_ALL ON
 GO
 
 select a, count(*) from t_babel4281 group by a order by 2; -- should not crash
 GO
 
-
 -- set configurations back
-SET BABELFISH_STATISTICS PROFILE OFF
+SET BABELFISH_SHOWPLAN_ALL OFF
+GO
+
+-- Verify Output
+select a, count(*) from t_babel4281 group by a order by 2; -- should not crash
 GO
 
 select set_config('babelfishpg_tsql.explain_timing', 'on', false);


### PR DESCRIPTION
### Description
Test BABEL-4281 gives the memory usage with STATISTICS PROFILE. During testing, this value can change, causing test failures. Switching to SHOWPLAN_ALL will give a plan without outputing memory usage.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).