### PR TITLE
Added escape hatch for IDENTITY() in select into (#2055) BABEL_3_4_STABLE

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2025,7 +2025,7 @@ func_expr_common_subexpr:
 					{
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							errmsg("To use IDENTITY(), set \'babelfishpg_tsql.escape_hatch_identity_function\' to \'ignore\'"),
 							parser_errposition(@1)));
 					}
 				}
@@ -2039,7 +2039,7 @@ func_expr_common_subexpr:
 					{
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							errmsg("To use IDENTITY(), set \'babelfishpg_tsql.escape_hatch_identity_function\' to \'ignore\'"),
 							parser_errposition(@1)));
 					}
 					
@@ -2054,7 +2054,7 @@ func_expr_common_subexpr:
 					{
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							errmsg("To use IDENTITY(), set \'babelfishpg_tsql.escape_hatch_identity_function\' to \'ignore\'"),
 							parser_errposition(@1)));
 					}
 				}

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2017,15 +2017,46 @@ func_expr_common_subexpr:
 				}
 			| IDENTITY_P '(' Typename ',' a_expr ',' a_expr ')'
 				{
-					$$ = TsqlFunctionIdentityInto($3, $5, $7, @1);	 
+					if (escape_hatch_identity_function)
+					{
+						$$ = TsqlFunctionIdentityInto($3, $5, $7, @1);	
+					}
+					else
+					{
+						ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							parser_errposition(@1)));
+					}
 				}
 			| IDENTITY_P '(' Typename ',' a_expr ')'
 				{ 
-					$$ = TsqlFunctionIdentityInto($3, $5, (Node *)makeIntConst(1, -1), @1);
+					if (escape_hatch_identity_function)
+					{
+						$$ = TsqlFunctionIdentityInto($3, $5, (Node *)makeIntConst(1, -1), @1);
+					}
+					else
+					{
+						ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							parser_errposition(@1)));
+					}
+					
 				}
 			| IDENTITY_P '(' Typename ')'
 				{
-					$$ = TsqlFunctionIdentityInto($3, (Node *)makeIntConst(1, -1), (Node *)makeIntConst(1, -1), @1);
+					if (escape_hatch_identity_function)
+					{
+						$$ = TsqlFunctionIdentityInto($3, (Node *)makeIntConst(1, -1), (Node *)makeIntConst(1, -1), @1);
+					}
+					else
+					{
+						ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							errmsg("IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore"),
+							parser_errposition(@1)));
+					}
 				}
 			| TSQL_CONTAINS '(' ColId ',' tsql_contains_search_condition ')'
 				{

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1229,6 +1229,7 @@ int			escape_hatch_checkpoint = EH_IGNORE;
 int			escape_hatch_set_transaction_isolation_level = EH_STRICT;
 int			pltsql_isolation_level_repeatable_read = ISOLATION_OFF;
 int 		pltsql_isolation_level_serializable = ISOLATION_OFF;
+int 		escape_hatch_identity_function = EH_STRICT;
 
 void
 define_escape_hatch_variables(void)
@@ -1598,6 +1599,17 @@ define_escape_hatch_variables(void)
 							 &pltsql_isolation_level_serializable,
 							 ISOLATION_OFF,
 							 bbf_isolation_options,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+	
+	/* IDENTITY() in SELECT-INTO */
+	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_identity_function",
+							 gettext_noop("escape hatch for IDENTITY() in SELECT-INTO"),
+							 NULL,
+							 &escape_hatch_identity_function,
+							 EH_STRICT,
+							 escape_hatch_options,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -23,6 +23,7 @@ extern bool pltsql_allow_fulltext_parser;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;
+extern int escape_hatch_identity_function;
 
 extern void define_custom_variables(void);
 extern void pltsql_validate_set_config_function(char *name, char *value);

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2028,6 +2028,7 @@ babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatc
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
 babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
 babelfishpg_tsql.escape_hatch_fulltext#!#strict#!#escape hatch for fulltext search
+babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDENTITY() in SELECT-INTO
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
@@ -2096,6 +2097,7 @@ babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatc
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
 babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
 babelfishpg_tsql.escape_hatch_fulltext#!#strict#!#escape hatch for fulltext search
+babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDENTITY() in SELECT-INTO
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
@@ -2145,6 +2147,7 @@ babelfishpg_tsql.escape_hatch_constraint_name_for_default#!#ignore#!#escape hatc
 babelfishpg_tsql.escape_hatch_database_misc_options#!#ignore#!#escape hatch for misc options in CREATE/ALTER DATABASE
 babelfishpg_tsql.escape_hatch_for_replication#!#strict#!#escape hatch for (NOT) FOR REPLICATION option
 babelfishpg_tsql.escape_hatch_fulltext#!#strict#!#escape hatch for fulltext search
+babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDENTITY() in SELECT-INTO
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX

--- a/test/JDBC/expected/BABEL_539-vu-verify.out
+++ b/test/JDBC/expected/BABEL_539-vu-verify.out
@@ -2,7 +2,7 @@ EXEC babel_539_prepare_proc
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore)~~
+~~ERROR (Message: To use IDENTITY(), set 'babelfishpg_tsql.escape_hatch_identity_function' to 'ignore')~~
 
 
 SELECT current_setting('babelfishpg_tsql.escape_hatch_identity_function');

--- a/test/JDBC/expected/BABEL_539-vu-verify.out
+++ b/test/JDBC/expected/BABEL_539-vu-verify.out
@@ -1,5 +1,23 @@
 EXEC babel_539_prepare_proc
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: IDENTITY() is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_identity_function to ignore)~~
+
+
+SELECT current_setting('babelfishpg_tsql.escape_hatch_identity_function');
+GO
+~~START~~
+text
+strict
+~~END~~
+
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'ignore';
+GO
+
+EXEC babel_539_prepare_proc
+GO
 
 SELECT id_num, col1, name  FROM babel_539NewTable_proc ORDER BY col1;
 GO
@@ -459,3 +477,6 @@ GO
 
 ~~ERROR (Message: function IDENTITY_INTO_BIGINT does not exist)~~
 
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'strict';
+GO

--- a/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
+++ b/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
@@ -2,7 +2,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_view
 GO
 ~~START~~
 int
-42
+43
 ~~END~~
 
 
@@ -10,7 +10,7 @@ EXEC sys_babelfish_configurations_view_vu_prepare_proc
 GO
 ~~START~~
 int
-42
+43
 ~~END~~
 
 
@@ -18,7 +18,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_func()
 GO
 ~~START~~
 int
-42
+43
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL_539-vu-verify.sql
+++ b/test/JDBC/input/BABEL_539-vu-verify.sql
@@ -1,6 +1,15 @@
 EXEC babel_539_prepare_proc
 GO
 
+SELECT current_setting('babelfishpg_tsql.escape_hatch_identity_function');
+GO
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'ignore';
+GO
+
+EXEC babel_539_prepare_proc
+GO
+
 SELECT id_num, col1, name  FROM babel_539NewTable_proc ORDER BY col1;
 GO
 
@@ -262,4 +271,7 @@ SELECT IDENTITY(int, 21);
 GO
 
 SELECT sys.IDENTITY_INTO_BIGINT(20, 1, 1);
+GO
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'strict';
 GO


### PR DESCRIPTION
Need this because identity column will always be the last one in table if created using a select into statement

Task: BABEL-539
Signed-off-by: Deepakshi Mittal <depakshi@amazon.com>
(cherry picked from commit 9237ce8be71c3cff202906b3cc7aa0d77702189c)

### Description

Cherry picked this Commit from [BABEL_3_X_DEV](https://github.com/babelfish-for-postgresql/babelfish_extensions) ([#2055](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2055))

https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/9237ce8be71c3cff202906b3cc7aa0d77702189c



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).