### PR TITLE
Blocked CS_AS collation for server_collation_name as it is not supported in babelfish

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -543,13 +543,12 @@ find_collation(const char *collation_name)
 }
 
 static bool
-collation_is_accent_insensitive(int collidx)
+collation_is_case_insensitive_and_accent_sensitive(int collidx)
 {
 	if (collidx < 0 || collidx >= TOTAL_COLL_COUNT)
 		return false;
 
-	if (coll_infos[collidx].collateflags == 0x000f ||	/* CI_AI  */
-		coll_infos[collidx].collateflags == 0x000e) /* CS_AI  */
+	if (coll_infos[collidx].collateflags == 0x000d) /* CI_AS  */
 		return true;
 
 	return false;
@@ -1300,7 +1299,7 @@ is_valid_server_collation_name(const char *collname)
 	int			collidx = find_any_collation(collname, true);
 
 	if (NOT_FOUND != collidx &&
-		!collation_is_accent_insensitive(collidx))
+		collation_is_case_insensitive_and_accent_sensitive(collidx))
 		return true;
 
 	return false;


### PR DESCRIPTION
### Description
Babelfish currently supports only CI_AS type of collation for server collation and other collations such as CI_AI, CS_AI and CS_AS should be blocked. Currently CI_AI and CS_AI collation for server collation name is blocked but CS_AS is not blocked. It should also be blocked.
This PR will block CS_AS collation for server collation name

### Tested locally
```
-- psql
ALTER SYSTEM SET babelfishpg_tsql.server_collation_name = 'chinese_prc_ci_as';  -- only CI_AS collation is supported for server collation
GO

ALTER SYSTEM SET babelfishpg_tsql.server_collation_name = 'chinese_prc_cs_as';  -- CS_AS collation is not supported for server collation, throw error
GO
~~ERROR (Code: 0)~~

~~ERROR (Message: ERROR: invalid value for parameter "babelfishpg_tsql.server_collation_name": "chinese_prc_cs_as"
    Server SQLState: 22023)~~


ALTER SYSTEM SET babelfishpg_tsql.server_collation_name = 'chinese_prc_ci_ai';  -- CI_AI collation is not supported for server collation, throw error
GO
~~ERROR (Code: 0)~~

~~ERROR (Message: ERROR: invalid value for parameter "babelfishpg_tsql.server_collation_name": "chinese_prc_ci_ai"
    Server SQLState: 22023)~~


ALTER SYSTEM SET babelfishpg_tsql.server_collation_name = 'chinese_prc_cs_ai';  -- CS_AI collation is not supported for server collation, throw error
GO
~~ERROR (Code: 0)~~

~~ERROR (Message: ERROR: invalid value for parameter "babelfishpg_tsql.server_collation_name": "chinese_prc_cs_ai"
    Server SQLState: 22023)~~
```

### Tested with setting value in postgresql.conf file
If we try to set server_collation_name value through postgresql.conf file while installing babelfish extensions, it will not throw any error and will keep the server_collation_name to default: sql_latin1_general_cp1_ci_as. Later if we try to connect to psql then a warning is thrown in logfile:
`(2023-12-18 11:25:21.182 UTC [66776] WARNING: invalid value for parameter "babelfishpg_tsql.server_collation_name": "chinese_prc_cs_as")` as well as in psql(shown below).

```
(23-12-18 11:30:55) <1> [~/postgres]  
dev-dsk-rohitbgt-1b-17c8fefc % ~/postgres/bin/psql -d jdbc_testdb -U <username>
WARNING:  invalid value for parameter "babelfishpg_tsql.server_collation_name": "chinese_prc_cs_as"
psql (15.5)
Type "help" for help.

jdbc_testdb=# show babelfishpg_tsql.server_collation_name;
 babelfishpg_tsql.server_collation_name 
----------------------------------------
 sql_latin1_general_cp1_ci_as
(1 row)
```


Cherry-picked from [PR-2141](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2141)
Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-4632

### Test Scenarios Covered
Use case based - NA

Boundary conditions - NA

Arbitrary inputs - NA

Negative test cases - NA

Minor version upgrade tests - NA

Major version upgrade tests - NA

Performance tests - NA

Tooling impact - NA

Client tests - NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).