### PR TITLE
Fix SPI clean up incase of errors for insert into execute with @table…

### DIFF
--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1273,10 +1273,8 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 					HOLD_INTERRUPTS();
 					elog(DEBUG1, "TSQL TXN PG semantics : Rollback current transaction");
 					HoldPinnedPortals();
-					SPI_setCurrentInternalTxnMode(true);
 					AbortCurrentTransaction();
 					StartTransactionCommand();
-					SPI_setCurrentInternalTxnMode(false);
 					MemoryContextSwitchTo(cur_ctxt);
 					RESUME_INTERRUPTS();
 				}

--- a/test/JDBC/expected/BABEL_4360.out
+++ b/test/JDBC/expected/BABEL_4360.out
@@ -1,0 +1,190 @@
+DECLARE @a TABLE (a INT);
+INSERT INTO @a EXECUTE('SELECT * FROM t1; SELECT 3');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "t1" does not exist)~~
+
+
+
+-- tsql
+
+-- Test nested procedure calls with rollback and error case
+CREATE TABLE babel_4360_t (id INT);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (99);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc2()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc1();
+  INSERT INTO babel_4360_t VALUES (98);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc1
+AS
+EXEC psql_interop_proc2;
+INSERT INTO babel_4360_t VALUES (97);
+GO
+
+CREATE PROCEDURE tsql_interop_proc2
+AS
+EXEC tsql_interop_proc1;
+INSERT INTO babel_4360_t VALUES (96);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc3()
+AS
+$$
+BEGIN
+  CALL tsql_interop_proc2();
+  INSERT INTO babel_4360_t VALUES (95);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc4()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc3();
+  INSERT INTO babel_4360_t VALUES (94);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc3
+AS
+EXEC psql_interop_proc4;
+INSERT INTO babel_4360_t VALUES (93);
+GO
+
+CREATE PROCEDURE tsql_interop_proc4
+AS
+EXEC tsql_interop_proc3;
+INSERT INTO babel_4360_t VALUES (92);
+GO
+
+EXEC tsql_interop_proc4;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4360_t
+GO
+~~START~~
+int
+99
+98
+97
+96
+95
+94
+93
+92
+~~END~~
+
+
+DELETE FROM babel_4360_t;
+GO
+~~ROW COUNT: 8~~
+
+
+-- psql     currentSchema=master_dbo,public
+-- alter procedure to throw error
+CREATE OR REPLACE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  INSERT INTO babel_4360_t VALUES (-1);
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (100);
+  COMMIT;
+  INSERT INTO babel_4360_t VALUES (-1);
+  RAISE EXCEPTION 'Throw an exception to check error case';
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+EXEC tsql_interop_proc4;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Throw an exception to check error case)~~
+
+
+SELECT * FROM babel_4360_t
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+DELETE FROM babel_4360_t;
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE PROCEDURE tsql_interop_proc5
+AS
+BEGIN TRY
+  EXEC tsql_interop_proc3;
+  INSERT INTO babel_4360_t VALUES (-1);
+END TRY
+BEGIN CATCH
+  INSERT INTO babel_4360_t VALUES (92);
+END CATCH
+GO
+
+-- test error handling for interop procedures with tsql try catch block
+EXEC tsql_interop_proc5
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4360_t
+GO
+~~START~~
+int
+100
+92
+~~END~~
+
+
+DROP TABLE babel_4360_t
+GO
+
+DROP PROCEDURE IF EXISTS tsql_interop_proc5, tsql_interop_proc4, tsql_interop_proc3, tsql_interop_proc2, tsql_interop_proc1;
+GO
+
+-- psql     currentSchema=master_dbo,public
+DROP PROCEDURE IF EXISTS psql_interop_proc4, psql_interop_proc3, psql_interop_proc2, psql_interop_proc1;
+GO

--- a/test/JDBC/input/BABEL_4360.mix
+++ b/test/JDBC/input/BABEL_4360.mix
@@ -1,0 +1,145 @@
+DECLARE @a TABLE (a INT);
+INSERT INTO @a EXECUTE('SELECT * FROM t1; SELECT 3');
+GO
+
+-- Test nested procedure calls with rollback and error case
+
+-- tsql
+
+CREATE TABLE babel_4360_t (id INT);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (99);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc2()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc1();
+  INSERT INTO babel_4360_t VALUES (98);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc1
+AS
+EXEC psql_interop_proc2;
+INSERT INTO babel_4360_t VALUES (97);
+GO
+
+CREATE PROCEDURE tsql_interop_proc2
+AS
+EXEC tsql_interop_proc1;
+INSERT INTO babel_4360_t VALUES (96);
+GO
+
+-- psql     currentSchema=master_dbo,public
+
+CREATE PROCEDURE psql_interop_proc3()
+AS
+$$
+BEGIN
+  CALL tsql_interop_proc2();
+  INSERT INTO babel_4360_t VALUES (95);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE psql_interop_proc4()
+AS
+$$
+BEGIN
+  CALL psql_interop_proc3();
+  INSERT INTO babel_4360_t VALUES (94);
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+
+CREATE PROCEDURE tsql_interop_proc3
+AS
+EXEC psql_interop_proc4;
+INSERT INTO babel_4360_t VALUES (93);
+GO
+
+CREATE PROCEDURE tsql_interop_proc4
+AS
+EXEC tsql_interop_proc3;
+INSERT INTO babel_4360_t VALUES (92);
+GO
+
+EXEC tsql_interop_proc4;
+GO
+
+SELECT * FROM babel_4360_t
+GO
+
+DELETE FROM babel_4360_t;
+GO
+
+-- alter procedure to throw error
+-- psql     currentSchema=master_dbo,public
+CREATE OR REPLACE PROCEDURE psql_interop_proc1()
+AS
+$$
+BEGIN
+  INSERT INTO babel_4360_t VALUES (-1);
+  ROLLBACK;
+  INSERT INTO babel_4360_t VALUES (100);
+  COMMIT;
+  INSERT INTO babel_4360_t VALUES (-1);
+  RAISE EXCEPTION 'Throw an exception to check error case';
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql
+EXEC tsql_interop_proc4;
+GO
+
+SELECT * FROM babel_4360_t
+GO
+
+DELETE FROM babel_4360_t;
+GO
+
+CREATE PROCEDURE tsql_interop_proc5
+AS
+BEGIN TRY
+  EXEC tsql_interop_proc3;
+  INSERT INTO babel_4360_t VALUES (-1);
+END TRY
+BEGIN CATCH
+  INSERT INTO babel_4360_t VALUES (92);
+END CATCH
+GO
+
+-- test error handling for interop procedures with tsql try catch block
+EXEC tsql_interop_proc5
+GO
+
+SELECT * FROM babel_4360_t
+GO
+
+DROP TABLE babel_4360_t
+GO
+
+DROP PROCEDURE IF EXISTS tsql_interop_proc5, tsql_interop_proc4, tsql_interop_proc3, tsql_interop_proc2, tsql_interop_proc1;
+GO
+
+-- psql     currentSchema=master_dbo,public
+DROP PROCEDURE IF EXISTS psql_interop_proc4, psql_interop_proc3, psql_interop_proc2, psql_interop_proc1;
+GO


### PR DESCRIPTION
### Description

Fix crash in insert into @tablevariable execute('some error generating statement')
Problem was how we were handling SPI connections clean up.
We marked the SPI connections as internal xact only when we were not inside a sys function or non tsql procedure.
But we always call SPI finish in following terminate batch. Marking it non internal will clean up the SPI connections when we abort transaction in error handling.

As a fix we always mark the SPI connection as internal_xact for pltsql_inline_handler and pltsql_call_handler. Also clean up any leftovers SPI connections in terminate_batch. If we are less than expected spi stack depth we throw a fatal error to kill session since this state is never expected.

Also make some changes to fix static code analyzer warnings for uninitialised variables in pltsql call handler.

### Issues Resolved

[BABEL-4360]

### Cherry Picked From 3_X

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2183

#### Merge Conflict

None

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).