### PR TITLE
Unprivileged T-SQL logins should not create users and roles (#2175)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2435,6 +2435,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					}
 					else if (isuser || isrole)
 					{
+						const char *db_owner_name;
+
+						db_owner_name = get_db_owner_name(get_cur_db_name());
+						if (!has_privs_of_role(GetUserId(),get_role_oid(db_owner_name, false)))
+							ereport(ERROR,
+									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+									 errmsg("User does not have permission to perform this action.")));
+
 						/* Set current user to dbo user for create permissions */
 						prev_current_user = GetUserNameFromId(GetUserId(), false);
 

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -2,6 +2,72 @@
 CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '123';
 GO
 
+CREATE LOGIN ownership_restrictions_from_pg_login2 WITH password = '12345678';
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login2 password=12345678
+CREATE ROLE ownership_restrictions_from_pg_role_by_pg_login2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+-- tsql
+ALTER SERVER ROLE sysadmin ADD MEMBER ownership_restrictions_from_pg_login2;
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login2 password=12345678
+CREATE DATABASE ownership_restrictions_from_pg_login2_db1;
+GO
+
+-- tsql
+ALTER SERVER ROLE sysadmin DROP MEMBER ownership_restrictions_from_pg_login2;
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login2 password=12345678
+USE ownership_restrictions_from_pg_login2_db1;
+GO
+
+SELECT current_user;
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+CREATE ROLE ownership_restrictions_from_pg_role_by_pg_login2;
+GO
+
+DROP ROLE ownership_restrictions_from_pg_role_by_pg_login2;
+GO
+
+-- This is a temporary failure, it will be fixed with BABEL-4652.
+CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: errstart was not called)~~
+
+
+
+-- DROP USER ownership_restrictions_from_pg_user_by_pg_login2;
+-- GO
+USE master;
+go
+
+-- tsql
+DROP DATABASE ownership_restrictions_from_pg_login2_db1;
+go
+
 CREATE ROLE ownership_restrictions_from_pg_role1;
 go
 
@@ -26,6 +92,15 @@ GO
 
 ~~ERROR (Message: ERROR: Babelfish-created login cannot be dropped or altered outside of a Babelfish session
     Server SQLState: 55006)~~
+
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'ownership_restrictions_from_pg_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
 
 
 -- Create a non babelfish role that is a member of master_guest
@@ -91,4 +166,7 @@ DROP ROLE ownership_restrictions_from_pg_role1;
 GO
 
 DROP LOGIN ownership_restrictions_from_pg_login1;
+GO
+
+DROP LOGIN ownership_restrictions_from_pg_login2;
 GO

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -2,6 +2,55 @@
 CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '123';
 GO
 
+CREATE LOGIN ownership_restrictions_from_pg_login2 WITH password = '12345678';
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login2 password=12345678
+CREATE ROLE ownership_restrictions_from_pg_role_by_pg_login2;
+GO
+
+CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
+GO
+
+-- tsql
+ALTER SERVER ROLE sysadmin ADD MEMBER ownership_restrictions_from_pg_login2;
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login2 password=12345678
+CREATE DATABASE ownership_restrictions_from_pg_login2_db1;
+GO
+
+-- tsql
+ALTER SERVER ROLE sysadmin DROP MEMBER ownership_restrictions_from_pg_login2;
+GO
+
+-- tsql user=ownership_restrictions_from_pg_login2 password=12345678
+USE ownership_restrictions_from_pg_login2_db1;
+GO
+
+SELECT current_user;
+GO
+
+CREATE ROLE ownership_restrictions_from_pg_role_by_pg_login2;
+GO
+
+DROP ROLE ownership_restrictions_from_pg_role_by_pg_login2;
+GO
+
+-- This is a temporary failure, it will be fixed with BABEL-4652.
+CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
+GO
+
+-- DROP USER ownership_restrictions_from_pg_user_by_pg_login2;
+-- GO
+
+USE master;
+go
+
+-- tsql
+DROP DATABASE ownership_restrictions_from_pg_login2_db1;
+go
+
 CREATE ROLE ownership_restrictions_from_pg_role1;
 go
 
@@ -16,6 +65,10 @@ GO
 -- psql
 -- Dropping login from psql port should fail
 DROP ROLE ownership_restrictions_from_pg_login1;
+GO
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'ownership_restrictions_from_pg_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 
 -- Create a non babelfish role that is a member of master_guest
@@ -71,4 +124,7 @@ DROP ROLE ownership_restrictions_from_pg_role1;
 GO
 
 DROP LOGIN ownership_restrictions_from_pg_login1;
+GO
+
+DROP LOGIN ownership_restrictions_from_pg_login2;
 GO


### PR DESCRIPTION
An unprivileged T-SQL login should not be allowed to create roles and users in Babelfish.

Issues Resolved: BABEL-4646,

Signed-off-by: Shalini Lohia lshalini@amazon.com

