### PR TITLE
Fix SPI clean up incase of errors for insert into execute with @table

### DIFF
--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1309,10 +1309,8 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 					HOLD_INTERRUPTS();
 					elog(DEBUG1, "TSQL TXN PG semantics : Rollback current transaction");
 					HoldPinnedPortals();
-					SPI_setCurrentInternalTxnMode(true);
 					AbortCurrentTransaction();
 					StartTransactionCommand();
-					SPI_setCurrentInternalTxnMode(false);
 					MemoryContextSwitchTo(cur_ctxt);
 					RESUME_INTERRUPTS();
 				}

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4056,10 +4056,11 @@ _PG_fini(void)
  */
 
 static void
-terminate_batch(bool send_error, bool compile_error)
+terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 {
 	bool		error_mapping_failed = false;
 	int			rc;
+	int 		current_spi_stack_depth;
 
 	HOLD_INTERRUPTS();
 
@@ -4067,9 +4068,24 @@ terminate_batch(bool send_error, bool compile_error)
 
 	/*
 	 * Disconnect from SPI manager
+	 * Also cleanup remnant SPI connections
+	 * Ideally current depth should be same as 
+	 * when caller was connecting to SPI Manager
 	 */
-	if ((rc = SPI_finish()) != SPI_OK_FINISH)
-		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
+	current_spi_stack_depth = SPI_get_depth();
+	
+	if (current_spi_stack_depth < SPI_depth)
+		elog(FATAL, "SPI connection stack is inconsistent, spi stack depth" 
+			 "expected count:%d, current count:%d",
+			 SPI_depth, current_spi_stack_depth);
+	
+	if (current_spi_stack_depth > SPI_depth)
+		elog(WARNING, "SPI connection leak found, expected count:%d, current count:%d",
+			 SPI_depth, current_spi_stack_depth);
+		
+	while (current_spi_stack_depth-- >= SPI_depth)
+		if ((rc = SPI_finish()) != SPI_OK_FINISH)
+			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	if (send_error)
 	{
@@ -4218,6 +4234,8 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	Oid			prev_procid = InvalidOid;
 	int			save_pltsql_trigger_depth = pltsql_trigger_depth;
 	int			saved_dialect = sql_dialect;
+	int 		current_spi_stack_depth;
+	bool 		send_error = false;
 
 	create_queryEnv2(CacheMemoryContext, false);
 
@@ -4242,8 +4260,9 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	if ((rc = SPI_connect_ext(nonatomic ? SPI_OPT_NONATOMIC : 0)) != SPI_OK_CONNECT)
 		elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 	PortalContext = savedPortalCxt;
-	if (support_tsql_trans)
-		SPI_setCurrentInternalTxnMode(true);
+
+	SPI_setCurrentInternalTxnMode(true);
+	current_spi_stack_depth = SPI_get_depth();
 
 	elog(DEBUG2, "TSQL TXN call handler, nonatomic : %d Tsql transaction support %d", nonatomic, support_tsql_trans);
 
@@ -4307,18 +4326,20 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 		PG_CATCH(2);
 		{
 			set_procid(prev_procid);
-			/* Decrement use-count, restore cur_estate, and propagate error */
 			pltsql_trigger_depth = save_pltsql_trigger_depth;
-			func->use_count--;
-			func->cur_estate = save_cur_estate;
-			pltsql_remove_current_query_env();
-			pltsql_revert_guc(save_nestlevel);
-			pltsql_revert_last_scope_identity(scope_level);
-			terminate_batch(true /* send_error */ , false /* compile_error */ );
-			sql_dialect = saved_dialect;
-			return retval;
+			
+			send_error = true;
 		}
 		PG_END_TRY(2);
+		
+		/* Decrement use-count, restore cur_estate, and propagate error */
+		func->use_count--;
+
+		func->cur_estate = save_cur_estate;
+
+		pltsql_remove_current_query_env();
+		pltsql_revert_guc(save_nestlevel);
+		pltsql_revert_last_scope_identity(scope_level);
 	}
 	PG_FINALLY();
 	{
@@ -4326,15 +4347,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	}
 	PG_END_TRY();
 
-	func->use_count--;
-
-	func->cur_estate = save_cur_estate;
-
-	pltsql_remove_current_query_env();
-	pltsql_revert_guc(save_nestlevel);
-	pltsql_revert_last_scope_identity(scope_level);
-
-	terminate_batch(false /* send_error */ , false /* compile_error */ );
+	terminate_batch(send_error /* send_error */ , false /* compile_error */ , current_spi_stack_depth);
 
 	return retval;
 }
@@ -4359,6 +4372,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 	int			saved_dialect = sql_dialect;
 	int			nargs = PG_NARGS();
 	int			i;
+	int 		current_spi_stack_depth;
 	MemoryContext savedPortalCxt;
 	FunctionCallInfo fake_fcinfo = palloc0(SizeForFunctionCallInfo(nargs));
 	bool		nonatomic;
@@ -4400,8 +4414,8 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 		elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 	PortalContext = savedPortalCxt;
 
-	if (support_tsql_trans)
-		SPI_setCurrentInternalTxnMode(true);
+	SPI_setCurrentInternalTxnMode(true);
+	current_spi_stack_depth = SPI_get_depth();
 
 	elog(DEBUG2, "TSQL TXN inline handler, nonatomic : %d Tsql transaction support %d", nonatomic, support_tsql_trans);
 
@@ -4444,7 +4458,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 	}
 	PG_CATCH();
 	{
-		terminate_batch(true /* send_error */ , true /* compile_error */ );
+		terminate_batch(true /* send_error */ , true /* compile_error */ , current_spi_stack_depth);
 		return retval;
 	}
 	PG_END_TRY();
@@ -4553,7 +4567,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 		}
 		sql_dialect = saved_dialect;
 
-		terminate_batch(true /* send_error */ , false /* compile_error */ );
+		terminate_batch(true /* send_error */ , false /* compile_error */ , current_spi_stack_depth);
 		return retval;
 	}
 	PG_END_TRY();
@@ -4592,7 +4606,7 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 	}
 	sql_dialect = saved_dialect;
 
-	terminate_batch(false /* send_error */ , false /* compile_error */ );
+	terminate_batch(false /* send_error */ , false /* compile_error */ , current_spi_stack_depth);
 
 	return retval;
 }

--- a/test/JDBC/expected/BABEL_4360.out
+++ b/test/JDBC/expected/BABEL_4360.out
@@ -1,0 +1,190 @@
+DECLARE @a TABLE (a INT);
+INSERT INTO @a EXECUTE('SELECT * FROM t1; SELECT 3');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "t1" does not exist)~~
+
+
+
+-- tsql
+
+-- Test nested procedure calls with rollback and error case
+CREATE TABLE babel_4360_t (id INT);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (99);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc2()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc1();
+  INSERT INTO babel_4360_t VALUES (98);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc1
+AS
+EXEC psql_interop_proc2;
+INSERT INTO babel_4360_t VALUES (97);
+GO
+
+CREATE PROCEDURE tsql_interop_proc2
+AS
+EXEC tsql_interop_proc1;
+INSERT INTO babel_4360_t VALUES (96);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc3()
+AS
+$$
+BEGIN
+  CALL tsql_interop_proc2();
+  INSERT INTO babel_4360_t VALUES (95);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc4()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc3();
+  INSERT INTO babel_4360_t VALUES (94);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc3
+AS
+EXEC psql_interop_proc4;
+INSERT INTO babel_4360_t VALUES (93);
+GO
+
+CREATE PROCEDURE tsql_interop_proc4
+AS
+EXEC tsql_interop_proc3;
+INSERT INTO babel_4360_t VALUES (92);
+GO
+
+EXEC tsql_interop_proc4;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4360_t
+GO
+~~START~~
+int
+99
+98
+97
+96
+95
+94
+93
+92
+~~END~~
+
+
+DELETE FROM babel_4360_t;
+GO
+~~ROW COUNT: 8~~
+
+
+-- psql     currentSchema=master_dbo,public
+-- alter procedure to throw error
+CREATE OR REPLACE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  INSERT INTO babel_4360_t VALUES (-1);
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (100);
+  COMMIT;
+  INSERT INTO babel_4360_t VALUES (-1);
+  RAISE EXCEPTION 'Throw an exception to check error case';
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+EXEC tsql_interop_proc4;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Throw an exception to check error case)~~
+
+
+SELECT * FROM babel_4360_t
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+DELETE FROM babel_4360_t;
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE PROCEDURE tsql_interop_proc5
+AS
+BEGIN TRY
+  EXEC tsql_interop_proc3;
+  INSERT INTO babel_4360_t VALUES (-1);
+END TRY
+BEGIN CATCH
+  INSERT INTO babel_4360_t VALUES (92);
+END CATCH
+GO
+
+-- test error handling for interop procedures with tsql try catch block
+EXEC tsql_interop_proc5
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4360_t
+GO
+~~START~~
+int
+100
+92
+~~END~~
+
+
+DROP TABLE babel_4360_t
+GO
+
+DROP PROCEDURE IF EXISTS tsql_interop_proc5, tsql_interop_proc4, tsql_interop_proc3, tsql_interop_proc2, tsql_interop_proc1;
+GO
+
+-- psql     currentSchema=master_dbo,public
+DROP PROCEDURE IF EXISTS psql_interop_proc4, psql_interop_proc3, psql_interop_proc2, psql_interop_proc1;
+GO

--- a/test/JDBC/input/BABEL_4360.mix
+++ b/test/JDBC/input/BABEL_4360.mix
@@ -1,0 +1,145 @@
+DECLARE @a TABLE (a INT);
+INSERT INTO @a EXECUTE('SELECT * FROM t1; SELECT 3');
+GO
+
+-- Test nested procedure calls with rollback and error case
+
+-- tsql
+
+CREATE TABLE babel_4360_t (id INT);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (99);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc2()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc1();
+  INSERT INTO babel_4360_t VALUES (98);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc1
+AS
+EXEC psql_interop_proc2;
+INSERT INTO babel_4360_t VALUES (97);
+GO
+
+CREATE PROCEDURE tsql_interop_proc2
+AS
+EXEC tsql_interop_proc1;
+INSERT INTO babel_4360_t VALUES (96);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc3()
+AS
+$$
+BEGIN
+  CALL tsql_interop_proc2();
+  INSERT INTO babel_4360_t VALUES (95);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc4()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc3();
+  INSERT INTO babel_4360_t VALUES (94);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc3
+AS
+EXEC psql_interop_proc4;
+INSERT INTO babel_4360_t VALUES (93);
+GO
+
+CREATE PROCEDURE tsql_interop_proc4
+AS
+EXEC tsql_interop_proc3;
+INSERT INTO babel_4360_t VALUES (92);
+GO
+
+EXEC tsql_interop_proc4;
+GO
+
+SELECT * FROM babel_4360_t
+GO
+
+DELETE FROM babel_4360_t;
+GO
+
+-- alter procedure to throw error
+-- psql     currentSchema=master_dbo,public
+CREATE OR REPLACE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  INSERT INTO babel_4360_t VALUES (-1);
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (100);
+  COMMIT;
+  INSERT INTO babel_4360_t VALUES (-1);
+  RAISE EXCEPTION 'Throw an exception to check error case';
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+EXEC tsql_interop_proc4;
+GO
+
+SELECT * FROM babel_4360_t
+GO
+
+DELETE FROM babel_4360_t;
+GO
+
+CREATE PROCEDURE tsql_interop_proc5
+AS
+BEGIN TRY
+  EXEC tsql_interop_proc3;
+  INSERT INTO babel_4360_t VALUES (-1);
+END TRY
+BEGIN CATCH
+  INSERT INTO babel_4360_t VALUES (92);
+END CATCH
+GO
+
+-- test error handling for interop procedures with tsql try catch block
+EXEC tsql_interop_proc5
+GO
+
+SELECT * FROM babel_4360_t
+GO
+
+DROP TABLE babel_4360_t
+GO
+
+DROP PROCEDURE IF EXISTS tsql_interop_proc5, tsql_interop_proc4, tsql_interop_proc3, tsql_interop_proc2, tsql_interop_proc1;
+GO
+
+-- psql     currentSchema=master_dbo,public
+DROP PROCEDURE IF EXISTS psql_interop_proc4, psql_interop_proc3, psql_interop_proc2, psql_interop_proc1;
+GO


### PR DESCRIPTION
### Description

Fix crash in insert into @tablevariable execute('some error generating statement')
Problem was how we were handling SPI connections clean up.
We marked the SPI connections as internal xact only when we were not inside a sys function or non tsql procedure.
But we always call SPI finish in following terminate batch. Marking it non internal will clean up the SPI connections when we abort transaction in error handling.

As a fix we always mark the SPI connection as internal_xact for pltsql_inline_handler and pltsql_call_handler. Also clean up any leftovers SPI connections in terminate_batch. If we are less than expected spi stack depth we throw a fatal error to kill session since this state is never expected.

Also make some changes to fix static code analyzer warnings for uninitialised variables in pltsql call handler.

### Issues Resolved

[BABEL-4360]

### Cherry Picked From 3_X

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2183

#### Merge Conflict

\++<<<<<<< HEAD
+PG_END_TRY(2);
\++=======
+PG_END_TRY();
        
+/* Decrement use-count, restore cur_estate, and propagate error */
+func->use_count--;

+func->cur_estate = save_cur_estate;

+pltsql_remove_current_query_env();
+pltsql_revert_guc(save_nestlevel);
+pltsql_revert_last_scope_identity(scope_level);
\++>>>>>>> 75d5f8040 (Fix SPI clean up incase of errors for insert into execute with @tablevarible 

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).