### PR TITLE
 Add support for subselect statments in FOR JSON AUTO

### DIFF
--- a/contrib/babelfishpg_tds/error_mapping.txt
+++ b/contrib/babelfishpg_tds/error_mapping.txt
@@ -185,5 +185,5 @@ XX000 ERRCODE_INTERNAL_ERROR	"The table-valued parameter \"%s\" must be declared
 22023 ERRCODE_INVALID_PARAMETER_VALUE   "The datepart %s is not supported by date function %s for data type %s." SQL_ERROR_9810 16
 22008 ERRCODE_DATETIME_VALUE_OUT_OF_RANGE	"Adding a value to a \'%s\' column caused an overflow." SQL_ERROR_517 16
 42P01 ERRCODE_UNDEFINED_TABLE	"FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name."		SQL_ERROR_13600	16
-42P01 ERRCODE_FEATURE_NOT_SUPPORTED	"Values for json auto is not currently supported."		SQL_ERROR_13600	16
+42P01 ERRCODE_FEATURE_NOT_SUPPORTED	"sub-select and values for json auto are not currently supported."		SQL_ERROR_13600	16
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -175,10 +175,11 @@ typedef struct {
 	int nestLevel;
 } forjson_table;
 
-static bool handleForJsonAuto(Query *query);
+static bool handleForJsonAuto(Query *query, forjson_table **tableInfoArr, int numTables);
 static bool isJsonAuto(List* target);
 static bool check_json_auto_walker(Node *node, ParseState *pstate);
-static TargetEntry* buildJsonEntry(forjson_table *table, TargetEntry* te);
+static TargetEntry* buildJsonEntry(int nestLevel, char* tableAlias, TargetEntry* te);
+static void modifyColumnEntries(List* targetList, forjson_table **tableInfoArr, int numTables, Alias *colnameAlias, bool isCve);
 
 extern bool pltsql_ansi_defaults;
 extern bool pltsql_quoted_identifier;
@@ -1344,7 +1345,7 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 }
 
 static bool
-handleForJsonAuto(Query *query)
+handleForJsonAuto(Query *query, forjson_table **tableInfoArr, int numTables)
 {
 	Query* subq;
 	List* target = query->targetList;
@@ -1356,11 +1357,8 @@ handleForJsonAuto(Query *query)
 	RangeTblEntry* subqRte;
 	RangeTblEntry* queryRte;
 	Alias *colnameAlias;
-	forjson_table **tableInfoArr;
-	int numTables = 0;
-	int currTables = 0;
-	int currMax = 0;
-	int i = 0;
+	int newTables = 0;
+	int currTables = numTables;
 	
 	if(!isJsonAuto(target))
 		return false;
@@ -1374,24 +1372,30 @@ handleForJsonAuto(Query *query)
 			if(subq != NULL && (subq->cteList == NULL || list_length(subq->cteList) == 0)) {
 				subqRtable = (List*) subq->rtable;
 				if(subqRtable != NULL && list_length(subqRtable) > 0) {
+					forjson_table **tempArr;
 					foreach(lc, subqRtable) {
 						subqRte = castNode(RangeTblEntry, lfirst(lc));
 						if(subqRte->rtekind == RTE_RELATION) {
-							numTables++;
+							newTables++;
 						} else if(subqRte->rtekind == RTE_SUBQUERY) {
 							ereport(ERROR,
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-										errmsg("Values for json auto is not currently supported ")));
+										errmsg("sub-select and values for json auto are not currently supported.")));
 						}
 					}
 
-					if(numTables == 0) {
+					if(numTables + newTables == 0) {
 						ereport(ERROR,
 									(errcode(ERRCODE_UNDEFINED_TABLE),
 										errmsg("FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.")));
 					}
 
-					tableInfoArr = malloc(numTables * sizeof(forjson_table));
+					tempArr = palloc((numTables + newTables) * sizeof(forjson_table));
+					for(int j = 0; j < numTables; j++) {
+						tempArr[j] = tableInfoArr[j];
+					}
+					tableInfoArr = tempArr;
+					tempArr = NULL;
 					queryRte = linitial_node(RangeTblEntry, query->rtable);
 					colnameAlias = (Alias*) queryRte->eref;
 
@@ -1407,52 +1411,43 @@ handleForJsonAuto(Query *query)
 							currTables++;
 						}
 					}
-
-					foreach(lc, subq->targetList) {
-						TargetEntry* te = castNode(TargetEntry, lfirst(lc));
-						int oid = te->resorigtbl;
-						for(int j = 0; j < numTables; j++) {
-							if(tableInfoArr[j]->oid == oid) {
-								// build entry
-								String* s = castNode(String, lfirst(list_nth_cell(colnameAlias->colnames, i)));
-								if(tableInfoArr[j]->nestLevel == -1) {
-									currMax++;
-									tableInfoArr[j]->nestLevel = currMax;
-								}
-								te = buildJsonEntry(tableInfoArr[j], te);
-								s->sval = te->resname;
-								break;
-							}
-						}
-						i++;
-					}
-					free(tableInfoArr);
+					numTables = numTables + newTables;
+					modifyColumnEntries(subq->targetList, tableInfoArr, numTables, colnameAlias, false);
 					return true;
 				}
 			} else if(subq->cteList != NULL && list_length(subq->cteList) > 0) {
 				Query* ctequery;
 				CommonTableExpr* cte;
+				forjson_table **tempArr;
 				foreach(lc, subq->cteList) {
 					cte = castNode(CommonTableExpr, lfirst(lc));
 					ctequery = (Query*) cte->ctequery;
 					foreach(lc2, ctequery->rtable) {
 						subqRte = castNode(RangeTblEntry, lfirst(lc2));
 						if(subqRte->rtekind == RTE_RELATION)
-							numTables++;
+							newTables++;
 					}
 				}
 
-				if(numTables == 0) {
+				if(newTables == 0) {
 					forjson_table *table = palloc(sizeof(forjson_table));
-					tableInfoArr = malloc(sizeof(forjson_table));
+					tempArr = palloc((numTables + 1) * sizeof(forjson_table));
 					table->oid = 0;
 					table->nestLevel = -1;
 					table->alias = "cteplaceholder";
-					tableInfoArr[numTables] = table;
-					numTables++;
+					tempArr[numTables] = table;
+					newTables++;
 				} else {
-					tableInfoArr = malloc(numTables * sizeof(forjson_table));
+					tempArr = palloc((numTables + newTables) * sizeof(forjson_table));
 				}
+
+				for(int j = 0; j < numTables; j++) {
+					tempArr[j] = tableInfoArr[j];
+				}
+
+				tableInfoArr = tempArr;
+				tempArr = NULL;
+				numTables = numTables + newTables;
 				queryRte = linitial_node(RangeTblEntry, query->rtable);
 				colnameAlias = (Alias*) queryRte->eref;
 
@@ -1472,26 +1467,9 @@ handleForJsonAuto(Query *query)
 						}
 					}
 				}
+
+				modifyColumnEntries(subq->targetList, tableInfoArr, numTables, colnameAlias, true);
 				
-				foreach(lc, subq->targetList) {
-					TargetEntry* te = castNode(TargetEntry, lfirst(lc));
-					int oid = te->resorigtbl;
-					for(int j = 0; j < numTables; j++) {
-						if(tableInfoArr[j]->oid == oid) {
-							// build entry
-							String* s = castNode(String, lfirst(list_nth_cell(colnameAlias->colnames, i)));
-							if(tableInfoArr[j]->nestLevel == -1) {
-								currMax++;
-								tableInfoArr[j]->nestLevel = currMax;
-							}
-							te = buildJsonEntry(tableInfoArr[j], te);
-							s->sval = te->resname;
-							break;
-						}
-					}
-					i++;
-				}
-				free(tableInfoArr);
 				return true;
 			}
 		}
@@ -1531,35 +1509,79 @@ isJsonAuto(List* target)
 }
 
 static TargetEntry*
-buildJsonEntry(forjson_table *table, TargetEntry* te)
+buildJsonEntry(int nestLevel, char* tableAlias, TargetEntry* te)
 {
 	char nest[NAMEDATALEN]; // check size appropriate
 	StringInfo new_resname = makeStringInfo();
-	sprintf(nest, "%d", table->nestLevel);
+	sprintf(nest, "%d", nestLevel);
 	// Adding JSONAUTOALIAS prevents us from modifying
 	// a column more than once
 	if(!strcmp(te->resname, "\?column\?")) {
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					errmsg("column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table")));
-	}
-	if(!strncmp(te->resname, "JSONAUTOALIAS", 13))
-		return te; 
+	} 
 	appendStringInfoString(new_resname, "JSONAUTOALIAS.");
 	appendStringInfoString(new_resname, nest);
 	appendStringInfoChar(new_resname, '.');
-	appendStringInfoString(new_resname, table->alias);
+	appendStringInfoString(new_resname, tableAlias);
 	appendStringInfoChar(new_resname, '.');
 	appendStringInfoString(new_resname, te->resname);
 	te->resname = new_resname->data;
 	return te;
 }
 
-static bool check_json_auto_walker(Node *node, ParseState *pstate) {
+static void modifyColumnEntries(List* targetList, forjson_table **tableInfoArr, int numTables, Alias *colnameAlias, bool isCve)
+{
+	int i = 0;
+	int currMax = 0;
+	ListCell* lc;
+	foreach(lc, targetList) {
+		TargetEntry* te = castNode(TargetEntry, lfirst(lc));
+		int oid = te->resorigtbl;
+		String* s = castNode(String, lfirst(list_nth_cell(colnameAlias->colnames, i)));
+		if(te->expr != NULL && nodeTag(te->expr) == T_SubLink) {
+			SubLink *sl = castNode(SubLink, te->expr);
+			if(sl->subselect != NULL && nodeTag(sl->subselect) == T_Query) {
+				if(handleForJsonAuto(castNode(Query, sl->subselect), tableInfoArr, numTables)) {
+					CoerceViaIO *iocoerce = makeNode(CoerceViaIO);
+					iocoerce->arg = (Expr*) sl;
+					iocoerce->resulttype = T_JsonArrayQueryConstructor;
+					iocoerce->resultcollid = 0;
+					iocoerce->coerceformat = COERCE_EXPLICIT_CAST;
+					buildJsonEntry(1, "temp", te);
+					s->sval = te->resname;
+					te->expr = (Expr*) iocoerce;
+					continue;
+				}
+			}
+		}
+		for(int j = 0; j < numTables; j++) {
+			if(tableInfoArr[j]->oid == oid) {
+				// build entry
+				if(tableInfoArr[j]->nestLevel == -1) {
+					currMax++;
+					tableInfoArr[j]->nestLevel = currMax;
+				}
+				te = buildJsonEntry(tableInfoArr[j]->nestLevel, tableInfoArr[j]->alias, te);
+				s->sval = te->resname;
+				break;
+			} else if(!isCve && oid == 0 && j == numTables - 1) {
+				te = buildJsonEntry(1, "temp", te);
+				s->sval = te->resname;
+				break;
+			}
+		}
+		i++;
+	}
+}
+
+static bool check_json_auto_walker(Node *node, ParseState *pstate)
+{
 	if (node == NULL)
 		return false;
 	if (IsA(node, Query)) {
-		if(handleForJsonAuto((Query*) node))
+		if(handleForJsonAuto((Query*) node, NULL, 0))
 			return true;
 		else {
 			return query_tree_walker((Query*) node,

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -325,6 +325,11 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 
 		// Determine if the value should be inserted as a nested json object
 		parts = determine_parts(colname, &num);
+		if(strcmp(parts[0], "JSONAUTOALIAS") != 0) {
+			ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("sub-select and values for json auto are not currently supported.")));
+		}
 		colname = remove_index_and_alias(colname);
 		nestedVal = value;
 

--- a/test/JDBC/expected/TestErrorHelperFunctions.out
+++ b/test/JDBC/expected/TestErrorHelperFunctions.out
@@ -208,7 +208,7 @@ XX000#!#The table-valued parameter "%s" must be declared with the READONLY optio
 22023#!#The datepart %s is not supported by date function %s for data type %s.#!##!#9810
 22008#!#Adding a value to a '%s' column caused an overflow.#!##!#517
 42P01#!#FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.#!##!#13600
-42P01#!#Values for json auto is not currently supported.#!##!#13600
+42P01#!#sub-select and values for json auto are not currently supported.#!##!#13600
 ~~END~~
 
 

--- a/test/JDBC/expected/forjsonauto-vu-cleanup.out
+++ b/test/JDBC/expected/forjsonauto-vu-cleanup.out
@@ -55,6 +55,35 @@ GO
 DROP PROCEDURE forjson_vu_p_5
 GO
 
+DROP PROCEDURE forjson_vu_p_6
+GO
+
+DROP PROCEDURE forjson_vu_p_7
+GO
+
+DROP PROCEDURE forjson_vu_p_8
+GO
+
+DROP PROCEDURE forjson_vu_p_9
+GO
+
+DROP PROCEDURE forjson_vu_p_10
+GO
+
+DROP PROCEDURE forjson_vu_p_11
+GO
+
+DROP PROCEDURE forjson_vu_p_12
+GO
+
+DROP PROCEDURE forjson_vu_p_13
+GO
+
+DROP PROCEDURE forjson_vu_p_14
+GO
+
+DROP PROCEDURE forjson_vu_p_15
+GO
 
 DROP FUNCTION forjson_vu_f_1()
 GO

--- a/test/JDBC/expected/forjsonauto-vu-prepare.out
+++ b/test/JDBC/expected/forjsonauto-vu-prepare.out
@@ -195,3 +195,79 @@ begin
 end;
 go
 
+CREATE PROCEDURE forjson_vu_p_6 AS
+BEGIN
+    select top 10 U.id, U.firstname, (select O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_7 AS
+BEGIN
+    select * from forjson_auto_vu_t_users U where
+    U.id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O)
+    for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_8 AS
+BEGIN
+    select * from forjson_auto_vu_t_users U where
+    U.id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O for json auto)
+    for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_9 AS
+BEGIN
+    select distinct top 10
+        U.id,
+        (select distinct O.productId from forjson_auto_vu_t_orders O where O.userid = U.id)
+        as details
+        from forjson_auto_vu_t_users U 
+        group by U.id
+        for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_10 AS
+BEGIN
+    select distinct top 2
+        U.Id,
+        O.orderdate
+        from forjson_auto_vu_t_users U INNER JOIN
+            forjson_auto_vu_t_orders O ON U.Id = O.Id
+        for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_11 AS
+BEGIN
+    select distinct top 10 U.id, (select distinct O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U group by U.id for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_12 AS
+BEGIN
+    select U.id, U.firstname, (select U.lastname, O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_13 AS
+BEGIN
+    select * from forjson_auto_vu_t_users U where U.Id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O) for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_14 AS
+BEGIN
+    select U.id, U.firstname, (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) as "details" from forjson_auto_vu_t_users U for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_15 AS 
+    BEGIN 
+        DECLARE @json_string NVARCHAR(2000) 
+        SET @json_string = (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) 
+        select U.id, U.firstname, @json_string as details from forjson_auto_vu_t_users U for json auto
+END
+GO

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -150,7 +150,88 @@ EXECUTE forjson_vu_p_5
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Values for json auto is not currently supported )~~
+~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+
+
+EXECUTE forjson_vu_p_6
+GO
+~~START~~
+nvarchar
+[{"id": 1, "firstname": "j", "details": {"productId": 1}}, {"id": 1, "firstname": "e", "details": {"productId": 1}}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_7
+GO
+~~START~~
+nvarchar
+[{"Id": 1, "firstname": "j", "lastname": "o", "email": "testemail"}, {"Id": 1, "firstname": "e", "lastname": "l", "email": "testemail2"}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_8
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+
+
+EXECUTE forjson_vu_p_9
+GO
+~~START~~
+nvarchar
+[{"id": 1, "details": 1}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_10
+GO
+~~START~~
+nvarchar
+[{"Id": 1, "o": [{"orderdate": "2023-06-25"}]}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_11
+GO
+~~START~~
+nvarchar
+[{"id": 1, "details": {"productId": 1}}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_12
+GO
+~~START~~
+nvarchar
+[{"id": 1, "firstname": "j", "details": {"lastname": "o", "productId": 1}}, {"id": 1, "firstname": "e", "details": {"lastname": "l", "productId": 1}}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_13
+GO
+~~START~~
+nvarchar
+[{"Id": 1, "firstname": "j", "lastname": "o", "email": "testemail"}, {"Id": 1, "firstname": "e", "lastname": "l", "email": "testemail2"}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_14
+GO
+~~START~~
+nvarchar
+[{"id": 1, "firstname": "j", "details": {"o": [{"productId": 1}, {"productId": 1}], "price": "30"}}, {"id": 1, "firstname": "e", "details": {"o": [{"productId": 1}, {"productId": 1}], "price": "30"}}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_15
+GO
+~~START~~
+nvarchar
+[{"id": 1, "firstname": "j", "details": "[{\"price\": \"30\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}, {\"price\": \"20\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}]"}, {"id": 1, "firstname": "e", "details": "[{\"price\": \"30\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}, {\"price\": \"20\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}]"}]
+~~END~~
 
 
 SELECT forjson_vu_f_1()

--- a/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
@@ -55,6 +55,35 @@ GO
 DROP PROCEDURE forjson_vu_p_5
 GO
 
+DROP PROCEDURE forjson_vu_p_6
+GO
+
+DROP PROCEDURE forjson_vu_p_7
+GO
+
+DROP PROCEDURE forjson_vu_p_8
+GO
+
+DROP PROCEDURE forjson_vu_p_9
+GO
+
+DROP PROCEDURE forjson_vu_p_10
+GO
+
+DROP PROCEDURE forjson_vu_p_11
+GO
+
+DROP PROCEDURE forjson_vu_p_12
+GO
+
+DROP PROCEDURE forjson_vu_p_13
+GO
+
+DROP PROCEDURE forjson_vu_p_14
+GO
+
+DROP PROCEDURE forjson_vu_p_15
+GO
 
 DROP FUNCTION forjson_vu_f_1()
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
@@ -181,3 +181,79 @@ begin
 end;
 go
 
+CREATE PROCEDURE forjson_vu_p_6 AS
+BEGIN
+    select top 10 U.id, U.firstname, (select O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_7 AS
+BEGIN
+    select * from forjson_auto_vu_t_users U where
+    U.id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O)
+    for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_8 AS
+BEGIN
+    select * from forjson_auto_vu_t_users U where
+    U.id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O for json auto)
+    for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_9 AS
+BEGIN
+    select distinct top 10
+        U.id,
+        (select distinct O.productId from forjson_auto_vu_t_orders O where O.userid = U.id)
+        as details
+        from forjson_auto_vu_t_users U 
+        group by U.id
+        for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_10 AS
+BEGIN
+    select distinct top 2
+        U.Id,
+        O.orderdate
+        from forjson_auto_vu_t_users U INNER JOIN
+            forjson_auto_vu_t_orders O ON U.Id = O.Id
+        for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_11 AS
+BEGIN
+    select distinct top 10 U.id, (select distinct O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U group by U.id for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_12 AS
+BEGIN
+    select U.id, U.firstname, (select U.lastname, O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_13 AS
+BEGIN
+    select * from forjson_auto_vu_t_users U where U.Id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O) for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_14 AS
+BEGIN
+    select U.id, U.firstname, (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) as "details" from forjson_auto_vu_t_users U for json auto
+END
+GO
+
+CREATE PROCEDURE forjson_vu_p_15 AS 
+    BEGIN 
+        DECLARE @json_string NVARCHAR(2000) 
+        SET @json_string = (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) 
+        select U.id, U.firstname, @json_string as details from forjson_auto_vu_t_users U for json auto
+END
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -55,6 +55,36 @@ GO
 EXECUTE forjson_vu_p_5
 GO
 
+EXECUTE forjson_vu_p_6
+GO
+
+EXECUTE forjson_vu_p_7
+GO
+
+EXECUTE forjson_vu_p_8
+GO
+
+EXECUTE forjson_vu_p_9
+GO
+
+EXECUTE forjson_vu_p_10
+GO
+
+EXECUTE forjson_vu_p_11
+GO
+
+EXECUTE forjson_vu_p_12
+GO
+
+EXECUTE forjson_vu_p_13
+GO
+
+EXECUTE forjson_vu_p_14
+GO
+
+EXECUTE forjson_vu_p_15
+GO
+
 SELECT forjson_vu_f_1()
 GO
 


### PR DESCRIPTION
### Description

This commit adds support for sub select statements in `FOR JSON AUTO`.  


### Issues Resolved
Task: BABEL-4701

### Test Scenarios Covered ###
* **Use case based -**

```
select top 10 
U.id, 
U.firstname, 
(select O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U for json auto

----------------------------------------
[{"id": 1, "firstname": "j", "details": {"productId": 1}}, {"id": 1, "firstname": "e", "details": {"productId": 1}}]

```

```
CREATE PROCEDURE forjson_vu_p_15 AS 
    BEGIN 
        DECLARE @json_string NVARCHAR(2000) 
        SET @json_string = (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) 
        select U.id, U.firstname, @json_string as details from forjson_auto_vu_t_users U for json auto
    END
GO

----------------------------------------
[{"id": 1, "firstname": "j", "details": "[{\"price\": \"30\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}, {\"price\": \"20\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}]"}, {"id": 1, "firstname": "e", "details": "[{\"price\": \"30\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}, {\"price\": \"20\", \"o\": [{\"productId\": 1}, {\"productId\": 1}]}]"}]

```

```
select U.id,
    U.firstname, 
    (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) as "details" from forjson_auto_vu_t_users U for json auto

----------------------------------------

[{"id": 1, "firstname": "j", "details": {"o": [{"productId": 1}, {"productId": 1}], "price": "30"}}, {"id": 1, "firstname": "e", "details": {"o": [{"productId": 1}, {"productId": 1}], "price": "30"}}]
```

```
select distinct top 10
        U.id,
        (select distinct O.productId from forjson_auto_vu_t_orders O where O.userid = U.id)
        as details
        from forjson_auto_vu_t_users U 
        group by U.id
        for json auto

----------------------------------------
[{"id": 1, "details": 1}]
```

* **Boundary conditions -**


* **Arbitrary inputs -**
```
select U.id, (select NULL) as details from forjson_auto_vu_t_users U for json auto
go
~~START~~
nvarchar
[{"id": 1}, {"id": 1}]
~~END~~
```

* **Negative test cases -**
 
```
select * from forjson_auto_vu_t_users U where U.Id = (SELECT MAX(O.userid) from forjson_auto_vu_t_orders O for json auto) for json auto
go
~~START~~
nvarchar
~~ERROR (Code: 33557097)~~

~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
```

```
select U.id,
    U.firstname, 
    (select P.price from fake_table P for json auto) as "details" from forjson_auto_vu_t_users U for json auto
GO
~~ERROR (Code: 33557097)~~

~~ERROR (Message: relation "fake_table" does not exist)~~
```

* **Minor version upgrade tests -**
Tests included in upgrade schedules

* **Major version upgrade tests -**
Tests included in upgrade schedules

* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).