### PR TITLE
Disable the custom fts parser guc and update test cases (#2074) BABEL_3_4_STABLE

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -683,7 +683,7 @@ define_custom_variables(void)
 							 gettext_noop("GUC for enabling or disabling full text search features"),
 							 NULL,
 							 &pltsql_allow_fulltext_parser,
-							 false,
+							 true,
 							 PGC_SUSET,
 							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY,
 							 NULL, NULL, NULL);

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-cleanup.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-cleanup.out
@@ -1,14 +1,3 @@
--- psql
--- enable CONTAINS
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
 -- tsql user=testLogin password=abc
 USE master;
 GO
@@ -158,15 +147,5 @@ GO
 ~~START~~
 text
 strict
-~~END~~
-
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
 ~~END~~
 

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-prepare.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-prepare.out
@@ -1,15 +1,5 @@
--- psql
--- enable CONTAINS
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
 -- tsql user=jdbc_user password=12345678
+-- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 ~~START~~
@@ -201,15 +191,5 @@ GO
 ~~START~~
 text
 strict
-~~END~~
-
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
 ~~END~~
 

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-verify.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-verify.out
@@ -1,14 +1,3 @@
--- psql
--- enable CONTAINS
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
 -- tsql user=jdbc_user password=12345678
 -- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
@@ -178,15 +167,5 @@ GO
 ~~START~~
 text
 strict
-~~END~~
-
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
 ~~END~~
 

--- a/test/JDBC/expected/fts-contains-vu-cleanup.out
+++ b/test/JDBC/expected/fts-contains-vu-cleanup.out
@@ -1,5 +1,5 @@
 -- tsql user=jdbc_user password=12345678
--- enable CONTAINS
+-- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 ~~START~~
@@ -20,21 +20,11 @@ GO
 DROP VIEW fts_contains_pgconfig_v1
 GO
 
--- disable CONTAINS
+-- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~
 text
 strict
-~~END~~
-
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
 ~~END~~
 

--- a/test/JDBC/expected/fts-contains-vu-prepare.out
+++ b/test/JDBC/expected/fts-contains-vu-prepare.out
@@ -1,15 +1,5 @@
--- psql
--- enable CONTAINS
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
 -- tsql user=jdbc_user password=12345678
+-- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 ~~START~~
@@ -5061,7 +5051,7 @@ GO
 ~~ROW COUNT: 1~~
 
 
--- disable CONTAINS
+-- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -1,16 +1,5 @@
--- psql
--- enable CONTAINS
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
 -- tsql user=jdbc_user password=12345678
--- enable CONTAINS
+-- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 ~~START~~
@@ -405,7 +394,7 @@ GO
 ~~ERROR (Message: Generation term is not currently supported in Babelfish)~~
 
 
--- disable CONTAINS
+-- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-cleanup.mix
@@ -1,9 +1,3 @@
--- enable CONTAINS
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-
 -- tsql user=testLogin password=abc
 USE master;
 GO
@@ -121,9 +115,4 @@ GO
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
-GO
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-prepare.mix
@@ -1,9 +1,4 @@
--- enable CONTAINS
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-
+-- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
@@ -165,9 +160,4 @@ GO
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
-GO
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-verify.mix
@@ -1,9 +1,3 @@
--- enable CONTAINS
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-
 -- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
@@ -83,9 +77,4 @@ GO
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
-GO
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
@@ -1,5 +1,5 @@
 -- tsql user=jdbc_user password=12345678
--- enable CONTAINS
+-- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 
@@ -15,11 +15,6 @@ GO
 DROP VIEW fts_contains_pgconfig_v1
 GO
 
--- disable CONTAINS
+-- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
-GO
-
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
-SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
@@ -1,9 +1,4 @@
--- enable CONTAINS
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-
+-- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
@@ -3047,6 +3042,6 @@ GO
 INSERT INTO fts_contains_vu_t VALUES (1000, 'Last month , scientists from the Hebrew University of Jerusalem reported that washing down red meat with a glass of red can actually prevent the build-up of cholesterol in the body ')
 GO
 
--- disable CONTAINS
+-- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
@@ -1,11 +1,5 @@
--- enable CONTAINS
--- psql
-ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
-SELECT pg_reload_conf();
-GO
-
+-- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
--- enable CONTAINS
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
 GO
 
@@ -125,6 +119,6 @@ GO
 EXEC fts_contains_vu_prepare_p1 'FORMSOF(THESAURUS, love)'
 GO
 
--- disable CONTAINS
+-- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO


### PR DESCRIPTION
Need this for disabling the custom fts parser guc.

Task: BABEL-4379
Signed-off-by: Roshan Kanwar [rskanwar@amazon.com](mailto:rskanwar@amazon.com)
(cherry picked from commit https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/a850f86fa7e3d1408aa5e35f162bd85e9d6e9904)

### Description
Cherry picked this Commit from [BABEL_3_X_DEV](https://github.com/babelfish-for-postgresql/babelfish_extensions) (https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2074)
https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/a850f86fa7e3d1408aa5e35f162bd85e9d6e9904

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).