### PR TITLE
Should set pltsql_implicit_transactions = false as default

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -49,7 +49,7 @@ bool		pltsql_allow_windows_login = true;
 bool		pltsql_allow_fulltext_parser = false;
 
 bool		pltsql_xact_abort = false;
-bool		pltsql_implicit_transactions = true;
+bool		pltsql_implicit_transactions = false;
 bool		pltsql_cursor_close_on_commit = false;
 bool		pltsql_disable_batch_auto_commit = false;
 bool		pltsql_disable_internal_savepoint = false;
@@ -880,11 +880,15 @@ define_custom_variables(void)
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);
 
+	pltsql_implicit_transactions = false;
+	// define babelfishpg_tsql.ansi_defaults will set pltsql_implicit_transactions = true
+	// that's not expected during initialize, set to false as the same for default
+
 	DefineCustomBoolVariable("babelfishpg_tsql.implicit_transactions",
 							 gettext_noop("enable implicit transactions"),
 							 NULL,
 							 &pltsql_implicit_transactions,
-							 true,
+							 false,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);


### PR DESCRIPTION
### Description

We have wrongly set default for pltsql_implicit_transactions = true for
Postgres 16 to pass the explicit value check.

- Why it happened
    - define babelfishpg_tsql.ansi_defaults will set init value pltsql_implicit_transactions = true since the feature ansi_defaults.
    - When PG_INIT variable, ansi_defaults will be defined as true.
    - So during PG_INIT init value pltsql_implicit_transactions will be changed to true, then changed to false in define babelfishpg_tsql.implicit_transactions.
    - PG 16 add extra check of the DefineCustomBoolVariable function to make sure the init value is the same as the default value, so it crashed the babel extension creating.
    - Our last attempt to fix this issue rudely set pltsql_implicit_transactions = true at first place to bypass the problem and it'll cause other potential problems during runtime.

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).