### PR TITLE
Add tests for toast in ENR change

### DIFF
--- a/test/JDBC/expected/BABEL-4554-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4554-vu-cleanup.out
@@ -1,0 +1,2 @@
+DROP TYPE babel_4554_type
+GO

--- a/test/JDBC/expected/BABEL-4554-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4554-vu-prepare.out
@@ -3,6 +3,7 @@
 CREATE TABLE #babel_4554_temp_table(a varchar(4000), b nvarchar(MAX), c sysname)
 GO
 
+-- 3: table, toast, index on toast
 SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
 GO
 ~~START~~
@@ -10,3 +11,54 @@ int
 3
 ~~END~~
 
+
+DROP TABLE #babel_4554_temp_table
+GO
+
+-- 4: table, toast, index on toast, pkey
+CREATE TABLE #babel_4554_temp_table_2(a sysname primary key, b nvarchar(MAX))
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- 1: index
+CREATE INDEX #babel_4554_idx1 ON #babel_4554_temp_table_2(b)
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+DROP INDEX #babel_4554_idx1 ON #babel_4554_temp_table_2
+GO
+
+DROP TABLE #babel_4554_temp_table_2
+GO
+
+-- Verify that non-ENR tables don't put their toasts in ENR.
+CREATE TYPE babel_4554_type FROM INT
+GO
+
+CREATE TABLE #babel_4554_temp_table_not_enr(a babel_4554_type, b nvarchar(MAX))
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DROP TABLE #babel_4554_temp_table_not_enr
+GO

--- a/test/JDBC/expected/BABEL-4554-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4554-vu-prepare.out
@@ -1,0 +1,12 @@
+
+-- Verify that newly created temp tables have toasts in ENR. 
+CREATE TABLE #babel_4554_temp_table(a varchar(4000), b nvarchar(MAX), c sysname)
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+~~START~~
+int
+3
+~~END~~
+

--- a/test/JDBC/expected/BABEL-4554-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4554-vu-verify.out
@@ -1,0 +1,25 @@
+
+-- We should have no dangling entries here (taken from BABEL-4554 DA)
+select *
+from pg_class where relname in
+(
+   select relname
+    from pg_class c
+    where not exists
+    (
+         SELECT * from pg_class d
+         WHERE c.oid = d.reltoastrelid
+    )
+    AND relname in
+    (
+      select s.relname from pg_stat_all_tables s where s.relname LIKE 'pg_toast_%'
+    )
+    AND pg_table_size(c.oid) = 0
+    AND c.relkind = 't'
+    AND c.relpersistence = 't'
+)
+GO
+~~START~~
+int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#real#!#int#!#int#!#bit#!#bit#!#varchar#!#varchar#!#smallint#!#smallint#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#varchar#!#bit#!#int#!#int#!#int#!#varchar#!#varchar#!#varchar
+~~END~~
+

--- a/test/JDBC/input/BABEL-4554-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4554-vu-cleanup.sql
@@ -1,0 +1,2 @@
+DROP TYPE babel_4554_type
+GO

--- a/test/JDBC/input/BABEL-4554-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4554-vu-prepare.sql
@@ -1,0 +1,7 @@
+-- Verify that newly created temp tables have toasts in ENR. 
+
+CREATE TABLE #babel_4554_temp_table(a varchar(4000), b nvarchar(MAX), c sysname)
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO

--- a/test/JDBC/input/BABEL-4554-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4554-vu-prepare.sql
@@ -3,5 +3,42 @@
 CREATE TABLE #babel_4554_temp_table(a varchar(4000), b nvarchar(MAX), c sysname)
 GO
 
+-- 3: table, toast, index on toast
 SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+
+DROP TABLE #babel_4554_temp_table
+GO
+
+-- 4: table, toast, index on toast, pkey
+CREATE TABLE #babel_4554_temp_table_2(a sysname primary key, b nvarchar(MAX))
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+
+-- 1: index
+CREATE INDEX #babel_4554_idx1 ON #babel_4554_temp_table_2(b)
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+
+DROP INDEX #babel_4554_idx1 ON #babel_4554_temp_table_2
+GO
+
+DROP TABLE #babel_4554_temp_table_2
+GO
+
+-- Verify that non-ENR tables don't put their toasts in ENR.
+CREATE TYPE babel_4554_type FROM INT
+GO
+
+CREATE TABLE #babel_4554_temp_table_not_enr(a babel_4554_type, b nvarchar(MAX))
+GO
+
+SELECT COUNT(*) FROM sys.babelfish_get_enr_list()
+GO
+
+DROP TABLE #babel_4554_temp_table_not_enr
 GO

--- a/test/JDBC/input/BABEL-4554-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4554-vu-verify.sql
@@ -1,0 +1,21 @@
+-- We should have no dangling entries here (taken from BABEL-4554 DA)
+
+select *
+from pg_class where relname in
+(
+   select relname
+    from pg_class c
+    where not exists
+    (
+         SELECT * from pg_class d
+         WHERE c.oid = d.reltoastrelid
+    )
+    AND relname in
+    (
+      select s.relname from pg_stat_all_tables s where s.relname LIKE 'pg_toast_%'
+    )
+    AND pg_table_size(c.oid) = 0
+    AND c.relkind = 't'
+    AND c.relpersistence = 't'
+)
+GO


### PR DESCRIPTION
### Description

Adding toasts to ENR for temp tables. This was originally introduced as part of #2259 , we are cherry-picking just this change into REL15 to fix an issue with orphaned temp toast table entries. 
 
### Issues Resolved
Adding tests for https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/298

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
