### PR TITLE
Fix Invalid Protocol Error when using CachedRowSet with JDBC Driver

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2776,9 +2776,9 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 
 		if (sendRowStat)
 			/* Extra bit for the ROWSTAT column */
-			nullMapSize = (natts >> 3) + 1;
+			nullMapSize = (natts + 1 + 7) >> 3;
 		else
-			nullMapSize = ((natts - 1) >> 3) + 1;
+			nullMapSize = (natts + 7) >> 3;
 
 		nullMap = palloc0(nullMapSize);
 		MemSet(nullMap, 0, nullMapSize * sizeof(int8_t));

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2773,7 +2773,13 @@ TdsPrintTup(TupleTableSlot *slot, DestReceiver *self)
 		 * NBCROW (0xD2). Count the number of nullable columns and build the
 		 * null bitmap just in case while we are at it.
 		 */
-		nullMapSize = (natts + 7) / 8;
+
+		if (sendRowStat)
+			/* Extra bit for the ROWSTAT column */
+			nullMapSize = (natts >> 3) + 1;
+		else
+			nullMapSize = ((natts - 1) >> 3) + 1;
+
 		nullMap = palloc0(nullMapSize);
 		MemSet(nullMap, 0, nullMapSize * sizeof(int8_t));
 		for (attno = 0; attno < natts; attno++)


### PR DESCRIPTION
### Description
When a user uses CachedRowSet API present in jdbc driver , an invalid TDS stream error is thrown by the driver for Babelfish, this is caused due to the improper calculation of **nullMapSize** that is sent after the `NBCROW` row token for `sp_cursorfetch` RPC call. 
According to old logic ,Consider a case where the result set has 32 columns (or any perfect multiple of 8)
```nullMapSize = (natts + 7) / 8;```
This gives us the size as **`4`** but we also send a ROWSTAT column along with sp_cursor* RPC calls (Check `SendCursorResponse`)
So the driver gets the length of columns as 33 instead of 32 from ColMetadata token and uses this information to calculate the size of null map ([link](https://github.com/microsoft/mssql-jdbc/blob/829321f23eecc47dcbcc380e238d5c65e9ac0c56/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java#L788)) which turns out to be **`5`** ,this doesnt cause any immediate issue but will cause the further bytes in the packet to be offset by 1 leading to incorrect values.

The new logic fixes this by adding rowstat column into size calculation and also uses bitshift instead of division to improve performance. 




### Issues Resolved
BABEL-4511

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Test Scenarios Covered ###
- **Use Case Based**
Added Test case for CacheRowSet in JUnit Test Framework





### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).