### PR TITLE
[Rel14] Improve defensive code for crash in AtEOXact_Parallel

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -100,6 +100,7 @@ static bool check_noexec (bool *newval, void **extra, GucSource source);
 static bool check_showplan_all (bool *newval, void **extra, GucSource source);
 static bool check_showplan_text (bool *newval, void **extra, GucSource source);
 static bool check_showplan_xml (bool *newval, void **extra, GucSource source);
+static bool check_enable_pg_hint(bool *newval, void **extra, GucSource source);
 static void assign_transform_null_equals (bool newval, void *extra);
 static void assign_ansi_defaults (bool newval, void *extra);
 static void assign_quoted_identifier (bool newval, void *extra);
@@ -380,22 +381,15 @@ static bool check_tsql_version (char **newval, void **extra, GucSource source)
 	return true;
 }
 
-static void assign_enable_pg_hint (bool newval, void *extra)
+static bool
+check_enable_pg_hint(bool *newval, void **extra, GucSource source)
 {
 	/*
      * Parallel workers send data to the leader, not the client. They always
      * send data using pg_hint_plan.enable_hint_plan.
      */
-    if (IsParallelWorker())
+    if (IsParallelWorker() && !InitializingParallelWorker)
     {
-        /*
-         * During parallel worker startup, we want to accept the leader's
-         * hint_plan setting so that anyone who looks at the value in
-         * the worker sees the same value that they would see in the leader.
-         */
-        if (InitializingParallelWorker)
-            return;
-
         /*
          * A change other than during startup, for example due to a SET clause
          * attached to a function definition, should be rejected, as there is
@@ -406,6 +400,16 @@ static void assign_enable_pg_hint (bool newval, void *extra)
                  errmsg("cannot change enable_hint_plan during a parallel operation")));
     }
 
+	return true;
+}
+
+
+static void
+assign_enable_pg_hint(bool newval, void *extra)
+{
+    if (IsParallelWorker())
+		return;
+    
 	if (newval)
 	{
 		/* Will throw an error if pg_hint_plan is not installed */
@@ -1098,7 +1102,7 @@ define_custom_variables(void)
 				 false,
 				 PGC_USERSET,
 				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-				 NULL, assign_enable_pg_hint, NULL);
+				 check_enable_pg_hint, assign_enable_pg_hint, NULL);
 
 	DefineCustomIntVariable("babelfishpg_tsql.insert_bulk_rows_per_batch",
 				gettext_noop("Sets the number of rows per batch to be processed for Insert Bulk"),

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -260,8 +260,24 @@ set_procid(Oid oid)
 static void
 assign_identity_insert(const char *newval, void *extra)
 {
+	/*
+	 * Workers synchronize the parameter at the beginning of each parallel 
+	 * operation. Avoid performing parameter assignment uring parallel operation.
+	 */
 	if (IsParallelWorker())
-		return;
+	{
+		if (InitializingParallelWorker)
+			return;
+
+        /*
+         * A change other than during startup, for example due to a SET clause
+         * attached to a function definition, should be rejected, as there is
+         * nothing we can do inside the worker to make it take effect.
+         */
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TRANSACTION_STATE),
+				 errmsg("cannot change identity_insert during a parallel operation")));
+	}
 
 	if (strcmp(newval, "") != 0)
 	{

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -94,6 +94,7 @@ extern bool pltsql_nocount;
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
 
+static bool check_identity_insert(char **newal, void **extra, GucSource source);
 static void assign_identity_insert(const char *newval, void *extra);
 static void assign_textsize(int newval, void *extra);
 extern Datum init_collid_trans_tab(PG_FUNCTION_ARGS);
@@ -257,18 +258,15 @@ set_procid(Oid oid)
 	procid_var = oid;
 }
 
-static void
-assign_identity_insert(const char *newval, void *extra)
+static bool
+check_identity_insert(char** newval, void **extra, GucSource source)
 {
 	/*
 	 * Workers synchronize the parameter at the beginning of each parallel 
 	 * operation. Avoid performing parameter assignment uring parallel operation.
 	 */
-	if (IsParallelWorker())
+	if (IsParallelWorker() && !InitializingParallelWorker)
 	{
-		if (InitializingParallelWorker)
-			return;
-
         /*
          * A change other than during startup, for example due to a SET clause
          * attached to a function definition, should be rejected, as there is
@@ -278,6 +276,15 @@ assign_identity_insert(const char *newval, void *extra)
 				(errcode(ERRCODE_INVALID_TRANSACTION_STATE),
 				 errmsg("cannot change identity_insert during a parallel operation")));
 	}
+
+	return true;
+}
+
+static void
+assign_identity_insert(const char *newval, void *extra)
+{
+	if (IsParallelWorker())
+		return;
 
 	if (strcmp(newval, "") != 0)
 	{
@@ -3514,7 +3521,7 @@ _PG_init(void)
 							   "",
 							   PGC_USERSET,
 							   GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-							   NULL,
+							   check_identity_insert,
 							   assign_identity_insert,
 							   NULL);
 

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -8,14 +8,6 @@
 
 ignore#!#table-variable-vu-verify
 
-# JIRA - BABEL-4419
-ignore#!#BABEL-1056
-ignore#!#BABEL-GUC-PLAN
-ignore#!#BABEL-3092
-ignore#!#BABEL-COLUMN-CONSTRAINT
-ignore#!#BABEL-1251-vu-verify
-ignore#!#BABEL-1251
-
 # These test should not get run in parallel query
 ignore#!#BABEL-1363
 


### PR DESCRIPTION
### Description
This is to bring two Rel15 commits into Rel14.
https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/939ff048721164270fafd51adb98504a1f8d1957
https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/43bfa08f48dd30fc703688b0cf5b1e8372da48ab

Setting GUC during parallel operation will cause GUC inconsistency
because there is no way to sync the GUC value among parallel workers.

This commit only allows setting insert_identity during parallel
operation initialization.

Previously the parallel mode check happens during GUC assignment for
GUCs enable_pg_hint and identity_insert. This commit follows PG custom
and moves the logic into the GUCs' check_hook function.

Task: BABEL-4340/4419/4423
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).