### PR TITLE
Fix typmod issues for vector

### DIFF
--- a/test/JDBC/expected/TestVectorDatatype.out
+++ b/test/JDBC/expected/TestVectorDatatype.out
@@ -1466,6 +1466,53 @@ int
 drop table t;
 go
 
+-- Testing with different typmod 
+CREATE TABLE document_embeddings (
+    id int PRIMARY KEY,
+    embedding vector(4) NOT NULL
+);
+go
+CREATE INDEX document_embeddings_embedding_idx ON document_embeddings USING hnsw (embedding vector_l2_ops);
+go
+INSERT INTO document_embeddings(id, embedding) VALUES(1, CAST('[21,-2,0,2.5]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(2, CAST('[5, 10000, -9.75, 8]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(3, CAST('[-0.02,23,3.14,00]' as vector));
+WITH cte AS (
+    SELECT CAST(2e2 AS real) a, 80 b, CAST('-3e05' AS real) c, -1 d
+)
+INSERT INTO document_embeddings(id, embedding) SELECT 4, CAST(CONCAT('[',a, ',', b, ',', c, ',', d, ']') as vector) FROM cte; 
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+SELECT * FROM document_embeddings;
+go
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+SELECT TOP 5 * FROM document_embeddings ORDER BY embedding <=> '[3,1,2,4]';
+go
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+3#!#[-0.02,23,3.14,0]
+2#!#[5,10000,-9.75,8]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+Drop table document_embeddings
+go
+
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
@@ -1466,6 +1466,53 @@ int
 drop table t;
 go
 
+-- Testing with different typmod 
+CREATE TABLE document_embeddings (
+    id int PRIMARY KEY,
+    embedding vector(4) NOT NULL
+);
+go
+CREATE INDEX document_embeddings_embedding_idx ON document_embeddings USING hnsw (embedding vector_l2_ops);
+go
+INSERT INTO document_embeddings(id, embedding) VALUES(1, CAST('[21,-2,0,2.5]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(2, CAST('[5, 10000, -9.75, 8]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(3, CAST('[-0.02,23,3.14,00]' as vector));
+WITH cte AS (
+    SELECT CAST(2e2 AS real) a, 80 b, CAST('-3e05' AS real) c, -1 d
+)
+INSERT INTO document_embeddings(id, embedding) SELECT 4, CAST(CONCAT('[',a, ',', b, ',', c, ',', d, ']') as vector) FROM cte; 
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+SELECT * FROM document_embeddings;
+go
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+SELECT TOP 5 * FROM document_embeddings ORDER BY embedding <=> '[3,1,2,4]';
+go
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+3#!#[-0.02,23,3.14,0]
+2#!#[5,10000,-9.75,8]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+Drop table document_embeddings
+go
+
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 

--- a/test/JDBC/expected/parallel_query/TestVectorDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestVectorDatatype.out
@@ -1541,6 +1541,53 @@ int
 drop table t;
 go
 
+-- Testing with different typmod 
+CREATE TABLE document_embeddings (
+    id int PRIMARY KEY,
+    embedding vector(4) NOT NULL
+);
+go
+CREATE INDEX document_embeddings_embedding_idx ON document_embeddings USING hnsw (embedding vector_l2_ops);
+go
+INSERT INTO document_embeddings(id, embedding) VALUES(1, CAST('[21,-2,0,2.5]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(2, CAST('[5, 10000, -9.75, 8]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(3, CAST('[-0.02,23,3.14,00]' as vector));
+WITH cte AS (
+    SELECT CAST(2e2 AS real) a, 80 b, CAST('-3e05' AS real) c, -1 d
+)
+INSERT INTO document_embeddings(id, embedding) SELECT 4, CAST(CONCAT('[',a, ',', b, ',', c, ',', d, ']') as vector) FROM cte; 
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+SELECT * FROM document_embeddings;
+go
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+SELECT TOP 5 * FROM document_embeddings ORDER BY embedding <=> '[3,1,2,4]';
+go
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+3#!#[-0.02,23,3.14,0]
+2#!#[5,10000,-9.75,8]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+Drop table document_embeddings
+go
+
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 

--- a/test/JDBC/input/datatypes/TestVectorDatatype.mix
+++ b/test/JDBC/input/datatypes/TestVectorDatatype.mix
@@ -547,6 +547,29 @@ go
 drop table t;
 go
 
+-- Testing with different typmod 
+CREATE TABLE document_embeddings (
+    id int PRIMARY KEY,
+    embedding vector(4) NOT NULL
+);
+go
+CREATE INDEX document_embeddings_embedding_idx ON document_embeddings USING hnsw (embedding vector_l2_ops);
+go
+INSERT INTO document_embeddings(id, embedding) VALUES(1, CAST('[21,-2,0,2.5]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(2, CAST('[5, 10000, -9.75, 8]' as vector));
+INSERT INTO document_embeddings(id, embedding) VALUES(3, CAST('[-0.02,23,3.14,00]' as vector));
+WITH cte AS (
+    SELECT CAST(2e2 AS real) a, 80 b, CAST('-3e05' AS real) c, -1 d
+)
+INSERT INTO document_embeddings(id, embedding) SELECT 4, CAST(CONCAT('[',a, ',', b, ',', c, ',', d, ']') as vector) FROM cte; 
+go
+SELECT * FROM document_embeddings;
+go
+SELECT TOP 5 * FROM document_embeddings ORDER BY embedding <=> '[3,1,2,4]';
+go
+Drop table document_embeddings
+go
+
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 


### PR DESCRIPTION
### Description
Based on the current codeflow in TDS, the typmod is being fetched from pg_attribute even for PG base types. In case of typmod > 4, our code will manipulate it based on assumptions of TSQL types which is wrong. With this commit we explicitly set the typmod to -1 for vector type. Going forward we can do this for other PG basetypes if they can have variable typmod based on data lens.

TASK: BABEL-4687
Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).