### PR TITLE
When creating a user, verify its login is not already sysadmin (#2418)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2797,6 +2797,10 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 													(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 													 errmsg("Windows login is not supported in babelfish")));
 									}
+									/* If login is a member of sysadmin, creating user for that login should not be allowed. */
+									if (has_privs_of_role(get_role_oid(login->rolename, false), get_sysadmin_oid()))
+										ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+														errmsg("Cannot create user for sysadmin role.")));
 								}
 							}
 

--- a/test/JDBC/expected/BABEL-3201-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3201-vu-verify.out
@@ -798,6 +798,10 @@ USE MASTER
 GO
 CREATE USER babel_3201_db1_log1_user_name_longer_then_64_char_abdhcdjddjdhskdsh FOR LOGIN babel_3201_log1
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
+
 
 -- tsql user=babel_3201_log1 password=12345678
 USE babel_3201_db1;
@@ -814,6 +818,4 @@ GO
 
 -- tsql
 USE master;
-GO
-DROP USER babel_3201_db1_log1_user_name_longer_then_64_char_abdhcdjddjdhskdsh
 GO

--- a/test/JDBC/expected/BABEL-3549.out
+++ b/test/JDBC/expected/BABEL-3549.out
@@ -38,7 +38,7 @@ CREATE USER babel_3549_login1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: The login already has an account under a different user name.)~~
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
 
 USE master
 GO
@@ -56,6 +56,10 @@ USE babel_3549_db1
 GO
 CREATE USER babel_3549_login2
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
+
 
 USE master
 GO

--- a/test/JDBC/expected/babel-4430-vu-prepare.out
+++ b/test/JDBC/expected/babel-4430-vu-prepare.out
@@ -1,0 +1,19 @@
+-- tsql
+-- run as sysadmin
+create login babel_4430_l1 with password= '123'
+go
+create database babel_4430_db
+go
+alter server role sysadmin add member babel_4430_l1;
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+babel_4430_db#!#babel_4430_l1#!#dbo
+~~END~~
+

--- a/test/JDBC/expected/babel-4430-vu-verify.out
+++ b/test/JDBC/expected/babel-4430-vu-verify.out
@@ -1,0 +1,44 @@
+-- tsql
+-- run as sysadmin
+use babel_4430_db
+go
+create user babel_4430_l1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create user for sysadmin role.)~~
+
+use master
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+babel_4430_db#!#babel_4430_l1#!#dbo
+~~END~~
+
+use master
+go
+
+-- tsql
+drop database babel_4430_db
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_4430_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+drop login babel_4430_l1
+go

--- a/test/JDBC/expected/ownership_restrictions_from_pg.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg.out
@@ -17,7 +17,7 @@ CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User does not have permission to perform this action.)~~
+~~ERROR (Message: role "ownership_restrictions_from_pg_user_by_pg_login2" does not exist)~~
 
 
 -- tsql
@@ -50,7 +50,6 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role_by_pg_login2;
 GO
 
--- This is a temporary failure, it will be fixed with BABEL-4652.
 CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
 GO
 ~~ERROR (Code: 33557097)~~
@@ -58,9 +57,6 @@ GO
 ~~ERROR (Message: role "ownership_restrictions_from_pg_user_by_pg_login2" does not exist)~~
 
 
-
--- DROP USER ownership_restrictions_from_pg_user_by_pg_login2;
--- GO
 USE master;
 go
 

--- a/test/JDBC/input/BABEL-3201-vu-verify.mix
+++ b/test/JDBC/input/BABEL-3201-vu-verify.mix
@@ -485,5 +485,3 @@ GO
 -- tsql
 USE master;
 GO
-DROP USER babel_3201_db1_log1_user_name_longer_then_64_char_abdhcdjddjdhskdsh
-GO

--- a/test/JDBC/input/babel-4430-vu-prepare.mix
+++ b/test/JDBC/input/babel-4430-vu-prepare.mix
@@ -1,0 +1,14 @@
+-- tsql
+-- run as sysadmin
+create login babel_4430_l1 with password= '123'
+go
+create database babel_4430_db
+go
+alter server role sysadmin add member babel_4430_l1;
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go

--- a/test/JDBC/input/babel-4430-vu-verify.mix
+++ b/test/JDBC/input/babel-4430-vu-verify.mix
@@ -1,0 +1,30 @@
+-- tsql
+-- run as sysadmin
+use babel_4430_db
+go
+create user babel_4430_l1
+go
+use master
+go
+
+-- tsql user=babel_4430_l1 password=123
+use babel_4430_db
+go
+select db_name(), suser_name(), user_name()
+go
+use master
+go
+
+-- tsql
+drop database babel_4430_db
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL) 
+WHERE sys.suser_name(usesysid) = 'babel_4430_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- tsql
+drop login babel_4430_l1
+go

--- a/test/JDBC/input/ownership_restrictions_from_pg.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg.mix
@@ -37,12 +37,8 @@ GO
 DROP ROLE ownership_restrictions_from_pg_role_by_pg_login2;
 GO
 
--- This is a temporary failure, it will be fixed with BABEL-4652.
 CREATE USER ownership_restrictions_from_pg_user_by_pg_login2;
 GO
-
--- DROP USER ownership_restrictions_from_pg_user_by_pg_login2;
--- GO
 
 USE master;
 go


### PR DESCRIPTION
Description

    Creation of a user should be blocked when its login is already sysadmin.
    Create user gives the error "errstart was not called"

Issues Resolved

Task: BABEL-4430, BABEL-4652
Signed-off-by: Shalini Lohia lshalini@amazon.com


