### PR TITLE
Added BABEL-4519 related fix in tsql upgrade script 2.8.0--3.0.0

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.8.0--3.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.8.0--3.0.0.sql
@@ -6,6 +6,26 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 
 -- please add your SQL here
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+SELECT sys.babelfish_update_server_collation_name();
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 CREATE OR REPLACE FUNCTION sys.datepart_internal(IN datepart PG_CATALOG.TEXT, IN arg anyelement,IN df_tz INTEGER DEFAULT 0) RETURNS INTEGER AS $$
 DECLARE
 	result INTEGER;

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -15,6 +15,7 @@ Unexpected drop found for function sys.babelfish_update_server_collation_name in
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.5.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.6.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.7.0--3.0.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.8.0--3.0.0.sql
 Unexpected drop found for function sys.babelfishpg_common_get_babel_server_collation_oid in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.3.0--3.0.0.sql


### PR DESCRIPTION
### Description
Fix added in [PR-2019](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2019) should also present in babelfishpg_tsql--2.8.0--3.0.0.sql.

This PR will
- update babelfishpg_tsql--2.8.0--3.0.0.sql to add fix mentioned in [PR-2019](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2019)
- update expected_drop.out 

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-4519

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).