### PR TITLE
Restrict privileges from Unauthorised TSQL logins (#2176)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.5.0--2.6.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.5.0--2.6.0.sql
@@ -101,5 +101,11 @@ LANGUAGE C STABLE;
 
 ALTER FUNCTION sys.replace (in input_string text, in pattern text, in replacement text) IMMUTABLE;
 
+-- Update existing logins to remove createrole privilege
+CREATE OR REPLACE PROCEDURE sys.bbf_remove_createrole_from_logins()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'remove_createrole_from_logins';
+CALL sys.bbf_remove_createrole_from_logins();
+
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -33,11 +33,11 @@ tsql_CreateLoginStmt:
 											@1)); /* Must be first */
 					n->options = lappend(n->options,
 										 makeDefElem("createdb",
-													 (Node *)makeInteger(true),
+													 (Node *)makeInteger(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("createrole",
-													 (Node *)makeInteger(true),
+													 (Node *)makeInteger(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("inherit",
@@ -59,11 +59,11 @@ tsql_CreateLoginStmt:
 											@1)); /* Must be first */
 					n->options = lappend(n->options,
 										 makeDefElem("createdb",
-													 (Node *)makeInteger(true),
+													 (Node *)makeInteger(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("createrole",
-													 (Node *)makeInteger(true),
+													 (Node *)makeInteger(false),
 													 @1));
 					n->options = lappend(n->options,
 										 makeDefElem("inherit",

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3042,10 +3042,18 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				{
 					const char *prev_current_user;
 					const char *session_user_name;
+					StringInfoData query;
+					RoleSpec   *spec;
 
 					check_alter_server_stmt(grant_role);
 					prev_current_user = GetUserNameFromId(GetUserId(), false);
 					session_user_name = GetUserNameFromId(GetSessionUserId(), false);
+					spec = (RoleSpec *) linitial(grant_role->grantee_roles);
+					initStringInfo(&query);
+					if (grant_role->is_grant)
+						appendStringInfo(&query, "ALTER ROLE dummy WITH createrole createdb; ");
+					else
+						appendStringInfo(&query, "ALTER ROLE dummy WITH nocreaterole nocreatedb; ");
 
 					bbf_set_current_user(session_user_name);
 					PG_TRY();
@@ -3057,17 +3065,20 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						else
 							standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 													queryEnv, dest, qc);
+						exec_alter_role_cmd(query.data, spec);
 
 					}
 					PG_CATCH();
 					{
 						/* Clean up. Restore previous state. */
 						bbf_set_current_user(prev_current_user);
+						pfree(query.data);
 						PG_RE_THROW();
 					}
 					PG_END_TRY();
 					/* Clean up. Restore previous state. */
 					bbf_set_current_user(prev_current_user);
+					pfree(query.data);
 					return;
 				}
 				else if (is_alter_role_stmt(grant_role))

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1878,6 +1878,7 @@ extern bool pltsql_support_tsql_transactions(void);
 extern bool pltsql_sys_function_pop(void);
 extern uint64 execute_bulk_load_insert(int ncol, int nrow,
 									   Datum *Values, bool *Nulls);
+extern void	exec_alter_role_cmd(char *query_str, RoleSpec *role);
 
 /*
  * Functions in pl_exec.c

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -22,6 +22,7 @@
 #include "access/table.h"
 #include "access/genam.h"
 #include "catalog.h"
+#include "tcop/utility.h"
 
 #include "multidb.h"
 
@@ -1322,4 +1323,53 @@ tsql_get_trigger_rel_oid(Oid object_id)
 	systable_endscan(tgscan);
 	table_close(tgrel, AccessShareLock);
 	return tgrelid;
+}
+
+/*
+ * Helper function to execute ALTER ROLE command using
+ * ProcessUtility(). Caller should make sure their
+ * inputs are sanitized to prevent unexpected behaviour.
+ */
+void
+exec_alter_role_cmd(char *query_str, RoleSpec *role)
+{
+	List	   *parsetree_list;
+	Node	   *stmt;
+	PlannedStmt *wrapper;
+
+	parsetree_list = raw_parser(query_str, RAW_PARSE_DEFAULT);
+
+	if (list_length(parsetree_list) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("Expected 1 statement but get %d statements after parsing",
+						list_length(parsetree_list))));
+
+	/* Update the dummy statement with real values */
+	stmt = parsetree_nth_stmt(parsetree_list, 0);
+
+	/* Update dummy statement with real values */
+	update_AlterRoleStmt(stmt, role);
+
+	/* Run the built query */
+	/* need to make a wrapper PlannedStmt */
+	wrapper = makeNode(PlannedStmt);
+	wrapper->commandType = CMD_UTILITY;
+	wrapper->canSetTag = false;
+	wrapper->utilityStmt = stmt;
+	wrapper->stmt_location = 0;
+	wrapper->stmt_len = strlen(query_str);
+
+	/* do this step */
+	ProcessUtility(wrapper,
+				   query_str,
+				   false,
+				   PROCESS_UTILITY_SUBCOMMAND,
+				   NULL,
+				   NULL,
+				   None_Receiver,
+				   NULL);
+
+	/* make sure later steps can see the object created here */
+	CommandCounterIncrement();
 }

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1397,15 +1397,15 @@ is_alter_server_stmt(GrantRoleStmt *stmt)
 	{
 		RoleSpec   *spec = (RoleSpec *) linitial(stmt->granted_roles);
 
-		if (strcmp(spec->rolename, "sysadmin") != 0)	/* only supported server
+		if (strcmp(spec->rolename, "sysadmin") == 0)	/* only supported server
 														 * role */
-			return false;
+			return true;
 	}
 	/* has one and only one grantee  */
 	if (list_length(stmt->grantee_roles) != 1)
 		return false;
 
-	return true;
+	return false;
 }
 
 void
@@ -1745,4 +1745,50 @@ has_user_in_db(const char *login, char **db_name)
 	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
 
 	return false;
+}
+
+PG_FUNCTION_INFO_V1(remove_createrole_from_logins);
+Datum
+remove_createrole_from_logins(PG_FUNCTION_ARGS)
+{
+	Relation	rel;
+	TableScanDesc scan;
+	HeapTuple	tuple;
+
+	rel = table_open(get_authid_login_ext_oid(), AccessShareLock);
+	scan = table_beginscan_catalog(rel, 0, NULL);
+	tuple = heap_getnext(scan, ForwardScanDirection);
+
+	while (HeapTupleIsValid(tuple))
+	{
+		Form_authid_login_ext loginform;
+		char *rolname;
+		loginform = (Form_authid_login_ext) GETSTRUCT(tuple);
+		rolname = pstrdup(NameStr(loginform->rolname));
+
+		/*
+		 * For each login (except sysadmin and the member of sysadmin), remove
+		 * createrole and createdb privileges from the logins.
+		 */
+		if ((strcmp(rolname, "sysadmin") != 0) && !has_privs_of_role(get_role_oid(rolname, false), get_role_oid("sysadmin", false)))
+		{
+			StringInfoData query;
+			RoleSpec *role;
+
+			role = makeNode(RoleSpec);
+			role->roletype = ROLESPEC_CSTRING;
+			role->location = -1;
+			role->rolename = rolname;
+			initStringInfo(&query);
+
+			appendStringInfo(&query, "ALTER ROLE dummy WITH nocreaterole nocreatedb; ");
+			exec_alter_role_cmd(query.data, role);
+			pfree(query.data);
+		}
+		pfree(rolname);
+		tuple = heap_getnext(scan, ForwardScanDirection);
+	}
+	table_endscan(scan);
+	table_close(rel, AccessShareLock);
+	PG_RETURN_INT32(0);
 }

--- a/test/JDBC/expected/permission_restrictions_from_pg-vu-prepare.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg-vu-prepare.out
@@ -1,0 +1,11 @@
+-- tsql
+create login permission_restrictions_tsql_login with password = '123';
+go
+
+select rolname, rolcreaterole, rolcreatedb from pg_roles where rolname = 'permission_restrictions_tsql_login';
+go
+~~START~~
+varchar#!#bit#!#bit
+permission_restrictions_tsql_login#!#1#!#1
+~~END~~
+

--- a/test/JDBC/expected/permission_restrictions_from_pg-vu-verify.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg-vu-verify.out
@@ -1,0 +1,63 @@
+-- psql user=permission_restrictions_tsql_login password=123
+-- user should not be able to create user since it is not a member of sysadmin.
+create user permission_restrictions_psql_user1 with password '123';
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create role
+    Server SQLState: 42501)~~
+
+
+-- tsql
+select rolname, rolcreaterole, rolcreatedb from pg_roles where rolname = 'permission_restrictions_tsql_login';
+go
+~~START~~
+varchar#!#bit#!#bit
+permission_restrictions_tsql_login#!#0#!#0
+~~END~~
+
+
+alter server role sysadmin add member permission_restrictions_tsql_login;
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- user should be able to create user since it is a member of sysadmin.
+create user permission_restrictions_psql_user1 with password '123';
+go
+
+drop user permission_restrictions_psql_user1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+select rolname, rolcreaterole, rolcreatedb from pg_roles where rolname = 'permission_restrictions_tsql_login';
+go
+~~START~~
+varchar#!#bit#!#bit
+permission_restrictions_tsql_login#!#1#!#1
+~~END~~
+
+
+alter server role sysadmin drop member permission_restrictions_tsql_login;
+go
+
+drop login permission_restrictions_tsql_login
+go

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -1,0 +1,167 @@
+-- tsql
+create login permission_restrictions_tsql_login with password = '123';
+go
+
+-- psql
+create user permission_restrictions_psql_user with password '123';
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_tsql_login;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Creating user by an underprivileged login should be restricted
+create user permission_restrictions_psql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create role
+    Server SQLState: 42501)~~
+
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Altering a role by an underprivileged login should be restricted
+alter user permission_restrictions_psql_user with password '123'
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to drop role
+    Server SQLState: 42501)~~
+
+
+-- psql user=permission_restrictions_psql_user password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_tsql_login;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Creating user by an underprivileged login should be restricted
+create user permission_restrictions_psql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create role
+    Server SQLState: 42501)~~
+
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+    Server SQLState: 42501)~~
+
+
+-- Altering a role by an underprivileged login should be restricted
+alter user permission_restrictions_tsql_login with password '123'
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to drop role
+    Server SQLState: 42501)~~
+
+
+-- tsql
+alter server role sysadmin add member permission_restrictions_tsql_login;
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- user has sysadmin membership via TDS Port, create user is allowed
+create user permission_restrictions_psql_user1 with password '123';
+go
+
+-- user has sysadmin membership, alter user is allowed
+alter user permission_restrictions_psql_user1 with password '1234'
+go
+
+-- user has sysadmin membership, drop user is allowed
+drop user permission_restrictions_psql_user1;
+go
+
+-- tsql
+alter server role sysadmin drop member permission_restrictions_tsql_login;
+go
+
+-- psql
+-- Grant sysadmin privilege to underprivileged T-SQL user
+grant sysadmin to permission_restrictions_tsql_login;
+go
+
+-- Grant sysadmin privilege to underprivileged PG user
+grant sysadmin to permission_restrictions_psql_user;
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- user has sysadmin membership via PG port, create user is not allowed
+create user permission_restrictions_psql_user1 with password '123';
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create role
+    Server SQLState: 42501)~~
+
+
+-- psql
+revoke sysadmin from permission_restrictions_psql_user;
+go
+drop user permission_restrictions_psql_user;
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login permission_restrictions_tsql_login
+go

--- a/test/JDBC/input/permission_restrictions_from_pg-vu-prepare.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg-vu-prepare.mix
@@ -1,0 +1,6 @@
+-- tsql
+create login permission_restrictions_tsql_login with password = '123';
+go
+
+select rolname, rolcreaterole, rolcreatedb from pg_roles where rolname = 'permission_restrictions_tsql_login';
+go

--- a/test/JDBC/input/permission_restrictions_from_pg-vu-verify.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg-vu-verify.mix
@@ -1,0 +1,38 @@
+-- psql user=permission_restrictions_tsql_login password=123
+-- user should not be able to create user since it is not a member of sysadmin.
+create user permission_restrictions_psql_user1 with password '123';
+go
+
+-- tsql
+select rolname, rolcreaterole, rolcreatedb from pg_roles where rolname = 'permission_restrictions_tsql_login';
+go
+
+alter server role sysadmin add member permission_restrictions_tsql_login;
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- user should be able to create user since it is a member of sysadmin.
+create user permission_restrictions_psql_user1 with password '123';
+go
+
+drop user permission_restrictions_psql_user1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+select pg_sleep(1);
+GO
+
+-- tsql
+select rolname, rolcreaterole, rolcreatedb from pg_roles where rolname = 'permission_restrictions_tsql_login';
+go
+
+alter server role sysadmin drop member permission_restrictions_tsql_login;
+go
+
+drop login permission_restrictions_tsql_login
+go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -1,0 +1,102 @@
+-- tsql
+create login permission_restrictions_tsql_login with password = '123';
+go
+
+-- psql
+create user permission_restrictions_psql_user with password '123';
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_tsql_login;
+go
+
+-- Creating user by an underprivileged login should be restricted
+create user permission_restrictions_psql_user1;
+go
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_psql_user;
+go
+
+-- Altering a role by an underprivileged login should be restricted
+alter user permission_restrictions_psql_user with password '123'
+go
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user permission_restrictions_psql_user;
+go
+
+-- psql user=permission_restrictions_psql_user password=123
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_tsql_login;
+go
+
+-- Creating user by an underprivileged login should be restricted
+create user permission_restrictions_psql_user1;
+go
+
+-- Granting sysadmin membership by an underprivileged login should be restricted
+grant sysadmin to permission_restrictions_psql_user;
+go
+
+-- Altering a role by an underprivileged login should be restricted
+alter user permission_restrictions_tsql_login with password '123'
+go
+
+-- Dropping a role by an underprivileged login should be restricted
+drop user permission_restrictions_psql_user;
+go
+
+-- tsql
+alter server role sysadmin add member permission_restrictions_tsql_login;
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- user has sysadmin membership via TDS Port, create user is allowed
+create user permission_restrictions_psql_user1 with password '123';
+go
+
+-- user has sysadmin membership, alter user is allowed
+alter user permission_restrictions_psql_user1 with password '1234'
+go
+
+-- user has sysadmin membership, drop user is allowed
+drop user permission_restrictions_psql_user1;
+go
+
+-- tsql
+alter server role sysadmin drop member permission_restrictions_tsql_login;
+go
+
+-- psql
+-- Grant sysadmin privilege to underprivileged T-SQL user
+grant sysadmin to permission_restrictions_tsql_login;
+go
+
+-- Grant sysadmin privilege to underprivileged PG user
+grant sysadmin to permission_restrictions_psql_user;
+go
+
+-- psql user=permission_restrictions_tsql_login password=123
+-- user has sysadmin membership via PG port, create user is not allowed
+create user permission_restrictions_psql_user1 with password '123';
+go
+
+-- psql
+revoke sysadmin from permission_restrictions_psql_user;
+go
+drop user permission_restrictions_psql_user;
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+select pg_sleep(1);
+GO
+
+-- tsql
+drop login permission_restrictions_tsql_login
+go

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -81,6 +81,8 @@ ignore#!#bbf_view_def-before-14_5-vu-prepare
 ignore#!#bbf_view_def-before-14_5-vu-verify
 ignore#!#bbf_view_def-before-14_7-or-15_2-vu-prepare
 ignore#!#bbf_view_def-before-14_7-or-15_2-vu-verify
+ignore#!#permission_restrictions_from_pg-vu-prepare
+ignore#!#permission_restrictions_from_pg-vu-verify
 
 # These tests are meant for upgrade scenario where source version is 13_X
 ignore#!#sys_database_principals_dep_for_13_x-vu-cleanup

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -202,3 +202,4 @@ BABEL-3938
 BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -253,3 +253,4 @@ BABEL-3938
 BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -312,3 +312,4 @@ BABEL-3938
 BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -312,3 +312,4 @@ BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -312,3 +312,4 @@ BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -311,3 +311,4 @@ BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -324,3 +324,4 @@ BABEL-4078-before-14_8-or-15_3
 BABEL-3215
 orderby-before-14_8-or-15_3
 BABEL_4330
+permission_restrictions_from_pg

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -336,3 +336,4 @@ BABEL-3215
 orderby-before-14_8-or-15_3
 getdate
 BABEL_4330
+permission_restrictions_from_pg


### PR DESCRIPTION
Avoid granting CREATEROLE and CREATEDB privilege to non-sysadmins logins Manage CREATEDB/CREATEROLE privileges as part of grant/revoke membership to/from sysadmin via TDS Port only. Though the grant sysadmin to user works from psql endpoint for superuser, it will not add CREATEDB/CREATEROLE privileges. If a TSQL user wants to have the sysadmin membership and CREATEDB /CREATEROLE privileges, it should alter the server role via TDS port. Issues Resolved Any unprivileged Babelfish role should not grant/revoke sysadmin role or non-Babelfish roles to itself and to others from the PG port. Any unprivileged Babelfish role should not drop any role via PG port. Any unprivileged Babelfish role should not alter any role via PG port. Any unprivileged Babelfish role should not create any role via PG port. Restrict PG user to "grant sysadmin to user" to any user via PG port.

Task: BABEL-4573, BABEL-4574

Signed-off-by: Shalini Lohia lshalini@amazon.com

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).