### PR TITLE
Deprecate sys.format(anyelement, nvarchar, varchar) only if it exists

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
@@ -1599,9 +1599,22 @@ left join sys.shipped_objects_not_in_sys nis on nis.name = ('TT_' || tt.name || 
 GRANT SELECT ON sys.all_objects TO PUBLIC;
 
 -- Rename function for dependencies
-ALTER FUNCTION sys.format_datetime(anyelement, NVARCHAR, VARCHAR, VARCHAR) RENAME TO format_datetime_deprecated_3_4_0;
-ALTER FUNCTION sys.format_numeric(anyelement, NVARCHAR, VARCHAR, VARCHAR, int) RENAME TO format_numeric_deprecated_3_4_0;
-ALTER FUNCTION sys.FORMAT(anyelement, NVARCHAR, VARCHAR) RENAME TO format_deprecated_3_4_0;
+ALTER FUNCTION sys.format_datetime(anyelement, NVARCHAR, VARCHAR, VARCHAR) RENAME TO format_datetime_deprecated_2_7_0;
+ALTER FUNCTION sys.format_numeric(anyelement, NVARCHAR, VARCHAR, VARCHAR, int) RENAME TO format_numeric_deprecated_2_7_0;
+
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    -- Rename FORMAT for dependencies
+    ALTER FUNCTION sys.FORMAT(anyelement, NVARCHAR, VARCHAR) RENAME TO format_deprecated_2_7_0;
+
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
 
 CREATE OR REPLACE FUNCTION sys.format_datetime(IN value anyelement, IN format_pattern sys.NVARCHAR,IN culture sys.VARCHAR,  IN data_type sys.VARCHAR DEFAULT '') RETURNS sys.nvarchar
 AS 'babelfishpg_tsql', 'format_datetime' LANGUAGE C IMMUTABLE PARALLEL UNSAFE;
@@ -1673,9 +1686,22 @@ LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.FORMAT(IN anyelement, IN sys.NVARCHAR, IN sys.VARCHAR) TO PUBLIC;
 
 -- === DROP deprecated functions (if exists)
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_datetime_deprecated_3_4_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_numeric_deprecated_3_4_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_deprecated_3_4_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_datetime_deprecated_2_7_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_numeric_deprecated_2_7_0');
+
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    -- === DROP format_deprecated_2_7_0
+    CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_deprecated_2_7_0');
+
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
 
 CREATE OR REPLACE PROCEDURE sys.analyze_babelfish_catalogs()
 LANGUAGE plpgsql

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.6.0--2.7.0.sql
@@ -1598,9 +1598,34 @@ left join sys.shipped_objects_not_in_sys nis on nis.name = ('TT_' || tt.name || 
 ) ot;
 GRANT SELECT ON sys.all_objects TO PUBLIC;
 
--- Rename function for dependencies
-ALTER FUNCTION sys.format_datetime(anyelement, NVARCHAR, VARCHAR, VARCHAR) RENAME TO format_datetime_deprecated_2_7_0;
-ALTER FUNCTION sys.format_numeric(anyelement, NVARCHAR, VARCHAR, VARCHAR, int) RENAME TO format_numeric_deprecated_2_7_0;
+-- Rename functions for dependencies
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    -- Rename format_datetime for dependencies
+    ALTER FUNCTION sys.format_datetime(anyelement, NVARCHAR, VARCHAR, VARCHAR) RENAME TO format_datetime_deprecated_2_7_0;
+
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    -- Rename format_numeric for dependencies
+    ALTER FUNCTION sys.format_numeric(anyelement, NVARCHAR, VARCHAR, VARCHAR, int) RENAME TO format_numeric_deprecated_2_7_0;
+
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
 
 DO $$
 DECLARE
@@ -1686,8 +1711,33 @@ LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE;
 GRANT EXECUTE ON FUNCTION sys.FORMAT(IN anyelement, IN sys.NVARCHAR, IN sys.VARCHAR) TO PUBLIC;
 
 -- === DROP deprecated functions (if exists)
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_datetime_deprecated_2_7_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_numeric_deprecated_2_7_0');
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    -- === DROP format_datetime_deprecated_2_7_0
+    CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_datetime_deprecated_2_7_0');
+
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    -- === DROP format_numeric_deprecated_2_7_0
+    CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'format_numeric_deprecated_2_7_0');
+
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
 
 DO $$
 DECLARE


### PR DESCRIPTION
### Description

This change deprecates babelfishpg_tsql--2.6.0--2.7.0.sql we need to deprecate sys.FORMAT(anyelement, NVARCHAR, VARCHAR) ONLY if it exists

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Issues Resolved

N/A

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).