### PR TITLE
When creating a user, verify its login is not already sysadmin (#2418)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2346,7 +2346,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									RoleSpec   *login = (RoleSpec *) linitial((List *) defel->arg);
 
 									/* If login is a member of sysadmin, creating user for that login should not be allowed. */
-									if (has_privs_of_role(get_role_oid(login->rolename, false), get_sysadmin_oid()))
+									if (has_privs_of_role(get_role_oid(login->rolename, false), get_role_oid("sysadmin", false)))
 										ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 														errmsg("Cannot create user for sysadmin role.")));
 								}

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2341,6 +2341,34 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									location = defel->location;
 									user_options = lappend(user_options, defel);
 								}
+								else if (strcmp(defel->defname, "rolemembers") == 0)
+								{
+									RoleSpec   *login = (RoleSpec *) linitial((List *) defel->arg);
+
+									if (strchr(login->rolename, '\\') != NULL)
+									{
+										/*
+										 * If login->rolename contains '\'
+										 * then treat it as windows login.
+										 */
+										char	   *upn_login = convertToUPN(login->rolename);
+
+										if (upn_login != login->rolename)
+										{
+											pfree(login->rolename);
+											login->rolename = upn_login;
+										}
+										from_windows = true;
+										if (!pltsql_allow_windows_login)
+											ereport(ERROR,
+													(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+													 errmsg("Windows login is not supported in babelfish")));
+									}
+									/* If login is a member of sysadmin, creating user for that login should not be allowed. */
+									if (has_privs_of_role(get_role_oid(login->rolename, false), get_sysadmin_oid()))
+										ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+														errmsg("Cannot create user for sysadmin role.")));
+								}
 							}
 
 							foreach(option, user_options)

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2345,25 +2345,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								{
 									RoleSpec   *login = (RoleSpec *) linitial((List *) defel->arg);
 
-									if (strchr(login->rolename, '\\') != NULL)
-									{
-										/*
-										 * If login->rolename contains '\'
-										 * then treat it as windows login.
-										 */
-										char	   *upn_login = convertToUPN(login->rolename);
-
-										if (upn_login != login->rolename)
-										{
-											pfree(login->rolename);
-											login->rolename = upn_login;
-										}
-										from_windows = true;
-										if (!pltsql_allow_windows_login)
-											ereport(ERROR,
-													(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-													 errmsg("Windows login is not supported in babelfish")));
-									}
 									/* If login is a member of sysadmin, creating user for that login should not be allowed. */
 									if (has_privs_of_role(get_role_oid(login->rolename, false), get_sysadmin_oid()))
 										ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/test/JDBC/expected/BABEL-3549.out
+++ b/test/JDBC/expected/BABEL-3549.out
@@ -38,7 +38,7 @@ CREATE USER babel_3549_login1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: The login already has an account under a different user name.)~~
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
 
 USE master
 GO
@@ -56,6 +56,10 @@ USE babel_3549_db1
 GO
 CREATE USER babel_3549_login2
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
+
 
 USE master
 GO

--- a/test/JDBC/expected/babel-4430-vu-prepare.out
+++ b/test/JDBC/expected/babel-4430-vu-prepare.out
@@ -1,0 +1,19 @@
+-- tsql
+-- run as sysadmin
+create login babel_4430_l1 with password= '123'
+go
+create database babel_4430_db
+go
+alter server role sysadmin add member babel_4430_l1;
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+babel_4430_db#!#babel_4430_l1#!#dbo
+~~END~~
+

--- a/test/JDBC/expected/babel-4430-vu-verify.out
+++ b/test/JDBC/expected/babel-4430-vu-verify.out
@@ -1,0 +1,44 @@
+-- tsql
+-- run as sysadmin
+use babel_4430_db
+go
+create user babel_4430_l1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
+
+use master
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+babel_4430_db#!#babel_4430_l1#!#dbo
+~~END~~
+
+use master
+go
+
+-- tsql
+drop database babel_4430_db
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_4430_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+drop login babel_4430_l1
+go

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -17,7 +17,7 @@ CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User does not have permission to perform this action.)~~
+~~ERROR (Message: role "ownership_restrictions_from_pg_user_by_pg_login2" does not exist)~~
 
 
 -- tsql
@@ -50,17 +50,13 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role_by_pg_login2;
 GO
 
--- This is a temporary failure, it will be fixed with BABEL-4652.
 CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: errstart was not called)~~
+~~ERROR (Message: role "ownership_restrictions_from_pg_user_by_pg_login2" does not exist)~~
 
 
-
--- DROP USER ownership_restrictions_from_pg_user_by_pg_login2;
--- GO
 USE master;
 go
 

--- a/test/JDBC/input/babel-4430-vu-prepare.mix
+++ b/test/JDBC/input/babel-4430-vu-prepare.mix
@@ -1,0 +1,14 @@
+-- tsql
+-- run as sysadmin
+create login babel_4430_l1 with password= '123'
+go
+create database babel_4430_db
+go
+alter server role sysadmin add member babel_4430_l1;
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go

--- a/test/JDBC/input/babel-4430-vu-verify.mix
+++ b/test/JDBC/input/babel-4430-vu-verify.mix
@@ -1,0 +1,30 @@
+-- tsql
+-- run as sysadmin
+use babel_4430_db
+go
+create user babel_4430_l1
+go
+use master
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go
+use master
+go
+
+-- tsql
+drop database babel_4430_db
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_4430_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- tsql
+drop login babel_4430_l1
+go

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -37,12 +37,8 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role_by_pg_login2;
 GO
 
--- This is a temporary failure, it will be fixed with BABEL-4652.
 CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
 GO
-
--- DROP USER ownership_restrictions_from_pg_user_by_pg_login2;
--- GO
 
 USE master;
 go


### PR DESCRIPTION
Description

    Creation of a user should be blocked when its login is already sysadmin.
    Create user gives the error "errstart was not called"

Issues Resolved

Task: BABEL-4430, BABEL-4652
Signed-off-by: Shalini Lohia lshalini@amazon.com

