### PR TITLE
Add a test case for get_trigger_object_address_hook usage change 2x

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -39,6 +39,7 @@ runs:
 
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
         cd postgresql_modified_for_babelfish
+        git rev-parse HEAD
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
           ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
         else

--- a/test/JDBC/expected/comment_on_trigger.out
+++ b/test/JDBC/expected/comment_on_trigger.out
@@ -1,0 +1,67 @@
+-- tsql
+
+create table tab1(id1 int)
+go
+
+create trigger trig1 on tab1
+for update
+as begin
+  return;
+end
+go
+
+
+-- psql
+
+create table tab2(id2 int)
+go
+
+create or replace function func2()
+  returns "trigger" as
+'begin
+    return NEW;
+end;'
+  language 'plpgsql' volatile
+go
+
+create trigger trig2 before update
+  on tab2 for each row
+  execute procedure func2();
+go
+
+comment on trigger trig1 on master_dbo.tab1 is 'hello1'
+go
+comment on trigger trig2 on tab2 is 'hello2'
+go
+
+select description 
+from pg_description 
+join pg_trigger
+on pg_description.objoid = pg_trigger.oid 
+where tgname = 'trig1'
+or tgname = 'trig2'
+go
+~~START~~
+text
+hello1
+hello2
+~~END~~
+
+
+
+-- tsql
+
+drop trigger trig1
+go
+drop table tab1
+go
+
+
+-- psql
+
+drop trigger trig2 on tab2
+go
+drop function func2
+go
+drop table tab2
+go

--- a/test/JDBC/input/triggers/comment_on_trigger.mix
+++ b/test/JDBC/input/triggers/comment_on_trigger.mix
@@ -1,0 +1,61 @@
+-- tsql
+
+create table tab1(id1 int)
+go
+
+create trigger trig1 on tab1
+for update
+as begin
+  return;
+end
+go
+
+
+-- psql
+
+create table tab2(id2 int)
+go
+
+create or replace function func2()
+  returns "trigger" as
+'begin
+    return NEW;
+end;'
+  language 'plpgsql' volatile
+go
+
+create trigger trig2 before update
+  on tab2 for each row
+  execute procedure func2();
+go
+
+comment on trigger trig1 on master_dbo.tab1 is 'hello1'
+go
+comment on trigger trig2 on tab2 is 'hello2'
+go
+
+select description 
+from pg_description 
+join pg_trigger
+on pg_description.objoid = pg_trigger.oid 
+where tgname = 'trig1'
+or tgname = 'trig2'
+go
+
+
+-- tsql
+
+drop trigger trig1
+go
+drop table tab1
+go
+
+
+-- psql
+
+drop trigger trig2 on tab2
+go
+drop function func2
+go
+drop table tab2
+go


### PR DESCRIPTION
### Description
`get_trigger_object_address_hook` does not expect to be called on a Postgres connection and returns empty address despite having `missing_ok` parameter as `false`. This was eventually leading to crash of the server.

Fix was provided in engine. This commit aims to add a test case for that change.

### Issues Resolved
4x PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2414
Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/331
Issue: https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/2413
Taks: BABEL-4844

### Test Scenarios Covered
A `.mix` test that creates PG and TSQL triggers and adds comments to them.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko [alex@staticlibs.net](mailto:alex@staticlibs.net)