### PR TITLE
add upgrade tests for DROP INDEX

### DIFF
--- a/test/JDBC/expected/drop_index-before-15_6-or-16_2-vu-cleanup.out
+++ b/test/JDBC/expected/drop_index-before-15_6-or-16_2-vu-cleanup.out
@@ -1,0 +1,11 @@
+use master
+go
+drop table dbo.t1_drop_index
+go
+drop table dbo.t2_drop_index
+go
+drop procedure dbo.p1_drop_index
+go
+drop procedure dbo.p2_drop_index
+go
+

--- a/test/JDBC/expected/drop_index-before-15_6-or-16_2-vu-prepare.out
+++ b/test/JDBC/expected/drop_index-before-15_6-or-16_2-vu-prepare.out
@@ -1,0 +1,26 @@
+use master
+go
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+
+create procedure p1_drop_index 
+as
+	drop index dbo.t1_drop_index.ix1
+	drop index if exists dbo.t1_drop_index.ix1	
+go
+
+create table dbo.t2_drop_index(a int)
+go
+create index ix1 on dbo.t2_drop_index(a)
+go
+
+create procedure p2_drop_index 
+as
+	drop index ix1 on dbo.t2_drop_index
+	drop index if exists ix1 on dbo.t2_drop_index	
+go
+
+
+

--- a/test/JDBC/expected/drop_index-before-15_6-or-16_2-vu-verify.out
+++ b/test/JDBC/expected/drop_index-before-15_6-or-16_2-vu-verify.out
@@ -1,0 +1,6 @@
+use master
+go
+execute p1_drop_index
+go
+execute p2_drop_index
+go

--- a/test/JDBC/input/drop_index-before-15_6-or-16_2-vu-cleanup.sql
+++ b/test/JDBC/input/drop_index-before-15_6-or-16_2-vu-cleanup.sql
@@ -1,0 +1,11 @@
+use master
+go
+drop table dbo.t1_drop_index
+go
+drop table dbo.t2_drop_index
+go
+drop procedure dbo.p1_drop_index
+go
+drop procedure dbo.p2_drop_index
+go
+

--- a/test/JDBC/input/drop_index-before-15_6-or-16_2-vu-prepare.sql
+++ b/test/JDBC/input/drop_index-before-15_6-or-16_2-vu-prepare.sql
@@ -1,0 +1,26 @@
+use master
+go
+create table dbo.t1_drop_index(a int)
+go
+create index ix1 on dbo.t1_drop_index(a)
+go
+
+create procedure p1_drop_index 
+as
+	drop index dbo.t1_drop_index.ix1
+	drop index if exists dbo.t1_drop_index.ix1	
+go
+
+create table dbo.t2_drop_index(a int)
+go
+create index ix1 on dbo.t2_drop_index(a)
+go
+
+create procedure p2_drop_index 
+as
+	drop index ix1 on dbo.t2_drop_index
+	drop index if exists ix1 on dbo.t2_drop_index	
+go
+
+
+

--- a/test/JDBC/input/drop_index-before-15_6-or-16_2-vu-verify.sql
+++ b/test/JDBC/input/drop_index-before-15_6-or-16_2-vu-verify.sql
@@ -1,0 +1,6 @@
+use master
+go
+execute p1_drop_index
+go
+execute p2_drop_index
+go

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -223,5 +223,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -276,5 +276,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -330,5 +330,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -324,5 +324,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -324,5 +324,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -327,5 +327,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -418,6 +418,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 sys-parsename-before-15_6-or-16_1
 permission_restrictions_from_pg

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -418,6 +418,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 sys-parsename-before-15_6-or-16_1
 permission_restrictions_from_pg

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -345,5 +345,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -360,5 +360,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -395,5 +395,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -416,5 +416,6 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -415,6 +415,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -417,6 +417,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 babel-4475
 BABEL-4606
 sys-parsename-before-15_6-or-16_1

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -394,6 +394,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -424,6 +424,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -446,6 +446,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -458,6 +458,7 @@ TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -486,6 +486,7 @@ TestDatatypeAggSort
 babel_index_nulls_order
 operator_binary_whitespace-before-15_5-or-16_1
 BABEL-2999
+drop_index-before-15_6-or-16_2
 BABEL-4606
 permission_restrictions_from_pg
 BABEL-4529-before-15_6-or-14_11

--- a/test/JDBC/upgrade/master/schedule
+++ b/test/JDBC/upgrade/master/schedule
@@ -343,4 +343,5 @@ BABEL-4175
 BABEL_4330
 TestDatatypeAggSort
 babel_index_nulls_order
+drop_index-before-15_6-or-16_2
 BABEL-730


### PR DESCRIPTION
### Description

Add upgrade tests for PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2216 , since procedures containing the non-supported DROP INDEX syntax could still be created in prior versions.

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)


### Issues Resolved

Add upgrade test for PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2216

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).