### PR TITLE
Handle cursor erros on transaction boundaries

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4704,7 +4704,7 @@ pltsql_persist_holdable_cursor_executor(Portal portal, QueryDesc *queryDesc,
 
 			pltsql_update_cursor_error_data(portal->name);
 
-			pop_top_error_stack();
+			pop_error_stack();
 
 			InterruptHoldoffCount = saveInterruptHoldoffCount;
 			QueryCancelHoldoffCount = saveQueryCancelHoldoffCount;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4689,6 +4689,9 @@ pltsql_persist_holdable_cursor_executor(Portal portal, QueryDesc *queryDesc,
 		}
 		PG_CATCH();
 		{
+			InterruptHoldoffCount = saveInterruptHoldoffCount;
+			QueryCancelHoldoffCount = saveQueryCancelHoldoffCount;
+
 			/*
 			 * Portal resources are transferred to current transaction resource
 			 * owner so transaction abort will handle the executor cleanup
@@ -4705,9 +4708,6 @@ pltsql_persist_holdable_cursor_executor(Portal portal, QueryDesc *queryDesc,
 			pltsql_update_cursor_error_data(portal->name);
 
 			pop_error_stack();
-
-			InterruptHoldoffCount = saveInterruptHoldoffCount;
-			QueryCancelHoldoffCount = saveQueryCancelHoldoffCount;
 
 			pltsql_non_tsql_proc_entry_count = 0;
 			pltsql_sys_func_entry_count = 0;

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -84,7 +84,6 @@ static void get_param_mode(List *params, int paramno, char **modes);
 extern void pltsql_update_cursor_row_count(char *curname, int64 row_count);
 extern void pltsql_update_cursor_last_operation(char *curname, int last_operation);
 extern bool pltsql_declare_cursor(PLtsql_execstate *estate, PLtsql_var *var, PLtsql_expr *explicit_expr, int cursor_options);
-extern char *pltsql_demangle_curname(char *curname);
 
 extern void enable_sp_cursor_find_param_hook(void);
 extern void disable_sp_cursor_find_param_hook(void);

--- a/contrib/babelfishpg_tsql/src/pl_gram.y
+++ b/contrib/babelfishpg_tsql/src/pl_gram.y
@@ -7492,19 +7492,16 @@ read_tsql_extended_cursor_options(void)
 
 	/* [ FORWARD_ONLY | SCROLL ] */
 	tok = yylex();
-	if (tok_is_keyword(tok, &yylval, K_FORWARD_ONLY, "forward_only"))
-	{
-		/* just mark TSQL_CURSOR_OPT_FORWARD_ONLY to indicate query explicitly specifies the option */
-		extended_cursor_options |= (CURSOR_OPT_NO_SCROLL | TSQL_CURSOR_OPT_FORWARD_ONLY);
-	}
-	else if (tok_is_keyword(tok, &yylval, K_SCROLL, "scroll"))
+	if (tok_is_keyword(tok, &yylval, K_SCROLL, "scroll"))
 	{
 		/* just mark TSQL_CURSOR_OPT_SCROLL to indicate query explicitly specifies the option */
 		extended_cursor_options |= (CURSOR_OPT_SCROLL | TSQL_CURSOR_OPT_SCROLL);
 	}
 	else
 	{
-		pltsql_push_back_token(tok);
+		/* just mark TSQL_CURSOR_OPT_FORWARD_ONLY to indicate query explicitly specifies the option */
+		/* not specifying anything should default to NO_SCROLL or FORWARD_ONLY */
+		extended_cursor_options |= (CURSOR_OPT_NO_SCROLL | TSQL_CURSOR_OPT_FORWARD_ONLY);
 	}
 
 	/* [ STATIC | KEYSET | DYNAMIC | FAST_FORWARD ] */

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2153,6 +2153,16 @@ int			execute_sp_cursoroption2(int cursor_handle, int code, const char *value);
 int			execute_sp_cursorclose(int cursor_handle);
 
 /*
+ * Utility functions for cursor hash tab
+ */
+extern bool pltsql_is_cursor_open(const char *curname);
+extern void pltsql_update_cursor_state(const char *curname, bool is_cursor_open);
+extern void pltsql_update_cursor_error_data(const char *curname);
+extern ErrorData *pltsql_get_cursor_error_data(const char *curname);
+extern char *pltsql_demangle_curname(char *curname);
+
+
+/*
  * Functions in string.c
  */
 void		prepare_format_string(StringInfo buf, char *msg_string, int nargs,

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5467,6 +5467,10 @@ makeDeclareCursorStatement(TSqlParser::Declare_cursorContext *ctx)
 	for (auto pctx : ctx->declare_cursor_options())
 			cursor_option = read_extended_cursor_option(pctx, cursor_option);
 
+	/* Default type should be FORWARD_ONLY */
+	if ((cursor_option & TSQL_CURSOR_OPT_SCROLL) == 0)
+		cursor_option |= (CURSOR_OPT_NO_SCROLL | TSQL_CURSOR_OPT_FORWARD_ONLY);
+
 	/* ANSI grammar */
 	if (ctx->SCROLL())
 	{

--- a/test/JDBC/expected/BABEL-1331.out
+++ b/test/JDBC/expected/BABEL-1331.out
@@ -4,7 +4,7 @@ go
 ~~ROW COUNT: 5~~
 
 
-declare cur cursor for select * from t_babel_1331
+DECLARE cur CURSOR SCROLL FOR SELECT * FROM t_babel_1331
 open cur
 fetch cur
 fetch next from cur

--- a/test/JDBC/expected/BABEL_4585.out
+++ b/test/JDBC/expected/BABEL_4585.out
@@ -1,0 +1,317 @@
+CREATE TABLE babel_4585_t1(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t1 values('2000-12-12');
+INSERT INTO babel_4585_t1 values('1000-01-01');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4585_t2(id INT);
+GO
+
+# JIRA
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+# Cursor should default to type NO SCROLL
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH PRIOR FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor can only scan forward)~~
+
+
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal)
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+BEGIN TRAN
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+
+# Use table which will be dropped through rollback -> open cursor after table dropped should throw error
+BEGIN TRAN
+GO
+CREATE TABLE babel_4585_t3(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t3 values('2000-12-12');
+INSERT INTO babel_4585_t3 values('1000-01-01');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+ROLLBACK
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_4585_t3" does not exist)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+DROP TABLE IF EXISTS babel_4585_t1, babel_4585_t2, babel_4585_t2
+GO

--- a/test/JDBC/expected/BABEL_4585.out
+++ b/test/JDBC/expected/BABEL_4585.out
@@ -49,7 +49,7 @@ GO
 
 
 
-# declare cur -> open cur -> insert stmt (forces holdpinned portal)
+# declare cur -> open cur -> insert stmt 
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
@@ -83,7 +83,7 @@ int
 ~~ROW COUNT: 1~~
 
 
-# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+# declare cur -> open cur -> insert stmt -> fetch error -> close and reopen cur
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
@@ -132,30 +132,30 @@ int
 ~~ROW COUNT: 1~~
 
 
-# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+# declare cur -> open cur -> begin tran -> insert stmt -> commit -> fetch next
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 BEGIN TRAN
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
 GO
 ~~START~~
-int
-0
+int#!#varchar
+0#!# ==> trancount
 ~~END~~
 
 ~~ROW COUNT: 1~~
 
 ~~START~~
-int
-1
+int#!#varchar
+1#!# ==> trancount
 ~~END~~
 
 ~~START~~
@@ -164,8 +164,8 @@ int
 ~~END~~
 
 ~~START~~
-int
-0
+int#!#varchar
+0#!# ==> trancount
 ~~END~~
 
 ~~START~~
@@ -186,17 +186,17 @@ int
 ~~ROW COUNT: 1~~
 
 
-# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+# begin tran -> declare cur -> open cur -> insert stmt -> fetch -> fetch -> commit
 BEGIN TRAN
 GO
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
@@ -204,8 +204,8 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-int
-1
+int#!#varchar
+1#!# ==> trancount
 ~~END~~
 
 ~~START~~
@@ -220,8 +220,8 @@ int
 ~~ERROR (Message: data out of range for datetime)~~
 
 ~~START~~
-int
-0
+int#!#varchar
+0#!# ==> trancount
 ~~END~~
 
 ~~ERROR (Code: 517)~~
@@ -256,11 +256,11 @@ GO
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 ROLLBACK
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 OPEN date_cursor
@@ -272,8 +272,8 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-int
-1
+int#!#varchar
+1#!# ==> trancount
 ~~END~~
 
 ~~START~~
@@ -288,8 +288,8 @@ int
 ~~ERROR (Message: data out of range for datetime)~~
 
 ~~START~~
-int
-0
+int#!#varchar
+0#!# ==> trancount
 ~~END~~
 
 ~~START~~
@@ -310,6 +310,200 @@ GO
 int
 0
 ~~END~~
+
+
+# begin tran -> begin tran -> declare cur -> open cur -> commit -> fetch  -> commit -> fetch
+BEGIN TRAN
+GO
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!# ==> trancount
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int#!#varchar
+0#!# ==> trancount
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+3
+~~END~~
+
+~~ROW COUNT: 3~~
+
+
+# begin tran -> save tran -> declare cur -> open cur -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!# ==> trancount
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int#!#varchar
+0#!# ==> trancount
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~ROW COUNT: 2~~
+
+
+# begin tran -> declare cur -> open cur -> save tran -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SAVE TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!# ==> trancount
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int#!#varchar
+0#!# ==> trancount
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~ROW COUNT: 2~~
 
 
 

--- a/test/JDBC/expected/BABEL_4585_SCROLL.out
+++ b/test/JDBC/expected/BABEL_4585_SCROLL.out
@@ -1,0 +1,239 @@
+CREATE TABLE babel_4585_t1(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t1 values('2000-12-12');
+INSERT INTO babel_4585_t1 values('1000-01-01');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4585_t2(id INT);
+GO
+
+# JIRA
+DECLARE date_cursor CURSOR SCROLL SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor "date_cursor" does not exist)~~
+
+
+# Cursor should default to type NO SCROLL
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH PRIOR FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~START~~
+int
+~~END~~
+
+
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal)
+#FETCH NEXT FROM date_cursor
+#FETCH NEXT FROM date_cursor
+#CLOSE date_cursor
+#DEALLOCATE date_cursor
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+BEGIN TRAN
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~START~~
+int
+0
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~START~~
+int
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor "date_cursor" does not exist)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+
+# Use table which will be dropped through rollback -> open cursor after table dropped should throw error
+BEGIN TRAN
+GO
+CREATE TABLE babel_4585_t3(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t3 values('2000-12-12');
+INSERT INTO babel_4585_t3 values('1000-01-01');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+ROLLBACK
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+DROP TABLE IF EXISTS babel_4585_t1, babel_4585_t2, babel_4585_t2
+GO

--- a/test/JDBC/expected/BABEL_4585_SCROLL.out
+++ b/test/JDBC/expected/BABEL_4585_SCROLL.out
@@ -72,7 +72,7 @@ int
 ~~END~~
 
 
-# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+# declare cur -> open cur -> insert stmt -> fetch error -> close and reopen cur
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
@@ -99,23 +99,23 @@ int
 ~~END~~
 
 
-# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+# declare cur -> open cur -> begin tran -> insert stmt -> commit -> fetch next
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 BEGIN TRAN
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
 GO
 ~~START~~
-int
-0
+int#!#varchar
+0#!# ==> trancount
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
@@ -130,17 +130,17 @@ int
 ~~END~~
 
 
-# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+# begin tran -> declare cur -> open cur -> insert stmt -> fetch -> fetch -> commit
 BEGIN TRAN
 GO
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
@@ -148,8 +148,8 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-int
-1
+int#!#varchar
+1#!# ==> trancount
 ~~END~~
 
 ~~START~~
@@ -164,8 +164,8 @@ int
 ~~ERROR (Message: data out of range for datetime)~~
 
 ~~START~~
-int
-0
+int#!#varchar
+0#!# ==> trancount
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~
@@ -200,11 +200,11 @@ GO
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 ROLLBACK
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 OPEN date_cursor
@@ -216,8 +216,8 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-int
-1
+int#!#varchar
+1#!# ==> trancount
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~
@@ -232,6 +232,136 @@ GO
 int
 0
 ~~END~~
+
+
+# begin tran -> begin tran -> declare cur -> open cur -> commit -> fetch  -> commit -> fetch
+BEGIN TRAN
+GO
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!# ==> trancount
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-24
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+# begin tran -> save tran -> declare cur -> open cur -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!# ==> trancount
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+# begin tran -> declare cur -> open cur -> save tran -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SAVE TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!# ==> trancount
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cursor error: data out of range for datetime, closing date_cursor)~~
+
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+~~START~~
+int
+0
+~~END~~
+
 
 
 

--- a/test/JDBC/input/BABEL-1331.sql
+++ b/test/JDBC/input/BABEL-1331.sql
@@ -2,7 +2,7 @@ create table t_babel_1331 (a int, b int);
 insert into t_babel_1331 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
 go
 
-declare cur cursor for select * from t_babel_1331
+DECLARE cur CURSOR SCROLL FOR SELECT * FROM t_babel_1331
 open cur
 fetch cur
 fetch next from cur

--- a/test/JDBC/input/BABEL_4585.sql
+++ b/test/JDBC/input/BABEL_4585.sql
@@ -1,0 +1,132 @@
+CREATE TABLE babel_4585_t1(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t1 values('2000-12-12');
+INSERT INTO babel_4585_t1 values('1000-01-01');
+GO
+
+CREATE TABLE babel_4585_t2(id INT);
+GO
+
+# JIRA
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+# Cursor should default to type NO SCROLL
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH PRIOR FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal)
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+BEGIN TRAN
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+
+# Use table which will be dropped through rollback -> open cursor after table dropped should throw error
+BEGIN TRAN
+GO
+CREATE TABLE babel_4585_t3(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t3 values('2000-12-12');
+INSERT INTO babel_4585_t3 values('1000-01-01');
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+ROLLBACK
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+
+DROP TABLE IF EXISTS babel_4585_t1, babel_4585_t2, babel_4585_t2
+GO

--- a/test/JDBC/input/BABEL_4585.sql
+++ b/test/JDBC/input/BABEL_4585.sql
@@ -26,7 +26,7 @@ DEALLOCATE date_cursor
 GO
 
 
-# declare cur -> open cur -> insert stmt (forces holdpinned portal)
+# declare cur -> open cur -> insert stmt 
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
@@ -40,7 +40,7 @@ SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
 
-# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+# declare cur -> open cur -> insert stmt -> fetch error -> close and reopen cur
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
@@ -58,16 +58,16 @@ SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
 
-# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+# declare cur -> open cur -> begin tran -> insert stmt -> commit -> fetch next
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 BEGIN TRAN
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
@@ -77,17 +77,17 @@ SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
 
-# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+# begin tran -> declare cur -> open cur -> insert stmt -> fetch -> fetch -> commit
 BEGIN TRAN
 GO
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
@@ -109,15 +109,89 @@ GO
 DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 ROLLBACK
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 OPEN date_cursor
 FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> begin tran -> declare cur -> open cur -> commit -> fetch  -> commit -> fetch
+BEGIN TRAN
+GO
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> save tran -> declare cur -> open cur -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> declare cur -> open cur -> save tran -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SAVE TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor

--- a/test/JDBC/input/BABEL_4585_SCROLL.sql
+++ b/test/JDBC/input/BABEL_4585_SCROLL.sql
@@ -1,0 +1,132 @@
+CREATE TABLE babel_4585_t1(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t1 values('2000-12-12');
+INSERT INTO babel_4585_t1 values('1000-01-01');
+GO
+
+CREATE TABLE babel_4585_t2(id INT);
+GO
+
+# JIRA
+DECLARE date_cursor CURSOR SCROLL SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+# Cursor should default to type NO SCROLL
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+FETCH PRIOR FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal)
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+#FETCH NEXT FROM date_cursor
+#FETCH NEXT FROM date_cursor
+#CLOSE date_cursor
+#DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+BEGIN TRAN
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+COMMIT
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+
+# Use table which will be dropped through rollback -> open cursor after table dropped should throw error
+BEGIN TRAN
+GO
+CREATE TABLE babel_4585_t3(a VARCHAR(10));
+GO
+INSERT INTO babel_4585_t3 values('2000-12-12');
+INSERT INTO babel_4585_t3 values('1000-01-01');
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount AS ['TRAN NEST COUNT']
+ROLLBACK
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+SELECT @@trancount AS ['TRAN NEST COUNT']
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+OPEN date_cursor
+FETCH NEXT FROM date_cursor
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+
+DROP TABLE IF EXISTS babel_4585_t1, babel_4585_t2, babel_4585_t2
+GO

--- a/test/JDBC/input/BABEL_4585_SCROLL.sql
+++ b/test/JDBC/input/BABEL_4585_SCROLL.sql
@@ -40,7 +40,7 @@ SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
 
-# declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch error -> close and reopen cur
+# declare cur -> open cur -> insert stmt -> fetch error -> close and reopen cur
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
@@ -58,16 +58,16 @@ SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
 
-# declare cur -> open cur -> begin tran -> insert stmt (forces holdpinned portal) -> commit -> fetch next
+# declare cur -> open cur -> begin tran -> insert stmt -> commit -> fetch next
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 BEGIN TRAN
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
@@ -77,17 +77,17 @@ SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
 
-# begin tran -> declare cur -> open cur -> insert stmt (forces holdpinned portal) -> fetch -> fetch -> commit
+# begin tran -> declare cur -> open cur -> insert stmt -> fetch -> fetch -> commit
 BEGIN TRAN
 GO
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
 COMMIT
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 DEALLOCATE date_cursor
@@ -109,11 +109,11 @@ GO
 DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t3
 OPEN date_cursor
 INSERT INTO babel_4585_t2 VALUES (1);
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 ROLLBACK
 FETCH NEXT FROM date_cursor
 FETCH NEXT FROM date_cursor
-SELECT @@trancount AS ['TRAN NEST COUNT']
+SELECT @@trancount, ' ==> trancount'
 FETCH NEXT FROM date_cursor
 CLOSE date_cursor
 OPEN date_cursor
@@ -126,6 +126,81 @@ GO
 SELECT COUNT(*) FROM babel_4585_t2
 DELETE FROM babel_4585_t2
 GO
+
+# begin tran -> begin tran -> declare cur -> open cur -> commit -> fetch  -> commit -> fetch
+BEGIN TRAN
+GO
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> save tran -> declare cur -> open cur -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
+# begin tran -> declare cur -> open cur -> save tran -> insert stmt -> rollback to -> fetch -> commit -> fetch
+BEGIN TRAN
+GO
+DECLARE date_cursor CURSOR SCROLL FOR SELECT DATEDIFF(Year, GetDate(), a) FROM babel_4585_t1
+OPEN date_cursor
+SAVE TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (1);
+SELECT @@trancount, ' ==> trancount'
+ROLLBACK TRAN sp1
+INSERT INTO babel_4585_t2 VALUES (2);
+FETCH NEXT FROM date_cursor
+COMMIT
+INSERT INTO babel_4585_t2 VALUES (3);
+FETCH NEXT FROM date_cursor
+SELECT @@trancount, ' ==> trancount'
+FETCH NEXT FROM date_cursor
+CLOSE date_cursor
+DEALLOCATE date_cursor
+GO
+
+SELECT COUNT(*) FROM babel_4585_t2
+DELETE FROM babel_4585_t2
+GO
+
 
 
 DROP TABLE IF EXISTS babel_4585_t1, babel_4585_t2, babel_4585_t2


### PR DESCRIPTION
### Description

On transaction boundaries, to prevent pinned portals (cursors) from being dropped, we hold them. Holding a portal internal fetches all the required tuples and stores them in the portal tuple store. This holding process could possible fail and fail our original command/error handling as well.

As a fix we put the executor run for persist portal inside try catch block and completely consume the error, if any. While for SCROLL cursors we simply unpin the portal and rethrow the error i.e. end execution.

We call HoldPinnedPortals from two places.
1. **PLTSQL Error handling:**
- No need for internal subtransaction for holding portal in this case, since we are anyway going to abort the transaction.
- We need to protect the original error in this case, since holdPinnedPortal can throw an error of its own & we may consume this error without rethrowing it.
2. **EXECSQL Stmt:** 
- If **txn command** then do hold portal before executing the txn command. (after txn command has been executed we are not in a state to create a new internal sub transaction for out hold portal step)
- If **NOT a txn command** - hold portal after executing the stmt & before commiting the transaction.

Not rethrowing the error means some clean up should be done to restore the state. (Releasing locks, clean up executor, guc level, restore user id etc)
In case of error while persisiting portals we rely on the following transaction/sub transaction abort to do the clean up. We transfer the portal->resowner to the current transaction resowner to make this happen. This also means that caller should ensures that transaction abort should be done after error in `pltsql_persist_holdable_cursor_executor`.

### Issues Resolved

[BABEL-4585]

#### Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/292

#### Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2251

### Test Scenarios Covered ###

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).