### PR TITLE
Handle keywords in full object names

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -843,8 +843,13 @@ public:
 			TSqlParser::IdContext *obj_name = ctx->object_name;
 
 			std::string full_object_name = ::getFullText(ctx);
+			std::string server_name_str;
 
-			std::string server_name_str = getIDName(obj_server->DOUBLE_QUOTE_ID(), obj_server->SQUARE_BRACKET_ID(), obj_server->ID());
+			if (obj_server->keyword())
+				server_name_str = getFullText(obj_server->keyword());
+			else
+				server_name_str = getIDName(obj_server->DOUBLE_QUOTE_ID(), obj_server->SQUARE_BRACKET_ID(), obj_server->ID());
+
 			std::string quoted_server_str = std::string("'") + server_name_str + std::string("'");
 
 			std::string three_part_name = ::getFullText(obj_database) + std::string(".") + ::getFullText(obj_schema) + std::string(".") + ::getFullText(obj_name);
@@ -1004,7 +1009,13 @@ public:
 		 */
 		if (linked_srv)
 		{
-			std::string linked_srv_name = getIDName(linked_srv->DOUBLE_QUOTE_ID(), linked_srv->SQUARE_BRACKET_ID(), linked_srv->ID());
+			std::string linked_srv_name;
+
+			if (linked_srv->keyword())
+				linked_srv_name = getFullText(linked_srv->keyword());
+			else
+				linked_srv_name = getIDName(linked_srv->DOUBLE_QUOTE_ID(), linked_srv->SQUARE_BRACKET_ID(), linked_srv->ID());
+
 			std::string str = std::string("'") + linked_srv_name + std::string("'");
 
 			rewritten_query_fragment.emplace(std::make_pair(ctx->OPENQUERY()->getSymbol()->getStartIndex(), std::make_pair(::getFullText(ctx->OPENQUERY()), "openquery_internal")));

--- a/test/JDBC/expected/BABEL-4406.out
+++ b/test/JDBC/expected/BABEL-4406.out
@@ -1,0 +1,32 @@
+-- MASTER is a T-SQL keyword in ANTLR however according to T-SQL it isn't
+-- When doing T-SQL parsing it will not throw syntax error and rewrite will
+-- happen as expected. We will throw server does not exist error
+SELECT COLUMN_NAME from master.[JDG_Refund_Requests].information_schema.columns where [TABLE_NAME] = 'vw_All_Requests'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "master" does not exist)~~
+
+
+SELECT * FROM OPENQUERY(master, 'select * from a.b.c.d')
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "master" does not exist)~~
+
+
+-- MERGE is a T-SQL keyword and in ANTLR as well
+-- So we will throw syntax error in T-SQL parsing itself
+SELECT COLUMN_NAME from merge.[JDG_Refund_Requests].information_schema.columns where [TABLE_NAME] = 'vw_All_Requests'
+GO
+~~ERROR (Code: 10733)~~
+
+~~ERROR (Message: syntax error near 'merge' at line 3 and character position 24)~~
+
+
+SELECT * FROM OPENQUERY(merge, 'select * from a.b.c.d')
+GO
+~~ERROR (Code: 10733)~~
+
+~~ERROR (Message: syntax error near 'merge' at line 1 and character position 24)~~
+

--- a/test/JDBC/input/BABEL-4406.sql
+++ b/test/JDBC/input/BABEL-4406.sql
@@ -1,0 +1,16 @@
+-- MASTER is a T-SQL keyword in ANTLR however according to T-SQL it isn't
+-- When doing T-SQL parsing it will not throw syntax error and rewrite will
+-- happen as expected. We will throw server does not exist error
+SELECT COLUMN_NAME from master.[JDG_Refund_Requests].information_schema.columns where [TABLE_NAME] = 'vw_All_Requests'
+GO
+
+SELECT * FROM OPENQUERY(master, 'select * from a.b.c.d')
+GO
+
+-- MERGE is a T-SQL keyword and in ANTLR as well
+-- So we will throw syntax error in T-SQL parsing itself
+SELECT COLUMN_NAME from merge.[JDG_Refund_Requests].information_schema.columns where [TABLE_NAME] = 'vw_All_Requests'
+GO
+
+SELECT * FROM OPENQUERY(merge, 'select * from a.b.c.d')
+GO


### PR DESCRIPTION
### Description

Currently, we are not handling T-SQL keywords used as server name in T-SQL OPENQUERY() and four-part object names. Ideally, during T-SQL parsing, the ANTLR parser will throw a syntax error if keywords are being used as server names. However, that is not the case for all keywords (Eg. MASTER is a T-SQL keyword according to ANTLR but using MATSER as a server name is allowed in T-SQL). To handle such cases, we check if server name is a keyword and if it is, we extract its text and use it as the linked server name; the same way we are doing it for regular IDs in ANTLR parser.

Task: BABEL-4406

Signed-off-by: Sharu Goel goelshar@amazon.com

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).