### PR TITLE
Fixed crash when trying to drop ENR relations during subtransaction.

### DIFF
--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -610,3 +610,81 @@ go
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+
+
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
+

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -583,10 +583,6 @@ AS
     DELETE trgt FROM Discount trgt           -- Discount does not exist
     COMMIT
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: Function 'usp_populatediscount' already exists with the same name)~~
-
 
 EXECUTE usp_PopulateDiscount
 go
@@ -609,14 +605,88 @@ BEGIN CATCH
     COMMIT
 END CATCH;
 GO
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: Function 'test' already exists with the same name)~~
-
 
 exec test
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+
+
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
 

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -565,10 +565,6 @@ AS
     DELETE trgt FROM Discount trgt           -- Discount does not exist
     COMMIT
 go
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: Function 'usp_populatediscount' already exists with the same name)~~
-
 
 EXECUTE usp_PopulateDiscount
 go
@@ -591,14 +587,88 @@ BEGIN CATCH
     COMMIT
 END CATCH;
 GO
-~~ERROR (Code: 2714)~~
-
-~~ERROR (Message: Function 'test' already exists with the same name)~~
-
 
 exec test
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+
+
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
 

--- a/test/JDBC/input/table_variables/table_variable_xact_errors.sql
+++ b/test/JDBC/input/table_variables/table_variable_xact_errors.sql
@@ -428,3 +428,65 @@ GO
 
 exec test
 go
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+
+EXECUTE myproc
+GO
+
+EXECUTE myproc2
+GO
+
+EXECUTE myproc2
+GO
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
+


### PR DESCRIPTION
Unable to drop ENR tables in subtransaction because invalidation messages was never accepted failing the check in
PrepareInvalidationState().

This is because ENR relations skip GetCurrentCommandId(true) hence making CommandCounterIncrement() practically a no-op.

Also fix a Day 1 issue when caller of pltsql_clean_table_variables() skips some important error handling when pltsql_clean_table_variables fails.

Task: BABEL-4737




### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).