### PR TITLE
Support table alias in CONTAINS predicate

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -767,52 +767,52 @@ makeToTSVectorFuncCall(char *colId, core_yyscan_t yyscanner, Node *pgconfig)
     
     if (dot1)
     {
-    	if (dot2)
-    	{
-    		/* If two dots are found, then the input is in the format "schema_name.table_name.column_name"
-    		 * Parse the schema name, table name, and column name accordingly
-    		 */
-    		*dot1 = '\0';
-    		*dot2 = '\0';
-    		schemaName = colId;
-    		tableName = dot1 + 1;
-    		columnName = dot2 + 1;
-    	} 
-    	else
-    	{
-    		/* If only one dot is found, then the input is in the format "table_name.column_name" or "alias_table.column_name"
-    		 * Parse the table name and column name accordingly
-    		 */
-    		*dot1 = '\0';
-    		tableName = colId;
-    		columnName = dot1 + 1;
-    	}
+        if (dot2)
+        {
+            /* If two dots are found, then the input is in the format "schema_name.table_name.column_name"
+             * Parse the schema name, table name, and column name accordingly
+             */
+            *dot1 = '\0';
+            *dot2 = '\0';
+            schemaName = colId;
+            tableName = dot1 + 1;
+            columnName = dot2 + 1;
+        } 
+        else
+        {
+            /* If only one dot is found, then the input is in the format "table_name.column_name" or "alias_table.column_name"
+             * Parse the table name and column name accordingly
+             */
+            *dot1 = '\0';
+            tableName = colId;
+            columnName = dot1 + 1;
+        }
     }
     else
     {
-    	/* If no dots are found, then the input is just the column name
-    	 * Set the column name directly
-    	 */
-    	columnName = colId;
+        /* If no dots are found, then the input is just the column name
+         * Set the column name directly
+         */
+        columnName = colId;
     }
     
     if (schemaName)
     {
-    	/* If a schema name is present, create column reference to the schema first then append the table name and column name */
-    	col = (Node *) makeColumnRef(schemaName, NIL, -1, yyscanner);
-    	((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(tableName));
-    	((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
+        /* If a schema name is present, create column reference to the schema first then append the table name and column name */
+        col = (Node *) makeColumnRef(schemaName, NIL, -1, yyscanner);
+        ((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(tableName));
+        ((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
     }
     else if (tableName)
     {
-    	/* If a table name is present, create column reference to the table first then append the column name */
-    	col = (Node *) makeColumnRef(tableName, NIL, -1, yyscanner);
-    	((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
+        /* If a table name is present, create column reference to the table first then append the column name */
+        col = (Node *) makeColumnRef(tableName, NIL, -1, yyscanner);
+        ((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
     }
     else
     {
-    	/* Create a ColumnRef node for the column */
-    	col = (Node *) makeColumnRef(columnName, NIL, -1, yyscanner);
+        /* Create a ColumnRef node for the column */
+        col = (Node *) makeColumnRef(columnName, NIL, -1, yyscanner);
     }
 
     /* Create a function call for replace_special_chars_fts(column_name) */

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -756,64 +756,64 @@ makeToTSVectorFuncCall(char *colId, core_yyscan_t yyscanner, Node *pgconfig)
     List	*args;
     Node	*replaceSpecialCharsFunc;
     List	*replaceSpecialCharsArgs;
-	char	*schemaName = NULL;
-	char	*tableName = NULL;
-	char	*columnName = NULL;
-	char	*dot1, *dot2;
-	
-	/* Find the first and second dots in the column identifier */
-	dot1 = strchr(colId, '.');
-	dot2 = (dot1) ? strchr(dot1 + 1, '.') : NULL;
-	
-	if (dot1)
-	{
-		if (dot2)
-		{
-			/* If two dots are found, then the input is in the format "schema_name.table_name.column_name"
-			 * Parse the schema name, table name, and column name accordingly
-			 */
-			*dot1 = '\0';
-			*dot2 = '\0';
-			schemaName = colId;
-			tableName = dot1 + 1;
-			columnName = dot2 + 1;
-		} 
-		else
-		{
-			/* If only one dot is found, then the input is in the format "table_name.column_name" or "alias_table.column_name"
-			 * Parse the table name and column name accordingly
-			 */
-			*dot1 = '\0';
-			tableName = colId;
-			columnName = dot1 + 1;
-		}
-	}
-	else
-	{
-		/* If no dots are found, then the input is just the column name
-		 * Set the column name directly
-		 */
-		columnName = colId;
-	}
-	
-	if (schemaName)
-	{
-		/* If a schema name is present, create column reference to the schema first then append the table name and column name */
-		col = (Node *) makeColumnRef(schemaName, NIL, -1, yyscanner);
-		((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(tableName));
-		((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
-	}
-	else if (tableName)
-	{
-		/* If a table name is present, create column reference to the table first then append the column name */
-		col = (Node *) makeColumnRef(tableName, NIL, -1, yyscanner);
-		((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
-	}
-	else
-	{
-		/* Create a ColumnRef node for the column */
-		col = (Node *) makeColumnRef(columnName, NIL, -1, yyscanner);
-	}
+    char	*schemaName = NULL;
+    char	*tableName = NULL;
+    char	*columnName = NULL;
+    char	*dot1, *dot2;
+    
+    /* Find the first and second dots in the column identifier */
+    dot1 = strchr(colId, '.');
+    dot2 = (dot1) ? strchr(dot1 + 1, '.') : NULL;
+    
+    if (dot1)
+    {
+    	if (dot2)
+    	{
+    		/* If two dots are found, then the input is in the format "schema_name.table_name.column_name"
+    		 * Parse the schema name, table name, and column name accordingly
+    		 */
+    		*dot1 = '\0';
+    		*dot2 = '\0';
+    		schemaName = colId;
+    		tableName = dot1 + 1;
+    		columnName = dot2 + 1;
+    	} 
+    	else
+    	{
+    		/* If only one dot is found, then the input is in the format "table_name.column_name" or "alias_table.column_name"
+    		 * Parse the table name and column name accordingly
+    		 */
+    		*dot1 = '\0';
+    		tableName = colId;
+    		columnName = dot1 + 1;
+    	}
+    }
+    else
+    {
+    	/* If no dots are found, then the input is just the column name
+    	 * Set the column name directly
+    	 */
+    	columnName = colId;
+    }
+    
+    if (schemaName)
+    {
+    	/* If a schema name is present, create column reference to the schema first then append the table name and column name */
+    	col = (Node *) makeColumnRef(schemaName, NIL, -1, yyscanner);
+    	((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(tableName));
+    	((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
+    }
+    else if (tableName)
+    {
+    	/* If a table name is present, create column reference to the table first then append the column name */
+    	col = (Node *) makeColumnRef(tableName, NIL, -1, yyscanner);
+    	((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
+    }
+    else
+    {
+    	/* Create a ColumnRef node for the column */
+    	col = (Node *) makeColumnRef(columnName, NIL, -1, yyscanner);
+    }
 
     /* Create a function call for replace_special_chars_fts(column_name) */
     replaceSpecialCharsArgs = list_make1(col);

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -794,7 +794,7 @@ makeToTSVectorFuncCall(char *colId, core_yyscan_t yyscanner, Node *pgconfig)
 		 * Set the column name directly
 		 */
 		columnName = colId;
-    }
+	}
 	
 	if (schemaName)
 	{

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -756,32 +756,61 @@ makeToTSVectorFuncCall(char *colId, core_yyscan_t yyscanner, Node *pgconfig)
     List	*args;
     Node	*replaceSpecialCharsFunc;
     List	*replaceSpecialCharsArgs;
-	char 	*tableName = NULL;
-    char 	*columnName = NULL;
-	size_t	tableNameLength;
-	char 	*dot;
-
-    /* Parse the column reference for alias table */
-    dot = strchr(colId, '.');
-    if (dot) {
-        columnName = dot + 1; /* Column name after the dot */
-
-		/* Determine the length of the table alias */
-		tableNameLength = dot - colId;
-
-		/* Allocate memory for the table alias and copy it */
-		tableName = (char *) palloc(tableNameLength + 1);
-		strncpy(tableName, colId, tableNameLength);
-		tableName[tableNameLength] = '\0'; // Null-terminate the string
-    } else {
-        columnName = colId;
+	char	*schemaName = NULL;
+	char	*tableName = NULL;
+	char	*columnName = NULL;
+	char	*dot1, *dot2;
+	
+	/* Find the first and second dots in the column identifier */
+	dot1 = strchr(colId, '.');
+	dot2 = (dot1) ? strchr(dot1 + 1, '.') : NULL;
+	
+	if (dot1)
+	{
+		if (dot2)
+		{
+			/* If two dots are found, then the input is in the format "schema_name.table_name.column_name"
+			 * Parse the schema name, table name, and column name accordingly
+			 */
+			*dot1 = '\0';
+			*dot2 = '\0';
+			schemaName = colId;
+			tableName = dot1 + 1;
+			columnName = dot2 + 1;
+		} 
+		else
+		{
+			/* If only one dot is found, then the input is in the format "table_name.column_name" or "alias_table.column_name"
+			 * Parse the table name and column name accordingly
+			 */
+			*dot1 = '\0';
+			tableName = colId;
+			columnName = dot1 + 1;
+		}
+	}
+	else
+	{
+		/* If no dots are found, then the input is just the column name
+		 * Set the column name directly
+		 */
+		columnName = colId;
     }
-
-    if (tableName) {
-		/* If a table alias is present, create column reference to the alias table first and then append the column name */
+	
+	if (schemaName)
+	{
+		/* If a schema name is present, create column reference to the schema first then append the table name and column name */
+		col = (Node *) makeColumnRef(schemaName, NIL, -1, yyscanner);
+		((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(tableName));
+		((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
+	}
+	else if (tableName)
+	{
+		/* If a table name is present, create column reference to the table first then append the column name */
 		col = (Node *) makeColumnRef(tableName, NIL, -1, yyscanner);
 		((ColumnRef *) col)->fields = lappend(((ColumnRef *) col)->fields, makeString(columnName));
-    } else {
+	}
+	else
+	{
 		/* Create a ColumnRef node for the column */
 		col = (Node *) makeColumnRef(columnName, NIL, -1, yyscanner);
 	}

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2075,7 +2075,7 @@ func_expr_common_subexpr:
 							parser_errposition(@1)));
 					}
 				}
-			| TSQL_CONTAINS '(' ColId ',' tsql_contains_search_condition ')'
+			| TSQL_CONTAINS '(' var_name ',' tsql_contains_search_condition ')'
 				{
 					$$ = TsqlExpressionContains($3, $5, yyscanner);
 				}

--- a/contrib/babelfishpg_tsql/src/fts_parser.y
+++ b/contrib/babelfishpg_tsql/src/fts_parser.y
@@ -141,7 +141,7 @@ static char
     inputLength = strlen(trimmedInputStr);
 
     /* Check if the input is a phrase enclosed in double quotes */
-    if (trimmedInputStr[0] == '"' && trimmedInputStr[inputLength - 1] == '"') {
+    if (inputLength >= 2 && trimmedInputStr[0] == '"' && trimmedInputStr[inputLength - 1] == '"') {
         trim(trimmedInputStr, true);
         isEnclosedInQuotes = true;
     }
@@ -212,7 +212,7 @@ replaceMultipleSpacesAndSpecialChars(char* input, char **str1, char **str2, bool
     StringInfoData  modifiedInput;
     const char      *specialChars = "~!&|@#$%^*+=\\;:<>?.\\/";
     const char      *boolOperators = "&!|";
-    const char      *forbiddenChars = "([{]})";
+    const char      *forbiddenChars = "([{]})\"";
     const char      *charInForbiddenChars;
     const char      *charInSpecialChars;
     const char      *charInBoolOperators;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -6661,17 +6661,21 @@ static void post_process_table_source(TSqlParser::Table_source_itemContext *ctx,
 		}
 		removeCtxStringFromQuery(expr, ctx->join_hint(), baseCtx);
 	}
-
-	// check for freetext predicate CONTAINS()
-	if(is_freetext_predicate)
+	
+	/* check for freetext predicate CONTAINS() */
+	if (is_freetext_predicate)
 	{
 		std::string schema_name = extractSchemaName(nullptr, ctx);
 		
-		const char * t_name = downcase_truncate_identifier(table_name.c_str(), table_name.length(), true);
-		const char * s_name = downcase_truncate_identifier(schema_name.c_str(), schema_name.length(), true);
+		/* Use the alias name if available, otherwise use the original table name */
+		if (alias_to_table_mapping.find(table_name) != alias_to_table_mapping.end())
+			table_name = alias_to_table_mapping[table_name];
 		
-		// check if full-text index exist for the table, if not throw error
-		if(!check_fulltext_exist(const_cast <char *>(s_name), const_cast <char *>(t_name)))
+		const char *t_name = downcase_truncate_identifier(table_name.c_str(), table_name.length(), true);
+		const char *s_name = downcase_truncate_identifier(schema_name.c_str(), schema_name.length(), true);
+		
+		/* Check if full-text index exists for the table, if not throw an error */
+		if (!check_fulltext_exist(const_cast<char *>(s_name), const_cast<char *>(t_name)))
 			throw PGErrorWrapperException(ERROR, ERRCODE_RAISE_EXCEPTION, format_errmsg("Cannot use a CONTAINS or FREETEXT predicate on table or indexed view '%s' because it is not full-text indexed.", table_name.c_str()), getLineAndPos(ctx));
 	}
 }

--- a/test/JDBC/expected/fts-contains-vu-cleanup.out
+++ b/test/JDBC/expected/fts-contains-vu-cleanup.out
@@ -26,6 +26,15 @@ go
 drop table test_special_char_t;
 go
 
+drop fulltext index on new_schema_fts.test;
+go
+
+drop table new_schema_fts.test;
+go
+
+drop schema new_schema_fts;
+go
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/expected/fts-contains-vu-cleanup.out
+++ b/test/JDBC/expected/fts-contains-vu-cleanup.out
@@ -26,6 +26,9 @@ go
 drop table test_special_char_t;
 go
 
+use fts_test_db;
+go
+
 drop fulltext index on new_schema_fts.test;
 go
 
@@ -33,6 +36,12 @@ drop table new_schema_fts.test;
 go
 
 drop schema new_schema_fts;
+go
+
+use master;
+go
+
+drop database fts_test_db;
 go
 
 -- disable FULLTEXT

--- a/test/JDBC/expected/fts-contains-vu-cleanup.out
+++ b/test/JDBC/expected/fts-contains-vu-cleanup.out
@@ -26,6 +26,15 @@ go
 drop table test_special_char_t;
 go
 
+drop fulltext index on new_schema_fts_t.test;
+go
+
+drop table new_schema_fts_t.test;
+go
+
+drop schema new_schema_fts_t;
+go
+
 use fts_test_db;
 go
 

--- a/test/JDBC/expected/fts-contains-vu-prepare.out
+++ b/test/JDBC/expected/fts-contains-vu-prepare.out
@@ -5065,6 +5065,24 @@ go
 create fulltext index on test_special_char_t(name) key index test_special_char_t_idx;
 go
 
+create schema new_schema_fts_t
+go
+
+create table new_schema_fts_t.test(id int not null, name text)
+go
+
+create unique index test_idx on new_schema_fts_t.test(id);
+go
+
+insert into new_schema_fts_t.test values(1, 'one two three');
+go
+~~ROW COUNT: 1~~
+
+
+create fulltext index on new_schema_fts_t.test(name) key index test_idx;
+go
+
+
 create database fts_test_db;
 go
 

--- a/test/JDBC/expected/fts-contains-vu-prepare.out
+++ b/test/JDBC/expected/fts-contains-vu-prepare.out
@@ -5065,6 +5065,24 @@ go
 create fulltext index on test_special_char_t(name) key index test_special_char_t_idx;
 go
 
+create schema new_schema_fts
+go
+
+create table new_schema_fts.test(id int not null, name text)
+go
+
+create unique index test_idx on new_schema_fts.test(id);
+go
+
+insert into new_schema_fts.test values(1, 'one two three');
+go
+~~ROW COUNT: 1~~
+
+
+create fulltext index on new_schema_fts.test(name) key index test_idx;
+go
+
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/expected/fts-contains-vu-prepare.out
+++ b/test/JDBC/expected/fts-contains-vu-prepare.out
@@ -5065,6 +5065,12 @@ go
 create fulltext index on test_special_char_t(name) key index test_special_char_t_idx;
 go
 
+create database fts_test_db;
+go
+
+use fts_test_db;
+go
+
 create schema new_schema_fts
 go
 
@@ -5081,7 +5087,6 @@ go
 
 create fulltext index on new_schema_fts.test(name) key index test_idx;
 go
-
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -2636,6 +2636,141 @@ int#!#text
 ~~END~~
 
 
+select t.name from test_special_char_t t where contains(t.name, '"one two"');
+go
+~~START~~
+text
+one two three
+one~two
+one!two
+one@two
+one#two
+one$two
+one%two
+one^two
+one&two
+one*two
+one-two
+one+two
+one=two
+one\two
+one|two
+one;two
+one:two
+one<two
+one>two
+one.two
+one?two
+one/two
+one :) two
+one @ @ @ @ two
+one   @ two    ^ three
+one     @    two
+one @ two @ three @ four
+one # two ' three ` four
+one    @ two    $ three ^ four * five
+one $ two % three * four * five
+one # two : three < four > five
+: one two three
+one: two
+:one two:
+~~END~~
+
+
+select * from test_special_char_t t where contains(t.name, 'one');
+go
+~~START~~
+int#!#text
+1#!#one two three
+2#!#two three one
+3#!#one
+7#!#one~two
+8#!#one!two
+9#!#one@two
+10#!#one#two
+11#!#one$two
+12#!#one%two
+13#!#one^two
+14#!#one&two
+15#!#one*two
+16#!#one-two
+18#!#one+two
+19#!#one=two
+20#!#one\two
+21#!#one|two
+22#!#one;two
+23#!#one:two
+25#!#one<two
+26#!#one>two
+27#!#one.two
+28#!#one?two
+29#!#one/two
+101#!#one :) two
+100#!#one @ @ @ @ two
+102#!#one   @ two    ^ three
+103#!#one     @    two
+104#!#one    ` two  @ three
+105#!#one @ two @ three @ four
+106#!#one ` two _ three ' four
+107#!#one # two ' three ` four
+108#!#one    @ two    $ three ^ four * five
+109#!#one ` two _ three ' four # five
+110#!#one ` two _ three ^ four : five
+111#!#one $ two % three * four * five
+112#!#one # two : three < four > five
+113#!#: one two three
+114#!#one: two
+115#!#:one two:
+~~END~~
+
+
+select * from test_special_char_t t where contains(t.name, 'two');
+go
+~~START~~
+int#!#text
+1#!#one two three
+2#!#two three one
+4#!#two
+7#!#one~two
+8#!#one!two
+9#!#one@two
+10#!#one#two
+11#!#one$two
+12#!#one%two
+13#!#one^two
+14#!#one&two
+15#!#one*two
+16#!#one-two
+18#!#one+two
+19#!#one=two
+20#!#one\two
+21#!#one|two
+22#!#one;two
+23#!#one:two
+25#!#one<two
+26#!#one>two
+27#!#one.two
+28#!#one?two
+29#!#one/two
+101#!#one :) two
+100#!#one @ @ @ @ two
+102#!#one   @ two    ^ three
+103#!#one     @    two
+104#!#one    ` two  @ three
+105#!#one @ two @ three @ four
+106#!#one ` two _ three ' four
+107#!#one # two ' three ` four
+108#!#one    @ two    $ three ^ four * five
+109#!#one ` two _ three ' four # five
+110#!#one ` two _ three ^ four : five
+111#!#one $ two % three * four * five
+112#!#one # two : three < four > five
+113#!#: one two three
+114#!#one: two
+115#!#:one two:
+~~END~~
+
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -2636,6 +2636,13 @@ int#!#text
 ~~END~~
 
 
+select * from test_special_char_t where contains(name, '"');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Syntax error near '"' in the full-text search condition '"'.)~~
+
+
 select t.name from test_special_char_t t where contains(t.name, '"one two"');
 go
 ~~START~~
@@ -3005,7 +3012,17 @@ one: two
 ~~END~~
 
 
-select * from new_schema_fts.test where contains(name, 'one');
+select name as txt from test_special_char_t where contains(txt, 'hello');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "txt" does not exist)~~
+
+
+use fts_test_db;
+go
+
+select * from fts_test_db.new_schema_fts.test t where contains(t.name, 'one');
 go
 ~~START~~
 int#!#text
@@ -3013,12 +3030,26 @@ int#!#text
 ~~END~~
 
 
-select * from new_schema_fts.test where contains(new_schema_fts.test.name, 'one');
+select * from fts_test_db.new_schema_fts.test t where contains(fts_test_db.new_schema_fts.t.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "new_schema_fts")~~
+
+
+select * from fts_test_db.new_schema_fts.test where contains(name, 'one');
 go
 ~~START~~
 int#!#text
 1#!#one two three
 ~~END~~
+
+
+select * from fts_test_db.new_schema_fts.test where contains(fts_test_db.new_schema_fts.test.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "new_schema_fts")~~
 
 
 -- disable FULLTEXT

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -2771,6 +2771,256 @@ int#!#text
 ~~END~~
 
 
+select t.* from test_special_char_t t where contains(t.name, 'one');
+go
+~~START~~
+int#!#text
+1#!#one two three
+2#!#two three one
+3#!#one
+7#!#one~two
+8#!#one!two
+9#!#one@two
+10#!#one#two
+11#!#one$two
+12#!#one%two
+13#!#one^two
+14#!#one&two
+15#!#one*two
+16#!#one-two
+18#!#one+two
+19#!#one=two
+20#!#one\two
+21#!#one|two
+22#!#one;two
+23#!#one:two
+25#!#one<two
+26#!#one>two
+27#!#one.two
+28#!#one?two
+29#!#one/two
+101#!#one :) two
+100#!#one @ @ @ @ two
+102#!#one   @ two    ^ three
+103#!#one     @    two
+104#!#one    ` two  @ three
+105#!#one @ two @ three @ four
+106#!#one ` two _ three ' four
+107#!#one # two ' three ` four
+108#!#one    @ two    $ three ^ four * five
+109#!#one ` two _ three ' four # five
+110#!#one ` two _ three ^ four : five
+111#!#one $ two % three * four * five
+112#!#one # two : three < four > five
+113#!#: one two three
+114#!#one: two
+115#!#:one two:
+~~END~~
+
+
+select t.name from test_special_char_t t where contains(.t.name, 'one');
+go
+~~START~~
+text
+one two three
+two three one
+one
+one~two
+one!two
+one@two
+one#two
+one$two
+one%two
+one^two
+one&two
+one*two
+one-two
+one+two
+one=two
+one\two
+one|two
+one;two
+one:two
+one<two
+one>two
+one.two
+one?two
+one/two
+one :) two
+one @ @ @ @ two
+one   @ two    ^ three
+one     @    two
+one    ` two  @ three
+one @ two @ three @ four
+one ` two _ three ' four
+one # two ' three ` four
+one    @ two    $ three ^ four * five
+one ` two _ three ' four # five
+one ` two _ three ^ four : five
+one $ two % three * four * five
+one # two : three < four > five
+: one two three
+one: two
+:one two:
+~~END~~
+
+
+select * from test_special_char_t t where contains(t..name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "..")~~
+
+
+select t..name from test_special_char_t t where contains(t.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "..")~~
+
+
+select t.name from test_special_char_t where contains(t.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "t")~~
+
+
+select t.name from test_special_char_t t where contains(x.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "x")~~
+
+
+select t.name from test_special_char_t t where contains(x.t.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "t")~~
+
+
+select t.name from test_special_char_t t where contains(t,name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 41)~~
+
+
+select t.name from test_special_char_t t where contains(.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near ".")~~
+
+
+select t.name from test_special_char_t t where contains(t., 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 41)~~
+
+
+select t.name from test_special_char_t t where contains(t.., 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 41)~~
+
+
+select t.name from test_special_char_t t where contains(, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 41)~~
+
+
+select t.name from test_special_char_t t where contains(t.txt, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column t.txt does not exist)~~
+
+
+select t.name from test_special_char_t t where contains(b, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" does not exist)~~
+
+
+select t.name from test_special_char_t t where .t.name = 'one';
+go
+~~START~~
+text
+one
+~~END~~
+
+
+select t.name from test_special_char_t t where contains('t.name', '"one two"');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 41)~~
+
+
+select t.name from test_special_char_t t where contains("t.name", '"one two"');
+go
+~~START~~
+text
+one two three
+one~two
+one!two
+one@two
+one#two
+one$two
+one%two
+one^two
+one&two
+one*two
+one-two
+one+two
+one=two
+one\two
+one|two
+one;two
+one:two
+one<two
+one>two
+one.two
+one?two
+one/two
+one :) two
+one @ @ @ @ two
+one   @ two    ^ three
+one     @    two
+one @ two @ three @ four
+one # two ' three ` four
+one    @ two    $ three ^ four * five
+one $ two % three * four * five
+one # two : three < four > five
+: one two three
+one: two
+:one two:
+~~END~~
+
+
+select * from new_schema_fts.test where contains(name, 'one');
+go
+~~START~~
+int#!#text
+1#!#one two three
+~~END~~
+
+
+select * from new_schema_fts.test where contains(new_schema_fts.test.name, 'one');
+go
+~~START~~
+int#!#text
+1#!#one two three
+~~END~~
+
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -3019,6 +3019,36 @@ go
 ~~ERROR (Message: column "txt" does not exist)~~
 
 
+select * from new_schema_fts_t.test t where contains(t.name, 'one');
+go
+~~START~~
+int#!#text
+1#!#one two three
+~~END~~
+
+
+select * from new_schema_fts_t.test t where contains(new_schema_fts_t.t.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "t")~~
+
+
+select * from new_schema_fts_t.test t where contains(new_schema_fts_t.test.name, 'one');
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "test")~~
+
+
+select * from new_schema_fts_t.test where contains(name, 'one');
+go
+~~START~~
+int#!#text
+1#!#one two three
+~~END~~
+
+
 use fts_test_db;
 go
 

--- a/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
@@ -21,6 +21,9 @@ go
 drop table test_special_char_t;
 go
 
+use fts_test_db;
+go
+
 drop fulltext index on new_schema_fts.test;
 go
 
@@ -28,6 +31,12 @@ drop table new_schema_fts.test;
 go
 
 drop schema new_schema_fts;
+go
+
+use master;
+go
+
+drop database fts_test_db;
 go
 
 -- disable FULLTEXT

--- a/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
@@ -21,6 +21,15 @@ go
 drop table test_special_char_t;
 go
 
+drop fulltext index on new_schema_fts.test;
+go
+
+drop table new_schema_fts.test;
+go
+
+drop schema new_schema_fts;
+go
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-cleanup.mix
@@ -21,6 +21,15 @@ go
 drop table test_special_char_t;
 go
 
+drop fulltext index on new_schema_fts_t.test;
+go
+
+drop table new_schema_fts_t.test;
+go
+
+drop schema new_schema_fts_t;
+go
+
 use fts_test_db;
 go
 

--- a/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
@@ -3054,6 +3054,22 @@ go
 create fulltext index on test_special_char_t(name) key index test_special_char_t_idx;
 go
 
+create schema new_schema_fts_t
+go
+
+create table new_schema_fts_t.test(id int not null, name text)
+go
+
+create unique index test_idx on new_schema_fts_t.test(id);
+go
+
+insert into new_schema_fts_t.test values(1, 'one two three');
+go
+
+create fulltext index on new_schema_fts_t.test(name) key index test_idx;
+go
+
+
 create database fts_test_db;
 go
 

--- a/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
@@ -3054,6 +3054,12 @@ go
 create fulltext index on test_special_char_t(name) key index test_special_char_t_idx;
 go
 
+create database fts_test_db;
+go
+
+use fts_test_db;
+go
+
 create schema new_schema_fts
 go
 
@@ -3068,7 +3074,6 @@ go
 
 create fulltext index on new_schema_fts.test(name) key index test_idx;
 go
-
 
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')

--- a/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-prepare.mix
@@ -3054,6 +3054,22 @@ go
 create fulltext index on test_special_char_t(name) key index test_special_char_t_idx;
 go
 
+create schema new_schema_fts
+go
+
+create table new_schema_fts.test(id int not null, name text)
+go
+
+create unique index test_idx on new_schema_fts.test(id);
+go
+
+insert into new_schema_fts.test values(1, 'one two three');
+go
+
+create fulltext index on new_schema_fts.test(name) key index test_idx;
+go
+
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
@@ -462,6 +462,63 @@ go
 select * from test_special_char_t t where contains(t.name, 'two');
 go
 
+select t.* from test_special_char_t t where contains(t.name, 'one');
+go
+
+select t.name from test_special_char_t t where contains(.t.name, 'one');
+go
+
+select * from test_special_char_t t where contains(t..name, 'one');
+go
+
+select t..name from test_special_char_t t where contains(t.name, 'one');
+go
+
+select t.name from test_special_char_t where contains(t.name, 'one');
+go
+
+select t.name from test_special_char_t t where contains(x.name, 'one');
+go
+
+select t.name from test_special_char_t t where contains(x.t.name, 'one');
+go
+
+select t.name from test_special_char_t t where contains(t,name, 'one');
+go
+
+select t.name from test_special_char_t t where contains(.name, 'one');
+go
+
+select t.name from test_special_char_t t where contains(t., 'one');
+go
+
+select t.name from test_special_char_t t where contains(t.., 'one');
+go
+
+select t.name from test_special_char_t t where contains(, 'one');
+go
+
+select t.name from test_special_char_t t where contains(t.txt, 'one');
+go
+
+select t.name from test_special_char_t t where contains(b, 'one');
+go
+
+select t.name from test_special_char_t t where .t.name = 'one';
+go
+
+select t.name from test_special_char_t t where contains('t.name', '"one two"');
+go
+
+select t.name from test_special_char_t t where contains("t.name", '"one two"');
+go
+
+select * from new_schema_fts.test where contains(name, 'one');
+go
+
+select * from new_schema_fts.test where contains(new_schema_fts.test.name, 'one');
+go
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
@@ -453,6 +453,9 @@ go
 select * from test_special_char_t where contains(name, '"one < two _ three '' four `     five"');
 go
 
+select * from test_special_char_t where contains(name, '"');
+go
+
 select t.name from test_special_char_t t where contains(t.name, '"one two"');
 go
 
@@ -513,10 +516,22 @@ go
 select t.name from test_special_char_t t where contains("t.name", '"one two"');
 go
 
-select * from new_schema_fts.test where contains(name, 'one');
+select name as txt from test_special_char_t where contains(txt, 'hello');
 go
 
-select * from new_schema_fts.test where contains(new_schema_fts.test.name, 'one');
+use fts_test_db;
+go
+
+select * from fts_test_db.new_schema_fts.test t where contains(t.name, 'one');
+go
+
+select * from fts_test_db.new_schema_fts.test t where contains(fts_test_db.new_schema_fts.t.name, 'one');
+go
+
+select * from fts_test_db.new_schema_fts.test where contains(name, 'one');
+go
+
+select * from fts_test_db.new_schema_fts.test where contains(fts_test_db.new_schema_fts.test.name, 'one');
 go
 
 -- disable FULLTEXT

--- a/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
@@ -519,6 +519,18 @@ go
 select name as txt from test_special_char_t where contains(txt, 'hello');
 go
 
+select * from new_schema_fts_t.test t where contains(t.name, 'one');
+go
+
+select * from new_schema_fts_t.test t where contains(new_schema_fts_t.t.name, 'one');
+go
+
+select * from new_schema_fts_t.test t where contains(new_schema_fts_t.test.name, 'one');
+go
+
+select * from new_schema_fts_t.test where contains(name, 'one');
+go
+
 use fts_test_db;
 go
 

--- a/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
+++ b/test/JDBC/input/full_text_search/fts-contains-vu-verify.mix
@@ -453,6 +453,15 @@ go
 select * from test_special_char_t where contains(name, '"one < two _ three '' four `     five"');
 go
 
+select t.name from test_special_char_t t where contains(t.name, '"one two"');
+go
+
+select * from test_special_char_t t where contains(t.name, 'one');
+go
+
+select * from test_special_char_t t where contains(t.name, 'two');
+go
+
 -- disable FULLTEXT
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO


### PR DESCRIPTION
### Description

This pull request addresses a bug in Babelfish where table aliases in the `CONTAINS` predicate caused errors stating _"relation 'xyz' does not exist"_ (here, xyz is the table alias). The fix ensures that Babelfish correctly handles table aliases in `CONTAINS` predicates, by accurately identifying the actual table name during full-text search query execution.  Additionally, included new JDBC test cases to verify the correctness of the fix.

### Issues Resolved

Task: JIRA-4742

### Test Scenarios Covered ###
* **Use case based -** added


* **Boundary conditions -** added


* **Arbitrary inputs -**


* **Negative test cases -** added


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).