### PR TITLE
Changed the function TdsSetAtAtStatVariable() to use integer comparis…

### DIFF
--- a/contrib/babelfishpg_common/src/babelfishpg_common.h
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.h
@@ -27,6 +27,13 @@
 #define BBF_Pragma_IgnoreFloatConversionWarning_Pop \
     _Pragma("GCC diagnostic pop")
 
+typedef enum TdsAtAtVarType 
+{
+  RCOUNT_TYPE, 
+  ERR_TYPE, 
+  TRANCOUNT_TYPE
+} TdsAtAtVarType;
+
 typedef struct common_utility_plugin
 {
 	/* Function pointers set up by the plugin */

--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -909,18 +909,26 @@ TdsSetGucStatVariable(const char *guc, bool boolVal, const char *strVal, int int
 }
 
 void
-TdsSetAtAtStatVariable(const char *at_at_var, int intVal, uint64 bigintVal)
+TdsSetAtAtStatVariable(TdsAtAtVarType at_at_var, int intVal, uint64 bigintVal)
 {
 	volatile TdsStatus *vtdsentry = MyTdsStatusEntry;
 
 	PGSTAT_BEGIN_WRITE_ACTIVITY(vtdsentry);
 
-	if (strcmp(at_at_var, "rowcount") == 0)
-		vtdsentry->rowcount = bigintVal;
-	else if (strcmp(at_at_var, "error") == 0)
-		vtdsentry->error = intVal;
-	else if (strcmp(at_at_var, "trancount") == 0)
-		vtdsentry->trancount = intVal;
+  switch (at_at_var)
+  {
+    case RCOUNT_TYPE:
+      vtdsentry->rowcount = bigintVal;
+      break;
+    case ERR_TYPE:
+      vtdsentry->error = intVal;
+      break;
+    case TRANCOUNT_TYPE:
+      vtdsentry->trancount = intVal;
+      break;
+    default:
+      break;
+  }
 
 	PGSTAT_END_WRITE_ACTIVITY(vtdsentry);
 }

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -330,7 +330,7 @@ extern void TdsDefineGucs(void);
 extern void tdsstat_initialize(void);
 extern void tdsstat_bestart(void);
 extern void TdsSetGucStatVariable(const char *guc, bool boolVal, const char *strVal, int intVal);
-extern void TdsSetAtAtStatVariable(const char *at_at_var, int intVal, uint64 bigintVal);
+extern void TdsSetAtAtStatVariable(TdsAtAtVarType at_at_var, int intVal, uint64 bigintVal);
 extern void TdsSetDatabaseStatVariable(int16 db_id);
 extern bool tds_stat_get_activity(Datum *values, bool *nulls, int len, int pid, int curr_backend);
 extern void invalidate_stat_table(void);

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9508,7 +9508,7 @@ exec_set_rowcount(uint64 rowno)
 	rowcount_var = rowno;
 
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->set_at_at_stat_var)
-		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var("rowcount", 0, rowcount_var);
+		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var(RCOUNT_TYPE, 0, rowcount_var);
 }
 
 int			latest_error_code;
@@ -9523,7 +9523,7 @@ exec_set_error(PLtsql_execstate *estate, int error, int pg_error, bool error_map
 	last_error_mapping_failed = error_mapping_failed;
 
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->set_at_at_stat_var)
-		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var("error", latest_error_code, 0);
+		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var(ERR_TYPE, latest_error_code, 0);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1633,7 +1633,7 @@ typedef struct PLtsql_protocol_plugin
 								   bool terminate_batch);
 	char	       *(*get_login_domainname) (void);
 	void		(*set_guc_stat_var) (const char *guc, bool boolVal, const char *strVal, int intVal);
-	void		(*set_at_at_stat_var) (const char *at_at_var, int intVal, uint64 bigintVal);
+	void		(*set_at_at_stat_var) (TdsAtAtVarType at_at_var, int intVal, uint64 bigintVal);
 	void		(*set_db_stat_var) (int16 db_id);
 	bool		(*get_stat_values) (Datum *values, bool *nulls, int len, int pid, int curr_backend);
 	void		(*invalidate_stat_view) (void);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -722,7 +722,7 @@ PLTsqlStartTransaction(char *txnName)
 	++NestedTranCount;
 
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->set_at_at_stat_var)
-		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var("trancount", NestedTranCount, 0);
+		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var(TRANCOUNT_TYPE, NestedTranCount, 0);
 }
 
 void
@@ -746,7 +746,7 @@ PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 	}
 
 	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->set_at_at_stat_var)
-		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var("trancount", NestedTranCount, 0);
+		(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var(TRANCOUNT_TYPE, NestedTranCount, 0);
 }
 
 void
@@ -761,7 +761,7 @@ PLTsqlRollbackTransaction(char *txnName, QueryCompletion *qc, bool chain)
 		NestedTranCount = 0;
 
 		if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->set_at_at_stat_var)
-			(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var("trancount", NestedTranCount, 0);
+			(*pltsql_protocol_plugin_ptr)->set_at_at_stat_var(TRANCOUNT_TYPE, NestedTranCount, 0);
 	}
 	else
 	{


### PR DESCRIPTION
…… (#2255)

Changed the function TdsSetAtAtStatVariable() to use integer comparison with enum instead of string comparison. This is for improved performance since this function is called very often.

Task: BABEL-3799
Signed-off by: Jay Sudrik <jsudrik@amazon.com>

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).