### PR TITLE
Fix the remaining issues about default keyword in proc/func call

### DIFF
--- a/contrib/babelfishpg_tds/error_mapping.txt
+++ b/contrib/babelfishpg_tds/error_mapping.txt
@@ -81,6 +81,7 @@ XX000 ERRCODE_INTERNAL_ERROR	"CREATE FUNCTION failed because a column name is no
 42883 ERRCODE_UNDEFINED_FUNCTION	"could not identify an equality operator for type %s"	SQL_ERROR_306	16
 42883 ERRCODE_UNDEFINED_FUNCTION	"could not identify an ordering operator for type %s"	SQL_ERROR_306	16
 42883 ERRCODE_UNDEFINED_FUNCTION	"%s %s expects parameter \"%s\", which was not supplied."	SQL_ERROR_201	16
+42883 ERRCODE_UNDEFINED_FUNCTION	"Procedure or function \'%s\' expects parameter \'%s\', which was not supplied."	SQL_ERROR_201	16
 42883 ERRCODE_UNDEFINED_FUNCTION	"%s %s has no parameters and arguments were supplied."	SQL_ERROR_8146	16
 42883 ERRCODE_UNDEFINED_FUNCTION	"%s %s has too many arguments specified."	SQL_ERROR_8144	16
 42883 ERRCODE_UNDEFINED_FUNCTION	"\"%s\" is not an parameter for %s %s."	SQL_ERROR_8145	16

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3702,7 +3702,7 @@ replace_pltsql_function_defaults(HeapTuple func_tuple, List *defaults, List *far
 					ret = lappend(ret, funcExpr);
 					has_default = true;
 				}
-				else
+				else if (proc_form->prokind == PROKIND_FUNCTION)
 				{
 					newArgs = lappend(newArgs, makeNullConst(proc_form->proargtypes.values[i], -1, InvalidOid));
 					for (j = 1; j < list_length(funcExpr->args); ++j)

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3729,9 +3729,9 @@ replace_pltsql_function_defaults(HeapTuple func_tuple, List *defaults, List *far
 			}
 			++i;
 		}
-		return ret;
-
 		ReleaseSysCache(bbffunctuple);
+
+		return ret;
 	}
 	else
 	{

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -94,6 +94,7 @@ static bool match_pltsql_func_call(HeapTuple proctup, int nargs, List *argnames,
 static ObjectAddress get_trigger_object_address(List *object, Relation *relp, bool missing_ok, bool object_from_input);
 Oid			get_tsql_trigger_oid(List *object, const char *tsql_trigger_name, bool object_from_input);
 static Node *transform_like_in_add_constraint(Node *node);
+static char** fetch_func_input_arg_names(HeapTuple func_tuple);
 
 /*****************************************
  * 			Analyzer Hooks
@@ -3566,13 +3567,15 @@ PlTsqlMatchNamedCall(HeapTuple proctup, int nargs, List *argnames,
 
 static int getDefaultPosition(const List *default_positions, const ListCell *def_idx, int argPosition)
 {
-	int currPosition = intVal((Node *) lfirst(def_idx));
+	int currPosition;
+	if (default_positions == NIL || def_idx == NULL)
+		return -1;
+	currPosition = intVal((Node *) lfirst(def_idx));
 	while (currPosition != argPosition)
 	{
 		def_idx = lnext(default_positions, def_idx);
 		if (def_idx == NULL)
 		{
-			elog(ERROR, "not enough default arguments");
 			return -1;
 		}
 		currPosition = intVal((Node *) lfirst(def_idx));
@@ -3581,10 +3584,40 @@ static int getDefaultPosition(const List *default_positions, const ListCell *def
 }
 
 /**
+ * @brief fetch the func input arg names
+ * 
+ * @param func_tuple or proc_tuple
+ * @return char** list of input arg names
+ */
+static char** fetch_func_input_arg_names(HeapTuple func_tuple)
+{
+	Datum proargnames;
+	Datum		proargmodes;
+	char**		arg_names;
+	bool 		isnull;
+
+	proargnames = SysCacheGetAttr(PROCNAMEARGSNSP, func_tuple,
+					Anum_pg_proc_proargnames,
+					&isnull);
+
+	proargmodes = SysCacheGetAttr(PROCNAMEARGSNSP, func_tuple,
+					Anum_pg_proc_proargmodes,
+					&isnull);
+
+	if (isnull)
+		proargmodes = PointerGetDatum(NULL);	/* just to be sure */
+
+	get_func_input_arg_names(proargnames,
+									proargmodes,
+									&arg_names);
+	return arg_names;
+}
+
+/**
  * @brief farg position default should get the corresponding default position value
  * 
  * @param func_tuple 
- * @param defaults 
+ * @param defaults can be NIL
  * @param fargs 
  * @return List* 
  */
@@ -3593,19 +3626,24 @@ replace_pltsql_function_defaults(HeapTuple func_tuple, List *defaults, List *far
 
 {
 	HeapTuple	bbffunctuple;
+	Form_pg_proc proc_form;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return fargs;
 
 	bbffunctuple = get_bbf_function_tuple_from_proctuple(func_tuple);
+	proc_form = (Form_pg_proc) GETSTRUCT(func_tuple);
 
-	if (HeapTupleIsValid(bbffunctuple)){
+	if (HeapTupleIsValid(bbffunctuple))
+	{
 		Datum		arg_default_positions;
 		bool		isnull;
 		char	   *str;
 		List	   *default_positions = NIL, *ret = NIL;
 		ListCell   *def_idx;
 		ListCell   *lc;
+		char	  **arg_names;
+
 		int		   position,i,j;
 
 		/* Fetch default positions */
@@ -3614,41 +3652,81 @@ replace_pltsql_function_defaults(HeapTuple func_tuple, List *defaults, List *far
 												Anum_bbf_function_ext_default_positions,
 												&isnull);
 
-		if (isnull)
-			elog(ERROR, "not enough default arguments");
+		if (!isnull)
+		{
+			str =TextDatumGetCString(arg_default_positions);
+			default_positions = castNode(List, stringToNode(str));
+			pfree(str);
 
-		str =TextDatumGetCString(arg_default_positions);
-		default_positions = castNode(List, stringToNode(str));
-		pfree(str);
-
-		def_idx = list_head(default_positions);
+			def_idx = list_head(default_positions);
+		}
+		else
+		{
+			default_positions = NIL;
+			def_idx = NULL;
+		}
 		i = 0;
 
 		foreach(lc, fargs)
 		{
+			bool has_default = false;
 			if (nodeTag((Node*)lfirst(lc)) == T_RelabelType &&
 				nodeTag(((RelabelType*)lfirst(lc))->arg) == T_SetToDefault)
 			{
 				position = getDefaultPosition(default_positions, def_idx, i);
-				ret = lappend(ret, list_nth(defaults, position));
-			}
-			else if (nodeTag((Node*)lfirst(lc)) == T_FuncExpr)
-			{
-				if(((FuncExpr*)lfirst(lc))->funcformat == COERCE_IMPLICIT_CAST &&
-					nodeTag(linitial(((FuncExpr*)lfirst(lc))->args)) == T_SetToDefault)
+				if (position >= 0)
 				{
+					ret = lappend(ret, list_nth(defaults, position));
+					has_default = true;
+				}
+				else if (proc_form->prokind == PROKIND_FUNCTION)
+				{
+					ret = lappend(ret, makeNullConst(proc_form->proargtypes.values[i], -1, InvalidOid));
+					has_default = true;
+				}
+			}
+			else if (nodeTag((Node*)lfirst(lc)) == T_FuncExpr && 
+			((FuncExpr*)lfirst(lc))->funcformat == COERCE_IMPLICIT_CAST &&
+					nodeTag(linitial(((FuncExpr*)lfirst(lc))->args)) == T_SetToDefault)
+			{
 				// We'll keep the implicit cast function when it needs implicit cast
-					FuncExpr *funcExpr = (FuncExpr*)lfirst(lc);
-					List *newArgs = NIL;
-					position = getDefaultPosition(default_positions, def_idx, i);
+				FuncExpr *funcExpr = (FuncExpr*)lfirst(lc);
+				List *newArgs = NIL;
+				position = getDefaultPosition(default_positions, def_idx, i);
+				if (position >= 0)
+				{
 					newArgs = lappend(newArgs, list_nth(defaults, position));
 					for (j = 1; j < list_length(funcExpr->args); ++j)
 						newArgs = lappend(newArgs, list_nth(funcExpr->args, j));
 					funcExpr->args = newArgs;
 					ret = lappend(ret, funcExpr);
+					has_default = true;
+				}
+				else
+				{
+					newArgs = lappend(newArgs, makeNullConst(proc_form->proargtypes.values[i], -1, InvalidOid));
+					for (j = 1; j < list_length(funcExpr->args); ++j)
+						newArgs = lappend(newArgs, list_nth(funcExpr->args, j));
+					funcExpr->args = newArgs;
+					ret = lappend(ret, funcExpr);
+					has_default = true;
 				}
 			}
-			else ret = lappend(ret, lfirst(lc));
+			else 
+			{
+				ret = lappend(ret, lfirst(lc));	
+				has_default = true;
+			}
+			if (!has_default)
+			{
+				arg_names = fetch_func_input_arg_names(func_tuple);
+				
+				if (proc_form->prokind == PROKIND_PROCEDURE)
+					ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_FUNCTION),
+						errmsg("Procedure or function \'%s\' expects parameter \'%s\', which was not supplied.",
+							NameStr(proc_form->proname), arg_names[i])));
+			}
 			++i;
 		}
 		return ret;

--- a/test/JDBC/expected/TestErrorHelperFunctions.out
+++ b/test/JDBC/expected/TestErrorHelperFunctions.out
@@ -104,6 +104,7 @@ XX000#!#CREATE FUNCTION failed because a column name is not specified for column
 42883#!#could not identify an equality operator for type %s#!##!#306
 42883#!#could not identify an ordering operator for type %s#!##!#306
 42883#!#%s %s expects parameter "%s", which was not supplied.#!##!#201
+42883#!#Procedure or function '%s' expects parameter '%s', which was not supplied.#!##!#201
 42883#!#%s %s has no parameters and arguments were supplied.#!##!#8146
 42883#!#%s %s has too many arguments specified.#!##!#8144
 42883#!#"%s" is not an parameter for %s %s.#!##!#8145

--- a/test/JDBC/expected/TestErrorHelperFunctionsUpgrade-vu-verify.out
+++ b/test/JDBC/expected/TestErrorHelperFunctionsUpgrade-vu-verify.out
@@ -211,6 +211,7 @@ int
 306
 306
 201
+201
 8146
 8144
 8145
@@ -381,6 +382,7 @@ int
 306
 306
 201
+201
 8146
 8144
 8145
@@ -490,6 +492,6 @@ EXEC TestErrorHelperFunctionsUpgrade_VU_PREPARE_PROC
 GO
 ~~START~~
 int
-163
+164
 ~~END~~
 

--- a/test/JDBC/expected/default_params-vu-cleanup.out
+++ b/test/JDBC/expected/default_params-vu-cleanup.out
@@ -7,6 +7,9 @@ GO
 drop function default_params_func3;
 GO
 
+drop function default_params_func4;
+GO
+
 drop procedure default_params_proc1;
 GO
 

--- a/test/JDBC/expected/default_params-vu-cleanup.out
+++ b/test/JDBC/expected/default_params-vu-cleanup.out
@@ -21,3 +21,6 @@ GO
 
 drop procedure default_params_proc4
 GO
+
+drop function default_params_func5;
+GO

--- a/test/JDBC/expected/default_params-vu-prepare.out
+++ b/test/JDBC/expected/default_params-vu-prepare.out
@@ -10,6 +10,9 @@ GO
 create function default_params_func4 (@p1 int) returns int as begin return @p1 end;
 GO
 
+create function default_params_func5 (@p1 varchar(20)) returns varchar as begin return @p1 end;
+GO
+
 create proc default_params_proc1 @p1 int=1, @p2 int=2, @p3 int=3 as select @p1, @p2, @p3
 GO
 

--- a/test/JDBC/expected/default_params-vu-prepare.out
+++ b/test/JDBC/expected/default_params-vu-prepare.out
@@ -7,6 +7,9 @@ GO
 create function default_params_func3 (@p1 varchar(20) = 'abc') returns varchar as begin return @p1 end;
 GO
 
+create function default_params_func4 (@p1 int) returns int as begin return @p1 end;
+GO
+
 create proc default_params_proc1 @p1 int=1, @p2 int=2, @p3 int=3 as select @p1, @p2, @p3
 GO
 

--- a/test/JDBC/expected/default_params-vu-verify.out
+++ b/test/JDBC/expected/default_params-vu-verify.out
@@ -170,7 +170,7 @@ d#!#3
 -- verify the error message
 exec default_params_proc3 default, default
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 201)~~
 
 ~~ERROR (Message: Procedure or function 'default_params_proc3' expects parameter '@p2', which was not supplied.)~~
 
@@ -178,7 +178,7 @@ GO
 -- verify the error message
 exec default_params_proc3 'ddd', default
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 201)~~
 
 ~~ERROR (Message: Procedure or function 'default_params_proc3' expects parameter '@p2', which was not supplied.)~~
 

--- a/test/JDBC/expected/default_params-vu-verify.out
+++ b/test/JDBC/expected/default_params-vu-verify.out
@@ -87,6 +87,14 @@ int
 ~~END~~
 
 
+select default_params_func5(default);
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
 exec default_params_proc1 111, default, 333
 GO
 ~~START~~
@@ -183,7 +191,16 @@ GO
 ~~ERROR (Message: Procedure or function 'default_params_proc3' expects parameter '@p2', which was not supplied.)~~
 
 
+-- verify the type cast
 exec default_params_proc4 1,2,default
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#2#!#dbb
+~~END~~
+
+
+exec default_params_proc4 1,2, @p3=default
 GO
 ~~START~~
 int#!#int#!#varchar

--- a/test/JDBC/expected/default_params-vu-verify.out
+++ b/test/JDBC/expected/default_params-vu-verify.out
@@ -78,6 +78,15 @@ d
 ~~END~~
 
 
+-- it'll use default 
+select default_params_func4(default);
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
 exec default_params_proc1 111, default, 333
 GO
 ~~START~~
@@ -99,6 +108,30 @@ GO
 ~~START~~
 int#!#int#!#int
 1#!#2#!#3
+~~END~~
+
+
+exec default_params_proc1 @p1=default, @p2=default,@p3=300
+GO
+~~START~~
+int#!#int#!#int
+1#!#2#!#300
+~~END~~
+
+
+exec default_params_proc1 @p1=300, @p2=default,@p3=default
+GO
+~~START~~
+int#!#int#!#int
+300#!#2#!#3
+~~END~~
+
+
+exec default_params_proc1 @p1=default, @p2=300,@p3=default
+GO
+~~START~~
+int#!#int#!#int
+1#!#300#!#3
 ~~END~~
 
 
@@ -132,6 +165,22 @@ GO
 varchar#!#int
 d#!#3
 ~~END~~
+
+
+-- verify the error message
+exec default_params_proc3 default, default
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Procedure or function 'default_params_proc3' expects parameter '@p2', which was not supplied.)~~
+
+
+-- verify the error message
+exec default_params_proc3 'ddd', default
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Procedure or function 'default_params_proc3' expects parameter '@p2', which was not supplied.)~~
 
 
 exec default_params_proc4 1,2,default

--- a/test/JDBC/input/default_params-vu-cleanup.sql
+++ b/test/JDBC/input/default_params-vu-cleanup.sql
@@ -7,6 +7,9 @@ GO
 drop function default_params_func3;
 GO
 
+drop function default_params_func4;
+GO
+
 drop procedure default_params_proc1;
 GO
 

--- a/test/JDBC/input/default_params-vu-cleanup.sql
+++ b/test/JDBC/input/default_params-vu-cleanup.sql
@@ -21,3 +21,6 @@ GO
 
 drop procedure default_params_proc4
 GO
+
+drop function default_params_func5;
+GO

--- a/test/JDBC/input/default_params-vu-prepare.sql
+++ b/test/JDBC/input/default_params-vu-prepare.sql
@@ -10,6 +10,9 @@ GO
 create function default_params_func4 (@p1 int) returns int as begin return @p1 end;
 GO
 
+create function default_params_func5 (@p1 varchar(20)) returns varchar as begin return @p1 end;
+GO
+
 create proc default_params_proc1 @p1 int=1, @p2 int=2, @p3 int=3 as select @p1, @p2, @p3
 GO
 

--- a/test/JDBC/input/default_params-vu-prepare.sql
+++ b/test/JDBC/input/default_params-vu-prepare.sql
@@ -7,6 +7,9 @@ GO
 create function default_params_func3 (@p1 varchar(20) = 'abc') returns varchar as begin return @p1 end;
 GO
 
+create function default_params_func4 (@p1 int) returns int as begin return @p1 end;
+GO
+
 create proc default_params_proc1 @p1 int=1, @p2 int=2, @p3 int=3 as select @p1, @p2, @p3
 GO
 

--- a/test/JDBC/input/default_params-vu-verify.sql
+++ b/test/JDBC/input/default_params-vu-verify.sql
@@ -28,6 +28,10 @@ GO
 select default_params_func3('dddd');
 GO
 
+-- it'll use default 
+select default_params_func4(default);
+GO
+
 exec default_params_proc1 111, default, 333
 GO
 
@@ -35,6 +39,15 @@ exec default_params_proc1 default, default, default
 GO
 
 exec default_params_proc1 default
+GO
+
+exec default_params_proc1 @p1=default, @p2=default,@p3=300
+GO
+
+exec default_params_proc1 @p1=300, @p2=default,@p3=default
+GO
+
+exec default_params_proc1 @p1=default, @p2=300,@p3=default
 GO
 
 exec default_params_proc2 default, 2
@@ -47,6 +60,14 @@ exec default_params_proc3 default, 2
 GO
 
 exec default_params_proc3 'dddd', 3
+GO
+
+-- verify the error message
+exec default_params_proc3 default, default
+GO
+
+-- verify the error message
+exec default_params_proc3 'ddd', default
 GO
 
 exec default_params_proc4 1,2,default

--- a/test/JDBC/input/default_params-vu-verify.sql
+++ b/test/JDBC/input/default_params-vu-verify.sql
@@ -32,6 +32,9 @@ GO
 select default_params_func4(default);
 GO
 
+select default_params_func5(default);
+GO
+
 exec default_params_proc1 111, default, 333
 GO
 
@@ -70,5 +73,9 @@ GO
 exec default_params_proc3 'ddd', default
 GO
 
+-- verify the type cast
 exec default_params_proc4 1,2,default
+GO
+
+exec default_params_proc4 1,2, @p3=default
 GO


### PR DESCRIPTION
1. The error message should be the same as sql server when there's no default define for a param called by a procedure.
2. If default keyword is used in function call and that param doesn't have default define value, then use NULL as the value.
3. Support call proc with NamedAssignExpr with a default keyword like exec proc @p1 = default

Task: BABEL-335

### Example 

case 1 : 
```
1> create proc p @p1 int as select @p1
2> go
1> exec p default
2> go
```

case 1: 
```
1> create function f (@p1 int) returns int as begin return @p1 end
2> go
1> select dbo.f(default)
2> go
----------
      NULL 
```

case 3:
```
1> create proc p @p1 int=123 as select @p1 
2> go 
1> exec p @p1=default 
2> go
-----------         
123
```

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).