### PR TITLE
Support sp_procedure_params_100 stored procedure

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
@@ -2877,6 +2877,95 @@ FROM
     WHERE CAST("COLUMN_NAME" AS sys.nvarchar(128)) NOT IN ('cmin', 'cmax', 'xmin', 'xmax', 'ctid', 'tableoid');
 GRANT SELECT ON sys.spt_columns_view_managed TO PUBLIC;
 
+CREATE OR REPLACE PROCEDURE sys.sp_procedure_params_100_managed(IN "@procedure_name" sys.sysname, 
+                                                                IN "@group_number" integer DEFAULT 1, 
+                                                                IN "@procedure_schema" sys.sysname DEFAULT NULL, 
+                                                                IN "@parameter_name" sys.sysname DEFAULT NULL)
+AS $$
+BEGIN
+	IF @procedure_schema IS NULL
+		BEGIN
+			SELECT @procedure_schema = default_schema_name from sys.babelfish_authid_user_ext WHERE orig_username = user_name() AND database_name = db_name();
+		END
+
+        SELECT 	v.column_name AS [PARAMETER_NAME],
+		CAST (CASE v.column_type
+			WHEN 5 THEN 4
+                        WHEN 3 THEN 4
+                        ELSE v.column_type END
+                     	AS smallint) AS [PARAMETER_TYPE],
+        	CAST (CASE v.type_name
+			WHEN 'int' THEN 8
+                        WHEN 'nchar' THEN 10
+                        WHEN 'char' THEN 3
+                        WHEN 'date' THEN 31
+                        WHEN 'nvarchar' THEN 12
+                        WHEN 'varchar' THEN 22
+                        WHEN 'table' THEN 23
+                        WHEN 'datetime' THEN 4
+                        WHEN 'datetime2' THEN 33
+                        WHEN 'datetimeoffset' THEN 34
+                        WHEN 'smalldatetime' THEN 15
+			WHEN 'time' THEN 32
+                        WHEN 'decimal' THEN 5
+			WHEN 'numeric' THEN 5
+                        WHEN 'float' THEN 6
+                        WHEN 'real' THEN 13
+                        WHEN 'nchar' THEN 10
+                        WHEN 'flag' THEN 2
+                        WHEN 'money' THEN 9
+                        WHEN 'smallmoney' THEN 17
+                        WHEN 'tinyint' THEN 20
+                        WHEN 'smallint' THEN 16
+                        WHEN 'bigint' THEN 0
+                        WHEN 'bit' THEN 2
+			WHEN 'text' THEN 18
+			WHEN 'ntext' THEN 11
+			WHEN 'binary' THEN 1
+			WHEN 'varbinary' THEN 21
+			WHEN 'image' THEN 7
+                        ELSE 0 END
+                	AS smallint) AS [MANAGED_DATA_TYPE],
+        	CAST (CASE 
+			WHEN v.type_name IN (N'nchar', N'nvarchar') AND p.max_length <> -1 THEN p.max_length / 2
+			WHEN v.type_name IN (N'char', N'varchar', N'binary', N'varbinary') AND p.max_length <> -1 THEN p.max_length
+			WHEN v.type_name IN (N'nvarchar', N'varchar', N'varbinary') AND p.max_length = -1 THEN 0
+                	WHEN v.type_name IN (N'text', N'image') THEN 2147483647
+                	WHEN v.type_name = 'ntext' THEN 1073741823
+                	ELSE NULL END 
+			AS INT) AS [CHARACTER_MAXIMUM_LENGTH],
+        	CAST(CASE 
+			WHEN v.type_name IN (N'int', N'smallint', N'bigint', N'tinyint', N'float', N'real', N'decimal', N'numeric', N'money', N'smallmoney') 
+				THEN v.PRECISION
+			ELSE NULL END 
+			AS smallint) AS [NUMERIC_PRECISION],
+        	CAST(CASE 
+			WHEN v.type_name IN (N'decimal', N'numeric') THEN v.SCALE 
+			ELSE NULL END 
+			AS smallint ) AS [NUMERIC_SCALE],
+        	CAST(NULL AS sys.nvarchar(128)) AS [TYPE_CATALOG_NAME],
+        	CAST(NULL AS sys.nvarchar(128)) AS [TYPE_SCHEMA_NAME],
+        	CAST(v.TYPE_NAME AS sys.nvarchar(128)) AS [TYPE_NAME],
+        	CAST(NULL AS sys.nvarchar(128)) AS XML_CATALOGNAME,
+        	CAST(NULL AS sys.nvarchar(128)) AS XML_SCHEMANAME,
+        	CAST(NULL AS sys.nvarchar(128)) AS XML_SCHEMACOLLECTIONNAME,
+        	CAST(CASE
+			WHEN v.type_name = 'datetime' THEN 3
+                    	WHEN v.type_name IN (N'datetime2', N'datetimeoffset', N'time') THEN 7
+			WHEN v.type_name IN (N'date', N'smalldatetime') THEN 0
+                    	ELSE NULL END AS int) AS [SS_DATETIME_PRECISION]
+   	FROM sys.sp_sproc_columns_view v
+   	LEFT OUTER JOIN sys.all_parameters AS p 
+	ON v.column_name = p.name AND p.object_id = object_id(CONCAT(@procedure_schema, '.', @procedure_name))
+   	WHERE v.original_procedure_name = @procedure_name
+    	AND v.procedure_owner = @procedure_schema
+	AND (@parameter_name IS NULL OR column_name = @parameter_name)
+	AND @group_number = 1
+    	ORDER BY PROCEDURE_OWNER, PROCEDURE_NAME, ORDINAL_POSITION;
+END;
+$$ LANGUAGE pltsql;
+GRANT EXECUTE ON PROCEDURE sys.sp_procedure_params_100_managed TO PUBLIC;
+
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'sysforeignkeys_deprecated_3_5_0');
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'system_objects_deprecated_3_5_0');
 CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'syscolumns_deprecated_3_5_0');

--- a/test/JDBC/expected/babel-3254-vu-cleanup.out
+++ b/test/JDBC/expected/babel-3254-vu-cleanup.out
@@ -1,0 +1,30 @@
+drop procedure babel_3254_p1
+go
+
+drop procedure babel_3254_p2
+go
+
+drop procedure babel_3254_p3
+go
+
+drop procedure babel_3254_p4
+go
+
+drop procedure babel_3254_p5
+go
+
+drop procedure babel_3254_s1.babel_3254_p6
+go
+
+drop procedure babel_3254_s1.babel_3254_p7
+go
+
+drop login babel_3254_l1
+go
+
+drop schema babel_3254_s1
+go
+
+drop user babel_3254_u1
+go
+

--- a/test/JDBC/expected/babel-3254-vu-prepare.out
+++ b/test/JDBC/expected/babel-3254-vu-prepare.out
@@ -1,0 +1,91 @@
+-- int, bigint, smallint, tinyint, bit
+create procedure babel_3254_p1 @a int,
+                           @b bigint,
+                           @c smallint OUTPUT,
+                           @d tinyint,
+                           @e bit,
+                           @f float OUTPUT,
+                           @g real
+as select 1
+go
+
+
+-- char, varchar, text, nchar, nvarchar, ntext
+create procedure babel_3254_p2 @a char(5),
+                           @b nchar(5),
+                           @c varchar(5) OUTPUT,
+                           @d nvarchar(5),
+                           @e text,
+                           @g ntext,
+                           @h varchar(max),
+                           @i nvarchar(max),
+                           @j char OUTPUT,
+                           @k varchar,
+                           @l nchar,
+                           @m nvarchar
+as select 1
+go
+
+-- binary, varbinary, image
+create procedure babel_3254_p3 @a binary,
+                            @b varbinary OUTPUT,
+                            @c binary(5),
+                            @d varbinary(5) OUTPUT,
+                            @e image,
+                            @f varbinary(max)
+as select 1
+go
+
+-- decimal and numeric
+create procedure babel_3254_p4 @a decimal OUTPUT,
+                            @b numeric,
+                            @c decimal(5,2),
+                            @d numeric(5,2) OUTPUT
+as select 1
+go
+
+-- date, datetimeoffset, datetime, datetime2, smalldatetime, time
+create procedure babel_3254_p5 @a date,
+                            @b datetimeoffset OUTPUT,
+                            @c datetime,
+                            @d datetime2,
+                            @e smalldatetime,
+                            @f time OUTPUT,
+                            @g datetime2(7),
+                            @h datetimeoffset(7),
+                            @i time(7)
+as select 1
+go
+
+create schema babel_3254_s1
+go
+
+-- money and smallmoney
+create procedure babel_3254_s1.babel_3254_p6 @a money OUTPUT,
+                                            @b smallmoney
+as select 1
+go
+
+create login babel_3254_l1 with password = '12345678'
+go
+
+create user babel_3254_u1 for login babel_3254_l1 with default_schema = babel_3254_s1
+go
+
+select rolname, login_name from sys.babelfish_authid_user_ext where login_name = 'babel_3254_l1'
+go
+~~START~~
+varchar#!#varchar
+master_babel_3254_u1#!#babel_3254_l1
+~~END~~
+
+
+-- psql
+grant all on schema master_babel_3254_s1 to master_babel_3254_u1;
+go
+
+-- tsql user=babel_3254_l1 password=12345678
+create procedure babel_3254_p7 @a int
+as select 1
+go
+

--- a/test/JDBC/expected/babel-3254-vu-verify.out
+++ b/test/JDBC/expected/babel-3254-vu-verify.out
@@ -1,0 +1,244 @@
+sp_procedure_params_100_managed 'babel_3254_p1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#0#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#bigint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#2#!#16#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#1#!#20#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#tinyint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@f#!#2#!#6#!#<NULL>#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#float#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@g#!#1#!#13#!#<NULL>#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed 'babel_3254_p2'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#3#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#10#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#2#!#22#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#1#!#12#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#18#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@g#!#1#!#11#!#1073741823#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@h#!#1#!#22#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@i#!#1#!#12#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@j#!#2#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@k#!#1#!#22#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@l#!#1#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@m#!#1#!#12#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed 'babel_3254_p3'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#2#!#21#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#1#!#1#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#2#!#21#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#7#!#2147483647#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@f#!#1#!#21#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed 'babel_3254_p4'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#2#!#5#!#<NULL>#!#38#!#38#!#<NULL>#!#<NULL>#!#decimal#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#5#!#<NULL>#!#38#!#38#!#<NULL>#!#<NULL>#!#numeric#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#1#!#5#!#<NULL>#!#38#!#38#!#<NULL>#!#<NULL>#!#decimal#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#2#!#5#!#<NULL>#!#38#!#38#!#<NULL>#!#<NULL>#!#numeric#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed 'babel_3254_p5'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#31#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#date#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+@b#!#2#!#34#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#datetimeoffset#!#<NULL>#!#<NULL>#!#<NULL>#!#7
+@c#!#1#!#4#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#datetime#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+@d#!#1#!#33#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#datetime2#!#<NULL>#!#<NULL>#!#<NULL>#!#7
+@e#!#1#!#15#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#smalldatetime#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+@f#!#2#!#32#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#time#!#<NULL>#!#<NULL>#!#<NULL>#!#7
+@g#!#1#!#33#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#datetime2#!#<NULL>#!#<NULL>#!#<NULL>#!#7
+@h#!#1#!#34#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#datetimeoffset#!#<NULL>#!#<NULL>#!#<NULL>#!#7
+@i#!#1#!#32#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#time#!#<NULL>#!#<NULL>#!#<NULL>#!#7
+~~END~~
+
+
+-- will result no rows as babel_3254_p6 is in babel_3254_s1 schema
+sp_procedure_params_100_managed 'babel_3254_p6'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p6', @procedure_schema = 'babel_3254_s1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#2#!#9#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#17#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#smallmoney#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p1', @group_number = 1
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#0#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#bigint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#2#!#16#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#1#!#20#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#tinyint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@f#!#2#!#6#!#<NULL>#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#float#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@g#!#1#!#13#!#<NULL>#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- group number anything other than 1 should return no rows
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p1', @group_number = 2
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p2', @group_number = 3
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p3', @group_number = 4
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p4', @group_number = 5
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p5', @group_number = 6
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p1', @parameter_name = '@a'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p2', @parameter_name = '@b'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@b#!#1#!#10#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p3', @parameter_name = '@c'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@c#!#1#!#1#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p4', @parameter_name = '@d'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@d#!#2#!#5#!#<NULL>#!#38#!#38#!#<NULL>#!#<NULL>#!#numeric#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p5', @parameter_name = '@e'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@e#!#1#!#15#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#smalldatetime#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = ''
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+-- reset the login password
+ALTER LOGIN babel_3254_l1 WITH PASSWORD = '12345678'
+GO
+
+select rolname, login_name from sys.babelfish_authid_user_ext where login_name = 'babel_3254_l1'
+go
+~~START~~
+varchar#!#varchar
+master_babel_3254_u1#!#babel_3254_l1
+~~END~~
+
+
+-- tsql user=babel_3254_l1 password=12345678
+-- check for the user having non-default schema
+select default_schema_name from sys.babelfish_authid_user_ext WHERE orig_username = user_name() AND database_name = db_name();
+go
+~~START~~
+nvarchar
+babel_3254_s1
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p7'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- should return no rows as babel_3254_p7 is in babel_3254_s1 schema
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p7', @procedure_schema = 'dbo'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+-- should return the result set as babel_3254_p7 is in babel_3254_s1 schema
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p7', @procedure_schema = 'babel_3254_s1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+

--- a/test/JDBC/input/babel-3254-vu-cleanup.sql
+++ b/test/JDBC/input/babel-3254-vu-cleanup.sql
@@ -1,0 +1,30 @@
+drop procedure babel_3254_p1
+go
+
+drop procedure babel_3254_p2
+go
+
+drop procedure babel_3254_p3
+go
+
+drop procedure babel_3254_p4
+go
+
+drop procedure babel_3254_p5
+go
+
+drop procedure babel_3254_s1.babel_3254_p6
+go
+
+drop procedure babel_3254_s1.babel_3254_p7
+go
+
+drop login babel_3254_l1
+go
+
+drop schema babel_3254_s1
+go
+
+drop user babel_3254_u1
+go
+

--- a/test/JDBC/input/babel-3254-vu-prepare.mix
+++ b/test/JDBC/input/babel-3254-vu-prepare.mix
@@ -1,0 +1,86 @@
+-- int, bigint, smallint, tinyint, bit
+create procedure babel_3254_p1 @a int,
+                           @b bigint,
+                           @c smallint OUTPUT,
+                           @d tinyint,
+                           @e bit,
+                           @f float OUTPUT,
+                           @g real
+as select 1
+go
+
+
+-- char, varchar, text, nchar, nvarchar, ntext
+create procedure babel_3254_p2 @a char(5),
+                           @b nchar(5),
+                           @c varchar(5) OUTPUT,
+                           @d nvarchar(5),
+                           @e text,
+                           @g ntext,
+                           @h varchar(max),
+                           @i nvarchar(max),
+                           @j char OUTPUT,
+                           @k varchar,
+                           @l nchar,
+                           @m nvarchar
+as select 1
+go
+
+-- binary, varbinary, image
+create procedure babel_3254_p3 @a binary,
+                            @b varbinary OUTPUT,
+                            @c binary(5),
+                            @d varbinary(5) OUTPUT,
+                            @e image,
+                            @f varbinary(max)
+as select 1
+go
+
+-- decimal and numeric
+create procedure babel_3254_p4 @a decimal OUTPUT,
+                            @b numeric,
+                            @c decimal(5,2),
+                            @d numeric(5,2) OUTPUT
+as select 1
+go
+
+-- date, datetimeoffset, datetime, datetime2, smalldatetime, time
+create procedure babel_3254_p5 @a date,
+                            @b datetimeoffset OUTPUT,
+                            @c datetime,
+                            @d datetime2,
+                            @e smalldatetime,
+                            @f time OUTPUT,
+                            @g datetime2(7),
+                            @h datetimeoffset(7),
+                            @i time(7)
+as select 1
+go
+
+create schema babel_3254_s1
+go
+
+-- money and smallmoney
+create procedure babel_3254_s1.babel_3254_p6 @a money OUTPUT,
+                                            @b smallmoney
+as select 1
+go
+
+create login babel_3254_l1 with password = '12345678'
+go
+
+create user babel_3254_u1 for login babel_3254_l1 with default_schema = babel_3254_s1
+go
+
+select rolname, login_name from sys.babelfish_authid_user_ext where login_name = 'babel_3254_l1'
+go
+
+-- psql
+grant all on schema master_babel_3254_s1 to master_babel_3254_u1;
+go
+
+-- tsql user=babel_3254_l1 password=12345678
+create procedure babel_3254_p7 @a int
+as select 1
+go
+

--- a/test/JDBC/input/babel-3254-vu-verify.mix
+++ b/test/JDBC/input/babel-3254-vu-verify.mix
@@ -1,0 +1,83 @@
+sp_procedure_params_100_managed 'babel_3254_p1'
+go
+
+sp_procedure_params_100_managed 'babel_3254_p2'
+go
+
+sp_procedure_params_100_managed 'babel_3254_p3'
+go
+
+sp_procedure_params_100_managed 'babel_3254_p4'
+go
+
+sp_procedure_params_100_managed 'babel_3254_p5'
+go
+
+-- will result no rows as babel_3254_p6 is in babel_3254_s1 schema
+sp_procedure_params_100_managed 'babel_3254_p6'
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p6', @procedure_schema = 'babel_3254_s1'
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p1', @group_number = 1
+go
+
+-- group number anything other than 1 should return no rows
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p1', @group_number = 2
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p2', @group_number = 3
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p3', @group_number = 4
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p4', @group_number = 5
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p5', @group_number = 6
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p1', @parameter_name = '@a'
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p2', @parameter_name = '@b'
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p3', @parameter_name = '@c'
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p4', @parameter_name = '@d'
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p5', @parameter_name = '@e'
+go
+
+sp_procedure_params_100_managed @procedure_name = ''
+go
+
+-- reset the login password
+ALTER LOGIN babel_3254_l1 WITH PASSWORD = '12345678'
+GO
+
+select rolname, login_name from sys.babelfish_authid_user_ext where login_name = 'babel_3254_l1'
+go
+
+-- check for the user having non-default schema
+-- tsql user=babel_3254_l1 password=12345678
+select default_schema_name from sys.babelfish_authid_user_ext WHERE orig_username = user_name() AND database_name = db_name();
+go
+
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p7'
+go
+
+-- should return no rows as babel_3254_p7 is in babel_3254_s1 schema
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p7', @procedure_schema = 'dbo'
+go
+
+-- should return the result set as babel_3254_p7 is in babel_3254_s1 schema
+sp_procedure_params_100_managed @procedure_name = 'babel_3254_p7', @procedure_schema = 'babel_3254_s1'
+go
+
+

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -426,4 +426,5 @@ permission_restrictions_from_pg
 BABEL-4529-before-15_6-or-14_11
 BABEL-730-before-15_6-or-16_1
 babel-4475
+babel-3254
 babel-4517

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -425,3 +425,4 @@ sys-parsename-before-15_6-or-16_1
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
 babel-4517
+babel-3254

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -492,4 +492,5 @@ BABEL-4606
 permission_restrictions_from_pg
 BABEL-4529-before-15_6-or-14_11
 BABEL-730-before-15_6-or-16_1
+babel-3254
 babel-4517

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -509,4 +509,5 @@ sys_availability_replicas
 table_constraint_without_comma
 BABEL-730
 babel-4475
+babel-3254
 babel-4517


### PR DESCRIPTION
### Description

This change supports TSQL procedure named sp_procedure_params_100.


### Issues Resolved

BABEL-3254

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** babel-3254-vu-*.sql


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -** babel-3254-vu-*.sql


* **Major version upgrade tests -** babel-3254-vu-*.sql


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).