### PR TITLE
[DO NOT MERGE] Restrict privileges from Unauthorised TSQL logins

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -55,7 +55,6 @@ static bool is_babelfish_ownership_enabled(ArrayType *array);
 static bool is_babelfish_role(const char *role);
 
 /* Role specific handlers */
-static bool handle_drop_role(DropRoleStmt *drop_role_stmt);
 static bool handle_rename(RenameStmt *rename_stmt);
 static bool handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt);
 
@@ -695,10 +694,6 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 	}
 	switch (nodeTag(parsetree))
 	{
-			/* Role lock down. */
-		case T_DropRoleStmt:
-			handle_result = handle_drop_role((DropRoleStmt *) parsetree);
-			break;
 		case T_RenameStmt:
 			handle_result = handle_rename((RenameStmt *) parsetree);
 			break;
@@ -746,48 +741,6 @@ call_next_ProcessUtility(PlannedStmt *pstmt,
 		next_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, completionTag);
 	else
 		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, completionTag);
-}
-
-/*
- * handle_drop_role
- *
- * Description: This function deals with DROP ROLE.
- *
- * Returns: true - should allow statement to continue
- * 	false - otherwise
- */
-static bool
-handle_drop_role(DropRoleStmt *drop_role_stmt)
-{
-	ListCell   *item = NULL;
-
-	/* We should not be handling superusers */
-	Assert(!superuser());
-	Assert(NULL != drop_role_stmt);
-
-	/*
-	 * Postgres allows you to drop multiple roles at the same time, which
-	 * means we get to parse out the roles by hand.  We could theoretically
-	 * allow for skipping this role if it's specified in a list; however,
-	 * blocking the statement seems less error prone at this point.
-	 */
-	foreach(item, drop_role_stmt->roles)
-	{
-		char	   *role = NULL;
-
-		/* Roles is a list of RoleSpecs now */
-		RoleSpec   *node = lfirst(item);
-
-		/* If the role does not exist, the role name will be NULL */
-		role = get_role_name(node);
-		if (NULL == role)
-			continue;
-
-		check_babelfish_droprole_restrictions(role);
-		pfree(role);
-		role = NULL;
-	}
-	return true;
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -33,11 +33,11 @@ tsql_CreateLoginStmt:
 											@1)); /* Must be first */
 					n->options = lappend(n->options,
 										 makeDefElem("createdb",
-													 (Node *)makeBoolean(true),
+													 (Node *)makeBoolean(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("createrole",
-													 (Node *)makeBoolean(true),
+													 (Node *)makeBoolean(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("inherit",
@@ -64,11 +64,11 @@ tsql_CreateLoginStmt:
 											@1)); /* Must be first */
 					n->options = lappend(n->options,
 										 makeDefElem("createdb",
-													 (Node *)makeBoolean(true),
+													 (Node *)makeBoolean(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("createrole",
-													 (Node *)makeBoolean(true),
+													 (Node *)makeBoolean(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("inherit",

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -33,11 +33,11 @@ tsql_CreateLoginStmt:
 											@1)); /* Must be first */
 					n->options = lappend(n->options,
 										 makeDefElem("createdb",
-													 (Node *)makeBoolean(true),
+													 (Node *)makeBoolean(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("createrole",
-													 (Node *)makeBoolean(true),
+													 (Node *)makeBoolean(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("inherit",

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -33,11 +33,11 @@ tsql_CreateLoginStmt:
 											@1)); /* Must be first */
 					n->options = lappend(n->options,
 										 makeDefElem("createdb",
-													 (Node *)makeBoolean(false),
+													 (Node *)makeBoolean(true),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("createrole",
-													 (Node *)makeBoolean(false),
+													 (Node *)makeBoolean(true),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("inherit",

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3360,14 +3360,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					char	   *grantee_name;
 					bool		is_windows_login = false;
 
-					check_alter_server_stmt(grant_role);
-					prev_current_user = GetUserNameFromId(GetUserId(), false);
-					session_user_name = GetUserNameFromId(GetSessionUserId(), false);
-					initStringInfo(&query);
 					spec = (RoleSpec *) linitial(grant_role->grantee_roles);
 					grantee_name = convertToUPN(spec->rolename);
 					if ((strcmp(grantee_name, spec->rolename) != 0))
 						is_windows_login = true;
+					check_alter_server_stmt(grant_role);
+					prev_current_user = GetUserNameFromId(GetUserId(), false);
+					session_user_name = GetUserNameFromId(GetSessionUserId(), false);
+					initStringInfo(&query);
 					if (grant_role->is_grant)
 						appendStringInfo(&query, "ALTER USER \"%s\" WITH CREATEDB CREATEROLE", spec->rolename);
 					else

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3366,9 +3366,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					spec = (RoleSpec *) linitial(grant_role->grantee_roles);
 					grantee_name = convertToUPN(spec->rolename);
 					if (grant_role->is_grant)
-						appendStringInfo(&query, "ALTER ROLE \"%s\" WITH CREATEDB CREATEROLE", grantee_name);
+						appendStringInfo(&query, "ALTER USER \"%s\" WITH CREATEDB CREATEROLE", grantee_name);
 					else
-						appendStringInfo(&query, "ALTER ROLE \"%s\" WITH NOCREATEDB NOCREATEROLE", grantee_name);
+						appendStringInfo(&query, "ALTER USER \"%s\" WITH NOCREATEDB NOCREATEROLE", grantee_name);
 
 					bbf_set_current_user(session_user_name);
 					PG_TRY();
@@ -3380,7 +3380,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						else
 							standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 													queryEnv, dest, qc);
-						exec_utility_cmd_helper(query.data);
+						if (strcmp(queryString, "(CREATE DATABASE )") != 0)
+							exec_utility_cmd_helper(query.data);
+
 					}
 					PG_CATCH();
 					{

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2190,5 +2190,6 @@ extern int64 last_scope_identity_value(void);
  */
 void		GetOpenqueryTupdescFromMetadata(char *linked_server, char *query, TupleDesc *tupdesc);
 extern void 	exec_utility_cmd_helper(char *query_str);
+extern void		exec_alter_role_cmd(char *query_str, RoleSpec *role);
 
 #endif							/* PLTSQL_H */

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1926,7 +1926,7 @@ exec_alter_role_cmd(char *query_str, RoleSpec *role)
 	stmt = parsetree_nth_stmt(parsetree_list, 0);
 
 	/* Update dummy statement with real values */
-	update_AlterRoleStmt(query_str, role);
+	update_AlterRoleStmt(stmt, role);
 
 	/* Run the built query */
 	/* need to make a wrapper PlannedStmt */

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1901,3 +1901,52 @@ char
 		appendStringInfo(&query, "\"%s\".\"%s\"", schema_name, index_name);
 	return query.data;
 }
+
+/*
+ * Helper function to execute ALTER ROLE command using
+ * ProcessUtility(). Caller should make sure their
+ * inputs are sanitized to prevent unexpected behaviour.
+ */
+void
+exec_alter_role_cmd(char *query_str, RoleSpec *role)
+{
+	List	   *parsetree_list;
+	Node	   *stmt;
+	PlannedStmt *wrapper;
+
+	parsetree_list = raw_parser(query_str, RAW_PARSE_DEFAULT);
+
+	if (list_length(parsetree_list) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("Expected 1 statement but get %d statements after parsing",
+						list_length(parsetree_list))));
+
+	/* Update the dummy statement with real values */
+	stmt = parsetree_nth_stmt(parsetree_list, 0);
+
+	/* Update dummy statement with real values */
+	update_AlterRoleStmt(query_str, role);
+
+	/* Run the built query */
+	/* need to make a wrapper PlannedStmt */
+	wrapper = makeNode(PlannedStmt);
+	wrapper->commandType = CMD_UTILITY;
+	wrapper->canSetTag = false;
+	wrapper->utilityStmt = stmt;
+	wrapper->stmt_location = 0;
+	wrapper->stmt_len = strlen(query_str);
+
+	/* do this step */
+	ProcessUtility(wrapper,
+				   query_str,
+				   false,
+				   PROCESS_UTILITY_SUBCOMMAND,
+				   NULL,
+				   NULL,
+				   None_Receiver,
+				   NULL);
+
+	/* make sure later steps can see the object created here */
+	CommandCounterIncrement();
+}

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1570,6 +1570,26 @@ is_alter_server_stmt(GrantRoleStmt *stmt)
 	return false;
 }
 
+bool
+is_grant_sysadmin_stmt(GrantRoleStmt *stmt)
+{
+	/*
+	 * is grant sysadmin statement, if any one granted role is
+	 * sysadmin role
+	 */
+	ListCell *cell;
+	foreach(cell, stmt->granted_roles)
+	{
+		RoleSpec   *spec = (RoleSpec *) lfirst(cell);
+
+		if (strcmp(spec->rolename, "sysadmin") == 0)	/* only supported server
+														 * role */
+			return true;
+	}
+
+	return false;
+}
+
 void
 check_alter_server_stmt(GrantRoleStmt *stmt)
 {

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1562,15 +1562,12 @@ is_alter_server_stmt(GrantRoleStmt *stmt)
 	{
 		RoleSpec   *spec = (RoleSpec *) linitial(stmt->granted_roles);
 
-		if (strcmp(spec->rolename, "sysadmin") != 0)	/* only supported server
+		if (strcmp(spec->rolename, "sysadmin") == 0)	/* only supported server
 														 * role */
-			return false;
+			return true;
 	}
-	/* has one and only one grantee  */
-	if (list_length(stmt->grantee_roles) != 1)
-		return false;
 
-	return true;
+	return false;
 }
 
 void

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -58,6 +58,7 @@ extern Oid get_sa_role_oid(void);
 extern bool tsql_has_pgstat_permissions(Oid roleid);
 extern bool tsql_has_linked_srv_permissions(Oid roleid);
 extern bool is_alter_server_stmt(GrantRoleStmt *stmt);
+extern bool is_grant_sysadmin_stmt(GrantRoleStmt *stmt);
 extern void check_alter_server_stmt(GrantRoleStmt *stmt);
 extern bool is_alter_role_stmt(GrantRoleStmt *stmt);
 extern void check_alter_role_stmt(GrantRoleStmt *stmt);

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -32,7 +32,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -48,7 +48,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -56,7 +56,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -64,7 +64,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -72,7 +72,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -80,7 +80,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -88,7 +88,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -96,7 +96,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -104,7 +104,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -112,7 +112,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -120,7 +120,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOSUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -128,7 +128,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 SUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -136,7 +136,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOINHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -144,7 +144,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 INHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -152,7 +152,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 REPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -160,7 +160,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOREPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -168,7 +168,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 BYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -176,7 +176,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOBYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -184,7 +184,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -265,7 +265,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -273,7 +273,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 CREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -281,7 +281,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -289,7 +289,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -297,7 +297,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOLOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -305,7 +305,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 LOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -313,7 +313,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOSUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -321,7 +321,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 SUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -329,7 +329,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOINHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -337,7 +337,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 INHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -345,7 +345,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 REPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -353,7 +353,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOREPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -361,7 +361,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 BYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -369,7 +369,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -403,7 +403,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTIO
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -411,7 +411,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMI
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -432,7 +432,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 VALID UNTIL 'infinity';
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -448,7 +448,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with ENCRYPTED password '
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -456,7 +456,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with password '12345678';
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -464,7 +464,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 with password NULL;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -472,7 +472,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -480,7 +480,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -488,7 +488,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOCREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -496,7 +496,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 CREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -504,7 +504,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOLOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -512,7 +512,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 LOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -520,7 +520,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOSUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -528,7 +528,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 SUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -536,7 +536,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOINHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -544,7 +544,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 INHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -552,7 +552,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 REPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -560,7 +560,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOREPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -568,7 +568,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 BYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -576,7 +576,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 NOBYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -584,7 +584,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH CONNECTION LIMIT 1;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -680,7 +680,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -688,7 +688,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 CREATEROLE;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -696,7 +696,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOCREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -704,7 +704,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 CREATEDB;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -712,7 +712,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOLOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -720,7 +720,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 LOGIN;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -728,7 +728,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOSUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -736,7 +736,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 SUPERUSER;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter superuser roles or change superuser attribute
     Server SQLState: 42501)~~
 
 
@@ -744,7 +744,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOINHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -752,7 +752,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 INHERIT;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -760,7 +760,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 REPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -768,7 +768,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOREPLICATION;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to alter replication roles or change replication attribute
     Server SQLState: 42501)~~
 
 
@@ -776,7 +776,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 BYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -784,7 +784,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: must be superuser to change bypassrls attribute
     Server SQLState: 42501)~~
 
 
@@ -817,7 +817,7 @@ ALTER ROLE master_ownership_restrictions_from_pg_role1 WITH NOCREATEDB CONNECTIO
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 
@@ -825,7 +825,7 @@ ALTER ROLE ownership_restrictions_from_pg_login1 WITH NOCREATEDB CONNECTION LIMI
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+~~ERROR (Message: ERROR: permission denied
     Server SQLState: 42501)~~
 
 

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -238,6 +238,11 @@ GO
 
 ALTER ROLE ownership_restrictions_from_pg_login1 VALID UNTIL 'infinity';
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
 
 ALTER ROLE ownership_restrictions_from_pg_login1 rename to master_ownership_restrictions_from_pg_role5;
 GO
@@ -368,14 +373,12 @@ GO
     Server SQLState: 42501)~~
 
 
--- after connection limit set to 1, shouldn't be able to connect to multiple sessions
 ALTER ROLE ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
 GO
+~~ERROR (Code: 0)~~
 
--- tsql user=ownership_restrictions_from_pg_login1 password=12345678
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: too many connections for role "ownership_restrictions_from_pg_login1" )~~
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
 
 
 -- psql user=ownership_restrictions_from_pg_login1 password=12345678

--- a/test/JDBC/expected/restricting_permission_on_role.out
+++ b/test/JDBC/expected/restricting_permission_on_role.out
@@ -1,0 +1,180 @@
+-- tsql
+create login restricting_permission_on_role_l1 with password = '123';
+go
+
+-- psql
+create user restricting_permission_on_role_u1 with password '123';
+go
+
+-- psql user=restricting_permission_on_role_l1 password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_l1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Creating user by an underprivileged login should be restricted
+create user restricting_permission_on_role_u2;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create role
+    Server SQLState: 42501)~~
+
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_u1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Altering a role by an underprivileged login should be restricted
+alter user restricting_permission_on_role_u1 with password '123'
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user restricting_permission_on_role_u1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to drop role
+    Server SQLState: 42501)~~
+
+
+-- psql user=restricting_permission_on_role_u1 password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_l1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Creating user by an underprivileged login should be restricted
+create user restricting_permission_on_role_u2;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create role
+    Server SQLState: 42501)~~
+
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_u1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Altering a role by an underprivileged login should be restricted
+alter user restricting_permission_on_role_l1 with password '123'
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user restricting_permission_on_role_u1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to drop role
+    Server SQLState: 42501)~~
+
+
+-- tsql
+alter server role sysadmin add member restricting_permission_on_role_l1;
+go
+
+-- psql user=restricting_permission_on_role_l1 password=123
+-- user has sysadmin membership, create user is allowed
+create user restricting_permission_on_role_u2 with password '123';
+go
+
+-- user has sysadmin membership, grant/revoke membership is allowed
+grant sysadmin to restricting_permission_on_role_u2;
+go
+
+revoke sysadmin from restricting_permission_on_role_u2;
+go
+
+-- user has sysadmin membership, alter user is allowed
+alter user restricting_permission_on_role_u2 with password '1234'
+go
+
+-- user has sysadmin membership, drop user is allowed
+drop user restricting_permission_on_role_u2;
+go
+
+-- tsql
+alter server role sysadmin drop member restricting_permission_on_role_l1;
+go
+
+-- psql
+-- Grant sysadmin privilege to underprivileged users
+grant sysadmin to restricting_permission_on_role_l1;
+go
+
+-- psql user=restricting_permission_on_role_l1 password=123
+-- user has sysadmin membership, create user is allowed
+create user restricting_permission_on_role_u2 with password '123';
+go
+
+-- user has sysadmin membership, grant/revoke membership is allowed
+grant sysadmin to restricting_permission_on_role_u2;
+go
+
+revoke sysadmin from restricting_permission_on_role_u2;
+go
+
+-- user has sysadmin membership, alter user is allowed
+alter user restricting_permission_on_role_u2 with password '1234'
+go
+
+-- user has sysadmin membership, drop user is allowed
+drop user restricting_permission_on_role_u2;
+go
+
+-- psql
+drop user restricting_permission_on_role_u1;
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'restricting_permission_on_role_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login restricting_permission_on_role_l1
+go
+
+

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -158,11 +158,8 @@ GO
 ALTER ROLE ownership_restrictions_from_pg_login1 NOBYPASSRLS;
 GO
 
--- after connection limit set to 1, shouldn't be able to connect to multiple sessions
 ALTER ROLE ownership_restrictions_from_pg_login1 WITH CONNECTION LIMIT 1;
 GO
-
--- tsql user=ownership_restrictions_from_pg_login1 password=12345678
 
 -- psql user=ownership_restrictions_from_pg_login1 password=12345678
 ALTER ROLE ownership_restrictions_from_pg_login1 set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;

--- a/test/JDBC/input/restricting_permission_on_role.mix
+++ b/test/JDBC/input/restricting_permission_on_role.mix
@@ -1,0 +1,120 @@
+-- tsql
+create login restricting_permission_on_role_l1 with password = '123';
+go
+
+-- psql
+create user restricting_permission_on_role_u1 with password '123';
+go
+
+-- psql user=restricting_permission_on_role_l1 password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_l1;
+go
+
+-- Creating user by an underprivileged login should be restricted
+create user restricting_permission_on_role_u2;
+go
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_u1;
+go
+
+-- Altering a role by an underprivileged login should be restricted
+alter user restricting_permission_on_role_u1 with password '123'
+go
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user restricting_permission_on_role_u1;
+go
+
+-- psql user=restricting_permission_on_role_u1 password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_l1;
+go
+
+-- Creating user by an underprivileged login should be restricted
+create user restricting_permission_on_role_u2;
+go
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to restricting_permission_on_role_u1;
+go
+
+-- Altering a role by an underprivileged login should be restricted
+alter user restricting_permission_on_role_l1 with password '123'
+go
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user restricting_permission_on_role_u1;
+go
+
+-- tsql
+alter server role sysadmin add member restricting_permission_on_role_l1;
+go
+
+-- psql user=restricting_permission_on_role_l1 password=123
+-- user has sysadmin membership, create user is allowed
+create user restricting_permission_on_role_u2 with password '123';
+go
+
+-- user has sysadmin membership, grant/revoke membership is allowed
+grant sysadmin to restricting_permission_on_role_u2;
+go
+
+revoke sysadmin from restricting_permission_on_role_u2;
+go
+
+-- user has sysadmin membership, alter user is allowed
+alter user restricting_permission_on_role_u2 with password '1234'
+go
+
+-- user has sysadmin membership, drop user is allowed
+drop user restricting_permission_on_role_u2;
+go
+
+-- tsql
+alter server role sysadmin drop member restricting_permission_on_role_l1;
+go
+
+-- psql
+-- Grant sysadmin privilege to underprivileged users
+grant sysadmin to restricting_permission_on_role_l1;
+go
+
+-- psql user=restricting_permission_on_role_l1 password=123
+-- user has sysadmin membership, create user is allowed
+create user restricting_permission_on_role_u2 with password '123';
+go
+
+-- user has sysadmin membership, grant/revoke membership is allowed
+grant sysadmin to restricting_permission_on_role_u2;
+go
+
+revoke sysadmin from restricting_permission_on_role_u2;
+go
+
+-- user has sysadmin membership, alter user is allowed
+alter user restricting_permission_on_role_u2 with password '1234'
+go
+
+-- user has sysadmin membership, drop user is allowed
+drop user restricting_permission_on_role_u2;
+go
+
+-- psql
+drop user restricting_permission_on_role_u1;
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'restricting_permission_on_role_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+select pg_sleep(1);
+GO
+
+-- tsql
+drop login restricting_permission_on_role_l1
+go
+
+


### PR DESCRIPTION
### Description

1. Avoid granting **CREATEROLE** and **CREATEDB** privilege to non-sysadmins logins
2. Manage **CREATEDB/CREATEROLE** privileges as part of grant/revoke membership to/from **sysadmin**.


### Issues Resolved

1. Any unprivileged Babelfish role should not grant/revoke sysadmin role or non-Babelfish roles to itself and to others from the PG port.
3. Any unprivileged Babelfish role should not drop any role via PG port.
4. Any unprivileged Babelfish role should not alter any role via PG port.
5. Any unprivileged Babelfish role should not create any role via PG port.

Task: [BABEL-4573](https://jira.rds.a2z.com/browse/BABEL-4573), [BABEL-4574](https://jira.rds.a2z.com/browse/BABEL-4574)
Signed-off-by: Shalini Lohia <lshalini@amazon.com> 

### Test Scenarios Covered ###
* **Use case based - Added**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).