### PR TITLE
fix sys.shipped_objects_not_in_sys entries in sys.views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -79,12 +79,6 @@ select t.name,t.type, ns.oid as schemaid from
   values
     ('xp_qv','master_dbo','P'),
     ('xp_instance_regread','master_dbo','P'),
-    ('sp_addlinkedserver', 'master_dbo', 'P'),
-    ('sp_addlinkedsrvlogin', 'master_dbo', 'P'),
-    ('sp_dropserver', 'master_dbo', 'P'),
-    ('sp_droplinkedsrvlogin', 'master_dbo', 'P'),
-    ('sp_testlinkedserver', 'master_dbo', 'P'),
-    ('sp_enum_oledb_providers','master_dbo','P'),
     ('fn_syspolicy_is_automation_enabled', 'msdb_dbo', 'FN'),
     ('syspolicy_configuration', 'msdb_dbo', 'V'),
     ('syspolicy_system_health_state', 'msdb_dbo', 'V')


### PR DESCRIPTION
### Description

This commit removes the extra entries that went into sys.shipped_objects_not_in_sys along with this commit 8df55f7ad70148388b5f6122239e560abfddf85b

Signed-off-by: Sandeep Kumawat <skumwt@amazon.com>


### Issues Resolved
 NO-JIRA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).