### PR TITLE
Fix broken link to ANTLR4 installation instructions

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -110,7 +110,7 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     ```
     Check that you have `uuid-devel` installed. If so, go to `antlr4/CMakeLists.txt` and comment out the line `pkg_check_modules(UUID REQUIRED uuid)` by adding a `#` to the beginning of the line.
 
-    More information about installing ANTLR4 can be found [at this link](https://www.cs.upc.edu/~padro/CL/practica/install.html).
+    More information about installing ANTLR4 can be found [at this link](https://www.cs.upc.edu/~cl/practica/install.html).
 
 
 


### PR DESCRIPTION
### Description

This commit fixes the broken link to ANTLR4 installation instructions mentioned in the Babelfish build instructions' README.md

Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).