### PR TITLE
String empty check in PLtsql_expr_query_mutator

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -629,7 +629,7 @@ void PLtsql_expr_query_mutator::add(int antlr_pos, std::string orig_text, std::s
 		}					
 	}	
 						
-	if ((orig_text.front() == '"') && (orig_text.back() == '"') && (repl_text.front() == '\'') && (repl_text.back() == '\'')) 
+	if (!orig_text.empty() && (orig_text.front() == '"') && (orig_text.back() == '"') && !repl_text.empty() && (repl_text.front() == '\'') && (repl_text.back() == '\'')) 
 	{
 		// Do not validate the positions of strings as these are not replaced by their positions
 	}


### PR DESCRIPTION
### Description

Add a check that string is not empty before calling `.front()` on it (that is apparently [an UB on empty string](https://en.cppreference.com/w/cpp/string/basic_string/front)).

There are many usages of `.front()` like this in `tsqlIface.cpp`, but AFAICS they always operate on known non-empty strings. Not sure if more non-empty checks before `.front()` calls are necessary there. Such crashes are deterministic with `-O0`, I've run JDBC test suite with `-O0` server and didn't get any more crashes.

### Issues Resolved

#2431

### Test Scenarios Covered ###

Without patch the problem is reproducible with [AVG-Aggregate-common-vu-verify](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/b38e6e2c0261725627d9ac751721e50501af6eef/test/JDBC/input/AVG-Aggregate-common-vu-verify.sql#L65) existing test (and probably some others).

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>