### PR TITLE
Updated sys.tsql_type_radix_for_sp_columns_helper function to return RADIX 10 for decimal datatype

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -235,6 +235,7 @@ BEGIN
     WHEN 'money' THEN radix = 10;
     WHEN 'smallmoney' THEN radix = 10;
     WHEN 'sql_variant' THEN radix = 10;
+    WHEN 'decimal' THEN radix = 10;
   ELSE
     radix = NULL;
   END CASE;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -4489,6 +4489,25 @@ RETURNS INT AS
 STRICT
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION sys.tsql_type_radix_for_sp_columns_helper(IN type TEXT)
+RETURNS SMALLINT
+AS $$
+DECLARE
+  radix SMALLINT;
+BEGIN
+  CASE type
+    WHEN 'tinyint' THEN radix = 10;
+    WHEN 'money' THEN radix = 10;
+    WHEN 'smallmoney' THEN radix = 10;
+    WHEN 'sql_variant' THEN radix = 10;
+    WHEN 'decimal' THEN radix = 10;
+  ELSE
+    radix = NULL;
+  END CASE;
+  RETURN radix;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/sp_columns_100.out
+++ b/test/JDBC/expected/sp_columns_100.out
@@ -291,7 +291,7 @@ go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 master#!#dbo#!#decimal_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#0#!#0#!#0#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#63
-master#!#dbo#!#decimal_int_identity#!#dec5int_col#!#3#!#decimal#!#5#!#7#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#106
+master#!#dbo#!#decimal_int_identity#!#dec5int_col#!#3#!#decimal#!#5#!#7#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#106
 ~~END~~
 
 exec [sys].sp_columns N'decimal_int_identity',N'dbo',NULL,NULL,@ODBCVer=3,@fUsePattern=1;
@@ -299,7 +299,7 @@ go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#int
 master#!#dbo#!#decimal_int_identity#!#i_col#!#-5#!#bigint#!#19#!#8#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#-5#!#<NULL>#!#<NULL>#!#1#!#NO#!#63
-master#!#dbo#!#decimal_int_identity#!#dec5int_col#!#3#!#decimal#!#5#!#7#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#2#!#YES#!#106
+master#!#dbo#!#decimal_int_identity#!#dec5int_col#!#3#!#decimal#!#5#!#7#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#2#!#YES#!#106
 ~~END~~
 
 


### PR DESCRIPTION
### Description

Currently, sp_columns and sp_columns_100 returns RADIX NULL for decimal datatype. 

This changes fixes it to return RADIX 10 for decimal datatype

### Issues Resolved

BABEL-4588

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** sp_columns_100.sql


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).