### PR TITLE
Block Babelfish restore on versions prior to 15.5 (#2088)

### DIFF
--- a/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
+++ b/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
@@ -112,6 +112,34 @@ $newnode->command_fails_like(
 	'Restore of Babelfish database failed since source and target versions do not match.');
 $newnode->stop;
 
+# Restore is not supported on versions older than 15.5.
+$oldnode->start;
+
+$oldnode->command_fails_like(
+	[
+		'psql',
+		'-d',         'testdb',
+		'-U',         'test_master',
+		'-p',         $oldnode->port,
+		'--single-transaction',
+		'-f',         $dump1_file,
+	],
+	qr/Target Postgres version must be 15.5 or higher for Babelfish restore./,
+	'Restore of global objects failed since target version is older than 15.5.');
+
+$oldnode->command_fails_like(
+	[
+		'psql',
+		'-d',         'testdb',
+		'-U',         'test_master',
+		'-p',         $oldnode->port,
+		'--single-transaction',
+		'-f',         $dump2_file,
+	],
+	qr/Target Postgres version must be 15.5 or higher for Babelfish restore./,
+	'Restore of Babelfish database failed since target version is older than 15.5.');
+$oldnode->stop;
+
 ############################################################################################
 ############################## Test for cross migration mode ###############################
 ############################################################################################


### PR DESCRIPTION
### Description
Restore can only be performed on PG15.5 or higher versions, this commits blocks it on older versions.

Signed-off-by: Rishabh Tanwar ritanwar@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).