### PR TITLE
Fix update-join error in trigger by checking resultRelation index

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_analyze.c
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.c
@@ -132,7 +132,7 @@ pltsql_update_query_result_relation(Query *qry, Relation target_rel, List *rtabl
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) list_nth(rtable, i);
 
-		if (rte->relid == target_relid)
+		if (rte->relid == target_relid && rte->rtekind == RTE_RELATION)
 		{
 			qry->resultRelation = i + 1;
 			return;

--- a/test/JDBC/input/transactions/TestTriggers.sql
+++ b/test/JDBC/input/transactions/TestTriggers.sql
@@ -556,3 +556,34 @@ drop table triggerTab2;
 go
 drop table triggerTab3;
 go
+
+-- Test Issue where update in trigger fails
+create table babel4606_t1 (a int primary key, b int, update_date datetime)
+go
+
+insert into babel4606_t1 (a, b) values (1, 7)
+go
+
+select * from babel4606_t1
+go
+
+create trigger tr_babel4606_t1_update_date
+on babel4606_t1
+after update
+AS
+begin
+	update t
+	set update_date = getdate()
+	from inserted as i
+	join babel4606_t1 as t
+		on t.a = i.a
+end
+go
+
+update babel4606_t1 set b = 11 where a = 1
+go
+
+drop trigger tr_babel4606_t1_update_date
+go
+drop table babel4606_t1
+go

--- a/test/JDBC/input/transactions/TestTriggers.sql
+++ b/test/JDBC/input/transactions/TestTriggers.sql
@@ -561,7 +561,7 @@ go
 create table babel4606_t1 (a int primary key, b int, update_date datetime)
 go
 
-insert into babel4606_t1 (a, b) values (1, 7)
+insert into babel4606_t1 (a, b) values (1, 7), (2, 8)
 go
 
 select * from babel4606_t1
@@ -573,7 +573,7 @@ after update
 AS
 begin
 	update t
-	set update_date = getdate()
+	set update_date = '2023-12-08 00:00:00.0'
 	from inserted as i
 	join babel4606_t1 as t
 		on t.a = i.a
@@ -583,7 +583,32 @@ go
 update babel4606_t1 set b = 11 where a = 1
 go
 
+select * from babel4606_t1
+go
+
 drop trigger tr_babel4606_t1_update_date
+go
+
+create trigger tr_babel4606_t1_delete
+on babel4606_t1
+after update
+AS
+begin
+	delete t
+	from inserted as i
+	join babel4606_t1 as t
+	on t.a < i.a
+	where t.update_date <= '2023-12-08 00:00:00.0'
+end
+go
+
+update babel4606_t1 set b = 21 where a = 2
+go
+
+select * from babel4606_t1;
+go
+
+drop trigger tr_babel4606_t1_delete
 go
 drop table babel4606_t1
 go

--- a/test/JDBC/sql_expected/TestTriggers.out
+++ b/test/JDBC/sql_expected/TestTriggers.out
@@ -998,3 +998,45 @@ drop table triggerTab2;
 go
 drop table triggerTab3;
 go
+
+-- Test Issue where update in trigger fails
+create table babel4606_t1 (a int primary key, b int, update_date datetime)
+go
+
+insert into babel4606_t1 (a, b) values (1, 7)
+go
+~~ROW COUNT: 1~~
+
+
+select * from babel4606_t1
+go
+~~START~~
+int#!#int#!#datetime
+1#!#7#!#<NULL>
+~~END~~
+
+
+create trigger tr_babel4606_t1_update_date
+on babel4606_t1
+after update
+AS
+begin
+	update t
+	set update_date = getdate()
+	from inserted as i
+	join babel4606_t1 as t
+		on t.a = i.a
+end
+go
+
+update babel4606_t1 set b = 11 where a = 1
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+drop trigger tr_babel4606_t1_update_date
+go
+drop table babel4606_t1
+go

--- a/test/JDBC/sql_expected/TestTriggers.out
+++ b/test/JDBC/sql_expected/TestTriggers.out
@@ -1003,9 +1003,9 @@ go
 create table babel4606_t1 (a int primary key, b int, update_date datetime)
 go
 
-insert into babel4606_t1 (a, b) values (1, 7)
+insert into babel4606_t1 (a, b) values (1, 7), (2, 8)
 go
-~~ROW COUNT: 1~~
+~~ROW COUNT: 2~~
 
 
 select * from babel4606_t1
@@ -1013,6 +1013,7 @@ go
 ~~START~~
 int#!#int#!#datetime
 1#!#7#!#<NULL>
+2#!#8#!#<NULL>
 ~~END~~
 
 
@@ -1022,7 +1023,7 @@ after update
 AS
 begin
 	update t
-	set update_date = getdate()
+	set update_date = '2023-12-08 00:00:00.0'
 	from inserted as i
 	join babel4606_t1 as t
 		on t.a = i.a
@@ -1036,7 +1037,47 @@ go
 ~~ROW COUNT: 1~~
 
 
+select * from babel4606_t1
+go
+~~START~~
+int#!#int#!#datetime
+2#!#8#!#<NULL>
+1#!#11#!#2023-12-08 00:00:00.0
+~~END~~
+
+
 drop trigger tr_babel4606_t1_update_date
+go
+
+create trigger tr_babel4606_t1_delete
+on babel4606_t1
+after update
+AS
+begin
+	delete t
+	from inserted as i
+	join babel4606_t1 as t
+	on t.a < i.a
+	where t.update_date <= '2023-12-08 00:00:00.0'
+end
+go
+
+update babel4606_t1 set b = 21 where a = 2
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from babel4606_t1;
+go
+~~START~~
+int#!#int#!#datetime
+2#!#21#!#<NULL>
+~~END~~
+
+
+drop trigger tr_babel4606_t1_delete
 go
 drop table babel4606_t1
 go


### PR DESCRIPTION
### Description

When an update is included in a trigger with a join statement, an error can be thrown that "result relation must be a regular relation". This change fixes the issue, allowing updates in triggers to work as expected. This change ensures that update/delete targets may only be RTEs of type RTE_RELATION, as opposed to RTE_NAMEDTUPLESTORE, even when the relids match.

### Issues Resolved

BABEL-4606

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).