### PR TITLE
Could commpile with BABEL_4_X_DEV__PG_16_X

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds-secure-openssl.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds-secure-openssl.c
@@ -855,11 +855,6 @@ Tds_be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
  * to retry; do we need to adopt their logic for that?
  */
 
-#ifndef HAVE_BIO_GET_DATA
-#define BIO_get_data(bio) (bio->ptr)
-#define BIO_set_data(bio, data) (bio->ptr = data)
-#endif
-
 static int
 my_sock_read(BIO * h, char *buf, int size)
 {
@@ -867,7 +862,7 @@ my_sock_read(BIO * h, char *buf, int size)
 
 	if (buf != NULL)
 	{
-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
+		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
 		BIO_clear_retry_flags(h);
 		if (res <= 0)
 		{
@@ -887,7 +882,7 @@ my_sock_write(BIO * h, const char *buf, int size)
 {
 	int			res = 0;
 
-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
+	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
 	BIO_clear_retry_flags(h);
 	if (res <= 0)
 	{
@@ -967,7 +962,7 @@ my_SSL_set_fd(Port *port, int fd)
 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
 		goto err;
 	}
-	BIO_set_data(bio, port);
+	BIO_set_app_data(bio, port);
 
 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
 	SSL_set_bio(port->ssl, bio, bio);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -71,7 +71,7 @@ SslRead(BIO * h, char *buf, int size)
 
 	if (buf != NULL)
 	{
-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
+		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
 		BIO_clear_retry_flags(h);
 		if (res <= 0)
 		{
@@ -171,7 +171,7 @@ SslWrite(BIO * h, const char *buf, int size)
 {
 	int			res = 0;
 
-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
+	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
 	BIO_clear_retry_flags(h);
 	if (res <= 0)
 	{

--- a/contrib/babelfishpg_tds/src/include/tds_secure.h
+++ b/contrib/babelfishpg_tds/src/include/tds_secure.h
@@ -31,13 +31,6 @@
 #include "libpq/libpq.h"
 #include "port/pg_bswap.h"
 
-#ifdef USE_SSL
-#ifndef HAVE_BIO_GET_DATA
-#define BIO_get_data(bio) (bio->ptr)
-#define BIO_set_data(bio, data) (bio->ptr = data)
-#endif
-#endif
-
 BIO_METHOD *TdsBioSecureSocket(BIO_METHOD * my_bio_methods);
 
 extern int	tds_ssl_min_protocol_version;


### PR DESCRIPTION
Hi,

When I try compile [BABEL_4_X_DEV](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/938b6fc9f7ba5f66f9a7bc8455f1b70b6b7531c3) with [postgresql_modified_for_babelfish/BABEL_4_X_DEV__PG_16_X](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/65c628c3335ef0afcd637a49c5fdf24b090e68e3), here are some erors:

1. `BIO_[get/set]_data()` is replace with `BIO_[get/set]_app_data()` in [21b3a29](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/21b3a29565dff7baa2548fd779a0afe737b42f33).
2. Some multiple definition errors.

Here are two commits for this, please take a look!