### PR TITLE
Resolve TDS protocol violation occurring due to parallel query enforced

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprinttup.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprinttup.c
@@ -60,6 +60,13 @@ TdsPrinttupStartup(DestReceiver *self, int operation, TupleDesc typeinfo)
 {
 	DR_printtup *myState = (DR_printtup *) self;
 	Portal		portal = myState->portal;
+	PlannedStmt *plannedStmt = PortalGetPrimaryStmt(portal);
+	List 		*targetList = NIL;
+
+	if (portal->strategy != PORTAL_MULTI_QUERY)
+	{
+		targetList = FetchStatementTargetList((Node *) plannedStmt);
+	}
 
 	/*
 	 * Create I/O buffer to be used for all messages.  This cannot be inside
@@ -78,7 +85,8 @@ TdsPrinttupStartup(DestReceiver *self, int operation, TupleDesc typeinfo)
 												ALLOCSET_DEFAULT_SIZES);
 
 	TdsSendRowDescription(typeinfo,
-						  FetchPortalTargetList(portal),
+						  plannedStmt,
+						  targetList,
 						  portal->formats);
 	return;
 }

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -26,6 +26,7 @@
 #include "miscadmin.h"
 #include "nodes/pathnodes.h"
 #include "parser/parse_coerce.h"
+#include "parser/parsetree.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -128,6 +129,8 @@ static void FillTabNameWithoutNumParts(StringInfo buf, uint8 numParts, TdsRelati
 static void SetTdsEstateErrorData(void);
 static void ResetTdsEstateErrorData(void);
 static void SetAttributesForColmetada(TdsColumnMetaData *col);
+static int32 resolve_numeric_typmod_from_exp(Plan *plan, Node *expr);
+static int32 resolve_numeric_typmod_outer_var(Plan *plan, AttrNumber attno);
 
 static inline void
 SendPendingDone(bool more)
@@ -401,9 +404,112 @@ PrintTupPrepareInfo(DR_printtup *myState, TupleDesc typeinfo, int numAttrs)
 	}
 }
 
+static int32
+resolve_numeric_typmod_from_append_or_mergeappend(Plan *plan, AttrNumber attno)
+{
+	ListCell	*lc;
+	int32		max_precision = 0,
+				max_scale = 0,
+				precision = 0,
+				scale = 0,
+				integralDigitCount = 0,
+				typmod = -1,
+				result_typmod = -1;
+	List		*planlist = NIL;
+	if (IsA(plan, Append))
+	{
+		planlist = ((Append *) plan)->appendplans;
+	}
+	else if(IsA(plan, MergeAppend))
+	{
+		planlist = ((MergeAppend *) plan)->mergeplans; 
+	}
+
+	Assert(planlist != NIL);
+	foreach(lc, planlist)
+	{
+		TargetEntry *tle;
+		Plan 		*outerplan = (Plan *) lfirst(lc);
+
+		/* if outerplan is SubqueryScan then use actual subplan */
+		if (IsA(outerplan, SubqueryScan))
+			outerplan = ((SubqueryScan *)outerplan)->subplan;
+
+		tle = get_tle_by_resno(outerplan->targetlist, attno);
+		if (IsA(tle->expr, Var))
+		{
+			Var *var = (Var *)tle->expr;
+			if (var->varno == OUTER_VAR)
+			{
+				typmod = resolve_numeric_typmod_outer_var(outerplan, var->varattno);
+			}
+			else
+			{
+				typmod = resolve_numeric_typmod_from_exp(outerplan, (Node *)tle->expr);
+			}
+		}
+		else
+		{
+			typmod = resolve_numeric_typmod_from_exp(outerplan, (Node *)tle->expr);
+		}
+		if (typmod == -1)
+			continue;
+		scale = (typmod - VARHDRSZ) & 0xffff;
+		precision = ((typmod - VARHDRSZ) >> 16) & 0xffff;
+		integralDigitCount = Max(precision - scale, max_precision - max_scale);
+		max_scale = Max(max_scale, scale);
+		max_precision = integralDigitCount + max_scale;
+		/*
+		 * If max_precision is more than TDS_MAX_NUM_PRECISION then adjust precision
+		 * to TDS_MAX_NUM_PRECISION at the cost of scale.
+		 */
+		if (max_precision > TDS_MAX_NUM_PRECISION)
+		{
+			max_scale = Max(0, max_scale - (max_precision - TDS_MAX_NUM_PRECISION));
+			max_precision = TDS_MAX_NUM_PRECISION;
+		}
+		result_typmod = ((max_precision << 16) | max_scale) + VARHDRSZ;
+	}
+	/* If max_precision is still default then use tds specific defaults */
+	if (result_typmod == -1)
+	{
+		result_typmod = ((tds_default_numeric_precision << 16) | tds_default_numeric_scale) + VARHDRSZ;
+	}
+	return result_typmod;
+}
+
+static int32
+resolve_numeric_typmod_outer_var(Plan *plan, AttrNumber attno)
+{
+	TargetEntry	*tle;
+	Plan		*outerplan = NULL;
+
+	if (IsA(plan, Append) || IsA(plan, MergeAppend))
+		return resolve_numeric_typmod_from_append_or_mergeappend(plan, attno);
+	else
+		outerplan = outerPlan(plan);
+
+	/* if outerplan is SubqueryScan then use actual subplan */
+	if (IsA(outerplan, SubqueryScan))
+		outerplan = ((SubqueryScan *)outerplan)->subplan;
+
+	/* outerplan must not be NULL */
+	Assert(outerplan);
+	tle = get_tle_by_resno(outerplan->targetlist, attno);
+	if (IsA(tle->expr, Var))
+	{
+		Var *var = (Var *)tle->expr;
+		if (var->varno == OUTER_VAR)
+		{
+			return resolve_numeric_typmod_outer_var(outerplan, var->varattno);
+		}
+	}
+	return resolve_numeric_typmod_from_exp(outerplan, (Node *)tle->expr);
+}
+
 /* look for a typmod to return from a numeric expression */
 static int32
-resolve_numeric_typmod_from_exp(Node *expr)
+resolve_numeric_typmod_from_exp(Plan *plan, Node *expr)
 {
 	if (expr == NULL)
 		return -1;
@@ -434,6 +540,12 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			{
 				Var		   *var = (Var *) expr;
 
+				/* If this var referes to tuple returned by its outer plan then find the original tle from it */
+				if (var->varno == OUTER_VAR)
+				{
+					Assert(plan);
+					return (resolve_numeric_typmod_outer_var(plan, var->varattno));
+				}
 				return var->vartypmod;
 			}
 		case T_OpExpr:
@@ -464,8 +576,8 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				{
 					arg1 = linitial(op->args);
 					arg2 = lsecond(op->args);
-					typmod1 = resolve_numeric_typmod_from_exp(arg1);
-					typmod2 = resolve_numeric_typmod_from_exp(arg2);
+					typmod1 = resolve_numeric_typmod_from_exp(plan, arg1);
+					typmod2 = resolve_numeric_typmod_from_exp(plan, arg2);
 					scale1 = (typmod1 - VARHDRSZ) & 0xffff;
 					precision1 = ((typmod1 - VARHDRSZ) >> 16) & 0xffff;
 					scale2 = (typmod2 - VARHDRSZ) & 0xffff;
@@ -474,7 +586,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				else if (list_length(op->args) == 1)
 				{
 					arg1 = linitial(op->args);
-					typmod1 = resolve_numeric_typmod_from_exp(arg1);
+					typmod1 = resolve_numeric_typmod_from_exp(plan, arg1);
 					scale1 = (typmod1 - VARHDRSZ) & 0xffff;
 					precision1 = ((typmod1 - VARHDRSZ) >> 16) & 0xffff;
 					scale2 = 0;
@@ -545,7 +657,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 							scale = Min(precision, TDS_MAX_NUM_PRECISION) - integralDigitCount;
 
 						/*
-						 * precisionn adjustment to TDS_MAX_NUM_PRECISION
+						 * precision adjustment to TDS_MAX_NUM_PRECISION
 						 */
 						if (precision > TDS_MAX_NUM_PRECISION)
 							precision = TDS_MAX_NUM_PRECISION;
@@ -653,7 +765,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				Assert(nullif->args != NIL);
 
 				arg1 = linitial(nullif->args);
-				return resolve_numeric_typmod_from_exp(arg1);
+				return resolve_numeric_typmod_from_exp(plan, arg1);
 			}
 		case T_CoalesceExpr:
 			{
@@ -676,7 +788,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				foreach(lc, coale->args)
 				{
 					arg = lfirst(lc);
-					arg_typmod = resolve_numeric_typmod_from_exp(arg);
+					arg_typmod = resolve_numeric_typmod_from_exp(plan, arg);
 					/* return -1 if we fail to resolve one of the arg's typmod */
 					if (arg_typmod == -1)
 						return -1;
@@ -717,7 +829,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				{
 					casewhen = lfirst(lc);
 					casewhen_result = (Node *) casewhen->result;
-					typmod = resolve_numeric_typmod_from_exp(casewhen_result);
+					typmod = resolve_numeric_typmod_from_exp(plan, casewhen_result);
 
 					/*
 					 * return -1 if we fail to resolve one of the result's
@@ -752,7 +864,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				Assert(aggref->args != NIL);
 
 				te = (TargetEntry *) linitial(aggref->args);
-				typmod = resolve_numeric_typmod_from_exp((Node *) te->expr);
+				typmod = resolve_numeric_typmod_from_exp(plan, (Node *) te->expr);
 				aggFuncName = get_func_name(aggref->aggfnoid);
 
 				scale = (typmod - VARHDRSZ) & 0xffff;
@@ -798,7 +910,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 			{
 				PlaceHolderVar *phv = (PlaceHolderVar *) expr;
 
-				return resolve_numeric_typmod_from_exp((Node *) phv->phexpr);
+				return resolve_numeric_typmod_from_exp(plan, (Node *) phv->phexpr);
 			}
 		case T_RelabelType:
 			{
@@ -807,7 +919,7 @@ resolve_numeric_typmod_from_exp(Node *expr)
 				if (rlt->resulttypmod != -1)
 					return rlt->resulttypmod;
 				else
-					return resolve_numeric_typmod_from_exp((Node *) rlt->arg);
+					return resolve_numeric_typmod_from_exp(plan, (Node *) rlt->arg);
 			}
 			/* TODO handle more Expr types if needed */
 		default:
@@ -1455,8 +1567,8 @@ TdsGetGenericTypmod(Node *expr)
  * 					for a relation. (used for keyset and dynamic cursors)
  */
 void
-PrepareRowDescription(TupleDesc typeinfo, List *targetlist, int16 *formats,
-					  bool extendedInfo, bool fetchPkeys)
+PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *targetlist,
+					  int16 *formats, bool extendedInfo, bool fetchPkeys)
 {
 	int			natts = typeinfo->natts;
 	int			attno;
@@ -1675,7 +1787,16 @@ PrepareRowDescription(TupleDesc typeinfo, List *targetlist, int16 *formats,
 					 * than -1.
 					 */
 					if (atttypmod == -1 && tle != NULL)
-						atttypmod = resolve_numeric_typmod_from_exp((Node *) tle->expr);
+					{
+						if (!plannedstmt || !plannedstmt->planTree)
+						{
+							ereport(ERROR,
+									(errcode(ERRCODE_INTERNAL_ERROR),
+									 errmsg("Internal error detected while calculating the precision of numeric expression"),
+									 errhint("plannedstmt is NULL while calculating the precision of numeric expression when it contains outer var")));
+						}
+						atttypmod = resolve_numeric_typmod_from_exp(plannedstmt->planTree, (Node *) tle->expr);
+					}
 
 					/*
 					 * Get the precision and scale out of the typmod value if
@@ -2459,7 +2580,7 @@ TdsSendInfoOrError(int token, int number, int state, int class,
 }
 
 void
-TdsSendRowDescription(TupleDesc typeinfo,
+TdsSendRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt,
 					  List *targetlist, int16 *formats)
 {
 	TDSRequest	request = TdsRequestCtrl->request;
@@ -2468,7 +2589,7 @@ TdsSendRowDescription(TupleDesc typeinfo,
 	Assert(typeinfo != NULL);
 
 	/* Prepare the column metadata first */
-	PrepareRowDescription(typeinfo, targetlist, formats, false, false);
+	PrepareRowDescription(typeinfo, plannedstmt, targetlist, formats, false, false);
 
 	/*
 	 * If fNoMetadata flags is set in RPC header flag, the server doesn't need
@@ -3194,7 +3315,8 @@ TDSStatementExceptionCallback(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool 
 void
 SendColumnMetadata(TupleDesc typeinfo, List *targetlist, int16 *formats)
 {
-	TdsSendRowDescription(typeinfo, targetlist, formats);
+	/* This will only be used for sp_preapre request hence do not need to pass plannedstmt */
+	TdsSendRowDescription(typeinfo, NULL, targetlist, formats);
 	TdsPrintTupShutdown();
 }
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -2287,10 +2287,15 @@ static void
 SendCursorResponse(TDSRequestSP req)
 {
 	int			cmd_type = TDS_CMD_UNKNOWN;
-	Portal		portal;
-
 	/* fetch the portal */
-	portal = GetPortalFromCursorHandle(req->cursorHandle, false);
+	Portal		portal = GetPortalFromCursorHandle(req->cursorHandle, false);
+	PlannedStmt *plannedStmt = PortalGetPrimaryStmt(portal);
+	List 		*targetList = NIL;
+
+	if (portal->strategy != PORTAL_MULTI_QUERY)
+	{
+		targetList = FetchStatementTargetList((Node *) plannedStmt);
+	}
 
 	/*
 	 * If we are in aborted transaction state, we can't run
@@ -2319,7 +2324,7 @@ SendCursorResponse(TDSRequestSP req)
 	 * break the protocol.  We also need to fetch the primary keys for dynamic
 	 * and keyset cursors (XXX: these cursors are not yet implemented).
 	 */
-	PrepareRowDescription(portal->tupDesc, FetchPortalTargetList(portal),
+	PrepareRowDescription(portal->tupDesc, plannedStmt, targetList,
 						  portal->formats, true,
 						  (req->scrollopt & (SP_CURSOR_SCROLLOPT_DYNAMIC | SP_CURSOR_SCROLLOPT_KEYSET)));
 

--- a/contrib/babelfishpg_tds/src/include/tds_response.h
+++ b/contrib/babelfishpg_tds/src/include/tds_response.h
@@ -70,8 +70,8 @@ extern void TdsSendDone(int tag, int status,
 extern void SendColumnMetadataToken(int natts, bool sendRowStat);
 extern void SendTabNameToken(void);
 extern void SendColInfoToken(int natts, bool sendRowStat);
-extern void PrepareRowDescription(TupleDesc typeinfo, List *targetlist, int16 *formats,
-								  bool extendedInfo, bool fetchPkeys);
+extern void PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *targetlist,
+								  int16 *formats, bool extendedInfo, bool fetchPkeys);
 extern void SendReturnValueTokenInternal(ParameterToken token, uint8 status,
 										 FmgrInfo *finfo, Datum datum, bool isNull,
 										 bool forceCoercion);
@@ -85,7 +85,7 @@ extern void TdsSendEnvChangeBinary(int envid,
 								   void *old, int old_nbytes);
 extern void TdsSendReturnStatus(int status);
 extern void TdsSendHandle(void);
-extern void TdsSendRowDescription(TupleDesc typeinfo,
+extern void TdsSendRowDescription(TupleDesc typeinfo, PlannedStmt *PlannedStmt,
 								  List *targetlist, int16 *formats);
 extern bool TdsPrintTup(TupleTableSlot *slot, DestReceiver *self);
 extern void TdsPrintTupShutdown(void);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2579,9 +2579,13 @@ pltsql_detect_numeric_overflow(int weight, int dscale, int first_block, int nume
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return false;
 
-
-	total_digit_count = (dscale == 0) ? (weight * numeric_base) :
-		((weight + 1) * numeric_base);
+	if (weight < 0)
+	{
+		/* weight < 0 means the integral part of the number is 0 */
+		total_digit_count = dscale;
+		return (total_digit_count > TDS_NUMERIC_MAX_PRECISION);
+	}
+	total_digit_count = weight * numeric_base;
 
 	/*
 	 * calculating exact #digits in the first partially filled numeric block,
@@ -2594,7 +2598,7 @@ pltsql_detect_numeric_overflow(int weight, int dscale, int first_block, int nume
 
 	/*
 	 * check if the first numeric block is partially filled If yes, add those
-	 * digit count Else if fully filled, Ignore as those digits are already
+	 * digit count Else if fully filled, Ignore as those digits might be already
 	 * added to total_digit_count
 	 */
 	if (partially_filled_numeric_block < pow(10, numeric_base - 1))
@@ -2604,18 +2608,13 @@ pltsql_detect_numeric_overflow(int weight, int dscale, int first_block, int nume
 			int log_10 = (int) log10(partially_filled_numeric_block); // keep compiler happy
 			total_digit_count += log_10 + 1;
 		}
-		else
-			total_digit_count += 1;
 	}
 
 	/*
-	 * calculating exact #digits in last block if decimal point exists If
-	 * dscale is an exact multiple of numeric_base, last block is not
-	 * partially filled, then, ignore as those digits are already added to
-	 * total_digit_count Else, add the remainder digits
+	 * Add dscale or display scale, the nominal precision expressed as number
+	 * of digits after the decimal point.
 	 */
-	if (dscale > 0)
-		total_digit_count += (dscale % numeric_base);
+	total_digit_count += dscale;
 
 	return (total_digit_count > TDS_NUMERIC_MAX_PRECISION);
 }

--- a/test/JDBC/expected/BABEL-3943.out
+++ b/test/JDBC/expected/BABEL-3943.out
@@ -16,7 +16,6 @@ GO
 
 
 -- tsql
--- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
 GO
 ~~START~~
@@ -25,7 +24,6 @@ numeric
 ~~END~~
 
 
--- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1 AND   [owner_amounts].[tax] is not null
 GO
 ~~START~~
@@ -34,7 +32,6 @@ numeric
 ~~END~~
 
 
--- TODO: Fix BABEL-4359
 SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1
 GO
 ~~START~~
@@ -43,16 +40,14 @@ numeric
 ~~END~~
 
 
--- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1 AND   [owner_amounts].[tax] is not null
 GO
 ~~START~~
 numeric
-0E-8
+0.000000
 ~~END~~
 
 
--- TODO: Fix BABEL-4359
 SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1
 GO
 ~~START~~

--- a/test/JDBC/expected/BABEL-4424.out
+++ b/test/JDBC/expected/BABEL-4424.out
@@ -1,0 +1,883 @@
+create table babel_4359_t1 (a numeric(6,4), b numeric(6,3), c numeric);
+go
+
+insert into babel_4359_t1 values (4, 16, 1111);
+insert into babel_4359_t1 values (10.1234, 10.123, 222222);
+insert into babel_4359_t1 values (1.2, 6, 33333333333333333);
+insert into babel_4359_t1 values (NULL, 101.123, 444444444444444444);
+insert into babel_4359_t1 values (10.123, NULL, 444444444444444444.44);
+insert into babel_4359_t1 values (10.12, 10.1234, NULL);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from 
+	(
+		select a as col from babel_4359_t1 Union All
+		select b as col from babel_4359_t1
+	) dummy
+order by col
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.2000
+4.0000
+6.0000
+10.1200
+10.1230
+10.1230
+10.1230
+10.1234
+16.0000
+101.1230
+~~END~~
+
+
+select * from 
+	(
+		select a as col from babel_4359_t1 union all
+		select b as col from babel_4359_t1 union all
+		select c as col from babel_4359_t1
+	) dummy
+order by col
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+<NULL>
+1.2000
+4.0000
+6.0000
+10.1200
+10.1230
+10.1230
+10.1230
+10.1234
+16.0000
+101.1230
+1111.0000
+222222.0000
+33333333333333333.0000
+444444444444444444.0000
+444444444444444444.0000
+~~END~~
+
+
+
+select * from
+	(
+		select avg(a) as col from babel_4359_t1 union all
+		select avg(b) as col from babel_4359_t1
+	) dummy
+order by col
+select * from 
+	(
+		select a + b as col from babel_4359_t1 Union All
+		select b + c as col from babel_4359_t1
+	) dummy
+order by col
+go
+~~START~~
+numeric
+7.113280
+28.673800
+~~END~~
+
+~~START~~
+numeric
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+7.2000
+20.0000
+20.2430
+20.2464
+1127.0000
+222232.1230
+33333333333333339.0000
+444444444444444545.1230
+~~END~~
+
+
+select * from 
+	(
+		(select a as col from babel_4359_t1 order by a) union all
+		(select b as col from babel_4359_t1 order by a) union all
+		(select c as col from babel_4359_t1 order by a)
+	) dummy
+order by col
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+<NULL>
+1.2000
+4.0000
+6.0000
+10.1200
+10.1230
+10.1230
+10.1230
+10.1234
+16.0000
+101.1230
+1111.0000
+222222.0000
+33333333333333333.0000
+444444444444444444.0000
+444444444444444444.0000
+~~END~~
+
+
+
+select * from 
+	(
+		(select min(a) as col from babel_4359_t1 ) union all
+		(select min(b) as col from babel_4359_t1 ) union all
+		(select min(c) as col from babel_4359_t1 )
+	) dummy
+order by col
+select min(col) from 
+	(
+		(select min(a) as col from babel_4359_t1 ) union all
+		(select min(b) as col from babel_4359_t1 ) union all
+		(select min(c) as col from babel_4359_t1 )
+	) dummy
+go
+~~START~~
+numeric
+1.2000
+6.0000
+1111.0000
+~~END~~
+
+~~START~~
+numeric
+1.2000
+~~END~~
+
+
+select * from 
+	(
+		select max(a + b) as col from babel_4359_t1 Union All
+		select min(b + c) as col from babel_4359_t1
+	) dummy
+order by col
+go
+~~START~~
+numeric
+20.2464
+1127.0000
+~~END~~
+
+
+create table events (event_id numeric(6,3) primary key);
+create table other_events (event_id numeric(6,5) primary key);
+create table other_events_2 (event_id numeric);
+go
+
+insert into events values (100.123), (10.12);
+insert into other_events values (1.123456);
+insert into other_events_2 values (111111111111111111), (NULL);
+go
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+
+-- merge append node
+select  event_id
+ from ((select event_id from events order by event_id)
+       union all
+       (select event_id from other_events order by event_id)
+	   union all
+	   (select event_id from other_events_2 order by event_id)) ss
+order by event_id;
+go
+~~START~~
+numeric
+<NULL>
+1.12346
+10.12000
+100.12300
+111111111111111111.00000
+~~END~~
+
+
+drop table babel_4359_t1
+go
+drop table events;
+go
+drop table other_events;
+go
+drop table other_events_2;
+go
+
+create table babel_4424_t1 (a numeric(38,0));
+go
+
+create table babel_4424_t2 (a numeric(6,4));
+go
+
+insert into babel_4424_t1 values (9999999999999999999999999999999999999);
+insert into babel_4424_t2 values (99.9999);
+insert into babel_4424_t1 values (1111111111111111111111111111111111111);
+insert into babel_4424_t2 values (11.1111);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from
+	(
+	  select a col from babel_4424_t1
+	  union all
+	  select a col from babel_4424_t2
+	)dummy
+order by col;
+go
+~~START~~
+numeric
+11
+99
+1111111111111111111111111111111111111
+9999999999999999999999999999999999999
+~~END~~
+
+
+select * from
+	( select a + a from babel_4424_t1 ) dummy
+go
+~~START~~
+numeric
+19999999999999999999999999999999999998
+2222222222222222222222222222222222222
+~~END~~
+
+
+select * from
+	(
+	  select a col from babel_4424_t1
+	  union all
+	  select a + a col from babel_4424_t1
+	)dummy
+order by col;
+go
+~~START~~
+numeric
+1111111111111111111111111111111111111
+2222222222222222222222222222222222222
+9999999999999999999999999999999999999
+19999999999999999999999999999999999998
+~~END~~
+
+
+select * from
+	(
+	  select a + a col from babel_4424_t1
+	  union all
+	  select a col from babel_4424_t2
+	)dummy
+order by col;
+go
+~~START~~
+numeric
+11
+99
+2222222222222222222222222222222222222
+19999999999999999999999999999999999998
+~~END~~
+
+
+create table babel_4424_t3 (a numeric(37,1));
+GO
+
+create table babel_4424_t4 (a numeric(38,1));
+GO
+
+insert into babel_4424_t3 values (999999999999999999999999999999999999.9);
+insert into babel_4424_t3 values (111111111111111111111111111111111111.1);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+insert into babel_4424_t4 values (9999999999999999999999999999999999999.9);
+insert into babel_4424_t4 values (1111111111111111111111111111111111111.1);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from (select a + a from babel_4424_t3) dummy;
+go
+~~START~~
+numeric
+1999999999999999999999999999999999999.8
+222222222222222222222222222222222222.2
+~~END~~
+
+
+select * from
+	(
+		select a col from babel_4424_t3
+		union all
+		select a col from babel_4424_t2
+	) dummy
+order by col;
+GO
+~~START~~
+numeric
+11.11
+99.99
+111111111111111111111111111111111111.10
+999999999999999999999999999999999999.90
+~~END~~
+
+
+select * from
+	(
+		select a col from babel_4424_t3
+		union all
+		select a col from babel_4424_t4
+	) dummy
+order by col;
+GO
+~~START~~
+numeric
+111111111111111111111111111111111111.1
+999999999999999999999999999999999999.9
+1111111111111111111111111111111111111.1
+9999999999999999999999999999999999999.9
+~~END~~
+
+
+create table babel_4424_t5 (a numeric(38, 37));
+GO
+
+create table babel_4424_t6 (a numeric(10, 10));
+GO
+
+insert into babel_4424_t5 values (9.99999999999999999999999999999999999);
+insert into babel_4424_t6 values (0.9999999999);
+insert into babel_4424_t5 values (1.11111111111111111111111111111111111);
+insert into babel_4424_t6 values (0.1111111111);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from ( select a + a from babel_4424_t5) dummy;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select * from ( select a + a from babel_4424_t6) dummy;
+GO
+~~START~~
+numeric
+1.9999999998
+0.2222222222
+~~END~~
+
+
+select * from 
+	(
+		select a col from babel_4424_t5
+		union all
+		select a col from babel_4424_t6
+	) dummy
+order by col;
+GO
+~~START~~
+numeric
+0.1111111111000000000000000000000000000
+0.9999999999000000000000000000000000000
+1.1111111111111111111111111111111111100
+9.9999999999999999999999999999999999900
+~~END~~
+
+
+DROP TABLE babel_4424_t1;
+go
+DROP TABLE babel_4424_t2;
+go
+DROP TABLE babel_4424_t3;
+go
+DROP TABLE babel_4424_t4;
+go
+DROP TABLE babel_4424_t5;
+go
+DROP TABLE babel_4424_t6;
+go
+
+create table babel_4424_t1 (a numeric(38,0) primary key);
+go
+
+create table babel_4424_t2(a numeric(6,3) primary key);
+go
+
+insert into babel_4424_t1 values (99999999999999999999999999999999999999);
+insert into babel_4424_t2 values (99.9999);
+insert into babel_4424_t1 values (11111111111111111111111111111111111111);
+insert into babel_4424_t2 values (11.1111);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- index scan + append
+select * from
+	(
+		select a col from babel_4424_t1 where a = 1
+		union all
+		select a col from babel_4424_t2 where a = 1
+	) dummy
+order by col;
+go
+~~START~~
+numeric
+~~END~~
+
+
+DROP TABLE babel_4424_t1;
+go
+DROP TABLE babel_4424_t2;
+go
+
+
+create table babel_4424_t1 (n3_0 numeric(3,0), n3_1 numeric(3,1), n6_0 numeric(6,0), n10_0 numeric(10,0), n10_9 numeric(10, 9),
+							n15_0 numeric(15,0), n16_15 numeric(16,15), n20_2 numeric(20,2), n25_5 numeric(25,0), n30_10 numeric(30, 10),
+							n30_29 numeric(30,29), n38_37 numeric(38,37));
+insert into babel_4424_t1 (n3_0) values (999);
+insert into babel_4424_t1 (n3_1) values (99.9);
+insert into babel_4424_t1 (n6_0) values (999999);
+insert into babel_4424_t1 (n10_0) values (9999999999);
+insert into babel_4424_t1 (n10_9) values (9.999999999);
+insert into babel_4424_t1 (n15_0) values (999999999999999);
+insert into babel_4424_t1 (n16_15) values (9.999999999999999);
+insert into babel_4424_t1 (n20_2) values (999999999999999999.99);
+insert into babel_4424_t1 (n25_5) values (99999999999999999999.99999);
+insert into babel_4424_t1 (n30_10) values (99999999999999999999.9999999999);
+insert into babel_4424_t1 (n30_29) values (9.99999999999999999999999999999);
+insert into babel_4424_t1 (n38_37) values (9.9999999999999999999999999999999999999);
+insert into babel_4424_t1 (n3_0, n3_1, n6_0, n10_0, n10_9, n15_0, n16_15, n20_2, n25_5, n30_10, n30_29, n38_37)
+values (999, 99.9, 999999, 9999999999, 9.999999999, 999999999999999, 9.999999999999999, 999999999999999999.99, 
+99999999999999999999.99999, 99999999999999999999.9999999999, 9.99999999999999999999999999999, 9.9999999999999999999999999999999999999);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+insert into babel_4424_t1 (n3_0) values (111);
+insert into babel_4424_t1 (n3_1) values (11.1);
+insert into babel_4424_t1 (n6_0) values (111111);
+insert into babel_4424_t1 (n10_0) values (1111111111);
+insert into babel_4424_t1 (n10_9) values (1.111111111);
+insert into babel_4424_t1 (n15_0) values (111111111111111);
+insert into babel_4424_t1 (n16_15) values (1.111111111111111);
+insert into babel_4424_t1 (n20_2) values (111111111111111111.11);
+insert into babel_4424_t1 (n25_5) values (11111111111111111111.11111);
+insert into babel_4424_t1 (n30_10) values (11111111111111111111.1111111111);
+insert into babel_4424_t1 (n30_29) values (1.11111111111111111111111111111);
+insert into babel_4424_t1 (n38_37) values (1.1111111111111111111111111111111111111);
+insert into babel_4424_t1 (n3_0, n3_1, n6_0, n10_0, n10_9, n15_0, n16_15, n20_2, n25_5, n30_10, n30_29, n38_37)
+values (111, 11.1, 111111, 1111111111, 1.111111111, 111111111111111, 1.111111111111111, 111111111111111111.11, 
+11111111111111111111.11111, 11111111111111111111.1111111111, 1.11111111111111111111111111111, 1.1111111111111111111111111111111111111);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select n38_37 + 100 from babel_4424_t1 where n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select n38_37 + n38_37 from babel_4424_t1 where n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select sum(n38_37) from babel_4424_t1 where n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select avg(n38_37) from babel_4424_t1 where n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select n30_29 * 100 from babel_4424_t1 where n30_29 is not null;
+GO
+~~START~~
+numeric
+999.99999999999999999999999999900
+999.99999999999999999999999999900
+111.11111111111111111111111111100
+111.11111111111111111111111111100
+~~END~~
+
+
+select n30_29 + n30_29 from babel_4424_t1 where n30_29 is not null;
+GO
+~~START~~
+numeric
+19.99999999999999999999999999998
+19.99999999999999999999999999998
+2.22222222222222222222222222222
+2.22222222222222222222222222222
+~~END~~
+
+
+select n30_29 + n38_37 from babel_4424_t1 where n30_29 is not null and n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select n3_0 * n3_0 from babel_4424_t1 where n3_0 is not null;
+GO
+~~START~~
+numeric
+998001
+998001
+12321
+12321
+~~END~~
+
+
+select n3_0 * n3_1 from babel_4424_t1 where n3_0 is not null and n3_1 is not null;
+GO
+~~START~~
+numeric
+99800.1
+1232.1
+~~END~~
+
+
+select n3_0 + n6_0 from babel_4424_t1 where n3_0 is not null and n6_0 is not null;
+GO
+~~START~~
+numeric
+1000998
+111222
+~~END~~
+
+
+select n6_0 + n10_9 from babel_4424_t1 where n6_0 is not null and n10_9 is not null;
+GO
+~~START~~
+numeric
+1000008.999999999
+111112.111111111
+~~END~~
+
+
+select n15_0 * n15_0 from babel_4424_t1 where n15_0 is not null;
+GO
+~~START~~
+numeric
+999999999999998000000000000001
+999999999999998000000000000001
+12345679012345654320987654321
+12345679012345654320987654321
+~~END~~
+
+
+select n15_0 + n38_37 from babel_4424_t1 where n15_0 is not null and n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select n15_0 + n16_15 from babel_4424_t1 where n15_0 is not null and n16_15 is not null;
+GO
+~~START~~
+numeric
+1000000000000008.999999999999999
+111111111111112.111111111111111
+~~END~~
+
+
+select avg(n16_15) from babel_4424_t1 where n16_15 is not null;
+GO
+~~START~~
+numeric
+5.555555555555555
+~~END~~
+
+
+select n16_15 * n16_15 from babel_4424_t1 where n16_15 is not null;
+GO
+~~START~~
+numeric
+99.999999999999980000000000000001
+99.999999999999980000000000000001
+1.234567901234567654320987654321
+1.234567901234567654320987654321
+~~END~~
+
+
+select n15_0 + n16_15 + n30_10 from babel_4424_t1 where n15_0 is not null and n16_15 is not null and n30_10 is not null;
+GO
+~~START~~
+numeric
+100001000000000000008.999999999899999
+11111222222222222223.222222222211111
+~~END~~
+
+
+select n20_2 + n38_37 from babel_4424_t1 where n20_2 is not null and n38_37 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select  n25_5 + n30_10 from babel_4424_t1 where n25_5 is not null and n30_10 is not null;
+GO
+~~START~~
+numeric
+199999999999999999999.9999999999
+22222222222222222222.1111111111
+~~END~~
+
+
+select n30_29 + n30_10 from babel_4424_t1 where n30_29 is not null and n30_10 is not null;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+select * from
+(
+	select n3_0 col from babel_4424_t1 where n3_0 is not null
+	union all
+	select n3_1 col from babel_4424_t1 where n3_1 is not null
+	union all
+	select n6_0 col from babel_4424_t1 where n6_0 is not null
+	union all
+	select n10_0 col from babel_4424_t1 where n10_0 is not null
+	union all
+	select n10_9 col from babel_4424_t1 where n10_9 is not null
+	union all
+	select n15_0 col from babel_4424_t1 where n15_0 is not null
+	union all
+	select n16_15 col from babel_4424_t1 where n16_15 is not null
+	union all
+	select n20_2 col from babel_4424_t1 where n20_2 is not null
+	union all
+	select n25_5 col from babel_4424_t1 where n25_5 is not null
+	union all
+	select n30_10 col from babel_4424_t1 where n30_10 is not null
+	union all
+	select n30_29 col from babel_4424_t1 where n30_29 is not null
+	union all
+	select n38_37 col from babel_4424_t1 where n38_37 is not null
+) dummy
+order by col;
+GO
+~~START~~
+numeric
+1.1111111110000
+1.1111111110000
+1.1111111111111
+1.1111111111111
+1.1111111111111
+1.1111111111111
+1.1111111111111
+1.1111111111111
+9.9999999990000
+9.9999999990000
+9.9999999999999
+9.9999999999999
+9.9999999999999
+9.9999999999999
+9.9999999999999
+9.9999999999999
+11.1000000000000
+11.1000000000000
+99.9000000000000
+99.9000000000000
+111.0000000000000
+111.0000000000000
+999.0000000000000
+999.0000000000000
+111111.0000000000000
+111111.0000000000000
+999999.0000000000000
+999999.0000000000000
+1111111111.0000000000000
+1111111111.0000000000000
+9999999999.0000000000000
+9999999999.0000000000000
+111111111111111.0000000000000
+111111111111111.0000000000000
+999999999999999.0000000000000
+999999999999999.0000000000000
+111111111111111111.1100000000000
+111111111111111111.1100000000000
+999999999999999999.9900000000000
+999999999999999999.9900000000000
+11111111111111111111.0000000000000
+11111111111111111111.0000000000000
+11111111111111111111.1111111111000
+11111111111111111111.1111111111000
+99999999999999999999.9999999999000
+99999999999999999999.9999999999000
+100000000000000000000.0000000000000
+100000000000000000000.0000000000000
+~~END~~
+
+
+DROP table babel_4424_t1;
+GO
+
+create table babel_4424_t1 (a numeric(38,38));
+GO
+
+insert into babel_4424_t1 values (0.1111111111111111111111111111111111111111);
+go
+~~ROW COUNT: 1~~
+
+
+select a + a from babel_4424_t1;
+GO
+~~START~~
+numeric
+0.22222222222222222222222222222222222222
+~~END~~
+
+
+truncate table babel_4424_t1;
+GO
+
+insert into babel_4424_t1 values (0.99999999999999999999999999999999999999)
+GO
+~~ROW COUNT: 1~~
+
+
+select a + a from babel_4424_t1;
+GO
+~~START~~
+numeric
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Arithmetic overflow error for data type numeric.)~~
+
+
+DROP table babel_4424_t1;
+GO

--- a/test/JDBC/expected/babel_613.out
+++ b/test/JDBC/expected/babel_613.out
@@ -154,19 +154,23 @@ numeric
 
 
 -- test Union All
-select a from t1 Union All
-select b from t1;
+select * from 
+	(
+		select a as col from t1 Union All
+		select b as col from t1
+	) dummy
+order by col
 go
 ~~START~~
 numeric
-4.00000000
-10.12340000
-1.20000000
 <NULL>
-16.00000000
-10.12300000
-6.00000000
-101.12300000
+1.2000
+4.0000
+6.0000
+10.1230
+10.1234
+16.0000
+101.1230
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-3943.mix
+++ b/test/JDBC/input/BABEL-3943.mix
@@ -14,23 +14,18 @@ select 0,1,862 from generate_series(1,200000);
 GO
 
 -- tsql
--- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and ISNULL([owner_amounts].[active], 0) = 1 AND   [owner_amounts].[tax] is not null
 GO
 
--- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1 AND   [owner_amounts].[tax] is not null
 GO
 
--- TODO: Fix BABEL-4359
 SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as smallint) = 1
 GO
 
--- TODO: Fix BABEL-4359
 SELECT avg([owner_amounts].[tax]) FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1 AND   [owner_amounts].[tax] is not null
 GO
 
--- TODO: Fix BABEL-4359
 SELECT TOP 1 [owner_amounts].[tax] FROM [owner_amounts] WHERE moment_id = 862 and cast([owner_amounts].[active] as int) = 1
 GO
 

--- a/test/JDBC/input/BABEL-4424.sql
+++ b/test/JDBC/input/BABEL-4424.sql
@@ -1,0 +1,400 @@
+create table babel_4359_t1 (a numeric(6,4), b numeric(6,3), c numeric);
+go
+
+insert into babel_4359_t1 values (4, 16, 1111);
+insert into babel_4359_t1 values (10.1234, 10.123, 222222);
+insert into babel_4359_t1 values (1.2, 6, 33333333333333333);
+insert into babel_4359_t1 values (NULL, 101.123, 444444444444444444);
+insert into babel_4359_t1 values (10.123, NULL, 444444444444444444.44);
+insert into babel_4359_t1 values (10.12, 10.1234, NULL);
+go
+
+select * from 
+	(
+		select a as col from babel_4359_t1 Union All
+		select b as col from babel_4359_t1
+	) dummy
+order by col
+go
+
+select * from 
+	(
+		select a as col from babel_4359_t1 union all
+		select b as col from babel_4359_t1 union all
+		select c as col from babel_4359_t1
+	) dummy
+order by col
+go
+
+select * from
+	(
+		select avg(a) as col from babel_4359_t1 union all
+		select avg(b) as col from babel_4359_t1
+	) dummy
+order by col
+
+select * from 
+	(
+		select a + b as col from babel_4359_t1 Union All
+		select b + c as col from babel_4359_t1
+	) dummy
+order by col
+go
+
+select * from 
+	(
+		(select a as col from babel_4359_t1 order by a) union all
+		(select b as col from babel_4359_t1 order by a) union all
+		(select c as col from babel_4359_t1 order by a)
+	) dummy
+order by col
+go
+
+select * from 
+	(
+		(select min(a) as col from babel_4359_t1 ) union all
+		(select min(b) as col from babel_4359_t1 ) union all
+		(select min(c) as col from babel_4359_t1 )
+	) dummy
+order by col
+
+select min(col) from 
+	(
+		(select min(a) as col from babel_4359_t1 ) union all
+		(select min(b) as col from babel_4359_t1 ) union all
+		(select min(c) as col from babel_4359_t1 )
+	) dummy
+go
+
+select * from 
+	(
+		select max(a + b) as col from babel_4359_t1 Union All
+		select min(b + c) as col from babel_4359_t1
+	) dummy
+order by col
+go
+
+create table events (event_id numeric(6,3) primary key);
+create table other_events (event_id numeric(6,5) primary key);
+create table other_events_2 (event_id numeric);
+go
+
+insert into events values (100.123), (10.12);
+insert into other_events values (1.123456);
+insert into other_events_2 values (111111111111111111), (NULL);
+go
+
+-- merge append node
+select  event_id
+ from ((select event_id from events order by event_id)
+       union all
+       (select event_id from other_events order by event_id)
+	   union all
+	   (select event_id from other_events_2 order by event_id)) ss
+order by event_id;
+go
+
+drop table babel_4359_t1
+go
+drop table events;
+go
+drop table other_events;
+go
+drop table other_events_2;
+go
+
+create table babel_4424_t1 (a numeric(38,0));
+go
+
+create table babel_4424_t2 (a numeric(6,4));
+go
+
+insert into babel_4424_t1 values (9999999999999999999999999999999999999);
+insert into babel_4424_t2 values (99.9999);
+insert into babel_4424_t1 values (1111111111111111111111111111111111111);
+insert into babel_4424_t2 values (11.1111);
+go
+
+select * from
+	(
+	  select a col from babel_4424_t1
+	  union all
+	  select a col from babel_4424_t2
+	)dummy
+order by col;
+go
+
+select * from
+	( select a + a from babel_4424_t1 ) dummy
+go
+
+select * from
+	(
+	  select a col from babel_4424_t1
+	  union all
+	  select a + a col from babel_4424_t1
+	)dummy
+order by col;
+go
+
+select * from
+	(
+	  select a + a col from babel_4424_t1
+	  union all
+	  select a col from babel_4424_t2
+	)dummy
+order by col;
+go
+
+create table babel_4424_t3 (a numeric(37,1));
+GO
+
+create table babel_4424_t4 (a numeric(38,1));
+GO
+
+insert into babel_4424_t3 values (999999999999999999999999999999999999.9);
+insert into babel_4424_t3 values (111111111111111111111111111111111111.1);
+go
+
+insert into babel_4424_t4 values (9999999999999999999999999999999999999.9);
+insert into babel_4424_t4 values (1111111111111111111111111111111111111.1);
+go
+
+select * from (select a + a from babel_4424_t3) dummy;
+go
+
+select * from
+	(
+		select a col from babel_4424_t3
+		union all
+		select a col from babel_4424_t2
+	) dummy
+order by col;
+GO
+
+select * from
+	(
+		select a col from babel_4424_t3
+		union all
+		select a col from babel_4424_t4
+	) dummy
+order by col;
+GO
+
+create table babel_4424_t5 (a numeric(38, 37));
+GO
+
+create table babel_4424_t6 (a numeric(10, 10));
+GO
+
+insert into babel_4424_t5 values (9.99999999999999999999999999999999999);
+insert into babel_4424_t6 values (0.9999999999);
+insert into babel_4424_t5 values (1.11111111111111111111111111111111111);
+insert into babel_4424_t6 values (0.1111111111);
+GO
+
+select * from ( select a + a from babel_4424_t5) dummy;
+GO
+
+select * from ( select a + a from babel_4424_t6) dummy;
+GO
+
+select * from 
+	(
+		select a col from babel_4424_t5
+		union all
+		select a col from babel_4424_t6
+	) dummy
+order by col;
+GO
+
+DROP TABLE babel_4424_t1;
+go
+DROP TABLE babel_4424_t2;
+go
+DROP TABLE babel_4424_t3;
+go
+DROP TABLE babel_4424_t4;
+go
+DROP TABLE babel_4424_t5;
+go
+DROP TABLE babel_4424_t6;
+go
+
+create table babel_4424_t1 (a numeric(38,0) primary key);
+go
+
+create table babel_4424_t2(a numeric(6,3) primary key);
+go
+
+insert into babel_4424_t1 values (99999999999999999999999999999999999999);
+insert into babel_4424_t2 values (99.9999);
+insert into babel_4424_t1 values (11111111111111111111111111111111111111);
+insert into babel_4424_t2 values (11.1111);
+GO
+
+-- index scan + append
+select * from
+	(
+		select a col from babel_4424_t1 where a = 1
+		union all
+		select a col from babel_4424_t2 where a = 1
+	) dummy
+order by col;
+go
+
+DROP TABLE babel_4424_t1;
+go
+DROP TABLE babel_4424_t2;
+go
+
+create table babel_4424_t1 (n3_0 numeric(3,0), n3_1 numeric(3,1), n6_0 numeric(6,0), n10_0 numeric(10,0), n10_9 numeric(10, 9),
+							n15_0 numeric(15,0), n16_15 numeric(16,15), n20_2 numeric(20,2), n25_5 numeric(25,0), n30_10 numeric(30, 10),
+							n30_29 numeric(30,29), n38_37 numeric(38,37));
+
+insert into babel_4424_t1 (n3_0) values (999);
+insert into babel_4424_t1 (n3_1) values (99.9);
+insert into babel_4424_t1 (n6_0) values (999999);
+insert into babel_4424_t1 (n10_0) values (9999999999);
+insert into babel_4424_t1 (n10_9) values (9.999999999);
+insert into babel_4424_t1 (n15_0) values (999999999999999);
+insert into babel_4424_t1 (n16_15) values (9.999999999999999);
+insert into babel_4424_t1 (n20_2) values (999999999999999999.99);
+insert into babel_4424_t1 (n25_5) values (99999999999999999999.99999);
+insert into babel_4424_t1 (n30_10) values (99999999999999999999.9999999999);
+insert into babel_4424_t1 (n30_29) values (9.99999999999999999999999999999);
+insert into babel_4424_t1 (n38_37) values (9.9999999999999999999999999999999999999);
+insert into babel_4424_t1 (n3_0, n3_1, n6_0, n10_0, n10_9, n15_0, n16_15, n20_2, n25_5, n30_10, n30_29, n38_37)
+values (999, 99.9, 999999, 9999999999, 9.999999999, 999999999999999, 9.999999999999999, 999999999999999999.99, 
+99999999999999999999.99999, 99999999999999999999.9999999999, 9.99999999999999999999999999999, 9.9999999999999999999999999999999999999);
+GO
+
+insert into babel_4424_t1 (n3_0) values (111);
+insert into babel_4424_t1 (n3_1) values (11.1);
+insert into babel_4424_t1 (n6_0) values (111111);
+insert into babel_4424_t1 (n10_0) values (1111111111);
+insert into babel_4424_t1 (n10_9) values (1.111111111);
+insert into babel_4424_t1 (n15_0) values (111111111111111);
+insert into babel_4424_t1 (n16_15) values (1.111111111111111);
+insert into babel_4424_t1 (n20_2) values (111111111111111111.11);
+insert into babel_4424_t1 (n25_5) values (11111111111111111111.11111);
+insert into babel_4424_t1 (n30_10) values (11111111111111111111.1111111111);
+insert into babel_4424_t1 (n30_29) values (1.11111111111111111111111111111);
+insert into babel_4424_t1 (n38_37) values (1.1111111111111111111111111111111111111);
+insert into babel_4424_t1 (n3_0, n3_1, n6_0, n10_0, n10_9, n15_0, n16_15, n20_2, n25_5, n30_10, n30_29, n38_37)
+values (111, 11.1, 111111, 1111111111, 1.111111111, 111111111111111, 1.111111111111111, 111111111111111111.11, 
+11111111111111111111.11111, 11111111111111111111.1111111111, 1.11111111111111111111111111111, 1.1111111111111111111111111111111111111);
+GO
+
+select n38_37 + 100 from babel_4424_t1 where n38_37 is not null;
+GO
+
+select n38_37 + n38_37 from babel_4424_t1 where n38_37 is not null;
+GO
+
+select sum(n38_37) from babel_4424_t1 where n38_37 is not null;
+GO
+
+select avg(n38_37) from babel_4424_t1 where n38_37 is not null;
+GO
+
+select n30_29 * 100 from babel_4424_t1 where n30_29 is not null;
+GO
+
+select n30_29 + n30_29 from babel_4424_t1 where n30_29 is not null;
+GO
+
+select n30_29 + n38_37 from babel_4424_t1 where n30_29 is not null and n38_37 is not null;
+GO
+
+select n3_0 * n3_0 from babel_4424_t1 where n3_0 is not null;
+GO
+
+select n3_0 * n3_1 from babel_4424_t1 where n3_0 is not null and n3_1 is not null;
+GO
+
+select n3_0 + n6_0 from babel_4424_t1 where n3_0 is not null and n6_0 is not null;
+GO
+
+select n6_0 + n10_9 from babel_4424_t1 where n6_0 is not null and n10_9 is not null;
+GO
+
+select n15_0 * n15_0 from babel_4424_t1 where n15_0 is not null;
+GO
+
+select n15_0 + n38_37 from babel_4424_t1 where n15_0 is not null and n38_37 is not null;
+GO
+
+select n15_0 + n16_15 from babel_4424_t1 where n15_0 is not null and n16_15 is not null;
+GO
+
+select avg(n16_15) from babel_4424_t1 where n16_15 is not null;
+GO
+
+select n16_15 * n16_15 from babel_4424_t1 where n16_15 is not null;
+GO
+
+select n15_0 + n16_15 + n30_10 from babel_4424_t1 where n15_0 is not null and n16_15 is not null and n30_10 is not null;
+GO
+
+select n20_2 + n38_37 from babel_4424_t1 where n20_2 is not null and n38_37 is not null;
+GO
+
+select  n25_5 + n30_10 from babel_4424_t1 where n25_5 is not null and n30_10 is not null;
+GO
+
+select n30_29 + n30_10 from babel_4424_t1 where n30_29 is not null and n30_10 is not null;
+GO
+
+select * from
+(
+	select n3_0 col from babel_4424_t1 where n3_0 is not null
+	union all
+	select n3_1 col from babel_4424_t1 where n3_1 is not null
+	union all
+	select n6_0 col from babel_4424_t1 where n6_0 is not null
+	union all
+	select n10_0 col from babel_4424_t1 where n10_0 is not null
+	union all
+	select n10_9 col from babel_4424_t1 where n10_9 is not null
+	union all
+	select n15_0 col from babel_4424_t1 where n15_0 is not null
+	union all
+	select n16_15 col from babel_4424_t1 where n16_15 is not null
+	union all
+	select n20_2 col from babel_4424_t1 where n20_2 is not null
+	union all
+	select n25_5 col from babel_4424_t1 where n25_5 is not null
+	union all
+	select n30_10 col from babel_4424_t1 where n30_10 is not null
+	union all
+	select n30_29 col from babel_4424_t1 where n30_29 is not null
+	union all
+	select n38_37 col from babel_4424_t1 where n38_37 is not null
+) dummy
+order by col;
+GO
+
+DROP table babel_4424_t1;
+GO
+
+create table babel_4424_t1 (a numeric(38,38));
+GO
+
+insert into babel_4424_t1 values (0.1111111111111111111111111111111111111111);
+go
+
+select a + a from babel_4424_t1;
+GO
+
+truncate table babel_4424_t1;
+GO
+
+insert into babel_4424_t1 values (0.99999999999999999999999999999999999999)
+GO
+
+select a + a from babel_4424_t1;
+GO
+
+DROP table babel_4424_t1;
+GO

--- a/test/JDBC/input/babel_613.sql
+++ b/test/JDBC/input/babel_613.sql
@@ -60,8 +60,12 @@ select coalesce(a, b) from t1;
 go
 
 -- test Union All
-select a from t1 Union All
-select b from t1;
+select * from 
+	(
+		select a as col from t1 Union All
+		select b as col from t1
+	) dummy
+order by col
 go
 
 -- test overflow from multiplication of columns

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -15,18 +15,7 @@ ignore#!#Test-sp_droprolemember-vu-verify
 ignore#!#Test-sp_droprolemember-vu-cleanup
 ignore#!#babel_datatype_sqlvariant-vu-verify
 
-# Group 2: Incorrect precision BABEL-4396
-ignore#!#BABEL-3943
-ignore#!#BABEL-785
-ignore#!#TestDecimal-vu-verify
-ignore#!#TestNumeric-vu-verify
-ignore#!#babel_613
-ignore#!#babel_datatype
-ignore#!#babel_isnull
-ignore#!#BABEL-3006
-ignore#!#BABEL-3147-vu-verify
-
-# Group 3: Need ORDER BY
+# Group 2: Need ORDER BY
 ignore#!#BABEL-2514
 ignore#!#BABEL-2998
 ignore#!#BABEL-328-vu-verify
@@ -297,14 +286,6 @@ ignore#!#BABEL-1251
 ignore#!#Test-sp_addrolemember-dep-vu-verify
 ignore#!#Test-sp_droprolemember-dep-vu-verify
 ignore#!#babel_table_type
-
-# BABEL-4423
-ignore#!#BABEL-IDENTITY
-
-# BABEL-4424
-ignore#!#TestDecimal
-ignore#!#TestNumeric
-ignore#!#numericOverflow
 
 # Taking too much time to complete. (TIME-OUT FAILURES)
 ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-verify


### PR DESCRIPTION
This issue was mainly caused by incorrect inference of typmod information for numeric expression where its being set to default when Parallel worker is planned. Reason for the same is explained below:

When parallel query is enforced, Postgres engine planes Gather node on the top of top plan. For example, consider following query -

SELECT amount + 100 FROM overflow_test where id = 1

-- If parallel query is not enforced-
Query Text: SELECT amount + 100 FROM overflow_test where id = 1 Index Scan using overflow_test_pkey on master_dbo.overflow_test  (cost=0.15..8.17 rows=1 width=32)
  Output: ((amount)::numeric + '100'::numeric)
  Index Cond: (overflow_test.id = 1)

-- If parallel query is enforced then Postgres will wrap the above plan under Gather node - Query Text: SELECT amount + 100 FROM overflow_test where id = 1 Gather  (cost=0.15..8.17 rows=1 width=32)
  Output: (((amount)::numeric + '100'::numeric))
  Workers Planned: 1
  Single Copy: true
  ->  Index Scan using overflow_test_pkey on master_dbo.overflow_test  (cost=0.15..8.17 rows=1 width=32)
        Output: ((amount)::numeric + '100'::numeric)
        Index Cond: (overflow_test.id = 1)

When Postgres does this, it also modifies targetlist of gather node to refer to the tuples returned by its lefttree subplan or outerplan (Indexscan in this case). Hence, targetlist of gather node will contain only one tle in above case which is Var with attno = OUTER_VAR (it indicates reference to its outer plan) and vartypmod being -1.

Now, While sending metadata from TDS layer we use this typmod to deduce max_scale and precision for numeric. This would be set to default since vartypmod = -1 whereas actual data being computed may not fit in it hence it will run into an error while sending numeric response. Hence, hang or crash of end client software.

This commit fixes this issue by taking special Var into account while We extract the information of outer plan from planned stmt and use the same to get the original/referenced tle from outer plan.

This commit further improves the implementation of resolve_numeric_typmod_from_exp to handle reference to outer var correctly. It can now handle Append and MergeAppend node correctly which was required for following test case -

-- setup
create table t1 (a numeric(6,4), b numeric(6,3));
insert into t1 values (4, 16);
insert into t1 values (10.1234, 10.123);
insert into t1 values (1.2, 6);
insert into t1 values (NULL, 101.123);

-- test
select a from t1 UNION All
select b from t1;
For this UNION ALL expression, typmod was always computed to be -1 which is not right and it should (7,4) ideally. This commit introduces helped function called resolve_numeric_typmod_from_append_or_mergeappend to compute typmod for expression correctly.

Task: BABEL-4424, BABEL-4359
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).