### PR TITLE
Improvements in handling of Babelfish specific GUC after commit a1a00b3bd00cf3f07d382ecb1219e1799b037676

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5173,11 +5173,6 @@ pltsql_guc_push_old_value(struct config_generic *gconf, GucAction action)
 	stack->scontext = gconf->scontext;
 	guc_set_stack_value(gconf, &stack->prior);
 
-	if (gconf->session_stack == NULL)
-	{
-		update_guc_stack_list(&gconf->stack_link);
-	}
-
 	gconf->session_stack = stack;
 	pltsql_guc_dirty = true;
 }
@@ -5331,10 +5326,6 @@ pltsql_revert_guc(int nest_level)
 			/* Finish popping the state stack */
 			gconf->session_stack = prev;
 
-			if (prev == NULL)
-			{
-				delete_guc_stack_list(&gconf->stack_link);
-			}
 			pfree(stack);
 		}						/* end of stack-popping loop */
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5173,6 +5173,11 @@ pltsql_guc_push_old_value(struct config_generic *gconf, GucAction action)
 	stack->scontext = gconf->scontext;
 	guc_set_stack_value(gconf, &stack->prior);
 
+	if (gconf->session_stack == NULL)
+	{
+		update_guc_stack_list(&gconf->stack_link);
+	}
+
 	gconf->session_stack = stack;
 	pltsql_guc_dirty = true;
 }
@@ -5320,11 +5325,16 @@ pltsql_revert_guc(int nest_level)
 			guc_set_extra_field(gconf, &(stack->masked.extra), NULL);
 
 			/* And restore source information */
-			gconf->source = newsource;
+			babelfish_set_guc_source(gconf, newsource);
 			gconf->scontext = newscontext;
 
 			/* Finish popping the state stack */
 			gconf->session_stack = prev;
+
+			if (prev == NULL)
+			{
+				delete_guc_stack_list(&gconf->stack_link);
+			}
 			pfree(stack);
 		}						/* end of stack-popping loop */
 

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -6,18 +6,6 @@
 # 5. To add a test, add test name (without extension, ,  and . For example if test file name is TestBigInt.txt write TestBigInt) on a new line
 # These tests are crashing/failing with parallel query mode is on. 
 
-# These tests are hanging in 16.1 with parallel query mode on
-# JIRA - BABEL-4668
-ignore#!#545_1
-
-# JIRA - BABEL-4669
-ignore#!#BABEL-3092
-
-# JIRA - BABEL-4670
-ignore#!#BABEL-SEQUENCE
-
-# JIRA - BABEL-4671
-ignore#!#TestSPPrepare
 
 # Hangs with unknown cause
 ignore#!#sp_who-vu-prepare


### PR DESCRIPTION

### Description

With engine commit a1a00b3bd00cf3f07d382ecb1219e1799b037676, community refactored the code related to GUC handling and introduced certain optimisation around GUC handling. For example, they have introduced following three
fields for various purpose --

```
static dlist_head guc_nondef_list;	/* list of variables that have source
									 * different from PGC_S_DEFAULT */
static slist_head guc_stack_list;	/* list of variables that have non-NULL
									 * stack */
static slist_head guc_report_list;	/* list of variables that have the
									 * GUC_NEEDS_REPORT bit set in status */
```

These all fields are getting updated in engine based on various operations on the GUC. Field guc_nondef_list is to track
non-default value of various GUCs and is updated through helper function set_guc_source(...). Now the logic of Babelfish
GUC handling is somewhat different and was not updated to accommodate these code changes. This resulted in hang
while communicating GUCs with non-default value to parallel worker. 

This commit aims to fix that issue by utilising appropriate wrapper around set_guc_source(...) exposed in engine to
update the guc_nondef_list stack appropriately. 

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/290
Task: BABEL-4668, BABEL-4669, BABEL-4670, BABEL-4671
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).