### PR TITLE
Increase retries to get PostGIS and PROJ files

### DIFF
--- a/.github/composite-actions/build-postgis-extension/action.yml
+++ b/.github/composite-actions/build-postgis-extension/action.yml
@@ -16,9 +16,20 @@ runs:
         export CMAKE_C_COMPILER_LAUNCHER=ccache
         export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
         sudo apt-get install wget
-        wget http://postgis.net/stuff/postgis-3.4.0.tar.gz
+        max_retries=20
+        retries=0
+        until [ $retries -ge $max_retries ]
+        do
+          wget http://postgis.net/stuff/postgis-3.4.0.tar.gz && break
+          retries=$((retries+1))
+        done
         tar -xvzf postgis-3.4.0.tar.gz
-        wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz
+        retries1=0
+        until [ $retries1 -ge $max_retries ]
+        do
+          wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
+          retries1=$((retries1+1))
+        done
         tar -xvzf proj-9.2.1.tar.gz
         cd proj-9.2.1
         if [ ! -d "build" ]; then

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -66,9 +66,20 @@ runs:
         export CMAKE_C_COMPILER_LAUNCHER=ccache
         export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
         sudo apt-get install wget
-        wget http://postgis.net/stuff/postgis-3.4.0.tar.gz
+        max_retries=20
+        retries=0
+        until [ $retries -ge $max_retries ]
+        do
+          wget http://postgis.net/stuff/postgis-3.4.0.tar.gz && break
+          retries=$((retries+1))
+        done
         tar -xvzf postgis-3.4.0.tar.gz
-        wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz
+        retries1=0
+        until [ $retries1 -ge $max_retries ]
+        do
+          wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
+          retries1=$((retries1+1))
+        done
         tar -xvzf proj-9.2.1.tar.gz
         cd proj-9.2.1
         if [ ! -d "build" ]; then

--- a/.github/configuration/upgrade-test-configuration.yml
+++ b/.github/configuration/upgrade-test-configuration.yml
@@ -96,7 +96,7 @@ upgrade-version: [[
 ],
 [
   {
-    version: 15.5,
+    version: 15.6,
     upgrade-type: null
   },
   { 

--- a/.github/scripts/clone_engine_repo
+++ b/.github/scripts/clone_engine_repo
@@ -44,7 +44,7 @@ BRANCH=$2
 # See https://unix.stackexchange.com/questions/474805/verify-if-a-url-exists
 check_repo () {
     echo "Checking $1"
-    wget --spider "$1" || return $?
+    wget --max-redirect=0 --spider "$1" || return $?
 }
 
 BASE_URL=https://github.com/$GH_USER/postgresql_modified_for_babelfish # NO /

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -54,9 +54,20 @@ jobs:
           export CMAKE_C_COMPILER_LAUNCHER=ccache
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
           sudo apt-get install wget
-          wget http://postgis.net/stuff/postgis-3.4.0.tar.gz
+          max_retries=20
+          retries=0
+          until [ $retries -ge $max_retries ]
+          do
+            wget http://postgis.net/stuff/postgis-3.4.0.tar.gz && break
+            retries=$((retries+1))
+          done
           tar -xvzf postgis-3.4.0.tar.gz
-          wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz
+          retries1=0
+          until [ $retries1 -ge $max_retries ]
+          do
+            wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
+            retries1=$((retries1+1))
+          done
           tar -xvzf proj-9.2.1.tar.gz
           cd proj-9.2.1
           if [ ! -d "build" ]; then

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -44,9 +44,20 @@ jobs:
           export CMAKE_C_COMPILER_LAUNCHER=ccache
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
           sudo apt-get install wget
-          wget http://postgis.net/stuff/postgis-3.4.0.tar.gz
+          max_retries=20
+          retries=0
+          until [ $retries -ge $max_retries ]
+          do
+            wget http://postgis.net/stuff/postgis-3.4.0.tar.gz && break
+            retries=$((retries+1))
+          done
           tar -xvzf postgis-3.4.0.tar.gz
-          wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz
+          retries1=0
+          until [ $retries1 -ge $max_retries ]
+          do
+            wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
+            retries1=$((retries1+1))
+          done
           tar -xvzf proj-9.2.1.tar.gz
           cd proj-9.2.1
           if [ ! -d "build" ]; then

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -60,9 +60,20 @@ jobs:
           export CMAKE_C_COMPILER_LAUNCHER=ccache
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
           sudo apt-get install wget
-          wget http://postgis.net/stuff/postgis-3.4.0.tar.gz
+          max_retries=20
+          retries=0
+          until [ $retries -ge $max_retries ]
+          do
+            wget http://postgis.net/stuff/postgis-3.4.0.tar.gz && break
+            retries=$((retries+1))
+          done
           tar -xvzf postgis-3.4.0.tar.gz
-          wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz
+          retries1=0
+          until [ $retries1 -ge $max_retries ]
+          do
+            wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
+            retries1=$((retries1+1))
+          done
           tar -xvzf proj-9.2.1.tar.gz
           cd proj-9.2.1
           if [ ! -d "build" ]; then


### PR DESCRIPTION
### Description

Increased Retries to get PostGIS and PROJ files from osgeo server

Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2224
Signed-off-by: Anikait Agrawal agraani@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).