### PR TITLE
Fix null port->gss->princ and emit principal in logs in case of GSS authentication

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -340,6 +340,25 @@ pe_authenticate(Port *port, const char **username)
 
 		appendStringInfo(&logmsg, _(" Tds Version=0x%X."), GetClientTDSVersion());
 
+#ifdef ENABLE_GSS
+		if (port->gss)
+		{
+			const char *princ = be_gssapi_get_princ(port);
+
+			if (princ)
+				appendStringInfo(&logmsg,
+								 _(" GSS (authenticated=%s, encrypted=%s, principal=%s)"),
+								 be_gssapi_get_auth(port) ? _("yes") : _("no"),
+								 be_gssapi_get_enc(port) ? _("yes") : _("no"),
+								 princ);
+			else
+				appendStringInfo(&logmsg,
+								 _(" GSS (authenticated=%s, encrypted=%s)"),
+								 be_gssapi_get_auth(port) ? _("yes") : _("no"),
+								 be_gssapi_get_enc(port) ? _("yes") : _("no"));
+		}
+#endif
+
 		ereport(LOG, errmsg_internal("%s", logmsg.data));
 		pfree(logmsg.data);
 	}

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1462,6 +1462,7 @@ CheckGSSAuth(Port *port)
 	gss_buffer_desc gbuf;
 	MemoryContext oldContext;
 	char	   *at_pos = NULL;
+	char	   *princ;
 
 	if (pg_krb_server_keyfile && strlen(pg_krb_server_keyfile) > 0)
 	{

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1584,6 +1584,24 @@ CheckGSSAuth(Port *port)
 						 maj_stat, min_stat);
 
 	/*
+	 * gbuf.value might not be null-terminated, so turn it into a regular
+	 * null-terminated string.
+	 */
+	princ = palloc(gbuf.length + 1);
+	memcpy(princ, gbuf.value, gbuf.length);
+	princ[gbuf.length] = '\0';
+
+	/*
+	 * Copy the original name of the authenticated principal into our backend
+	 * memory for display later.
+	 *
+	 * This is also our authenticated identity.  Set it now, rather than
+	 * waiting for the usermap check below, because authentication has already
+	 * succeeded and we want the log file to reflect that.
+	 */
+	port->gss->princ = MemoryContextStrdup(TopMemoryContext, princ);
+
+	/*
 	 * XXX: In PG there are options to match realm names or perform ident
 	 * mappings. We're not going to do those checks now.  If required, we can
 	 * implement the same in future. For now, we just get the realm(domain)

--- a/contrib/babelfishpg_tds/test/TDSNode.pm
+++ b/contrib/babelfishpg_tds/test/TDSNode.pm
@@ -246,7 +246,7 @@ sub safe_tsql {
 		print $stderr;
 		print "\n#### End standard error\n";
 	}
-
+	print $stdout;
 	return $stdout;
 }
 

--- a/contrib/babelfishpg_tds/test/TDSNode.pm
+++ b/contrib/babelfishpg_tds/test/TDSNode.pm
@@ -246,6 +246,7 @@ sub safe_tsql {
 		print $stderr;
 		print "\n#### End standard error\n";
 	}
+
 	return $stdout;
 }
 

--- a/contrib/babelfishpg_tds/test/TDSNode.pm
+++ b/contrib/babelfishpg_tds/test/TDSNode.pm
@@ -246,7 +246,6 @@ sub safe_tsql {
 		print $stderr;
 		print "\n#### End standard error\n";
 	}
-	print $stdout;
 	return $stdout;
 }
 

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -417,6 +417,8 @@ $node->restart;
 
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
+my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
+is($ret, "test1\@$realm", 'Verified');
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -417,8 +417,8 @@ $node->restart;
 
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
-my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
-is($ret, "test1\@$realm", 'Verified');
+# my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
+# is($ret, "test1\@$realm", 'Verified');
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -417,8 +417,8 @@ $node->restart;
 
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
-# my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
-# is($ret, "test1\@$realm", 'Verified');
+my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
+is($ret, "test1\@$realm", 'Verified');
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -417,6 +417,7 @@ $node->restart;
 
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
+
 my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
 is($ret, "test1\@$realm", 'Verified');
 

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -418,8 +418,8 @@ $node->restart;
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
 
-my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();');
-is($ret, "test1\@$realm", 'Verified');
+my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated from pg_stat_gssapi where pid = pg_backend_pid();');
+is($ret, '1', 'Verified');
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -418,10 +418,10 @@ $node->restart;
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
 
-my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated from pg_stat_gssapi where pid = pg_backend_pid();');
+# my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated from pg_stat_gssapi where pid = pg_backend_pid();');
 note "printing ret value";
-note "$ret";
-is($ret, 1, 'Verified');
+# note "$ret";
+# is($ret, 1, 'Verified');
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -419,7 +419,9 @@ my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
 
 my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated from pg_stat_gssapi where pid = pg_backend_pid();');
-is($ret, '1', 'Verified');
+note "printing ret value";
+note "$ret";
+is($ret, 1, 'Verified');
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -418,10 +418,12 @@ $node->restart;
 my @connstr1 = $tsql_node->tsql_connstr('master');
 $tsql_node->connect_ok('Kerberos auth test', (connstr => \@connstr1));
 
-# my $ret = $tsql_node->safe_tsql('master', 'SELECT gss_authenticated from pg_stat_gssapi where pid = pg_backend_pid();');
-note "printing ret value";
-# note "$ret";
-# is($ret, 1, 'Verified');
+$tsql_node->connect_ok('pg_stat_gssapi and connection log test',
+			(connstr => \@connstr1,
+			 sql => "SELECT gss_authenticated, principal from pg_stat_gssapi where pid = pg_backend_pid();",
+      			 expected_stdout => qr/1.*test1\@$realm/,
+	    		 log_like => [qr/connection authorized: user=test1\@$realm, application=SQLCMD, Tds Version=0x\d\d\d\d\d\d\d\d. GSS \(authenticated=yes, encrypted=no, principal=test1\@$realm\)/]));
+
 
 # Reset pg_hba.conf and mark every connection to use password based auth
 # But we should be able to use kerberos auth through TDS endpoint irrespective


### PR DESCRIPTION
### Description

Earlier, GSS authenticated backend was not reporting GSS specific information like authenticated, encrypted and principal name while logging the connections. Even pg_stat_gssapi was showing principal as NULL since princ field in port->gss->princ was uninitialised.

This commit resolves above issue by initialising the port->gss->princ at the time of authentication and including authenticated, encrypted and principal name field in connection logs if GSS authentication is enabled. It cherry-picks some changes from https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=622ae4621ece72a9f64b5602c74d7aaf373c1631 and https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=126cdaf47af275f76b2f2ddb023bfdc6f018ae30 in the TDS extension.

Task: BABEL-4660
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved
BABEL-4660

### Test Scenarios Covered ###
* **Use case based -**
Verified connection logs and pg_stat_gssapi principal column.

* **Boundary conditions -**
NA

* **Arbitrary inputs -**
NA

* **Negative test cases -**
NA

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).