### PR TITLE
Support SET TRAN ISOLATION syntax

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -4140,7 +4140,7 @@ tsql_VariableSetStmt:
 					n->is_local = false;
 					$$ = (Node *) n;
 				}
-			| SET TRANSACTION tsql_IsolationLevel
+			| SET tsql_TranKeyword tsql_IsolationLevel
 				{
 					VariableSetStmt *n = makeNode(VariableSetStmt);
 					n->kind = VAR_SET_MULTI;

--- a/test/JDBC/expected/set_tran_isolvl-vu-cleanup.out
+++ b/test/JDBC/expected/set_tran_isolvl-vu-cleanup.out
@@ -1,0 +1,5 @@
+drop procedure p1_set_tran_isolvl
+go
+
+drop procedure p2_set_tran_isolvl
+go

--- a/test/JDBC/expected/set_tran_isolvl-vu-prepare.out
+++ b/test/JDBC/expected/set_tran_isolvl-vu-prepare.out
@@ -1,0 +1,5 @@
+create procedure p1_set_tran_isolvl as set transaction isolation level repeatable read
+go
+
+create procedure p2_set_tran_isolvl as set tran isolation level repeatable read
+go

--- a/test/JDBC/expected/set_tran_isolvl-vu-verify.out
+++ b/test/JDBC/expected/set_tran_isolvl-vu-verify.out
@@ -1,0 +1,50 @@
+set transaction isolation level serializable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
+
+
+set tran isolation level serializable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Isolation level 'SERIALIZABLE' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_serializable' config option to 'pg_isolation' to get PG serializable isolation level.)~~
+
+
+set transaction isolation level read committed
+go
+
+set tran isolation level read committed
+go
+
+EXECUTE p1_set_tran_isolvl
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+
+
+EXECUTE p2_set_tran_isolvl 
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+
+
+EXECUTE('set transaction isolation level repeatable read')
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+
+
+EXECUTE('set tran isolation level repeatable read')
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Isolation level 'REPEATABLE READ' is not currently supported in Babelfish. Set 'babelfishpg_tsql.isolation_level_repeatable_read' config option to 'pg_isolation' to get PG repeatable read isolation level.)~~
+
+
+set transaction isolation level read committed
+go

--- a/test/JDBC/input/set_tran_isolvl-vu-cleanup.sql
+++ b/test/JDBC/input/set_tran_isolvl-vu-cleanup.sql
@@ -1,0 +1,5 @@
+drop procedure p1_set_tran_isolvl
+go
+
+drop procedure p2_set_tran_isolvl
+go

--- a/test/JDBC/input/set_tran_isolvl-vu-prepare.sql
+++ b/test/JDBC/input/set_tran_isolvl-vu-prepare.sql
@@ -1,0 +1,5 @@
+create procedure p1_set_tran_isolvl as set transaction isolation level repeatable read
+go
+
+create procedure p2_set_tran_isolvl as set tran isolation level repeatable read
+go

--- a/test/JDBC/input/set_tran_isolvl-vu-verify.sql
+++ b/test/JDBC/input/set_tran_isolvl-vu-verify.sql
@@ -1,0 +1,26 @@
+set transaction isolation level serializable
+go
+
+set tran isolation level serializable
+go
+
+set transaction isolation level read committed
+go
+
+set tran isolation level read committed
+go
+
+EXECUTE p1_set_tran_isolvl
+go
+
+EXECUTE p2_set_tran_isolvl 
+go
+
+EXECUTE('set transaction isolation level repeatable read')
+go
+
+EXECUTE('set tran isolation level repeatable read')
+go
+
+set transaction isolation level read committed
+go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -473,6 +473,7 @@ BABEL-4175
 sp_who
 BABEL_4330
 kill
+set_tran_isolvl
 BABEL-4217
 Test_ISNULL
 BABEL-4270


### PR DESCRIPTION
### Description

Support SET TRAN ISOLATION syntax (in addition to SET TRANSACTION ISOLATION).

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-4104 Support SET TRAN ISOLATION LEVEL shorthand 

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** Yes


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).