### PR TITLE
Unblock test cases blocked due to BABEL-4539

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -345,6 +345,7 @@ pe_authenticate(Port *port, const char **username)
 	ClientAuthInProgress = false;	/* client_min_messages is active now */
 
 	*username = port->user_name;
+	port->is_tds_conn = true;
 }
 
 static void

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -57,15 +57,6 @@ ignore#!#BABEL-ROLE-MEMBER
 # current_setting('role') returns NULL.
 ignore#!#BABEL-1444
 
-# ERROR CODE DIFFERENCE.  JIRA-4539
-ignore#!#babel_datetime-vu-verify
-ignore#!#babel_datetime
-ignore#!#BABEL-2812-vu-verify
-
-# relation "onek" does not exist: JIRA-4541
-ignore#!#pgr_select
-ignore#!#pgr_select_distinct
-
 # Test failures caused by babel_extra_join_test_cases_northwind failure
 ignore#!#babelfish_sysdatabases-vu-prepare
 ignore#!#babelfish_sysdatabases-vu-verify


### PR DESCRIPTION
With engine changes babelfish-for-postgresql/postgresql_modified_for_babelfish#260, we introduced new field in Port data structure to track whether given backend is Babelfish backend or not. This commit changes extension part of code to initialise it properly. Additionally, it also unblocks test cases blocked due to BABEL-4539.

Engine changes: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/271
Task: BABEL-4539
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).