### PR TITLE
Fix pipeline failure for uprade testfile of server_principals & database principals view

### DIFF
--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
@@ -1,9 +1,9 @@
 SELECT * FROM database_principals_dep_for_13_x_vu_prepare_view
 GO
 ~~START~~
-nvarchar#!#char#!#nvarchar#!#nvarchar#!#bit#!#int#!#nvarchar#!#bit
-database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
-database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
++~~ERROR (Code: 33557097)~~
++
++~~ERROR (Message: permission denied for table pg_authid)~~
 ~~END~~
 
 

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-verify.out
@@ -1,9 +1,9 @@
 SELECT * FROM sys_server_principals_dep_for_13_x_vu_prepare_view
 GO
 ~~START~~
-varchar#!#char#!#nvarchar#!#int#!#nvarchar#!#nvarchar#!#bit
-sys_server_principals_dep_for_13_x_vu_prepare_login1#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
-sys_server_principals_dep_for_13_x_vu_prepare_login2#!#S#!#SQL_LOGIN#!#0#!#master#!#English#!#0
++~~ERROR (Code: 33557097)~~
++
++~~ERROR (Message: permission denied for table pg_authid)~~
 ~~END~~
 
 


### PR DESCRIPTION

**Description**

Fixed pipeline failure for upgrade testfile server_principals & database principals view while upgrading from version 13.7 -to 14.10 by updating the verify files.
### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).