### PR TITLE
sp_executesql with NULL argument should not raise error

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -928,7 +928,7 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 
 		stmt->is_scalar_func = is_scalar_func;
 
-		/* T-SQL doens't allow call prcedure in function */
+		/* T-SQL doesn't allow call procedure in function */
 		if (estate->func && estate->func->fn_oid != InvalidOid && estate->func->fn_prokind == PROKIND_FUNCTION && estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER /* check EXEC is running
 																																									 * in the body of
 																																									 * function */
@@ -2127,11 +2127,13 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 				int			save_nestlevel;
 				int			scope_level;
 				InlineCodeBlockArgs *args = NULL;
-
+				
 				batch = exec_eval_expr(estate, stmt->query, &isnull, &restype, &restypmod);
 				if (isnull)
-					ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
-									errmsg("batch string argument of sp_executesql is null")));
+				{
+					// When called with a NULL argument, sp_executesql should take no action at all
+					break;
+				}
 
 				batchstr = convert_value_to_string(estate, batch, restype);
 

--- a/test/JDBC/expected/BABEL-2748.out
+++ b/test/JDBC/expected/BABEL-2748.out
@@ -229,10 +229,6 @@ declare @query_str varchar(100);
 declare @param_def varchar(100);
 exec sp_executesql @query_str, @param_def;
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: batch string argument of sp_executesql is null)~~
-
 
 exec sp_prepexec;
 go

--- a/test/JDBC/expected/BABEL-3092.out
+++ b/test/JDBC/expected/BABEL-3092.out
@@ -60,10 +60,6 @@ GO
 
 sp_executesql NULL;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: batch string argument of sp_executesql is null)~~
-
 
 CREATE TABLE t_3092_fmtonly(a INT);
 GO


### PR DESCRIPTION
### Description

**sp_executesql** currently raises an error when called with a NULL argument for the SQL statement, but it should do nothing at all.

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-4106 sp_executesql with NULL argument should not raise error 

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).