### PR TITLE
Fixed information_schema.tables, information_schema.views and sys.views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -419,9 +419,11 @@ CREATE VIEW information_schema_tsql.tables AS
 
 	FROM sys.pg_namespace_ext nc JOIN pg_class c ON (nc.oid = c.relnamespace)
 		   LEFT OUTER JOIN sys.babelfish_namespace_ext ext on nc.nspname = ext.nspname
+		   LEFT JOIN sys.table_types_internal tt on c.oid = tt.typrelid
 
 	WHERE c.relkind IN ('r', 'v', 'p')
 		AND (NOT pg_is_other_temp_schema(nc.oid))
+		AND tt.typrelid IS NULL
 		AND (pg_has_role(c.relowner, 'USAGE')
 			OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
 			OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )
@@ -492,9 +494,11 @@ CREATE OR REPLACE VIEW information_schema_tsql.views AS
 			ON ext.dbid = vd.dbid
 				AND (ext.orig_name = vd.schema_name COLLATE sys.database_default)
 				AND (CAST(c.relname AS sys.nvarchar(128)) = vd.object_name COLLATE sys.database_default)
+		LEFT JOIN sys.shipped_objects_not_in_sys nis on (nis.name = c.relname and nis.schemaid = nc.oid and nis.type = 'V')
 
 	WHERE c.relkind = 'v'
 		AND (NOT pg_is_other_temp_schema(nc.oid))
+		AND nis.name is null
 		AND (pg_has_role(c.relowner, 'USAGE')
 			OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
 			OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -70,6 +70,40 @@ and has_schema_privilege(t.relnamespace, 'USAGE')
 and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
 GRANT SELECT ON sys.tables TO PUBLIC;
 
+create or replace view sys.shipped_objects_not_in_sys AS
+-- This portion of view retrieves information on objects that reside in a schema in one specfic database.
+-- For example, 'master_dbo' schema can only exist in the 'master' database.
+-- Internally stored schema name (nspname) must be provided.
+select t.name,t.type, ns.oid as schemaid from
+(
+  values
+    ('xp_qv','master_dbo','P'),
+    ('xp_instance_regread','master_dbo','P'),
+    ('sp_addlinkedserver', 'master_dbo', 'P'),
+    ('sp_addlinkedsrvlogin', 'master_dbo', 'P'),
+    ('sp_dropserver', 'master_dbo', 'P'),
+    ('sp_droplinkedsrvlogin', 'master_dbo', 'P'),
+    ('sp_testlinkedserver', 'master_dbo', 'P'),
+    ('sp_enum_oledb_providers','master_dbo','P'),
+    ('fn_syspolicy_is_automation_enabled', 'msdb_dbo', 'FN'),
+    ('syspolicy_configuration', 'msdb_dbo', 'V'),
+    ('syspolicy_system_health_state', 'msdb_dbo', 'V')
+) t(name,schema_name, type)
+inner join pg_catalog.pg_namespace ns on t.schema_name = ns.nspname
+
+union all
+
+-- This portion of view retrieves information on objects that reside in a schema in any number of databases.
+-- For example, 'dbo' schema can exist in the 'master', 'tempdb', 'msdb', and any user created database.
+select t.name,t.type, ns.oid as schemaid from
+(
+  values
+    ('sysdatabases','dbo','V')
+) t (name, schema_name, type)
+inner join sys.babelfish_namespace_ext b on t.schema_name = b.orig_name
+inner join pg_catalog.pg_namespace ns on b.nspname = ns.nspname;
+GRANT SELECT ON sys.shipped_objects_not_in_sys TO PUBLIC;
+
 create or replace view sys.views as 
 select 
   t.relname as name
@@ -87,9 +121,11 @@ select
   , 0 as with_check_option 
   , 0 as is_date_correlation_view 
   , 0 as is_tracked_by_cdc 
-from pg_class t inner join sys.schemas sch on t.relnamespace = sch.schema_id 
+from pg_class t inner join sys.schemas sch on (t.relnamespace = sch.schema_id)
+left join sys.shipped_objects_not_in_sys nis on (nis.name = t.relname and nis.schemaid = sch.schema_id and nis.type = 'V')
 left outer join sys.babelfish_view_def vd on t.relname::sys.sysname = vd.object_name and sch.name = vd.schema_name and vd.dbid = sys.db_id() 
 where t.relkind = 'v'
+and nis.name is null
 and has_schema_privilege(sch.schema_id, 'USAGE')
 and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
 GRANT SELECT ON sys.views TO PUBLIC;
@@ -1231,34 +1267,6 @@ INNER JOIN sys.schemas s on c.connamespace = s.schema_id
 WHERE has_schema_privilege(s.schema_id, 'USAGE')
 AND c.contype = 'c' and c.conrelid != 0;
 GRANT SELECT ON sys.check_constraints TO PUBLIC;
-
-create or replace view sys.shipped_objects_not_in_sys AS
--- This portion of view retrieves information on objects that reside in a schema in one specfic database.
--- For example, 'master_dbo' schema can only exist in the 'master' database.
--- Internally stored schema name (nspname) must be provided.
-select t.name,t.type, ns.oid as schemaid from
-(
-  values
-    ('xp_qv','master_dbo','P'),
-    ('xp_instance_regread','master_dbo','P'),
-    ('fn_syspolicy_is_automation_enabled', 'msdb_dbo', 'FN'),
-    ('syspolicy_configuration', 'msdb_dbo', 'V'),
-    ('syspolicy_system_health_state', 'msdb_dbo', 'V')
-) t(name,schema_name, type)
-inner join pg_catalog.pg_namespace ns on t.schema_name = ns.nspname
-
-union all
-
--- This portion of view retrieves information on objects that reside in a schema in any number of databases.
--- For example, 'dbo' schema can exist in the 'master', 'tempdb', 'msdb', and any user created database.
-select t.name,t.type, ns.oid as schemaid from
-(
-  values
-    ('sysdatabases','dbo','V')
-) t (name, schema_name, type)
-inner join sys.babelfish_namespace_ext b on t.schema_name = b.orig_name
-inner join pg_catalog.pg_namespace ns on b.nspname = ns.nspname;
-GRANT SELECT ON sys.shipped_objects_not_in_sys TO PUBLIC;
 
 create or replace view sys.all_objects as
 select 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
@@ -1831,6 +1831,94 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
+CREATE OR REPLACE VIEW information_schema_tsql.tables AS
+	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		   CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+		   CAST(
+			 CASE WHEN c.reloptions[1] LIKE 'bbf_original_rel_name%' THEN substring(c.reloptions[1], 23)
+                  ELSE c.relname END
+			 AS sys._ci_sysname) AS "TABLE_NAME",
+
+		   CAST(
+			 CASE WHEN c.relkind IN ('r', 'p') THEN 'BASE TABLE'
+				  WHEN c.relkind = 'v' THEN 'VIEW'
+				  ELSE null END
+			 AS sys.varchar(10)) COLLATE sys.database_default AS "TABLE_TYPE"
+
+	FROM sys.pg_namespace_ext nc JOIN pg_class c ON (nc.oid = c.relnamespace)
+		   LEFT OUTER JOIN sys.babelfish_namespace_ext ext on nc.nspname = ext.nspname
+		   LEFT JOIN sys.table_types_internal tt on c.oid = tt.typrelid
+
+	WHERE c.relkind IN ('r', 'v', 'p')
+		AND (NOT pg_is_other_temp_schema(nc.oid))
+		AND tt.typrelid IS NULL
+		AND (pg_has_role(c.relowner, 'USAGE')
+			OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+			OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )
+		AND ext.dbid = sys.db_id()
+		AND (NOT c.relname = 'sysdatabases');
+
+GRANT SELECT ON information_schema_tsql.tables TO PUBLIC;
+
+CREATE OR REPLACE VIEW information_schema_tsql.views AS
+	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+			CAST(ext.orig_name AS sys.nvarchar(128)) AS  "TABLE_SCHEMA",
+			CAST(c.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
+			CAST(vd.definition AS sys.nvarchar(4000)) AS "VIEW_DEFINITION",
+
+			CAST(
+				CASE WHEN 'check_option=cascaded' = ANY (c.reloptions)
+					THEN 'CASCADE'
+					ELSE 'NONE' END
+				AS sys.varchar(7)) COLLATE sys.database_default AS "CHECK_OPTION",
+
+			CAST('NO' AS sys.varchar(2)) AS "IS_UPDATABLE"
+
+	FROM sys.pg_namespace_ext nc JOIN pg_class c ON (nc.oid = c.relnamespace)
+		LEFT OUTER JOIN sys.babelfish_namespace_ext ext
+			ON (nc.nspname = ext.nspname COLLATE sys.database_default)
+		LEFT OUTER JOIN sys.babelfish_view_def vd
+			ON ext.dbid = vd.dbid
+				AND (ext.orig_name = vd.schema_name COLLATE sys.database_default)
+				AND (CAST(c.relname AS sys.nvarchar(128)) = vd.object_name COLLATE sys.database_default)
+		LEFT JOIN sys.shipped_objects_not_in_sys nis on (nis.name = c.relname and nis.schemaid = nc.oid and nis.type = 'V')
+
+	WHERE c.relkind = 'v'
+		AND (NOT pg_is_other_temp_schema(nc.oid))
+		AND nis.name is null
+		AND (pg_has_role(c.relowner, 'USAGE')
+			OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+			OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )
+		AND ext.dbid = sys.db_id();
+
+GRANT SELECT ON information_schema_tsql.views TO PUBLIC;
+
+create or replace view sys.views as 
+select 
+  t.relname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , sch.schema_id as schema_id
+  , 0 as parent_object_id
+  , 'V'::varchar(2) as type 
+  , 'VIEW'::varchar(60) as type_desc
+  , vd.create_date::timestamp as create_date
+  , vd.create_date::timestamp as modify_date
+  , 0 as is_ms_shipped 
+  , 0 as is_published 
+  , 0 as is_schema_published 
+  , 0 as with_check_option 
+  , 0 as is_date_correlation_view 
+  , 0 as is_tracked_by_cdc 
+from pg_class t inner join sys.schemas sch on (t.relnamespace = sch.schema_id)
+left join sys.shipped_objects_not_in_sys nis on (nis.name = t.relname and nis.schemaid = sch.schema_id and nis.type = 'V')
+left outer join sys.babelfish_view_def vd on t.relname::sys.sysname = vd.object_name and sch.name = vd.schema_name and vd.dbid = sys.db_id() 
+where t.relkind = 'v'
+and nis.name is null
+and has_schema_privilege(sch.schema_id, 'USAGE')
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
+GRANT SELECT ON sys.views TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/BABEL-SP_COLUMNS_MANAGED-dep-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_COLUMNS_MANAGED-dep-vu-verify.out
@@ -3,18 +3,6 @@ EXEC babel_sp_columns_managed_dep_vu_prepare_p1 "master", "dbo", "sysdatabases";
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#status#!#5#!#<NULL>#!#YES#!#int#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#status2#!#6#!#<NULL>#!#YES#!#int#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#crdate#!#7#!#<NULL>#!#YES#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#reserved#!#8#!#<NULL>#!#YES#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#category#!#9#!#<NULL>#!#YES#!#int#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#cmptlevel#!#10#!#<NULL>#!#YES#!#tinyint#!#<NULL>#!#<NULL>#!#3#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#filename#!#11#!#<NULL>#!#YES#!#nvarchar#!#260#!#520#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#version#!#12#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
 ~~END~~
 
 
@@ -22,18 +10,6 @@ EXEC babel_sp_columns_managed_dep_vu_prepare_p1 "master", "dbo", "SYSDATABASES";
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#status#!#5#!#<NULL>#!#YES#!#int#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#status2#!#6#!#<NULL>#!#YES#!#int#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#crdate#!#7#!#<NULL>#!#YES#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#reserved#!#8#!#<NULL>#!#YES#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#category#!#9#!#<NULL>#!#YES#!#int#!#<NULL>#!#<NULL>#!#10#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#cmptlevel#!#10#!#<NULL>#!#YES#!#tinyint#!#<NULL>#!#<NULL>#!#3#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#filename#!#11#!#<NULL>#!#YES#!#nvarchar#!#260#!#520#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
-master#!#dbo#!#sysdatabases#!#version#!#12#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
 ~~END~~
 
 
@@ -41,7 +17,6 @@ EXEC babel_sp_columns_managed_dep_vu_prepare_p1 "master", "dbo", "sysdatabases",
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
 ~~END~~
 
 
@@ -49,6 +24,5 @@ EXEC babel_sp_columns_managed_dep_vu_prepare_p1 "MASTER", "DbO", "SYSDATABASES",
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int#!#int#!#int#!#int#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#int#!#int
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#0
 ~~END~~
 

--- a/test/JDBC/expected/ISC-Tables-vu-cleanup.out
+++ b/test/JDBC/expected/ISC-Tables-vu-cleanup.out
@@ -1,6 +1,9 @@
 DROP TABLE isc_tables_sc1.t2
 GO
 
+DROP TYPE isc_tables_sc1.isc_table_type2
+GO
+
 DROP SCHEMA isc_tables_sc1
 GO
 
@@ -15,4 +18,7 @@ DROP PROCEDURE isc_tables_vu_prepare_p1
 GO
 
 DROP TABLE isc_tables_vu_prepare_t1
+GO
+
+DROP TYPE isc_table_type1
 GO

--- a/test/JDBC/expected/ISC-Tables-vu-prepare.out
+++ b/test/JDBC/expected/ISC-Tables-vu-prepare.out
@@ -1,11 +1,17 @@
 CREATE TABLE isc_tables_vu_prepare_t1(a INT,b INT)
 GO
 
+CREATE TYPE isc_table_type1 AS TABLE(a INT)
+GO
+
 -- test different schema 
 CREATE SCHEMA isc_tables_sc1
 GO
 
 CREATE TABLE isc_tables_sc1.t2(a INT,b INT)
+GO
+
+CREATE TYPE isc_tables_sc1.isc_table_type2 AS TABLE(a INT)
 GO
 
 --Dep Proc

--- a/test/JDBC/expected/ISC-Tables-vu-verify.out
+++ b/test/JDBC/expected/ISC-Tables-vu-verify.out
@@ -12,6 +12,15 @@ master#!#dbo#!#isc_tables_vu_prepare_t1#!#BASE TABLE
 ~~END~~
 
 
+-- Table types should not be a result
+-- Should not return any rows.
+SELECT * FROM information_schema.tables WHERE TABLE_NAME = 'isc_table_type1'
+GO
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#varchar
+~~END~~
+
+
 SELECT * FROM information_schema.tables WHERE TABLE_SCHEMA = 'isc_tables_sc1'
 SELECT * FROM information_schema.tables WHERE TABLE_SCHEMA = 'ISC_TABLES_SC1'
 GO
@@ -23,6 +32,15 @@ master#!#isc_tables_sc1#!#t2#!#BASE TABLE
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
 master#!#isc_tables_sc1#!#t2#!#BASE TABLE
+~~END~~
+
+
+-- Table types should not be a result
+-- Should not return any rows.
+SELECT * FROM information_schema.tables WHERE (TABLE_NAME = 'isc_table_type2' AND TABLE_SCHEMA = 'isc_tables_sc1')
+GO
+~~START~~
+nvarchar#!#nvarchar#!#varchar#!#varchar
 ~~END~~
 
 

--- a/test/JDBC/expected/ISC-Views-vu-verify.out
+++ b/test/JDBC/expected/ISC-Views-vu-verify.out
@@ -144,7 +144,15 @@ select table_catalog, table_schema, table_name from information_schema.views
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar
-isc_db#!#dbo#!#sysdatabases
+~~END~~
+
+
+-- Should return 0 rows. 
+select count(*) from information_schema.views WHERE TABLE_NAME = 'sysdatabases'
+GO
+~~START~~
+int
+0
 ~~END~~
 
 

--- a/test/JDBC/expected/ISC-Views.out
+++ b/test/JDBC/expected/ISC-Views.out
@@ -321,7 +321,6 @@ Select table_catalog, table_schema, table_name from information_schema.views
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar
-isc_db#!#dbo#!#sysdatabases
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-objects-vu-verify.out
+++ b/test/JDBC/expected/sys-objects-vu-verify.out
@@ -41,7 +41,6 @@ varchar
 sys_objects_vu_prepare_proc1
 sys_objects_vu_prepare_table1
 sys_objects_vu_prepare_trig1
-sysdatabases
 ~~END~~
 
 
@@ -52,7 +51,6 @@ select name, type, type_desc from tempdb.sys.objects order by name;
 GO
 ~~START~~
 varchar#!#char#!#nvarchar
-sysdatabases#!#V #!#VIEW
 ~~END~~
 
 
@@ -67,7 +65,6 @@ varchar
 sys_objects_vu_prepare_proc1
 sys_objects_vu_prepare_table1
 sys_objects_vu_prepare_trig1
-sysdatabases
 ~~END~~
 
 
@@ -75,7 +72,6 @@ select name, type, type_desc from tempdb.sys.objects order by name;
 GO
 ~~START~~
 varchar#!#char#!#nvarchar
-sysdatabases#!#V #!#VIEW
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-views-vu-verify.out
+++ b/test/JDBC/expected/sys-views-vu-verify.out
@@ -9,6 +9,15 @@ int
 ~~END~~
 
 
+-- Should not include sysdatabases
+SELECT COUNT(*) FROM sys.views WHERE type = 'V' and name = 'sysdatabases'
+GO
+~~START~~
+int
+0
+~~END~~
+
+
 SELECT COUNT(*) FROM sys.objects WHERE type='V' and name = 'sys_views_vu_prepare_t1';
 GO
 ~~START~~

--- a/test/JDBC/input/ISC-Tables-vu-cleanup.sql
+++ b/test/JDBC/input/ISC-Tables-vu-cleanup.sql
@@ -1,6 +1,9 @@
 DROP TABLE isc_tables_sc1.t2
 GO
 
+DROP TYPE isc_tables_sc1.isc_table_type2
+GO
+
 DROP SCHEMA isc_tables_sc1
 GO
 
@@ -15,4 +18,7 @@ DROP PROCEDURE isc_tables_vu_prepare_p1
 GO
 
 DROP TABLE isc_tables_vu_prepare_t1
+GO
+
+DROP TYPE isc_table_type1
 GO

--- a/test/JDBC/input/ISC-Tables-vu-prepare.sql
+++ b/test/JDBC/input/ISC-Tables-vu-prepare.sql
@@ -1,11 +1,17 @@
 CREATE TABLE isc_tables_vu_prepare_t1(a INT,b INT)
 GO
 
+CREATE TYPE isc_table_type1 AS TABLE(a INT)
+GO
+
 -- test different schema 
 CREATE SCHEMA isc_tables_sc1
 GO
 
 CREATE TABLE isc_tables_sc1.t2(a INT,b INT)
+GO
+
+CREATE TYPE isc_tables_sc1.isc_table_type2 AS TABLE(a INT)
 GO
 
 --Dep Proc

--- a/test/JDBC/input/ISC-Tables-vu-verify.sql
+++ b/test/JDBC/input/ISC-Tables-vu-verify.sql
@@ -2,8 +2,18 @@ SELECT * FROM information_schema.tables WHERE TABLE_NAME = 'isc_tables_vu_prepar
 SELECT * FROM information_schema.tables WHERE TABLE_NAME = 'ISC_TABLES_VU_PREPARE_T1'
 GO
 
+-- Table types should not be a result
+-- Should not return any rows.
+SELECT * FROM information_schema.tables WHERE TABLE_NAME = 'isc_table_type1'
+GO
+
 SELECT * FROM information_schema.tables WHERE TABLE_SCHEMA = 'isc_tables_sc1'
 SELECT * FROM information_schema.tables WHERE TABLE_SCHEMA = 'ISC_TABLES_SC1'
+GO
+
+-- Table types should not be a result
+-- Should not return any rows.
+SELECT * FROM information_schema.tables WHERE (TABLE_NAME = 'isc_table_type2' AND TABLE_SCHEMA = 'isc_tables_sc1')
 GO
 
 EXEC isc_tables_vu_prepare_p1

--- a/test/JDBC/input/ISC-Views-vu-verify.sql
+++ b/test/JDBC/input/ISC-Views-vu-verify.sql
@@ -51,6 +51,10 @@ go
 select table_catalog, table_schema, table_name from information_schema.views
 go
 
+-- Should return 0 rows. 
+select count(*) from information_schema.views WHERE TABLE_NAME = 'sysdatabases'
+GO
+
 -- Will only include sysdatabases view
 select count(*) from information_schema.views WHERE TABLE_NAME != 'sysdatabases'
 go

--- a/test/JDBC/input/views/sys-views-vu-verify.sql
+++ b/test/JDBC/input/views/sys-views-vu-verify.sql
@@ -4,6 +4,10 @@ GO
 SELECT COUNT(*) FROM sys.views WHERE name = 'sys_views_vu_prepare_t1';
 GO
 
+-- Should not include sysdatabases
+SELECT COUNT(*) FROM sys.views WHERE type = 'V' and name = 'sysdatabases'
+GO
+
 SELECT COUNT(*) FROM sys.objects WHERE type='V' and name = 'sys_views_vu_prepare_t1';
 GO
 


### PR DESCRIPTION
### Description

Previously in Babelfish, table types are included in `information_schema.tables` and sysdatabases is included in `sys.views`, and `information_schema.views`. This is contrary to T-SQL. This PR removes tables type from `information_schema.tables` and sysdatabases from `sys.views` and `information_schema.views`. 

Cherry-pick commit 61d6378d4c1696134c8a0c8d726e7984e062a1d9 from BABEL_2_7_STABLE to BABEL_2_X_DEV

### Issues Resolved
BABEL-4587


Signed-off-by: Sandeep Kumawat <skumwt@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**

Added test cases related to changes in the below test files. 

> sys-views-vu-prepare/verify/cleanup
> ISC-Tables-vu-prepare/verify/cleanup
> ISC-Views-vu-prepare/verify/cleanup
> ISC-Views


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).