### PR TITLE
fix jdbc tests fails locally with error " 'tds_fdw' extension does not exists". BABEL_2_X_DEV

### DIFF
--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -35,32 +35,37 @@ ignore#!#BABEL-4281
 ignore#!#babel_collection
 ignore#!#binary-index-vu-verify
 ignore#!#pgr_select_into
+ignore#!#cast_eliminate-vu-verify
 
-# Other or mixed issues
-ignore#!#545_1
-ignore#!#8107_1
-ignore#!#8143_1
-ignore#!#BABEL-741-vu-verify
-ignore#!#BABEL-1444
+# Query plan change (verified)
+# Need to design a way to allow expected parallel mode output to be accepted
+ignore#!#babel_index_nulls_order-vu-verify
+# Query Plan changed. (verified)
+ignore#!#BABEL-4264
+
+# Other or mixed issues - JIRA-BABEL-4538
+# database "" does not exists. (calls is_member() functions)
 ignore#!#BABEL-1621
+# database "" does not exists. (calls schema_id())
+ignore#!#BABEL-741-vu-verify
 ignore#!#BABEL-2416
-ignore#!#BABEL-2812-vu-verify
 ignore#!#BABEL-2833
+# database "" does not exists. (calls IS_ROLEMEMBER())
+ignore#!#BABEL-ROLE-MEMBER-vu-verify
+ignore#!#BABEL-ROLE-MEMBER
+
+# current_setting('role') returns NULL.
+ignore#!#BABEL-1444
+
+# ERROR CODE DIFFERENCE.  JIRA-4539
+ignore#!#babel_datetime-vu-verify
+ignore#!#babel_datetime
+ignore#!#BABEL-2812-vu-verify
+
+# "tds_fdw" does not exist - JIRA-4540
 ignore#!#BABEL-4168-vu-prepare
 ignore#!#BABEL-4168-vu-verify
 ignore#!#BABEL-4168-vu-cleanup
-ignore#!#BABEL-ROLE-MEMBER-vu-verify
-ignore#!#BABEL-ROLE-MEMBER
-ignore#!#BABEL-SP_PKEYS
-ignore#!#BABEL-SP_STATISTICS
-ignore#!#Test-sp_execute_postgresql
-ignore#!#babel_datetime-vu-verify
-ignore#!#babel_datetime
-ignore#!#babel_extra_join_test_cases
-ignore#!#babelfish_migration_mode-vu-verify
-ignore#!#bbf_view_def
-ignore#!#case_insensitive_collation-vu-prepare
-ignore#!#case_insensitive_collation-vu-verify
 ignore#!#four-part-names-vu-prepare
 ignore#!#four-part-names-vu-verify
 ignore#!#four-part-names-vu-cleanup
@@ -73,17 +78,14 @@ ignore#!#linked_srv_4229-vu-cleanup
 ignore#!#openquery-vu-prepare
 ignore#!#openquery-vu-verify
 ignore#!#openquery-vu-cleanup
-ignore#!#pg_stat_statements_tsql
+
+# relation "onek" does not exist: JIRA-4541
 ignore#!#pgr_select
 ignore#!#pgr_select_distinct
-ignore#!#sp_statistics_100
+
+# output difference: JIRA-4542
 ignore#!#sys-sp_pkeys-dep-vu-verify
-ignore#!#sys-sp_statistics_100-vu-prepare
-ignore#!#sys-sp_statistics_100-vu-verify
-ignore#!#sys-sp_statistics_100-vu-cleanup
-ignore#!#sys-sp_statistics_100-dep-vu-verify
-ignore#!#BABEL-4264
-ignore#!#BABEL_4145
+ignore#!#BABEL-SP_PKEYS
 
 # Test failures caused by babel_extra_join_test_cases_northwind failure
 ignore#!#babelfish_sysdatabases-vu-prepare

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -365,6 +365,8 @@ ignore#!#sys_server_principals_dep-vu-cleanup
 ignore#!#sys_server_principals_dep-vu-prepare
 ignore#!#Test-sp_rename-dep-vu-prepare
 ignore#!#Test-sp_rename-dep-vu-cleanup
+# This test is failing only in github check
+ignore#!#bbf_view_def
 
 # TIME-OUT
 ignore#!#TestSimpleErrorsWithImplicitTran

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -62,23 +62,6 @@ ignore#!#babel_datetime-vu-verify
 ignore#!#babel_datetime
 ignore#!#BABEL-2812-vu-verify
 
-# "tds_fdw" does not exist - JIRA-4540
-ignore#!#BABEL-4168-vu-prepare
-ignore#!#BABEL-4168-vu-verify
-ignore#!#BABEL-4168-vu-cleanup
-ignore#!#four-part-names-vu-prepare
-ignore#!#four-part-names-vu-verify
-ignore#!#four-part-names-vu-cleanup
-ignore#!#linked_servers-vu-prepare
-ignore#!#linked_servers-vu-verify
-ignore#!#linked_servers-vu-cleanup
-ignore#!#linked_srv_4229-vu-prepare
-ignore#!#linked_srv_4229-vu-verify
-ignore#!#linked_srv_4229-vu-cleanup
-ignore#!#openquery-vu-prepare
-ignore#!#openquery-vu-verify
-ignore#!#openquery-vu-cleanup
-
 # relation "onek" does not exist: JIRA-4541
 ignore#!#pgr_select
 ignore#!#pgr_select_distinct
@@ -388,6 +371,8 @@ ignore#!#TestSimpleErrorsWithImplicitTran
 ignore#!#babel_cursor
 ignore#!#TestDatetime-numeric-representation-vu-prepare
 ignore#!#TestDatetime-numeric-representation-vu-verify
+ignore#!#four-part-names-vu-verify
+
 
 #crashing
 ignore#!#sys-server_principals-vu-prepare


### PR DESCRIPTION
### Description

Cherry-pick commits c44dcf7ed4a324958d8d152fc7ca6eff334572c4, 5ef13d21d2a8f063928731a79e948bdbad33610c to BABEL_2_X_DEV

Some tests listed in issue BABEL-4540 failing with error " 'tds_fdw' extension does not exists". This is because of
tds_fdw extension is not installed locally. However while running jdbc test check in GitHub we install 'tds_fdw'
extension in GitHub check. These tests are running now as expected in parallel query mode. Removed these tests from
ignore file. One of the test four-part-names-vu-verify still failing due to time-out. Included this test to appropriate group.

Task: BABEL-4540
Signed-off-by: Sandeep Kumawat <skumwt@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).