### PR TITLE
Implemented sys.availability_replicas and sys.availability_groups as empty views 

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -3158,3 +3158,53 @@ SELECT
     CAST('' as sys.NVARCHAR(60)) AS state_desc
 WHERE FALSE;
 GRANT SELECT ON sys.database_permissions TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.availability_replicas 
+AS SELECT  
+    CAST(NULL as sys.UNIQUEIDENTIFIER) AS replica_id
+    , CAST(NULL as sys.UNIQUEIDENTIFIER) AS group_id
+    , CAST(0 as INT) AS replica_metadata_id
+    , CAST(NULL as sys.NVARCHAR(256)) AS replica_server_name
+    , CAST(NULL as sys.VARBINARY(85)) AS owner_sid
+    , CAST(NULL as sys.NVARCHAR(128)) AS endpoint_url
+    , CAST(0 as sys.TINYINT) AS availability_mode
+    , CAST(NULL as sys.NVARCHAR(60)) AS availability_mode_desc
+    , CAST(0 as sys.TINYINT) AS failover_mode
+    , CAST(NULL as sys.NVARCHAR(60)) AS failover_mode_desc
+    , CAST(0 as INT) AS session_timeout
+    , CAST(0 as sys.TINYINT) AS primary_role_allow_connections
+    , CAST(NULL as sys.NVARCHAR(60)) AS primary_role_allow_connections_desc
+    , CAST(0 as sys.TINYINT) AS secondary_role_allow_connections
+    , CAST(NULL as sys.NVARCHAR(60)) AS secondary_role_allow_connections_desc
+    , CAST(NULL as sys.DATETIME) AS create_date
+    , CAST(NULL as sys.DATETIME) AS modify_date
+    , CAST(0 as INT) AS backup_priority
+    , CAST(NULL as sys.NVARCHAR(256)) AS read_only_routing_url
+    , CAST(NULL as sys.NVARCHAR(256)) AS read_write_routing_url
+    , CAST(0 as sys.TINYINT) AS seeding_mode
+    , CAST(NULL as sys.NVARCHAR(60)) AS seeding_mode_desc
+WHERE FALSE;
+GRANT SELECT ON sys.availability_replicas TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.availability_groups 
+AS SELECT  
+    CAST(NULL as sys.UNIQUEIDENTIFIER) AS group_id
+    , CAST(NULL as sys.SYSNAME) AS name
+    , CAST(NULL as sys.NVARCHAR(40)) AS resource_id
+    , CAST(NULL as sys.NVARCHAR(40)) AS resource_group_id
+    , CAST(0 as INT) AS failure_condition_level
+    , CAST(0 as INT) AS health_check_timeout
+    , CAST(0 as sys.TINYINT) AS automated_backup_preference
+    , CAST(NULL as sys.NVARCHAR(60)) AS automated_backup_preference_desc
+    , CAST(0 as SMALLINT) AS version
+    , CAST(0 as sys.BIT) AS basic_features
+    , CAST(0 as sys.BIT) AS dtc_support
+    , CAST(0 as sys.BIT) AS db_failover
+    , CAST(0 as sys.BIT) AS is_distributed
+    , CAST(0 as sys.TINYINT) AS cluster_type
+    , CAST(NULL as sys.NVARCHAR(60)) AS cluster_type_desc
+    , CAST(0 as INT) AS required_synchronized_secondaries_to_commit
+    , CAST(0 as sys.BIGINT) AS sequence_number
+    , CAST(0 as sys.BIT) AS is_contained
+WHERE FALSE;
+GRANT SELECT ON sys.availability_groups TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.7.0--2.8.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.7.0--2.8.0.sql
@@ -215,6 +215,56 @@ LANGUAGE C
 AS 'babelfishpg_tsql', 'remove_createrole_from_logins';
 CALL sys.bbf_remove_createrole_from_logins();
 
+CREATE OR REPLACE VIEW sys.availability_replicas 
+AS SELECT  
+    CAST(NULL as sys.UNIQUEIDENTIFIER) AS replica_id
+    , CAST(NULL as sys.UNIQUEIDENTIFIER) AS group_id
+    , CAST(0 as INT) AS replica_metadata_id
+    , CAST(NULL as sys.NVARCHAR(256)) AS replica_server_name
+    , CAST(NULL as sys.VARBINARY(85)) AS owner_sid
+    , CAST(NULL as sys.NVARCHAR(128)) AS endpoint_url
+    , CAST(0 as sys.TINYINT) AS availability_mode
+    , CAST(NULL as sys.NVARCHAR(60)) AS availability_mode_desc
+    , CAST(0 as sys.TINYINT) AS failover_mode
+    , CAST(NULL as sys.NVARCHAR(60)) AS failover_mode_desc
+    , CAST(0 as INT) AS session_timeout
+    , CAST(0 as sys.TINYINT) AS primary_role_allow_connections
+    , CAST(NULL as sys.NVARCHAR(60)) AS primary_role_allow_connections_desc
+    , CAST(0 as sys.TINYINT) AS secondary_role_allow_connections
+    , CAST(NULL as sys.NVARCHAR(60)) AS secondary_role_allow_connections_desc
+    , CAST(NULL as sys.DATETIME) AS create_date
+    , CAST(NULL as sys.DATETIME) AS modify_date
+    , CAST(0 as INT) AS backup_priority
+    , CAST(NULL as sys.NVARCHAR(256)) AS read_only_routing_url
+    , CAST(NULL as sys.NVARCHAR(256)) AS read_write_routing_url
+    , CAST(0 as sys.TINYINT) AS seeding_mode
+    , CAST(NULL as sys.NVARCHAR(60)) AS seeding_mode_desc
+WHERE FALSE;
+GRANT SELECT ON sys.availability_replicas TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.availability_groups 
+AS SELECT  
+    CAST(NULL as sys.UNIQUEIDENTIFIER) AS group_id
+    , CAST(NULL as sys.SYSNAME) AS name
+    , CAST(NULL as sys.NVARCHAR(40)) AS resource_id
+    , CAST(NULL as sys.NVARCHAR(40)) AS resource_group_id
+    , CAST(0 as INT) AS failure_condition_level
+    , CAST(0 as INT) AS health_check_timeout
+    , CAST(0 as sys.TINYINT) AS automated_backup_preference
+    , CAST(NULL as sys.NVARCHAR(60)) AS automated_backup_preference_desc
+    , CAST(0 as SMALLINT) AS version
+    , CAST(0 as sys.BIT) AS basic_features
+    , CAST(0 as sys.BIT) AS dtc_support
+    , CAST(0 as sys.BIT) AS db_failover
+    , CAST(0 as sys.BIT) AS is_distributed
+    , CAST(0 as sys.TINYINT) AS cluster_type
+    , CAST(NULL as sys.NVARCHAR(60)) AS cluster_type_desc
+    , CAST(0 as INT) AS required_synchronized_secondaries_to_commit
+    , CAST(0 as sys.BIGINT) AS sequence_number
+    , CAST(0 as sys.BIT) AS is_contained
+WHERE FALSE;
+GRANT SELECT ON sys.availability_groups TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/sys_availability_groups-vu-cleanup.out
+++ b/test/JDBC/expected/sys_availability_groups-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP VIEW sys_availability_groups_test_view
+GO
+
+DROP PROC sys_availability_groups_test_proc
+GO
+
+DROP FUNCTION sys_availability_groups_test_func
+GO

--- a/test/JDBC/expected/sys_availability_groups-vu-prepare.out
+++ b/test/JDBC/expected/sys_availability_groups-vu-prepare.out
@@ -1,0 +1,17 @@
+CREATE VIEW sys_availability_groups_test_view
+AS
+    SELECT * FROM sys.availability_groups;
+GO
+
+CREATE PROC sys_availability_groups_test_proc
+AS
+    SELECT * FROM sys.availability_groups
+GO
+
+CREATE FUNCTION sys_availability_groups_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.availability_groups)
+END
+GO

--- a/test/JDBC/expected/sys_availability_groups-vu-verify.out
+++ b/test/JDBC/expected/sys_availability_groups-vu-verify.out
@@ -1,0 +1,28 @@
+SELECT * FROM sys.availability_groups
+GO
+~~START~~
+uniqueidentifier#!#varchar#!#nvarchar#!#nvarchar#!#int#!#int#!#tinyint#!#nvarchar#!#smallint#!#bit#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#int#!#bigint#!#bit
+~~END~~
+
+
+SELECT * FROM sys_availability_groups_test_view
+GO
+~~START~~
+uniqueidentifier#!#varchar#!#nvarchar#!#nvarchar#!#int#!#int#!#tinyint#!#nvarchar#!#smallint#!#bit#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#int#!#bigint#!#bit
+~~END~~
+
+
+EXEC sys_availability_groups_test_proc
+GO
+~~START~~
+uniqueidentifier#!#varchar#!#nvarchar#!#nvarchar#!#int#!#int#!#tinyint#!#nvarchar#!#smallint#!#bit#!#bit#!#bit#!#bit#!#tinyint#!#nvarchar#!#int#!#bigint#!#bit
+~~END~~
+
+
+SELECT sys_availability_groups_test_func()
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/sys_availability_replicas-vu-cleanup.out
+++ b/test/JDBC/expected/sys_availability_replicas-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP VIEW sys_availability_replicas_test_view
+GO
+
+DROP PROC sys_availability_replicas_test_proc
+GO
+
+DROP FUNCTION sys_availability_replicas_test_func
+GO

--- a/test/JDBC/expected/sys_availability_replicas-vu-prepare.out
+++ b/test/JDBC/expected/sys_availability_replicas-vu-prepare.out
@@ -1,0 +1,17 @@
+CREATE VIEW sys_availability_replicas_test_view
+AS
+    SELECT * FROM sys.availability_replicas;
+GO
+
+CREATE PROC sys_availability_replicas_test_proc
+AS
+    SELECT * FROM sys.availability_replicas
+GO
+
+CREATE FUNCTION sys_availability_replicas_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.availability_replicas)
+END
+GO

--- a/test/JDBC/expected/sys_availability_replicas-vu-verify.out
+++ b/test/JDBC/expected/sys_availability_replicas-vu-verify.out
@@ -1,0 +1,28 @@
+SELECT * FROM sys.availability_replicas
+GO
+~~START~~
+uniqueidentifier#!#uniqueidentifier#!#int#!#nvarchar#!#varbinary#!#nvarchar#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#int#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#datetime#!#datetime#!#int#!#nvarchar#!#nvarchar#!#tinyint#!#nvarchar
+~~END~~
+
+
+SELECT * FROM sys_availability_replicas_test_view
+GO
+~~START~~
+uniqueidentifier#!#uniqueidentifier#!#int#!#nvarchar#!#varbinary#!#nvarchar#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#int#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#datetime#!#datetime#!#int#!#nvarchar#!#nvarchar#!#tinyint#!#nvarchar
+~~END~~
+
+
+EXEC sys_availability_replicas_test_proc
+GO
+~~START~~
+uniqueidentifier#!#uniqueidentifier#!#int#!#nvarchar#!#varbinary#!#nvarchar#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#int#!#tinyint#!#nvarchar#!#tinyint#!#nvarchar#!#datetime#!#datetime#!#int#!#nvarchar#!#nvarchar#!#tinyint#!#nvarchar
+~~END~~
+
+
+SELECT sys_availability_replicas_test_func()
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/input/views/sys_availability_groups-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys_availability_groups-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP VIEW sys_availability_groups_test_view
+GO
+
+DROP PROC sys_availability_groups_test_proc
+GO
+
+DROP FUNCTION sys_availability_groups_test_func
+GO

--- a/test/JDBC/input/views/sys_availability_groups-vu-prepare.sql
+++ b/test/JDBC/input/views/sys_availability_groups-vu-prepare.sql
@@ -1,0 +1,17 @@
+CREATE VIEW sys_availability_groups_test_view
+AS
+    SELECT * FROM sys.availability_groups;
+GO
+
+CREATE PROC sys_availability_groups_test_proc
+AS
+    SELECT * FROM sys.availability_groups
+GO
+
+CREATE FUNCTION sys_availability_groups_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.availability_groups)
+END
+GO

--- a/test/JDBC/input/views/sys_availability_groups-vu-verify.sql
+++ b/test/JDBC/input/views/sys_availability_groups-vu-verify.sql
@@ -1,0 +1,11 @@
+SELECT * FROM sys.availability_groups
+GO
+
+SELECT * FROM sys_availability_groups_test_view
+GO
+
+EXEC sys_availability_groups_test_proc
+GO
+
+SELECT sys_availability_groups_test_func()
+GO

--- a/test/JDBC/input/views/sys_availability_replicas-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys_availability_replicas-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP VIEW sys_availability_replicas_test_view
+GO
+
+DROP PROC sys_availability_replicas_test_proc
+GO
+
+DROP FUNCTION sys_availability_replicas_test_func
+GO

--- a/test/JDBC/input/views/sys_availability_replicas-vu-prepare.sql
+++ b/test/JDBC/input/views/sys_availability_replicas-vu-prepare.sql
@@ -1,0 +1,17 @@
+CREATE VIEW sys_availability_replicas_test_view
+AS
+    SELECT * FROM sys.availability_replicas;
+GO
+
+CREATE PROC sys_availability_replicas_test_proc
+AS
+    SELECT * FROM sys.availability_replicas
+GO
+
+CREATE FUNCTION sys_availability_replicas_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.availability_replicas)
+END
+GO

--- a/test/JDBC/input/views/sys_availability_replicas-vu-verify.sql
+++ b/test/JDBC/input/views/sys_availability_replicas-vu-verify.sql
@@ -1,0 +1,11 @@
+SELECT * FROM sys.availability_replicas
+GO
+
+SELECT * FROM sys_availability_replicas_test_view
+GO
+
+EXEC sys_availability_replicas_test_proc
+GO
+
+SELECT sys_availability_replicas_test_func()
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -421,3 +421,5 @@ sys_certificates
 sys_database_permissions
 BABEL-4606
 babel-4475
+sys_availability_groups
+sys_availability_replicas

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -943,7 +943,6 @@ Operator sys.^(integer,integer)
 Operator sys.^(smallint,smallint)
 Operator sys.^(sys.tinyint,sys.tinyint)
 Operator sys.~(NONE,sys."bit")
-Type sys."bigint"
 Type sys."real"
 Type sys.bbf_varbinary
 Type sys.cursor


### PR DESCRIPTION
### Description

Currently, in newer version of SSMS (SSMS version 19.2), a call to sys.availability_replicas and sys.availability_groups is occurring during databases enumeration in Object Explorer. These views are not in Babelfish, hence SSMS Object Explorer is not able to list user defined databases when connected with babelfish server.
This PR implements sys.availability_replicas and sys.availability_groups as an empty views to resolve this issue with Object Explorer Database enumeration in SSMS version 19.2.

### Test
Tested this PR changes with SSMS version 19.2

Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2184
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved
BABEL-4636

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).