### PR TITLE
Handle empty procedure_schema case in sp_procedure_params_100_managed procedure

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3666,7 +3666,7 @@ CREATE OR REPLACE PROCEDURE sys.sp_procedure_params_100_managed(IN "@procedure_n
                                                                 IN "@parameter_name" sys.sysname DEFAULT NULL)
 AS $$
 BEGIN
-	IF @procedure_schema IS NULL
+	IF @procedure_schema IS NULL OR @procedure_schema = ''
 		BEGIN
 			SELECT @procedure_schema = default_schema_name from sys.babelfish_authid_user_ext WHERE orig_username = user_name() AND database_name = db_name();
 		END

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.4.0--3.5.0.sql
@@ -2197,7 +2197,7 @@ CREATE OR REPLACE PROCEDURE sys.sp_procedure_params_100_managed(IN "@procedure_n
                                                                 IN "@parameter_name" sys.sysname DEFAULT NULL)
 AS $$
 BEGIN
-	IF @procedure_schema IS NULL
+	IF @procedure_schema IS NULL OR @procedure_schema = ''
 		BEGIN
 			SELECT @procedure_schema = default_schema_name from sys.babelfish_authid_user_ext WHERE orig_username = user_name() AND database_name = db_name();
 		END

--- a/test/JDBC/expected/babel-3254-vu-verify.out
+++ b/test/JDBC/expected/babel-3254-vu-verify.out
@@ -1,3 +1,182 @@
+sp_procedure_params_100_managed NULL
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed ''
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed 'bABEl_3254_p1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#0#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#bigint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#2#!#16#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#1#!#20#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#tinyint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@f#!#2#!#6#!#<NULL>#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#float#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@g#!#1#!#13#!#<NULL>#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed 'invalid_name'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed 'babel_3254_p1          '
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#0#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#bigint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#2#!#16#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#1#!#20#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#tinyint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@f#!#2#!#6#!#<NULL>#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#float#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@g#!#1#!#13#!#<NULL>#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed '          babel_3254_p1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed 'babel_    3254_p1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema=NULL
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p1', @group_number=1, @procedure_schema=''
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#1#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#0#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#bigint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@c#!#2#!#16#!#<NULL>#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#smallint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@d#!#1#!#20#!#<NULL>#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#tinyint#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@e#!#1#!#2#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#bit#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@f#!#2#!#6#!#<NULL>#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#float#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@g#!#1#!#13#!#<NULL>#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#real#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='invalid_schema'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema=NULL
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1     '
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#2#!#9#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#17#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#smallmoney#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='      babel_3254_s1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_    3254_s1'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name=NULL
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@RETURN_VALUE#!#4#!#8#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#int#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@a#!#2#!#9#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+@b#!#1#!#17#!#<NULL>#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#smallmoney#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name=''
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='@A'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@a#!#2#!#9#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='@a    '
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+@a#!#2#!#9#!#<NULL>#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#money#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='    @a'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='@   a'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='invalid_name'
+go
+~~START~~
+varchar#!#smallint#!#smallint#!#int#!#smallint#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int
+~~END~~
+
+
 sp_procedure_params_100_managed 'babel_3254_p1'
 go
 ~~START~~

--- a/test/JDBC/input/babel-3254-vu-verify.mix
+++ b/test/JDBC/input/babel-3254-vu-verify.mix
@@ -1,3 +1,66 @@
+sp_procedure_params_100_managed NULL
+go
+
+sp_procedure_params_100_managed ''
+go
+
+sp_procedure_params_100_managed 'bABEl_3254_p1'
+go
+
+sp_procedure_params_100_managed 'invalid_name'
+go
+
+sp_procedure_params_100_managed 'babel_3254_p1          '
+go
+
+sp_procedure_params_100_managed '          babel_3254_p1'
+go
+
+sp_procedure_params_100_managed 'babel_    3254_p1'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema=NULL
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p1', @group_number=1, @procedure_schema=''
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='invalid_schema'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema=NULL
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1     '
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='      babel_3254_s1'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_    3254_s1'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name=NULL
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name=''
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='@A'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='@a    '
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='    @a'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='@   a'
+go
+
+sp_procedure_params_100_managed @procedure_name='babel_3254_p6', @group_number=1, @procedure_schema='babel_3254_s1', @parameter_name='invalid_name'
+go
+
 sp_procedure_params_100_managed 'babel_3254_p1'
 go
 


### PR DESCRIPTION
### Description

If the procedure_schema argument in the sp_procedure_params_100_managed procedure is empty, we should return procedure metadata from the user's default schema. But, currently we return no rows in this case.

This commit resolves the above issue.

### Issues Resolved

BABEL-3254

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** babel-3254-vu-*.sql


* **Boundary conditions -** babel-3254-vu-*.sql


* **Arbitrary inputs -** babel-3254-vu-*.sql


* **Negative test cases -** babel-3254-vu-*.sql


* **Minor version upgrade tests -** babel-3254-vu-*.sql


* **Major version upgrade tests -** babel-3254-vu-*.sql


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).