### PR TITLE
fix valgrind warning for is_set_userid not being initialised in create_bbf_db_internal/drop_bbf_db

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -425,7 +425,7 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 	const char *prev_current_user;
 	int			stmt_number = 0;
 	int 			save_sec_context;
-	bool 			is_set_userid;
+	bool 			is_set_userid = false;
 	Oid 			save_userid;
 
 	/* TODO: Extract options */
@@ -626,7 +626,7 @@ drop_bbf_db(const char *dbname, bool missing_ok, bool force_drop)
 	ListCell   *parsetree_item;
 	const char *prev_current_user;
 	int 		save_sec_context;
-	bool 		is_set_userid;
+	bool 		is_set_userid = false;
 	Oid 		save_userid;
 
 	if ((strlen(dbname) == 6 && (strncmp(dbname, "master", 6) == 0)) ||


### PR DESCRIPTION
### Description
In drop_bbf_db & create_bbf_db_internal functions ,inside try block if we error out earlier and move to catch block. the variable is_set_userid might be used without ever being explicitly initialised. Bool variables by default initialise with false but we now initialise it explicitly to avoid valgrind related warning.

### Issues Resolved

[BABEL-4593]

#### Signo Off
Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).