### PR TITLE
Fix ambiguous operator calls during restore (#44)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2359,14 +2359,14 @@ CREATE OR REPLACE VIEW sys.syslanguages
 AS
 SELECT
     lang_id AS langid,
-    CAST(lower(lang_data_jsonb ->> 'date_format') AS SYS.NCHAR(3)) AS dateformat,
-    CAST(lang_data_jsonb -> 'date_first' AS SYS.TINYINT) AS datefirst,
+    CAST(lower(lang_data_jsonb ->> 'date_format'::TEXT) AS SYS.NCHAR(3)) AS dateformat,
+    CAST(lang_data_jsonb -> 'date_first'::TEXT AS SYS.TINYINT) AS datefirst,
     CAST(NULL AS INT) AS upgrade,
     CAST(coalesce(lang_name_mssql, lang_name_pg) AS SYS.SYSNAME) AS name,
     CAST(coalesce(lang_alias_mssql, lang_alias_pg) AS SYS.SYSNAME) AS alias,
-    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_names')), ',') AS SYS.NVARCHAR(372)) AS months,
-    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_shortnames')),',') AS SYS.NVARCHAR(132)) AS shortmonths,
-    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'days_shortnames')),',') AS SYS.NVARCHAR(217)) AS days,
+    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_names'::TEXT)), ',') AS SYS.NVARCHAR(372)) AS months,
+    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_shortnames'::TEXT)),',') AS SYS.NVARCHAR(132)) AS shortmonths,
+    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'days_shortnames'::TEXT)),',') AS SYS.NVARCHAR(217)) AS days,
     CAST(NULL AS INT) AS lcid,
     CAST(NULL AS SMALLINT) AS msglangid
 FROM sys.babelfish_syslanguages;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.7.0--2.8.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--2.7.0--2.8.0.sql
@@ -1268,6 +1268,23 @@ and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
 order by object_id, type_desc;
 GRANT SELECT ON sys.indexes TO PUBLIC;
 
+ CREATE OR REPLACE VIEW sys.syslanguages
+ AS
+ SELECT
+     lang_id AS langid,
+     CAST(lower(lang_data_jsonb ->> 'date_format'::TEXT) AS SYS.NCHAR(3)) AS dateformat,
+     CAST(lang_data_jsonb -> 'date_first'::TEXT AS SYS.TINYINT) AS datefirst,
+     CAST(NULL AS INT) AS upgrade,
+     CAST(coalesce(lang_name_mssql, lang_name_pg) AS SYS.SYSNAME) AS name,
+     CAST(coalesce(lang_alias_mssql, lang_alias_pg) AS SYS.SYSNAME) AS alias,
+     CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_names'::TEXT)), ',') AS SYS.NVARCHAR(372)) AS months,
+     CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_shortnames'::TEXT)),',') AS SYS.NVARCHAR(132)) AS shortmonths,
+     CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'days_shortnames'::TEXT)),',') AS SYS.NVARCHAR(217)) AS days,
+     CAST(NULL AS INT) AS lcid,
+     CAST(NULL AS SMALLINT) AS msglangid
+ FROM sys.babelfish_syslanguages;
+ GRANT SELECT ON sys.syslanguages TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);


### PR DESCRIPTION
### Description

* The JSONB operators like `->` and `->>` become ambiguous under `dump_restore` GUC so fixed this by adding proper casts in `sys.syslanguages` view.

Signed-off-by: Rishabh Tanwar [ritanwar@amazon.com](mailto:ritanwar@amazon.com)

This is a cherry-pick commit of [72effa85f1b188d918e29a379c3c5c10c2471ee0](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/72effa85f1b188d918e29a379c3c5c10c2471ee0) to fix the build failures

And is related to [#319](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/319) of engine repo

### Issues Resolved

Task: BABEL-3826

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).