### PR TITLE
Add check hook for pgstat_end_function_usage in fmgr

### DIFF
--- a/.github/composite-actions/run-pg-upgrade/action.yml
+++ b/.github/composite-actions/run-pg-upgrade/action.yml
@@ -43,6 +43,7 @@ runs:
         echo 'Reset bbf database settings...'
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           sudo echo "babelfishpg_tsql.server_collation_name = '${{ inputs.server_collation_name }}'" >> ~/${{ inputs.pg_new_dir }}/data/postgresql.conf

--- a/.github/scripts/create_extension.sql
+++ b/.github/scripts/create_extension.sql
@@ -8,6 +8,7 @@ GRANT ALL ON SCHEMA sys to :user;
 ALTER USER :user CREATEDB;
 ALTER SYSTEM SET babelfishpg_tsql.database_name = :db;
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = :'migration_mode';
+ALTER SYSTEM SET track_functions = 'pl';
 
 \if :parallel_query_mode
     ALTER SYSTEM SET parallel_setup_cost = 0;

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -133,6 +133,8 @@ jobs:
           ~/psql/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
           sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE; ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
+          sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
+          sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
           sudo ~/psql/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
 

--- a/test/JDBC/expected/BABEL_4740.out
+++ b/test/JDBC/expected/BABEL_4740.out
@@ -1,0 +1,338 @@
+-- tsql
+
+-- create a deep nested procedure call
+-- we will run this after all the test to
+-- force utilize all the free memory in the session
+-- if there was any corruption of pg_stat before
+-- we might catch it while executing this
+CREATE PROCEDURE babel_4740_nested_1 @in INT
+AS SELECT @in;
+GO
+
+DECLARE @i int = 2;
+while (@i <= 100)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'
+        CREATE PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4)) + ' @in INT
+        AS SET @in = @in + 1; EXEC babel_4740_nested_' + cast((@i-1) as VARCHAR(4)) + ' @in;';
+    EXEC(@query);
+    SET @i = @i + 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1
+AS 
+        SELECT 'dropping myself and committing top transaction';
+        DROP PROCEDURE babel_4740_p1;
+        COMMIT;
+        BEGIN TRAN;
+GO
+
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p1
+GO
+~~START~~
+varchar
+dropping myself and committing top transaction
+~~END~~
+
+COMMIT
+GO
+EXEC babel_4740_nested_100 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+-- terminate-tsql-conn
+
+-- tsql
+CREATE TABLE babel_4740_t (id INT)
+GO
+
+CREATE TRIGGER babel_4740_trigger1
+ON babel_4740_t
+AFTER INSERT
+AS 
+        SELECT 'executing trigger and dropping itself';
+        DROP TRIGGER babel_4740_trigger1
+GO
+
+INSERT INTO babel_4740_t VALUES (1), (2)
+GO
+~~START~~
+varchar
+executing trigger and dropping itself
+~~END~~
+
+~~ROW COUNT: 2~~
+
+
+DROP TABLE babel_4740_t
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1 AS EXEC babel_4740_p2;
+GO
+CREATE PROCEDURE babel_4740_p2 AS SELECT 'commited procedure';
+GO
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1;
+GO
+DROP PROCEDURE babel_4740_p1
+GO
+CREATE PROCEDURE babel_4740_p1 AS SELECT 'not yet commited procedure'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p1;
+GO
+~~START~~
+varchar
+not yet commited procedure
+~~END~~
+
+EXEC babel_4740_p1
+GO
+~~START~~
+varchar
+commited procedure
+~~END~~
+
+COMMIT
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+CREATE PROCEDURE babel_4740_p3 AS SELECT 'stats shuld exists for this procedure with call count as 1'; ROLLBACK; BEGIN TRAN;
+GO
+BEGIN TRAN
+GO
+EXEC babel_4740_p3
+GO
+~~START~~
+varchar
+stats shuld exists for this procedure with call count as 1
+~~END~~
+
+COMMIT
+GO
+
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p4 AS SELECT 'rollback to savepoint plus but stat should exists for this procedure with call count 1'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p4
+GO
+~~START~~
+varchar
+rollback to savepoint plus but stat should exists for this procedure with call count 1
+~~END~~
+
+COMMIT
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p5 AS SELECT 'rollback to savepoint but stat should not exists because of overall rollback'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p5
+GO
+~~START~~
+varchar
+rollback to savepoint but stat should not exists because of overall rollback
+~~END~~
+
+ROLLBACK
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+CREATE PROCEDURE babel_4740_p6 AS SELECT 'rollback to savepoint but stat should not exists because of rolling back create proc'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p6
+GO
+~~START~~
+varchar
+rollback to savepoint but stat should not exists because of rolling back create proc
+~~END~~
+
+COMMIT
+GO
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+CREATE PROCEDURE babel_4740_p7 AS DROP PROCEDURE babel_4740_p7
+GO
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p7
+GO
+COMMIT
+GO
+
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+
+-- Execute this procedure 64 times
+DECLARE @i INT = 0;
+WHILE @i < 64
+BEGIN
+        BEGIN TRAN
+        EXEC babel_4740_p8
+        ROLLBACK
+        SET @i = @i + 1;
+END
+GO
+
+
+-- Original entry for procedure 8 should still exists even if we 
+-- drop and recreate a new procedure inside a txn & rollback the txn
+BEGIN TRAN
+GO
+DROP PROCEDURE babel_4740_p8
+GO
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+EXEC babel_4740_p8
+GO
+ROLLBACK
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+-- terminate-tsql-conn
+
+
+-- tsql
+
+
+-- Use new session to make sure pg_stats are updated to latest
+-- Calls count 1 indicates we entered pgstat_end_function_usage
+-- and successfully increamented numcalls count
+-- Procedure 1, 2, 3, 4 are executed once and still exists
+-- So their entry should exists with count 1
+-- Procedure 8 dropped itslef but that txn was rolled back
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+~~START~~
+varchar#!#bigint
+babel_4740_p1#!#1
+babel_4740_p2#!#1
+babel_4740_p3#!#1
+babel_4740_p4#!#1
+babel_4740_p8#!#64
+~~END~~
+
+
+DROP PROCEDURE IF EXISTS babel_4740_p1, babel_4740_p2,
+        babel_4740_p3, babel_4740_p4, babel_4740_p5,
+        babel_4740_p6, babel_4740_p7, babel_4740_p8
+GO
+
+-- terminate-tsql-conn
+
+-- tsql
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+~~START~~
+varchar#!#bigint
+~~END~~
+
+
+DECLARE @i int = 100;
+while (@i >= 1)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'DROP PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4));
+    EXEC(@query);
+    SET @i = @i - 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+-- check if we have cleaned up everything
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_%'
+        ORDER BY funcname;
+GO
+~~START~~
+varchar#!#bigint
+~~END~~
+

--- a/test/JDBC/input/BABEL_4740.mix
+++ b/test/JDBC/input/BABEL_4740.mix
@@ -1,0 +1,239 @@
+-- tsql
+-- create a deep nested procedure call
+-- we will run this after all the test to
+-- force utilize all the free memory in the session
+-- if there was any corruption of pg_stat before
+-- we might catch it while executing this
+
+CREATE PROCEDURE babel_4740_nested_1 @in INT
+AS SELECT @in;
+GO
+
+DECLARE @i int = 2;
+while (@i <= 100)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'
+        CREATE PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4)) + ' @in INT
+        AS SET @in = @in + 1; EXEC babel_4740_nested_' + cast((@i-1) as VARCHAR(4)) + ' @in;';
+    EXEC(@query);
+    SET @i = @i + 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1
+AS 
+        SELECT 'dropping myself and committing top transaction';
+        DROP PROCEDURE babel_4740_p1;
+        COMMIT;
+        BEGIN TRAN;
+GO
+
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p1
+GO
+COMMIT
+GO
+EXEC babel_4740_nested_100 1
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE TABLE babel_4740_t (id INT)
+GO
+
+CREATE TRIGGER babel_4740_trigger1
+ON babel_4740_t
+AFTER INSERT
+AS 
+        SELECT 'executing trigger and dropping itself';
+        DROP TRIGGER babel_4740_trigger1
+GO
+
+INSERT INTO babel_4740_t VALUES (1), (2)
+GO
+
+DROP TABLE babel_4740_t
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+-- terminate-tsql-conn
+
+-- tsql
+CREATE PROCEDURE babel_4740_p1 AS EXEC babel_4740_p2;
+GO
+CREATE PROCEDURE babel_4740_p2 AS SELECT 'commited procedure';
+GO
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1;
+GO
+DROP PROCEDURE babel_4740_p1
+GO
+CREATE PROCEDURE babel_4740_p1 AS SELECT 'not yet commited procedure'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p1;
+GO
+EXEC babel_4740_p1
+GO
+COMMIT
+GO
+SELECT @@trancount
+GO
+
+
+CREATE PROCEDURE babel_4740_p3 AS SELECT 'stats shuld exists for this procedure with call count as 1'; ROLLBACK; BEGIN TRAN;
+GO
+BEGIN TRAN
+GO
+EXEC babel_4740_p3
+GO
+COMMIT
+GO
+
+SELECT @@trancount
+GO
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p4 AS SELECT 'rollback to savepoint plus but stat should exists for this procedure with call count 1'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p4
+GO
+COMMIT
+GO
+SELECT @@trancount
+GO
+
+
+
+BEGIN TRAN
+GO
+CREATE PROCEDURE babel_4740_p5 AS SELECT 'rollback to savepoint but stat should not exists because of overall rollback'; ROLLBACK TRAN sp1;
+GO
+SAVE TRAN sp1
+GO
+EXEC babel_4740_p5
+GO
+ROLLBACK
+GO
+SELECT @@trancount
+GO
+
+
+
+BEGIN TRAN
+GO
+SAVE TRAN sp1
+GO
+CREATE PROCEDURE babel_4740_p6 AS SELECT 'rollback to savepoint but stat should not exists because of rolling back create proc'; ROLLBACK TRAN sp1;
+GO
+EXEC babel_4740_p6
+GO
+COMMIT
+GO
+SELECT @@trancount
+GO
+
+
+CREATE PROCEDURE babel_4740_p7 AS DROP PROCEDURE babel_4740_p7
+GO
+
+BEGIN TRAN
+GO
+EXEC babel_4740_p7
+GO
+COMMIT
+GO
+
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+
+-- Execute this procedure 64 times
+DECLARE @i INT = 0;
+WHILE @i < 64
+BEGIN
+        BEGIN TRAN
+        EXEC babel_4740_p8
+        ROLLBACK
+        SET @i = @i + 1;
+END
+GO
+
+
+-- Original entry for procedure 8 should still exists even if we 
+-- drop and recreate a new procedure inside a txn & rollback the txn
+BEGIN TRAN
+GO
+DROP PROCEDURE babel_4740_p8
+GO
+CREATE PROCEDURE babel_4740_p8 AS DROP PROCEDURE babel_4740_p8
+GO
+EXEC babel_4740_p8
+GO
+ROLLBACK
+GO
+
+EXEC babel_4740_nested_100 1
+GO
+
+-- terminate-tsql-conn
+
+
+-- tsql
+
+-- Use new session to make sure pg_stats are updated to latest
+-- Calls count 1 indicates we entered pgstat_end_function_usage
+-- and successfully increamented numcalls count
+-- Procedure 1, 2, 3, 4 are executed once and still exists
+-- So their entry should exists with count 1
+-- Procedure 8 dropped itslef but that txn was rolled back
+
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+
+DROP PROCEDURE IF EXISTS babel_4740_p1, babel_4740_p2,
+        babel_4740_p3, babel_4740_p4, babel_4740_p5,
+        babel_4740_p6, babel_4740_p7, babel_4740_p8
+GO
+
+-- terminate-tsql-conn
+
+-- tsql
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_p%'
+        ORDER BY funcname;
+GO
+
+DECLARE @i int = 100;
+while (@i >= 1)
+BEGIN
+    DECLARE @query NVARCHAR(max);
+    SET @query = N'DROP PROCEDURE babel_4740_nested_' + cast(@i as VARCHAR(4));
+    EXEC(@query);
+    SET @i = @i - 1;
+END;
+GO
+-- terminate-tsql-conn
+
+-- tsql
+-- check if we have cleaned up everything
+SELECT funcname, calls
+        FROM pg_stat_user_functions 
+        WHERE funcname LIKE 'babel_4740_%'
+        ORDER BY funcname;
+GO


### PR DESCRIPTION
### Description

Introduce function to check if pg_stat entry exists in local cache for given key.
Add a hook to validate if pg_stat entry still exists before calling pgstat_end_function_usage.

#### Cherry Picked From: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2352

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/309
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2367

### Issues Resolved

[BABEL-4740]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).