### PR TITLE
Disable temp oid generation

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1163,7 +1163,7 @@ define_custom_variables(void)
 							gettext_noop("Temp oid buffer size"),
 							NULL,
 							&temp_oid_buffer_size,
-							65536, 0, 131072,
+							0, 0, 131072,
 							PGC_SUSET,
 							GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							NULL, NULL, NULL);

--- a/test/JDBC/expected/temp_oid.out
+++ b/test/JDBC/expected/temp_oid.out
@@ -1,0 +1,379 @@
+-- psql
+show babelfishpg_tsql.temp_oid_buffer_size
+GO
+~~START~~
+text
+0
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+CREATE LOGIN babel_object_id_login1 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user1 FOR LOGIN babel_object_id_login1;
+GO
+
+CREATE LOGIN babel_object_id_login2 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user2 FOR LOGIN babel_object_id_login2;
+GO
+
+-- tsql      user=babel_object_id_login1 password=12345678
+USE master
+GO
+
+CREATE TABLE #temp(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+GO
+
+INSERT INTO #temp(c1) VALUES(1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp
+GO
+~~START~~
+int#!#int#!#char
+1#!#1#!#Whoops!        
+~~END~~
+
+
+-- tsql      user=babel_object_id_login2 password=12345678
+USE master
+GO
+
+-- This should succeed and not fail with duplicate key in pg_attrdef
+CREATE TABLE #temp(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Hello!')
+GO
+
+INSERT INTO #temp(c1) VALUES(1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp
+GO
+~~START~~
+int#!#int#!#char
+1#!#1#!#Hello!         
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+DROP USER babel_object_id_master_user1
+GO
+
+DROP USER babel_object_id_master_user2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) IN ('babel_object_id_login1', 'babel_object_id_login2')
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+t
+~~END~~
+
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP LOGIN babel_object_id_login1;
+GO
+
+DROP LOGIN babel_object_id_login2;
+GO
+
+-- tsql
+USE master;
+GO
+
+
+-- Test Table Variables
+DECLARE @OrderTable TABLE (ID INT, OrderNumber INT DEFAULT 1)
+INSERT into @OrderTable (ID) VALUES (1), (2)
+select * from @OrderTable
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+~~END~~
+
+
+-- Test temp Table and alter default
+CREATE TABLE #temptable(ID INT, ProductName varchar(20) DEFAULT 'product')
+INSERT into #temptable (ID) VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+ALTER TABLE #temptable ADD CONSTRAINT df_ProductName DEFAULT 'item' FOR ProductName
+GO
+
+INSERT into #temptable (ID) VALUES (2)
+GO
+~~ROW COUNT: 1~~
+
+
+BEGIN TRANSACTION
+ALTER TABLE #temptable ADD CONSTRAINT df_ProductName DEFAULT 'service' FOR ProductName
+INSERT into #temptable (ID) VALUES (3)
+SELECT * FROM #temptable
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#product
+2#!#item
+3#!#service
+~~END~~
+
+
+INSERT into #temptable (ID) VALUES (4)
+SELECT * FROM #temptable
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#product
+2#!#item
+4#!#item
+~~END~~
+
+
+DROP TABLE #temptable
+GO
+
+CREATE PROCEDURE babel_4752_p1
+AS
+    CREATE TABLE #temp(a INT PRIMARY KEY, b INT, c CHAR(15) DEFAULT 'babel_4752_p1') 
+    insert into #temp (a, b) values (1, 2)
+    select * from #temp
+GO
+
+EXEC babel_4752_p1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+EXEC babel_4752_p1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+CREATE TABLE #temp(a INT PRIMARY KEY, b INT, c CHAR(15) DEFAULT 'Foo') 
+EXEC babel_4752_p1
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+CREATE PROCEDURE babel_4752_p2
+AS
+    CREATE TABLE #temp(a INT PRIMARY KEY, b INT, c CHAR(15) DEFAULT 'babel_4752_p2') 
+    insert into #temp (a, b) values (1, 2)
+    select * from #temp
+GO
+
+EXEC babel_4752_p2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p2  
+~~END~~
+
+
+CREATE LOGIN babel_object_id_login1b WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user1b FOR LOGIN babel_object_id_login1b;
+GO
+
+CREATE LOGIN babel_object_id_login2b WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user2b FOR LOGIN babel_object_id_login2b;
+GO
+
+GRANT EXECUTE ON babel_4752_p1 TO babel_object_id_master_user1b;
+GRANT EXECUTE ON babel_4752_p1 TO babel_object_id_master_user2b;
+GRANT EXECUTE ON babel_4752_p2 TO babel_object_id_master_user1b;
+GRANT EXECUTE ON babel_4752_p2 TO babel_object_id_master_user2b;
+GO
+
+-- tsql      user=babel_object_id_login1b password=12345678
+USE master
+GO
+
+EXEC babel_4752_p1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+EXEC babel_4752_p1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+EXEC babel_4752_p2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p2  
+~~END~~
+
+
+EXEC babel_4752_p2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p2  
+~~END~~
+
+
+-- tsql      user=babel_object_id_login2b password=12345678
+USE master
+GO
+
+EXEC babel_4752_p1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+EXEC babel_4752_p1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p1  
+~~END~~
+
+
+EXEC babel_4752_p2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p2  
+~~END~~
+
+
+EXEC babel_4752_p2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#char
+1#!#2#!#babel_4752_p2  
+~~END~~
+
+
+
+-- tsql
+USE master;
+GO
+
+DROP PROCEDURE babel_4752_p1
+GO
+
+DROP PROCEDURE babel_4752_p2
+GO
+
+DROP USER babel_object_id_master_user1b
+GO
+
+DROP USER babel_object_id_master_user2b
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) IN ('babel_object_id_login1b', 'babel_object_id_login2b')
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+t
+~~END~~
+
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+DROP LOGIN babel_object_id_login1b;
+GO
+
+DROP LOGIN babel_object_id_login2b;
+GO

--- a/test/JDBC/input/temp_tables/temp_oid.mix
+++ b/test/JDBC/input/temp_tables/temp_oid.mix
@@ -1,0 +1,224 @@
+-- psql
+show babelfishpg_tsql.temp_oid_buffer_size
+GO
+
+-- tsql
+USE master;
+GO
+
+CREATE LOGIN babel_object_id_login1 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user1 FOR LOGIN babel_object_id_login1;
+GO
+
+CREATE LOGIN babel_object_id_login2 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user2 FOR LOGIN babel_object_id_login2;
+GO
+
+-- tsql      user=babel_object_id_login1 password=12345678
+USE master
+GO
+
+CREATE TABLE #temp(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Whoops!')
+GO
+
+INSERT INTO #temp(c1) VALUES(1)
+GO
+
+SELECT * FROM #temp
+GO
+
+-- tsql      user=babel_object_id_login2 password=12345678
+USE master
+GO
+
+-- This should succeed and not fail with duplicate key in pg_attrdef
+CREATE TABLE #temp(c1 INT PRIMARY KEY, b INT IDENTITY, c CHAR(15) DEFAULT 'Hello!')
+GO
+
+INSERT INTO #temp(c1) VALUES(1)
+GO
+
+SELECT * FROM #temp
+GO
+
+-- tsql
+USE master;
+GO
+
+DROP USER babel_object_id_master_user1
+GO
+
+DROP USER babel_object_id_master_user2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) IN ('babel_object_id_login1', 'babel_object_id_login2')
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+
+-- tsql
+DROP LOGIN babel_object_id_login1;
+GO
+
+DROP LOGIN babel_object_id_login2;
+GO
+
+-- tsql
+USE master;
+GO
+
+-- Test Table Variables
+DECLARE @OrderTable TABLE (ID INT, OrderNumber INT DEFAULT 1)
+INSERT into @OrderTable (ID) VALUES (1), (2)
+
+select * from @OrderTable
+go
+
+-- Test temp Table and alter default
+CREATE TABLE #temptable(ID INT, ProductName varchar(20) DEFAULT 'product')
+INSERT into #temptable (ID) VALUES (1)
+GO
+
+ALTER TABLE #temptable ADD CONSTRAINT df_ProductName DEFAULT 'item' FOR ProductName
+GO
+
+INSERT into #temptable (ID) VALUES (2)
+GO
+
+BEGIN TRANSACTION
+ALTER TABLE #temptable ADD CONSTRAINT df_ProductName DEFAULT 'service' FOR ProductName
+INSERT into #temptable (ID) VALUES (3)
+SELECT * FROM #temptable
+ROLLBACK
+GO
+
+INSERT into #temptable (ID) VALUES (4)
+SELECT * FROM #temptable
+go
+
+DROP TABLE #temptable
+GO
+
+CREATE PROCEDURE babel_4752_p1
+AS
+    CREATE TABLE #temp(a INT PRIMARY KEY, b INT, c CHAR(15) DEFAULT 'babel_4752_p1') 
+    insert into #temp (a, b) values (1, 2)
+    select * from #temp
+GO
+
+EXEC babel_4752_p1
+GO
+
+EXEC babel_4752_p1
+GO
+
+CREATE TABLE #temp(a INT PRIMARY KEY, b INT, c CHAR(15) DEFAULT 'Foo') 
+EXEC babel_4752_p1
+go
+
+CREATE PROCEDURE babel_4752_p2
+AS
+    CREATE TABLE #temp(a INT PRIMARY KEY, b INT, c CHAR(15) DEFAULT 'babel_4752_p2') 
+    insert into #temp (a, b) values (1, 2)
+    select * from #temp
+GO
+
+EXEC babel_4752_p2
+GO
+
+CREATE LOGIN babel_object_id_login1b WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user1b FOR LOGIN babel_object_id_login1b;
+GO
+
+CREATE LOGIN babel_object_id_login2b WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_object_id_master_user2b FOR LOGIN babel_object_id_login2b;
+GO
+
+GRANT EXECUTE ON babel_4752_p1 TO babel_object_id_master_user1b;
+GRANT EXECUTE ON babel_4752_p1 TO babel_object_id_master_user2b;
+GRANT EXECUTE ON babel_4752_p2 TO babel_object_id_master_user1b;
+GRANT EXECUTE ON babel_4752_p2 TO babel_object_id_master_user2b;
+GO
+
+-- tsql      user=babel_object_id_login1b password=12345678
+USE master
+GO
+
+EXEC babel_4752_p1
+GO
+
+EXEC babel_4752_p1
+GO
+
+EXEC babel_4752_p2
+GO
+
+EXEC babel_4752_p2
+GO
+
+-- tsql      user=babel_object_id_login2b password=12345678
+USE master
+GO
+
+EXEC babel_4752_p1
+GO
+
+EXEC babel_4752_p1
+GO
+
+EXEC babel_4752_p2
+GO
+
+EXEC babel_4752_p2
+GO
+
+
+-- tsql
+USE master;
+GO
+
+DROP PROCEDURE babel_4752_p1
+GO
+
+DROP PROCEDURE babel_4752_p2
+GO
+
+DROP USER babel_object_id_master_user1b
+GO
+
+DROP USER babel_object_id_master_user2b
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) IN ('babel_object_id_login1b', 'babel_object_id_login2b')
+AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+-- (Not a huge fan of this because this could lead to intermittent issue.)
+SELECT pg_sleep(2);
+GO
+
+-- tsql
+DROP LOGIN babel_object_id_login1b;
+GO
+
+DROP LOGIN babel_object_id_login2b;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -209,6 +209,10 @@ ignore#!#load_road
 ignore#!#load_tenk
 ignore#!#load_stud_emp
 ignore#!#load_student
+ignore#!#temp_table_jdbc
+ignore#!#temp_tables_concurrent-vu-cleanup
+ignore#!#temp_tables_concurrent-vu-prepare
+ignore#!#temp_tables_concurrent-vu-verify
 
 # These tests are running in multidb mode in upgrade and singledb mode in JDBC
 ignore#!#BABEL-4279-vu-prepare


### PR DESCRIPTION
### Description
This commit disables temp oid generation due to errors discovered during testing


### Issues Resolved
Task: BABEL-4752

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).