### PR TITLE
Fixed crash when trying to drop ENR relations during subtransaction.

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5030,12 +5030,27 @@ set_current_query_is_create_tbl_check_constraint(Node *expr)
 void
 pltsql_remove_current_query_env(void)
 {
-	ENRDropTempTables(currentQueryEnv);
-	remove_queryEnv();
+	bool old_abort_curr_txn = AbortCurTransaction;
 
-	if (!currentQueryEnv ||
-		(currentQueryEnv == topLevelQueryEnv && get_namedRelList() == NIL))
+	PG_TRY();
 	{
-		destroy_failed_transactions_map();
-	} 
+		// see pltsql_clean_table_variables()
+		AbortCurTransaction = false;
+
+		ENRDropTempTables(currentQueryEnv);
+	}
+	PG_FINALLY();
+	{
+		remove_queryEnv();
+
+		if (!currentQueryEnv ||
+			(currentQueryEnv == topLevelQueryEnv && get_namedRelList() == NIL))
+		{
+			destroy_failed_transactions_map();
+		}
+	
+		AbortCurTransaction = old_abort_curr_txn;
+	}
+	PG_END_TRY();
 }
+

--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -569,3 +569,122 @@ nvarchar
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
+
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+
+EXECUTE usp_PopulateDiscount
+go
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "discount" does not exist)~~
+
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+
+exec test
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+
+
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
+

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -571,3 +571,122 @@ nvarchar
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
+
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+
+EXECUTE usp_PopulateDiscount
+go
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "discount" does not exist)~~
+
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+
+exec test
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+
+
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
+

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -553,3 +553,122 @@ nvarchar
 DROP FUNCTION [dbo].[WOSQL_BuildRevenueDetailOLUQuery]
 GO
 
+
+-------------------------------------------------------------------------------
+-- BABEL-4267: Error should not cause crash
+-------------------------------------------------------------------------------
+CREATE PROCEDURE usp_PopulateDiscount
+AS
+    DECLARE @Lookup TABLE (StartDate DATETIME NOT NULL)
+    INSERT INTO @Lookup SELECT GETDATE()
+    BEGIN TRANSACTION
+    DELETE trgt FROM Discount trgt           -- Discount does not exist
+    COMMIT
+go
+
+EXECUTE usp_PopulateDiscount
+go
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "discount" does not exist)~~
+
+
+CREATE PROCEDURE test
+AS
+BEGIN TRY
+    DECLARE @tv1 TABLE(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+    SELECT 1/0
+END TRY
+BEGIN CATCH
+    BEGIN TRANSACTION
+    INSERT INTO @tv1 VALUES(1, 3, 'Three')          -- invalid syntax, should do a clean shutdown
+    COMMIT
+END CATCH;
+GO
+
+exec test
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+DROP PROCEDURE usp_PopulateDiscount
+GO
+
+DROP PROCEDURE test
+GO
+
+-------------------------------------------------------------------------------
+-- BABEL-4737: Error during subtxn should not cause crash
+-------------------------------------------------------------------------------
+DROP TABLE IF EXISTS mytab
+GO
+
+CREATE TABLE mytab(a VARCHAR(30) NULL) 
+GO
+
+
+
+
+CREATE PROC myproc
+AS
+BEGIN
+    DECLARE @tv TABLE(a int)
+    BEGIN TRANSACTION
+    SAVE TRANSACTION savept1
+    UPDATE mytab
+    SET a = 'x'
+    OUTPUT i.Item INTO @tv
+    FROM
+    (SELECT 'b' AS Item) AS i
+     COMMIT
+END
+go
+
+CREATE PROC myproc2
+AS
+BEGIN
+	BEGIN TRANSACTION
+	SAVE TRANSACTION savept0
+		EXEC myproc
+	COMMIT
+END
+GO
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+EXECUTE myproc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "i")~~
+
+
+DROP PROCEDURE myproc
+GO
+
+DROP PROCEDURE myproc2
+GO
+


### PR DESCRIPTION
Unable to drop ENR tables in subtransaction because invalidation messages was never accepted failing the check in
PrepareInvalidationState().

This is because ENR relations skip GetCurrentCommandId(true) hence making CommandCounterIncrement() practically a no-op.

Also fix a Day 1 issue when caller of pltsql_clean_table_variables() skips some important error handling when pltsql_clean_table_variables fails.

Task: BABEL-4737



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).