### PR TITLE
Fix database does not exists error when is_member(), schema_id() function gets called in parallel query mode.

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -431,6 +431,9 @@ InstallExtendedHooks(void)
 
 	pre_exec_tsql_cast_value_hook = exec_tsql_cast_value_hook;
 	exec_tsql_cast_value_hook = pltsql_exec_tsql_cast_value;
+
+	bbf_InitializeParallelDSM_hook = babelfixedparallelstate_insert;
+	bbf_ParallelWorkerMain_hook = babelfixedparallelstate_restore;
 }
 
 void
@@ -491,6 +494,9 @@ UninstallExtendedHooks(void)
 	transform_pivot_clause_hook = pre_transform_pivot_clause_hook;
 	optimize_explicit_cast_hook = prev_optimize_explicit_cast_hook;
 	called_from_tsql_insert_exec_hook = pre_called_from_tsql_insert_exec_hook;
+
+	bbf_InitializeParallelDSM_hook = NULL;
+	bbf_ParallelWorkerMain_hook = NULL;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/session.h
+++ b/contrib/babelfishpg_tsql/src/session.h
@@ -1,6 +1,8 @@
 #ifndef SESSION_H
 #define SESSION_H
 #include "postgres.h"
+#include "multidb.h"
+#include "access/parallel.h"
 
 extern int16 get_cur_db_id(void);
 extern void set_cur_db(int16 id, const char *name);
@@ -11,5 +13,15 @@ extern void check_session_db_access(const char *dn_name);
 extern void set_cur_user_db_and_path(const char *db_name);
 extern void restore_session_properties(void);
 extern void reset_session_properties(void);
+extern void set_cur_db_name_for_parallel_worker(const char* logical_db_name);
+
+/* Hooks for parallel workers for babelfish fixed state */
+extern void babelfixedparallelstate_insert(ParallelContext *pcxt, bool estimate);
+extern void babelfixedparallelstate_restore(shm_toc *toc);
+
+/* Babelfish Fixed-size parallel state */
+typedef struct BabelfishFixedParallelState {
+    char logical_db_name[MAX_BBF_NAMEDATALEND + 1]; 
+} BabelfishFixedParallelState;
 
 #endif

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -6,39 +6,14 @@
 # 5. To add a test, add test name (without extension, ,  and . For example if test file name is TestBigInt.txt write TestBigInt) on a new line
 # These tests are crashing/failing with parallel query mode is on. 
 
-
 # Hangs with unknown cause
 ignore#!#sp_who-vu-prepare
 ignore#!#sp_who-vu-verify
 ignore#!#sp_who-vu-cleanup
 
-# Group 1: BABEL-4481
-ignore#!#Test-sp_addrolemember-vu-prepare
-ignore#!#Test-sp_addrolemember-vu-verify
-ignore#!#Test-sp_addrolemember-vu-cleanup
-ignore#!#Test-sp_droprolemember-vu-prepare
-ignore#!#Test-sp_droprolemember-vu-verify
-ignore#!#Test-sp_droprolemember-vu-cleanup
-
 ignore#!#table-variable-vu-verify
 
-# Other or mixed issues - JIRA-BABEL-4538
-# database "" does not exists. (calls is_member() functions)
-ignore#!#BABEL-1621
-# database "" does not exists. (calls schema_id())
-ignore#!#BABEL-741-vu-verify
-ignore#!#BABEL-2416
-ignore#!#BABEL-2833
-# database "" does not exists. (calls IS_ROLEMEMBER())
-ignore#!#BABEL-ROLE-MEMBER-vu-verify
-ignore#!#BABEL-ROLE-MEMBER
-
-# JIRA - BABEL-4421
-ignore#!#Test-sp_addrolemember-dep-vu-verify
-ignore#!#Test-sp_droprolemember-dep-vu-verify
-ignore#!#babel_table_type
-
-# These test should not get ran in parallel query
+# These test should not get run in parallel query
 ignore#!#BABEL-1363
 
 # Taking too much time to complete. (TIME-OUT FAILURES)


### PR DESCRIPTION
### Description

This PR intends to solve the issue of parallel worker not being able to obtain correct logical database name. Whenever get_cur_db_name() is called, it returns static char current_db_name[] which is initialised as empty. Now, parallel workers are not aware of the database name. For them, it is empty whenever get_cur_db_name() gets called. Hence, we were getting the following error: 
```
database "" does not exist
```
So, to communicate the logical database name and more data related to babelfish we have introduced a struct BabelfishFixedParallelState. Currently BabelfishFixedParallelState has only 1 field, i.e., logical_db_name, we can add more fields to it whenever necessary. Then we will write the logical_db_name in DSM during initialisation (in InitializeParallelDSM) using a hook. Another hook is used while trying to fetch the logical database name in ParallelWorkerMain().

In this way we are introduction a mechanism through which we can communicate any babelfish related information to parallel workers.

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:rcv@amazon.com)
 
### Issues Resolved

BABEL-4538, BABEL-4481, BABEL-4421
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
