### PR TITLE
sp_rename should update the object name in babelfish_schema_permission catalog

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2732,8 +2732,8 @@ rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_
 
 	/* scan */
 	scan = systable_beginscan(bbf_schema_rel,
-			get_bbf_schema_perms_idx_oid(),
-			true, NULL, 4, key);
+			get_bbf_schema_perms_oid(),
+			false, NULL, 4, key);
 
 	/* get the scan result -> original tuple */
 	tuple_bbf_schema = systable_getnext(scan);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2727,7 +2727,7 @@ rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_
 	/* get the scan result -> original tuple */
 	tuple_bbf_schema = systable_getnext(scan);
 
-	if (HeapTupleIsValid(tuple_bbf_schema))
+	while (HeapTupleIsValid(tuple_bbf_schema))
 	{
 		/* create new tuple to substitute */
 		new_record_bbf_schema[Anum_bbf_schema_perms_object_name - 1] = CStringGetTextDatum(stmt->newname);
@@ -2742,6 +2742,7 @@ rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_
 		CatalogTupleUpdate(bbf_schema_rel, &new_tuple->t_self, new_tuple);
 
 		heap_freetuple(new_tuple);
+		tuple_bbf_schema = systable_getnext(scan);
 	}
 
 	systable_endscan(scan);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2668,7 +2668,7 @@ rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_
 	bool		new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {false};
 	const char *logical_schema_name;
 	const char *object_name;
-	char	*object_type;
+	char	*object_type = NULL;
 	int16		dbid = get_cur_db_id();
 	Node	   *schema;
 	ObjectWithArgs *objwargs;

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2682,7 +2682,7 @@ rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_
 	bool		new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {false};
 	char		*logical_schema_name = NULL;
 	char		*object_name = NULL;
-	char		*object_type = NULL;
+	const char	*object_type = NULL;
 	int16		dbid = get_cur_db_id();
 	ObjectWithArgs *objwargs;
 
@@ -2765,6 +2765,11 @@ rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_
 		heap_freetuple(new_tuple);
 		tuple_bbf_schema = systable_getnext(scan);
 	}
+
+	if (logical_schema_name != NULL)
+		pfree(logical_schema_name);
+	if (object_name != NULL)
+		pfree(object_name);
 
 	systable_endscan(scan);
 	table_close(bbf_schema_rel, RowExclusiveLock);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1583,6 +1583,7 @@ static void alter_guest_schema_for_db(const char *dbname);
 /* Helper function Rename BBF catalog update*/
 static void rename_view_update_bbf_catalog(RenameStmt *stmt);
 static void rename_procfunc_update_bbf_catalog(RenameStmt *stmt);
+static void rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, const char *obj_type);
 
 static int get_privilege_of_object(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
 
@@ -2625,15 +2626,19 @@ rename_update_bbf_catalog(RenameStmt *stmt)
 	switch (stmt->renameType)
 	{
 		case OBJECT_TABLE:
+			rename_object_update_bbf_schema_permission_catalog(stmt, OBJ_RELATION);
 			break;
 		case OBJECT_VIEW:
 			rename_view_update_bbf_catalog(stmt);
+			rename_object_update_bbf_schema_permission_catalog(stmt, OBJ_RELATION);
 			break;
 		case OBJECT_PROCEDURE:
 			rename_procfunc_update_bbf_catalog(stmt);
+			rename_object_update_bbf_schema_permission_catalog(stmt, OBJ_PROCEDURE);
 			break;
 		case OBJECT_FUNCTION:
 			rename_procfunc_update_bbf_catalog(stmt);
+			rename_object_update_bbf_schema_permission_catalog(stmt, OBJ_FUNCTION);
 			break;
 		case OBJECT_SEQUENCE:
 			break;
@@ -2646,6 +2651,93 @@ rename_update_bbf_catalog(RenameStmt *stmt)
 		default:
 			break;
 	}
+}
+
+static void
+rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, const char *obj_type)
+{
+	/* Update 'object_name' in 'babelfish_schema_permissions' */
+	Relation	bbf_schema_rel;
+	TupleDesc	bbf_schema_dsc;
+	ScanKeyData key[4];
+	HeapTuple	tuple_bbf_schema;
+	HeapTuple	new_tuple;
+	TableScanDesc tblscan;
+	Datum		new_record_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {0};
+	bool		new_record_nulls_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {false};
+	bool		new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {false};
+	const char *logical_schema_name;
+	const char *object_name;
+	int16		dbid = get_cur_db_id();
+	Node	   *schema;
+	ObjectWithArgs *objwargs;
+
+	/* open the catalog table */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(), RowExclusiveLock);
+	/* get the description of the table */
+	bbf_schema_dsc = RelationGetDescr(bbf_schema_rel);
+
+	if (strcmp(obj_type, OBJ_RELATION) == 0)
+	{
+		logical_schema_name = get_logical_schema_name(stmt->relation->schemaname, true);
+		object_name = stmt->relation->relname;
+	}
+	else if (strcmp(obj_type, OBJ_PROCEDURE) == 0 || strcmp(obj_type, OBJ_FUNCTION) == 0)
+	{
+		objwargs = (ObjectWithArgs *) stmt->object;
+		schema = (Node *) linitial(objwargs->objname);
+		logical_schema_name = strVal(schema);
+		object_name = stmt->subname;
+	}
+
+	/* search for the row for update => build the key */
+	ScanKeyInit(&key[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&key[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ, CStringGetTextDatum(logical_schema_name));
+	ScanKeyEntryInitialize(&key[2], 0,
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ, CStringGetTextDatum(object_name));
+	ScanKeyEntryInitialize(&key[3], 0,
+				Anum_bbf_schema_perms_object_type,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(obj_type));
+
+	/* scan */
+	tblscan = table_beginscan_catalog(bbf_schema_rel, 4, key);
+
+	/* get the scan result -> original tuple */
+	tuple_bbf_schema = heap_getnext(tblscan, ForwardScanDirection);
+
+	if (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		/* create new tuple to substitute */
+		new_record_bbf_schema[Anum_bbf_schema_perms_object_name - 1] = CStringGetTextDatum(stmt->newname);
+		new_record_repl_bbf_schema[Anum_bbf_schema_perms_object_name - 1] = true;
+
+		new_tuple = heap_modify_tuple(tuple_bbf_schema,
+									bbf_schema_dsc,
+									new_record_bbf_schema,
+									new_record_nulls_bbf_schema,
+									new_record_repl_bbf_schema);
+
+		CatalogTupleUpdate(bbf_schema_rel, &new_tuple->t_self, new_tuple);
+
+		heap_freetuple(new_tuple);
+	}
+
+	table_endscan(tblscan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
 }
 
 static void

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -706,28 +706,44 @@ go
 -- REVOKE OBJECT privileges
 use babel_4344_d1;
 go
+
 REVOKE SELECT on schema::"bAbel_4344 s1" from "BABEL_4344_U1";
 go
 REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
 go
-REVOKE all on babel_4344_s1.babel_4344_t1 FROM babel_4344_u1;
+
+-- rename the objects where permissions are already granted
+sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
 go
-REVOKE select on babel_4344_s1.babel_4344_t3(a) FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_t3', 'babel_4344_t3_new', 'OBJECT';
 go
-REVOKE select on babel_4344_s1.babel_4344_v1 FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_v1', 'babel_4344_v1_new', 'OBJECT';
 go
-REVOKE execute on babel_4344_s1.babel_4344_p1 FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_p1', 'babel_4344_p1_new', 'OBJECT';
 go
-REVOKE execute on babel_4344_s1.babel_4344_f1 FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_f1', 'babel_4344_f1_new', 'OBJECT';
 go
-REVOKE all on babel_4344_s1.babel_4344_f1 FROM babel_4344_u1;
+
+-- permissions are transferred to the new objects 
+-- Revoke permissions from the new objects
+REVOKE all on babel_4344_s1.babel_4344_t1_new FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_t3_new(a) FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_v1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_p1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
+go
+REVOKE all on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
 go
 
 -- tsql user=babel_4344_l1 password=12345678
 -- User has SCHEMA privileges, should be accessible.
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1
+select * from babel_4344_s1.babel_4344_t1_new
 go
 ~~START~~
 int
@@ -737,31 +753,31 @@ int
 4
 ~~END~~
 
-insert into babel_4344_s1.babel_4344_t1 values(5);
+insert into babel_4344_s1.babel_4344_t1_new values(5);
 go
 ~~ROW COUNT: 1~~
 
-select * from babel_4344_s1.babel_4344_t3;
+select * from babel_4344_s1.babel_4344_t3_new;
 go
 ~~START~~
 int#!#int
 ~~END~~
 
-select * from babel_4344_s1.babel_4344_v1;
+select * from babel_4344_s1.babel_4344_v1_new;
 go
 ~~START~~
 int
 2
 ~~END~~
 
-exec babel_4344_s1.babel_4344_p1;
+exec babel_4344_s1.babel_4344_p1_new;
 go
 ~~START~~
 int
 2
 ~~END~~
 
-select * from babel_4344_s1.babel_4344_f1();
+select * from babel_4344_s1.babel_4344_f1_new();
 go
 ~~START~~
 int
@@ -799,48 +815,48 @@ int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar
 -- User has no privileges, shouldn't be accessible.
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1;
+select * from babel_4344_s1.babel_4344_t1_new;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for table babel_4344_t1)~~
+~~ERROR (Message: permission denied for table babel_4344_t1_new)~~
 
-insert into babel_4344_s1.babel_4344_t1 values(5);
+insert into babel_4344_s1.babel_4344_t1_new values(5);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for table babel_4344_t1)~~
+~~ERROR (Message: permission denied for table babel_4344_t1_new)~~
 
-select * from babel_4344_s1.babel_4344_t3;
+select * from babel_4344_s1.babel_4344_t3_new;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for table babel_4344_t3)~~
+~~ERROR (Message: permission denied for table babel_4344_t3_new)~~
 
-select * from babel_4344_s1.babel_4344_v1;
+select * from babel_4344_s1.babel_4344_v1_new;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for view babel_4344_v1)~~
+~~ERROR (Message: permission denied for view babel_4344_v1_new)~~
 
-exec babel_4344_s1.babel_4344_p1;
+exec babel_4344_s1.babel_4344_p1_new;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for procedure babel_4344_p1)~~
+~~ERROR (Message: permission denied for procedure babel_4344_p1_new)~~
 
-select * from babel_4344_s1.babel_4344_f1();
+select * from babel_4344_s1.babel_4344_f1_new();
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for function babel_4344_f1)~~
+~~ERROR (Message: permission denied for function babel_4344_f1_new)~~
 
 use master;
 go
 
 -- psql
 -- grant object permission
-grant select on babel_4344_s1.babel_4344_t1 to babel_4344_d1_babel_4344_u1;
+grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql
@@ -855,7 +871,7 @@ go
 -- tsql user=babel_4344_l1 password=12345678
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1; -- accessible
+select * from babel_4344_s1.babel_4344_t1_new; -- accessible
 go
 ~~START~~
 int
@@ -877,11 +893,11 @@ go
 -- tsql user=babel_4344_l1 password=12345678
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1; -- not accessible
+select * from babel_4344_s1.babel_4344_t1_new; -- not accessible
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for table babel_4344_t1)~~
+~~ERROR (Message: permission denied for table babel_4344_t1_new)~~
 
 use master
 go
@@ -897,13 +913,13 @@ go
 drop table babel_4344_t1;
 go
 
-drop table babel_4344_s1.babel_4344_t1;
+drop table babel_4344_s1.babel_4344_t1_new;
 go
 
 drop table babel_4344_t3;
 go
 
-drop table babel_4344_s1.babel_4344_t3;
+drop table babel_4344_s1.babel_4344_t3_new;
 go
 
 drop table babel_4344_s1.babel_4344_t2;
@@ -912,7 +928,7 @@ go
 drop view babel_4344_v1;
 go
 
-drop view babel_4344_s1.babel_4344_v1;
+drop view babel_4344_s1.babel_4344_v1_new;
 go
 
 drop view babel_4344_s1.babel_4344_v2;
@@ -921,7 +937,7 @@ go
 drop proc babel_4344_p1;
 go
 
-drop proc babel_4344_s1.babel_4344_p1;
+drop proc babel_4344_s1.babel_4344_p1_new;
 go
 
 drop proc babel_4344_s1.babel_4344_p2;
@@ -933,7 +949,7 @@ go
 drop function babel_4344_f1;
 go
 
-drop function babel_4344_s1.babel_4344_f1;
+drop function babel_4344_s1.babel_4344_f1_new;
 go
 
 drop function babel_4344_s1.babel_4344_f2;

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -712,6 +712,21 @@ go
 REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
 go
 
+-- psql
+-- should show original object names
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1
+~~END~~
+
+
+-- tsql
 -- rename the objects where permissions are already granted
 sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
 go
@@ -724,6 +739,21 @@ go
 sp_rename 'babel_4344_s1.babel_4344_f1', 'babel_4344_f1_new', 'OBJECT';
 go
 
+-- psql
+-- should show renamed objects
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_f1_new#!#128#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_p1_new#!#128#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_t1_new#!#47#!#babel_4344_d1_babel_4344_u1
+babel_4344_s1#!#babel_4344_v1_new#!#2#!#babel_4344_d1_babel_4344_u1
+~~END~~
+
+
+-- tsql
 -- permissions are transferred to the new objects 
 -- Revoke permissions from the new objects
 REVOKE all on babel_4344_s1.babel_4344_t1_new FROM babel_4344_u1;

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -711,6 +711,8 @@ REVOKE SELECT on schema::"bAbel_4344 s1" from "BABEL_4344_U1";
 go
 REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
 go
+GRANT SELECT on babel_4344_t1 to BABEL_4344_U1;
+go
 
 -- psql
 -- should show original object names
@@ -728,6 +730,8 @@ babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1
 
 -- tsql
 -- rename the objects where permissions are already granted
+sp_rename 'babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
+go
 sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
 go
 sp_rename 'babel_4344_s1.babel_4344_t3', 'babel_4344_t3_new', 'OBJECT';
@@ -773,6 +777,12 @@ go
 -- User has SCHEMA privileges, should be accessible.
 use babel_4344_d1;
 go
+select * from babel_4344_t1_new;
+go
+~~START~~
+int
+~~END~~
+
 select * from babel_4344_s1.babel_4344_t1_new
 go
 ~~START~~
@@ -940,7 +950,7 @@ go
 drop schema "update pg_class set oid = 0 where relname = 'babel_4344_t1'";
 go
 
-drop table babel_4344_t1;
+drop table babel_4344_t1_new;
 go
 
 drop table babel_4344_s1.babel_4344_t1_new;

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -439,6 +439,12 @@ go
 REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
 go
 
+-- psql
+-- should show original object names
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+
+-- tsql
 -- rename the objects where permissions are already granted
 sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
 go
@@ -451,6 +457,12 @@ go
 sp_rename 'babel_4344_s1.babel_4344_f1', 'babel_4344_f1_new', 'OBJECT';
 go
 
+-- psql
+-- should show renamed objects
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+
+-- tsql
 -- permissions are transferred to the new objects 
 -- Revoke permissions from the new objects
 REVOKE all on babel_4344_s1.babel_4344_t1_new FROM babel_4344_u1;

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -438,6 +438,8 @@ REVOKE SELECT on schema::"bAbel_4344 s1" from "BABEL_4344_U1";
 go
 REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
 go
+GRANT SELECT on babel_4344_t1 to BABEL_4344_U1;
+go
 
 -- psql
 -- should show original object names
@@ -446,6 +448,8 @@ go
 
 -- tsql
 -- rename the objects where permissions are already granted
+sp_rename 'babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
+go
 sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
 go
 sp_rename 'babel_4344_s1.babel_4344_t3', 'babel_4344_t3_new', 'OBJECT';
@@ -481,6 +485,8 @@ go
 -- tsql user=babel_4344_l1 password=12345678
 -- User has SCHEMA privileges, should be accessible.
 use babel_4344_d1;
+go
+select * from babel_4344_t1_new;
 go
 select * from babel_4344_s1.babel_4344_t1_new
 go
@@ -575,7 +581,7 @@ go
 drop schema "update pg_class set oid = 0 where relname = 'babel_4344_t1'";
 go
 
-drop table babel_4344_t1;
+drop table babel_4344_t1_new;
 go
 
 drop table babel_4344_s1.babel_4344_t1_new;

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -433,38 +433,54 @@ go
 -- REVOKE OBJECT privileges
 use babel_4344_d1;
 go
+
 REVOKE SELECT on schema::"bAbel_4344 s1" from "BABEL_4344_U1";
 go
 REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
 go
-REVOKE all on babel_4344_s1.babel_4344_t1 FROM babel_4344_u1;
+
+-- rename the objects where permissions are already granted
+sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
 go
-REVOKE select on babel_4344_s1.babel_4344_t3(a) FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_t3', 'babel_4344_t3_new', 'OBJECT';
 go
-REVOKE select on babel_4344_s1.babel_4344_v1 FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_v1', 'babel_4344_v1_new', 'OBJECT';
 go
-REVOKE execute on babel_4344_s1.babel_4344_p1 FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_p1', 'babel_4344_p1_new', 'OBJECT';
 go
-REVOKE execute on babel_4344_s1.babel_4344_f1 FROM babel_4344_u1;
+sp_rename 'babel_4344_s1.babel_4344_f1', 'babel_4344_f1_new', 'OBJECT';
 go
-REVOKE all on babel_4344_s1.babel_4344_f1 FROM babel_4344_u1;
+
+-- permissions are transferred to the new objects 
+-- Revoke permissions from the new objects
+REVOKE all on babel_4344_s1.babel_4344_t1_new FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_t3_new(a) FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_v1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_p1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
+go
+REVOKE all on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
 go
 
 -- tsql user=babel_4344_l1 password=12345678
 -- User has SCHEMA privileges, should be accessible.
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1
+select * from babel_4344_s1.babel_4344_t1_new
 go
-insert into babel_4344_s1.babel_4344_t1 values(5);
+insert into babel_4344_s1.babel_4344_t1_new values(5);
 go
-select * from babel_4344_s1.babel_4344_t3;
+select * from babel_4344_s1.babel_4344_t3_new;
 go
-select * from babel_4344_s1.babel_4344_v1;
+select * from babel_4344_s1.babel_4344_v1_new;
 go
-exec babel_4344_s1.babel_4344_p1;
+exec babel_4344_s1.babel_4344_p1_new;
 go
-select * from babel_4344_s1.babel_4344_f1();
+select * from babel_4344_s1.babel_4344_f1_new();
 go
 select * from babel_4344_s2.babel_4344_t1;
 go
@@ -489,24 +505,24 @@ go
 -- User has no privileges, shouldn't be accessible.
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1;
+select * from babel_4344_s1.babel_4344_t1_new;
 go
-insert into babel_4344_s1.babel_4344_t1 values(5);
+insert into babel_4344_s1.babel_4344_t1_new values(5);
 go
-select * from babel_4344_s1.babel_4344_t3;
+select * from babel_4344_s1.babel_4344_t3_new;
 go
-select * from babel_4344_s1.babel_4344_v1;
+select * from babel_4344_s1.babel_4344_v1_new;
 go
-exec babel_4344_s1.babel_4344_p1;
+exec babel_4344_s1.babel_4344_p1_new;
 go
-select * from babel_4344_s1.babel_4344_f1();
+select * from babel_4344_s1.babel_4344_f1_new();
 go
 use master;
 go
 
 -- psql
 -- grant object permission
-grant select on babel_4344_s1.babel_4344_t1 to babel_4344_d1_babel_4344_u1;
+grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql
@@ -521,7 +537,7 @@ go
 -- tsql user=babel_4344_l1 password=12345678
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1; -- accessible
+select * from babel_4344_s1.babel_4344_t1_new; -- accessible
 go
 use master
 go
@@ -534,7 +550,7 @@ go
 -- tsql user=babel_4344_l1 password=12345678
 use babel_4344_d1;
 go
-select * from babel_4344_s1.babel_4344_t1; -- not accessible
+select * from babel_4344_s1.babel_4344_t1_new; -- not accessible
 go
 use master
 go
@@ -550,13 +566,13 @@ go
 drop table babel_4344_t1;
 go
 
-drop table babel_4344_s1.babel_4344_t1;
+drop table babel_4344_s1.babel_4344_t1_new;
 go
 
 drop table babel_4344_t3;
 go
 
-drop table babel_4344_s1.babel_4344_t3;
+drop table babel_4344_s1.babel_4344_t3_new;
 go
 
 drop table babel_4344_s1.babel_4344_t2;
@@ -565,7 +581,7 @@ go
 drop view babel_4344_v1;
 go
 
-drop view babel_4344_s1.babel_4344_v1;
+drop view babel_4344_s1.babel_4344_v1_new;
 go
 
 drop view babel_4344_s1.babel_4344_v2;
@@ -574,7 +590,7 @@ go
 drop proc babel_4344_p1;
 go
 
-drop proc babel_4344_s1.babel_4344_p1;
+drop proc babel_4344_s1.babel_4344_p1_new;
 go
 
 drop proc babel_4344_s1.babel_4344_p2;
@@ -586,7 +602,7 @@ go
 drop function babel_4344_f1;
 go
 
-drop function babel_4344_s1.babel_4344_f1;
+drop function babel_4344_s1.babel_4344_f1_new;
 go
 
 drop function babel_4344_s1.babel_4344_f2;


### PR DESCRIPTION
### Description

We had introduced a catalog `babelfish_schema_permission` to hold the information about objects and its permissions. With this change, `sp_rename` should update the object name in `babelfish_schema_permission` catalog so that the permission is tracked correctly in the catalogs.


### Issues Resolved

Task: [BABEL-4485](https://jira.rds.a2z.com/browse/BABEL-4485)
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Added
* Rename objects with schema name
* Rename objects without schema name
* Rename objects like relations and functions


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**

