### PR TITLE
Restrict unintended/unauthorized use of bbf_role_admin role (#2193)

### DIFF
--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -251,6 +251,7 @@ extern ProcessUtility_hook_type next_ProcessUtility;
 /* Postgres Public role name */
 #define PUBLIC_ROLE_NAME "public"
 #define BABELFISH_SYSADMIN "sysadmin"
+#define BABELFISH_ROLE_ADMIN "bbf_role_admin"
 
 /* Functions in backend/tds/tdscomm.c */
 extern void TdsSetMessageType(uint8_t msgType);

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -272,6 +272,7 @@ BEGIN
 
 	EXECUTE format('CREATE ROLE bbf_role_admin CREATEDB CREATEROLE INHERIT PASSWORD NULL');
 	EXECUTE format('GRANT CREATE ON DATABASE %s TO bbf_role_admin WITH GRANT OPTION', CURRENT_DATABASE());
+	EXECUTE format('GRANT %I to bbf_role_admin WITH ADMIN TRUE;', sa_name);
 	EXECUTE format('CREATE ROLE sysadmin CREATEDB CREATEROLE INHERIT ROLE %I', sa_name);
 	EXECUTE format('GRANT sysadmin TO bbf_role_admin WITH ADMIN TRUE');
 	EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE sys.babelfish_db_seq TO sysadmin WITH GRANT OPTION');

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3161,7 +3161,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					{
 						int			role_oid = get_role_oid(role_name, true);
 
-						if (role_oid == InvalidOid || !is_member_of_role(GetSessionUserId(), get_sysadmin_oid()))
+						if (!OidIsValid(role_oid) ||
+							!is_member_of_role(GetSessionUserId(), get_sysadmin_oid()) ||
+							role_oid == get_bbf_role_admin_oid())
 							ereport(ERROR, (errcode(ERRCODE_DUPLICATE_OBJECT),
 											errmsg("Cannot drop the login '%s', because it does not exist or you do not have permission.", role_name)));
 

--- a/test/JDBC/expected/bbf_role_admin_restrictions.out
+++ b/test/JDBC/expected/bbf_role_admin_restrictions.out
@@ -1,0 +1,240 @@
+-- tsql
+-- normal tsql login
+CREATE LOGIN bbf_role_admin_restrictions_login WITH password = '12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER bbf_role_admin_restrictions_login;
+GO
+
+-- psql
+-- normal PG user
+CREATE USER bbf_role_admin_restrictions_pg_user WITH LOGIN CREATEROLE CREATEDB PASSWORD '12345678' inherit;
+go
+
+-- tsql user=bbf_role_admin_restrictions_login password=12345678
+CREATE ROLE bbf_role_admin_restrictions_role;
+GO
+
+-- a tsql login should not be able to alter/drop bbf_role_admin explicitly from tsql port
+ALTER SERVER ROLE bbf_role_admin ADD MEMBER bbf_role_admin_restrictions_role;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: only sysadmin role is supported in ALTER SERVER ROLE statement)~~
+
+
+ALTER ROLE bbf_role_admin_restrictions_role ADD MEMBER bbf_role_admin;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "master_bbf_role_admin" does not exist)~~
+
+
+DROP LOGIN bbf_role_admin;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the login 'bbf_role_admin', because it does not exist or you do not have permission.)~~
+
+
+DROP ROLE bbf_role_admin_restrictions_role;
+GO
+
+-- psql user=bbf_role_admin_restrictions_login password=12345678
+-- a tsql login should not be able to alter/grant/drop bbf_role_admin from pg port
+ALTER ROLE bbf_role_admin NOCREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE bbf_role_admin WITH PASSWORD '12345678';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE bbf_role_admin VALID UNTIL 'infinity';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE bbf_role_admin WITH CONNECTION LIMIT 1;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+GRANT bbf_role_admin TO bbf_role_admin_restrictions_login;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+GRANT bbf_role_admin_restrictions_login TO bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+REVOKE bbf_role_admin FROM master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+REVOKE master_dbo FROM bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+DROP ROLE bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+SET SESSION AUTHORIZATION bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set session authorization
+    Server SQLState: 42501)~~
+
+
+SET ROLE bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set role "bbf_role_admin"
+    Server SQLState: 42501)~~
+
+
+-- psql user=bbf_role_admin_restrictions_pg_user password=12345678
+-- a normal psql user should not be able to alter/grant/drop bbf_role_admin from pg port
+ALTER ROLE bbf_role_admin NOCREATEROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE bbf_role_admin WITH PASSWORD '12345678';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE bbf_role_admin VALID UNTIL 'infinity';
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+ALTER ROLE bbf_role_admin WITH CONNECTION LIMIT 1;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+GRANT bbf_role_admin TO bbf_role_admin_restrictions_login;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+GRANT bbf_role_admin_restrictions_login TO bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+REVOKE bbf_role_admin FROM master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+REVOKE master_dbo FROM bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+DROP ROLE bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+SET SESSION AUTHORIZATION bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set session authorization
+    Server SQLState: 42501)~~
+
+
+SET ROLE bbf_role_admin;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to set role "bbf_role_admin"
+    Server SQLState: 42501)~~
+
+
+-- psql
+DROP USER bbf_role_admin_restrictions_pg_user;
+GO
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'bbf_role_admin_restrictions_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+t
+~~END~~
+
+
+-- tsql
+DROP LOGIN bbf_role_admin_restrictions_login;
+GO

--- a/test/JDBC/input/bbf_role_admin_restrictions.mix
+++ b/test/JDBC/input/bbf_role_admin_restrictions.mix
@@ -1,0 +1,112 @@
+-- tsql
+-- normal tsql login
+CREATE LOGIN bbf_role_admin_restrictions_login WITH password = '12345678';
+GO
+
+ALTER SERVER ROLE sysadmin ADD MEMBER bbf_role_admin_restrictions_login;
+GO
+
+-- psql
+-- normal PG user
+CREATE USER bbf_role_admin_restrictions_pg_user WITH LOGIN CREATEROLE CREATEDB PASSWORD '12345678' inherit;
+go
+
+-- tsql user=bbf_role_admin_restrictions_login password=12345678
+CREATE ROLE bbf_role_admin_restrictions_role;
+GO
+
+-- a tsql login should not be able to alter/drop bbf_role_admin explicitly from tsql port
+ALTER SERVER ROLE bbf_role_admin ADD MEMBER bbf_role_admin_restrictions_role;
+GO
+
+ALTER ROLE bbf_role_admin_restrictions_role ADD MEMBER bbf_role_admin;
+GO
+
+DROP LOGIN bbf_role_admin;
+GO
+
+DROP ROLE bbf_role_admin_restrictions_role;
+GO
+
+-- psql user=bbf_role_admin_restrictions_login password=12345678
+-- a tsql login should not be able to alter/grant/drop bbf_role_admin from pg port
+ALTER ROLE bbf_role_admin NOCREATEROLE;
+GO
+
+ALTER ROLE bbf_role_admin WITH PASSWORD '12345678';
+GO
+
+ALTER ROLE bbf_role_admin VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE bbf_role_admin WITH CONNECTION LIMIT 1;
+GO
+
+GRANT bbf_role_admin TO bbf_role_admin_restrictions_login;
+GO
+
+GRANT bbf_role_admin_restrictions_login TO bbf_role_admin;
+GO
+
+REVOKE bbf_role_admin FROM master_dbo;
+GO
+
+REVOKE master_dbo FROM bbf_role_admin;
+GO
+
+DROP ROLE bbf_role_admin;
+GO
+
+SET SESSION AUTHORIZATION bbf_role_admin;
+GO
+
+SET ROLE bbf_role_admin;
+GO
+
+-- psql user=bbf_role_admin_restrictions_pg_user password=12345678
+-- a normal psql user should not be able to alter/grant/drop bbf_role_admin from pg port
+ALTER ROLE bbf_role_admin NOCREATEROLE;
+GO
+
+ALTER ROLE bbf_role_admin WITH PASSWORD '12345678';
+GO
+
+ALTER ROLE bbf_role_admin VALID UNTIL 'infinity';
+GO
+
+ALTER ROLE bbf_role_admin WITH CONNECTION LIMIT 1;
+GO
+
+GRANT bbf_role_admin TO bbf_role_admin_restrictions_login;
+GO
+
+GRANT bbf_role_admin_restrictions_login TO bbf_role_admin;
+GO
+
+REVOKE bbf_role_admin FROM master_dbo;
+GO
+
+REVOKE master_dbo FROM bbf_role_admin;
+GO
+
+DROP ROLE bbf_role_admin;
+GO
+
+SET SESSION AUTHORIZATION bbf_role_admin;
+GO
+
+SET ROLE bbf_role_admin;
+GO
+
+-- psql
+DROP USER bbf_role_admin_restrictions_pg_user;
+GO
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'bbf_role_admin_restrictions_login' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- tsql
+DROP LOGIN bbf_role_admin_restrictions_login;
+GO


### PR DESCRIPTION
### Description
bbf_role_admin has been introduced to manage and administer all the
Babelfish users/logins/roles so it important to restrict its unintended/unauthorized
use so that no user can alter/grant/revoke/drop this role, otherwise
there can be permission leaks.

This commit brings following changes:
1. Blocked GRANT/REVOKE for bbf_role_admin from PG endpoint, ALTER/DROP is already being handled.
2. Blocked SET SESSION AUTHORIZATION and SET ROLE bbf_role_admin to non-superusers.
3. Replaced dialect with the better TDS connection checks so that we properly disallow any activity from PG endpoint no matter the dialect.
4. Added test cases for each scenario which shouldn't be allowed.
5. Fixed few syntax issues in upgrade script.

Task: BABEL-4659
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).