### PR TITLE
Fix failure in MVU with non-default server collation name

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.0.0--2.1.0.sql
@@ -55,19 +55,5 @@ SELECT sys.babelfish_update_server_collation_name();
 
 DROP FUNCTION sys.babelfish_update_server_collation_name();
 
--- And reset babelfishpg_tsql.restored_server_collation_name and babelfishpg_tsql.restored_default_locale GUC
-do
-language plpgsql
-$$
-    declare
-        query text;
-    begin
-        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
-        execute query;
-        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_default_locale', CURRENT_DATABASE());
-        execute query;
-    end;
-$$;
-
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.0.0--2.1.0.sql
@@ -3,6 +3,26 @@
  
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+SELECT sys.babelfish_update_server_collation_name();
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 -- Drops an object (view/function/procedure) if it does not have any dependent objects.
 -- Is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
 -- Please have this be one of the first statements executed in this upgrade script. 

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -4,6 +4,7 @@ Unexpected drop found for cast  in file babelfishpg_common--1.0.0--1.1.0.sql
 Unexpected drop found for cast  in file babelfishpg_common--1.0.0--1.1.0.sql
 Unexpected drop found for function get_bbf_binary_ops_count in file babelfishpg_common--2.3.0--2.4.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.0.0--2.1.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.0.0--2.1.0.sql
 Unexpected drop found for function sys.babelfishpg_common_get_babel_server_collation_oid in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for operator sys.+ in file babelfishpg_common--1.1.0--1.2.0.sql


### PR DESCRIPTION
### Description
Currently, in upgrade scripts, server_collation_name is set to restored_server_collation_name in babelfishpg_common upgrade scripts only and then GUC restored_server_collation_name is being reset. Now this server_collation_name is being set only for that connection, when a new connection is created server_collation_name will contain the default value. This will cause issue when different connections are used to update babelfishpg_common and babelfishpg_tsql, as the server_collation_name contains default value in connection in which babelfishpg_tsql is getting updated, but expected value of server_collation_name is the value of restored_server_collation_name.

Due to this, incorrect collation(default collation) is getting assigned to a column in spt_tablecollation_view instead of the collation stored in restored_server_collation_name.

This commit will resolve this issue by setting the server_collation_name to restored_server_collation_name in babelfishpg_tsql upgrade scripts as well.

Tested the changes locally against following upgrade paths
13.6 to 14.latest
13.9 to 14.latest
13.6 to 14.latest to 15.latest
13.9 to 14.latest to 15.latest

Cherry-picked from [PR-2028](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2028)
Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved

BABEL-4519

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).