### PR TITLE
Add check hook for pgstat_end_function_usage in fmgr

### DIFF
--- a/.github/composite-actions/run-pg-upgrade/action.yml
+++ b/.github/composite-actions/run-pg-upgrade/action.yml
@@ -43,6 +43,7 @@ runs:
         echo 'Reset bbf database settings...'
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           sudo echo "babelfishpg_tsql.server_collation_name = '${{ inputs.server_collation_name }}'" >> ~/${{ inputs.pg_new_dir }}/data/postgresql.conf

--- a/.github/scripts/create_extension.sql
+++ b/.github/scripts/create_extension.sql
@@ -9,6 +9,7 @@ ALTER USER :user CREATEDB;
 ALTER SYSTEM SET babelfishpg_tsql.database_name = :db;
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = :'migration_mode';
 ALTER SYSTEM SET babelfishpg_tds.port = :tsql_port;
+ALTER SYSTEM SET track_functions = 'pl';
 
 \if :parallel_query_mode
     ALTER SYSTEM SET parallel_setup_cost = 0;

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -133,6 +133,8 @@ jobs:
           ~/psql/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
           sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE; ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
+          sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
+          sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
           sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -27,6 +27,7 @@
 #include "commands/dbcommands.h"
 #include "commands/explain.h"
 #include "commands/tablecmds.h"
+#include "commands/trigger.h"
 #include "commands/view.h"
 #include "common/logging.h"
 #include "funcapi.h"
@@ -184,6 +185,9 @@ extern bool called_from_tsql_insert_exec();
 extern Datum pltsql_exec_tsql_cast_value(Datum value, bool *isnull,
 							 Oid valtype, int32 valtypmod,
 							 Oid reqtype, int32 reqtypmod);
+static void is_function_pg_stat_valid(FunctionCallInfo fcinfo,
+									  PgStat_FunctionCallUsage *fcu,
+									  char prokind, bool finalize);
 
 /*****************************************
  * 			Replication Hooks
@@ -253,6 +257,7 @@ static bbf_get_sysadmin_oid_hook_type prev_bbf_get_sysadmin_oid_hook = NULL;
 static transform_pivot_clause_hook_type pre_transform_pivot_clause_hook = NULL;
 static called_from_tsql_insert_exec_hook_type pre_called_from_tsql_insert_exec_hook = NULL;
 static exec_tsql_cast_value_hook_type pre_exec_tsql_cast_value_hook = NULL;
+static pltsql_pgstat_end_function_usage_hook_type prev_pltsql_pgstat_end_function_usage_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -433,6 +438,9 @@ InstallExtendedHooks(void)
 
 	bbf_InitializeParallelDSM_hook = babelfixedparallelstate_insert;
 	bbf_ParallelWorkerMain_hook = babelfixedparallelstate_restore;
+
+	prev_pltsql_pgstat_end_function_usage_hook = pltsql_pgstat_end_function_usage_hook;
+	pltsql_pgstat_end_function_usage_hook = is_function_pg_stat_valid;
 }
 
 void
@@ -493,6 +501,7 @@ UninstallExtendedHooks(void)
 	transform_pivot_clause_hook = pre_transform_pivot_clause_hook;
 	optimize_explicit_cast_hook = prev_optimize_explicit_cast_hook;
 	called_from_tsql_insert_exec_hook = pre_called_from_tsql_insert_exec_hook;
+	pltsql_pgstat_end_function_usage_hook = prev_pltsql_pgstat_end_function_usage_hook;
 
 	bbf_InitializeParallelDSM_hook = NULL;
 	bbf_ParallelWorkerMain_hook = NULL;
@@ -4920,4 +4929,33 @@ static Node* optimize_explicit_cast(ParseState *pstate, Node *node)
 		}
 	}
 	return node;
+}
+
+/*
+ * Pltsql allows rolling back parent transaction/sub-transaction while executing
+ * a procedure. The rollback will result into drop of all objects created in
+ * parent transaction/sub-transaction including the procedure itself if it is
+ * part of the active transaction. Also, PG will drop pg_stat entry for a
+ * procedure as part of rollback if the procedure is created in the same
+ * transaction. As a result, we can have a scenario where pg_stat entry for a
+ * procedure becomes invalid by the time it ends due to rollback inside it.
+ * This hook will validate if a pg_stat entry is valid before touching it.
+ */
+static void
+is_function_pg_stat_valid(FunctionCallInfo fcinfo, PgStat_FunctionCallUsage *fcu, char prokind, bool finalize)
+{
+	/* stats not wanted */
+	if (fcu->fs == NULL)
+		return;
+
+	/* check local hash entry if procedure or trigger */
+	if ((prokind == PROKIND_PROCEDURE || CALLED_AS_TRIGGER(fcinfo))
+	    && !lookup_pgstat_entry_in_cache(PGSTAT_KIND_FUNCTION,
+										 MyDatabaseId,
+										 fcinfo->flinfo->fn_oid))
+	{
+		return;
+	}
+
+	pgstat_end_function_usage(fcu, finalize);
 }

--- a/test/JDBC/expected/BABEL_4740.out
+++ b/test/JDBC/expected/BABEL_4740.out
@@ -1,0 +1,338 @@
+-- tsql
+
+-- create a deep nested procedure call
+-- we will run this after all the test to
+-- force utilize all the free memory in the session
+-- if there was any corruption of pg_stat before
+-- we might catch it while executing this
+CREATE PROCEDURE babel_4740_nested_1 @in INT
+AS SELECT @in;
+GO
+
+DECLARE @i int = 2;
+while (@i <= 100)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'
+        CREATE PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4)) + ' @in INT
+        AS SET @in = @in + 1; EXEC babel_4740_nested_' + cast((@i-1) as VARCHAR(4)) + ' @in;';
+    EXEC(@query);
+    SET @i = @i + 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1
+AS 
+        SELECT 'dropping myself and committing top transaction';
+        DROP PROCEDURE babel_4740_p1;
+        COMMIT;
+        BEGIN TRAN;
+GO
+
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p1
+GO
+~~START~~
+varchar
+dropping myself and committing top transaction
+~~END~~
+
+COMMIT
+GO
+EXEC babel_4740_nested_100 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+-- terminate-tsql-conn
+
+-- tsql
+CREATE TABLE babel_4740_t (id INT)
+GO
+
+CREATE TRIGGER babel_4740_trigger1
+ON babel_4740_t
+AFTER INSERT
+AS 
+        SELECT 'executing trigger and dropping itself';
+        DROP TRIGGER babel_4740_trigger1
+GO
+
+INSERT INTO babel_4740_t VALUES (1), (2)
+GO
+~~START~~
+varchar
+executing trigger and dropping itself
+~~END~~
+
+~~ROW COUNT: 2~~
+
+
+DROP TABLE babel_4740_t
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1 AS EXEC babel_4740_p2;
+GO
+CREATE PROCEDURE babel_4740_p2 AS SELECT 'commited procedure';
+GO
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1;
+GO
+DROP PROCEDURE babel_4740_p1
+GO
+CREATE PROCEDURE babel_4740_p1 AS SELECT 'not yet commited procedure'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p1;
+GO
+~~START~~
+varchar
+not yet commited procedure
+~~END~~
+
+EXEC babel_4740_p1
+GO
+~~START~~
+varchar
+commited procedure
+~~END~~
+
+COMMIT
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+CREATE PROCEDURE babel_4740_p3 AS SELECT 'stats shuld exists for this procedure with call count as 1'; ROLLBACK; BEGIN TRAN;
+GO
+BEGIN TRAN
+GO
+EXEC babel_4740_p3
+GO
+~~START~~
+varchar
+stats shuld exists for this procedure with call count as 1
+~~END~~
+
+COMMIT
+GO
+
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p4 AS SELECT 'rollback to savepoint plus but stat should exists for this procedure with call count 1'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p4
+GO
+~~START~~
+varchar
+rollback to savepoint plus but stat should exists for this procedure with call count 1
+~~END~~
+
+COMMIT
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p5 AS SELECT 'rollback to savepoint but stat should not exists because of overall rollback'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p5
+GO
+~~START~~
+varchar
+rollback to savepoint but stat should not exists because of overall rollback
+~~END~~
+
+ROLLBACK
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+CREATE PROCEDURE babel_4740_p6 AS SELECT 'rollback to savepoint but stat should not exists because of rolling back create proc'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p6
+GO
+~~START~~
+varchar
+rollback to savepoint but stat should not exists because of rolling back create proc
+~~END~~
+
+COMMIT
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+CREATE PROCEDURE babel_4740_p7 AS DROP PROCEDURE babel_4740_p7
+GO
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p7
+GO
+COMMIT
+GO
+
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+
+-- Execute this procedure 64 times
+DECLARE @i INT = 0;
+WHILE @i < 64
+BEGIN
+        BEGIN TRAN
+        EXEC babel_4740_p8
+        ROLLBACK
+        SET @i = @i + 1;
+END
+GO
+
+
+-- Original entry for procedure 8 should still exists even if we 
+-- drop and recreate a new procedure inside a txn & rollback the txn
+BEGIN TRAN
+GO
+DROP PROCEDURE babel_4740_p8
+GO
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+EXEC babel_4740_p8
+GO
+ROLLBACK
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+-- terminate-tsql-conn
+
+
+-- tsql
+
+
+-- Use new session to make sure pg_stats are updated to latest
+-- Calls count 1 indicates we entered pgstat_end_function_usage
+-- and successfully increamented numcalls count
+-- Procedure 1, 2, 3, 4 are executed once and still exists
+-- So their entry should exists with count 1
+-- Procedure 8 dropped itslef but that txn was rolled back
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+~~START~~
+varchar#!#bigint
+babel_4740_p1#!#1
+babel_4740_p2#!#1
+babel_4740_p3#!#1
+babel_4740_p4#!#1
+babel_4740_p8#!#64
+~~END~~
+
+
+DROP PROCEDURE IF EXISTS babel_4740_p1, babel_4740_p2,
+        babel_4740_p3, babel_4740_p4, babel_4740_p5,
+        babel_4740_p6, babel_4740_p7, babel_4740_p8
+GO
+
+-- terminate-tsql-conn
+
+-- tsql
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+~~START~~
+varchar#!#bigint
+~~END~~
+
+
+DECLARE @i int = 100;
+while (@i >= 1)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'DROP PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4));
+    EXEC(@query);
+    SET @i = @i - 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+-- check if we have cleaned up everything
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_%'
+        ORDER BY funcname;
+GO
+~~START~~
+varchar#!#bigint
+~~END~~
+

--- a/test/JDBC/input/BABEL_4740.mix
+++ b/test/JDBC/input/BABEL_4740.mix
@@ -1,0 +1,239 @@
+-- tsql
+-- create a deep nested procedure call
+-- we will run this after all the test to
+-- force utilize all the free memory in the session
+-- if there was any corruption of pg_stat before
+-- we might catch it while executing this
+
+CREATE PROCEDURE babel_4740_nested_1 @in INT
+AS SELECT @in;
+GO
+
+DECLARE @i int = 2;
+while (@i <= 100)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'
+        CREATE PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4)) + ' @in INT
+        AS SET @in = @in + 1; EXEC babel_4740_nested_' + cast((@i-1) as VARCHAR(4)) + ' @in;';
+    EXEC(@query);
+    SET @i = @i + 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1
+AS 
+        SELECT 'dropping myself and committing top transaction';
+        DROP PROCEDURE babel_4740_p1;
+        COMMIT;
+        BEGIN TRAN;
+GO
+
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p1
+GO
+COMMIT
+GO
+EXEC babel_4740_nested_100 1
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE TABLE babel_4740_t (id INT)
+GO
+
+CREATE TRIGGER babel_4740_trigger1
+ON babel_4740_t
+AFTER INSERT
+AS 
+        SELECT 'executing trigger and dropping itself';
+        DROP TRIGGER babel_4740_trigger1
+GO
+
+INSERT INTO babel_4740_t VALUES (1), (2)
+GO
+
+DROP TABLE babel_4740_t
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1 AS EXEC babel_4740_p2;
+GO
+CREATE PROCEDURE babel_4740_p2 AS SELECT 'commited procedure';
+GO
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1;
+GO
+DROP PROCEDURE babel_4740_p1
+GO
+CREATE PROCEDURE babel_4740_p1 AS SELECT 'not yet commited procedure'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p1;
+GO
+EXEC babel_4740_p1
+GO
+COMMIT
+GO
+SELECT @@trancount
+GO
+
+
+CREATE PROCEDURE babel_4740_p3 AS SELECT 'stats shuld exists for this procedure with call count as 1'; ROLLBACK; BEGIN TRAN;
+GO
+BEGIN TRAN
+GO
+EXEC babel_4740_p3
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+GO
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p4 AS SELECT 'rollback to savepoint plus but stat should exists for this procedure with call count 1'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p4
+GO
+COMMIT
+GO
+SELECT @@trancount
+GO
+
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p5 AS SELECT 'rollback to savepoint but stat should not exists because of overall rollback'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p5
+GO
+ROLLBACK
+GO
+SELECT @@trancount
+GO
+
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+CREATE PROCEDURE babel_4740_p6 AS SELECT 'rollback to savepoint but stat should not exists because of rolling back create proc'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p6
+GO
+COMMIT
+GO
+SELECT @@trancount
+GO
+
+
+CREATE PROCEDURE babel_4740_p7 AS DROP PROCEDURE babel_4740_p7
+GO
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p7
+GO
+COMMIT
+GO
+
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+
+-- Execute this procedure 64 times
+DECLARE @i INT = 0;
+WHILE @i < 64
+BEGIN
+        BEGIN TRAN
+        EXEC babel_4740_p8
+        ROLLBACK
+        SET @i = @i + 1;
+END
+GO
+
+
+-- Original entry for procedure 8 should still exists even if we 
+-- drop and recreate a new procedure inside a txn & rollback the txn
+BEGIN TRAN
+GO
+DROP PROCEDURE babel_4740_p8
+GO
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+EXEC babel_4740_p8
+GO
+ROLLBACK
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+
+-- terminate-tsql-conn
+
+
+-- tsql
+
+-- Use new session to make sure pg_stats are updated to latest
+-- Calls count 1 indicates we entered pgstat_end_function_usage
+-- and successfully increamented numcalls count
+-- Procedure 1, 2, 3, 4 are executed once and still exists
+-- So their entry should exists with count 1
+-- Procedure 8 dropped itslef but that txn was rolled back
+
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+
+DROP PROCEDURE IF EXISTS babel_4740_p1, babel_4740_p2,
+        babel_4740_p3, babel_4740_p4, babel_4740_p5,
+        babel_4740_p6, babel_4740_p7, babel_4740_p8
+GO
+
+-- terminate-tsql-conn
+
+-- tsql
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+
+DECLARE @i int = 100;
+while (@i >= 1)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'DROP PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4));
+    EXEC(@query);
+    SET @i = @i - 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+-- check if we have cleaned up everything
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_%'
+        ORDER BY funcname;
+GO


### PR DESCRIPTION
### Description

In babelfish there could be cases where a procedure rollbacks/deletes it self during execution.
For example 
```
BEGIN TRAN
CREATE PROCEDURE poc1 AS ROLLBACK;
EXEC p;
```
Procedure 'proc1' does not exists after its execution since the transaction in which it was created
was rolled back by the procedure itself.
Now while executing rollback inside such procedures, the pg_stat entry for this proc is also deleted.
When we return to fmgr to end the proc invocation, we will overwrite on this freed block of memory.
In future, when alloc tries to allocate this freed block if memory to some other process,
it may hit an assert since this block was corrupted.

To avoid this, we add an additional check before writing on the pg_stat entry post invocation.
Check involves simply looking for a local cache pg_stat entry for given key.

Note* PG does not need this check since such a case is not possible there.

#### Performance Effect
Use the simplest of procedures to avoid diluting the performance changes and get the worst case scenario.
Before & after numbers are taken as average of 4 runs.
```
CREATE PROCEDURE proc1 AS SELECT 1;
CREATE PROCEDURE proc2 @in INT AS SELECT @in + 1;
```
**CASE 1**
```
DECLARE @i INT = 0;
DECLARE @dt DATETIME = getdate();
WHILE (@i < 1000000)
BEGIN
    EXEC proc1;
    SET @i = @i + 1;
END;
DECLARE @duration_ms int;
SET @duration_ms = DATEDIFF(ms, @dt, getdate());
SELECT @duration_ms
GO
```
Before Fix:
_track_functions -->_ disabled: 29189 ms enabled: 29367.75 **Change: +0.62%**
After Fix:
_track_functions -->_ disabled: 28261 ms enabled: 28266 **Change: ~0%**


**CASE 2**
```
DECLARE @i INT = 0;
DECLARE @dt DATETIME = getdate();
WHILE (@in < 1000000)
BEGIN
    EXEC proc2 1;
    SET @i = @i + 1;
END;
DECLARE @duration_ms int;
SET @duration_ms = DATEDIFF(ms, @dt, getdate());
SELECT @duration_ms
GO
```
Before Fix:
_track_functions -->_ disabled: 34730.25 ms enabled: 34732.25 **Change: ~0%**
After Fix:
_track_functions -->_ disabled: 33918.75 ms enabled: 34075.5 **Change: +0.4%**

Tests show no visible change in performance.


#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/305
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2352

### Issues Resolved

[BABEL-4740]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Test Scenarios Covered ###

1. Enable track_function GUC for github actions otherwise execution does not even enter the pg_stat related code.
2. Different permutation and variation of example in description.
3. Existing test cases like TestTransactionSupportForProcedure & TestSimpleErrorsWithImplicitTran crashes without this fix when track function GUC is enabled.
4. Todo: Check how much the check hook deteriorates the performance.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).