### PR TITLE
Enable the guc for fulltext search, update test cases, and add fts related tests in ignore list

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -683,7 +683,7 @@ define_custom_variables(void)
 							 gettext_noop("GUC for enabling or disabling full text search features"),
 							 NULL,
 							 &pltsql_allow_fulltext_parser,
-							 true,
+							 false,
 							 PGC_SUSET,
 							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY,
 							 NULL, NULL, NULL);

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-cleanup.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-cleanup.out
@@ -1,3 +1,14 @@
+-- psql
+-- enable CONTAINS
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
 -- tsql user=testLogin password=abc
 USE master;
 GO
@@ -147,5 +158,15 @@ GO
 ~~START~~
 text
 strict
+~~END~~
+
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
 ~~END~~
 

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-prepare.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-prepare.out
@@ -1,3 +1,14 @@
+-- psql
+-- enable CONTAINS
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
 -- tsql user=jdbc_user password=12345678
 -- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
@@ -191,5 +202,15 @@ GO
 ~~START~~
 text
 strict
+~~END~~
+
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
 ~~END~~
 

--- a/test/JDBC/expected/FULLTEXT_INDEX-vu-verify.out
+++ b/test/JDBC/expected/FULLTEXT_INDEX-vu-verify.out
@@ -1,3 +1,14 @@
+-- psql
+-- enable CONTAINS
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
 -- tsql user=jdbc_user password=12345678
 -- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
@@ -167,5 +178,15 @@ GO
 ~~START~~
 text
 strict
+~~END~~
+
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
 ~~END~~
 

--- a/test/JDBC/expected/fts-contains-vu-cleanup.out
+++ b/test/JDBC/expected/fts-contains-vu-cleanup.out
@@ -28,3 +28,13 @@ text
 strict
 ~~END~~
 
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+

--- a/test/JDBC/expected/fts-contains-vu-prepare.out
+++ b/test/JDBC/expected/fts-contains-vu-prepare.out
@@ -1,3 +1,14 @@
+-- psql
+-- enable CONTAINS
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
 -- tsql user=jdbc_user password=12345678
 -- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -1,3 +1,14 @@
+-- psql
+-- enable CONTAINS
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
 -- tsql user=jdbc_user password=12345678
 -- enable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-cleanup.mix
@@ -1,3 +1,9 @@
+-- enable CONTAINS
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+
 -- tsql user=testLogin password=abc
 USE master;
 GO
@@ -115,4 +121,9 @@ GO
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-prepare.mix
@@ -1,3 +1,9 @@
+-- enable CONTAINS
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+
 -- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
@@ -160,4 +166,9 @@ GO
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/FULLTEXT_INDEX-vu-verify.mix
@@ -1,3 +1,9 @@
+-- enable CONTAINS
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+
 -- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
@@ -77,4 +83,9 @@ GO
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
+GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
@@ -18,3 +18,8 @@ GO
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = off;
+SELECT pg_reload_conf();
+GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
@@ -1,3 +1,9 @@
+-- enable CONTAINS
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+
 -- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')

--- a/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
@@ -1,3 +1,9 @@
+-- enable CONTAINS
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.allow_fulltext_parser = on;
+SELECT pg_reload_conf();
+GO
+
 -- enable FULLTEXT
 -- tsql user=jdbc_user password=12345678
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -39,6 +39,12 @@ ignore#!#sys-types-before-dep-vu-cleanup
 ignore#!#sys-table_types-before-dep-vu-prepare
 ignore#!#sys-table_types-before-dep-vu-verify
 ignore#!#sys-table_types-before-dep-vu-cleanup
+ignore#!#fts-contains-vu-prepare
+ignore#!#fts-contains-vu-verify
+ignore#!#fts-contains-vu-cleanup
+ignore#!#FULLTEXT_INDEX-vu-prepare
+ignore#!#FULLTEXT_INDEX-vu-verify
+ignore#!#FULLTEXT_INDEX-vu-cleanup
 
 # These tests are meant for upgrade scenario prior to (potential) 14_5 release
 ignore#!#BABEL-3147-before-14_5-vu-prepare


### PR DESCRIPTION
### Description

This commits turns the custom fts parser off resulting in disabling the full-text search feature. Also updated jdbc test files and added fts tests in the ignore list.

### Issues Resolved

JIRA: BABEL-4379
Signed-off-by: Roshan Kanwar [rskanwar@amazon.com](mailto:rskanwar@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).