### PR TITLE
Added Geometry and Geography datatype related metadata support to the…

### DIFF
--- a/contrib/babelfishpg_common/src/typecode.c
+++ b/contrib/babelfishpg_common/src/typecode.c
@@ -51,7 +51,12 @@ type_info_t type_infos[TOTAL_TYPECODE_COUNT] =
 	{0, 1, "decimal", "decimal", 5, 30, 5},
 	{0, 1, "sysname", "sysname", 5, 31, 5},
 	{0, 1, "rowversion", "timestamp", 8, 32, 3},
-	{0, 1, "timestamp", "timestamp", 8, 33, 3}
+	{0, 1, "timestamp", "timestamp", 8, 33, 3},
+	/*
+	 * Geospatial types cannot be stored in SQL variant so setting sqlvariant header size to 1
+	 */
+	{0, 1, "geometry", "geometry", 5, 34, 1},
+	{0, 1, "geography", "geography", 5, 35, 1}
 };
 
 /* Hash tables to help backward searching (from OID to Persist ID) */

--- a/contrib/babelfishpg_common/src/typecode.h
+++ b/contrib/babelfishpg_common/src/typecode.h
@@ -45,7 +45,7 @@
 #define FIXEDDECIMAL_MULTIPLIER 10000LL
 #endif
 
-#define TOTAL_TYPECODE_COUNT 33
+#define TOTAL_TYPECODE_COUNT 35
 
 struct Node;
 

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -157,6 +157,8 @@ GRANT SELECT ON sys.spt_datatype_info_table TO PUBLIC;
 INSERT INTO sys.spt_datatype_info_table VALUES (N'datetimeoffset', -155, 34, N'''', N'''', N'scale               ', 1, 0, 3, NULL, 0, NULL, N'datetimeoffset', 0, 7, -155, 0, NULL, NULL, 0, 68, 0, 'datetimeoffset');
 INSERT INTO sys.spt_datatype_info_table VALUES (N'time', -154, 16, N'''', N'''', N'scale               ', 1, 0, 3, NULL, 0, NULL, N'time', 0, 7, -154, 0, NULL, NULL, 0, 32, 0, 'time');
 INSERT INTO sys.spt_datatype_info_table VALUES (N'xml', -152, 0, N'N''', N'''', NULL, 1, 1, 0, NULL, 0, NULL, N'xml', NULL, NULL, -152, NULL, NULL, NULL, 0, 2147483646, 0, N'xml');
+INSERT INTO sys.spt_datatype_info_table VALUES (N'geometry', -151, 0, NULL, NULL, NULL, 1, 1, 0, NULL, 0, NULL, N'geometry', NULL, NULL, -151, NULL, NULL, NULL, 0, 2147483646, 23, NULL);
+INSERT INTO sys.spt_datatype_info_table VALUES (N'geography', -151, 0, NULL, NULL, NULL, 1, 1, 0, NULL, 0, NULL, N'geography', NULL, NULL, -151, NULL, NULL, NULL, 0, 2147483646, 23, NULL);
 INSERT INTO sys.spt_datatype_info_table VALUES (N'sql_variant', -150, 8000, NULL, NULL, NULL, 1, 0, 2, NULL, 0, NULL, N'sql_variant', 0, 0, -150, NULL, 10, NULL, 0, 8000, 39, 'sql_variant');
 INSERT INTO sys.spt_datatype_info_table VALUES (N'uniqueidentifier', -11, 36, N'''', N'''', NULL, 1, 0, 2, NULL, 0, NULL, N'uniqueidentifier', NULL, NULL, -11, NULL, NULL, NULL, 0, 16, 37, 'uniqueidentifier');
 INSERT INTO sys.spt_datatype_info_table VALUES (N'ntext', -10, 1073741823, N'N''', N'''', NULL, 1, 1, 1, NULL, 0, NULL, N'ntext', NULL, NULL, -10, NULL, NULL, NULL, 0, 2147483646, 35, NULL);
@@ -283,6 +285,7 @@ BEGIN
   WHEN type in ('text', 'image') THEN length = 2147483647;
   WHEN type = 'ntext' THEN length = 2147483646;
   WHEN type = 'xml' THEN length = 0;
+  WHEN type IN ('geometry', 'geography') THEN length = -1;
   WHEN type = 'sql_variant' THEN length = 8000;
   WHEN type = 'money' THEN length = 21;
   WHEN type = 'sysname' THEN length = (typemod - 4) * 2;
@@ -636,6 +639,8 @@ BEGIN
 		WHEN 'sql_variant' THEN tds_id = 98;
 		WHEN 'datetimeoffset' THEN tds_id = 43;
 		WHEN 'timestamp' THEN tds_id = 173;
+		WHEN 'geometry' THEN tds_id = 240;
+		WHEN 'geography' THEN tds_id = 240;
 		ELSE tds_id = 0;
 	END CASE;
 	RETURN tds_id;

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -57,7 +57,7 @@ $$SELECT
 		THEN 1073741823
 		WHEN type = 'sysname'
 		THEN 128
-		WHEN type = 'xml'
+		WHEN type IN ('xml', 'geometry', 'geography')
 		THEN -1
 		WHEN type = 'sql_variant'
 		THEN 0
@@ -89,7 +89,7 @@ $$SELECT
 		THEN 256
 		WHEN type = 'sql_variant'
 		THEN 0
-		WHEN type = 'xml'
+		WHEN type IN ('xml', 'geometry', 'geography')
 		THEN -1
 	   ELSE null
   END$$;
@@ -112,7 +112,7 @@ $$SELECT
                 THEN 1073741823
                 WHEN type = 'sysname'
                 THEN 128
-                WHEN type = 'xml'
+                WHEN type IN ('xml', 'geometry', 'geography')
                 THEN -1
                 WHEN type = 'sql_variant'
                 THEN 0

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -368,6 +368,7 @@ BEGIN
 			END IF;
 		WHEN v_type in ('binary', 'char', 'bpchar', 'nchar') THEN max_length = 8000;
 		WHEN v_type in ('decimal', 'numeric') THEN max_length = 17;
+		WHEN v_type in ('geometry', 'geography') THEN max_length = -1;
 		ELSE max_length = typemod;
 		END CASE;
 		RETURN max_length;
@@ -1105,7 +1106,12 @@ select
     END as collation_name
   , case when typnotnull then cast(0 as sys.bit) else cast(1 as sys.bit) end as is_nullable
   , CAST(0 as sys.bit) as is_user_defined
-  , CAST(0 as sys.bit) as is_assembly_type
+  , CASE tsql_type_name
+    -- CLR UDT have is_assembly_type = 1
+    WHEN 'geometry' THEN CAST(1 as sys.bit)
+    WHEN 'geography' THEN CAST(1 as sys.bit)
+    ELSE  CAST(0 as sys.bit)
+    END as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , CAST(0 as sys.bit) as is_table_type
@@ -1138,7 +1144,12 @@ select cast(t.typname as sys.sysname) as name
     as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , CAST(1 as sys.bit) as is_user_defined
-  , CAST(0 as sys.bit) as is_assembly_type
+  , CASE tsql_type_name
+    -- CLR UDT have is_assembly_type = 1
+    WHEN 'geometry' THEN CAST(1 as sys.bit)
+    WHEN 'geography' THEN CAST(1 as sys.bit)
+    ELSE  CAST(0 as sys.bit)
+    END as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , case when tt.typrelid is not null then CAST(1 as sys.bit) else CAST(0 as sys.bit) end as is_table_type

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -880,7 +880,12 @@ select
     END as collation_name
   , case when typnotnull then cast(0 as sys.bit) else cast(1 as sys.bit) end as is_nullable
   , CAST(0 as sys.bit) as is_user_defined
-  , CAST(0 as sys.bit) as is_assembly_type
+  , CASE tsql_type_name
+    -- CLR UDT have is_assembly_type = 1
+    WHEN 'geometry' THEN CAST(1 as sys.bit)
+    WHEN 'geography' THEN CAST(1 as sys.bit)
+    ELSE  CAST(0 as sys.bit)
+    END as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , CAST(0 as sys.bit) as is_table_type
@@ -913,7 +918,12 @@ select cast(t.typname as sys.sysname) as name
     as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , CAST(1 as sys.bit) as is_user_defined
-  , CAST(0 as sys.bit) as is_assembly_type
+  , CASE tsql_type_name
+    -- CLR UDT have is_assembly_type = 1
+    WHEN 'geometry' THEN CAST(1 as sys.bit)
+    WHEN 'geography' THEN CAST(1 as sys.bit)
+    ELSE  CAST(0 as sys.bit)
+    END as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , case when tt.typrelid is not null then CAST(1 as sys.bit) else CAST(0 as sys.bit) end as is_table_type

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -880,12 +880,7 @@ select
     END as collation_name
   , case when typnotnull then cast(0 as sys.bit) else cast(1 as sys.bit) end as is_nullable
   , CAST(0 as sys.bit) as is_user_defined
-  , CASE tsql_type_name
-    -- CLR UDT have is_assembly_type = 1
-    WHEN 'geometry' THEN CAST(1 as sys.bit)
-    WHEN 'geography' THEN CAST(1 as sys.bit)
-    ELSE  CAST(0 as sys.bit)
-    END as is_assembly_type
+  , CAST(0 as sys.bit) as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , CAST(0 as sys.bit) as is_table_type
@@ -918,12 +913,7 @@ select cast(t.typname as sys.sysname) as name
     as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , CAST(1 as sys.bit) as is_user_defined
-  , CASE tsql_type_name
-    -- CLR UDT have is_assembly_type = 1
-    WHEN 'geometry' THEN CAST(1 as sys.bit)
-    WHEN 'geography' THEN CAST(1 as sys.bit)
-    ELSE  CAST(0 as sys.bit)
-    END as is_assembly_type
+  , CAST(0 as sys.bit) as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , case when tt.typrelid is not null then CAST(1 as sys.bit) else CAST(0 as sys.bit) end as is_table_type

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
@@ -880,7 +880,12 @@ select
     END as collation_name
   , case when typnotnull then cast(0 as sys.bit) else cast(1 as sys.bit) end as is_nullable
   , CAST(0 as sys.bit) as is_user_defined
-  , CAST(0 as sys.bit) as is_assembly_type
+  , CASE tsql_type_name
+    -- CLR UDT have is_assembly_type = 1
+    WHEN 'geometry' THEN CAST(1 as sys.bit)
+    WHEN 'geography' THEN CAST(1 as sys.bit)
+    ELSE  CAST(0 as sys.bit)
+    END as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , CAST(0 as sys.bit) as is_table_type
@@ -913,7 +918,12 @@ select cast(t.typname as sys.sysname) as name
     as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , CAST(1 as sys.bit) as is_user_defined
-  , CAST(0 as sys.bit) as is_assembly_type
+  , CASE tsql_type_name
+    -- CLR UDT have is_assembly_type = 1
+    WHEN 'geometry' THEN CAST(1 as sys.bit)
+    WHEN 'geography' THEN CAST(1 as sys.bit)
+    ELSE  CAST(0 as sys.bit)
+    END as is_assembly_type
   , CAST(0 as int) as default_object_id
   , CAST(0 as int) as rule_object_id
   , case when tt.typrelid is not null then CAST(1 as sys.bit) else CAST(0 as sys.bit) end as is_table_type
@@ -2201,6 +2211,301 @@ AS SELECT
     , CAST(0 as sys.BIT) AS is_contained
 WHERE FALSE;
 GRANT SELECT ON sys.availability_groups TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.tsql_type_max_length_helper(IN type TEXT, IN typelen INT, IN typemod INT, IN for_sys_types boolean DEFAULT false, IN used_typmod_array boolean DEFAULT false)
+RETURNS SMALLINT
+AS $$
+DECLARE
+	max_length SMALLINT;
+	precision INT;
+	v_type TEXT COLLATE sys.database_default := type;
+BEGIN
+	-- unknown tsql type
+	IF v_type IS NULL THEN
+		RETURN CAST(typelen as SMALLINT);
+	END IF;
+
+	-- if using typmod_array from pg_proc.probin
+	IF used_typmod_array THEN
+		IF v_type = 'sysname' THEN
+			RETURN 256;
+		ELSIF (v_type in ('char', 'bpchar', 'varchar', 'binary', 'varbinary', 'nchar', 'nvarchar'))
+		THEN
+			IF typemod < 0 THEN -- max value. 
+				RETURN -1;
+			ELSIF v_type in ('nchar', 'nvarchar') THEN
+				RETURN (2 * typemod);
+			ELSE
+				RETURN typemod;
+			END IF;
+		END IF;
+	END IF;
+
+	IF typelen != -1 THEN
+		CASE v_type 
+		WHEN 'tinyint' THEN max_length = 1;
+		WHEN 'date' THEN max_length = 3;
+		WHEN 'smalldatetime' THEN max_length = 4;
+		WHEN 'smallmoney' THEN max_length = 4;
+		WHEN 'datetime2' THEN
+			IF typemod = -1 THEN max_length = 8;
+			ELSIF typemod <= 2 THEN max_length = 6;
+			ELSIF typemod <= 4 THEN max_length = 7;
+			ELSEIF typemod <= 7 THEN max_length = 8;
+			-- typemod = 7 is not possible for datetime2 in Babel
+			END IF;
+		WHEN 'datetimeoffset' THEN
+			IF typemod = -1 THEN max_length = 10;
+			ELSIF typemod <= 2 THEN max_length = 8;
+			ELSIF typemod <= 4 THEN max_length = 9;
+			ELSIF typemod <= 7 THEN max_length = 10;
+			-- typemod = 7 is not possible for datetimeoffset in Babel
+			END IF;
+		WHEN 'time' THEN
+			IF typemod = -1 THEN max_length = 5;
+			ELSIF typemod <= 2 THEN max_length = 3;
+			ELSIF typemod <= 4 THEN max_length = 4;
+			ELSIF typemod <= 7 THEN max_length = 5;
+			END IF;
+		WHEN 'timestamp' THEN max_length = 8;
+		ELSE max_length = typelen;
+		END CASE;
+		RETURN max_length;
+	END IF;
+
+	IF typemod = -1 THEN
+		CASE 
+		WHEN v_type in ('image', 'text', 'ntext') THEN max_length = 16;
+		WHEN v_type = 'sql_variant' THEN max_length = 8016;
+		WHEN v_type in ('varbinary', 'varchar', 'nvarchar') THEN 
+			IF for_sys_types THEN max_length = 8000;
+			ELSE max_length = -1;
+			END IF;
+		WHEN v_type in ('binary', 'char', 'bpchar', 'nchar') THEN max_length = 8000;
+		WHEN v_type in ('decimal', 'numeric') THEN max_length = 17;
+		WHEN v_type in ('geometry', 'geography') THEN max_length = -1;
+		ELSE max_length = typemod;
+		END CASE;
+		RETURN max_length;
+	END IF;
+
+	CASE
+	WHEN v_type in ('char', 'bpchar', 'varchar', 'binary', 'varbinary') THEN max_length = typemod - 4;
+	WHEN v_type in ('nchar', 'nvarchar') THEN max_length = (typemod - 4) * 2;
+	WHEN v_type = 'sysname' THEN max_length = (typemod - 4) * 2;
+	WHEN v_type in ('numeric', 'decimal') THEN
+		precision = ((typemod - 4) >> 16) & 65535;
+		IF precision >= 1 and precision <= 9 THEN max_length = 5;
+		ELSIF precision <= 19 THEN max_length = 9;
+		ELSIF precision <= 28 THEN max_length = 13;
+		ELSIF precision <= 38 THEN max_length = 17;
+	ELSE max_length = typelen;
+	END IF;
+	ELSE
+		max_length = typemod;
+	END CASE;
+	RETURN max_length;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION information_schema_tsql._pgtsql_char_max_length(type text, typmod int4) RETURNS integer
+	LANGUAGE sql
+	IMMUTABLE
+	PARALLEL SAFE
+	RETURNS NULL ON NULL INPUT
+	AS
+$$SELECT
+	CASE WHEN type IN ('char', 'nchar', 'varchar', 'nvarchar', 'binary', 'varbinary')
+		THEN CASE WHEN typmod = -1
+			THEN -1
+			ELSE typmod - 4
+			END
+		WHEN type IN ('text', 'image')
+		THEN 2147483647
+		WHEN type = 'ntext'
+		THEN 1073741823
+		WHEN type = 'sysname'
+		THEN 128
+		WHEN type IN ('xml', 'geometry', 'geography')
+		THEN -1
+		WHEN type = 'sql_variant'
+		THEN 0
+		ELSE null
+	END$$;
+
+create or replace function sys.get_tds_id(
+	datatype sys.varchar(50)
+)
+returns INT
+AS $$
+DECLARE
+	tds_id INT;
+BEGIN
+	IF datatype IS NULL THEN
+		RETURN 0;
+	END IF;
+	CASE datatype
+		WHEN 'text' THEN tds_id = 35;
+		WHEN 'uniqueidentifier' THEN tds_id = 36;
+		WHEN 'tinyint' THEN tds_id = 38;
+		WHEN 'smallint' THEN tds_id = 38;
+		WHEN 'int' THEN tds_id = 38;
+		WHEN 'bigint' THEN tds_id = 38;
+		WHEN 'ntext' THEN tds_id = 99;
+		WHEN 'bit' THEN tds_id = 104;
+		WHEN 'float' THEN tds_id = 109;
+		WHEN 'real' THEN tds_id = 109;
+		WHEN 'varchar' THEN tds_id = 167;
+		WHEN 'nvarchar' THEN tds_id = 231;
+		WHEN 'nchar' THEN tds_id = 239;
+		WHEN 'money' THEN tds_id = 110;
+		WHEN 'smallmoney' THEN tds_id = 110;
+		WHEN 'char' THEN tds_id = 175;
+		WHEN 'date' THEN tds_id = 40;
+		WHEN 'datetime' THEN tds_id = 111;
+		WHEN 'smalldatetime' THEN tds_id = 111;
+		WHEN 'numeric' THEN tds_id = 108;
+		WHEN 'xml' THEN tds_id = 241;
+		WHEN 'decimal' THEN tds_id = 106;
+		WHEN 'varbinary' THEN tds_id = 165;
+		WHEN 'binary' THEN tds_id = 173;
+		WHEN 'image' THEN tds_id = 34;
+		WHEN 'time' THEN tds_id = 41;
+		WHEN 'datetime2' THEN tds_id = 42;
+		WHEN 'sql_variant' THEN tds_id = 98;
+		WHEN 'datetimeoffset' THEN tds_id = 43;
+		WHEN 'timestamp' THEN tds_id = 173;
+		WHEN 'geometry' THEN tds_id = 240;
+		WHEN 'geography' THEN tds_id = 240;
+		ELSE tds_id = 0;
+	END CASE;
+	RETURN tds_id;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION information_schema_tsql._pgtsql_char_octet_length(type text, typmod int4) RETURNS integer
+	LANGUAGE sql
+	IMMUTABLE
+	PARALLEL SAFE
+	RETURNS NULL ON NULL INPUT
+	AS
+$$SELECT
+	CASE WHEN type IN ('char', 'varchar', 'binary', 'varbinary')
+		THEN CASE WHEN typmod = -1 /* default typmod */
+			THEN -1
+			ELSE typmod - 4
+			END
+		WHEN type IN ('nchar', 'nvarchar')
+		THEN CASE WHEN typmod = -1 /* default typmod */
+			THEN -1
+			ELSE (typmod - 4) * 2
+			END
+		WHEN type IN ('text', 'image')
+		THEN 2147483647 /* 2^30 + 1 */
+		WHEN type = 'ntext'
+		THEN 2147483646 /* 2^30 */
+		WHEN type = 'sysname'
+		THEN 256
+		WHEN type = 'sql_variant'
+		THEN 0
+		WHEN type IN ('xml', 'geometry', 'geography')
+		THEN -1
+	   ELSE null
+  END$$;
+
+CREATE OR REPLACE FUNCTION information_schema_tsql._pgtsql_char_max_length_for_routines(type text, typmod int4) RETURNS integer
+        LANGUAGE sql
+        IMMUTABLE
+        PARALLEL SAFE
+        RETURNS NULL ON NULL INPUT
+        AS
+$$SELECT
+        CASE WHEN type IN ('char', 'nchar', 'varchar', 'nvarchar', 'binary', 'varbinary')
+                THEN CASE WHEN typmod = -1
+                        THEN 1
+                        ELSE typmod - 4
+                        END
+                WHEN type IN ('text', 'image')
+                THEN 2147483647
+                WHEN type = 'ntext'
+                THEN 1073741823
+                WHEN type = 'sysname'
+                THEN 128
+                WHEN type IN ('xml', 'geometry', 'geography')
+                THEN -1
+                WHEN type = 'sql_variant'
+                THEN 0
+                ELSE null
+        END$$;
+
+CREATE OR REPLACE FUNCTION sys.tsql_type_length_for_sp_columns_helper(IN type TEXT, IN typelen INT, IN typemod INT)
+RETURNS INT
+AS $$
+DECLARE
+  length INT;
+  precision INT;
+BEGIN
+  -- unknown tsql type
+  IF type IS NULL THEN
+    RETURN typelen::INT;
+  END IF;
+
+  IF typemod = -1 AND (type = 'varchar' OR type = 'nvarchar' OR type = 'varbinary') THEN
+    length = 0;
+    RETURN length;
+  END IF;
+
+  IF typelen != -1 THEN
+    CASE type
+    WHEN 'tinyint' THEN length = 1;
+    WHEN 'date' THEN length = 6;
+    WHEN 'smalldatetime' THEN length = 16;
+    WHEN 'smallmoney' THEN length = 12;
+    WHEN 'money' THEN length = 21;
+    WHEN 'datetime' THEN length = 16;
+    WHEN 'datetime2' THEN length = 16;
+    WHEN 'datetimeoffset' THEN length = 20;
+    WHEN 'time' THEN length = 12;
+    WHEN 'timestamp' THEN length = 8;
+    ELSE length = typelen;
+    END CASE;
+    RETURN length;
+  END IF;
+
+  CASE
+  WHEN type in ('char', 'bpchar', 'varchar', 'binary', 'varbinary') THEN length = typemod - 4;
+  WHEN type in ('nchar', 'nvarchar') THEN length = (typemod - 4) * 2;
+  WHEN type in ('text', 'image') THEN length = 2147483647;
+  WHEN type = 'ntext' THEN length = 2147483646;
+  WHEN type = 'xml' THEN length = 0;
+  WHEN type IN ('geometry', 'geography') THEN length = -1;
+  WHEN type = 'sql_variant' THEN length = 8000;
+  WHEN type = 'money' THEN length = 21;
+  WHEN type = 'sysname' THEN length = (typemod - 4) * 2;
+  WHEN type in ('numeric', 'decimal') THEN
+    precision = ((typemod - 4) >> 16) & 65535;
+    length = precision + 2;
+  ELSE
+    length = typemod;
+  END CASE;
+  RETURN length;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM sys.spt_datatype_info_table WHERE TYPE_NAME = N'geometry') THEN
+    BEGIN
+        INSERT INTO sys.spt_datatype_info_table VALUES (N'geometry', -151, 0, NULL, NULL, NULL, 1, 1, 0, NULL, 0, NULL, N'geometry', NULL, NULL, -151, NULL, NULL, NULL, 0, 2147483646, 23, NULL);
+    END;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM sys.spt_datatype_info_table WHERE TYPE_NAME = N'geography') THEN
+    BEGIN
+        INSERT INTO sys.spt_datatype_info_table VALUES (N'geography', -151, 0, NULL, NULL, NULL, 1, 1, 0, NULL, 0, NULL, N'geography', NULL, NULL, -151, NULL, NULL, NULL, 0, 2147483646, 23, NULL);
+    END;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
 
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysforeignkeys_deprecated_3_5_0');
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'system_objects_deprecated_3_5_0');

--- a/contrib/babelfishpg_tsql/src/datatype_info.h
+++ b/contrib/babelfishpg_tsql/src/datatype_info.h
@@ -4,7 +4,7 @@
 #define NULLVAL		PG_INT32_MIN
 #define NULLVAL_STR	"NULL"
 
-#define DATATYPE_INFO_TABLE_ROWS 37
+#define DATATYPE_INFO_TABLE_ROWS 39
 
 typedef struct DatatypeInfo
 {
@@ -487,6 +487,30 @@ static const DatatypeInfo datatype_info_table[DATATYPE_INFO_TABLE_ROWS] = {
 		"smalldatetime",
 		0, 0, 9, 3, NULLVAL, NULLVAL, 22, 16, 111,
 		"smalldatetime"
+	},
+	{
+		"geometry",
+		-4, -4, -151, -151,
+		0,
+		NULLVAL_STR,
+		NULLVAL_STR,
+		NULLVAL_STR,
+		1, 1, 0, NULLVAL, 0, NULLVAL,
+		"geometry",
+		NULLVAL, NULLVAL, -151, NULLVAL, NULLVAL, NULLVAL, 0, 2147483646, 23,
+		NULLVAL_STR
+	},
+	{
+		"geography",
+		-4, -4, -151, -151,
+		0,
+		NULLVAL_STR,
+		NULLVAL_STR,
+		NULLVAL_STR,
+		1, 1, 0, NULLVAL, 0, NULLVAL,
+		"geography",
+		NULLVAL, NULLVAL, -151, NULLVAL, NULLVAL, NULLVAL, 0, 2147483646, 23,
+		NULLVAL_STR
 	}
 };
 

--- a/test/JDBC/expected/13_5__preparation__sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/13_5__preparation__sys-assembly_types-vu-prepare.out
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/13_6__preparation__sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/13_6__preparation__sys-assembly_types-vu-prepare.out
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/13_7__preparation__sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/13_7__preparation__sys-assembly_types-vu-prepare.out
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/13_8__preparation__sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/13_8__preparation__sys-assembly_types-vu-prepare.out
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/13_9__preparation__sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/13_9__preparation__sys-assembly_types-vu-prepare.out
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/14_3__preparation__sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/14_3__preparation__sys-assembly_types-vu-prepare.out
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/BABEL-2869.out
+++ b/test/JDBC/expected/BABEL-2869.out
@@ -48,6 +48,8 @@ datetime2
 datetimeoffset
 decimal
 float
+geography
+geometry
 image
 int
 money

--- a/test/JDBC/expected/TestSpatialPoint-vu-cleanup.out
+++ b/test/JDBC/expected/TestSpatialPoint-vu-cleanup.out
@@ -72,6 +72,12 @@ DROP TABLE IF EXISTS TypeToGeog
 
 DROP TABLE IF EXISTS SPATIALPOINT_dt
 
+drop procedure IF EXISTS geometry_proc_1;
+
+drop procedure IF EXISTS geography_proc_1;
+
+drop table IF EXISTS geo_view_test;
+
 DROP PROCEDURE IF EXISTS GetPointsByXCoordinate
 
 DROP PROCEDURE IF EXISTS GetPointsByXCoordinate1

--- a/test/JDBC/expected/TestSpatialPoint-vu-prepare.out
+++ b/test/JDBC/expected/TestSpatialPoint-vu-prepare.out
@@ -491,6 +491,10 @@ prepst#!#INSERT INTO SPATIALPOINT_dt(PrimaryKey, GeomColumn, GeogColumn) values(
 ~~ROW COUNT: 1~~
 
 
+create procedure geometry_proc_1 @a geometry, @b varchar(max) as select @a as a, @b as b;
+create procedure geography_proc_1 @a geography, @b varchar(max) as select @a as a, @b as b;
+create table geo_view_test(a geometry, b geography)
+
 create schema geom_schema;
 CREATE FUNCTION geom_schema.STDistance(@point geometry) RETURNS nvarchar(max) AS BEGIN RETURN @point.STAsText(); END;
 create table geometry_test(geom_schema geometry)

--- a/test/JDBC/expected/TestSpatialPoint-vu-verify.out
+++ b/test/JDBC/expected/TestSpatialPoint-vu-verify.out
@@ -2677,3 +2677,57 @@ int
 1
 ~~END~~
 
+
+SELECT name, object_name(t.system_type_id), principal_id, max_length, precision, scale , collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, is_table_type from sys.types t WHERE name = 'geometry'
+go
+~~START~~
+varchar#!#varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#bit
+geometry#!#geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#0
+~~END~~
+
+
+SELECT name, object_name(t.system_type_id), principal_id, max_length, precision, scale , collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, is_table_type from sys.types t WHERE name = 'geography'
+go
+~~START~~
+varchar#!#varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#bit
+geography#!#geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#0
+~~END~~
+
+
+exec sp_sproc_columns_100 @procedure_name= 'geometry_proc_1'
+GO
+~~START~~
+varchar#!#varchar#!#nvarchar#!#varchar#!#smallint#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+master#!#dbo#!#geometry_proc_1;1#!#@RETURN_VALUE#!#5#!#4#!#int#!#10#!#4#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#0#!#NO#!#56
+master#!#dbo#!#geometry_proc_1;1#!#@a#!#1#!#-151#!#geometry#!#0#!#-1#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#1#!#YES#!#23
+master#!#dbo#!#geometry_proc_1;1#!#@b#!#1#!#12#!#varchar#!#0#!#8000#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#2#!#YES#!#39
+~~END~~
+
+
+exec sp_sproc_columns_100 @procedure_name= 'geography_proc_1'
+GO
+~~START~~
+varchar#!#varchar#!#nvarchar#!#varchar#!#smallint#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#tinyint
+master#!#dbo#!#geography_proc_1;1#!#@RETURN_VALUE#!#5#!#4#!#int#!#10#!#4#!#0#!#10#!#0#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#0#!#NO#!#56
+master#!#dbo#!#geography_proc_1;1#!#@a#!#1#!#-151#!#geography#!#0#!#-1#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#1#!#YES#!#23
+master#!#dbo#!#geography_proc_1;1#!#@b#!#1#!#12#!#varchar#!#0#!#8000#!#0#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#2#!#YES#!#39
+~~END~~
+
+
+select * from information_schema.columns where table_name = 'geo_view_test'
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+master#!#dbo#!#geo_view_test#!#a#!#1#!#<NULL>#!#YES#!#geometry#!#-1#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+master#!#dbo#!#geo_view_test#!#b#!#2#!#<NULL>#!#YES#!#geography#!#-1#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+select name , column_id , max_length , precision , scale , collation_name ,is_nullable , is_ansi_padded , is_rowguidcol , is_identity ,is_computed , is_filestream , is_replicated , is_non_sql_subscribed , is_merge_published , is_dts_replicated , is_xml_document , xml_collection_id , default_object_id , rule_object_id , is_sparse , is_column_set , generated_always_type , generated_always_type_desc , encryption_type , encryption_type_desc , encryption_algorithm_name , column_encryption_key_id , column_encryption_key_database_name , is_hidden , is_masked , graph_type , graph_type_desc from sys.columns where object_id = object_id('geo_view_test') ORDER BY name;
+GO
+~~START~~
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#bit#!#bit#!#tinyint#!#nvarchar#!#int#!#nvarchar#!#varchar#!#int#!#varchar#!#bit#!#bit#!#int#!#nvarchar
+a#!#1#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#<NULL>#!#<NULL>
+b#!#2#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#<NULL>#!#<NULL>
+~~END~~
+

--- a/test/JDBC/expected/babel_typecode.out
+++ b/test/JDBC/expected/babel_typecode.out
@@ -36,5 +36,7 @@ sys#!#decimal#!#decimal#!#5#!#30#!#5
 sys#!#sysname#!#sysname#!#5#!#31#!#5
 sys#!#rowversion#!#timestamp#!#8#!#32#!#3
 sys#!#timestamp#!#timestamp#!#8#!#33#!#3
+sys#!#geometry#!#geometry#!#5#!#34#!#1
+sys#!#geography#!#geography#!#5#!#35#!#1
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__13_5__sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_5__sys-assembly_types-vu-verify.out
@@ -8,7 +8,9 @@ int#!#varchar
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +18,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__13_6__sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_6__sys-assembly_types-vu-verify.out
@@ -8,7 +8,9 @@ int#!#varchar
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +18,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__13_7__sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_7__sys-assembly_types-vu-verify.out
@@ -8,7 +8,9 @@ int#!#varchar
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +18,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__13_8__sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_8__sys-assembly_types-vu-verify.out
@@ -8,7 +8,9 @@ int#!#varchar
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +18,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__13_9__sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_9__sys-assembly_types-vu-verify.out
@@ -8,7 +8,9 @@ int#!#varchar
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +18,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__sys-assembly_types-vu-verify.out
@@ -8,7 +8,9 @@ int#!#varchar
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +18,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/latest__verification_cleanup__14_3__sys-types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_3__sys-types-vu-verify.out
@@ -17,6 +17,8 @@ datetime2#!#8#!#26#!#6#!#<NULL>
 datetimeoffset#!#10#!#33#!#6#!#<NULL>
 decimal#!#17#!#38#!#38#!#<NULL>
 float#!#8#!#53#!#0#!#<NULL>
+geography#!#-1#!#0#!#0#!#<NULL>
+geometry#!#-1#!#0#!#0#!#<NULL>
 image#!#16#!#0#!#0#!#<NULL>
 int#!#4#!#10#!#0#!#<NULL>
 money#!#8#!#19#!#4#!#<NULL>

--- a/test/JDBC/expected/latest__verification_cleanup__14_5__sys-types-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_5__sys-types-vu-verify.out
@@ -17,6 +17,8 @@ datetime2#!#8#!#26#!#6#!#<NULL>
 datetimeoffset#!#10#!#33#!#6#!#<NULL>
 decimal#!#17#!#38#!#38#!#<NULL>
 float#!#8#!#53#!#0#!#<NULL>
+geography#!#-1#!#0#!#0#!#<NULL>
+geometry#!#-1#!#0#!#0#!#<NULL>
 image#!#16#!#0#!#0#!#<NULL>
 int#!#4#!#10#!#0#!#<NULL>
 money#!#8#!#19#!#4#!#<NULL>

--- a/test/JDBC/expected/sys-assembly_types-vu-prepare.out
+++ b/test/JDBC/expected/sys-assembly_types-vu-prepare.out
@@ -1,9 +1,9 @@
 CREATE VIEW sys_assembly_types_view_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/expected/sys-assembly_types-vu-verify.out
+++ b/test/JDBC/expected/sys-assembly_types-vu-verify.out
@@ -1,14 +1,18 @@
 SELECT * FROM sys_assembly_types_view_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
 EXEC sys_assembly_types_proc_vu_prepare
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 
 
@@ -16,14 +20,16 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 ~~START~~
 int
-0
+2
 ~~END~~
 
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 ~~START~~
-varchar#!#int#!#int#!#int#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geometry#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
 ~~END~~
 

--- a/test/JDBC/expected/sys-systypes-vu-verify.out
+++ b/test/JDBC/expected/sys-systypes-vu-verify.out
@@ -16,6 +16,8 @@ datetime2#!#0#!#8#!#0#!#1#!#<NULL>#!#<NULL>
 datetimeoffset#!#0#!#10#!#0#!#1#!#<NULL>#!#<NULL>
 decimal#!#0#!#17#!#0#!#1#!#<NULL>#!#<NULL>
 float#!#0#!#8#!#0#!#1#!#<NULL>#!#<NULL>
+geography#!#0#!#-1#!#0#!#1#!#<NULL>#!#<NULL>
+geometry#!#0#!#-1#!#0#!#1#!#<NULL>#!#<NULL>
 image#!#0#!#16#!#0#!#1#!#<NULL>#!#<NULL>
 int#!#0#!#4#!#0#!#1#!#<NULL>#!#<NULL>
 money#!#0#!#8#!#0#!#1#!#<NULL>#!#<NULL>

--- a/test/JDBC/expected/sys-types-vu-verify.out
+++ b/test/JDBC/expected/sys-types-vu-verify.out
@@ -17,6 +17,8 @@ datetime2#!#8#!#26#!#6#!#<NULL>
 datetimeoffset#!#10#!#33#!#6#!#<NULL>
 decimal#!#17#!#38#!#38#!#<NULL>
 float#!#8#!#53#!#0#!#<NULL>
+geography#!#-1#!#0#!#0#!#<NULL>
+geometry#!#-1#!#0#!#0#!#<NULL>
 image#!#16#!#0#!#0#!#<NULL>
 int#!#4#!#10#!#0#!#<NULL>
 money#!#8#!#19#!#4#!#<NULL>

--- a/test/JDBC/expected/sys-types.out
+++ b/test/JDBC/expected/sys-types.out
@@ -17,6 +17,8 @@ datetime2#!#8#!#26#!#6#!#<NULL>
 datetimeoffset#!#10#!#33#!#6#!#<NULL>
 decimal#!#17#!#38#!#38#!#<NULL>
 float#!#8#!#53#!#0#!#<NULL>
+geography#!#-1#!#0#!#0#!#<NULL>
+geometry#!#-1#!#0#!#0#!#<NULL>
 image#!#16#!#0#!#0#!#<NULL>
 int#!#4#!#10#!#0#!#<NULL>
 money#!#8#!#19#!#4#!#<NULL>

--- a/test/JDBC/input/datatypes/TestSpatialPoint-vu-cleanup.txt
+++ b/test/JDBC/input/datatypes/TestSpatialPoint-vu-cleanup.txt
@@ -72,6 +72,12 @@ DROP TABLE IF EXISTS TypeToGeog
 
 DROP TABLE IF EXISTS SPATIALPOINT_dt
 
+drop procedure IF EXISTS geometry_proc_1;
+
+drop procedure IF EXISTS geography_proc_1;
+
+drop table IF EXISTS geo_view_test;
+
 DROP PROCEDURE IF EXISTS GetPointsByXCoordinate
 
 DROP PROCEDURE IF EXISTS GetPointsByXCoordinate1

--- a/test/JDBC/input/datatypes/TestSpatialPoint-vu-prepare.txt
+++ b/test/JDBC/input/datatypes/TestSpatialPoint-vu-prepare.txt
@@ -273,6 +273,10 @@ prepst#!#INSERT INTO SPATIALPOINT_dt(PrimaryKey, GeomColumn) values(@PrimaryKey,
 prepst#!#INSERT INTO SPATIALPOINT_dt(PrimaryKey, GeogColumn) values(@PrimaryKey, @GeogColumn) #!#int|-|PrimaryKey|-|5#!#GEOGRAPHY|-|GeogColumn|-|Point(47.65100 -22.34900):4326
 prepst#!#INSERT INTO SPATIALPOINT_dt(PrimaryKey, GeomColumn, GeogColumn) values(@PrimaryKey, @GeomColumn, @GeogColumn) #!#int|-|PrimaryKey|-|6#!#GEOMETRY|-|GeomColumn|-|Point(1.0 2.0):4326#!#GEOGRAPHY|-|GeogColumn|-|Point(1.0 2.0):4326
 
+create procedure geometry_proc_1 @a geometry, @b varchar(max) as select @a as a, @b as b;
+create procedure geography_proc_1 @a geography, @b varchar(max) as select @a as a, @b as b;
+create table geo_view_test(a geometry, b geography)
+
 create schema geom_schema;
 CREATE FUNCTION geom_schema.STDistance(@point geometry) RETURNS nvarchar(max) AS BEGIN RETURN @point.STAsText(); END;
 create table geometry_test(geom_schema geometry)

--- a/test/JDBC/input/datatypes/TestSpatialPoint-vu-verify.sql
+++ b/test/JDBC/input/datatypes/TestSpatialPoint-vu-verify.sql
@@ -976,3 +976,21 @@ DECLARE @mig_mode VARCHAR(10)
 SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
 SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
 GO
+
+SELECT name, object_name(t.system_type_id), principal_id, max_length, precision, scale , collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, is_table_type from sys.types t WHERE name = 'geometry'
+go
+
+SELECT name, object_name(t.system_type_id), principal_id, max_length, precision, scale , collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, is_table_type from sys.types t WHERE name = 'geography'
+go
+
+exec sp_sproc_columns_100 @procedure_name= 'geometry_proc_1'
+GO
+
+exec sp_sproc_columns_100 @procedure_name= 'geography_proc_1'
+GO
+
+select * from information_schema.columns where table_name = 'geo_view_test'
+GO
+
+select name , column_id , max_length , precision , scale , collation_name ,is_nullable , is_ansi_padded , is_rowguidcol , is_identity ,is_computed , is_filestream , is_replicated , is_non_sql_subscribed , is_merge_published , is_dts_replicated , is_xml_document , xml_collection_id , default_object_id , rule_object_id , is_sparse , is_column_set , generated_always_type , generated_always_type_desc , encryption_type , encryption_type_desc , encryption_algorithm_name , column_encryption_key_id , column_encryption_key_database_name , is_hidden , is_masked , graph_type , graph_type_desc from sys.columns where object_id = object_id('geo_view_test') ORDER BY name;
+GO

--- a/test/JDBC/input/views/sys-assembly_types-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-assembly_types-vu-prepare.sql
@@ -1,9 +1,9 @@
 CREATE VIEW sys_assembly_types_view_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/input/views/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/input/views/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/13_5/preparation/sys-assembly_types-vu-prepare.sql
+++ b/test/JDBC/upgrade/13_5/preparation/sys-assembly_types-vu-prepare.sql
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/upgrade/13_6/preparation/sys-assembly_types-vu-prepare.sql
+++ b/test/JDBC/upgrade/13_6/preparation/sys-assembly_types-vu-prepare.sql
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/upgrade/13_8/preparation/sys-assembly_types-vu-prepare.sql
+++ b/test/JDBC/upgrade/13_8/preparation/sys-assembly_types-vu-prepare.sql
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/upgrade/13_9/preparation/sys-assembly_types-vu-prepare.sql
+++ b/test/JDBC/upgrade/13_9/preparation/sys-assembly_types-vu-prepare.sql
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/upgrade/14_3/preparation/sys-assembly_types-vu-prepare.sql
+++ b/test/JDBC/upgrade/14_3/preparation/sys-assembly_types-vu-prepare.sql
@@ -3,7 +3,7 @@ SELECT * FROM sys.assembly_types
 GO
 
 CREATE PROC sys_assembly_types_proc_vu_prepare AS
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO
 
 CREATE FUNCTION sys_assembly_types_func_vu_prepare()

--- a/test/JDBC/upgrade/14_5/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_5/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_5/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_5/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_5/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_5/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_5/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_5/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_5/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_5/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_6/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_6/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_6/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_6/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_6/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_6/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_6/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_6/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_6/verification_cleanup/13_9/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_6/verification_cleanup/13_9/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/14_6/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/14_6/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/15_1/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/15_1/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/15_1/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/15_1/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/15_1/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/15_1/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/15_1/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/15_1/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/15_1/verification_cleanup/13_9/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/15_1/verification_cleanup/13_9/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/15_1/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/15_1/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_5/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_6/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_7/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_8/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_9/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_9/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_3/sys-assembly_types-vu-verify.sql
@@ -8,5 +8,5 @@ SELECT * FROM sys_assembly_types_func_vu_prepare()
 GO
 
 -- Test from sys-assembly_types.sql
-SELECT * FROM sys.assembly_types
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
 GO


### PR DESCRIPTION
### Description

- This commit contains Geometry and Geography datatype related metadata support to the system views

- Added Test Cases to check system views for Geospatial datatypes

#### Differences
- Found that in sp_sproc_columns_view 3 fields - LENGTH, SCALE, CHAR_OCTET_LENGTH have difference which can also be seen in other datatypes as well such as Varchar.
This is probably due to different implementation of this view.


Cherry-Picked: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2277
Task: BABEL- 4710
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)


### Test Scenarios Covered ###
* **Use case based -**   TestSpatialPoint-vu-prepare, TestSpatialPoint-vu-verify, TestSpatialPoint-vu-cleanup, babel_typecode


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).