### PR TITLE
Improve performance of sp_tablecollations_100 (spt_tablecollations_view)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -709,7 +709,7 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         c.object_id                      AS object_id,
         CAST(p.relnamespace AS int)      AS schema_id,
         c.column_id                      AS colid,
-        CAST(c.name AS sys.sysname)      AS name,
+        CAST(c.name AS sys.varchar)      AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -709,7 +709,7 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         c.object_id                      AS object_id,
         CAST(p.relnamespace AS int)      AS schema_id,
         c.column_id                      AS colid,
-        c.name                           AS name,
+        CAST(c.name AS sys.sysname)      AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -706,11 +706,10 @@ GRANT ALL on PROCEDURE sys.sp_describe_first_result_set TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
     SELECT
-        o.object_id         AS object_id,
-        o.schema_id         AS schema_id,
+        c.object_id         AS object_id,
+        p.relnamespace      AS schema_id,
         c.column_id         AS colid,
-        CASE WHEN p.attoptions[1] LIKE 'bbf_original_name=%' THEN CAST(split_part(p.attoptions[1], '=', 2) AS sys.VARCHAR)
-			ELSE c.name COLLATE sys.database_default END AS name,
+        c.name              AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,
@@ -718,11 +717,10 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         CAST(c.collation_name AS nvarchar(128)) AS collation_90,
         CAST(c.collation_name AS nvarchar(128)) AS collation_100
     FROM
-        sys.all_columns c INNER JOIN
-        sys.all_objects o ON (c.object_id = o.object_id) JOIN
-        pg_attribute p ON (c.name = p.attname COLLATE sys.database_default AND c.object_id = p.attrelid)
+        sys.all_columns c
+        INNER JOIN pg_catalog.pg_class p ON (c.object_id = p.oid)
     WHERE
-        c.is_sparse = 0 AND p.attnum >= 0;
+        c.is_sparse = 0;
 GRANT SELECT ON sys.spt_tablecollations_view TO PUBLIC;
 
 -- We are limited by what postgres procedures can return here, but IEW may not

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -706,10 +706,10 @@ GRANT ALL on PROCEDURE sys.sp_describe_first_result_set TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
     SELECT
-        c.object_id         AS object_id,
-        p.relnamespace      AS schema_id,
-        c.column_id         AS colid,
-        c.name              AS name,
+        c.object_id                      AS object_id,
+        CAST(p.relnamespace AS int)      AS schema_id,
+        c.column_id                      AS colid,
+        c.name                           AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -2206,7 +2206,7 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         c.object_id                      AS object_id,
         CAST(p.relnamespace AS int)      AS schema_id,
         c.column_id                      AS colid,
-        CAST(c.name AS sys.sysname)      AS name,
+        CAST(c.name AS sys.varchar)      AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -2203,10 +2203,10 @@ GRANT SELECT ON sys.availability_groups TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
     SELECT
-        c.object_id         AS object_id,
-        p.relnamespace      AS schema_id,
-        c.column_id         AS colid,
-        c.name              AS name,
+        c.object_id                      AS object_id,
+        CAST(p.relnamespace AS int)      AS schema_id,
+        c.column_id                      AS colid,
+        c.name                           AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -2201,6 +2201,25 @@ AS SELECT
 WHERE FALSE;
 GRANT SELECT ON sys.availability_groups TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
+    SELECT
+        c.object_id         AS object_id,
+        p.relnamespace      AS schema_id,
+        c.column_id         AS colid,
+        c.name              AS name,
+        CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
+        CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
+        CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,
+        CAST(c.collation_name AS nvarchar(128)) AS collation_28,
+        CAST(c.collation_name AS nvarchar(128)) AS collation_90,
+        CAST(c.collation_name AS nvarchar(128)) AS collation_100
+    FROM
+        sys.all_columns c
+        INNER JOIN pg_catalog.pg_class p ON (c.object_id = p.oid)
+    WHERE
+        c.is_sparse = 0;
+GRANT SELECT ON sys.spt_tablecollations_view TO PUBLIC;
+
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysforeignkeys_deprecated_3_5_0');
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'system_objects_deprecated_3_5_0');
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'syscolumns_deprecated_3_5_0');

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -2206,7 +2206,7 @@ CREATE OR REPLACE VIEW sys.spt_tablecollations_view AS
         c.object_id                      AS object_id,
         CAST(p.relnamespace AS int)      AS schema_id,
         c.column_id                      AS colid,
-        c.name                           AS name,
+        CAST(c.name AS sys.sysname)      AS name,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_28,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_90,
         CAST(CollationProperty(c.collation_name,'tdscollation') AS binary(5)) AS tds_collation_100,


### PR DESCRIPTION
### Description

Make changes to sys.spt_tablecollations_view which is used by sys.sp_tablecollations_100
1.  Remove join on pg_attribute catalog and always use the sys.all_columns.name since we use it everywhere else for column name (no longer try to fetch the original name.)
2. Use pg_catalog.pg_class to fetch schema oid for given object oid instead of sys.all_objects.

### Local Performance Numbers

We first insert 40K tables with 3 columns each. We then run the procedure sys.sp_tablecollations_100 '@tablename'
All steps execute in the same session
**Step 1** EXEC sys.sp_tablecollations_100 'table_19000' (first time in the session takes longer)
**Step 2** EXEC sys.sp_tablecollations_100 'table_29000'
**Step 3** EXEC sys.sp_tablecollations_100 'table_39000' 
                 *-- Now insert another 10K new tables without terminating the current session.*
**Step 4** EXEC sys.sp_tablecollations_100 'table_44000'
**Step 5** EXEC sys.sp_tablecollations_100 'table_49000'

| Step             | After | Before |
| :----------------: | :------: | :----: |
| 1        |   745  | 14581 |
| 2     |   59  | 12294 |
| 3    |  59   | 12369 |
| 4   |  79   | 14886 |
| 5   |  72   | 14257 |

### Issues Resolved

[BABEL-3466]

### Sign-Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).