### PR TITLE
Add Support to run Babelfish in Release Mode in Github Actions

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Tap Tests Enabled'
     required: no
     default: no
+  release_mode:
+    description: 'Build in Release Mode'
+    required: no
+    default: no
 
 runs:
   using: "composite"
@@ -42,7 +46,11 @@ runs:
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
           ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
         else
-          ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          if [[ ${{inputs.release_mode}} == "yes" ]]; then
+            ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 CFLAGS="-ggdb -O2" --with-libxml --with-uuid=ossp --with-icu
+          else
+            ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          fi
         fi
         make -j 4 2>error.txt
         make install

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -175,6 +175,13 @@ jobs:
         if: always() && steps.setup-new-datadir.outcome == 'success'
         uses: ./.github/composite-actions/run-pg-upgrade
 
+      - name: Disable TDS fault injection tests in release mode
+        id: disable-fault-injection
+        if: always() && steps.setup-new-datadir.outcome == 'success'
+        run: |
+          cd test/JDBC/
+          echo "ignore#\!#babel_tds_fault_injection" >> jdbc_schedule 
+
       - name: Run JDBC Tests
         id: jdbc
         timeout-minutes: 60

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -180,7 +180,8 @@ jobs:
         if: always() && steps.setup-new-datadir.outcome == 'success'
         run: |
           cd test/JDBC/
-          echo "ignore#\!#babel_tds_fault_injection" >> jdbc_schedule 
+          echo "ignore#\!#babel_tds_fault_injection" >> jdbc_schedule
+          echo "ignore#\!#tds_faultinjection" >> jdbc_schedule
 
       - name: Run JDBC Tests
         id: jdbc

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -180,8 +180,9 @@ jobs:
         if: always() && steps.setup-new-datadir.outcome == 'success'
         run: |
           cd test/JDBC/
-          echo "ignore#\!#babel_tds_fault_injection" >> jdbc_schedule
-          echo "ignore#\!#tds_faultinjection" >> jdbc_schedule
+          echo 'ignore#!#babel_tds_fault_injection' >> jdbc_schedule
+          echo 'ignore#!#tds_faultinjection' >> jdbc_schedule
+          echo jdbc_schedule
 
       - name: Run JDBC Tests
         id: jdbc

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -123,6 +123,7 @@ jobs:
         uses: ./.github/composite-actions/build-modified-postgres
         with:
           install_dir: ${{env.NEW_INSTALL_DIR}}
+          release_mode: 'yes'
 
       - name: Copy ANTLR
         run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -1304,7 +1304,7 @@ select_common_type_for_isnull(ParseState *pstate, List *exprs)
 static int32
 tsql_select_common_typmod_hook(ParseState *pstate, List *exprs, Oid common_type)
 {
-	int32		max_typmods;
+	int32		max_typmods=0;
 	ListCell	*lc;
 	common_utility_plugin *utilptr = common_utility_plugin_ptr;
 


### PR DESCRIPTION
### Description
With this change the Github Action **`Major Version Upgrade for Empty Database`** will run Babelfish in RELEASE Mode with same tests running as normal JDBC Test Framework except the fault_injection tests which are only aimed for DEBUG Mode binaries.


### Issues Resolved
BABEL-4449

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).