### PR TITLE
Update some test cases for Vector based on it's own Extension drawbacks

### DIFF
--- a/test/JDBC/expected/TestVectorDatatype.out
+++ b/test/JDBC/expected/TestVectorDatatype.out
@@ -1511,32 +1511,23 @@ int#!#varchar
 ~~END~~
 
 -- extending PG syntax to have generic vector expression support
-SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+SELECT count(embedding <-> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <=> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <#> '[3,1,2,0]') FROM document_embeddings; 
 go
 ~~START~~
-float
-18.527007313648905
-9999.009950990148
-22.235556725887395
-300002.0735928337
+int
+4
 ~~END~~
 
 ~~START~~
-float
-0.23253741926949456
-0.7328592714157935
-0.6635827783424582
-1.5339165489191127
+int
+4
 ~~END~~
 
 ~~START~~
-float
--61.0
--9995.5
--29.220001220703125
-599320.0
+int
+4
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
@@ -1511,32 +1511,23 @@ int#!#varchar
 ~~END~~
 
 -- extending PG syntax to have generic vector expression support
-SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+SELECT count(embedding <-> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <=> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <#> '[3,1,2,0]') FROM document_embeddings; 
 go
 ~~START~~
-float
-18.527007313648905
-9999.009950990148
-22.235556725887395
-300002.0735928337
+int
+4
 ~~END~~
 
 ~~START~~
-float
-0.23253741926949456
-0.7328592714157935
-0.6635827783424582
-1.5339165489191127
+int
+4
 ~~END~~
 
 ~~START~~
-float
--61.0
--9995.5
--29.220001220703125
-599320.0
+int
+4
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/TestVectorDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestVectorDatatype.out
@@ -1586,32 +1586,23 @@ int#!#varchar
 ~~END~~
 
 -- extending PG syntax to have generic vector expression support
-SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+SELECT count(embedding <-> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <=> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <#> '[3,1,2,0]') FROM document_embeddings; 
 go
 ~~START~~
-float
-18.527007313648905
-9999.009950990148
-22.235556725887395
-300002.0735928337
+int
+4
 ~~END~~
 
 ~~START~~
-float
-0.23253741926949456
-0.7328592714157935
-0.6635827783424582
-1.5339165489191127
+int
+4
 ~~END~~
 
 ~~START~~
-float
--61.0
--9995.5
--29.220001220703125
-599320.0
+int
+4
 ~~END~~
 
 

--- a/test/JDBC/input/datatypes/TestVectorDatatype.mix
+++ b/test/JDBC/input/datatypes/TestVectorDatatype.mix
@@ -568,9 +568,9 @@ go
 SELECT TOP 5 * FROM document_embeddings ORDER BY embedding <=> '[3,1,2,4]';
 go
 -- extending PG syntax to have generic vector expression support
-SELECT embedding <-> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <=> '[3,1,2,0]' FROM document_embeddings;
-SELECT embedding <#> '[3,1,2,0]' FROM document_embeddings; 
+SELECT count(embedding <-> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <=> '[3,1,2,0]') FROM document_embeddings;
+SELECT count(embedding <#> '[3,1,2,0]') FROM document_embeddings; 
 go
 
 -- WHERE clause expressions


### PR DESCRIPTION
### Description
In certain cases, the l2_distance is having some precession differences which seem flaky. The same issue persists with vector extension from PG front. To deal with this, we surround those tests with coun() since those tests are responsible for testing the support in the parser and not the function response

TASK: BABEL-4687
Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).