### PR TITLE
Fix bugs for CREATE FULLTEXT INDEX logic for supporting unique index creation via primary key during table creation (#2067) BABEL_3_4_STABLE

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3801,7 +3801,7 @@ exec_stmt_fulltextindex(PLtsql_execstate *estate, PLtsql_stmt_fulltextindex *stm
 	if (is_create)
 	{
 		uniq_index_name = construct_unique_index_name((char *) stmt->index_name, table_name);
-		if(is_unique_index(relid, (const char *) uniq_index_name))
+		if(is_unique_index(relid, (const char *) uniq_index_name) || is_unique_index(relid, (const char *)stmt->index_name))
 		{
 			column_name = stmt->column_name;
 			ft_index_name = construct_unique_index_name("ft_index", table_name);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1824,7 +1824,10 @@ is_unique_index(Oid relid, const char *index_name)
 							{
 								unique_key_count++;
 								if (unique_key_count > 1)
+								{
+									ReleaseSysCache(attTuple);
 									break;
+								}
 							}
 						}
                         ReleaseSysCache(attTuple);

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-prepare.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-prepare.out
@@ -62,7 +62,7 @@ ignore
 
 
 -- Index creation on different character data type columns
-CREATE TABLE fti_table_t1(id int NOT NULL, a text);
+CREATE TABLE fti_table_t1(id int NOT NULL constraint pk_mytexts primary key, a text);
 GO
 
 -- should throw syntax error for NULL index name
@@ -81,10 +81,7 @@ GO
 ~~ERROR (Message: '"ix_t1_a"' is not a valid index to enforce a full-text search key. A full-text search key must be a unique, non-nullable, single-column index which is not offline, is not defined on a non-deterministic or imprecise nonpersisted computed column, does not have a filter, and has maximum size of 900 bytes. Choose another index for the full-text key.)~~
 
 
-CREATE UNIQUE INDEX IX_t1_a ON fti_table_t1(id);
-GO
-
-CREATE FULLTEXT INDEX ON fti_table_t1(a) KEY INDEX IX_t1_a;
+CREATE FULLTEXT INDEX ON fti_table_t1(a) KEY INDEX pk_mytexts;
 GO
 
 CREATE TABLE fti_table_t2(id int not null, b char(10));

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-prepare.mix
@@ -38,7 +38,7 @@ SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 
 -- Index creation on different character data type columns
-CREATE TABLE fti_table_t1(id int NOT NULL, a text);
+CREATE TABLE fti_table_t1(id int NOT NULL constraint pk_mytexts primary key, a text);
 GO
 
 -- should throw syntax error for NULL index name
@@ -49,10 +49,7 @@ GO
 CREATE FULLTEXT INDEX ON fti_table_t1(a) KEY INDEX IX_t1_a;
 GO
 
-CREATE UNIQUE INDEX IX_t1_a ON fti_table_t1(id);
-GO
-
-CREATE FULLTEXT INDEX ON fti_table_t1(a) KEY INDEX IX_t1_a;
+CREATE FULLTEXT INDEX ON fti_table_t1(a) KEY INDEX pk_mytexts;
 GO
 
 CREATE TABLE fti_table_t2(id int not null, b char(10));


### PR DESCRIPTION
### Description

This commit resolved the bug that was found when we execute the following query to create a unique index during table creation and when we use that index name for fulltext index creation, it was failing.

Need this in stable first because tests in #2067 were failing and we can't merge that pr directly as other PRs will fail too.

```
CREATE TABLE tableName(ID INT NOT NULL CONSTRAINT indexName PRIMARY KEY, txt TEXT);
GO

CREATE FULLTEXT INDEX ON tableName(txt) KEY INDEX indexName;
GO
```

This was failing because of the unique index check logic in `exec_stmt_fulltextindex`. Added an extra check in the if clause for handling this.

### Issues Resolved

JIRA: BABEL-4383
Signed-off-by: Roshan Kanwar [rskanwar@amazon.com](mailto:rskanwar@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** Added


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).