### PR TITLE
Add escape hatch for Insert Bulk Unsupported Features

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5039,6 +5039,7 @@ keyword
     | SYSTEM_TIME
     | SYSTEM_VERSIONING
     | T
+    | TABLOCK
     | TAKE
     | TAPE
     | TARGET

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1259,7 +1259,6 @@ int			escape_hatch_set_transaction_isolation_level = EH_STRICT;
 int			pltsql_isolation_level_repeatable_read = ISOLATION_OFF;
 int 		pltsql_isolation_level_serializable = ISOLATION_OFF;
 int 		escape_hatch_identity_function = EH_STRICT;
-int			escape_hatch_insert_bulk_options = EH_STRICT;
 
 void
 define_escape_hatch_variables(void)
@@ -1638,16 +1637,6 @@ define_escape_hatch_variables(void)
 							 gettext_noop("escape hatch for IDENTITY() in SELECT-INTO"),
 							 NULL,
 							 &escape_hatch_identity_function,
-							 EH_STRICT,
-							 escape_hatch_options,
-							 PGC_USERSET,
-							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-							 NULL, NULL, NULL);
-
-	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_insert_bulk_options",
-							 gettext_noop("escape hatch for unsupported INSERT BULK OPTIONS"),
-							 NULL,
-							 &escape_hatch_insert_bulk_options,
 							 EH_STRICT,
 							 escape_hatch_options,
 							 PGC_USERSET,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1259,6 +1259,7 @@ int			escape_hatch_set_transaction_isolation_level = EH_STRICT;
 int			pltsql_isolation_level_repeatable_read = ISOLATION_OFF;
 int 		pltsql_isolation_level_serializable = ISOLATION_OFF;
 int 		escape_hatch_identity_function = EH_STRICT;
+int			escape_hatch_insert_bulk_options = EH_STRICT;
 
 void
 define_escape_hatch_variables(void)
@@ -1637,6 +1638,16 @@ define_escape_hatch_variables(void)
 							 gettext_noop("escape hatch for IDENTITY() in SELECT-INTO"),
 							 NULL,
 							 &escape_hatch_identity_function,
+							 EH_STRICT,
+							 escape_hatch_options,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+
+	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_insert_bulk_options",
+							 gettext_noop("escape hatch for unsupported INSERT BULK OPTIONS"),
+							 NULL,
+							 &escape_hatch_insert_bulk_options,
 							 EH_STRICT,
 							 escape_hatch_options,
 							 PGC_USERSET,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1259,7 +1259,7 @@ int			escape_hatch_set_transaction_isolation_level = EH_STRICT;
 int			pltsql_isolation_level_repeatable_read = ISOLATION_OFF;
 int 		pltsql_isolation_level_serializable = ISOLATION_OFF;
 int 		escape_hatch_identity_function = EH_STRICT;
-int			escape_hatch_insert_bulk_options = EH_STRICT;
+int			escape_hatch_insert_bulk_options = EH_IGNORE;
 
 void
 define_escape_hatch_variables(void)
@@ -1648,7 +1648,7 @@ define_escape_hatch_variables(void)
 							 gettext_noop("escape hatch for unsupported INSERT BULK OPTIONS"),
 							 NULL,
 							 &escape_hatch_insert_bulk_options,
-							 EH_STRICT,
+							 EH_IGNORE,
 							 escape_hatch_options,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1259,7 +1259,7 @@ int			escape_hatch_set_transaction_isolation_level = EH_STRICT;
 int			pltsql_isolation_level_repeatable_read = ISOLATION_OFF;
 int 		pltsql_isolation_level_serializable = ISOLATION_OFF;
 int 		escape_hatch_identity_function = EH_STRICT;
-int			escape_hatch_insert_bulk_options = EH_IGNORE;
+int 		escape_hatch_insert_bulk_options = EH_IGNORE;
 
 void
 define_escape_hatch_variables(void)

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -24,7 +24,6 @@ extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;
 extern int escape_hatch_identity_function;
-extern int escape_hatch_insert_bulk_options;
 
 extern void define_custom_variables(void);
 extern void pltsql_validate_set_config_function(char *name, char *value);

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -24,6 +24,7 @@ extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;
 extern int escape_hatch_identity_function;
+extern int escape_hatch_insert_bulk_options;
 
 extern void define_custom_variables(void);
 extern void pltsql_validate_set_config_function(char *name, char *value);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5393,16 +5393,16 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 				else if (pg_strcasecmp("KEEP_NULLS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					stmt->keep_nulls = true;
 
-				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option check_constraints is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option fire_triggers is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
-					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
+				// else if (pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				// 	throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else if (escape_hatch_insert_bulk_options == EH_STRICT)
+				else
 					throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, format_errmsg("invalid insert bulk option %s", ::getFullText(option_list[i]->id()).c_str()), getLineAndPos(bulk_ctx->WITH()));
 			}
 		}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5393,16 +5393,16 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 				else if (pg_strcasecmp("KEEP_NULLS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					stmt->keep_nulls = true;
 
-				else if (pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option check_constraints is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else if (pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option fire_triggers is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else if (pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else
+				else if (escape_hatch_insert_bulk_options == EH_STRICT)
 					throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, format_errmsg("invalid insert bulk option %s", ::getFullText(option_list[i]->id()).c_str()), getLineAndPos(bulk_ctx->WITH()));
 			}
 		}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5393,16 +5393,16 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 				else if (pg_strcasecmp("KEEP_NULLS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					stmt->keep_nulls = true;
 
-				else if (pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option check_constraints is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else if (pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option fire_triggers is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				// else if (pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
-				// 	throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
+				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
+					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 
-				else
+				else if (escape_hatch_insert_bulk_options == EH_STRICT)
 					throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, format_errmsg("invalid insert bulk option %s", ::getFullText(option_list[i]->id()).c_str()), getLineAndPos(bulk_ctx->WITH()));
 			}
 		}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -5393,16 +5393,25 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 				else if (pg_strcasecmp("KEEP_NULLS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					stmt->keep_nulls = true;
 
-				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
-					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option check_constraints is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
-
-				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
-					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option fire_triggers is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
-
-				else if (escape_hatch_insert_bulk_options == EH_STRICT && pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
-					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
-
-				else if (escape_hatch_insert_bulk_options == EH_STRICT)
+				else if (pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				{
+					/* Throw Unsupported error only when escape hatch is set to strict. */
+					if (escape_hatch_insert_bulk_options == EH_STRICT)
+						throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option check_constraints is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
+				}
+				else if (pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				{
+					/* Throw Unsupported error only when escape hatch is set to strict. */
+					if (escape_hatch_insert_bulk_options == EH_STRICT)
+						throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option fire_triggers is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
+				}
+				else if (pg_strcasecmp("TABLOCK", ::getFullText(option_list[i]->id()).c_str()) == 0)
+				{
+					/* Throw Unsupported error only when escape hatch is set to strict. */
+					if (escape_hatch_insert_bulk_options == EH_STRICT)
+						throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option tablock is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
+				}
+				else
 					throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, format_errmsg("invalid insert bulk option %s", ::getFullText(option_list[i]->id()).c_str()), getLineAndPos(bulk_ctx->WITH()));
 			}
 		}

--- a/test/JDBC/expected/BABEL-TABLEHINT.out
+++ b/test/JDBC/expected/BABEL-TABLEHINT.out
@@ -206,7 +206,7 @@ select * from t1 (tablock, index(i1)) order by id; -- syntax error
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error near ',' at line 1 and character position 25)~~
+~~ERROR (Message: syntax error near 'index' at line 1 and character position 27)~~
 
 -- BABEL-1263: syntax "FROM [table] ([table_hint]) [alias]" should be supported
 Select * FROM t1 n1 (Nolock) WHERE (Select Count(*) FROM t1 (Nolock) n2) <= 0;

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2038,7 +2038,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#ignore#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2108,7 +2108,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#ignore#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2159,7 +2159,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#ignore#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2038,6 +2038,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2107,6 +2108,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2157,6 +2159,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2038,7 +2038,6 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2108,7 +2107,6 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2159,7 +2157,6 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -2046,7 +2046,6 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2116,7 +2115,6 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2167,7 +2165,6 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -2046,6 +2046,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2115,6 +2116,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2165,6 +2167,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -2046,7 +2046,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#ignore#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2116,7 +2116,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#ignore#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords
@@ -2167,7 +2167,7 @@ babelfishpg_tsql.escape_hatch_identity_function#!#strict#!#escape hatch for IDEN
 babelfishpg_tsql.escape_hatch_ignore_dup_key#!#strict#!#escape hatch for ignore_dup_key=on option in CREATE/ALTER TABLE/INDEX
 babelfishpg_tsql.escape_hatch_index_clustering#!#ignore#!#escape hatch for CLUSTERED option in CREATE INDEX
 babelfishpg_tsql.escape_hatch_index_columnstore#!#strict#!#escape hatch for COLUMNSTORE option in CREATE INDEX
-babelfishpg_tsql.escape_hatch_insert_bulk_options#!#strict#!#escape hatch for unsupported INSERT BULK OPTIONS
+babelfishpg_tsql.escape_hatch_insert_bulk_options#!#ignore#!#escape hatch for unsupported INSERT BULK OPTIONS
 babelfishpg_tsql.escape_hatch_join_hints#!#ignore#!#escape hatch for join hints
 babelfishpg_tsql.escape_hatch_language_non_english#!#strict#!#escape hatch for non-english language
 babelfishpg_tsql.escape_hatch_login_hashed_password#!#strict#!#escape hatch for login hashed passwords

--- a/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
+++ b/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
@@ -2,7 +2,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_view
 GO
 ~~START~~
 int
-44
+43
 ~~END~~
 
 
@@ -10,7 +10,7 @@ EXEC sys_babelfish_configurations_view_vu_prepare_proc
 GO
 ~~START~~
 int
-44
+43
 ~~END~~
 
 
@@ -18,7 +18,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_func()
 GO
 ~~START~~
 int
-44
+43
 ~~END~~
 
 

--- a/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
+++ b/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
@@ -2,7 +2,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_view
 GO
 ~~START~~
 int
-43
+44
 ~~END~~
 
 
@@ -10,7 +10,7 @@ EXEC sys_babelfish_configurations_view_vu_prepare_proc
 GO
 ~~START~~
 int
-43
+44
 ~~END~~
 
 
@@ -18,7 +18,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_func()
 GO
 ~~START~~
 int
-43
+44
 ~~END~~
 
 

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -499,3 +499,11 @@ bcp#!#in#!#bcp_source#!#destinationTable
 01/01/2000 00:00:00#!#01/01/2060 00:00:00
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+#E#insert bulk option tablock is not yet supported in babelfish
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+#E#insert bulk option check_constraints is not yet supported in babelfish
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+#E#insert bulk option fire_triggers is not yet supported in babelfish
+#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+#E#insert bulk option tablock is not yet supported in babelfish

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -223,6 +223,9 @@ bcp -h "CHECK_CONSTRAINTS"#!#in#!#bcp_source#!#destinationTable2
 1#!#1
 2#!#2
 #Q#Select * from destinationTable2
+#D#bigint#!#bigint
+1#!#1
+2#!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#drop table destinationTable2
@@ -243,6 +246,9 @@ bcp -h "FIRE_TRIGGERS"#!#in#!#bcp_source#!#destinationTable2
 1#!#1
 2#!#2
 #Q#Select * from destinationTable2
+#D#bigint#!#bigint
+1#!#1
+2#!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#drop table destinationTable2
@@ -283,6 +289,9 @@ bcp -h "TABLOCK"#!#in#!#bcp_source#!#destinationTable2
 1#!#1
 #!#2
 #Q#Select * from destinationTable2
+#D#bigint#!#bigint
+1#!#1
+#!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#drop table destinationTable2

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -507,3 +507,12 @@ bcp#!#in#!#bcp_source#!#destinationTable
 #E#insert bulk option fire_triggers is not yet supported in babelfish
 #Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
 #E#insert bulk option tablock is not yet supported in babelfish
+#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
+#D#text
+strict
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -506,13 +506,9 @@ bcp#!#in#!#bcp_source#!#destinationTable
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 #E#insert bulk option fire_triggers is not yet supported in babelfish
 #Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-#E#insert bulk option tablock is not yet supported in babelfish
-#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
-#D#text
-strict
-#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 #Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+#E#invalid insert bulk option hello

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -500,6 +500,16 @@ bcp#!#in#!#bcp_source#!#destinationTable
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+#E#invalid insert bulk option hello
+#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
+#D#text
+ignore
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 #E#insert bulk option tablock is not yet supported in babelfish
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 #E#insert bulk option check_constraints is not yet supported in babelfish
@@ -507,12 +517,6 @@ bcp#!#in#!#bcp_source#!#destinationTable
 #E#insert bulk option fire_triggers is not yet supported in babelfish
 #Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
 #E#insert bulk option tablock is not yet supported in babelfish
-#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
-#D#text
-strict
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+#E#invalid insert bulk option hello
 #Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
-#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -506,9 +506,13 @@ bcp#!#in#!#bcp_source#!#destinationTable
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 #E#insert bulk option fire_triggers is not yet supported in babelfish
 #Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+#E#insert bulk option tablock is not yet supported in babelfish
+#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
+#D#text
+strict
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 #Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 #Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
-#E#invalid insert bulk option hello
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -358,3 +358,12 @@ Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+
+# Testing Explicit Escape Hatch For Unsupported Options
+SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -358,12 +358,14 @@ Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
 
 # Testing Explicit Escape Hatch For Unsupported Options
 SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
-EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -359,11 +359,11 @@ Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
 
-# Testing Explicitly For Unsupported Options
+# Testing Explicit Escape Hatch For Unsupported Options
+SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-
-# Testing Invalid Options
-Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -352,3 +352,9 @@ Select * from sourceTable
 Select * from destinationTable
 drop table sourceTable
 drop table destinationTable
+
+# Testing Explicit Error Messages For Unsupported Options
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -359,11 +359,11 @@ Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
 
-# Testing Explicit Escape Hatch For Unsupported Options
-SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
-EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';
+# Testing Explicitly For Unsupported Options
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
 Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
 insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
+
+# Testing Invalid Options
+Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);


### PR DESCRIPTION
### Description
This commit fixed TABLOCK not being parsed as a KEYWORD because of which users were getting Syntax Errors rather than Unsupported erros.
To alleviate the drawback of unsupported Tablock options and to keep it consistent with Query options - where its ignored too using an escape hatch - we ignore the unsupported Insert Bulk Option by adding a new a escape hatch for it escape_hatch_insert_bulk_options which is set to ignore be default

Authored-by: Kushaal Shroff <kushaal@amazon.com>
Signed-off-by: Kushaal Shroff <kushaal@amazon.com>

### Issues Resolved

BABEL-4830/BABEL-4831

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).