### PR TITLE
[cherrypicked 4_X_DEV] Support ORDER BY...OFFSET...FETCH

### DIFF
--- a/test/JDBC/expected/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-cleanup.out
+++ b/test/JDBC/expected/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP PROC p1_upgr_order_by_offset_fetch
+go
+DROP FUNCTION f1_upgr_order_by_offset_fetch
+go
+DROP VIEW v1_upgr_order_by_offset_fetch 
+go
+DROP table t1_upgr_order_by_offset_fetch
+go

--- a/test/JDBC/expected/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-prepare.out
+++ b/test/JDBC/expected/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-prepare.out
@@ -1,0 +1,8 @@
+create table t1_upgr_order_by_offset_fetch(a int, b int)
+go
+CREATE PROC p1_upgr_order_by_offset_fetch @p int=1,@q int=1  AS SELECT * FROM t1_upgr_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY
+go
+CREATE FUNCTION f1_upgr_order_by_offset_fetch(@p int, @q int) returns int as begin declare @v int SELECT @v=count(a) FROM t1_upgr_order_by_offset_fetch group by b ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY return @v end
+go
+CREATE VIEW v1_upgr_order_by_offset_fetch as select * FROM t1_upgr_order_by_offset_fetch ORDER BY b OFFSET 5 ROWS FETCH NEXT 3 rows only 
+go

--- a/test/JDBC/expected/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-verify.out
+++ b/test/JDBC/expected/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-verify.out
@@ -1,0 +1,73 @@
+insert t1_upgr_order_by_offset_fetch select generate_series, 0 from generate_series(1,100)
+go
+~~ROW COUNT: 100~~
+
+update t1_upgr_order_by_offset_fetch set b=a
+go
+~~ROW COUNT: 100~~
+
+exec p1_upgr_order_by_offset_fetch 1, 3
+go
+~~START~~
+int#!#int
+4#!#4
+5#!#5
+6#!#6
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+~~END~~
+
+exec p1_upgr_order_by_offset_fetch 2, 3
+go
+~~START~~
+int#!#int
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+16#!#16
+~~END~~
+
+p1_upgr_order_by_offset_fetch 3, 3
+go
+~~START~~
+int#!#int
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+16#!#16
+17#!#17
+18#!#18
+19#!#19
+~~END~~
+
+select dbo.f1_upgr_order_by_offset_fetch(1,1)
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from v1_upgr_order_by_offset_fetch
+go
+~~START~~
+int#!#int
+6#!#6
+7#!#7
+8#!#8
+~~END~~
+
+

--- a/test/JDBC/expected/order_by_offset_fetch_rows-vu-cleanup.out
+++ b/test/JDBC/expected/order_by_offset_fetch_rows-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP PROC p1_order_by_offset_fetch
+go
+DROP FUNCTION f1_order_by_offset_fetch
+go
+DROP VIEW v1_order_by_offset_fetch 
+go
+DROP table t1_order_by_offset_fetch
+go

--- a/test/JDBC/expected/order_by_offset_fetch_rows-vu-prepare.out
+++ b/test/JDBC/expected/order_by_offset_fetch_rows-vu-prepare.out
@@ -1,0 +1,16 @@
+create table t1_order_by_offset_fetch(a int, b int)
+go
+insert t1_order_by_offset_fetch select generate_series, 0 from generate_series(1,100)
+go
+~~ROW COUNT: 100~~
+
+update t1_order_by_offset_fetch set b=a
+go
+~~ROW COUNT: 100~~
+
+CREATE PROC p1_order_by_offset_fetch @p int=1,@q int=1  AS SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY
+go
+CREATE FUNCTION f1_order_by_offset_fetch(@p int, @q int) returns int as begin declare @v int SELECT @v=count(a) FROM t1_order_by_offset_fetch group by b ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY return @v end
+go
+CREATE VIEW v1_order_by_offset_fetch as select * FROM t1_order_by_offset_fetch ORDER BY b OFFSET 5 ROWS FETCH NEXT 3 rows only 
+go

--- a/test/JDBC/expected/order_by_offset_fetch_rows-vu-verify.out
+++ b/test/JDBC/expected/order_by_offset_fetch_rows-vu-verify.out
@@ -1,0 +1,390 @@
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT (5) ROWS ONLY
+go
+~~START~~
+int#!#int
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROW FETCH NEXT 5 ROW ONLY
+go
+~~START~~
+int#!#int
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+11#!#11
+12#!#12
+13#!#13
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT 1+2 ROWS ONLY
+go
+~~START~~
+int#!#int
+11#!#11
+12#!#12
+13#!#13
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT (1+2) ROWS ONLY
+go
+~~START~~
+int#!#int
+11#!#11
+12#!#12
+13#!#13
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT +3 ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=0 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+~~END~~
+
+declare @p int =0,@q int=1 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET 1+1 ROWS FETCH NEXT 2 ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET 1+1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=0 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+~~END~~
+
+declare @p int =2,@q int=1 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+~~END~~
+
+declare @p int =0,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+~~END~~
+
+declare @p int =1,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+2#!#2
+3#!#3
+4#!#4
+~~END~~
+
+declare @p int =3,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p+1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+5#!#5
+6#!#6
+7#!#7
+~~END~~
+
+declare @p int =3,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*2 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+7#!#7
+8#!#8
+9#!#9
+~~END~~
+
+declare @p int =1,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+4#!#4
+5#!#5
+6#!#6
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+7#!#7
+8#!#8
+9#!#9
+~~END~~
+
+declare @p int=2,@q int=0 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+~~END~~
+
+declare @p int=1,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+4#!#4
+5#!#5
+6#!#6
+~~END~~
+
+declare @p int=2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+7#!#7
+8#!#8
+9#!#9
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(2) ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+5#!#5
+6#!#6
+7#!#7
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(@p)+@p ROWS FETCH NEXT @q+1 ROWS ONLY
+go
+~~START~~
+int#!#int
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+~~END~~
+
+declare @p int=2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p+1 ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+4#!#4
+5#!#5
+6#!#6
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*(@p) ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p ROWS FETCH NEXT @q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*square(1) ROWS FETCH NEXT @q*square(1) ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p ROWS FETCH NEXT square(1)+@q ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)* @p ROWS FETCH NEXT square(@q)*@q+1 ROWS ONLY
+go
+~~START~~
+int#!#int
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+16#!#16
+17#!#17
+18#!#18
+19#!#19
+20#!#20
+21#!#21
+22#!#22
+23#!#23
+24#!#24
+25#!#25
+26#!#26
+27#!#27
+28#!#28
+29#!#29
+30#!#30
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*3+1 ROWS FETCH NEXT @p+1 ROWS ONLY
+go
+~~START~~
+int#!#int
+5#!#5
+6#!#6
+7#!#7
+~~END~~
+
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*@p) ROWS FETCH NEXT @p*@q ROWS ONLY
+go
+~~START~~
+int#!#int
+5#!#5
+6#!#6
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+~~END~~
+
+exec p1_order_by_offset_fetch 1, 3
+go
+~~START~~
+int#!#int
+4#!#4
+5#!#5
+6#!#6
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+~~END~~
+
+exec p1_order_by_offset_fetch 2, 3
+go
+~~START~~
+int#!#int
+7#!#7
+8#!#8
+9#!#9
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+16#!#16
+~~END~~
+
+p1_order_by_offset_fetch 3, 3
+go
+~~START~~
+int#!#int
+10#!#10
+11#!#11
+12#!#12
+13#!#13
+14#!#14
+15#!#15
+16#!#16
+17#!#17
+18#!#18
+19#!#19
+~~END~~
+
+select dbo.f1_order_by_offset_fetch(1,1)
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from v1_order_by_offset_fetch
+go
+~~START~~
+int#!#int
+6#!#6
+7#!#7
+8#!#8
+~~END~~
+

--- a/test/JDBC/input/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-cleanup.sql
+++ b/test/JDBC/input/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP PROC p1_upgr_order_by_offset_fetch
+go
+DROP FUNCTION f1_upgr_order_by_offset_fetch
+go
+DROP VIEW v1_upgr_order_by_offset_fetch 
+go
+DROP table t1_upgr_order_by_offset_fetch
+go

--- a/test/JDBC/input/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-prepare.sql
+++ b/test/JDBC/input/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-prepare.sql
@@ -1,0 +1,8 @@
+create table t1_upgr_order_by_offset_fetch(a int, b int)
+go
+CREATE PROC p1_upgr_order_by_offset_fetch @p int=1,@q int=1  AS SELECT * FROM t1_upgr_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY
+go
+CREATE FUNCTION f1_upgr_order_by_offset_fetch(@p int, @q int) returns int as begin declare @v int SELECT @v=count(a) FROM t1_upgr_order_by_offset_fetch group by b ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY return @v end
+go
+CREATE VIEW v1_upgr_order_by_offset_fetch as select * FROM t1_upgr_order_by_offset_fetch ORDER BY b OFFSET 5 ROWS FETCH NEXT 3 rows only 
+go

--- a/test/JDBC/input/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-verify.sql
+++ b/test/JDBC/input/order_by_offset_fetch_rows-before-15_6-or-16_2-vu-verify.sql
@@ -1,0 +1,15 @@
+insert t1_upgr_order_by_offset_fetch select generate_series, 0 from generate_series(1,100)
+go
+update t1_upgr_order_by_offset_fetch set b=a
+go
+exec p1_upgr_order_by_offset_fetch 1, 3
+go
+exec p1_upgr_order_by_offset_fetch 2, 3
+go
+p1_upgr_order_by_offset_fetch 3, 3
+go
+select dbo.f1_upgr_order_by_offset_fetch(1,1)
+go
+select * from v1_upgr_order_by_offset_fetch
+go
+

--- a/test/JDBC/input/order_by_offset_fetch_rows-vu-cleanup.sql
+++ b/test/JDBC/input/order_by_offset_fetch_rows-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP PROC p1_order_by_offset_fetch
+go
+DROP FUNCTION f1_order_by_offset_fetch
+go
+DROP VIEW v1_order_by_offset_fetch 
+go
+DROP table t1_order_by_offset_fetch
+go

--- a/test/JDBC/input/order_by_offset_fetch_rows-vu-prepare.sql
+++ b/test/JDBC/input/order_by_offset_fetch_rows-vu-prepare.sql
@@ -1,0 +1,12 @@
+create table t1_order_by_offset_fetch(a int, b int)
+go
+insert t1_order_by_offset_fetch select generate_series, 0 from generate_series(1,100)
+go
+update t1_order_by_offset_fetch set b=a
+go
+CREATE PROC p1_order_by_offset_fetch @p int=1,@q int=1  AS SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY
+go
+CREATE FUNCTION f1_order_by_offset_fetch(@p int, @q int) returns int as begin declare @v int SELECT @v=count(a) FROM t1_order_by_offset_fetch group by b ORDER BY b OFFSET @p*@q ROWS FETCH NEXT square(@q)+1 ROWS ONLY return @v end
+go
+CREATE VIEW v1_order_by_offset_fetch as select * FROM t1_order_by_offset_fetch ORDER BY b OFFSET 5 ROWS FETCH NEXT 3 rows only 
+go

--- a/test/JDBC/input/order_by_offset_fetch_rows-vu-verify.sql
+++ b/test/JDBC/input/order_by_offset_fetch_rows-vu-verify.sql
@@ -1,0 +1,78 @@
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT (5) ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROW FETCH NEXT 5 ROW ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT 1+2 ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*5) ROWS FETCH NEXT (1+2) ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT +3 ROWS ONLY
+go
+declare @p int =2,@q int=0 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =0,@q int=1 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET 1+1 ROWS FETCH NEXT 2 ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET 1+1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=0 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=1 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =0,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =1,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =3,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p+1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =3,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*2 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =1,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int=2,@q int=0 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int=1,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int=2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*@q ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(2) ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(@p)+@p ROWS FETCH NEXT @q+1 ROWS ONLY
+go
+declare @p int=2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p+1 ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*(@p) ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p ROWS FETCH NEXT @q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET @p*square(1) ROWS FETCH NEXT @q*square(1) ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*@p ROWS FETCH NEXT square(1)+@q ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)* @p ROWS FETCH NEXT square(@q)*@q+1 ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET square(1)*3+1 ROWS FETCH NEXT @p+1 ROWS ONLY
+go
+declare @p int =2,@q int=3 SELECT * FROM t1_order_by_offset_fetch ORDER BY b OFFSET (@p*@p) ROWS FETCH NEXT @p*@q ROWS ONLY
+go
+exec p1_order_by_offset_fetch 1, 3
+go
+exec p1_order_by_offset_fetch 2, 3
+go
+p1_order_by_offset_fetch 3, 3
+go
+select dbo.f1_order_by_offset_fetch(1,1)
+go
+select * from v1_order_by_offset_fetch
+go

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -220,6 +220,7 @@ table_constraint_wo_comma-before-15_6-or-16_2
 getdate
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -273,6 +273,7 @@ table_constraint_wo_comma-before-15_6-or-16_2
 getdate
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -321,6 +321,7 @@ table_constraint_wo_comma-before-15_6-or-16_2
 getdate
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -321,6 +321,7 @@ table_constraint_wo_comma-before-15_6-or-16_2
 getdate
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -324,6 +324,7 @@ getdate
 BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -414,6 +414,7 @@ BABEL-4384
 default_params
 BABEL-3326
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -414,6 +414,7 @@ BABEL-4384
 default_params
 BABEL-3326
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -342,6 +342,7 @@ BABEL-2619
 BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -357,6 +357,7 @@ BABEL-2619
 BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -392,6 +392,7 @@ BABEL-2619
 BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -413,6 +413,7 @@ BABEL_4330
 BABEL-2619
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -412,6 +412,7 @@ BABEL-2619
 AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -414,6 +414,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -391,6 +391,7 @@ BABEL_4330
 AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -420,6 +420,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -443,6 +443,7 @@ BABEL_4330
 AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -455,6 +455,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -482,6 +482,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
+order_by_offset_fetch_rows-before-15_6-or-16_2
 TestDatatypeAggSort
 babel_index_nulls_order
 operator_binary_whitespace-before-15_6-or-16_2

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -461,6 +461,7 @@ TestXML
 timefromparts
 todatetimeoffset-dep
 triggers_with_transaction
+order_by_offset_fetch_rows
 typeid-typename
 typeid-typename-dep
 print_null


### PR DESCRIPTION
### Description

Cherry-picked https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2284 into BABEL_4_X_DEV

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-1174: Support expressions in SELECT...OFFSET...FETCH clauses


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).