### PR TITLE
Support double-escaping and unbalanced quotes in sp_tables table_type

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1000,10 +1000,10 @@ CREATE OR REPLACE FUNCTION sys.sp_tables_internal(
 		DECLARE opt_view sys.varchar(16) = '';
 		DECLARE cs_as_in_table_type varchar COLLATE "C" = in_table_type;
 	BEGIN
-		IF (SELECT count(*) FROM unnest(string_to_array(cs_as_in_table_type, ',')) WHERE upper(trim(unnest)) = '''TABLE''' OR upper(trim(unnest)) = '''''''TABLE''''''') >= 1 THEN
+		IF upper(cs_as_in_table_type) LIKE '%''TABLE''%' THEN
 			opt_table = 'TABLE';
 		END IF;
-		IF (SELECT count(*) from unnest(string_to_array(cs_as_in_table_type, ',')) WHERE upper(trim(unnest)) = '''VIEW''' OR upper(trim(unnest)) = '''''''VIEW''''''') >= 1 THEN
+		IF upper(cs_as_in_table_type) LIKE '%''VIEW''%' THEN
 			opt_view = 'VIEW';
 		END IF;
 		IF in_fusepattern = 1 THEN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
@@ -47,3 +47,64 @@ CALL sys.analyze_babelfish_catalogs();
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
+
+CREATE OR REPLACE FUNCTION sys.sp_tables_internal(
+	in_table_name sys.nvarchar(384) = '',
+	in_table_owner sys.nvarchar(384) = '', 
+	in_table_qualifier sys.sysname = '',
+	in_table_type sys.varchar(100) = '',
+	in_fusepattern sys.bit = '1')
+	RETURNS TABLE (
+		out_table_qualifier sys.sysname,
+		out_table_owner sys.sysname,
+		out_table_name sys.sysname,
+		out_table_type sys.varchar(32),
+		out_remarks sys.varchar(254)
+	)
+	AS $$
+		DECLARE opt_table sys.varchar(16) = '';
+		DECLARE opt_view sys.varchar(16) = '';
+		DECLARE cs_as_in_table_type varchar COLLATE "C" = in_table_type;
+	BEGIN
+		IF upper(cs_as_in_table_type) LIKE '%''TABLE''%' THEN
+			opt_table = 'TABLE';
+		END IF;
+		IF upper(cs_as_in_table_type) LIKE '%''VIEW''%' THEN
+			opt_view = 'VIEW';
+		END IF;
+		IF in_fusepattern = 1 THEN
+			RETURN query
+			SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(remarks AS sys.varchar(254)) AS REMARKS
+			FROM sys.sp_tables_view
+			WHERE ((SELECT coalesce(in_table_name,'')) = '' OR table_name LIKE in_table_name collate sys.database_default)
+			AND ((SELECT coalesce(in_table_owner,'')) = '' OR table_owner LIKE in_table_owner collate sys.database_default)
+			AND ((SELECT coalesce(in_table_qualifier,'')) = '' OR table_qualifier LIKE in_table_qualifier collate sys.database_default)
+			AND ((SELECT coalesce(cs_as_in_table_type,'')) = ''
+			    OR table_type = opt_table
+			    OR table_type = opt_view)
+			ORDER BY table_qualifier, table_owner, table_name;
+		ELSE 
+			RETURN query
+			SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(remarks AS sys.varchar(254)) AS REMARKS
+			FROM sys.sp_tables_view
+			WHERE ((SELECT coalesce(in_table_name,'')) = '' OR table_name = in_table_name collate sys.database_default)
+			AND ((SELECT coalesce(in_table_owner,'')) = '' OR table_owner = in_table_owner collate sys.database_default)
+			AND ((SELECT coalesce(in_table_qualifier,'')) = '' OR table_qualifier = in_table_qualifier collate sys.database_default)
+			AND ((SELECT coalesce(cs_as_in_table_type,'')) = ''
+			    OR table_type = opt_table
+			    OR table_type = opt_view)
+			ORDER BY table_qualifier, table_owner, table_name;
+		END IF;
+	END;
+$$
+LANGUAGE plpgsql STABLE;

--- a/test/JDBC/expected/BABEL-SP_TABLES.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES.out
@@ -291,6 +291,81 @@ db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
 ~~END~~
 
 
+-- table_type list
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'',''VIEW'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+-- table_type list with unsupported type
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'',''VIEW'',''SYSTEM TABLE'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+-- table_type list without tables
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''VIEW'',''SYSTEM TABLE'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+-- table_type list without views
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'',''SYSTEM TABLE'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+-- table_type list with double-escaping
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''''''TABLE'''',''''VIEW'''',''''SYSTEM TABLE'''''''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+-- table_type list with unbalanced quotes
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'''''',''''VIEW'',''SYSTEM TABLE'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+-- table_type list with spaces
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE '','' VIEW'',''SYSTEM TABLE'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+-- table_type list with mixed case
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''Table'',''View'',''System Table'''
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+
 drop view t_sptables5
 go
 drop table t_sptables

--- a/test/JDBC/input/BABEL-SP_TABLES.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES.sql
@@ -129,6 +129,31 @@ go
 exec [sys].sp_tables N't_sptables',N'dbo',NULL,N'''TABLE''',@fUsePattern=1;
 go
 
+-- table_type list
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'',''VIEW'''
+go
+-- table_type list with unsupported type
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'',''VIEW'',''SYSTEM TABLE'''
+go
+-- table_type list without tables
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''VIEW'',''SYSTEM TABLE'''
+go
+-- table_type list without views
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'',''SYSTEM TABLE'''
+go
+-- table_type list with double-escaping
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''''''TABLE'''',''''VIEW'''',''''SYSTEM TABLE'''''''
+go
+-- table_type list with unbalanced quotes
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE'''''',''''VIEW'',''SYSTEM TABLE'''
+go
+-- table_type list with spaces
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''TABLE '','' VIEW'',''SYSTEM TABLE'''
+go
+-- table_type list with mixed case
+exec [sys].sp_tables 't_sptable%','dbo',NULL,'''Table'',''View'',''System Table'''
+go
+
 drop view t_sptables5
 go
 drop table t_sptables


### PR DESCRIPTION
### Description

It is suggested to relax `table_type` parameter handling in `sp_tables` procedure, so strings with technically invalid quotation are also accepted. See details in the linked issue. 

### Issues Resolved

#2404

### Test Scenarios Covered ###

Existing test is updated with new input.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).