### PR TITLE
Fixed blankspace padding in char datatype for multibyte characters

### DIFF
--- a/contrib/babelfishpg_common/src/varchar.c
+++ b/contrib/babelfishpg_common/src/varchar.c
@@ -1133,6 +1133,7 @@ bpchar(PG_FUNCTION_ARGS)
 		size_t		maxmblen;
 
 		maxmblen = pg_encoding_mbcliplen(collInfo.enc, tmp, byteLen, maxByteLen);
+		blankSpace = maxByteLen - maxmblen;
 
 		if (!isExplicit &&
 			!(suppress_string_truncation_error_hook && (*suppress_string_truncation_error_hook) ()))

--- a/test/JDBC/expected/BABEL-4638-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4638-vu-cleanup.out
@@ -2,4 +2,15 @@ DROP TABLE babel_4638_t1
 DROP TABLE babel_4638_t2
 DROP TABLE babel_4638_t3
 DROP TABLE babel_4638_t4
+DROP TABLE babel_4638_t5
+DROP TABLE babel_4638_char_t1
+DROP TABLE babel_4638_char_t2
+DROP TABLE babel_4638_char_t3
+DROP TABLE babel_4638_char_t4
+DROP TABLE babel_4638_char_t5
+DROP TABLE babel_4638_nchar_t1
+DROP TABLE babel_4638_nchar_t2
+DROP TABLE babel_4638_nchar_t3
+DROP TABLE babel_4638_nchar_t4
+DROP TABLE babel_4638_nchar_t5
 GO

--- a/test/JDBC/expected/BABEL-4638-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4638-vu-cleanup.out
@@ -1,0 +1,5 @@
+DROP TABLE babel_4638_t1
+DROP TABLE babel_4638_t2
+DROP TABLE babel_4638_t3
+DROP TABLE babel_4638_t4
+GO

--- a/test/JDBC/expected/BABEL-4638-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4638-vu-prepare.out
@@ -2,13 +2,31 @@ CREATE TABLE babel_4638_t1(a VARCHAR(10) COLLATE arabic_ci_as);
 CREATE TABLE babel_4638_t2(a VARCHAR(10) COLLATE chinese_prc_ci_as);
 CREATE TABLE babel_4638_t3(a VARCHAR(10) COLLATE japanese_ci_as);
 CREATE TABLE babel_4638_t4(a VARCHAR(10) COLLATE hebrew_ci_as);
+CREATE TABLE babel_4638_t5(a VARCHAR(10));
+GO
+
+CREATE TABLE babel_4638_char_t1(a CHAR(10) COLLATE arabic_ci_as);
+CREATE TABLE babel_4638_char_t2(a CHAR(10) COLLATE chinese_prc_ci_as);
+CREATE TABLE babel_4638_char_t3(a CHAR(10) COLLATE japanese_ci_as);
+CREATE TABLE babel_4638_char_t4(a CHAR(10) COLLATE hebrew_ci_as);
+CREATE TABLE babel_4638_char_t5(a CHAR(10));
+GO
+
+CREATE TABLE babel_4638_nchar_t1(a NCHAR(10) COLLATE arabic_ci_as);
+CREATE TABLE babel_4638_nchar_t2(a NCHAR(10) COLLATE chinese_prc_ci_as);
+CREATE TABLE babel_4638_nchar_t3(a NCHAR(10) COLLATE japanese_ci_as);
+CREATE TABLE babel_4638_nchar_t4(a NCHAR(10) COLLATE hebrew_ci_as);
+CREATE TABLE babel_4638_nchar_t5(a NCHAR(10));
 GO
 
 INSERT INTO babel_4638_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل');
 INSERT INTO babel_4638_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚');
 INSERT INTO babel_4638_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ');
 INSERT INTO babel_4638_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+INSERT INTO babel_4638_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
 GO
+~~ROW COUNT: 4~~
+
 ~~ROW COUNT: 4~~
 
 ~~ROW COUNT: 4~~

--- a/test/JDBC/expected/BABEL-4638-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4638-vu-prepare.out
@@ -1,0 +1,19 @@
+CREATE TABLE babel_4638_t1(a VARCHAR(10) COLLATE arabic_ci_as);
+CREATE TABLE babel_4638_t2(a VARCHAR(10) COLLATE chinese_prc_ci_as);
+CREATE TABLE babel_4638_t3(a VARCHAR(10) COLLATE japanese_ci_as);
+CREATE TABLE babel_4638_t4(a VARCHAR(10) COLLATE hebrew_ci_as);
+GO
+
+INSERT INTO babel_4638_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل');
+INSERT INTO babel_4638_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚');
+INSERT INTO babel_4638_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ');
+INSERT INTO babel_4638_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+

--- a/test/JDBC/expected/BABEL-4638-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4638-vu-verify.out
@@ -10,10 +10,10 @@ varchar
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t1
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t1
 GO
 ~~START~~
-text
+varchar
 ح|
 غ|
 س|
@@ -21,10 +21,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t1
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t1
 GO
 ~~START~~
-text
+varchar
 ح    |
 غ    |
 سسس  |
@@ -32,10 +32,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t1
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t1
 GO
 ~~START~~
-text
+nvarchar
 ح|
 غ|
 س|
@@ -43,10 +43,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t1
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t1
 GO
 ~~START~~
-text
+nvarchar
 ح    |
 غ    |
 سسس  |
@@ -63,10 +63,10 @@ GO
 
 
 -- here a is defined as CHAR(10) COLLATE arabic_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t1
+SELECT a + '|' FROM babel_4638_char_t1
 GO
 ~~START~~
-text
+varchar
 ح         |
 غ         |
 سسس       |
@@ -75,10 +75,10 @@ text
 
 
 -- here a is defined as NCHAR(10) COLLATE arabic_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t1
+SELECT a + '|' FROM babel_4638_nchar_t1
 GO
 ~~START~~
-text
+nvarchar
 ح         |
 غ         |
 سسس       |
@@ -98,10 +98,10 @@ varchar
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t2
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t2
 GO
 ~~START~~
-text
+varchar
  |
  |
  |
@@ -109,10 +109,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t2
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t2
 GO
 ~~START~~
-text
+varchar
 五   |
 九   |
 乙乙 |
@@ -120,10 +120,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t2
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t2
 GO
 ~~START~~
-text
+nvarchar
 五|
 九|
 乙|
@@ -131,10 +131,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t2
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t2
 GO
 ~~START~~
-text
+nvarchar
 五    |
 九    |
 乙乙乙  |
@@ -151,10 +151,10 @@ GO
 
 
 -- here a is defined as CHAR(10) COLLATE chinese_prc_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t2
+SELECT a + '|' FROM babel_4638_char_t2
 GO
 ~~START~~
-text
+varchar
 五        |
 九        |
 乙乙乙    |
@@ -163,10 +163,10 @@ text
 
 
 -- here a is defined as NCHAR(10) COLLATE chinese_prc_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t2
+SELECT a + '|' FROM babel_4638_nchar_t2
 GO
 ~~START~~
-text
+nvarchar
 五         |
 九         |
 乙乙乙       |
@@ -186,10 +186,10 @@ varchar
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t3
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t3
 GO
 ~~START~~
-text
+varchar
  |
  |
  |
@@ -197,10 +197,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t3
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t3
 GO
 ~~START~~
-text
+varchar
 あ   |
 九   |
 ちち |
@@ -208,10 +208,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t3
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t3
 GO
 ~~START~~
-text
+nvarchar
 あ|
 九|
 ち|
@@ -219,10 +219,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t3
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t3
 GO
 ~~START~~
-text
+nvarchar
 あ    |
 九    |
 ちちち  |
@@ -239,10 +239,10 @@ GO
 
 
 -- here a is defined as CHAR(10) COLLATE japanese_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t3
+SELECT a + '|' FROM babel_4638_char_t3
 GO
 ~~START~~
-text
+varchar
 あ        |
 九        |
 ちちち    |
@@ -251,10 +251,10 @@ text
 
 
 -- here a is defined as NCHAR(10) COLLATE japanese_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t3
+SELECT a + '|' FROM babel_4638_nchar_t3
 GO
 ~~START~~
-text
+nvarchar
 あ         |
 九         |
 ちちち       |
@@ -274,10 +274,10 @@ varchar
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t4
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t4
 GO
 ~~START~~
-text
+varchar
 ב|
 א|
 ק|
@@ -285,10 +285,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t4
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t4
 GO
 ~~START~~
-text
+varchar
 ב    |
 א    |
 קקק  |
@@ -296,10 +296,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t4
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t4
 GO
 ~~START~~
-text
+nvarchar
 ב|
 א|
 ק|
@@ -307,10 +307,10 @@ text
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t4
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t4
 GO
 ~~START~~
-text
+nvarchar
 ב    |
 א    |
 קקק  |
@@ -327,10 +327,10 @@ GO
 
 
 -- here a is defined as CHAR(10) COLLATE hebrew_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t4
+SELECT a + '|' FROM babel_4638_char_t4
 GO
 ~~START~~
-text
+varchar
 ב         |
 א         |
 קקק       |
@@ -339,10 +339,10 @@ text
 
 
 -- here a is defined as NCHAR(10) COLLATE hebrew_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t4
+SELECT a + '|' FROM babel_4638_nchar_t4
 GO
 ~~START~~
-text
+nvarchar
 ב         |
 א         |
 קקק       |
@@ -363,10 +363,21 @@ a
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t5
+SELECT CAST(a as NVARCHAR(10)) FROM babel_4638_t5
 GO
 ~~START~~
-text
+nvarchar
+a
+🙂
+🙂🙂🙂
+さささ
+~~END~~
+
+
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t5
+GO
+~~START~~
+varchar
 a|
 ?|
 ?|
@@ -374,10 +385,10 @@ a|
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t5
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t5
 GO
 ~~START~~
-text
+varchar
 a    |
 ?    |
 ???  |
@@ -385,32 +396,25 @@ a    |
 ~~END~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t5
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t5
 GO
 ~~START~~
-text
+nvarchar
 a|
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: value too long for type character(1) as UTF16 output)~~
 
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t5
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t5
 GO
 ~~START~~
-text
+nvarchar
 a    |
-?    |
+🙂    |
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: value too long for type character(5) as UTF16 output)~~
-
-
-SELECT CAST('🙂' as NCHAR(1))
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: value too long for type character(1) as UTF16 output)~~
 
 
 INSERT INTO babel_4638_char_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
@@ -421,49 +425,27 @@ GO
 ~~ROW COUNT: 4~~
 
 
-SELECT * FROM babel_4638_char_t5
-GO
-~~START~~
-char
-a         
-?         
-???       
-???       
-~~END~~
-
-
 -- here a is defined as CHAR(10)
-SELECT CONCAT(a,'|') FROM babel_4638_char_t5
+SELECT a + '|' FROM babel_4638_char_t5
 GO
 ~~START~~
-text
+varchar
 a         |
 ?         |
 ???       |
 ???       |
-~~END~~
-
-
-SELECT * FROM babel_4638_nchar_t5
-GO
-~~START~~
-nchar
-a         
-🙂        
-🙂🙂🙂    
-さささ       
 ~~END~~
 
 
 -- here a is defined as NCHAR(10)
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t5
+SELECT a + '|' FROM babel_4638_nchar_t5
 GO
 ~~START~~
-text
+nvarchar
 a         |
-?         |
-???       |
-???       |
+🙂         |
+🙂🙂🙂       |
+さささ       |
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-4638-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4638-vu-verify.out
@@ -32,6 +32,60 @@ text
 ~~END~~
 
 
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t1
+GO
+~~START~~
+text
+ح|
+غ|
+س|
+ل|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t1
+GO
+~~START~~
+text
+ح    |
+غ    |
+سسس  |
+للل  |
+~~END~~
+
+
+INSERT INTO babel_4638_char_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل')
+INSERT INTO babel_4638_nchar_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل')
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+
+-- here a is defined as CHAR(10) COLLATE arabic_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t1
+GO
+~~START~~
+text
+ح         |
+غ         |
+سسس       |
+للل       |
+~~END~~
+
+
+-- here a is defined as NCHAR(10) COLLATE arabic_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t1
+GO
+~~START~~
+text
+ح         |
+غ         |
+سسس       |
+للل       |
+~~END~~
+
+
 -- chinese_prc_ci_as
 SELECT * FROM babel_4638_t2
 GO
@@ -63,6 +117,60 @@ text
 九   |
 乙乙 |
 魚魚 |
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t2
+GO
+~~START~~
+text
+五|
+九|
+乙|
+魚|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t2
+GO
+~~START~~
+text
+五    |
+九    |
+乙乙乙  |
+魚魚魚  |
+~~END~~
+
+
+INSERT INTO babel_4638_char_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚')
+INSERT INTO babel_4638_nchar_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚')
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+
+-- here a is defined as CHAR(10) COLLATE chinese_prc_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t2
+GO
+~~START~~
+text
+五        |
+九        |
+乙乙乙    |
+魚魚魚    |
+~~END~~
+
+
+-- here a is defined as NCHAR(10) COLLATE chinese_prc_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t2
+GO
+~~START~~
+text
+五         |
+九         |
+乙乙乙       |
+魚魚魚       |
 ~~END~~
 
 
@@ -100,6 +208,60 @@ text
 ~~END~~
 
 
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t3
+GO
+~~START~~
+text
+あ|
+九|
+ち|
+さ|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t3
+GO
+~~START~~
+text
+あ    |
+九    |
+ちちち  |
+さささ  |
+~~END~~
+
+
+INSERT INTO babel_4638_char_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ')
+INSERT INTO babel_4638_nchar_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ')
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+
+-- here a is defined as CHAR(10) COLLATE japanese_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t3
+GO
+~~START~~
+text
+あ        |
+九        |
+ちちち    |
+さささ    |
+~~END~~
+
+
+-- here a is defined as NCHAR(10) COLLATE japanese_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t3
+GO
+~~START~~
+text
+あ         |
+九         |
+ちちち       |
+さささ       |
+~~END~~
+
+
 -- hebrew_ci_as
 SELECT * FROM babel_4638_t4
 GO
@@ -132,4 +294,176 @@ text
 קקק  |
 מממ  |
 ~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t4
+GO
+~~START~~
+text
+ב|
+א|
+ק|
+מ|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t4
+GO
+~~START~~
+text
+ב    |
+א    |
+קקק  |
+מממ  |
+~~END~~
+
+
+INSERT INTO babel_4638_char_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+INSERT INTO babel_4638_nchar_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+
+-- here a is defined as CHAR(10) COLLATE hebrew_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t4
+GO
+~~START~~
+text
+ב         |
+א         |
+קקק       |
+מממ       |
+~~END~~
+
+
+-- here a is defined as NCHAR(10) COLLATE hebrew_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t4
+GO
+~~START~~
+text
+ב         |
+א         |
+קקק       |
+מממ       |
+~~END~~
+
+
+
+-- Default
+SELECT * FROM babel_4638_t5
+GO
+~~START~~
+varchar
+a
+?
+???
+???
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t5
+GO
+~~START~~
+text
+a|
+?|
+?|
+?|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t5
+GO
+~~START~~
+text
+a    |
+?    |
+???  |
+???  |
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t5
+GO
+~~START~~
+text
+a|
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: value too long for type character(1) as UTF16 output)~~
+
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t5
+GO
+~~START~~
+text
+a    |
+?    |
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: value too long for type character(5) as UTF16 output)~~
+
+
+SELECT CAST('🙂' as NCHAR(1))
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: value too long for type character(1) as UTF16 output)~~
+
+
+INSERT INTO babel_4638_char_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
+INSERT INTO babel_4638_nchar_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 4~~
+
+
+SELECT * FROM babel_4638_char_t5
+GO
+~~START~~
+char
+a         
+?         
+???       
+???       
+~~END~~
+
+
+-- here a is defined as CHAR(10)
+SELECT CONCAT(a,'|') FROM babel_4638_char_t5
+GO
+~~START~~
+text
+a         |
+?         |
+???       |
+???       |
+~~END~~
+
+
+SELECT * FROM babel_4638_nchar_t5
+GO
+~~START~~
+nchar
+a         
+🙂        
+🙂🙂🙂    
+さささ       
+~~END~~
+
+
+-- here a is defined as NCHAR(10)
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t5
+GO
+~~START~~
+text
+a         |
+?         |
+???       |
+???       |
+~~END~~
+
 

--- a/test/JDBC/expected/BABEL-4638-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4638-vu-verify.out
@@ -1,0 +1,135 @@
+-- arabic_ci_as
+SELECT * FROM babel_4638_t1
+GO
+~~START~~
+varchar
+ح
+غ
+سسس
+للل
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t1
+GO
+~~START~~
+text
+ح|
+غ|
+س|
+ل|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t1
+GO
+~~START~~
+text
+ح    |
+غ    |
+سسس  |
+للل  |
+~~END~~
+
+
+-- chinese_prc_ci_as
+SELECT * FROM babel_4638_t2
+GO
+~~START~~
+varchar
+五
+九
+乙乙乙
+魚魚魚
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t2
+GO
+~~START~~
+text
+ |
+ |
+ |
+ |
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t2
+GO
+~~START~~
+text
+五   |
+九   |
+乙乙 |
+魚魚 |
+~~END~~
+
+
+-- japanese_ci_as
+SELECT * FROM babel_4638_t3
+GO
+~~START~~
+varchar
+あ
+九
+ちちち
+さささ
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t3
+GO
+~~START~~
+text
+ |
+ |
+ |
+ |
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t3
+GO
+~~START~~
+text
+あ   |
+九   |
+ちち |
+ささ |
+~~END~~
+
+
+-- hebrew_ci_as
+SELECT * FROM babel_4638_t4
+GO
+~~START~~
+varchar
+ב
+א
+קקק
+מממ
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t4
+GO
+~~START~~
+text
+ב|
+א|
+ק|
+מ|
+~~END~~
+
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t4
+GO
+~~START~~
+text
+ב    |
+א    |
+קקק  |
+מממ  |
+~~END~~
+

--- a/test/JDBC/input/BABEL-4638-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4638-vu-cleanup.sql
@@ -2,4 +2,15 @@ DROP TABLE babel_4638_t1
 DROP TABLE babel_4638_t2
 DROP TABLE babel_4638_t3
 DROP TABLE babel_4638_t4
+DROP TABLE babel_4638_t5
+DROP TABLE babel_4638_char_t1
+DROP TABLE babel_4638_char_t2
+DROP TABLE babel_4638_char_t3
+DROP TABLE babel_4638_char_t4
+DROP TABLE babel_4638_char_t5
+DROP TABLE babel_4638_nchar_t1
+DROP TABLE babel_4638_nchar_t2
+DROP TABLE babel_4638_nchar_t3
+DROP TABLE babel_4638_nchar_t4
+DROP TABLE babel_4638_nchar_t5
 GO

--- a/test/JDBC/input/BABEL-4638-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4638-vu-cleanup.sql
@@ -1,0 +1,5 @@
+DROP TABLE babel_4638_t1
+DROP TABLE babel_4638_t2
+DROP TABLE babel_4638_t3
+DROP TABLE babel_4638_t4
+GO

--- a/test/JDBC/input/BABEL-4638-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4638-vu-prepare.sql
@@ -2,10 +2,26 @@ CREATE TABLE babel_4638_t1(a VARCHAR(10) COLLATE arabic_ci_as);
 CREATE TABLE babel_4638_t2(a VARCHAR(10) COLLATE chinese_prc_ci_as);
 CREATE TABLE babel_4638_t3(a VARCHAR(10) COLLATE japanese_ci_as);
 CREATE TABLE babel_4638_t4(a VARCHAR(10) COLLATE hebrew_ci_as);
+CREATE TABLE babel_4638_t5(a VARCHAR(10));
+GO
+
+CREATE TABLE babel_4638_char_t1(a CHAR(10) COLLATE arabic_ci_as);
+CREATE TABLE babel_4638_char_t2(a CHAR(10) COLLATE chinese_prc_ci_as);
+CREATE TABLE babel_4638_char_t3(a CHAR(10) COLLATE japanese_ci_as);
+CREATE TABLE babel_4638_char_t4(a CHAR(10) COLLATE hebrew_ci_as);
+CREATE TABLE babel_4638_char_t5(a CHAR(10));
+GO
+
+CREATE TABLE babel_4638_nchar_t1(a NCHAR(10) COLLATE arabic_ci_as);
+CREATE TABLE babel_4638_nchar_t2(a NCHAR(10) COLLATE chinese_prc_ci_as);
+CREATE TABLE babel_4638_nchar_t3(a NCHAR(10) COLLATE japanese_ci_as);
+CREATE TABLE babel_4638_nchar_t4(a NCHAR(10) COLLATE hebrew_ci_as);
+CREATE TABLE babel_4638_nchar_t5(a NCHAR(10));
 GO
 
 INSERT INTO babel_4638_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل');
 INSERT INTO babel_4638_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚');
 INSERT INTO babel_4638_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ');
 INSERT INTO babel_4638_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+INSERT INTO babel_4638_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
 GO

--- a/test/JDBC/input/BABEL-4638-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4638-vu-prepare.sql
@@ -1,0 +1,11 @@
+CREATE TABLE babel_4638_t1(a VARCHAR(10) COLLATE arabic_ci_as);
+CREATE TABLE babel_4638_t2(a VARCHAR(10) COLLATE chinese_prc_ci_as);
+CREATE TABLE babel_4638_t3(a VARCHAR(10) COLLATE japanese_ci_as);
+CREATE TABLE babel_4638_t4(a VARCHAR(10) COLLATE hebrew_ci_as);
+GO
+
+INSERT INTO babel_4638_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل');
+INSERT INTO babel_4638_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚');
+INSERT INTO babel_4638_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ');
+INSERT INTO babel_4638_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+GO

--- a/test/JDBC/input/BABEL-4638-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4638-vu-verify.sql
@@ -1,0 +1,39 @@
+-- arabic_ci_as
+SELECT * FROM babel_4638_t1
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t1
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t1
+GO
+
+-- chinese_prc_ci_as
+SELECT * FROM babel_4638_t2
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t2
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t2
+GO
+
+-- japanese_ci_as
+SELECT * FROM babel_4638_t3
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t3
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t3
+GO
+
+-- hebrew_ci_as
+SELECT * FROM babel_4638_t4
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t4
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t4
+GO

--- a/test/JDBC/input/BABEL-4638-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4638-vu-verify.sql
@@ -2,16 +2,16 @@
 SELECT * FROM babel_4638_t1
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t1
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t1
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t1
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t1
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t1
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t1
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t1
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t1
 GO
 
 INSERT INTO babel_4638_char_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل')
@@ -19,27 +19,27 @@ INSERT INTO babel_4638_nchar_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل')
 GO
 
 -- here a is defined as CHAR(10) COLLATE arabic_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t1
+SELECT a + '|' FROM babel_4638_char_t1
 GO
 
 -- here a is defined as NCHAR(10) COLLATE arabic_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t1
+SELECT a + '|' FROM babel_4638_nchar_t1
 GO
 
 -- chinese_prc_ci_as
 SELECT * FROM babel_4638_t2
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t2
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t2
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t2
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t2
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t2
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t2
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t2
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t2
 GO
 
 INSERT INTO babel_4638_char_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚')
@@ -47,27 +47,27 @@ INSERT INTO babel_4638_nchar_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚�
 GO
 
 -- here a is defined as CHAR(10) COLLATE chinese_prc_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t2
+SELECT a + '|' FROM babel_4638_char_t2
 GO
 
 -- here a is defined as NCHAR(10) COLLATE chinese_prc_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t2
+SELECT a + '|' FROM babel_4638_nchar_t2
 GO
 
 -- japanese_ci_as
 SELECT * FROM babel_4638_t3
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t3
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t3
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t3
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t3
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t3
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t3
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t3
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t3
 GO
 
 INSERT INTO babel_4638_char_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ')
@@ -75,27 +75,27 @@ INSERT INTO babel_4638_nchar_t3 VALUES('あ'), ('九'), ('ちちち'), ('ささ�
 GO
 
 -- here a is defined as CHAR(10) COLLATE japanese_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t3
+SELECT a + '|' FROM babel_4638_char_t3
 GO
 
 -- here a is defined as NCHAR(10) COLLATE japanese_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t3
+SELECT a + '|' FROM babel_4638_nchar_t3
 GO
 
 -- hebrew_ci_as
 SELECT * FROM babel_4638_t4
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t4
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t4
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t4
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t4
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t4
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t4
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t4
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t4
 GO
 
 INSERT INTO babel_4638_char_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
@@ -103,11 +103,11 @@ INSERT INTO babel_4638_nchar_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
 GO
 
 -- here a is defined as CHAR(10) COLLATE hebrew_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_char_t4
+SELECT a + '|' FROM babel_4638_char_t4
 GO
 
 -- here a is defined as NCHAR(10) COLLATE hebrew_ci_as
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t4
+SELECT a + '|' FROM babel_4638_nchar_t4
 GO
 
 
@@ -115,36 +115,30 @@ GO
 SELECT * FROM babel_4638_t5
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t5
+SELECT CAST(a as NVARCHAR(10)) FROM babel_4638_t5
 GO
 
-SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t5
+SELECT CAST(a AS CHAR(1)) + '|' FROM babel_4638_t5
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t5
+SELECT CAST(a AS CHAR(5)) + '|' FROM babel_4638_t5
 GO
 
-SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t5
+SELECT CAST(a AS NCHAR(1)) + '|' FROM babel_4638_t5
 GO
 
-SELECT CAST('🙂' as NCHAR(1))
+SELECT CAST(a AS NCHAR(5)) + '|' FROM babel_4638_t5
 GO
 
 INSERT INTO babel_4638_char_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
 INSERT INTO babel_4638_nchar_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
 GO
 
-SELECT * FROM babel_4638_char_t5
-GO
-
 -- here a is defined as CHAR(10)
-SELECT CONCAT(a,'|') FROM babel_4638_char_t5
-GO
-
-SELECT * FROM babel_4638_nchar_t5
+SELECT a + '|' FROM babel_4638_char_t5
 GO
 
 -- here a is defined as NCHAR(10)
-SELECT CONCAT(a,'|') FROM babel_4638_nchar_t5
+SELECT a + '|' FROM babel_4638_nchar_t5
 GO
 

--- a/test/JDBC/input/BABEL-4638-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4638-vu-verify.sql
@@ -8,6 +8,24 @@ GO
 SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t1
 GO
 
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t1
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t1
+GO
+
+INSERT INTO babel_4638_char_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل')
+INSERT INTO babel_4638_nchar_t1 VALUES('ح'), ('غ'), ('سسس'), ('للل')
+GO
+
+-- here a is defined as CHAR(10) COLLATE arabic_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t1
+GO
+
+-- here a is defined as NCHAR(10) COLLATE arabic_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t1
+GO
+
 -- chinese_prc_ci_as
 SELECT * FROM babel_4638_t2
 GO
@@ -16,6 +34,24 @@ SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t2
 GO
 
 SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t2
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t2
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t2
+GO
+
+INSERT INTO babel_4638_char_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚')
+INSERT INTO babel_4638_nchar_t2 VALUES('五'), ('九'), ('乙乙乙'), ('魚魚魚')
+GO
+
+-- here a is defined as CHAR(10) COLLATE chinese_prc_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t2
+GO
+
+-- here a is defined as NCHAR(10) COLLATE chinese_prc_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t2
 GO
 
 -- japanese_ci_as
@@ -28,6 +64,24 @@ GO
 SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t3
 GO
 
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t3
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t3
+GO
+
+INSERT INTO babel_4638_char_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ')
+INSERT INTO babel_4638_nchar_t3 VALUES('あ'), ('九'), ('ちちち'), ('さささ')
+GO
+
+-- here a is defined as CHAR(10) COLLATE japanese_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t3
+GO
+
+-- here a is defined as NCHAR(10) COLLATE japanese_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t3
+GO
+
 -- hebrew_ci_as
 SELECT * FROM babel_4638_t4
 GO
@@ -37,3 +91,60 @@ GO
 
 SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t4
 GO
+
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t4
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t4
+GO
+
+INSERT INTO babel_4638_char_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+INSERT INTO babel_4638_nchar_t4 VALUES('ב'), ('א'), ('קקק'), ('מממ');
+GO
+
+-- here a is defined as CHAR(10) COLLATE hebrew_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_char_t4
+GO
+
+-- here a is defined as NCHAR(10) COLLATE hebrew_ci_as
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t4
+GO
+
+
+-- Default
+SELECT * FROM babel_4638_t5
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(1)), '|') FROM babel_4638_t5
+GO
+
+SELECT CONCAT(CAST(a AS CHAR(5)), '|') FROM babel_4638_t5
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(1)), '|') FROM babel_4638_t5
+GO
+
+SELECT CONCAT(CAST(a AS NCHAR(5)), '|') FROM babel_4638_t5
+GO
+
+SELECT CAST('🙂' as NCHAR(1))
+GO
+
+INSERT INTO babel_4638_char_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
+INSERT INTO babel_4638_nchar_t5 VALUES('a'), ('🙂'), ('🙂🙂🙂'), ('さささ');
+GO
+
+SELECT * FROM babel_4638_char_t5
+GO
+
+-- here a is defined as CHAR(10)
+SELECT CONCAT(a,'|') FROM babel_4638_char_t5
+GO
+
+SELECT * FROM babel_4638_nchar_t5
+GO
+
+-- here a is defined as NCHAR(10)
+SELECT CONCAT(a,'|') FROM babel_4638_nchar_t5
+GO
+


### PR DESCRIPTION
### Description
Currently when multi-byte character is casted to char(1) space padding was not done properly. This PR will fix this issue.

### Tested locally
```
-- with server collation name = japanese_ci_as
1> select concat(cast('£' as char(1)), '|')
2> go
concat                                                                                                                                                                                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 |                                                                                                                                                                                                                                                              

(1 rows affected)

-- with server collation name = chinese_prc_ci_as
1> select CONCAT(CAST('ち' AS char(1)),'|');
2> go
concat                                                                                                                                                                                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 |                                                                                                                                                                                                                                                              

(1 rows affected)
```

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved

BABEL-4638

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).