### PR TITLE
Support PSQL Syntax for general vector expression

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -3451,6 +3451,7 @@ expression
     | over_clause                                                               #over_clause_expr
     | odbc_literal                                                              #odbc_literal_expr
     | DOLLAR_ACTION                                                             #dollar_action_expr
+    | expression vector_operator expression                                     #vector_expr
     ;       
 
 clr_udt_func_call
@@ -3594,7 +3595,6 @@ xml_common_directives
 
 order_by_expression 
     : order_by=expression (ascending=ASC | descending=DESC)?
-    | order_by=expression vector_operator expression (ascending=ASC | descending=DESC)? 
     ;
 
 group_by_item

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2448,7 +2448,7 @@ public:
 		 * is done because the TSQL ordering is NULLS FIRST but for PG it's the opposite
 		 * and the order does not matter for bit indexes.
 		 */
-		if (statementMutator && ctx->vector_operator())
+		if (statementMutator && ctx->expression() && ((TSqlParser::Vector_exprContext *) ctx->expression())->vector_operator())
 		{
 			PLtsql_expr_query_mutator *mutator = statementMutator.get();
 			if (ctx->ASC())
@@ -2461,7 +2461,7 @@ public:
 			}
 			else
 			{
-				mutator->add(ctx->expression()[1]->stop->getStopIndex()+1, "", " NULLS LAST");
+				mutator->add(ctx->expression()->stop->getStopIndex()+1, "", " NULLS LAST");
 			}
 		}
 	}

--- a/test/JDBC/expected/TestVectorDatatype.out
+++ b/test/JDBC/expected/TestVectorDatatype.out
@@ -1510,6 +1510,80 @@ int#!#varchar
 4#!#[200,80,-300000,-1]
 ~~END~~
 
+-- extending PG syntax to have generic vector expression support
+SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+go
+~~START~~
+float
+18.527007313648905
+9999.009950990148
+22.235556725887395
+300002.0735928337
+~~END~~
+
+~~START~~
+float
+0.23253741926949456
+0.7328592714157935
+0.6635827783424582
+1.5339165489191127
+~~END~~
+
+~~START~~
+float
+-61.0
+-9995.5
+-29.220001220703125
+599320.0
+~~END~~
+
+
+-- WHERE clause expressions
+SELECT * FROM document_embeddings WHERE embedding <-> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <=> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <#> '[3,20, 1,-2.5]' < 5; 
+go
+~~START~~
+int#!#varchar
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+~~END~~
+
+
+SELECT AVG(embedding) FROM document_embeddings;
+go
+~~START~~
+varchar
+[56.495,2525.25,-75001.66,2.375]
+~~END~~
+
+
+SELECT id, AVG(embedding) FROM document_embeddings GROUP BY id;
+go
+~~START~~
+int#!#varchar
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+1#!#[21,-2,0,2.5]
+~~END~~
+
+
 Drop table document_embeddings
 go
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
@@ -1510,6 +1510,80 @@ int#!#varchar
 4#!#[200,80,-300000,-1]
 ~~END~~
 
+-- extending PG syntax to have generic vector expression support
+SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+go
+~~START~~
+float
+18.527007313648905
+9999.009950990148
+22.235556725887395
+300002.0735928337
+~~END~~
+
+~~START~~
+float
+0.23253741926949456
+0.7328592714157935
+0.6635827783424582
+1.5339165489191127
+~~END~~
+
+~~START~~
+float
+-61.0
+-9995.5
+-29.220001220703125
+599320.0
+~~END~~
+
+
+-- WHERE clause expressions
+SELECT * FROM document_embeddings WHERE embedding <-> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <=> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <#> '[3,20, 1,-2.5]' < 5; 
+go
+~~START~~
+int#!#varchar
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+~~END~~
+
+
+SELECT AVG(embedding) FROM document_embeddings;
+go
+~~START~~
+varchar
+[56.495,2525.25,-75001.66,2.375]
+~~END~~
+
+
+SELECT id, AVG(embedding) FROM document_embeddings GROUP BY id;
+go
+~~START~~
+int#!#varchar
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+1#!#[21,-2,0,2.5]
+~~END~~
+
+
 Drop table document_embeddings
 go
 

--- a/test/JDBC/expected/parallel_query/TestVectorDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestVectorDatatype.out
@@ -1585,6 +1585,80 @@ int#!#varchar
 4#!#[200,80,-300000,-1]
 ~~END~~
 
+-- extending PG syntax to have generic vector expression support
+SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+go
+~~START~~
+float
+18.527007313648905
+9999.009950990148
+22.235556725887395
+300002.0735928337
+~~END~~
+
+~~START~~
+float
+0.23253741926949456
+0.7328592714157935
+0.6635827783424582
+1.5339165489191127
+~~END~~
+
+~~START~~
+float
+-61.0
+-9995.5
+-29.220001220703125
+599320.0
+~~END~~
+
+
+-- WHERE clause expressions
+SELECT * FROM document_embeddings WHERE embedding <-> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <=> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <#> '[3,20, 1,-2.5]' < 5; 
+go
+~~START~~
+int#!#varchar
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#[21,-2,0,2.5]
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+~~END~~
+
+
+SELECT AVG(embedding) FROM document_embeddings;
+go
+~~START~~
+varchar
+[56.495,2525.25,-75001.66,2.375]
+~~END~~
+
+
+SELECT id, AVG(embedding) FROM document_embeddings GROUP BY id;
+go
+~~START~~
+int#!#varchar
+2#!#[5,10000,-9.75,8]
+3#!#[-0.02,23,3.14,0]
+4#!#[200,80,-300000,-1]
+1#!#[21,-2,0,2.5]
+~~END~~
+
+
 Drop table document_embeddings
 go
 

--- a/test/JDBC/input/datatypes/TestVectorDatatype.mix
+++ b/test/JDBC/input/datatypes/TestVectorDatatype.mix
@@ -567,6 +567,24 @@ SELECT * FROM document_embeddings;
 go
 SELECT TOP 5 * FROM document_embeddings ORDER BY embedding <=> '[3,1,2,4]';
 go
+-- extending PG syntax to have generic vector expression support
+SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
+SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+go
+
+-- WHERE clause expressions
+SELECT * FROM document_embeddings WHERE embedding <-> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <=> '[3,20, 1,-2.5]' < 5;
+SELECT * FROM document_embeddings WHERE embedding <#> '[3,20, 1,-2.5]' < 5; 
+go
+
+SELECT AVG(embedding) FROM document_embeddings;
+go
+
+SELECT id, AVG(embedding) FROM document_embeddings GROUP BY id;
+go
+
 Drop table document_embeddings
 go
 


### PR DESCRIPTION
### Description
Earlier we were restricting the use of vector based on TSQL Syntax and not supporting the entire scope of PSQL Syntax, plus this general expression could have been worked around using order by clause - order by expression - which was supported. With this commit we add support for a general vector expression which is only valid in PSQL. 

TASK: BABEL-4687
Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)

FYI, Earlier Syntax like
```
SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
```
Could be worked around by:
```
SELECT embedding FROM document_embeddings order by embedding <-> '[3,1,2,0]';
```

### Test Scenarios Covered ###
* **Use case based -**
Added

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).