### PR TITLE
Updated error message for IDENTITY() escape hatch

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2019,7 +2019,7 @@ func_expr_common_subexpr:
 					{
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							errmsg("To use IDENTITY(), set \'babelfishpg_tsql.escape_hatch_identity_function\' to \'ignore\'"),
 							parser_errposition(@1)));
 					}
 				}
@@ -2033,7 +2033,7 @@ func_expr_common_subexpr:
 					{
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							errmsg("To use IDENTITY(), set \'babelfishpg_tsql.escape_hatch_identity_function\' to \'ignore\'"),
 							parser_errposition(@1)));
 					}
 					
@@ -2048,7 +2048,7 @@ func_expr_common_subexpr:
 					{
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							errmsg("To use IDENTITY(), set \'babelfishpg_tsql.escape_hatch_identity_function\' to \'ignore\'"),
 							parser_errposition(@1)));
 					}
 				}

--- a/test/JDBC/expected/BABEL_539-vu-verify.out
+++ b/test/JDBC/expected/BABEL_539-vu-verify.out
@@ -2,7 +2,7 @@ EXEC babel_539_prepare_proc
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore)~~
+~~ERROR (Message: To use IDENTITY(), set 'babelfishpg_tsql.escape_hatch_identity_function' to 'ignore')~~
 
 
 SELECT current_setting('babelfishpg_tsql.escape_hatch_identity_function');


### PR DESCRIPTION
Updated error message for IDENTITY() escape hatch

Task: BABEL-539

### Description
This is a minor code change to update error message for IDENTITY() escape hatch 
Past Pr: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2055

### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).