### PR TITLE
Fix invalid newval assignment in check_version_number and Reenable test cases for parallel query testing on PG14

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/guc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/guc.c
@@ -113,6 +113,17 @@ TdsGucDefaultPacketSizeCheck(int *newvalue, void **extra, GucSource source)
 	return true;
 }
 
+static void
+set_newval_to_product_version(char **newval)
+{
+	free(*newval);
+	*newval = strdup(product_version);
+	if (*newval == NULL)
+			ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("out of memory")));
+}
+
 static bool
 check_version_number(char **newval, void **extra, GucSource source)
 {
@@ -134,7 +145,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by \'.\' ")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 
@@ -143,7 +154,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 
@@ -155,7 +166,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter a valid minor version number between 0 and 255")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 
@@ -167,7 +178,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 		{
 			ereport(WARNING,
 					(errmsg("babelfishpg_tds.product_version cannot be set. Please enter a valid micro version number between 0 and 65535")));
-			*newval = product_version;
+			set_newval_to_product_version(newval);
 			return true;
 		}
 		part++;
@@ -177,7 +188,7 @@ check_version_number(char **newval, void **extra, GucSource source)
 	{
 		ereport(WARNING,
 				(errmsg("babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by \'.\' ")));
-		*newval = product_version;
+		set_newval_to_product_version(newval);
 		return true;
 	}
 

--- a/test/JDBC/expected/parallel_query/BABEL-1363.out
+++ b/test/JDBC/expected/parallel_query/BABEL-1363.out
@@ -1,28 +1,51 @@
--- parallel_query_expected
 -- NOTE: this test should not run in parallel due to DB config change.
 GO
 
 -- tsql
+
 -- VariableSetStmt doens't work in JDBC. use workaround
 DECLARE @orig_force_parallel_mode varchar(10);
 SET @orig_force_parallel_mode = (SELECT current_setting('force_parallel_mode'));
-
 SELECT 'enable force_parallel_mode' FROM (SELECT
 		set_config('force_parallel_mode', 'on', false)) sq;
 GO
+~~START~~
+varchar
+enable force_parallel_mode
+~~END~~
+
 
 -- tsql
 create table babel_1363_t1 (a int);
 insert into babel_1363_t1 values (1), (2), (3), (4), (5), (6);
 GO
+~~ROW COUNT: 6~~
+
 
 -- psql     currentSchema=master_dbo,public
 explain (costs off) select * from babel_1363_t1;
 GO
+~~START~~
+text
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on babel_1363_t1
+~~END~~
+
 
 -- tsql
 select * from babel_1363_t1;
 GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+~~END~~
+
 
 -- tsql
 DECLARE @orig_force_parallel_mode varchar(10);
@@ -30,6 +53,11 @@ SET @orig_force_parallel_mode = (SELECT current_setting('force_parallel_mode'));
 SELECT 'reset force_parallel_mode' FROM (SELECT
 		set_config('force_parallel_mode', @orig_force_parallel_mode, false)) sq;
 GO
+~~START~~
+varchar
+reset force_parallel_mode
+~~END~~
+
 
 -- tsql
 DROP TABLE babel_1363_t1

--- a/test/JDBC/expected/parallel_query/table-variable-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/table-variable-vu-verify.out
@@ -1,0 +1,278 @@
+--babel-1149
+select * from table_variable_vu_prepareitvf_1(5);
+GO
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+
+select * from table_variable_vu_preparemstvf_1(10);
+GO
+~~START~~
+nvarchar#!#int#!#int
+hello1#!#1#!#100
+~~END~~
+
+
+select table_variable_vu_preparefunc_1(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+exec table_variable_vu_prepareproc_1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+--babel-2647
+SELECT * from dbo.table_variable_vu_preparemstvf_2();
+go
+~~START~~
+int
+0
+~~END~~
+
+
+--babel-2903
+use master;
+go
+
+select * from table_variable_vu_preparet1;
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+~~END~~
+
+
+set BABELFISH_SHOWPLAN_ALL ON;
+go
+
+declare @a int = 5, @b int = 5;
+declare @c int;
+execute table_variable_vu_prepareouter_proc @a, @b;
+select @a, @b;
+go
+~~START~~
+text
+Query Text: ASSIGN @a = SELECT 5
+  Query Text: SELECT 5
+  ->  Result  (cost=0.00..0.01 rows=1 width=4)
+Query Text: ASSIGN @b = SELECT 5
+  Query Text: SELECT 5
+  ->  Result  (cost=0.00..0.01 rows=1 width=4)
+Query Text: EXEC table_variable_vu_prepareouter_proc @a, @b
+  Query Text: DECLARE TABLE @t
+    Query Text: CREATE TEMPORARY TABLE IF NOT EXISTS @t_1 (a int, b int)
+  Query Text: ASSIGN @a = SELECT 3
+    Query Text: SELECT 3
+    ->  Result  (cost=0.00..0.01 rows=1 width=4)
+  Query Text: insert into table_variable_vu_preparet1 values ("@a", "@b");
+  ->  Insert on table_variable_vu_preparet1  (cost=0.00..0.01 rows=0 width=0)
+        ->  Result  (cost=0.00..0.01 rows=1 width=8)
+  Query Text: EXEC table_variable_vu_prepareinner_proc @b
+    Query Text: ASSIGN @b = SELECT (select top 1 a+b from table_variable_vu_preparet1 order by b)
+      Query Text: SELECT (select top 1 a+b from table_variable_vu_preparet1 order by b)
+      ->  Result  (cost=49.55..49.56 rows=1 width=4)
+            InitPlan 1 (returns $0)
+              ->  Limit  (cost=49.55..49.55 rows=1 width=8)
+                    ->  Sort  (cost=49.55..55.20 rows=2260 width=8)
+                          Sort Key: table_variable_vu_preparet1.b NULLS FIRST
+                          ->  Seq Scan on table_variable_vu_preparet1  (cost=0.00..38.25 rows=2260 width=8)
+    Query Text: insert into table_variable_vu_preparet1 values ("@b", "@b");
+    ->  Insert on table_variable_vu_preparet1  (cost=0.00..0.01 rows=0 width=0)
+          ->  Result  (cost=0.00..0.01 rows=1 width=8)
+  Query Text: insert into "@t" select * from table_variable_vu_preparet1;
+  ->  Insert on "@t_1"  (cost=0.00..32.60 rows=0 width=0)
+        ->  Seq Scan on table_variable_vu_preparet1  (cost=0.00..32.60 rows=2260 width=8)
+  Query Text: select * from "@t"
+  ->  Seq Scan on "@t_1"  (cost=0.00..32.60 rows=2260 width=8)
+  Query Text: DROP TABLE @t_1
+Query Text: select "@a", "@b"
+Gather  (cost=0.00..0.01 rows=1 width=8)
+  Workers Planned: 1
+  Single Copy: true
+  ->  Result  (cost=0.00..0.01 rows=1 width=8)
+~~END~~
+
+
+set BABELFISH_SHOWPLAN_ALL Off;
+go
+
+select * from table_variable_vu_preparet1;
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+~~END~~
+
+
+--babel-3101
+select * from table_variable_vu_preparemy_splitstring('this,is,split')
+GO
+~~START~~
+nvarchar
+this
+is
+split
+~~END~~
+
+
+--babel-3088
+use table_variable_vu_preparedb
+go
+
+exec table_variable_vu_prepareproc_2 1;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+aaa
+~~END~~
+
+
+use master
+go
+
+--babel-2034
+SELECT count(*) FROM table_variable_vu_prepareCalculateEasDateTime();
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select * from table_variable_vu_preparemstvf_3(1);
+GO
+~~START~~
+text#!#int#!#int
+hello1#!#1#!#100
+hello2#!#2#!#200
+~~END~~
+
+
+--babel-2676
+-- should return both rows
+select * from table_variable_vu_preparemstvf_conditional(0)
+go
+~~START~~
+text
+hello1
+hello2
+~~END~~
+
+
+-- should only return the first row
+select * from table_variable_vu_preparemstvf_conditional(1)
+go
+~~START~~
+text
+hello1
+~~END~~
+
+
+-- BABEL-3967 - table variable in sp_executesql
+declare @var1 table_variable_vu_type
+insert into @var1 values ('1', 2, 3, 4)
+exec sp_executesql N'EXEC table_variable_vu_proc1 @x = @p0', N'@p0 table_variable_vu_type readonly', @p0=@var1
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+declare @tableVar table_variable_vu_type;
+insert into @tableVar values('1', 2, 3, 4);
+declare @ret int;
+select @ret = table_variable_vu_tvp_function(@tableVar);
+select @ret 
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- double-check that the underlying type for table_variable_vu_type is pass-by-val
+select typbyval from pg_type where typname = 'table_variable_vu_type';
+go
+~~START~~
+bit
+1
+1
+~~END~~
+
+
+declare @tableVar table_variable_vu_schema.table_variable_vu_type
+insert into @tableVar values ('a', 'b'), ('c', 'd')
+select * from @tableVar
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+nvarchar#!#ntext
+a#!#b
+c#!#d
+~~END~~
+
+
+declare @tableVar as table (x int)
+insert into @tableVar values (1),(2),(3)
+select * from @tableVar
+select typbyval from pg_catalog.pg_type where typname like '@tablevar%';
+go
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+~~START~~
+bit
+1
+1
+1
+~~END~~
+
+
+select * from table_variable_vu_func2()
+select typbyval from pg_catalog.pg_type where typname like '@sometable_table_variable_vu_func2%';
+go
+~~START~~
+int#!#varchar
+1234#!#abcd
+~~END~~
+
+~~START~~
+bit
+1
+~~END~~
+
+
+-- BABEL-4337 - check nested TV for null; should not crash but throw an error
+SELECT * FROM tv_nested_func2(NULL)
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: table variable underlying typename is NULL. refname: @t)~~
+

--- a/test/JDBC/input/errorHandling/TestSimpleErrors.sql
+++ b/test/JDBC/input/errorHandling/TestSimpleErrors.sql
@@ -1,3 +1,4 @@
+-- sla_for_parallel_query_enforced 100000
 CREATE TABLE simpleErrorTable (a varchar(15) UNIQUE NOT NULL, b nvarchar(25), c int PRIMARY KEY, d char(15) DEFAULT 'Whoops!', e nchar(25), f datetime, g numeric(4,1) CHECK (g >= 103.5))
 GO
 

--- a/test/JDBC/input/sp_columns_100.sql
+++ b/test/JDBC/input/sp_columns_100.sql
@@ -1,3 +1,4 @@
+-- sla_for_parallel_query_enforced 55000
 -- create tables with most of the datatypes
 create table var(a char(10), b nchar(9), c nvarchar(8), d varchar(7), e text, f ntext, g varbinary(10), h binary(9), i image, j xml)
 go

--- a/test/JDBC/input/table_variables/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-verify.sql
@@ -1,3 +1,4 @@
+-- parallel_query_expected
 --babel-1149
 select * from table_variable_vu_prepareitvf_1(5);
 GO

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -6,23 +6,6 @@
 # 5. To add a test, add test name (without extension, ,  and . For example if test file name is TestBigInt.txt write TestBigInt) on a new line
 # These tests are crashing/failing with parallel query mode is on. 
 
-#BABEL_2_X_DEV PROBLEMETIC TESTS
-
-# TIME-OUT
-ignore#!#TestSimpleErrorsWithImplicitTran
-ignore#!#babel_cursor
-ignore#!#TestDatetime-numeric-representation-vu-prepare
-ignore#!#TestDatetime-numeric-representation-vu-verify
-ignore#!#four-part-names-vu-verify
-ignore#!#sp_columns_100
-ignore#!#sys-has_perms_by_name-vu-verify
-
-
-#crashing
-ignore#!#sys-server_principals-vu-prepare
-ignore#!#sys-server_principals-vu-verify
-ignore#!#sys-server_principals-vu-cleanup
-
 #taking too much time to complete
 ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-prepare
 ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-verify
@@ -30,3 +13,4 @@ ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-cleanup
 ignore#!#BABEL-3013
 ignore#!#BABEL-SP_TABLE_PRIVILEGES
 ignore#!#ISC-Columns-vu-verify
+ignore#!#sys-has_perms_by_name-vu-verify

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -6,106 +6,7 @@
 # 5. To add a test, add test name (without extension, ,  and . For example if test file name is TestBigInt.txt write TestBigInt) on a new line
 # These tests are crashing/failing with parallel query mode is on. 
 
-ignore#!#table-variable-vu-verify
-
-# These test should not get run in parallel query
-ignore#!#BABEL-1363
-
-# Taking too much time to complete. (TIME-OUT FAILURES)
-ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-verify
-ignore#!#BABEL-SP_COLUMNS_MANAGED-dep-vu-verify
-ignore#!#BABEL-SP_TABLES
-ignore#!#ISC-Domains-vu-verify
-ignore#!#Test-sp_rename-vu-prepare
-ignore#!#Test-sp_rename-vu-verify
-ignore#!#Test-sp_rename-vu-cleanup
-ignore#!#BABEL-3013
-ignore#!#BABEL-SP_COLUMN_PRIVILEGES
-ignore#!#BABEL-SP_TABLE_PRIVILEGES
-ignore#!#ISC-Columns-vu-verify
-ignore#!#TestSimpleErrors
-ignore#!#ISC-Views
-ignore#!#TestSimpleErrorsWithXactAbort
-ignore#!#BABEL-2513
-
-
 #BABEL_2_X_DEV PROBLEMETIC TESTS
-# 1st RUN FAILED
-ignore#!#BABEL-1091
-ignore#!#BABEL-1100
-ignore#!#BABEL-VERSION
-
-ignore#!#BABEL-1164
-ignore#!#BABEL-1435
-ignore#!#BABEL-1454
-
-ignore#!#BABEL-2337
-ignore#!#BABEL-2371
-ignore#!#BABEL-2877-vu-verify
-ignore#!#BABEL-3215-vu-verify
-ignore#!#BABEL-LOGIN-vu-verify
-ignore#!#BABEL-LOGIN-USER-EXT
-ignore#!#BABEL-RECURSIVE-CTE
-
-ignore#!#BABEL-ROLE-vu-prepare
-ignore#!#BABEL-ROLE-vu-verify
-ignore#!#BABEL-ROLE-vu-cleanup
-ignore#!#BABEL-ROLE
-ignore#!#BABEL-SP_FKEYS-vu-verify
-ignore#!#BABEL-3121-vu-prepare
-ignore#!#BABEL-3121-vu-verify
-ignore#!#BABEL-3121-vu-cleanup
-ignore#!#BABEL-SP_FKEYS
-ignore#!#BABEL-SP_FKEYS-dep-vu-verify
-ignore#!#BABEL-SP_STORED_PROCEDURES-vu-verify
-ignore#!#BABEL-SP_STORED_PROCEDURES
-ignore#!#BABEL-SP_STORED_PROCEDURES-dep-vu-verify
-ignore#!#BABEL-SYS-DATABASES
-ignore#!#BABEL-UNSUPPORTED
-ignore#!#BABEL-USER-vu-verify
-ignore#!#BABEL-USER
-ignore#!#ISC-Check-Constraints-vu-verify
-ignore#!#ISC-Table_Constraints-vu-verify
-ignore#!#ISC-Table_Constraints
-ignore#!#ISC-Views-vu-verify
-ignore#!#ISC-Views
-ignore#!#Test-sp_rename-dep-vu-verify
-ignore#!#babelfish_authid_login_ext-vu-verify
-ignore#!#babelfish_authid_user_ext-vu-verify
-ignore#!#babelfish_namespace_ext-vu-verify
-ignore#!#bbf_view_def-vu-verify
-ignore#!#column_domain_usage
-ignore#!#constraint_column_usage
-
-ignore#!#forxml-vu-prepare
-ignore#!#forxml-vu-verify
-ignore#!#forxml-vu-cleanup
-ignore#!#sys-default_constraints-vu-verify
-ignore#!#sys-default_constraints
-ignore#!#sys-default_constraints-dep-vu-verify
-
-ignore#!#sys-server_principals
-
-ignore#!#sys-xml_indexes-vu-verify
-
-ignore#!#sys-xml_indexes
-ignore#!#sys_server_principals_dep-vu-verify
-ignore#!#BABEL-guest
-ignore#!#sys-schemas-vu-verify
-ignore#!#sys-schemas
-ignore#!#sys_database_principals_dep-vu-verify
-
-ignore#!#AUTO_ANALYZE-vu-prepare
-ignore#!#AUTO_ANALYZE-vu-verify
-ignore#!#BABEL-4279
-
-#Failing. 
-ignore#!#sys_server_principals_dep-vu-cleanup
-ignore#!#sys_server_principals_dep-vu-prepare
-ignore#!#Test-sp_rename-dep-vu-prepare
-ignore#!#Test-sp_rename-dep-vu-cleanup
-# This test is failing only in github check
-ignore#!#bbf_view_def
 
 # TIME-OUT
 ignore#!#TestSimpleErrorsWithImplicitTran
@@ -121,3 +22,11 @@ ignore#!#sys-has_perms_by_name-vu-verify
 ignore#!#sys-server_principals-vu-prepare
 ignore#!#sys-server_principals-vu-verify
 ignore#!#sys-server_principals-vu-cleanup
+
+#taking too much time to complete
+ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-prepare
+ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-verify
+ignore#!#BABEL-SP_TABLE_PRIVILIGES-vu-cleanup
+ignore#!#BABEL-3013
+ignore#!#BABEL-SP_TABLE_PRIVILEGES
+ignore#!#ISC-Columns-vu-verify


### PR DESCRIPTION
### Description

This commit makes two changes:

1. Re-enabled test cases for parallel query testing on PG14
2. Cherry-pick commit https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1408 - Fix invalid newval assignment in check_version_number. 

### Details

When new value of a GUC version field is set [like this](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/test/JDBC/input/BABEL-VERSION.mix#L2), this value is passed to `check_version_number` function in [tds/guc.c](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/contrib/babelfishpg_tds/src/backend/tds/guc.c#L116) as a `newval`. Memory for the value copy in `newal` is [allocated with strdup](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/ff43eb60c73a7da7d20ea7d691edbc4b67ce0445/src/backend/utils/misc/guc.c#L7517).

When `check_version_number` founds a problem, it re-assigns `newal` [to a product_version](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/contrib/babelfishpg_tds/src/backend/tds/guc.c#L146) that was [initialized with a string literal](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/contrib/babelfishpg_tds/src/backend/tds/guc.c#L42). Original strdupped `newal` value is leaked at this point. When `check_version_number` returns `true` (it happens always) and `parse_and_validate_value` returns, the `newal` pointer is being `free`'d [in the caller function AlterSystemSetConfigFile](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/ff43eb60c73a7da7d20ea7d691edbc4b67ce0445/src/backend/utils/misc/guc.c#L8988) effectively freeing `product_version` value.

When the offending `alter system` is run multiple times, it manifests itself in Valgrind the following way:

```
2023-04-08 14:25:00.314 IST [55573] WARNING:  babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16
2023-04-08 14:25:04.686 IST [55573] WARNING:  babelfishpg_tds.product_version cannot be set. Please enter a valid major version number between 11 and 16
==55573== Invalid free() / delete / delete[] / realloc()
==55573==    at 0x48480E4: free (vg_replace_malloc.c:872)
==55573==    by 0xAD2941: AlterSystemSetConfigFile (guc.c:8988)
==55573==    by 0x92562C: standard_ProcessUtility (utility.c:886)
==55573==    by 0x1528AE7A: call_next_ProcessUtility (tdsutils.c:744)
==55573==    by 0x1528AD4F: tdsutils_ProcessUtility (tdsutils.c:692)
==55573==    by 0x924D6E: ProcessUtility (utility.c:527)
==55573==    by 0x923BE7: PortalRunUtility (pquery.c:1158)
==55573==    by 0x923DE6: PortalRunMulti (pquery.c:1315)
==55573==    by 0x9233CE: PortalRun (pquery.c:791)
==55573==    by 0x91D26F: exec_simple_query (postgres.c:1252)
==55573==    by 0x921739: PostgresMain (postgres.c:4647)
==55573==    by 0x86E44B: libpq_mainfunc (postmaster.c:1554)
==55573==  Address 0x7a0fa70 is 0 bytes inside a block of size 8 free'd
==55573==    at 0x48480E4: free (vg_replace_malloc.c:872)
==55573==    by 0xAD2941: AlterSystemSetConfigFile (guc.c:8988)
==55573==    by 0x92562C: standard_ProcessUtility (utility.c:886)
==55573==    by 0x1528AE7A: call_next_ProcessUtility (tdsutils.c:744)
==55573==    by 0x1528AD4F: tdsutils_ProcessUtility (tdsutils.c:692)
==55573==    by 0x924D6E: ProcessUtility (utility.c:527)
==55573==    by 0x923BE7: PortalRunUtility (pquery.c:1158)
==55573==    by 0x923DE6: PortalRunMulti (pquery.c:1315)
==55573==    by 0x9233CE: PortalRun (pquery.c:791)
==55573==    by 0x91D26F: exec_simple_query (postgres.c:1252)
==55573==    by 0x921739: PostgresMain (postgres.c:4647)
==55573==    by 0x86E44B: libpq_mainfunc (postmaster.c:1554)
==55573==  Block was alloc'd at
==55573==    at 0x484586F: malloc (vg_replace_malloc.c:381)
==55573==    by 0x55E952D: strdup (strdup.c:42)
==55573==    by 0xACC132: guc_strdup (guc.c:5256)
==55573==    by 0xACD80F: InitializeOneGUCOption (guc.c:6089)
==55573==    by 0xAD371A: define_custom_variable (guc.c:9431)
==55573==    by 0xAD3E36: DefineCustomStringVariable (guc.c:9707)
==55573==    by 0x1527BB11: TdsDefineGucs (guc.c:254)
==55573==    by 0x152874A4: _PG_init (tds.c:208)
==55573==    by 0xAB9ABC: internal_load_library (dfmgr.c:289)
==55573==    by 0xAB9647: load_file (dfmgr.c:156)
==55573==    by 0xAC669C: load_libraries (miscinit.c:1668)
==55573==    by 0xAC6785: process_shared_preload_libraries (miscinit.c:1686)
```

It is suggested to copy `product_version` value before assigning it to `newval` and to `free` the old value (that was allocated with `strdup`).


### Issues Resolved

Current behaviour, while being a UB, does not seem to cause problems besides a minor memory leak.

### Test Scenarios Covered ###

[BABEL-VERSION.mix](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/9a6b2cde9ede7ee47c6abdb02499db74d24e1d09/test/JDBC/input/BABEL-VERSION.mix)

Authored-by: Alex Kasko <alex@staticlibs.net>
Co-Authored-by: Dipesh Dhameliya <dddhamel@amazon.com>
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).