### PR TITLE
TSQL connection ps status always shows idle.

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -20,6 +20,7 @@
 #include "utils/guc.h"
 #include "lib/stringinfo.h"
 #include "pgstat.h"
+#include "utils/ps_status.h"
 
 #include "src/include/tds_instr.h"
 #include "src/include/tds_int.h"
@@ -909,6 +910,7 @@ ProcessBCPRequest(TDSRequest request)
 	TDSRequestBulkLoad req = (TDSRequestBulkLoad) request;
 	StringInfo	message = req->firstMessage;
 
+	set_ps_display("active");
 	TdsErrorContext->err_text = "Processing Bulk Load Request";
 	pgstat_report_activity(STATE_RUNNING, "Processing Bulk Load Request");
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -17,6 +17,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/ps_status.h"
 #include "utils/snapmgr.h"
 
 #include "src/include/tds_debug.h"
@@ -508,6 +509,7 @@ SPExecuteSQL(TDSRequestSP req)
 	initStringInfo(&s);
 	FillQueryFromParameterToken(req, &s);
 
+	set_ps_display("active");
 	activity = psprintf("SP_EXECUTESQL: %s", s.data);
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);
@@ -641,6 +643,7 @@ SPPrepare(TDSRequestSP req)
 	initStringInfo(&s);
 	FillQueryFromParameterToken(req, &s);
 
+	set_ps_display("active");
 	activity = psprintf("SP_PREPARE: %s", s.data);
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);
@@ -717,6 +720,7 @@ SPExecute(TDSRequestSP req)
 
 	char	   *activity = psprintf("SP_EXECUTE Handle: %d", req->handle);
 
+	set_ps_display("active");
 	TdsErrorContext->err_text = "Processing SP_EXECUTE Request";
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);
@@ -859,6 +863,7 @@ SPPrepExec(TDSRequestSP req)
 	initStringInfo(&s);
 	FillQueryFromParameterToken(req, &s);
 
+	set_ps_display("active");
 	activity = psprintf("SP_PREPEXEC: %s", s.data);
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);
@@ -1105,6 +1110,7 @@ SPCustomType(TDSRequestSP req)
 	initStringInfo(&s);
 	FillStoredProcedureCallFromParameterToken(req, &s);
 
+	set_ps_display("active");
 	activity = psprintf("SP_CUSTOMTYPE: %s", s.data);
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);
@@ -1229,6 +1235,7 @@ SPUnprepare(TDSRequestSP req)
 
 	char	   *activity = psprintf("SP_UNPREPARE Handle: %d", req->handle);
 
+	set_ps_display("active");
 	TdsErrorContext->err_text = "Processing SP_UNPREPARE Request";
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);
@@ -2465,7 +2472,7 @@ HandleSPCursorOpenCommon(TDSRequestSP req)
 		if (req->spType == SP_CURSOREXEC)
 		{
 			char	   *activity = psprintf("SP_CURSOREXEC Handle: %d", (int) req->cursorPreparedHandle);
-
+			set_ps_display("active");
 			pgstat_report_activity(STATE_RUNNING, activity);
 			pfree(activity);
 
@@ -2484,6 +2491,7 @@ HandleSPCursorOpenCommon(TDSRequestSP req)
 			switch (req->spType)
 			{
 				case SP_CURSOROPEN:
+					set_ps_display("active");
 					activity = psprintf("SP_CURSOROPEN: %s", buf.data);
 					pgstat_report_activity(STATE_RUNNING, activity);
 					pfree(activity);
@@ -2492,6 +2500,7 @@ HandleSPCursorOpenCommon(TDSRequestSP req)
 																			NULL /* TODO row_count */ , req->nTotalParams, req->boundParamsData, req->boundParamsNullList);
 					break;
 				case SP_CURSORPREPARE:
+					set_ps_display("active");
 					activity = psprintf("SP_CURSORPREPARE: %s", buf.data);
 					pgstat_report_activity(STATE_RUNNING, activity);
 					pfree(activity);
@@ -2500,6 +2509,7 @@ HandleSPCursorOpenCommon(TDSRequestSP req)
 																			   (int) req->nTotalBindParams, req->boundParamsOidList);
 					break;
 				case SP_CURSORPREPEXEC:
+					set_ps_display("active");
 					activity = psprintf("SP_CURSORPREPEXEC: %s", buf.data);
 					pgstat_report_activity(STATE_RUNNING, activity);
 					pfree(activity);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssqlbatch.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssqlbatch.c
@@ -23,6 +23,7 @@
 #include "nodes/parsenodes.h"
 #include "pgstat.h"
 #include "tcop/tcopprot.h"
+#include "utils/ps_status.h"
 
 #include "src/include/tds_int.h"
 #include "src/include/tds_protocol.h"
@@ -73,6 +74,7 @@ ExecuteSQLBatch(char *query)
 	InlineCodeBlock *codeblock = makeNode(InlineCodeBlock);
 	char	   *activity = psprintf("SQL_BATCH: %s", query);
 
+	set_ps_display("active");
 	TdsErrorContext->err_text = "Processing SQL Batch Request";
 	pgstat_report_activity(STATE_RUNNING, activity);
 	pfree(activity);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -278,7 +278,7 @@ static bool
 check_identity_insert(char** newval, void **extra, GucSource source)
 {
 	/*
-	 * Workers synchronize the parameter at the beginning of each parallel 
+	 * Workers synchronize the parameter at the beginning of each parallel
 	 * operation. Avoid performing parameter assignment uring parallel operation.
 	 */
 	if (IsParallelWorker() && !InitializingParallelWorker)
@@ -1036,8 +1036,8 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 												{
 													ColumnDef* def = (ColumnDef *) element;
 
-													if (strlen(def->colname) == colname_len && 
-														strncmp(def->colname, colname, colname_len) == 0 && 
+													if (strlen(def->colname) == colname_len &&
+														strncmp(def->colname, colname, colname_len) == 0 &&
 														has_nullable_constraint(def))
 													{
 														ereport(ERROR,
@@ -1045,9 +1045,9 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 															errmsg("Nullable UNIQUE constraint is not supported. Please use babelfishpg_tsql.escape_hatch_unique_constraint to ignore "
 																"or add a NOT NULL constraint")));
 													}
-												}	
+												}
 											}
-										}		
+										}
 									}
 
 									if (rowversion_column_name)
@@ -2293,7 +2293,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							if (atstmt->relation->schemaname != NULL)
 							{
 								/*
-								* As syntax1 ( { ENABLE | DISABLE } TRIGGER <trigger> ON <table> ) 
+								* As syntax1 ( { ENABLE | DISABLE } TRIGGER <trigger> ON <table> )
 								* is mapped to syntax2 ( ALTER TABLE <table> { ENABLE | DISABLE } TRIGGER <trigger> ),
 								* objtype of atstmt for syntax1 is temporarily set to OBJECT_TRIGGER to identify whether the
 								* query was originally of syntax1 or syntax2, here astmt->objtype is reset back to OBJECT_TABLE
@@ -4396,6 +4396,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 	/* Set statement_timestamp() */
 	SetCurrentStatementStartTimestamp();
 
+	set_ps_display("active");
 	pgstat_report_activity(STATE_RUNNING, codeblock->source_text);
 
 	if (nargs > 1)
@@ -5386,7 +5387,7 @@ get_oid_type_string(int type_oid)
 	return type_string;
 }
 
-static int64 
+static int64
 get_identity_into_args(Node *node)
 {
 	int64 val = 0;
@@ -5798,7 +5799,7 @@ bbf_set_tran_isolation(char *new_isolation_level_str)
 
 	if(new_isolation_int_val != DefaultXactIsoLevel)
 	{
-		if(FirstSnapshotSet || IsSubTransaction() || 
+		if(FirstSnapshotSet || IsSubTransaction() ||
 				(new_isolation_int_val == XACT_SERIALIZABLE && RecoveryInProgress()))
 		{
 			if(escape_hatch_set_transaction_isolation_level == EH_IGNORE)

--- a/contrib/babelfishpg_tsql/src/plerrcodes.h
+++ b/contrib/babelfishpg_tsql/src/plerrcodes.h
@@ -1007,3 +1007,4 @@
 {
 	"pltsql_error_not_mapped", ERRCODE_PLTSQL_ERROR_NOT_MAPPED
 },
+


### PR DESCRIPTION
This causes confusion because it would appear as if there is a memory leak issue because ps status shows idle while memory usage increases. This commit fixes that issue and will set the ps status to active when it is really active. PG engine code resets it back to idle.

Testing Done:
I ran testing manually because JDBC test framework currently does not support testing this scenario where we have to block the connection while active and check ps status. 

Manual testing involved checking status during DML, sp_executesql, cursor and confirmed ps status is correct.
Also tested ps status involving "idle" and "idle in transaction".


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).