### PR TITLE
Fixed metadata for geospatial types (#2322)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1145,7 +1145,7 @@ select cast(t.typname as sys.sysname) as name
     as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , CAST(1 as sys.bit) as is_user_defined
-  , CASE tsql_type_name
+  , CASE tsql_base_type_name
     -- CLR UDT have is_assembly_type = 1
     WHEN 'geometry' THEN CAST(1 as sys.bit)
     WHEN 'geography' THEN CAST(1 as sys.bit)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
@@ -918,7 +918,7 @@ select cast(t.typname as sys.sysname) as name
     as is_nullable
   -- CREATE TYPE ... FROM is implemented as CREATE DOMAIN in babel
   , CAST(1 as sys.bit) as is_user_defined
-  , CASE tsql_type_name
+  , CASE tsql_base_type_name
     -- CLR UDT have is_assembly_type = 1
     WHEN 'geometry' THEN CAST(1 as sys.bit)
     WHEN 'geography' THEN CAST(1 as sys.bit)

--- a/test/JDBC/expected/TestSpatialPoint-vu-cleanup.out
+++ b/test/JDBC/expected/TestSpatialPoint-vu-cleanup.out
@@ -116,6 +116,8 @@ Drop Table IF EXISTS babelfish_migration_mode_table
 
 DROP TABLE IF EXISTS geometry_test
 
+DROP TYPE IF EXISTS dbo.GeospatialUDT;
+
 DROP FUNCTION IF EXISTS geom_schema.STDistance
 
 DROP SCHEMA IF EXISTS geom_schema

--- a/test/JDBC/expected/TestSpatialPoint-vu-prepare.out
+++ b/test/JDBC/expected/TestSpatialPoint-vu-prepare.out
@@ -494,6 +494,7 @@ prepst#!#INSERT INTO SPATIALPOINT_dt(PrimaryKey, GeomColumn, GeogColumn) values(
 create procedure geometry_proc_1 @a geometry, @b varchar(max) as select @a as a, @b as b ORDER by a;
 create procedure geography_proc_1 @a geography, @b varchar(max) as select @a as a, @b as b ORDER by a;
 create table geo_view_test(a geometry, b geography)
+CREATE TYPE dbo.GeospatialUDT FROM geometry NOT NULL;
 
 create schema geom_schema;
 CREATE FUNCTION geom_schema.STDistance(@point geometry) RETURNS nvarchar(max) AS BEGIN RETURN @point.STAsText(); END;

--- a/test/JDBC/expected/TestSpatialPoint-vu-verify.out
+++ b/test/JDBC/expected/TestSpatialPoint-vu-verify.out
@@ -2734,3 +2734,13 @@ a#!#1#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#
 b#!#2#!#-1#!#0#!#0#!#<NULL>#!#1#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#0#!#NOT_APPLICABLE#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#<NULL>#!#<NULL>
 ~~END~~
 
+
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
+WHERE user_type_id = TYPE_ID('dbo.GeospatialUDT')
+ORDER BY name DESC
+GO
+~~START~~
+varchar#!#int#!#smallint#!#tinyint#!#tinyint#!#varchar#!#bit#!#bit#!#bit#!#int#!#int#!#int#!#varchar#!#bit#!#bit#!#nvarchar#!#nvarchar#!#bit
+geospatialudt#!#<NULL>#!#-1#!#0#!#0#!#<NULL>#!#0#!#1#!#1#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+

--- a/test/JDBC/input/datatypes/TestSpatialPoint-vu-cleanup.txt
+++ b/test/JDBC/input/datatypes/TestSpatialPoint-vu-cleanup.txt
@@ -116,6 +116,8 @@ Drop Table IF EXISTS babelfish_migration_mode_table
 
 DROP TABLE IF EXISTS geometry_test
 
+DROP TYPE IF EXISTS dbo.GeospatialUDT;
+
 DROP FUNCTION IF EXISTS geom_schema.STDistance
 
 DROP SCHEMA IF EXISTS geom_schema

--- a/test/JDBC/input/datatypes/TestSpatialPoint-vu-prepare.txt
+++ b/test/JDBC/input/datatypes/TestSpatialPoint-vu-prepare.txt
@@ -276,6 +276,7 @@ prepst#!#INSERT INTO SPATIALPOINT_dt(PrimaryKey, GeomColumn, GeogColumn) values(
 create procedure geometry_proc_1 @a geometry, @b varchar(max) as select @a as a, @b as b ORDER by a;
 create procedure geography_proc_1 @a geography, @b varchar(max) as select @a as a, @b as b ORDER by a;
 create table geo_view_test(a geometry, b geography)
+CREATE TYPE dbo.GeospatialUDT FROM geometry NOT NULL;
 
 create schema geom_schema;
 CREATE FUNCTION geom_schema.STDistance(@point geometry) RETURNS nvarchar(max) AS BEGIN RETURN @point.STAsText(); END;

--- a/test/JDBC/input/datatypes/TestSpatialPoint-vu-verify.sql
+++ b/test/JDBC/input/datatypes/TestSpatialPoint-vu-verify.sql
@@ -997,3 +997,8 @@ GO
 
 select name , column_id , max_length , precision , scale , collation_name ,is_nullable , is_ansi_padded , is_rowguidcol , is_identity ,is_computed , is_filestream , is_replicated , is_non_sql_subscribed , is_merge_published , is_dts_replicated , is_xml_document , xml_collection_id , default_object_id , rule_object_id , is_sparse , is_column_set , generated_always_type , generated_always_type_desc , encryption_type , encryption_type_desc , encryption_algorithm_name , column_encryption_key_id , column_encryption_key_database_name , is_hidden , is_masked , graph_type , graph_type_desc from sys.columns where object_id = object_id('geo_view_test') ORDER BY name;
 GO
+
+SELECT name, principal_id, max_length, precision, scale, collation_name, is_nullable, is_user_defined, is_assembly_type, default_object_id, rule_object_id, assembly_id, assembly_class, is_binary_ordered, is_fixed_length, prog_id, assembly_qualified_name, is_table_type FROM sys.assembly_types
+WHERE user_type_id = TYPE_ID('dbo.GeospatialUDT')
+ORDER BY name DESC
+GO


### PR DESCRIPTION
### Description

-  Fixed metadata for geospatial types:

- Create Type - currently Babelfish supports it but TSQL doesn't for geospatial Types, Although it doesn't break anything and we will handle this case later

cherry-picked: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2322
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**  TestSpatialPoint-vu-cleanup, TestSpatialPoint-vu-prepare, TestSpatialPoint-vu-verify


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).