### PR TITLE
Fix uninitialised value in SetColMetadataForTvp

### DIFF
--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -506,7 +506,7 @@ SetColMetadataForTvp(ParameterToken temp, const StringInfo message, uint64_t *of
 	char	   *tempString;
 	int			i = 0;
 	char	   *messageData = message->data;
-	StringInfo	tempStringInfo = palloc(sizeof(StringInfoData));
+	StringInfoData	tempStringInfo;
 	uint32_t	collation;
 
 	/* Database-Name.Schema-Name.TableType-Name */
@@ -524,19 +524,21 @@ SetColMetadataForTvp(ParameterToken temp, const StringInfo message, uint64_t *of
 								"has a non-zero length database name specified. Database name is not allowed with a table-valued parameter, "
 								"only schema name and type name are valid.",
 								temp->paramOrdinal + 1, temp->paramMeta.colName.data, 1, 1, temp->type)));
-			initStringInfo(tempStringInfo);
+			initStringInfo(&tempStringInfo);
+			
+			memset(tempStringInfo.data, 0, tempStringInfo.maxlen);
 
 			tempString = palloc0(len * 2);
 			memcpy(tempString, &messageData[*offset], len * 2);
-			TdsUTF16toUTF8StringInfo(tempStringInfo, tempString, len * 2);
+			TdsUTF16toUTF8StringInfo(&tempStringInfo, tempString, len * 2);
 
 			*offset += len * 2;
 			temp->len += len;
 
 			if (i == 1)
-				temp->tvpInfo->tvpTypeSchemaName = tempStringInfo->data;
+				temp->tvpInfo->tvpTypeSchemaName = tempStringInfo.data;
 			else
-				temp->tvpInfo->tvpTypeName = tempStringInfo->data;
+				temp->tvpInfo->tvpTypeName = tempStringInfo.data;
 
 		}
 		else if (i == 2)
@@ -550,7 +552,7 @@ SetColMetadataForTvp(ParameterToken temp, const StringInfo message, uint64_t *of
 		}
 	}
 
-	temp->tvpInfo->tableName = tempStringInfo->data;
+	temp->tvpInfo->tableName = tempStringInfo.data;
 	i = 0;
 
 	memcpy(&isTvpNull, &messageData[*offset], sizeof(uint16));


### PR DESCRIPTION
### Description

Zero out StringInfoData in SetColMetadataForTvp before use. Valgrind runs showed the following errors: 

```
==00:01:38:57.728 30190== VALGRINDERROR-BEGIN
==00:01:38:57.728 30190== Conditional jump or move depends on uninitialised value(s)
==00:01:38:57.728 30190== at 0xB4D6BE: calc_bucket (dynahash.c:920)
==00:01:38:57.728 30190== by 0xB4D7DF: hash_search_with_hash_value (dynahash.c:1012)
==00:01:38:57.728 30190== by 0xB4D724: hash_search (dynahash.c:959)
==00:01:38:57.728 30190== by 0xB37D6D: lookup_type_cache (typcache.c:371)
==00:01:38:57.728 30190== by 0xB3A428: lookup_rowtype_tupdesc_internal (typcache.c:1745)
==00:01:38:57.728 30190== by 0xB3A6AE: lookup_rowtype_tupdesc (typcache.c:1834)
==00:01:38:57.728 30190== by 0xAA9CC9: record_out (rowtypes.c:323)
==00:01:38:57.728 30190== by 0xB46F14: FunctionCall1Coll (fmgr.c:1303)
==00:01:38:57.728 30190== by 0xB47F80: OutputFunctionCall (fmgr.c:1740)
==00:01:38:57.728 30190== by 0xB481A5: OidOutputFunctionCall (fmgr.c:1823)
==00:01:38:57.728 30190== by 0x89DEC38: errdetail_params (tdsrpc.c:463)
==00:01:38:57.728 30190== by 0x89DF500: SPExecuteSQL (tdsrpc.c:596)
==00:01:38:57.728 30190== Uninitialised value was created by a heap allocation
==00:01:38:57.728 30190== at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==00:01:38:57.728 30190== by 0xB72269: AllocSetAlloc (aset.c:920)
==00:01:38:57.728 30190== by 0xB7D635: palloc (mcxt.c:1082)
==00:01:38:57.728 30190== by 0xBAAC1D: initStringInfo (stringinfo.c:63)
==00:01:38:57.728 30190== by 0x89DD0B5: SetColMetadataForTvp (tds_request.h:527)
==00:01:38:57.728 30190== by 0x89E2835: ReadParameters (tdsrpc.c:1703)
==00:01:38:57.728 30190== by 0x89E5FB7: GetRPCRequest (tdsrpc.c:3064)
==00:01:38:57.728 30190== by 0x89C1736: GetTDSRequest (tdsprotocol.c:317)
==00:01:38:57.728 30190== by 0x89C2659: TdsSocketBackend (tdsprotocol.c:597)
==00:01:38:57.728 30190== by 0x89D669C: pe_read_command (tds_srv.c:410)
==00:01:38:57.728 30190== by 0x993F67: ReadCommand (postgres.c:476)
==00:01:38:57.728 30190== by 0x998FF9: PostgresMain (postgres.c:4573)
==00:01:38:57.728 30190== 
==00:01:38:57.728 30190== VALGRINDERROR-END
```

After this fix, we no longer see the valgrind errors above.


### Issues Resolved

[BABEL-4634](https://jira.rds.a2z.com/browse/BABEL-4634)


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).