### PR TITLE
Fix the issue that PIVOT execution not return row affected line

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -5062,7 +5062,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		/* If query affects IDENTITY_INSERT relation then update sequence */
 		pltsql_update_identity_insert_sequence(expr);
 
-		/* If current plan constains a pivot operator, we remove the plan */
+		/* If current plan constains a pivot operator, we set it as execute oneshot */
 		if (is_pivot)
 		{
 			expr->plan->oneshot = true;

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4693,6 +4693,12 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			return ret;
 		}
 
+		if (expr->plan && expr->plan->oneshot)
+		{
+			SPI_freeplan(expr->plan);
+			expr->plan = NULL;
+		}
+
 		if (expr->plan == NULL)
 		{
 			/*
@@ -5059,8 +5065,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		/* If current plan constains a pivot operator, we remove the plan */
 		if (is_pivot)
 		{
-			SPI_freeplan(expr->plan);
-			expr->plan = NULL;
+			expr->plan->oneshot = true;
 		}
 
 		/* Expect SPI_tuptable to be NULL else complain */

--- a/test/JDBC/expected/pivot-vu-verify.out
+++ b/test/JDBC/expected/pivot-vu-verify.out
@@ -738,6 +738,8 @@ PIVOT (
 ) AS pvt;
 SELECT TOP 10 * FROM pivot_insert_into ORDER by 1, 2;
 GO
+~~ROW COUNT: 197~~
+
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int
 1200#!#200#!#0#!#0#!#0#!#0#!#0


### PR DESCRIPTION
Previous our implement of PIVOT has a issue that it didn't return the row affected line as result, this fix has fixed the bug.

Task: BABEL-284

### Description

This fix mainly fixed this problem : 

```
select *
from 
(
select store, week, xCount
from yt 
) src
pivot
(
sum(xcount)
for week in ([1], [2], [3])
) piv;
 
store       1           2           3          
----------- ----------- ----------- -----------
        101         138         282         220
        102          96         212         123
        105          37          78          60
        109          59          97          87

(4 rows affected)  
```

the 

```
(4 rows affected)  
```

will be missing on previous fix, it's due to too early release of the cached plan

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).