### PR TITLE
Support non-ENR temp tables in OBJECT_ID and OBJECT_NAME

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1645,6 +1645,12 @@ object_id(PG_FUNCTION_ARGS)
 			}
 		}
 	}
+
+	if (is_temp_object && !result)
+	{
+		result = get_relname_relid((const char *) object_name, LookupNamespaceNoError("pg_temp"));
+	}
+
 	pfree(object_name);
 	if (object_type)
 		pfree(object_type);
@@ -1821,7 +1827,8 @@ object_name(PG_FUNCTION_ARGS)
 		if (!OidIsValid(schema_id) ||
 			is_schema_from_db(schema_id, database_id) ||
 			(schema_id == get_namespace_oid("sys", true)) ||
-			(schema_id == get_namespace_oid("information_schema_tsql", true)))
+			(schema_id == get_namespace_oid("information_schema_tsql", true)) ||
+			(isTempNamespace(schema_id)))
 		{
 			PG_RETURN_VARCHAR_P((VarChar *) result_text);
 		}

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1549,6 +1549,10 @@ object_id(PG_FUNCTION_ARGS)
 				{
 					result = enr->md.reliddesc;
 				}
+				else if (enr == NULL)
+				{
+					result = get_relname_relid((const char *) object_name, LookupNamespaceNoError("pg_temp"));
+				}
 			}
 			else if (!strcmp(object_type, "r") || !strcmp(object_type, "ec") || !strcmp(object_type, "pg") ||
 					 !strcmp(object_type, "sn") || !strcmp(object_type, "sq") || !strcmp(object_type, "tt"))
@@ -1614,6 +1618,10 @@ object_id(PG_FUNCTION_ARGS)
 			if (enr != NULL && enr->md.enrtype == ENR_TSQL_TEMP)
 			{
 				result = enr->md.reliddesc;
+			} 
+			else if (enr == NULL)
+			{
+				result = get_relname_relid((const char *) object_name, LookupNamespaceNoError("pg_temp"));
 			}
 		}
 		else
@@ -1644,11 +1652,6 @@ object_id(PG_FUNCTION_ARGS)
 				result = tsql_get_constraint_oid(object_name, schema_oid, user_id);
 			}
 		}
-	}
-
-	if (is_temp_object && !result)
-	{
-		result = get_relname_relid((const char *) object_name, LookupNamespaceNoError("pg_temp"));
 	}
 
 	pfree(object_name);

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-cleanup.out
@@ -39,6 +39,9 @@ GO
 DROP SCHEMA [babel_object_id_schema .with .dot_and_spaces]
 GO
 
+DROP TYPE babel_object_id_type
+GO
+
 DROP TABLE [babel_object_id_t2 .with .dot_an_spaces]
 GO
 

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-prepare.out
@@ -46,6 +46,9 @@ GO
 CREATE TABLE [babel_object_id_schema .with .dot_and_spaces]."babel_object_id_t3 .with .dot_and_spaces" (a int);
 GO
 
+CREATE TYPE babel_object_id_type FROM int
+GO
+
 -- To test lookup in different database
 CREATE DATABASE babel_object_id_db;
 GO

--- a/test/JDBC/expected/BABEL_OBJECT_ID-vu-verify.out
+++ b/test/JDBC/expected/BABEL_OBJECT_ID-vu-verify.out
@@ -255,6 +255,18 @@ varchar
 ~~END~~
 
 
+-- Test temp objects not in ENR
+CREATE TABLE #babel_object_id_temp_t2(a babel_object_id_type);
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('#babel_object_id_temp_t2'))
+GO
+~~START~~
+varchar
+#babel_object_id_temp_t2
+~~END~~
+
+
 -- We can also specify object_type as parameter
 SELECT OBJECT_NAME(OBJECT_ID('#babel_object_id_temp_t1', 'U'))
 GO

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-cleanup.mix
@@ -39,6 +39,9 @@ GO
 DROP SCHEMA [babel_object_id_schema .with .dot_and_spaces]
 GO
 
+DROP TYPE babel_object_id_type
+GO
+
 DROP TABLE [babel_object_id_t2 .with .dot_an_spaces]
 GO
 

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-prepare.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-prepare.mix
@@ -46,6 +46,9 @@ GO
 CREATE TABLE [babel_object_id_schema .with .dot_and_spaces]."babel_object_id_t3 .with .dot_and_spaces" (a int);
 GO
 
+CREATE TYPE babel_object_id_type FROM int
+GO
+
 -- To test lookup in different database
 CREATE DATABASE babel_object_id_db;
 GO

--- a/test/JDBC/input/BABEL_OBJECT_ID-vu-verify.mix
+++ b/test/JDBC/input/BABEL_OBJECT_ID-vu-verify.mix
@@ -104,6 +104,13 @@ GO
 SELECT OBJECT_NAME(OBJECT_ID('tempdb..#babel_object_id_temp_t1'))
 GO
 
+-- Test temp objects not in ENR
+CREATE TABLE #babel_object_id_temp_t2(a babel_object_id_type);
+GO
+
+SELECT OBJECT_NAME(OBJECT_ID('#babel_object_id_temp_t2'))
+GO
+
 -- We can also specify object_type as parameter
 SELECT OBJECT_NAME(OBJECT_ID('#babel_object_id_temp_t1', 'U'))
 GO


### PR DESCRIPTION
### Description

Adding the ability for the OBJECT_ID and OBJECT_NAME functions to see Non-ENR temp tables. Temp tables not in ENR will still be visible in pg catalogs, and so the OBJECT functions should be able to return information about then. 


### Issues Resolved

[BABEL-4498](https://jira.rds.a2z.com/browse/BABEL-4498) - Support non-ENR temp tables in OBJECT_ID and OBJECT_NAME.

### Test Scenarios Covered ###
Expanded unit test coverage. 



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).