### PR TITLE
Support PRINT NULL and PRINT <empty string>

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -409,11 +409,22 @@ exec_stmt_print(PLtsql_execstate *estate, PLtsql_stmt_print *stmt)
 								 &formattypmod);
 
 	if (formatisnull)
-		extval = "<NULL>";
+	{
+		// Printing NULL prints a single space in T-SQL 
+		extval = " ";
+	}
 	else
+	{
 		extval = convert_value_to_string(estate,
 										 formatdatum,
 										 formattypeid);
+	}
+
+	if (strlen(extval) == 0)
+	{
+		// Printing an empty string prints a single space in T-SQL
+		extval = " ";
+	}
 
 	ereport(INFO, errmsg_internal("%s", extval));
 

--- a/test/JDBC/expected/print_null-vu-cleanup.out
+++ b/test/JDBC/expected/print_null-vu-cleanup.out
@@ -1,0 +1,2 @@
+drop procedure p1_print_null
+go

--- a/test/JDBC/expected/print_null-vu-prepare.out
+++ b/test/JDBC/expected/print_null-vu-prepare.out
@@ -1,0 +1,10 @@
+create procedure p1_print_null as
+declare @v varchar = null
+print null
+print @v
+print ''
+set @v = ''
+print @v
+print ' '
+print '  '
+go

--- a/test/JDBC/expected/print_null-vu-verify.out
+++ b/test/JDBC/expected/print_null-vu-verify.out
@@ -1,5 +1,5 @@
 
--- Since the JDBC tests do not capture output from PRINT statements, these tests actually don;t do anything
+-- Since the JDBC tests do not capture output from PRINT statements, these tests actually don't do anything
 -- Keeping them for when then moment comes that PRINT tests are supported
 -- prints a single space:
 print null

--- a/test/JDBC/expected/print_null-vu-verify.out
+++ b/test/JDBC/expected/print_null-vu-verify.out
@@ -1,0 +1,31 @@
+
+-- Since the JDBC tests do not capture output from PRINT statements, these tests actually don;t do anything
+-- Keeping them for when then moment comes that PRINT tests are supported
+-- prints a single space:
+print null
+go
+
+-- prints a single space:
+declare @v varchar = null
+print @v
+go
+-- prints a single space:
+print ''
+go
+
+-- prints a single space:
+declare @v varchar = ''
+print @v
+go
+
+-- prints a single space:
+print ' '
+go
+
+-- prints two spaces:
+print '  '
+go
+
+-- same set of tests as above, but inside a stored proc:
+exec p1_print_null
+go

--- a/test/JDBC/input/print_null-vu-cleanup.sql
+++ b/test/JDBC/input/print_null-vu-cleanup.sql
@@ -1,0 +1,2 @@
+drop procedure p1_print_null
+go

--- a/test/JDBC/input/print_null-vu-prepare.sql
+++ b/test/JDBC/input/print_null-vu-prepare.sql
@@ -1,0 +1,10 @@
+create procedure p1_print_null as
+declare @v varchar = null
+print null
+print @v
+print ''
+set @v = ''
+print @v
+print ' '
+print '  '
+go

--- a/test/JDBC/input/print_null-vu-verify.sql
+++ b/test/JDBC/input/print_null-vu-verify.sql
@@ -1,0 +1,31 @@
+-- Since the JDBC tests do not capture output from PRINT statements, these tests actually don;t do anything
+-- Keeping them for when then moment comes that PRINT tests are supported
+
+-- prints a single space:
+print null
+go
+
+-- prints a single space:
+declare @v varchar = null
+print @v
+go
+-- prints a single space:
+print ''
+go
+
+-- prints a single space:
+declare @v varchar = ''
+print @v
+go
+
+-- prints a single space:
+print ' '
+go
+
+-- prints two spaces:
+print '  '
+go
+
+-- same set of tests as above, but inside a stored proc:
+exec p1_print_null
+go

--- a/test/JDBC/input/print_null-vu-verify.sql
+++ b/test/JDBC/input/print_null-vu-verify.sql
@@ -1,4 +1,4 @@
--- Since the JDBC tests do not capture output from PRINT statements, these tests actually don;t do anything
+-- Since the JDBC tests do not capture output from PRINT statements, these tests actually don't do anything
 -- Keeping them for when then moment comes that PRINT tests are supported
 
 -- prints a single space:

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -461,6 +461,7 @@ todatetimeoffset-dep
 triggers_with_transaction
 typeid-typename
 typeid-typename-dep
+print_null
 unquoted_string
 doublequoted_string
 alter_authorization_change_db_owner


### PR DESCRIPTION
### Description

When the argument to PRINT is NULL or an empty string, a single space should be printed. However Babelfish currently prints `<NULL>` and an empty string, respectively. 

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-4005 PRINT NULL prints a string but should print NULL

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).