### PR TITLE
Fix case-sensitive semantics of sys.sysdatabases catalog columns 

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -45,7 +45,7 @@ GRANT SELECT ON sys.babelfish_namespace_ext TO PUBLIC;
 -- SYSDATABASES
 CREATE OR REPLACE VIEW sys.sysdatabases AS
 SELECT
-t.name,
+CAST(t.name as sys.sysname),
 sys.db_id(t.name) AS dbid,
 CAST(CAST(r.oid AS int) AS SYS.VARBINARY(85)) AS sid,
 CAST(0 AS SMALLINT) AS mode,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -66,19 +66,22 @@ DECLARE
     query1 text;
     query2 text;
     query3 text;
+    query4 text;
 BEGIN
     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
     LOOP
         BEGIN
             query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
             query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
-            query3 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
+            query3 := pg_catalog.format('GRANT SELECT ON %s.sysdatabases TO PUBLIC;', nsp_name);
+            query4 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
             RAISE INFO '%', query1;
             RAISE INFO '%', query2;
             RAISE INFO '%', query3;
             execute query1;
             execute query2;
             execute query3;
+            execute query4;
         EXCEPTION WHEN OTHERS THEN
 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
 			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -71,20 +71,21 @@ BEGIN
     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
     LOOP
         BEGIN
-            query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
-            query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
-            query3 := pg_catalog.format('GRANT SELECT ON %s.sysdatabases TO PUBLIC;', nsp_name);
-            query4 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
+            query1 := pg_catalog.format('ALTER VIEW "%s".sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name, nsp_name);
+            query2 := pg_catalog.format('CREATE OR REPLACE VIEW "%s".sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
+            query3 := pg_catalog.format('GRANT SELECT ON "%s".sysdatabases TO PUBLIC;', nsp_name);
+            query4 := pg_catalog.format('DROP VIEW "%s"."schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
             RAISE INFO '%', query1;
             RAISE INFO '%', query2;
             RAISE INFO '%', query3;
+            RAISE INFO '%', query4;
             execute query1;
             execute query2;
             execute query3;
             execute query4;
         EXCEPTION WHEN OTHERS THEN
 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
-			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;
+			RAISE WARNING 'creation of database level sysdatabases catalog view for schema % failed with error: %', nsp_name, error_msg;
 		END;
     END LOOP;
 END $$;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -1,3 +1,4 @@
+\c jdbc_testdb
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_tsql"" UPDATE TO '3.4.0'" to load this file. \quit
 
@@ -70,10 +71,10 @@ BEGIN
             EXECUTE
             'ALTER VIEW ' || nsp_name || '.sysdatabases RENAME TO ' || nsp_name || 'sysdatabases_deprecated_3_4;
             CREATE OR REPLACE VIEW ' || nsp_name || '.sysdatabases AS SELECT * FROM sys.sysdatabases;
-            CALL sys.babelfish_drop_deprecated_object(''view'', ''' || nsp_name || ''', ''' || nsp_name || 'sysdatabases_deprecated_3_4'');';
+            DROP VIEW ' || nsp_name || '.' || nsp_name || 'sysdatabases_deprecated_3_4;';
         EXCEPTION WHEN OTHERS THEN
 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
-			RAISE WARNING 'CREATE sysdatabases catalog view for database schema failed with error: %s', error_msg;
+			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %s', error_msg;
 		END;
     END LOOP;
 END $$;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -59,29 +59,32 @@ LEFT OUTER JOIN pg_catalog.pg_roles r on r.rolname = t.owner;
 
 GRANT SELECT ON sys.sysdatabases TO PUBLIC;
 
--- DO $$
--- DECLARE
---     nsp_name NAME;
---     error_msg text;
---     query1 text;
---     query2 text;
---     query3 text;
--- BEGIN
---     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
---     LOOP
---         BEGIN
---             query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO %s_sysdatabases_deprecated_3_4', nsp_name, nsp_name);
---             query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
---             query3 := pg_catalog.format('DROP VIEW %s.%s_sysdatabases_deprecated_3_4', nsp_name,nsp_name);
---             execute query1;
---             execute query2;
---             execute query3;
---         EXCEPTION WHEN OTHERS THEN
--- 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
--- 			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %s', error_msg;
--- 		END;
---     END LOOP;
--- END $$;
+DO $$
+DECLARE
+    nsp_name NAME;
+    error_msg text;
+    query1 text;
+    query2 text;
+    query3 text;
+BEGIN
+    FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
+    LOOP
+        BEGIN
+            query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
+            query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
+            query3 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
+            RAISE INFO '%', query1;
+            RAISE INFO '%', query2;
+            RAISE INFO '%', query3;
+            execute query1;
+            execute query2;
+            execute query3;
+        EXCEPTION WHEN OTHERS THEN
+			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;
+		END;
+    END LOOP;
+END $$;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysdatabases_deprecated_3_4');
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -59,32 +59,32 @@ LEFT OUTER JOIN pg_catalog.pg_roles r on r.rolname = t.owner;
 
 GRANT SELECT ON sys.sysdatabases TO PUBLIC;
 
-DO $$
-DECLARE
-    nsp_name NAME;
-    error_msg text;
-    query1 text;
-    query2 text;
-    query3 text;
-BEGIN
-    FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
-    LOOP
-        BEGIN
-            query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
-            query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
-            query3 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
-            RAISE INFO '%', query1;
-            RAISE INFO '%', query2;
-            RAISE INFO '%', query3;
-            execute query1;
-            execute query2;
-            execute query3;
-        EXCEPTION WHEN OTHERS THEN
-			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
-			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;
-		END;
-    END LOOP;
-END $$;
+-- DO $$
+-- DECLARE
+--     nsp_name NAME;
+--     error_msg text;
+--     query1 text;
+--     query2 text;
+--     query3 text;
+-- BEGIN
+--     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
+--     LOOP
+--         BEGIN
+--             query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
+--             query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
+--             query3 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
+--             RAISE INFO '%', query1;
+--             RAISE INFO '%', query2;
+--             RAISE INFO '%', query3;
+--             execute query1;
+--             execute query2;
+--             execute query3;
+--         EXCEPTION WHEN OTHERS THEN
+-- 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+-- 			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;
+-- 		END;
+--     END LOOP;
+-- END $$;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysdatabases_deprecated_3_4');
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -38,6 +38,29 @@ LANGUAGE plpgsql;
  * final behaviour.
  */
 
+ALTER VIEW sys.sysdatabases RENAME TO sysdatabases_deprecated_3_4;
+
+CREATE OR REPLACE VIEW sys.sysdatabases AS
+SELECT
+CAST(t.name as sys.sysname),
+sys.db_id(t.name) AS dbid,
+CAST(CAST(r.oid AS int) AS SYS.VARBINARY(85)) AS sid,
+CAST(0 AS SMALLINT) AS mode,
+t.status,
+t.status2,
+CAST(t.crdate AS SYS.DATETIME) AS crdate,
+CAST('1900-01-01 00:00:00.000' AS SYS.DATETIME) AS reserved,
+CAST(0 AS INT) AS category,
+CAST(120 AS SYS.TINYINT) AS cmptlevel,
+CAST(NULL AS SYS.NVARCHAR(260)) AS filename,
+CAST(NULL AS SMALLINT) AS version
+FROM sys.babelfish_sysdatabases AS t
+LEFT OUTER JOIN pg_catalog.pg_roles r on r.rolname = t.owner;
+
+GRANT SELECT ON sys.sysdatabases TO PUBLIC;
+
+CALL sys.babelfish_drop_deprecated_view('sys', 'sysdatabases_deprecated_3_4');
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -1,4 +1,3 @@
-\c jdbc_testdb
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_tsql"" UPDATE TO '3.4.0'" to load this file. \quit
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -67,8 +67,10 @@ BEGIN
     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
     LOOP
         BEGIN
-            EXECUTE 'CREATE OR REPLACE VIEW ' || nsp_name || '.sysdatabases AS
-            SELECT * FROM sys.sysdatabases';
+            EXECUTE
+            'ALTER VIEW ' || nsp_name || '.sysdatabases RENAME TO ' || nsp_name || 'sysdatabases_deprecated_3_4;
+            CREATE OR REPLACE VIEW ' || nsp_name || '.sysdatabases AS SELECT * FROM sys.sysdatabases;
+            CALL sys.babelfish_drop_deprecated_object(''view'', ''' || nsp_name || ''', ''' || nsp_name || 'sysdatabases_deprecated_3_4'');';
         EXCEPTION WHEN OTHERS THEN
 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
 			RAISE WARNING 'CREATE sysdatabases catalog view for database schema failed with error: %s', error_msg;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -59,29 +59,29 @@ LEFT OUTER JOIN pg_catalog.pg_roles r on r.rolname = t.owner;
 
 GRANT SELECT ON sys.sysdatabases TO PUBLIC;
 
-DO $$
-DECLARE
-    nsp_name NAME;
-    error_msg text;
-    query1 text;
-    query2 text;
-    query3 text;
-BEGIN
-    FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
-    LOOP
-        BEGIN
-            query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO %s_sysdatabases_deprecated_3_4', nsp_name, nsp_name);
-            query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
-            query3 := pg_catalog.format('DROP VIEW %s.%s_sysdatabases_deprecated_3_4', nsp_name,nsp_name);
-            execute query1;
-            execute query2;
-            execute query3;
-        EXCEPTION WHEN OTHERS THEN
-			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
-			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %s', error_msg;
-		END;
-    END LOOP;
-END $$;
+-- DO $$
+-- DECLARE
+--     nsp_name NAME;
+--     error_msg text;
+--     query1 text;
+--     query2 text;
+--     query3 text;
+-- BEGIN
+--     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
+--     LOOP
+--         BEGIN
+--             query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO %s_sysdatabases_deprecated_3_4', nsp_name, nsp_name);
+--             query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
+--             query3 := pg_catalog.format('DROP VIEW %s.%s_sysdatabases_deprecated_3_4', nsp_name,nsp_name);
+--             execute query1;
+--             execute query2;
+--             execute query3;
+--         EXCEPTION WHEN OTHERS THEN
+-- 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+-- 			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %s', error_msg;
+-- 		END;
+--     END LOOP;
+-- END $$;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysdatabases_deprecated_3_4');
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -59,7 +59,7 @@ LEFT OUTER JOIN pg_catalog.pg_roles r on r.rolname = t.owner;
 
 GRANT SELECT ON sys.sysdatabases TO PUBLIC;
 
-CALL sys.babelfish_drop_deprecated_view('sys', 'sysdatabases_deprecated_3_4');
+CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysdatabases_deprecated_3_4');
 
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -59,32 +59,32 @@ LEFT OUTER JOIN pg_catalog.pg_roles r on r.rolname = t.owner;
 
 GRANT SELECT ON sys.sysdatabases TO PUBLIC;
 
--- DO $$
--- DECLARE
---     nsp_name NAME;
---     error_msg text;
---     query1 text;
---     query2 text;
---     query3 text;
--- BEGIN
---     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
---     LOOP
---         BEGIN
---             query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
---             query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
---             query3 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
---             RAISE INFO '%', query1;
---             RAISE INFO '%', query2;
---             RAISE INFO '%', query3;
---             execute query1;
---             execute query2;
---             execute query3;
---         EXCEPTION WHEN OTHERS THEN
--- 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
--- 			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;
--- 		END;
---     END LOOP;
--- END $$;
+DO $$
+DECLARE
+    nsp_name NAME;
+    error_msg text;
+    query1 text;
+    query2 text;
+    query3 text;
+BEGIN
+    FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
+    LOOP
+        BEGIN
+            query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name);
+            query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
+            query3 := pg_catalog.format('DROP VIEW %s.schema_sysdatabases_deprecated_3_4', nsp_name);
+            RAISE INFO '%', query1;
+            RAISE INFO '%', query2;
+            RAISE INFO '%', query3;
+            execute query1;
+            execute query2;
+            execute query3;
+        EXCEPTION WHEN OTHERS THEN
+			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %', error_msg;
+		END;
+    END LOOP;
+END $$;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysdatabases_deprecated_3_4');
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -66,7 +66,7 @@ DECLARE
     query1 text;
     query2 text;
     query3 text;
-    query4 text;
+    -- query4 text;
 BEGIN
     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
     LOOP
@@ -74,15 +74,15 @@ BEGIN
             query1 := pg_catalog.format('ALTER VIEW "%s".sysdatabases RENAME TO "%s_schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
             query2 := pg_catalog.format('CREATE OR REPLACE VIEW "%s".sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
             query3 := pg_catalog.format('GRANT SELECT ON "%s".sysdatabases TO PUBLIC;', nsp_name);
-            query4 := pg_catalog.format('DROP VIEW "%s"."%s_schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
+            -- query4 := pg_catalog.format('DROP VIEW "%s"."%s_schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
             RAISE INFO '%', query1;
             RAISE INFO '%', query2;
             RAISE INFO '%', query3;
-            RAISE INFO '%', query4;
+            -- RAISE INFO '%', query4;
             execute query1;
             execute query2;
             execute query3;
-            execute query4;
+            -- execute query4;
         EXCEPTION WHEN OTHERS THEN
 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
 			RAISE WARNING 'creation of database level sysdatabases catalog view for schema % failed with error: %', nsp_name, error_msg;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -71,10 +71,10 @@ BEGIN
     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
     LOOP
         BEGIN
-            query1 := pg_catalog.format('ALTER VIEW "%s".sysdatabases RENAME TO schema_sysdatabases_deprecated_3_4', nsp_name, nsp_name);
+            query1 := pg_catalog.format('ALTER VIEW "%s".sysdatabases RENAME TO "%s_schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
             query2 := pg_catalog.format('CREATE OR REPLACE VIEW "%s".sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
             query3 := pg_catalog.format('GRANT SELECT ON "%s".sysdatabases TO PUBLIC;', nsp_name);
-            query4 := pg_catalog.format('DROP VIEW "%s"."schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
+            query4 := pg_catalog.format('DROP VIEW "%s"."%s_schema_sysdatabases_deprecated_3_4"', nsp_name, nsp_name);
             RAISE INFO '%', query1;
             RAISE INFO '%', query2;
             RAISE INFO '%', query3;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -63,14 +63,19 @@ DO $$
 DECLARE
     nsp_name NAME;
     error_msg text;
+    query1 text;
+    query2 text;
+    query3 text;
 BEGIN
     FOR nsp_name IN (SELECT nspname FROM sys.babelfish_namespace_ext WHERE orig_name = 'dbo')
     LOOP
         BEGIN
-            EXECUTE
-            'ALTER VIEW ' || nsp_name || '.sysdatabases RENAME TO ' || nsp_name || 'sysdatabases_deprecated_3_4;
-            CREATE OR REPLACE VIEW ' || nsp_name || '.sysdatabases AS SELECT * FROM sys.sysdatabases;
-            DROP VIEW ' || nsp_name || '.' || nsp_name || 'sysdatabases_deprecated_3_4;';
+            query1 := pg_catalog.format('ALTER VIEW %s.sysdatabases RENAME TO %s_sysdatabases_deprecated_3_4', nsp_name, nsp_name);
+            query2 := pg_catalog.format('CREATE OR REPLACE VIEW %s.sysdatabases AS SELECT * FROM sys.sysdatabases', nsp_name);
+            query3 := pg_catalog.format('DROP VIEW %s.%s_sysdatabases_deprecated_3_4', nsp_name,nsp_name);
+            execute query1;
+            execute query2;
+            execute query3;
         EXCEPTION WHEN OTHERS THEN
 			GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
 			RAISE WARNING 'creation of database level sysdatabases catalog view failed with error: %s', error_msg;

--- a/test/JDBC/expected/BABEL-1435.out
+++ b/test/JDBC/expected/BABEL-1435.out
@@ -2,7 +2,7 @@
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO
 ~~START~~
-text
+varchar
 master
 msdb
 tempdb
@@ -84,7 +84,7 @@ GO
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO
 ~~START~~
-text
+varchar
 db1
 master
 msdb
@@ -196,7 +196,7 @@ multi-db
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO
 ~~START~~
-text
+varchar
 master
 msdb
 tempdb
@@ -266,7 +266,7 @@ GO
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO
 ~~START~~
-text
+varchar
 master
 msdb
 tempdb

--- a/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
+++ b/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
@@ -48,7 +48,7 @@ go
 -- allowed for msdb
 alter authorization on database::msdb to new_owner_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'msdb'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'msdb'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -66,7 +66,7 @@ go
 
 -- tsql user=dba_login password=12345678
 -- before owner change:
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -76,7 +76,7 @@ change_owner_db#!#dba_login
 ALTER authorization on database::change_owner_db to new_owner_login
 go
 -- after owner change:
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -87,7 +87,7 @@ change_owner_db#!#new_OWNER_login
 -- change back to current user
 alter AUTHORIZATION on database::change_owner_db to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -188,7 +188,7 @@ grant connect to guest
 go
 alter authorization on database::CHANGE_owner_db to NEW_owner_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -247,7 +247,7 @@ go
 
 ~~ERROR (Message: The proposed new database owner is already a user or aliased in the database.)~~
 
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -262,7 +262,7 @@ go
 
 ~~ERROR (Message: The proposed new database owner is already a user or aliased in the database.)~~
 
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -287,9 +287,9 @@ go
 create procedure p_change_db_owner_1
 as
 begin
-	select 'p_change_db_owner_1: before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	
+	select 'p_change_db_owner_1: before owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	
 	alter authorization on database::change_owner_db to new_owner_login
-	select 'p_change_db_owner_1: after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	  
+	select 'p_change_db_owner_1: after owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	  
 end	
 go
 exec p_change_db_owner_1
@@ -325,9 +325,9 @@ begin
 	declare @cmd nvarchar(100) 
 	set @cmd = 'alter authorization on database::' + @dbname + ' to ' + @owner
 	select @cmd
-	select 'p_change_db_owner_2: before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	
+	select 'p_change_db_owner_2: before owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	
 	execute(@cmd)
-	select 'p_change_db_owner_2: after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	  
+	select 'p_change_db_owner_2: after owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	  
 end	
 go
 exec p_change_db_owner_2 change_owner_db, new_owner_login
@@ -415,7 +415,7 @@ alter authorization on database::change_owner_db to dba_login
 go
 begin tran
 go
-select 'before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select 'before owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#varchar#!#nvarchar
@@ -424,7 +424,7 @@ before owner change#!#change_owner_db#!#dba_login
 
 alter authorization on database::change_owner_db to new_owner_login
 go
-select 'after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select 'after owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#varchar#!#nvarchar
@@ -433,7 +433,7 @@ after owner change#!#change_owner_db#!#new_OWNER_login
 
 rollback
 go
-select 'after rollback', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select 'after rollback', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
 varchar#!#varchar#!#nvarchar
@@ -462,7 +462,7 @@ create login    LOGIN63long_345678901234567890123456789012345678901234567890123 
 go
 alter authorization on database::DB63long_012345678901234567890123456789012345678901234567890123 to LOGIN63long_345678901234567890123456789012345678901234567890123
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -471,7 +471,7 @@ db63long_012345678901234567890123456789012345678901234567890123#!#LOGIN63long_34
 
 alter authorization on database::[DB63long_012345678901234567890123456789012345678901234567890123] to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -480,7 +480,7 @@ db63long_012345678901234567890123456789012345678901234567890123#!#dba_login
 
 alter authorization on database::[DB63long_012345678901234567890123456789012345678901234567890123] to [LOGIN63long_345678901234567890123456789012345678901234567890123]
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -491,7 +491,7 @@ set quoted_identifier on
 go
 alter authorization on database::"DB63long_012345678901234567890123456789012345678901234567890123" to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -500,7 +500,7 @@ db63long_012345678901234567890123456789012345678901234567890123#!#dba_login
 
 alter authorization on database::"DB63long_012345678901234567890123456789012345678901234567890123" to "LOGIN63long_345678901234567890123456789012345678901234567890123"
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -532,7 +532,7 @@ create login    LOGIN64long_3456789012345678901234567890123456789012345678901234
 go
 alter authorization on database::DB64long_0123456789012345678901234567890123456789012345678901234 to LOGIN64long_3456789012345678901234567890123456789012345678901234
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -541,7 +541,7 @@ db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#LOGIN64long_34
 
 alter authorization on database::[DB64long_0123456789012345678901234567890123456789012345678901234] to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -550,7 +550,7 @@ db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#dba_login
 
 alter authorization on database::[DB64long_0123456789012345678901234567890123456789012345678901234] to [LOGIN64long_3456789012345678901234567890123456789012345678901234]
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -561,7 +561,7 @@ set quoted_identifier on
 go
 alter authorization on database::"DB64long_0123456789012345678901234567890123456789012345678901234" to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
 varchar#!#nvarchar
@@ -570,7 +570,7 @@ db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#dba_login
 
 alter authorization on DATABASE::"DB64long_0123456789012345678901234567890123456789012345678901234" to "LOGIN64long_3456789012345678901234567890123456789012345678901234"
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
 varchar#!#nvarchar

--- a/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
+++ b/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
@@ -51,7 +51,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'msdb'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 msdb#!#new_OWNER_login
 ~~END~~
 
@@ -69,7 +69,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db#!#dba_login
 ~~END~~
 
@@ -79,7 +79,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db#!#new_OWNER_login
 ~~END~~
 
@@ -90,7 +90,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db#!#dba_login
 ~~END~~
 
@@ -191,7 +191,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db#!#new_OWNER_login
 ~~END~~
 
@@ -250,7 +250,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db#!#dba_login
 ~~END~~
 
@@ -265,7 +265,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db#!#dba_login
 ~~END~~
 
@@ -295,12 +295,12 @@ go
 exec p_change_db_owner_1
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 p_change_db_owner_1: before owner change#!#change_owner_db#!#dba_login
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 p_change_db_owner_1: after owner change#!#change_owner_db#!#new_OWNER_login
 ~~END~~
 
@@ -338,12 +338,12 @@ alter authorization on database::change_owner_db to new_owner_login
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 p_change_db_owner_2: before owner change#!#change_owner_db#!#dba_login
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 p_change_db_owner_2: after owner change#!#change_owner_db#!#new_OWNER_login
 ~~END~~
 
@@ -418,7 +418,7 @@ go
 select 'before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 before owner change#!#change_owner_db#!#dba_login
 ~~END~~
 
@@ -427,7 +427,7 @@ go
 select 'after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 after owner change#!#change_owner_db#!#new_OWNER_login
 ~~END~~
 
@@ -436,7 +436,7 @@ go
 select 'after rollback', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 after rollback#!#change_owner_db#!#dba_login
 ~~END~~
 
@@ -465,7 +465,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db63long_012345678901234567890123456789012345678901234567890123#!#LOGIN63long_345678901234567890123456789012345678901234567890123
 ~~END~~
 
@@ -474,7 +474,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db63long_012345678901234567890123456789012345678901234567890123#!#dba_login
 ~~END~~
 
@@ -483,7 +483,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db63long_012345678901234567890123456789012345678901234567890123#!#LOGIN63long_345678901234567890123456789012345678901234567890123
 ~~END~~
 
@@ -494,7 +494,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db63long_012345678901234567890123456789012345678901234567890123#!#dba_login
 ~~END~~
 
@@ -503,7 +503,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db63long_012345678901234567890123456789012345678901234567890123#!#LOGIN63long_345678901234567890123456789012345678901234567890123
 ~~END~~
 
@@ -535,7 +535,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#LOGIN64long_3456789012345678901234567890123456789012345678901234
 ~~END~~
 
@@ -544,7 +544,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#dba_login
 ~~END~~
 
@@ -553,7 +553,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#LOGIN64long_3456789012345678901234567890123456789012345678901234
 ~~END~~
 
@@ -564,7 +564,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#dba_login
 ~~END~~
 
@@ -573,7 +573,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#LOGIN64long_3456789012345678901234567890123456789012345678901234
 ~~END~~
 

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -172,7 +172,7 @@ WHERE name LIKE 'babelfish_migration_mode%'
 ORDER BY name
 GO
 ~~START~~
-text
+varchar
 babelfish_migration_mode_db1
 babelfish_migration_mode_db2
 ~~END~~

--- a/test/JDBC/expected/bbf_view_def.out
+++ b/test/JDBC/expected/bbf_view_def.out
@@ -90,7 +90,7 @@ go
 select sb.name, vd.schema_name, vd.object_name, vd.definition from babelfish_view_def vd left join sys.sysdatabases sb on vd.dbid=sb.dbid where vd.object_name like '%def_%' order by vd.dbid, vd.schema_name, vd.object_name, vd.definition;
 go
 ~~START~~
-text#!#varchar#!#varchar#!#ntext
+varchar#!#varchar#!#varchar#!#ntext
 master#!#dbo#!#def_v1#!#create view def_v1 as select c1 as a from vd_t1;
 master#!#dbo#!#def_v2#!#create view  def_v2<newline>as<newline>select 							2 as a;
 ~~END~~
@@ -205,7 +205,7 @@ go
 select sb.name, vd.schema_name, vd.object_name, vd.definition from sys.babelfish_view_def vd left join sys.sysdatabases sb on vd.dbid=sb.dbid where vd.object_name like ('def_vwalt') order by vd.dbid, vd.schema_name, vd.object_name, vd.definition;
 go
 ~~START~~
-text#!#"sys"."varchar"#!#"sys"."varchar"#!#text
+"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#text
 master#!#dbo#!#def_vwalt#!#create view def_vwalt as select 123 as a;
 ~~END~~
 
@@ -251,7 +251,7 @@ go
 select sb.name, vd.schema_name, vd.object_name, vd.definition from babelfish_view_def vd left join sys.sysdatabases sb on vd.dbid=sb.dbid where vd.object_name like ('%def_v%') order by vd.dbid, vd.schema_name, vd.object_name, vd.definition;
 go
 ~~START~~
-text#!#varchar#!#varchar#!#ntext
+varchar#!#varchar#!#varchar#!#ntext
 master#!#dbo#!#def_v1#!#create view def_v1 as select c1 as a from vd_t1;
 master#!#dbo#!#def_v2#!#create view  def_v2<newline>as<newline>select 							2 as a;
 ~~END~~
@@ -268,7 +268,7 @@ go
 select sb.name, vd.schema_name, vd.object_name, vd.definition from babelfish_view_def vd left join sys.sysdatabases sb on vd.dbid=sb.dbid where vd.object_name like ('%def_v%') order by vd.dbid, vd.schema_name, vd.object_name, vd.definition;
 go
 ~~START~~
-text#!#varchar#!#varchar#!#ntext
+varchar#!#varchar#!#varchar#!#ntext
 master#!#dbo#!#def_v1#!#create view def_v1 as select c1 as a from vd_t1;
 master#!#dbo#!#def_v2#!#create view  def_v2<newline>as<newline>select 							2 as a;
 master#!#def_sch1#!#def_v1#!#create view def_sch1.def_v1 as select 1;
@@ -293,7 +293,7 @@ go
 select sb.name, vd.schema_name, vd.object_name, vd.definition from babelfish_view_def vd left join sys.sysdatabases sb on vd.dbid=sb.dbid where vd.object_name like ('%db1_v%') order by vd.dbid, vd.schema_name, vd.object_name, vd.definition;
 go
 ~~START~~
-text#!#varchar#!#varchar#!#ntext
+varchar#!#varchar#!#varchar#!#ntext
 db1#!#db1_sch1#!#db1_v2#!#create view db1_sch1.db1_v2 as select 2;
 db1#!#dbo#!#db1_v1#!#create view db1_v1 as select 1;
 ~~END~~
@@ -317,7 +317,7 @@ go
 select sb.name, vd.schema_name, vd.object_name, vd.definition from babelfish_view_def vd left join sys.sysdatabases sb on vd.dbid=sb.dbid where vd.object_name like ('%db1_v%') order by vd.dbid, vd.schema_name, vd.object_name, vd.definition;
 go
 ~~START~~
-text#!#varchar#!#varchar#!#ntext
+varchar#!#varchar#!#varchar#!#ntext
 ~~END~~
 
 

--- a/test/JDBC/expected/psql_logical_babelfish_db.out
+++ b/test/JDBC/expected/psql_logical_babelfish_db.out
@@ -34,7 +34,7 @@ select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases';
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#varchar#!#"sys"."varchar"#!#int4#!#int4#!#int2#!#int2#!#int4#!#int2#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#C#!#<NULL>#!#<NULL>#!#<NULL>
+master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#varchar#!#128#!#256#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
@@ -67,7 +67,7 @@ select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases'
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#C#!#<NULL>#!#<NULL>#!#<NULL>
+master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#varchar#!#128#!#256#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
@@ -100,7 +100,7 @@ select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases'
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#C#!#<NULL>#!#<NULL>#!#<NULL>
+master#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#varchar#!#128#!#256#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 master#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
@@ -123,7 +123,7 @@ select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases'
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-logical_database_db1#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#C#!#<NULL>#!#<NULL>#!#<NULL>
+logical_database_db1#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#varchar#!#128#!#256#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>
 logical_database_db1#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 logical_database_db1#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 logical_database_db1#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
@@ -160,7 +160,7 @@ select * from information_schema_tsql.columns where "TABLE_NAME"='sysdatabases';
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#varchar#!#"sys"."varchar"#!#int4#!#int4#!#int2#!#int2#!#int4#!#int2#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"#!#"sys"."varchar"
-logical_database_db1#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#text#!#2147483647#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#C#!#<NULL>#!#<NULL>#!#<NULL>
+logical_database_db1#!#dbo#!#sysdatabases#!#name#!#1#!#<NULL>#!#YES#!#varchar#!#128#!#256#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bbf_unicode_cp1_ci_as#!#<NULL>#!#<NULL>#!#<NULL>
 logical_database_db1#!#dbo#!#sysdatabases#!#dbid#!#2#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 logical_database_db1#!#dbo#!#sysdatabases#!#sid#!#3#!#<NULL>#!#YES#!#varbinary#!#85#!#85#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 logical_database_db1#!#dbo#!#sysdatabases#!#mode#!#4#!#<NULL>#!#YES#!#smallint#!#<NULL>#!#<NULL>#!#5#!#10#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>

--- a/test/JDBC/expected/sp_changedbowner-vu-verify.out
+++ b/test/JDBC/expected/sp_changedbowner-vu-verify.out
@@ -51,7 +51,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'msdb'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 msdb#!#new_OWNER_login_sp
 ~~END~~
 
@@ -60,7 +60,7 @@ go
 select name, suser_sname(sid) from sysdatabases where name = 'msdb'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 msdb#!#dba_login_sp
 ~~END~~
 
@@ -86,7 +86,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#dba_login_sp
 ~~END~~
 
@@ -109,7 +109,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#dba_login_sp
 ~~END~~
 
@@ -120,7 +120,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -147,7 +147,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp2
 ~~END~~
 
@@ -156,7 +156,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp3
 ~~END~~
 
@@ -165,7 +165,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp3
 ~~END~~
 
@@ -174,7 +174,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp 4
 ~~END~~
 
@@ -183,7 +183,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp5
 ~~END~~
 
@@ -192,7 +192,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp 6
 ~~END~~
 
@@ -218,7 +218,7 @@ dbo#!#change_owner_db_sp
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -227,7 +227,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -236,7 +236,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -245,7 +245,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -261,7 +261,7 @@ go
 select 'before owner change', name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 before owner change#!#change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -270,7 +270,7 @@ go
 select 'after owner change', name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 after owner change#!#change_owner_db_sp#!#new_OWNER_login_sp2
 ~~END~~
 
@@ -279,7 +279,7 @@ go
 select 'after rollback', name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-varchar#!#text#!#nvarchar
+varchar#!#varchar#!#nvarchar
 after rollback#!#change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -291,7 +291,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -300,7 +300,7 @@ go
 select name, suser_sname(sid) from sysdatabases where lower(name) = 'change_owner_db_sp'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 change_owner_db_sp#!#new_OWNER_login_sp
 ~~END~~
 
@@ -353,7 +353,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db63long_012345678901234567890123456789012345678901234567890123#!#LOGIN63long_345678901234567890123456789012345678901234567890123
 ~~END~~
 
@@ -392,7 +392,7 @@ go
 select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
 go
 ~~START~~
-text#!#nvarchar
+varchar#!#nvarchar
 db64long_012345678901234567890109e0da63a1cdb0673c21e39afa6178e9#!#dba_login_sp
 ~~END~~
 

--- a/test/JDBC/expected/sys-sysdatabases-before-14_11-or-15_5-vu-cleanup.out
+++ b/test/JDBC/expected/sys-sysdatabases-before-14_11-or-15_5-vu-cleanup.out
@@ -1,0 +1,14 @@
+DROP DATABASE sys_sysdatabases_vu_prepare_db
+GO
+
+DROP VIEW sys_sysdatabases_vu_prepare_view
+GO
+
+DROP VIEW sys_sysdatabases_vu_prepare_view_case
+GO
+
+DROP PROC sys_sysdatabases_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_sysdatabases_vu_prepare_func
+GO

--- a/test/JDBC/expected/sys-sysdatabases-before-14_11-or-15_5-vu-prepare.out
+++ b/test/JDBC/expected/sys-sysdatabases-before-14_11-or-15_5-vu-prepare.out
@@ -1,0 +1,35 @@
+CREATE DATABASE sys_sysdatabases_vu_prepare_db
+GO
+
+CREATE VIEW sys_sysdatabases_vu_prepare_view
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO
+
+CREATE PROC sys_sysdatabases_vu_prepare_proc
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_sysdatabases_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.sysdatabases WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%')
+END
+GO
+
+-- test case-sensitivity
+CREATE VIEW sys_sysdatabases_vu_prepare_view_case
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'SYS_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO

--- a/test/JDBC/expected/sys-sysdatabases-before-14_11-or-15_5-vu-verify.out
+++ b/test/JDBC/expected/sys-sysdatabases-before-14_11-or-15_5-vu-verify.out
@@ -1,0 +1,71 @@
+SELECT * FROM sys_sysdatabases_vu_prepare_view
+GO
+~~START~~
+text#!#tinyint
+sys_sysdatabases_vu_prepare_db#!#120
+~~END~~
+
+
+SELECT * FROM sys_sysdatabases_vu_prepare_view_case
+GO
+~~START~~
+text#!#tinyint
+~~END~~
+
+
+EXEC sys_sysdatabases_vu_prepare_proc
+GO
+~~START~~
+varchar#!#tinyint
+sys_sysdatabases_vu_prepare_db#!#120
+~~END~~
+
+
+SELECT sys_sysdatabases_vu_prepare_func()
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- BABEL-3441: Ensure that sys.databases.compatibilty_level and sysdatabases.cmptlevel is equal 
+SELECT compatibility_level FROM sys.databases WHERE name = 'master'
+GO
+~~START~~
+tinyint
+120
+~~END~~
+
+
+SELECT cmptlevel FROM sys.sysdatabases WHERE name = 'master'
+GO
+~~START~~
+tinyint
+120
+~~END~~
+
+
+SELECT cmptlevel FROM master.dbo.sysdatabases WHERE name = 'master'
+GO
+~~START~~
+tinyint
+120
+~~END~~
+
+
+SELECT cmptlevel FROM msdb.dbo.sysdatabases WHERE name = 'master'
+GO
+~~START~~
+tinyint
+120
+~~END~~
+
+
+SELECT cmptlevel FROM tempdb.dbo.sysdatabases WHERE name = 'master'
+GO
+~~START~~
+tinyint
+120
+~~END~~
+

--- a/test/JDBC/expected/sys-sysdatabases-vu-cleanup.out
+++ b/test/JDBC/expected/sys-sysdatabases-vu-cleanup.out
@@ -4,6 +4,9 @@ GO
 DROP VIEW sys_sysdatabases_vu_prepare_view
 GO
 
+DROP VIEW sys_sysdatabases_vu_prepare_view_case
+GO
+
 DROP PROC sys_sysdatabases_vu_prepare_proc
 GO
 

--- a/test/JDBC/expected/sys-sysdatabases-vu-prepare.out
+++ b/test/JDBC/expected/sys-sysdatabases-vu-prepare.out
@@ -24,3 +24,12 @@ BEGIN
 RETURN (SELECT COUNT(*) FROM sys.sysdatabases WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%')
 END
 GO
+
+-- test case-sensitivity
+CREATE VIEW sys_sysdatabases_vu_prepare_view_case
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'SYS_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO

--- a/test/JDBC/expected/sys-sysdatabases-vu-verify.out
+++ b/test/JDBC/expected/sys-sysdatabases-vu-verify.out
@@ -1,7 +1,15 @@
 SELECT * FROM sys_sysdatabases_vu_prepare_view
 GO
 ~~START~~
-text#!#tinyint
+varchar#!#tinyint
+sys_sysdatabases_vu_prepare_db#!#120
+~~END~~
+
+
+SELECT * FROM sys_sysdatabases_vu_prepare_view_case
+GO
+~~START~~
+varchar#!#tinyint
 sys_sysdatabases_vu_prepare_db#!#120
 ~~END~~
 
@@ -9,7 +17,7 @@ sys_sysdatabases_vu_prepare_db#!#120
 EXEC sys_sysdatabases_vu_prepare_proc
 GO
 ~~START~~
-text#!#tinyint
+varchar#!#tinyint
 sys_sysdatabases_vu_prepare_db#!#120
 ~~END~~
 

--- a/test/JDBC/input/alter_authorization_change_db_owner-vu-verify.mix
+++ b/test/JDBC/input/alter_authorization_change_db_owner-vu-verify.mix
@@ -27,7 +27,7 @@ go
 -- allowed for msdb
 alter authorization on database::msdb to new_owner_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'msdb'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'msdb'
 go
 
 -- tsql
@@ -40,18 +40,18 @@ go
 
 -- tsql user=dba_login password=12345678
 -- before owner change:
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 ALTER authorization on database::change_owner_db to new_owner_login
 go
 -- after owner change:
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 
 -- change back to current user
 alter AUTHORIZATION on database::change_owner_db to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 
 -- grant ownership to new owner and verify access
@@ -111,7 +111,7 @@ grant connect to guest
 go
 alter authorization on database::CHANGE_owner_db to NEW_owner_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 
 -- tsql user=new_owner_login password=12345678
@@ -146,13 +146,13 @@ go
 -- should raise error
 alter authorization on database::change_owner_db to new_owner_login
 go
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 
 -- should raise error
 alter authorization on database::change_owner_db to new_owner_login2
 go
-select name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 
 -- tsql user=dba_login password=12345678
@@ -167,9 +167,9 @@ go
 create procedure p_change_db_owner_1
 as
 begin
-	select 'p_change_db_owner_1: before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	
+	select 'p_change_db_owner_1: before owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	
 	alter authorization on database::change_owner_db to new_owner_login
-	select 'p_change_db_owner_1: after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	  
+	select 'p_change_db_owner_1: after owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	  
 end	
 go
 exec p_change_db_owner_1
@@ -190,9 +190,9 @@ begin
 	declare @cmd nvarchar(100) 
 	set @cmd = 'alter authorization on database::' + @dbname + ' to ' + @owner
 	select @cmd
-	select 'p_change_db_owner_2: before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	
+	select 'p_change_db_owner_2: before owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	
 	execute(@cmd)
-	select 'p_change_db_owner_2: after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'	  
+	select 'p_change_db_owner_2: after owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'	  
 end	
 go
 exec p_change_db_owner_2 change_owner_db, new_owner_login
@@ -239,15 +239,15 @@ alter authorization on database::change_owner_db to dba_login
 go
 begin tran
 go
-select 'before owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select 'before owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 alter authorization on database::change_owner_db to new_owner_login
 go
-select 'after owner change', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select 'after owner change', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 rollback
 go
-select 'after rollback', name, suser_sname(sid) from sysdatabases where name = 'change_owner_db'
+select 'after rollback', name, suser_sname(sid) from sys.sysdatabases where name = 'change_owner_db'
 go
 
 use master
@@ -266,25 +266,25 @@ create login    LOGIN63long_345678901234567890123456789012345678901234567890123 
 go
 alter authorization on database::DB63long_012345678901234567890123456789012345678901234567890123 to LOGIN63long_345678901234567890123456789012345678901234567890123
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 alter authorization on database::[DB63long_012345678901234567890123456789012345678901234567890123] to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 alter authorization on database::[DB63long_012345678901234567890123456789012345678901234567890123] to [LOGIN63long_345678901234567890123456789012345678901234567890123]
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 set quoted_identifier on
 go
 alter authorization on database::"DB63long_012345678901234567890123456789012345678901234567890123" to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 alter authorization on database::"DB63long_012345678901234567890123456789012345678901234567890123" to "LOGIN63long_345678901234567890123456789012345678901234567890123"
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB63LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB63LONG%'
 go
 set quoted_identifier off
 go
@@ -306,25 +306,25 @@ create login    LOGIN64long_3456789012345678901234567890123456789012345678901234
 go
 alter authorization on database::DB64long_0123456789012345678901234567890123456789012345678901234 to LOGIN64long_3456789012345678901234567890123456789012345678901234
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 alter authorization on database::[DB64long_0123456789012345678901234567890123456789012345678901234] to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 alter authorization on database::[DB64long_0123456789012345678901234567890123456789012345678901234] to [LOGIN64long_3456789012345678901234567890123456789012345678901234]
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 set quoted_identifier on
 go
 alter authorization on database::"DB64long_0123456789012345678901234567890123456789012345678901234" to dba_login
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 alter authorization on DATABASE::"DB64long_0123456789012345678901234567890123456789012345678901234" to "LOGIN64long_3456789012345678901234567890123456789012345678901234"
 go
-select name, suser_sname(sid) from sysdatabases where upper(name) like 'DB64LONG%'
+select name, suser_sname(sid) from sys.sysdatabases where upper(name) like 'DB64LONG%'
 go
 set quoted_identifier off
 go

--- a/test/JDBC/input/sys-sysdatabases-before-14_11-or-15_5-vu-cleanup.sql
+++ b/test/JDBC/input/sys-sysdatabases-before-14_11-or-15_5-vu-cleanup.sql
@@ -1,0 +1,14 @@
+DROP DATABASE sys_sysdatabases_vu_prepare_db
+GO
+
+DROP VIEW sys_sysdatabases_vu_prepare_view
+GO
+
+DROP VIEW sys_sysdatabases_vu_prepare_view_case
+GO
+
+DROP PROC sys_sysdatabases_vu_prepare_proc
+GO
+
+DROP FUNCTION sys_sysdatabases_vu_prepare_func
+GO

--- a/test/JDBC/input/sys-sysdatabases-before-14_11-or-15_5-vu-prepare.sql
+++ b/test/JDBC/input/sys-sysdatabases-before-14_11-or-15_5-vu-prepare.sql
@@ -1,0 +1,35 @@
+CREATE DATABASE sys_sysdatabases_vu_prepare_db
+GO
+
+CREATE VIEW sys_sysdatabases_vu_prepare_view
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO
+
+CREATE PROC sys_sysdatabases_vu_prepare_proc
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO
+
+CREATE FUNCTION sys_sysdatabases_vu_prepare_func()
+RETURNS INT
+AS
+BEGIN
+RETURN (SELECT COUNT(*) FROM sys.sysdatabases WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%')
+END
+GO
+
+-- test case-sensitivity
+CREATE VIEW sys_sysdatabases_vu_prepare_view_case
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'SYS_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO

--- a/test/JDBC/input/sys-sysdatabases-before-14_11-or-15_5-vu-verify.sql
+++ b/test/JDBC/input/sys-sysdatabases-before-14_11-or-15_5-vu-verify.sql
@@ -1,0 +1,27 @@
+SELECT * FROM sys_sysdatabases_vu_prepare_view
+GO
+
+SELECT * FROM sys_sysdatabases_vu_prepare_view_case
+GO
+
+EXEC sys_sysdatabases_vu_prepare_proc
+GO
+
+SELECT sys_sysdatabases_vu_prepare_func()
+GO
+
+-- BABEL-3441: Ensure that sys.databases.compatibilty_level and sysdatabases.cmptlevel is equal 
+SELECT compatibility_level FROM sys.databases WHERE name = 'master'
+GO
+
+SELECT cmptlevel FROM sys.sysdatabases WHERE name = 'master'
+GO
+
+SELECT cmptlevel FROM master.dbo.sysdatabases WHERE name = 'master'
+GO
+
+SELECT cmptlevel FROM msdb.dbo.sysdatabases WHERE name = 'master'
+GO
+
+SELECT cmptlevel FROM tempdb.dbo.sysdatabases WHERE name = 'master'
+GO

--- a/test/JDBC/input/views/sys-sysdatabases-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys-sysdatabases-vu-cleanup.sql
@@ -4,6 +4,9 @@ GO
 DROP VIEW sys_sysdatabases_vu_prepare_view
 GO
 
+DROP VIEW sys_sysdatabases_vu_prepare_view_case
+GO
+
 DROP PROC sys_sysdatabases_vu_prepare_proc
 GO
 

--- a/test/JDBC/input/views/sys-sysdatabases-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-sysdatabases-vu-prepare.sql
@@ -24,3 +24,12 @@ BEGIN
 RETURN (SELECT COUNT(*) FROM sys.sysdatabases WHERE name LIKE 'sys_sysdatabases_vu_prepare_db%')
 END
 GO
+
+-- test case-sensitivity
+CREATE VIEW sys_sysdatabases_vu_prepare_view_case
+AS
+SELECT name, cmptlevel 
+FROM sys.sysdatabases 
+WHERE name LIKE 'SYS_sysdatabases_vu_prepare_db%'
+ORDER BY name
+GO

--- a/test/JDBC/input/views/sys-sysdatabases-vu-verify.sql
+++ b/test/JDBC/input/views/sys-sysdatabases-vu-verify.sql
@@ -1,6 +1,9 @@
 SELECT * FROM sys_sysdatabases_vu_prepare_view
 GO
 
+SELECT * FROM sys_sysdatabases_vu_prepare_view_case
+GO
+
 EXEC sys_sysdatabases_vu_prepare_proc
 GO
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -170,6 +170,9 @@ ignore#!#BABEL-4078-before-14_8-or-15_3-vu-cleanup
 ignore#!#babel_index_nulls_order-before-15-5-vu-prepare
 ignore#!#babel_index_nulls_order-before-15-5-vu-verify
 ignore#!#babel_index_nulls_order-before-15-5-vu-cleanup
+ignore#!#sys-sysdatabases-before-14_11-or-15_5-vu-prepare
+ignore#!#sys-sysdatabases-before-14_11-or-15_5-vu-verify
+ignore#!#sys-sysdatabases-before-14_11-or-15_5-vu-cleanup
 
 # These are bash scripts that should not be executed
 ignore#!#load_aggtest

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -221,3 +221,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -159,7 +159,6 @@ sys-suser_sid
 sys-suser_sname
 sys-syscharsets
 sys-syscolumns
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysobjects

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -202,7 +202,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -274,3 +274,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -254,7 +254,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -328,3 +328,4 @@ AUTO_ANALYZE-before-15-5-or-14-10
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -248,7 +248,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -322,3 +322,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -248,7 +248,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -322,3 +322,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -325,3 +325,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -250,7 +250,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -416,3 +416,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -81,7 +81,6 @@ sys-original_login
 sys-schema-name
 sys-objects
 sys-procedures
-sys-sysdatabases
 sys-sysobjects
 sys-trigger_nestlevel
 schema_resolution_proc

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -416,3 +416,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -81,7 +81,6 @@ sys-original_login
 sys-schema-name
 sys-objects
 sys-procedures
-sys-sysdatabases
 sys-sysobjects
 sys-trigger_nestlevel
 schema_resolution_proc

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -343,3 +343,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -265,7 +265,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -358,3 +358,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -279,7 +279,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -393,3 +393,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -311,7 +311,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -329,7 +329,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -414,3 +414,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -413,3 +413,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -327,7 +327,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -80,7 +80,6 @@ sys-original_login
 sys-schema-name
 sys-objects
 sys-procedures
-sys-sysdatabases
 sys-sysobjects
 sys-trigger_nestlevel
 schema_resolution_proc

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -415,3 +415,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -310,7 +310,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -392,3 +392,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -422,3 +422,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -334,7 +334,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -444,3 +444,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -348,7 +348,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -355,7 +355,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -456,4 +456,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 BABEL-2999
-
+sys-sysdatabases-before-14_11-or-15_5

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -364,7 +364,6 @@ sys-synonyms
 sys-syscharsets
 sys-syscolumns
 sys-syscolumns-dep
-sys-sysdatabases
 sys-sysforeignkeys
 sys-sysforeignkeys-dep
 sys-sysindexes

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -484,3 +484,4 @@ cast_eliminate
 TestDatatypeAggSort
 babel_index_nulls_order
 BABEL-2999
+sys-sysdatabases-before-14_11-or-15_5


### PR DESCRIPTION
### Description

This PR tries to fix case-sensitive semantics of some catalog columns by fixing appropriate datatypes of columns. 

1. Fixed name column of catalog sys.sysdatabases.

### Issues Resolved

BABEL-4529

### Test Scenarios Covered ###
Added test-cases in test files for changes of respective catalogs.

```
sys.sysdatabases catalog

- BABEL-1435
- BABEL-2470
- sys-sysdatabases-vu-prepare
- sys-sysdatabases-vu-verify
- sys-sysdatabases-vu-cleanup

```


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).