### PR TITLE
Throw appropriate error for unsupported features for GRANT/REVOKE on SCHEMA

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1108,7 +1108,6 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 	 || ctx->create_fulltext_index()
 	 || ctx->create_index()
 	 || ctx->create_login()
-	 //|| ctx->create_schema()
 	 || ctx->create_sequence()
 	 || (ctx->create_server_role() && pltsql_allow_antlr_to_unsupported_grammar_for_testing)
 	 || ctx->create_table()

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1894,6 +1894,8 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Rev
 				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(revoke));
 			if (revoke->CASCADE())
 				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE on SCHEMA .. CASCADE is not yet supported in Babelfish.", getLineAndPos(revoke));
+			if (revoke->GRANT())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE GRANT OPTION FOR .. on SCHEMA is not yet supported in Babelfish.", getLineAndPos(revoke));
 		}
 		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1108,7 +1108,7 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 	 || ctx->create_fulltext_index()
 	 || ctx->create_index()
 	 || ctx->create_login()
-	 || ctx->create_schema()
+	 //|| ctx->create_schema()
 	 || ctx->create_sequence()
 	 || (ctx->create_server_role() && pltsql_allow_antlr_to_unsupported_grammar_for_testing)
 	 || ctx->create_table()
@@ -1136,6 +1136,20 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 	 )
 	{
 		// supported DDL or DDL which need special handling
+		return visitChildren(ctx);
+	}
+
+	if (ctx->create_schema())
+	{
+		auto create_schema = ctx->create_schema();
+		if (create_schema->grant_statement().size() > 0)
+		{
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "GRANT inside CREATE SCHEMA is not yet supported in Babelfish", getLineAndPos(ctx));
+		}
+		if (create_schema->revoke_statement().size() > 0)
+		{
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE inside CREATE SCHEMA is not yet supported in Babelfish", getLineAndPos(ctx));
+		}
 		return visitChildren(ctx);
 	}
 
@@ -1774,8 +1788,13 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedGrantStmt(TSqlParser::Gran
 	{
 		auto perm_obj = grant->permission_object();
 		auto obj_type = perm_obj->object_type();
-		if (grant->ALL() && obj_type && obj_type->SCHEMA())
-			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(grant));
+		if (obj_type && obj_type->SCHEMA())
+		{
+			if (grant->ALL())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(grant));
+			if (grant->WITH())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "GRANT on SCHEMA .. WITH GRANT OPTION is not yet supported in Babelfish.", getLineAndPos(grant));
+		}
 		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{
 			unsupported_feature = "GRANT ON " + obj_type->getText();
@@ -1870,8 +1889,13 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Rev
 	{
 		auto perm_obj = revoke->permission_object();
 		auto obj_type = perm_obj->object_type();
-		if (revoke->ALL() && obj_type && obj_type->SCHEMA())
-			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(revoke));
+		if (obj_type && obj_type->SCHEMA())
+		{
+			if (revoke->ALL())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(revoke));
+			if (revoke->CASCADE())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE on SCHEMA .. CASCADE is not yet supported in Babelfish.", getLineAndPos(revoke));
+		}
 		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{
 			unsupported_feature = "REVOKE ON " + obj_type->getText();

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1143,11 +1143,11 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 		auto create_schema = ctx->create_schema();
 		if (create_schema->grant_statement().size() > 0)
 		{
-			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "GRANT inside CREATE SCHEMA is not yet supported in Babelfish", getLineAndPos(ctx));
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "GRANT inside CREATE SCHEMA is not yet supported in Babelfish.", getLineAndPos(ctx));
 		}
 		if (create_schema->revoke_statement().size() > 0)
 		{
-			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE inside CREATE SCHEMA is not yet supported in Babelfish", getLineAndPos(ctx));
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE inside CREATE SCHEMA is not yet supported in Babelfish.", getLineAndPos(ctx));
 		}
 		return visitChildren(ctx);
 	}

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -789,14 +789,14 @@ CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema 
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish)~~
+~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish.)~~
 
 
 CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish)~~
+~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish.)~~
 
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -785,6 +785,20 @@ GO
 DROP TABLE t_unsupported_ft2;
 GO
 
+CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish)~~
+
+
+CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish)~~
+
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -217,6 +217,20 @@ go
 revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 with grant option;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: GRANT on SCHEMA .. WITH GRANT OPTION is not yet supported in Babelfish.)~~
+
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 cascade;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE on SCHEMA .. CASCADE is not yet supported in Babelfish.)~~
+
+
 grant select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -217,6 +217,7 @@ go
 revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 
+-- unsupported features
 grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 with grant option;
 go
 ~~ERROR (Code: 33557097)~~
@@ -229,6 +230,13 @@ go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: REVOKE on SCHEMA .. CASCADE is not yet supported in Babelfish.)~~
+
+
+revoke grant option for select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE GRANT OPTION FOR .. on SCHEMA is not yet supported in Babelfish.)~~
 
 
 grant select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -797,14 +797,14 @@ CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema 
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish)~~
+~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish.)~~
 
 
 CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish)~~
+~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish.)~~
 
 
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -793,6 +793,20 @@ GO
 DROP TABLE t_unsupported_ft2;
 GO
 
+CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish)~~
+
+
+CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish)~~
+
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~

--- a/test/JDBC/input/BABEL-UNSUPPORTED.sql
+++ b/test/JDBC/input/BABEL-UNSUPPORTED.sql
@@ -488,6 +488,12 @@ GO
 DROP TABLE t_unsupported_ft2;
 GO
 
+CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema TO guest;
+GO
+
+CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
+GO
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -168,6 +168,12 @@ go
 revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 with grant option;
+go
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 cascade;
+go
+
 grant select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -168,10 +168,14 @@ go
 revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 
+-- unsupported features
 grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 with grant option;
 go
 
 revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 cascade;
+go
+
+revoke grant option for select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
 go
 
 grant select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;


### PR DESCRIPTION
### Description

1. GRANT/REVOKE ... ON ... SCHEMA ... WITH GRANT OPTION/CASCADE does not work as expected -> Throw unsupported error
2. CREATE SCHEMA ... GRANT ... ON ... SCHEMA throws syntax error -> Throw unsupported error
3. REVOKE GRANT OPTION FOR ... ON SCHEMA should be unsupported in Babelfish

### Issues Resolved

Task: [BABEL-4739](https://jira.rds.a2z.com/browse/BABEL-4739), [BABEL-4738](https://jira.rds.a2z.com/browse/BABEL-4738), [BABEL-4758](https://jira.rds.a2z.com/browse/BABEL-4758)
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Added


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).