### PR TITLE
Call pltsql_predicate_transformer for NOT expr argument

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -470,7 +470,6 @@ pltsql_predicate_transformer(Node *expr)
 		 * Nonsingleton predicate, which could either a BoolExpr with a list
 		 * of predicates or a simple List of predicates.
 		 */
-		BoolExpr   *boolexpr = (BoolExpr *) expr;
 		ListCell   *lc;
 		List	   *new_predicates = NIL;
 		List	   *predicates;
@@ -481,14 +480,7 @@ pltsql_predicate_transformer(Node *expr)
 		}
 		else if (IsA(expr, BoolExpr))
 		{
-			if (boolexpr->boolop != AND_EXPR &&
-				boolexpr->boolop != OR_EXPR)
-				return expression_tree_mutator(
-											   expr,
-											   pgtsql_expression_tree_mutator,
-											   NULL);
-
-			predicates = boolexpr->args;
+			predicates = ((BoolExpr *)expr)->args;
 		}
 		else if (IsA(expr, FuncExpr))
 		{
@@ -511,7 +503,8 @@ pltsql_predicate_transformer(Node *expr)
 		{
 			Node	   *qual = (Node *) lfirst(lc);
 
-			if (is_andclause(qual) || is_orclause(qual))
+			/* For bool expr recall pltsql_predicate_transformer on its args */
+			if (IsA(qual, BoolExpr))
 			{
 				new_predicates = lappend(new_predicates,
 										 pltsql_predicate_transformer(qual));
@@ -527,7 +520,7 @@ pltsql_predicate_transformer(Node *expr)
 
 		if (IsA(expr, BoolExpr))
 		{
-			boolexpr->args = new_predicates;
+			((BoolExpr *)expr)->args = new_predicates;
 			return expr;
 		}
 		else

--- a/test/JDBC/expected/BABEL_4566.out
+++ b/test/JDBC/expected/BABEL_4566.out
@@ -1,0 +1,127 @@
+CREATE TABLE babel_4566 (id int)
+GO
+CREATE TABLE bábèl_4566 (id int)
+GO
+INSERT INTO babel_4566 VALUES (OBJECT_ID('babel_4566')), (OBJECT_ID('bábèl_4566'))
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT OBJECT_NAME(id) LIKE '%Blah%'
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    NOT 1>1 AND ((NOT OBJECT_NAME(id) LIKE '%Blah%') AND (OBJECT_NAME(id) LIKE '%4566%'))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    1>1 OR ((NOT OBJECT_NAME(id) LIKE '%Blah%') AND (NOT OBJECT_NAME(id) LIKE '%Blâh%'))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    (1=1 AND NOT OBJECT_NAME(id) LIKE '%Blah%') OR ((NOT 2<1) AND (NOT OBJECT_NAME(id) LIKE '%Blâh%'))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+CREATE FUNCTION like_in_function (@id INT, @cmp_string VARCHAR(30))
+RETURNS INT
+AS
+BEGIN
+    DECLARE @result INT
+    SELECT @result = CASE 
+            WHEN ( OBJECT_NAME(@id) LIKE @cmp_string ) THEN 1
+            ELSE 0
+            END
+    RETURN @result;
+END;
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT like_in_function(id, '%Blah%') = 1
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    NOT 1>1 AND ((NOT like_in_function(id, '%Blah%') = 1) AND like_in_function(id, '%4566%') = 1)
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    1>1 OR ((NOT like_in_function(id, '%Blah%') = 1) AND (NOT like_in_function(id, '%Blah%') = 1))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    (1=1 AND (NOT like_in_function(id, '%Blah%') = 1)) OR ((NOT 2<1) AND (NOT like_in_function(id, '%Blah%') = 1))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT (SELECT COUNT(*) FROM babel_4566 WHERE (1=1 AND (NOT like_in_function(id, '%Blah%') = 1))) != 2
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT (SELECT COUNT(*) FROM babel_4566 WHERE 1=1 AND NOT OBJECT_NAME(id) LIKE '%Blah%') != 2
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+DROP TABLE babel_4566, bábèl_4566
+GO
+
+DROP FUNCTION like_in_function
+GO

--- a/test/JDBC/input/BABEL_4566.sql
+++ b/test/JDBC/input/BABEL_4566.sql
@@ -1,0 +1,75 @@
+CREATE TABLE babel_4566 (id int)
+GO
+CREATE TABLE bábèl_4566 (id int)
+GO
+INSERT INTO babel_4566 VALUES (OBJECT_ID('babel_4566')), (OBJECT_ID('bábèl_4566'))
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT OBJECT_NAME(id) LIKE '%Blah%'
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    NOT 1>1 AND ((NOT OBJECT_NAME(id) LIKE '%Blah%') AND (OBJECT_NAME(id) LIKE '%4566%'))
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    1>1 OR ((NOT OBJECT_NAME(id) LIKE '%Blah%') AND (NOT OBJECT_NAME(id) LIKE '%Blâh%'))
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    (1=1 AND NOT OBJECT_NAME(id) LIKE '%Blah%') OR ((NOT 2<1) AND (NOT OBJECT_NAME(id) LIKE '%Blâh%'))
+GO
+
+CREATE FUNCTION like_in_function (@id INT, @cmp_string VARCHAR(30))
+RETURNS INT
+AS
+BEGIN
+    DECLARE @result INT
+    SELECT @result = CASE 
+            WHEN ( OBJECT_NAME(@id) LIKE @cmp_string ) THEN 1
+            ELSE 0
+            END
+    RETURN @result;
+END;
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT like_in_function(id, '%Blah%') = 1
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    NOT 1>1 AND ((NOT like_in_function(id, '%Blah%') = 1) AND like_in_function(id, '%4566%') = 1)
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    1>1 OR ((NOT like_in_function(id, '%Blah%') = 1) AND (NOT like_in_function(id, '%Blah%') = 1))
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 
+    (1=1 AND (NOT like_in_function(id, '%Blah%') = 1)) OR ((NOT 2<1) AND (NOT like_in_function(id, '%Blah%') = 1))
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT (SELECT COUNT(*) FROM babel_4566 WHERE (1=1 AND (NOT like_in_function(id, '%Blah%') = 1))) != 2
+GO
+
+SELECT COUNT(*) FROM babel_4566
+WHERE 1=1
+    AND NOT (SELECT COUNT(*) FROM babel_4566 WHERE 1=1 AND NOT OBJECT_NAME(id) LIKE '%Blah%') != 2
+GO
+
+DROP TABLE babel_4566, bábèl_4566
+GO
+
+DROP FUNCTION like_in_function
+GO


### PR DESCRIPTION
### Description

in pltsql_predicate_transformer we recursively call the function for arguments for AND / OR clause.
We did not do this for NOT clause but there were cases where `LIKE` operator inside a `NOT` clause was not transformed because of this exclusion.
example: `SELECT COUNT(*) FROM babel_4566 WHERE 1=1 AND NOT OBJECT_NAME(id) LIKE '%Blah%'`
In this query the top clause is AND. So, we analyse its arguments individually. Then one of the predicates is a NOT clause and previously we directly returned it without transforming its like operator.
With this fix, the arguments of `NOT` will again be passed to pltsql_predicate_transformer for further break down and transformation.

As a fix we handle NOT clause similar to AND/OR and call the pltsql_predicate_transformer recursively for its argument.
NOT clause only has one argument, but ipltsql_predicate_transformer still needs to be called for its argument again.

#### Cherry Picked From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2377
No merge conflicts

#### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Issues Resolved

[BABEL-4566]

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).