### PR TITLE
FETCH from CURSOR inside a function should be disabled without a destination

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5550,12 +5550,13 @@ makeFetchCursorStatement(TSqlParser::Fetch_cursorContext *ctx)
 	/* cursor_name */
 	auto targetText = ::getFullText(ctx->cursor_name());
 	result->curvar = lookup_cursor_variable(targetText.c_str())->dno;
-    
+
 	/* FETCH CURSOR without destination should be blocked inside a function. */
 
-	if (is_compiling_create_function() && !ctx->INTO()){
+	if (is_compiling_create_function() && !ctx->INTO())
+	{
 		throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "SELECT statements included within a function cannot return data to a client.", getLineAndPos(ctx));
-    } 
+    }
 	/* fetch option */
 	if (ctx->NEXT()) {
 		result->direction = FETCH_FORWARD;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5556,7 +5556,7 @@ makeFetchCursorStatement(TSqlParser::Fetch_cursorContext *ctx)
 	if (is_compiling_create_function() && !ctx->INTO())
 	{
 		throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "SELECT statements included within a function cannot return data to a client.", getLineAndPos(ctx));
-    }
+	}
 	/* fetch option */
 	if (ctx->NEXT()) {
 		result->direction = FETCH_FORWARD;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5550,7 +5550,12 @@ makeFetchCursorStatement(TSqlParser::Fetch_cursorContext *ctx)
 	/* cursor_name */
 	auto targetText = ::getFullText(ctx->cursor_name());
 	result->curvar = lookup_cursor_variable(targetText.c_str())->dno;
+    
+	/* FETCH CURSOR without destination should be blocked inside a function. */
 
+	if (is_compiling_create_function() && !ctx->INTO()){
+		throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "SELECT statements included within a function cannot return data to a client.", getLineAndPos(ctx));
+    } 
 	/* fetch option */
 	if (ctx->NEXT()) {
 		result->direction = FETCH_FORWARD;

--- a/test/JDBC/expected/BABEL-2218.out
+++ b/test/JDBC/expected/BABEL-2218.out
@@ -3,7 +3,10 @@ go
 
 CREATE TABLE t2218(c1 INT)
 INSERT INTO t2218 VALUES (2218);
+INSERT INTO t2218 VALUES (2219);
 GO
+~~ROW COUNT: 1~~
+
 ~~ROW COUNT: 1~~
 
 
@@ -45,7 +48,7 @@ DROP FUNCTION f2218;
 GO
 ~~START~~
 int
-2218
+2219
 ~~END~~
 
 
@@ -79,5 +82,42 @@ DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
 go
 
 DROP FUNCTION f_getval;
+GO
+
+-- cursor for select work with multiple fetch if the destination(INTO @variable) is provided inside a function BABEL-4586
+CREATE FUNCTION f_getval() RETURNS INTEGER
+AS
+BEGIN
+DECLARE @my_var int
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+  RETURN @my_var
+  END
+go
+
+DROP FUNCTION f_getval;
+GO
+
+-- cursor for select should throw error even if one fetch tries to return results to client
+CREATE FUNCTION f_getval() RETURNS INTEGER
+AS
+BEGIN
+DECLARE @my_var int
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  FETCH NEXT FROM temp_cursor
+  CLOSE temp_cursor
+  RETURN @my_var
+  END
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SELECT statements included within a function cannot return data to a client.)~~
+
+
 DROP TABLE t2218;
 GO

--- a/test/JDBC/expected/BABEL-2218.out
+++ b/test/JDBC/expected/BABEL-2218.out
@@ -42,10 +42,42 @@ DECLARE @ret INT;
 SET @ret = f2218();
 SELECT @ret;
 DROP FUNCTION f2218;
-DROP TABLE t2218;
 GO
 ~~START~~
 int
 2218
 ~~END~~
 
+
+-- Throw error if cursor for select doesn't have a destination(INTO @variable) inside a function BABEL-4586
+CREATE FUNCTION f_getval()RETURNS INTEGER
+AS
+BEGIN
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor
+  CLOSE temp_cursor
+  RETURN 1
+  END
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SELECT statements included within a function cannot return data to a client.)~~
+
+
+-- cursor for select work if the destination(INTO @variable) is provided inside a function BABEL-4586
+CREATE FUNCTION f_getval() RETURNS INTEGER
+AS
+BEGIN
+DECLARE @my_var int
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+  RETURN @my_var
+  END
+go
+
+DROP FUNCTION f_getval;
+DROP TABLE t2218;
+GO

--- a/test/JDBC/expected/BABEL-2218.out
+++ b/test/JDBC/expected/BABEL-2218.out
@@ -56,12 +56,12 @@ int
 CREATE FUNCTION f_getval()RETURNS INTEGER
 AS
 BEGIN
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor
   CLOSE temp_cursor
   RETURN 1
-  END
+END
 go
 ~~ERROR (Code: 33557097)~~
 
@@ -72,13 +72,13 @@ go
 CREATE FUNCTION f_getval() RETURNS INTEGER
 AS
 BEGIN
-DECLARE @my_var int
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE @my_var int
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor INTO @my_var
   CLOSE temp_cursor
   RETURN @my_var
-  END
+END
 go
 
 DROP FUNCTION f_getval;
@@ -88,14 +88,14 @@ GO
 CREATE FUNCTION f_getval() RETURNS INTEGER
 AS
 BEGIN
-DECLARE @my_var int
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE @my_var int
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor INTO @my_var
   FETCH NEXT FROM temp_cursor INTO @my_var
   CLOSE temp_cursor
   RETURN @my_var
-  END
+END
 go
 
 DROP FUNCTION f_getval;
@@ -105,19 +105,76 @@ GO
 CREATE FUNCTION f_getval() RETURNS INTEGER
 AS
 BEGIN
-DECLARE @my_var int
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE @my_var int
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor INTO @my_var
   FETCH NEXT FROM temp_cursor
   CLOSE temp_cursor
   RETURN @my_var
-  END
-go
+END
+GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: SELECT statements included within a function cannot return data to a client.)~~
 
 
-DROP TABLE t2218;
+-- cursor for select should work for procedure
+CREATE PROCEDURE proc_with_cursor_fetch
+AS
+BEGIN
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor
+  CLOSE temp_cursor
+END
+GO
+
+DROP PROCEDURE proc_with_cursor_fetch;
+GO
+
+-- cursor for select should work for procedure with INTO
+CREATE PROCEDURE proc_with_cursor_fetch
+AS
+BEGIN
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
+  DECLARE @my_var int
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+END
+GO
+
+DROP PROCEDURE proc_with_cursor_fetch;
+GO
+
+CREATE TRIGGER trg1 ON t2218 AFTER INSERT AS
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
+  DECLARE @my_var int
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+GO
+
+CREATE TRIGGER trg2 ON t2218 AFTER INSERT AS
+  DECLARE temp_cursor1 CURSOR FOR SELECT c1 FROM t2218
+  OPEN temp_cursor1
+  FETCH NEXT FROM temp_cursor1
+  CLOSE temp_cursor1
+GO
+
+-- Trigger after insert
+INSERT INTO t2218 VALUES (2218);
+GO
+~~START~~
+int
+2218
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+DROP TRIGGER trg1
+DROP TRIGGER trg2
+DROP TABLE t2218
 GO

--- a/test/JDBC/input/BABEL-2218.sql
+++ b/test/JDBC/input/BABEL-2218.sql
@@ -43,25 +43,25 @@ GO
 CREATE FUNCTION f_getval()RETURNS INTEGER
 AS
 BEGIN
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor
   CLOSE temp_cursor
   RETURN 1
-  END
+END
 go
 
 -- cursor for select work if the destination(INTO @variable) is provided inside a function BABEL-4586
 CREATE FUNCTION f_getval() RETURNS INTEGER
 AS
 BEGIN
-DECLARE @my_var int
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE @my_var int
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor INTO @my_var
   CLOSE temp_cursor
   RETURN @my_var
-  END
+END
 go
 
 DROP FUNCTION f_getval;
@@ -71,14 +71,14 @@ GO
 CREATE FUNCTION f_getval() RETURNS INTEGER
 AS
 BEGIN
-DECLARE @my_var int
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE @my_var int
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor INTO @my_var
   FETCH NEXT FROM temp_cursor INTO @my_var
   CLOSE temp_cursor
   RETURN @my_var
-  END
+END
 go
 
 DROP FUNCTION f_getval;
@@ -88,15 +88,65 @@ GO
 CREATE FUNCTION f_getval() RETURNS INTEGER
 AS
 BEGIN
-DECLARE @my_var int
-DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  DECLARE @my_var int
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
   OPEN temp_cursor
   FETCH NEXT FROM temp_cursor INTO @my_var
   FETCH NEXT FROM temp_cursor
   CLOSE temp_cursor
   RETURN @my_var
-  END
-go
+END
+GO
 
-DROP TABLE t2218;
+-- cursor for select should work for procedure
+CREATE PROCEDURE proc_with_cursor_fetch
+AS
+BEGIN
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor
+  CLOSE temp_cursor
+END
+GO
+
+DROP PROCEDURE proc_with_cursor_fetch;
+GO
+
+-- cursor for select should work for procedure with INTO
+CREATE PROCEDURE proc_with_cursor_fetch
+AS
+BEGIN
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
+  DECLARE @my_var int
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+END
+GO
+
+DROP PROCEDURE proc_with_cursor_fetch;
+GO
+
+CREATE TRIGGER trg1 ON t2218 AFTER INSERT AS
+  DECLARE temp_cursor CURSOR FOR SELECT c1 FROM t2218
+  DECLARE @my_var int
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+GO
+
+CREATE TRIGGER trg2 ON t2218 AFTER INSERT AS
+  DECLARE temp_cursor1 CURSOR FOR SELECT c1 FROM t2218
+  OPEN temp_cursor1
+  FETCH NEXT FROM temp_cursor1
+  CLOSE temp_cursor1
+GO
+
+-- Trigger after insert
+INSERT INTO t2218 VALUES (2218);
+GO
+
+DROP TRIGGER trg1
+DROP TRIGGER trg2
+DROP TABLE t2218
 GO

--- a/test/JDBC/input/BABEL-2218.sql
+++ b/test/JDBC/input/BABEL-2218.sql
@@ -36,5 +36,33 @@ SET @ret = f2218();
 SELECT @ret;
 
 DROP FUNCTION f2218;
+GO
+
+-- Throw error if cursor for select doesn't have a destination(INTO @variable) inside a function BABEL-4586
+CREATE FUNCTION f_getval()RETURNS INTEGER
+AS
+BEGIN
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor
+  CLOSE temp_cursor
+  RETURN 1
+  END
+go
+
+-- cursor for select work if the destination(INTO @variable) is provided inside a function BABEL-4586
+CREATE FUNCTION f_getval() RETURNS INTEGER
+AS
+BEGIN
+DECLARE @my_var int
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+  RETURN @my_var
+  END
+go
+
+DROP FUNCTION f_getval;
 DROP TABLE t2218;
 GO

--- a/test/JDBC/input/BABEL-2218.sql
+++ b/test/JDBC/input/BABEL-2218.sql
@@ -3,6 +3,7 @@ go
 
 CREATE TABLE t2218(c1 INT)
 INSERT INTO t2218 VALUES (2218);
+INSERT INTO t2218 VALUES (2219);
 GO
 
 -- should throw an error
@@ -64,5 +65,38 @@ DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
 go
 
 DROP FUNCTION f_getval;
+GO
+
+-- cursor for select work with multiple fetch if the destination(INTO @variable) is provided inside a function BABEL-4586
+CREATE FUNCTION f_getval() RETURNS INTEGER
+AS
+BEGIN
+DECLARE @my_var int
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  CLOSE temp_cursor
+  RETURN @my_var
+  END
+go
+
+DROP FUNCTION f_getval;
+GO
+
+-- cursor for select should throw error even if one fetch tries to return results to client
+CREATE FUNCTION f_getval() RETURNS INTEGER
+AS
+BEGIN
+DECLARE @my_var int
+DECLARE temp_cursor CURSOR FOR SELECT a FROM t2218
+  OPEN temp_cursor
+  FETCH NEXT FROM temp_cursor INTO @my_var
+  FETCH NEXT FROM temp_cursor
+  CLOSE temp_cursor
+  RETURN @my_var
+  END
+go
+
 DROP TABLE t2218;
 GO


### PR DESCRIPTION
### Description

SELECT statements included within a function cannot return data to a client. This operation was not blocked with the FETCH CURSOR operation. This commit aim to restrict defining such function.  

### Issues Resolved
BABEL-4586

### Test Scenarios Covered ###
* **Use case based -** - Included


* **Boundary conditions -** - NA


* **Arbitrary inputs -** - NA


* **Negative test cases -** - INCLUDED


* **Minor version upgrade tests -** - NA


* **Major version upgrade tests -** - NA


* **Performance tests -** - NA


* **Tooling impact -** - NA


* **Client tests -** - NA


### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).