### PR TITLE
Fix the issue that inserted table refered in update join will cause crash

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_analyze.c
+++ b/contrib/babelfishpg_tsql/src/tsql_analyze.c
@@ -128,7 +128,7 @@ pltsql_update_query_result_relation(Query *qry, Relation target_rel, List *rtabl
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) list_nth(rtable, i);
 
-		if (rte->relid == target_relid)
+		if (rte->relid == target_relid && rte->rtekind != RTE_NAMEDTUPLESTORE)
 		{
 			qry->resultRelation = i + 1;
 			return;

--- a/test/JDBC/expected/BABEL-4606-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4606-vu-cleanup.out
@@ -1,0 +1,18 @@
+drop trigger babel_4606_trigger
+go
+
+drop table babel_4606
+go
+
+drop trigger babel_4606_2_trigger
+go
+
+drop table babel_4606_2
+go
+
+drop trigger babel_4606_3_trigger
+go
+
+drop table babel_4606_3
+go
+

--- a/test/JDBC/expected/BABEL-4606-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4606-vu-prepare.out
@@ -1,0 +1,61 @@
+create table babel_4606 (a int primary key, b int)
+go
+
+insert into babel_4606 (a, b) values (1,7),(2,8),(3,9),(4,10),(5,11),(6,12)
+go
+~~ROW COUNT: 6~~
+
+
+create trigger babel_4606_trigger
+on babel_4606
+after update
+AS
+begin
+	update t
+	set t.b = t.b + 1
+	from inserted as i
+	join babel_4606 as t
+		on t.a = i.a
+end
+go
+
+create table babel_4606_2 (a int primary key, b int)
+go
+
+insert into babel_4606_2 (a, b) values (1,7),(2,8),(3,9),(4,10),(5,11),(6,12)
+go
+~~ROW COUNT: 6~~
+
+
+create trigger babel_4606_2_trigger
+on babel_4606_2
+after update
+AS
+begin
+	update babel_4606_2
+	set babel_4606_2.b = babel_4606_2.b + 2
+	from inserted as i
+		where babel_4606_2.a = i.a
+end
+go
+
+create table babel_4606_3 (a int primary key, b int)
+go
+
+insert into babel_4606_3 (a, b) values (1,7),(2,8),(3,9),(4,10),(5,11),(6,12)
+go
+~~ROW COUNT: 6~~
+
+
+create trigger babel_4606_3_trigger
+on babel_4606_3
+after update
+AS
+begin
+	update babel_4606_3
+	set babel_4606_3.b = babel_4606_3.b + 200
+	from deleted as i
+		where babel_4606_3.a = i.a
+end
+go
+

--- a/test/JDBC/expected/BABEL-4606-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4606-vu-verify.out
@@ -1,0 +1,98 @@
+select * from babel_4606
+GO
+~~START~~
+int#!#int
+1#!#7
+2#!#8
+3#!#9
+4#!#10
+5#!#11
+6#!#12
+~~END~~
+
+
+update babel_4606 set b = 100 where a = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from babel_4606
+GO
+~~START~~
+int#!#int
+2#!#8
+3#!#9
+4#!#10
+5#!#11
+6#!#12
+1#!#101
+~~END~~
+
+
+select * from babel_4606_2
+GO
+~~START~~
+int#!#int
+1#!#7
+2#!#8
+3#!#9
+4#!#10
+5#!#11
+6#!#12
+~~END~~
+
+
+update babel_4606_2 set b = 100 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from babel_4606_2
+GO
+~~START~~
+int#!#int
+2#!#8
+3#!#9
+4#!#10
+5#!#11
+6#!#12
+1#!#102
+~~END~~
+
+
+select * from babel_4606_3
+GO
+~~START~~
+int#!#int
+1#!#7
+2#!#8
+3#!#9
+4#!#10
+5#!#11
+6#!#12
+~~END~~
+
+
+update babel_4606_3 set b = 100 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from babel_4606_3
+GO
+~~START~~
+int#!#int
+2#!#8
+3#!#9
+4#!#10
+5#!#11
+6#!#12
+1#!#300
+~~END~~
+

--- a/test/JDBC/input/BABEL-4606-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4606-vu-cleanup.sql
@@ -1,0 +1,18 @@
+drop trigger babel_4606_trigger
+go
+
+drop table babel_4606
+go
+
+drop trigger babel_4606_2_trigger
+go
+
+drop table babel_4606_2
+go
+
+drop trigger babel_4606_3_trigger
+go
+
+drop table babel_4606_3
+go
+

--- a/test/JDBC/input/BABEL-4606-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4606-vu-prepare.sql
@@ -1,0 +1,55 @@
+create table babel_4606 (a int primary key, b int)
+go
+
+insert into babel_4606 (a, b) values (1,7),(2,8),(3,9),(4,10),(5,11),(6,12)
+go
+
+create trigger babel_4606_trigger
+on babel_4606
+after update
+AS
+begin
+	update t
+	set t.b = t.b + 1
+	from inserted as i
+	join babel_4606 as t
+		on t.a = i.a
+end
+go
+
+create table babel_4606_2 (a int primary key, b int)
+go
+
+insert into babel_4606_2 (a, b) values (1,7),(2,8),(3,9),(4,10),(5,11),(6,12)
+go
+
+create trigger babel_4606_2_trigger
+on babel_4606_2
+after update
+AS
+begin
+	update babel_4606_2
+	set babel_4606_2.b = babel_4606_2.b + 2
+	from inserted as i
+		where babel_4606_2.a = i.a
+end
+go
+
+create table babel_4606_3 (a int primary key, b int)
+go
+
+insert into babel_4606_3 (a, b) values (1,7),(2,8),(3,9),(4,10),(5,11),(6,12)
+go
+
+create trigger babel_4606_3_trigger
+on babel_4606_3
+after update
+AS
+begin
+	update babel_4606_3
+	set babel_4606_3.b = babel_4606_3.b + 200
+	from deleted as i
+		where babel_4606_3.a = i.a
+end
+go
+

--- a/test/JDBC/input/BABEL-4606-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4606-vu-verify.sql
@@ -1,0 +1,26 @@
+select * from babel_4606
+GO
+
+update babel_4606 set b = 100 where a = 1;
+GO
+
+select * from babel_4606
+GO
+
+select * from babel_4606_2
+GO
+
+update babel_4606_2 set b = 100 where a = 1;
+go
+
+select * from babel_4606_2
+GO
+
+select * from babel_4606_3
+GO
+
+update babel_4606_3 set b = 100 where a = 1;
+go
+
+select * from babel_4606_3
+GO

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -406,3 +406,4 @@ BABEL-4046
 getdate
 BABEL_4330
 permission_restrictions_from_pg
+BABEL-4606

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -406,5 +406,4 @@ orderby
 BABEL-4046
 getdate
 BABEL_4330
-permission_restrictions_from_pg
 BABEL-4606

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -407,3 +407,4 @@ BABEL-4046
 getdate
 BABEL_4330
 permission_restrictions_from_pg
+BABEL-4606

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -386,3 +386,5 @@ BABEL-4046
 getdate
 BABEL_4330
 permission_restrictions_from_pg
+BABEL-2999
+BABEL-4606

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -414,3 +414,4 @@ BABEL-4046
 getdate
 BABEL_4330
 permission_restrictions_from_pg
+BABEL-4606

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -437,3 +437,4 @@ BABEL-4046
 getdate
 BABEL_4330
 permission_restrictions_from_pg
+BABEL-4606

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -447,3 +447,4 @@ linked_srv_4229
 BABEL-4175
 sp_who
 BABEL_4330
+BABEL-4606


### PR DESCRIPTION
Previously when we implement update join, we missed a corner case that one of the join relations can be a named tuple store instead of RTE relation. And it'll lead analyzer to wrongly set resultRelation for the Query and lead to crash later.
This fix resolved the corner case by add a if condition to exclude RTE named tuple store for being resultRelation.

Task: BABEL-4606

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).