### PR TITLE
Support 'DROP INDEX table.index' and 'DROP INDEX ix ON schema.table'

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-decl.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-decl.y
@@ -16,6 +16,7 @@
 
 %type <node> tsql_CreateFunctionStmt tsql_VariableSetStmt tsql_CreateTrigStmt tsql_TransactionStmt tsql_UpdateStmt tsql_DeleteStmt tsql_IndexStmt
 %type <node> tsql_DropIndexStmt tsql_InsertStmt
+%type <str> tsql_DropIndexStmtSchema
 %type <node> tsql_CreateLoginStmt tsql_AlterLoginStmt tsql_DropLoginStmt
 %type <node> tsql_CreateUserStmt tsql_DropRoleStmt tsql_AlterUserStmt
 %type <node> tsql_CreateRoleStmt

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -1183,8 +1183,13 @@ DropStmt:
 				}
 			;
 
+tsql_DropIndexStmtSchema:
+            SCHEMA name     { $$ = $2;  }
+            | /* EMPTY */   { $$ = NULL; }
+            ;
+ 
 tsql_DropIndexStmt:
-			DROP object_type_any_name name ON name_list
+			DROP object_type_any_name name ON name_list tsql_DropIndexStmtSchema
 				{
 					DropStmt *n = makeNode(DropStmt);
 					if(sql_dialect != SQL_DIALECT_TSQL)
@@ -1203,12 +1208,21 @@ tsql_DropIndexStmt:
 					}
 					n->removeType = $2;
 					n->missing_ok = false;
-					n->objects = list_make1(list_make1(makeString(construct_unique_index_name($3, makeRangeVarFromAnyName($5, @5, yyscanner)->relname))));
+					if ($6 != NULL)
+					{
+						/* SCHEMA clause present, use it to qualify the index name */
+						n->objects = list_make1(list_make2(makeString($6), makeString(construct_unique_index_name($3, makeRangeVarFromAnyName($5, @5, yyscanner)->relname))));  
+					}
+					else 
+					{
+						/* SCHEMA clause not present */
+						n->objects = list_make1(list_make1(makeString(construct_unique_index_name($3, makeRangeVarFromAnyName($5, @5, yyscanner)->relname))));   
+					}
 					n->behavior = DROP_CASCADE;
 					n->concurrent = false;
 					$$ = (Node *)n;
 				}
-			| DROP object_type_any_name IF_P EXISTS name ON name_list
+			| DROP object_type_any_name IF_P EXISTS name ON name_list tsql_DropIndexStmtSchema
 				{
 					DropStmt *n = makeNode(DropStmt);
 					if(sql_dialect != SQL_DIALECT_TSQL)
@@ -1227,7 +1241,16 @@ tsql_DropIndexStmt:
 					}
 					n->removeType = $2;
 					n->missing_ok = true;
-					n->objects = list_make1(list_make1(makeString(construct_unique_index_name($5, makeRangeVarFromAnyName($7, @5, yyscanner)->relname))));
+					if ($8 != NULL)
+					{
+						/* SCHEMA clause present, use it to qualify the index name */
+						n->objects = list_make1(list_make2(makeString($8), makeString(construct_unique_index_name($5, makeRangeVarFromAnyName($7, @5, yyscanner)->relname))));  
+					}
+					else 
+					{
+						/* SCHEMA clause not present */
+						n->objects = list_make1(list_make1(makeString(construct_unique_index_name($5, makeRangeVarFromAnyName($7, @5, yyscanner)->relname))));   
+					}
 					n->behavior = DROP_CASCADE;
 					n->concurrent = false;
 					$$ = (Node *)n;

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1068,6 +1068,25 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 	{
 		handle(INSTR_UNSUPPORTED_TSQL_UNKNOWN_DDL, "ALTER FULLTEXT INDEX",  getLineAndPos(ctx));
 	}
+	if (ctx->drop_index())
+	{
+		auto drop_index = ctx->drop_index();
+		if (drop_index->drop_relational_or_xml_or_spatial_index().size() > 0)
+		{
+			/* Raise proper error messages for the non-supported cases */
+			if (drop_index->drop_relational_or_xml_or_spatial_index(0)->full_object_name()->server)
+			{
+				/* DROP INDEX index_name ON srv.db.owner.table */
+				handle(INSTR_TSQL_DROP_INDEX, "DROP INDEX on remote table",  getLineAndPos(ctx));
+			}
+			else if (drop_index->drop_relational_or_xml_or_spatial_index(0)->full_object_name()->database)
+			{
+				/* DROP INDEX index_name ON db.owner.table */
+				handle(INSTR_TSQL_DROP_INDEX, "DROP INDEX cross-database",  getLineAndPos(ctx));
+			}
+		}
+	}
+	
 	/*
 	 * We have more than 100 DDLs but support a few of them.
 	 * manage the whitelist here.

--- a/test/JDBC/expected/drop_index-vu-cleanup.out
+++ b/test/JDBC/expected/drop_index-vu-cleanup.out
@@ -1,0 +1,17 @@
+use master
+go
+drop table guest.t1_drop_index
+go
+drop table dbo.t1_drop_index
+go
+drop procedure dbo.p1_drop_index
+go
+drop procedure dbo.p2_drop_index
+go
+
+use tempdb
+go
+drop table guest.t1_drop_index
+go
+drop table dbo.t1_drop_index
+go

--- a/test/JDBC/expected/drop_index-vu-prepare.out
+++ b/test/JDBC/expected/drop_index-vu-prepare.out
@@ -1,0 +1,25 @@
+use master
+go
+
+create procedure p1_drop_index @p int=0
+as
+if @p = 0
+	drop index guest.t1_drop_index.ix1
+else
+	drop index if exists guest.t1_drop_index.ix1	
+	select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+
+
+create procedure p2_drop_index @p int=0
+as
+if @p = 0
+	drop index ix1 on guest.t1_drop_index
+else
+	drop index if exists ix1 on guest.t1_drop_index	
+	select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+
+use tempdb
+go
+

--- a/test/JDBC/expected/drop_index-vu-verify.out
+++ b/test/JDBC/expected/drop_index-vu-verify.out
@@ -1,0 +1,532 @@
+-- This covers BABEL-1483 (Support DROP INDEX table.index syntax) and BABEL-1652 (Support DROP INDEX ix ON schema.table syntax)
+use master
+go
+
+-- tests with '[schema_name.]table_name.index_name' syntax
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+create table guest.t1_drop_index(a int)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+drop index guest.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+drop index guest.t1_drop_index.ix1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists guest.t1_drop_index.ix1
+go
+drop index guest.t1_drop_index.ix2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix2t1_drop_indexbe63f9a1e6e197a9b4c58fbc7b470d87" does not exist)~~
+
+drop index if exists guest.t1_drop_index.ix2
+go
+
+drop index dbo.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+drop index dbo.t1_drop_index.ix1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists dbo.t1_drop_index.ix1
+go
+drop index dbo.t1_drop_index.ix2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix2t1_drop_indexbe63f9a1e6e197a9b4c58fbc7b470d87" does not exist)~~
+
+drop index if exists dbo.t1_drop_index.ix2
+go
+
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+drop index t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+drop index t1_drop_index.ix1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists t1_drop_index.ix1
+go
+
+-- dynamic SQL
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+execute('drop index guest.t1_drop_index.ix1')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+execute('drop index guest.t1_drop_index.ix1')
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+execute('drop index if exists guest.t1_drop_index.ix1')
+go
+
+execute('drop index t1_drop_index.ix1')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+execute('drop index t1_drop_index.ix1')
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+execute('drop index if exists t1_drop_index.ix1')
+go
+
+-- stored proc
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+execute p1_drop_index
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+execute p1_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+execute p1_drop_index 1
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+-- non-existing schema/table
+drop index nosuchtable.ix1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1nosuchtablea5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists nosuchtable.ix1
+go
+drop index nosuchschema.nosuchtable.ix1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_nosuchschema" does not exist)~~
+
+drop index if exists nosuchschema.nosuchtable.ix1
+go
+
+
+use master
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+
+use tempdb
+go
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+create table guest.t1_drop_index(a int)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+tempdb#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+tempdb#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+drop index guest.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+tempdb#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+use master
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+drop index dbo.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+use tempdb
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+tempdb#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+use master
+go
+drop index guest.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+use tempdb
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+tempdb#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+-- cross-db reference: always error with 3-part table name
+use master
+go
+drop index tempdb.dbo.sometable.someindex
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '.' at line 1 and character position 31)~~
+
+drop index if exists tempdb.dbo.sometable.someindex
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '.' at line 1 and character position 41)~~
+
+
+
+-- tests with 'index_name ON [schema_name.]table_name' syntax
+use master
+go
+drop table dbo.t1_drop_index
+go
+drop table guest.t1_drop_index
+go
+
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+create table guest.t1_drop_index(a int)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+drop index ix1 on guest.t1_drop_index
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+drop index ix1 on guest.t1_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists ix1 on guest.t1_drop_index
+go
+drop index ix2 on guest.t1_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix2t1_drop_indexbe63f9a1e6e197a9b4c58fbc7b470d87" does not exist)~~
+
+drop index if exists ix2 on guest.t1_drop_index
+go
+
+drop index ix1 on dbo.t1_drop_index
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+drop index ix1 on dbo.t1_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists ix1 on dbo.t1_drop_index
+go
+drop index ix2 on dbo.t1_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix2t1_drop_indexbe63f9a1e6e197a9b4c58fbc7b470d87" does not exist)~~
+
+drop index if exists ix2 on dbo.t1_drop_index
+go
+
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+drop index ix1 on t1_drop_index
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+drop index ix1 on t1_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists ix1 on t1_drop_index
+go
+
+-- dynamic SQL
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+master#!#t1_drop_index#!#guest#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+execute('drop index ix1 on guest.t1_drop_index')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+execute('drop index ix1 on guest.t1_drop_index')
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+execute('drop index if exists ix1 on guest.t1_drop_index')
+go
+
+execute('drop index ix1 on t1_drop_index')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+execute('drop index ix1 on t1_drop_index')
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+execute('drop index if exists ix1 on t1_drop_index')
+go
+
+-- stored proc
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+execute p2_drop_index
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+execute p2_drop_index
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+execute p2_drop_index 1
+go
+~~START~~
+nvarchar#!#varchar#!#varchar#!#varchar
+master#!#t1_drop_index#!#dbo#!#ix1t1_drop_indexa5111d2a1767bc43a700e9f2162be019
+~~END~~
+
+
+-- non-existing schema/table
+drop index ix1 on nosuchtable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "ix1nosuchtablea5111d2a1767bc43a700e9f2162be019" does not exist)~~
+
+drop index if exists ix1 on nosuchtable
+go
+drop index ix1 on nosuchschema.nosuchtable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_nosuchschema" does not exist)~~
+
+drop index if exists ix1 on nosuchschema.nosuchtable
+go
+
+-- always error with cross-db syntax (3-part table name) and remote syntax (4-part table name)
+use master
+go
+drop index someindex ON tempdb.dbo.sometable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DROP INDEX cross-database' is not currently supported in Babelfish)~~
+
+drop index if exists someindex ON tempdb.dbo.sometable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DROP INDEX cross-database' is not currently supported in Babelfish)~~
+
+drop index someindex ON someserver.tempdb.dbo.sometable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DROP INDEX on remote table' is not currently supported in Babelfish)~~
+
+drop index if exists someindex ON someserver.tempdb.dbo.sometable
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DROP INDEX on remote table' is not currently supported in Babelfish)~~
+

--- a/test/JDBC/input/drop_index-vu-cleanup.sql
+++ b/test/JDBC/input/drop_index-vu-cleanup.sql
@@ -1,0 +1,17 @@
+use master
+go
+drop table guest.t1_drop_index
+go
+drop table dbo.t1_drop_index
+go
+drop procedure dbo.p1_drop_index
+go
+drop procedure dbo.p2_drop_index
+go
+
+use tempdb
+go
+drop table guest.t1_drop_index
+go
+drop table dbo.t1_drop_index
+go

--- a/test/JDBC/input/drop_index-vu-prepare.sql
+++ b/test/JDBC/input/drop_index-vu-prepare.sql
@@ -1,0 +1,25 @@
+use master
+go
+create procedure p1_drop_index @p int=0
+as
+if @p = 0
+	drop index guest.t1_drop_index.ix1
+else
+	drop index if exists guest.t1_drop_index.ix1	
+
+	select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+
+create procedure p2_drop_index @p int=0
+as
+if @p = 0
+	drop index ix1 on guest.t1_drop_index
+else
+	drop index if exists ix1 on guest.t1_drop_index	
+
+	select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+
+use tempdb
+go
+

--- a/test/JDBC/input/drop_index-vu-verify.sql
+++ b/test/JDBC/input/drop_index-vu-verify.sql
@@ -1,0 +1,280 @@
+-- This covers BABEL-1483 (Support DROP INDEX table.index syntax) and BABEL-1652 (Support DROP INDEX ix ON schema.table syntax)
+use master
+go
+
+-- tests with '[schema_name.]table_name.index_name' syntax
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+
+create table guest.t1_drop_index(a int)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+
+drop index guest.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+drop index guest.t1_drop_index.ix1
+go
+drop index if exists guest.t1_drop_index.ix1
+go
+drop index guest.t1_drop_index.ix2
+go
+drop index if exists guest.t1_drop_index.ix2
+go
+
+drop index dbo.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+drop index dbo.t1_drop_index.ix1
+go
+drop index if exists dbo.t1_drop_index.ix1
+go
+drop index dbo.t1_drop_index.ix2
+go
+drop index if exists dbo.t1_drop_index.ix2
+go
+
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+
+drop index t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+drop index t1_drop_index.ix1
+go
+drop index if exists t1_drop_index.ix1
+go
+
+-- dynamic SQL
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+execute('drop index guest.t1_drop_index.ix1')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+execute('drop index guest.t1_drop_index.ix1')
+go
+execute('drop index if exists guest.t1_drop_index.ix1')
+go
+
+execute('drop index t1_drop_index.ix1')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+execute('drop index t1_drop_index.ix1')
+go
+execute('drop index if exists t1_drop_index.ix1')
+go
+
+-- stored proc
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+execute p1_drop_index
+go
+execute p1_drop_index
+go
+execute p1_drop_index 1
+go
+
+-- non-existing schema/table
+drop index nosuchtable.ix1
+go
+drop index if exists nosuchtable.ix1
+go
+drop index nosuchschema.nosuchtable.ix1
+go
+drop index if exists nosuchschema.nosuchtable.ix1
+go
+
+
+use master
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+
+use tempdb
+go
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+create table guest.t1_drop_index(a int)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+drop index guest.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+use master
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+drop index dbo.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+use tempdb
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+use master
+go
+drop index guest.t1_drop_index.ix1
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+use tempdb
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4	
+go
+
+-- cross-db reference: always error with 3-part table name
+use master
+go
+drop index tempdb.dbo.sometable.someindex
+go
+drop index if exists tempdb.dbo.sometable.someindex
+go
+
+-- tests with 'index_name ON [schema_name.]table_name' syntax
+
+use master
+go
+drop table dbo.t1_drop_index
+go
+drop table guest.t1_drop_index
+go
+
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+
+create table guest.t1_drop_index(a int)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+
+drop index ix1 on guest.t1_drop_index
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+drop index ix1 on guest.t1_drop_index
+go
+drop index if exists ix1 on guest.t1_drop_index
+go
+drop index ix2 on guest.t1_drop_index
+go
+drop index if exists ix2 on guest.t1_drop_index
+go
+
+drop index ix1 on dbo.t1_drop_index
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+drop index ix1 on dbo.t1_drop_index
+go
+drop index if exists ix1 on dbo.t1_drop_index
+go
+drop index ix2 on dbo.t1_drop_index
+go
+drop index if exists ix2 on dbo.t1_drop_index
+go
+
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+
+drop index ix1 on t1_drop_index
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+drop index ix1 on t1_drop_index
+go
+drop index if exists ix1 on t1_drop_index
+go
+
+-- dynamic SQL
+create index ix1 on dbo.t1_drop_index(a)
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+execute('drop index ix1 on guest.t1_drop_index')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+execute('drop index ix1 on guest.t1_drop_index')
+go
+execute('drop index if exists ix1 on guest.t1_drop_index')
+go
+
+execute('drop index ix1 on t1_drop_index')
+go
+select db_name(), object_name(id), object_schema_name(id), name from sysindexes where name like 'ix1%' order by 1,2,3,4
+go
+execute('drop index ix1 on t1_drop_index')
+go
+execute('drop index if exists ix1 on t1_drop_index')
+go
+
+-- stored proc
+create index ix1 on dbo.t1_drop_index(a)
+go
+create index ix1 on guest.t1_drop_index(a)
+go
+execute p2_drop_index
+go
+execute p2_drop_index
+go
+execute p2_drop_index 1
+go
+
+-- non-existing schema/table
+drop index ix1 on nosuchtable
+go
+drop index if exists ix1 on nosuchtable
+go
+drop index ix1 on nosuchschema.nosuchtable
+go
+drop index if exists ix1 on nosuchschema.nosuchtable
+go
+
+-- always error with cross-db syntax (3-part table name) and remote syntax (4-part table name)
+use master
+go
+drop index someindex ON tempdb.dbo.sometable
+go
+drop index if exists someindex ON tempdb.dbo.sometable
+go
+drop index someindex ON someserver.tempdb.dbo.sometable
+go
+drop index if exists someindex ON someserver.tempdb.dbo.sometable
+go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -472,6 +472,7 @@ float_exponent
 datetimeoffset-timezone
 BABEL-4046
 host_id
+drop_index
 linked_srv_4229
 BABEL-4175
 sp_who


### PR DESCRIPTION
### Description

To support the syntax `DROP INDEX table.index`, the statement is rewritten in ANTLR as `DROP INDEX index ON table`, which is picked up by the backend parser.
To support the syntax `DROP INDEX schema.table.index` and `DROP INDEX index ON schema.table`, the statement is rewritten in ANTLR as `DROP INDEX index ON table SCHEMA schema`, which is picked up by the backend parser. Adding the `SCHEMA` clause for this case was necessary to avoid Bison reduce conflicts which resulted from seemingly more straightforward syntax options. In the backend parser, the trick is then to create an object reference in the `DropStmt` structure for the schema-qualified index with the schema name from the `SCHEMA` clause that was added, since PG's `DROP INDEX` only references the index, instead of its table like in T-SQL. 
Also, proper error messages are now raised when attempting DROP INDEX with a 3-part of 4-part name.

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-1483 Support DROP INDEX table.index syntax
BABEL-1652 Support DROP INDEX ix ON schema.table syntax

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** N/A


* **Negative test cases -** Yes


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).