### PR TITLE
Fix SSMS and DOTNET issue while SELECTing Geospatial columns

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2063,10 +2063,10 @@ PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *target
 				}
 				break;
 			case TDS_SEND_GEOMETRY:
-				SetColMetadataForGeometryType(col, TDS_TYPE_CLRUDT, TDS_MAXLEN_POINT, "", "geometry");
+				SetColMetadataForGeometryType(col, TDS_TYPE_CLRUDT, TDS_MAXLEN_POINT, TDS_ASSEMBLY_TYPE_NAME_GEOMETRY, "geometry");
 				break;
 			case TDS_SEND_GEOGRAPHY:
-				SetColMetadataForGeographyType(col, TDS_TYPE_CLRUDT, TDS_MAXLEN_POINT, "", "geography");
+				SetColMetadataForGeographyType(col, TDS_TYPE_CLRUDT, TDS_MAXLEN_POINT, TDS_ASSEMBLY_TYPE_NAME_GEOGRAPHY, "geography");
 				break;
 			default:
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -1777,13 +1777,13 @@ ReadParameters(TDSRequestSP request, uint64_t offset, StringInfo message, int *p
 					/* Set column metadata for given CLR-UDT type depending upon the underlying typename. */
 					if (pg_strcasecmp(typeName.data, "geometry") == 0)
 					{
-						SetColMetadataForGeometryType(&temp->paramMeta, tdsType, TDS_MAXLEN_POINT, "", "geometry");
+						SetColMetadataForGeometryType(&temp->paramMeta, tdsType, TDS_MAXLEN_POINT, TDS_ASSEMBLY_TYPE_NAME_GEOMETRY, "geometry");
 						temp->type = TDS_TYPE_GEOMETRY;
 						tdsType = TDS_TYPE_GEOMETRY;
 					}
 					else
 					{
-						SetColMetadataForGeographyType(&temp->paramMeta, tdsType, TDS_MAXLEN_POINT, "", "geography");
+						SetColMetadataForGeographyType(&temp->paramMeta, tdsType, TDS_MAXLEN_POINT, TDS_ASSEMBLY_TYPE_NAME_GEOGRAPHY, "geography");
 						temp->type = TDS_TYPE_GEOGRAPHY;
 						tdsType = TDS_TYPE_GEOGRAPHY;
 					}

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -1468,6 +1468,10 @@ TdsTypeSpatialToDatum(StringInfo buf)
 	 */
 	/* We are copying first 4 Byte SRID from buf */
 	appendBinaryStringInfo(destBuf, buf->data + buf->cursor, 4);
+	/* Swapping first 3 bytes of SRID as the driver expects SRID to be in little endian order
+	 * 4th byte is always 0
+	 */
+	SwapData(destBuf, destBuf->cursor + 0, destBuf->cursor + 2);
 	
 	npoints = (buf->len - buf->cursor - 6)/16;
 	nbytes = buf->len - buf->cursor + 6;

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -61,6 +61,10 @@
 /* default server name */
 #define TDS_DEFAULT_SERVER_NAME "Microsoft SQL Server"
 
+/* Assembly type name for Geospatial types */
+#define TDS_ASSEMBLY_TYPE_NAME_GEOMETRY "Microsoft.SqlServer.Types.SqlGeometry, Microsoft.SqlServer.Types"
+#define TDS_ASSEMBLY_TYPE_NAME_GEOGRAPHY "Microsoft.SqlServer.Types.SqlGeography, Microsoft.SqlServer.Types"
+
 /* default compatibility version */
 #define BABEL_COMPATIBILITY_VERSION "12.0.2000.8"
 

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -848,7 +848,7 @@ SetColMetadataForGeometryType(TdsColumnMetaData *col, uint8_t tdsType, uint16_t 
 {
 	col->sizeLen = 1;
 	col->metaLen = sizeof(col->metaEntry.type7);
-	col->metaEntry.type7.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
+	col->metaEntry.type7.flags = TDS_COL_METADATA_COMPUTED_FLAGS;
 	col->metaEntry.type7.tdsTypeId = tdsType;
 	col->metaEntry.type7.maxSize = maxSize;
 	col->isSpatialType = true;
@@ -861,7 +861,7 @@ SetColMetadataForGeographyType(TdsColumnMetaData *col, uint8_t tdsType, uint16_t
 {
 	col->sizeLen = 1;
 	col->metaLen = sizeof(col->metaEntry.type7);
-	col->metaEntry.type7.flags = TDS_COL_METADATA_DEFAULT_FLAGS;
+	col->metaEntry.type7.flags = TDS_COL_METADATA_COMPUTED_FLAGS;
 	col->metaEntry.type7.tdsTypeId = tdsType;
 	col->metaEntry.type7.maxSize = maxSize;
 	col->isSpatialType = true;

--- a/test/dotnet/ExpectedOutput/TestPoint.out
+++ b/test/dotnet/ExpectedOutput/TestPoint.out
@@ -24,6 +24,33 @@
 #Q#INSERT INTO POINTGEOG_dt(location) values(geography::STGeomFromText('Point(47.65100 -22.34900)', 4326))
 #Q#INSERT INTO POINTGEOG_dt(location) values(geography::STPointFromText('Point(47.65100 -22.34900)', 4326))
 #Q#INSERT INTO POINTGEOG_dt(location) values(geography::Point(47.65100, -22.34900, 4326))
+#Q#SELECT location, location.STX, location.STY FROM POINTGEOM_dt;
+#D#master.sys.geometry#!#float#!#float
+POINT (47.651 -22.349)#!#47.651#!#-22.349
+POINT (1 2)#!#1#!#2
+POINT (47.651 -22.349)#!#47.651#!#-22.349
+POINT (47.651 -22.349)#!#47.651#!#-22.349
+POINT (47.651 -22.349)#!#47.651#!#-22.349
+POINT (47.651 -22.349)#!#47.651#!#-22.349
+POINT (47.651 -22.349)#!#47.651#!#-22.349
+#Q#SELECT location, location.Lat, location.Long FROM POINTGEOG_dt;
+#D#master.sys.geography#!#float#!#float
+POINT (47.651 -22.349)#!#-22.349#!#47.651
+POINT (1 2)#!#2#!#1
+POINT (47.651 -22.349)#!#-22.349#!#47.651
+POINT (47.651 -22.349)#!#-22.349#!#47.651
+POINT (-22.349 47.651)#!#47.651#!#-22.349
+#Q#SELECT * FROM  POINT_dt;
+#D#master.sys.geometry#!#master.sys.geography
+POINT (47.651 -22.349)#!#
+#!#POINT (47.651 -22.349)
+POINT (1 2)#!#POINT (1 2)
+#Q#select geometry::Point(10,500,4326);
+#D#master.sys.geometry
+POINT (10 500)
+#Q#select geography::Point(10,500,4326);
+#D#master.sys.geography
+POINT (500 10)
 #Q#SELECT location.STAsText() FROM POINTGEOM_dt;
 #D#text
 POINT(47.651 -22.349)

--- a/test/dotnet/input/Datatypes/TestPoint.txt
+++ b/test/dotnet/input/Datatypes/TestPoint.txt
@@ -40,6 +40,11 @@ INSERT INTO POINTGEOG_dt(location) values(geography::STGeomFromText('Point(47.65
 INSERT INTO POINTGEOG_dt(location) values(geography::STPointFromText('Point(47.65100 -22.34900)', 4326))
 INSERT INTO POINTGEOG_dt(location) values(geography::Point(47.65100, -22.34900, 4326))
 
+SELECT location, location.STX, location.STY FROM POINTGEOM_dt;
+SELECT location, location.Lat, location.Long FROM POINTGEOG_dt;
+SELECT * FROM  POINT_dt;
+select geometry::Point(10,500,4326);
+select geography::Point(10,500,4326);
 SELECT location.STAsText() FROM POINTGEOM_dt;
 SELECT location.STAsText() FROM POINTGEOG_dt;
 SELECT geom.STAsText(), geog.STAsText() FROM POINT_dt;


### PR DESCRIPTION
### Description

Currently, in SSMS when we try to SELECT Geospatial columns, we get an error saying `An error occurred while executing batch. Error message is: Value cannot be null.
Parameter name: typeName`.

SSMS internally uses .NET driver, hence we are seeing this failure in .NET as well. 

This is due to incorrect assembly type name in TDS response metadata. This change addresses the above mentioned issue to send correct assembly type name and flags in TDS response.

### Issues Resolved

Task: BABEL- 4756
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)


### Test Scenarios Covered ###
* **Use case based -**   Added relevant dotnet tests in TestPoint.txt file


* **Boundary conditions -** 


* **Arbitrary inputs -** 


* **Negative test cases -** 


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).