### PR TITLE
Properly handle nested json values in json auto

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -320,7 +320,8 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 			// Extract the colummn value in the correct format
 			value = palloc(sizeof(JsonbValue));
 			jsonb_get_value(colval, isnull, value, datatype_oid);
-			value = &value->val.array.elems[0];
+			if(datatype_oid != JSONOID)
+				value = &value->val.array.elems[0];
 		}
 
 		// Determine if the value should be inserted as a nested json object

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -157,7 +157,7 @@ EXECUTE forjson_vu_p_6
 GO
 ~~START~~
 nvarchar
-[{"id": 1, "firstname": "j", "details": {"productId": 1}}, {"id": 1, "firstname": "e", "details": {"productId": 1}}]
+[{"id": 1, "firstname": "j", "details": [{"productId": 1}, {"productId": 1}]}, {"id": 1, "firstname": "e", "details": [{"productId": 1}, {"productId": 1}]}]
 ~~END~~
 
 
@@ -198,7 +198,7 @@ EXECUTE forjson_vu_p_11
 GO
 ~~START~~
 nvarchar
-[{"id": 1, "details": {"productId": 1}}]
+[{"id": 1, "details": [{"productId": 1}]}]
 ~~END~~
 
 
@@ -206,7 +206,7 @@ EXECUTE forjson_vu_p_12
 GO
 ~~START~~
 nvarchar
-[{"id": 1, "firstname": "j", "details": {"lastname": "o", "productId": 1}}, {"id": 1, "firstname": "e", "details": {"lastname": "l", "productId": 1}}]
+[{"id": 1, "firstname": "j", "details": [{"lastname": "o", "productId": 1}, {"lastname": "o", "productId": 1}]}, {"id": 1, "firstname": "e", "details": [{"lastname": "l", "productId": 1}, {"lastname": "l", "productId": 1}]}]
 ~~END~~
 
 
@@ -222,7 +222,7 @@ EXECUTE forjson_vu_p_14
 GO
 ~~START~~
 nvarchar
-[{"id": 1, "firstname": "j", "details": {"o": [{"productId": 1}, {"productId": 1}], "price": "30"}}, {"id": 1, "firstname": "e", "details": {"o": [{"productId": 1}, {"productId": 1}], "price": "30"}}]
+[{"id": 1, "firstname": "j", "details": [{"o": [{"productId": 1}, {"productId": 1}], "price": "30"}, {"o": [{"productId": 1}, {"productId": 1}], "price": "20"}]}, {"id": 1, "firstname": "e", "details": [{"o": [{"productId": 1}, {"productId": 1}], "price": "30"}, {"o": [{"productId": 1}, {"productId": 1}], "price": "20"}]}]
 ~~END~~
 
 


### PR DESCRIPTION
### Description

This commit fixes a bug in the json auto implementation where certain nested cases did not have proper array brackets.

### Issues Resolved

### Test Scenarios Covered ###
* **Use case based -**
```
select U.id, U.firstname, (select O.productId from forjson_auto_vu_t_orders O where O.userid = U.id for json auto) as details from forjson_auto_vu_t_users U for json auto

[{"id": 1, "firstname": "j", "details": [{"productId": 1}, {"productId": 1}]}, {"id": 1, "firstname": "e", "details": [{"productId": 1}, {"productId": 1}]}]
```

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).