### PR TITLE
fix single quotes in isolation error message

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -4441,7 +4441,7 @@ tsql_IsolationLevelStr:
 						TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_ISOLATION_LEVEL_REPEATABLE_READ);
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level."),
+							errmsg("Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level."),
 							parser_errposition(@1)));
 					}
 
@@ -4463,7 +4463,7 @@ tsql_IsolationLevelStr:
 						TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_ISOLATION_LEVEL_SERIALIZABLE);
 						ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
-							errmsg("Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level."),
+							errmsg("Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level."),
 							parser_errposition(@1)));
 					}
 				}

--- a/test/JDBC/expected/BABEL-3214.out
+++ b/test/JDBC/expected/BABEL-3214.out
@@ -44,7 +44,7 @@ SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
 
 SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
 SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;
@@ -65,7 +65,7 @@ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level.)~~
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
 
 SELECT CAST(current_setting('transaction_isolation') AS VARCHAR);
 SELECT transaction_isolation_level from sys.dm_exec_sessions WHERE session_id = @@SPID;

--- a/test/JDBC/expected/BABEL_4145.out
+++ b/test/JDBC/expected/BABEL_4145.out
@@ -115,7 +115,7 @@ SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
 
 SELECT current_setting('transaction_isolation');
 GO
@@ -137,7 +137,7 @@ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level.)~~
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
 
 SELECT current_setting('transaction_isolation');
 GO
@@ -208,7 +208,7 @@ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level.)~~
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
 
 SELECT current_setting('transaction_isolation');
 GO
@@ -261,7 +261,7 @@ SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
 
 SELECT current_setting('transaction_isolation');
 GO

--- a/test/JDBC/expected/TestIsolationLevels.out
+++ b/test/JDBC/expected/TestIsolationLevels.out
@@ -22,7 +22,7 @@ set transaction isolation level repeatable read;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
 
 
 set transaction isolation level snapshot;
@@ -32,7 +32,7 @@ set transaction isolation level serializable;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level.)~~
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
 
 
 select set_config('default_transaction_isolation', 'read uncommitted', false);

--- a/test/JDBC/expected/TestTransactionsSQLBatch.out
+++ b/test/JDBC/expected/TestTransactionsSQLBatch.out
@@ -108,7 +108,7 @@ int
 set transaction isolation level repeatable read;
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
 
 #show transaction_isolation;
 #show default_transaction_isolation;
@@ -374,7 +374,7 @@ int
 set transaction isolation level serializable;
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level.)~~
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
 
 #show transaction_isolation;
 #show default_transaction_isolation;

--- a/test/python/expected/pymssql/TestTransactionsSQLBatch.out
+++ b/test/python/expected/pymssql/TestTransactionsSQLBatch.out
@@ -129,7 +129,7 @@ int
 
 set transaction isolation level repeatable read;
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: 'Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level.DB-Lib error message 20018, severity 16:\nGeneral SQL Server error: Check messages from the SQL Server\n')~~
+~~ERROR (Message: 'Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.DB-Lib error message 20018, severity 16:\nGeneral SQL Server error: Check messages from the SQL Server\n')~~
 
 #show transaction_isolation;
 #show default_transaction_isolation;
@@ -430,7 +430,7 @@ int
 # begin transaction name -> save transaction name -> rollback tran name, Rollback whole transaction
 set transaction isolation level serializable;
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: 'Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level.DB-Lib error message 20018, severity 16:\nGeneral SQL Server error: Check messages from the SQL Server\n')~~
+~~ERROR (Message: 'Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.DB-Lib error message 20018, severity 16:\nGeneral SQL Server error: Check messages from the SQL Server\n')~~
 
 #show transaction_isolation;
 #show default_transaction_isolation;

--- a/test/python/expected/pyodbc/TestTransactionsSQLBatch.out
+++ b/test/python/expected/pyodbc/TestTransactionsSQLBatch.out
@@ -107,7 +107,7 @@ int
 
 set transaction isolation level repeatable read;
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Isolation level ‘REPEATABLE READ’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_repeatable_read’ config option to 'pg_isolation' to get PG repeatable read isolation level. (33557097) (SQLExecDirectW))~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level. (33557097) (SQLExecDirectW))~~
 
 #show transaction_isolation;
 #show default_transaction_isolation;
@@ -372,7 +372,7 @@ int
 # begin transaction name -> save transaction name -> rollback tran name, Rollback whole transaction
 set transaction isolation level serializable;
 ~~ERROR (Code: 33557097)~~
-~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Isolation level ‘SERIALIZABLE’ is not currently supported in Babelfish. Set ‘babelfishpg_tsql.isolation_level_serializable’ config option to 'pg_isolation' to get PG serializable isolation level. (33557097) (SQLExecDirectW))~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level. (33557097) (SQLExecDirectW))~~
 
 #show transaction_isolation;
 #show default_transaction_isolation;


### PR DESCRIPTION
### Description

Currently single quotes in isolation error message are some times interpreted as back ticks. 
We replace these with correct single quotes.

### Issues Resolved

[BABEL-4579]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).