### PR TITLE
Support grant/revoke on schema feature (#2415)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -14,6 +14,21 @@ CREATE TABLE sys.babelfish_sysdatabases (
 
 GRANT SELECT on sys.babelfish_sysdatabases TO PUBLIC;
 
+-- BABELFISH_SCHEMA_PERMISSIONS
+-- This catalog is implemented specially to support GRANT/REVOKE .. ON SCHEMA ..
+-- Please avoid using this catalog anywhere else.
+CREATE TABLE sys.babelfish_schema_permissions (
+  dbid smallint NOT NULL,
+  schema_name sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  object_name sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  permission INT CHECK(permission > 0),
+  grantee sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  object_type CHAR(1) NOT NULL COLLATE sys.database_default,
+  function_args TEXT COLLATE "C",
+  grantor sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  PRIMARY KEY(dbid, schema_name, object_name, grantee, object_type)
+);
+
 -- BABELFISH_FUNCTION_EXT
 CREATE TABLE sys.babelfish_function_ext (
 	nspname NAME NOT NULL,
@@ -384,6 +399,7 @@ SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_db_seq', '');
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_namespace_ext', '');
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_login_ext', '');
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_user_ext', '');
+SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_schema_permissions', '');
 
 -- DATABASE_PRINCIPALS
 CREATE OR REPLACE VIEW sys.database_principals AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
@@ -31,6 +31,21 @@ end
 $$
 LANGUAGE plpgsql;
 
+-- BABELFISH_SCHEMA_PERMISSIONS
+CREATE TABLE IF NOT EXISTS sys.babelfish_schema_permissions (
+  dbid smallint NOT NULL,
+  schema_name sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  object_name sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  permission INT CHECK(permission > 0),
+  grantee sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  object_type CHAR(1) NOT NULL COLLATE sys.database_default,
+  function_args TEXT COLLATE "C",
+  grantor sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  PRIMARY KEY(dbid, schema_name, object_name, grantee, object_type)
+);
+
+SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_schema_permissions', '');
+
 -- Please add your SQLs here
 /*
  * Note: These SQL statements may get executed multiple times specially when some features get backpatched.

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -84,6 +84,14 @@ Oid			bbf_function_ext_oid;
 Oid			bbf_function_ext_idx_oid;
 
 /*****************************************
+ *			SCHEMA
+ *****************************************/
+Oid			bbf_schema_perms_oid;
+Oid			bbf_schema_perms_idx_oid;
+
+int			permissions[NUMBER_OF_PERMISSIONS] = {ACL_INSERT, ACL_SELECT, ACL_UPDATE, ACL_DELETE, ACL_REFERENCES, ACL_EXECUTE};
+
+/*****************************************
  *			DOMAIN MAPPING
  *****************************************/
 Oid			bbf_domain_mapping_oid = InvalidOid;
@@ -184,6 +192,10 @@ init_catalog(PG_FUNCTION_ARGS)
 	/* bbf_view_def */
 	bbf_view_def_oid = get_relname_relid(BBF_VIEW_DEF_TABLE_NAME, sys_schema_oid);
 	bbf_view_def_idx_oid = get_relname_relid(BBF_VIEW_DEF_IDX_NAME, sys_schema_oid);
+
+	/* bbf_schema_perms */
+	bbf_schema_perms_oid = get_relname_relid(BBF_SCHEMA_PERMS_TABLE_NAME, sys_schema_oid);
+	bbf_schema_perms_idx_oid = get_relname_relid(BBF_SCHEMA_PERMS_IDX_NAME, sys_schema_oid);
 
 	/* bbf_servers_def */
 	bbf_servers_def_oid = get_relname_relid(BBF_SERVERS_DEF_TABLE_NAME, sys_schema_oid);
@@ -1439,6 +1451,29 @@ clean_up_bbf_function_ext(int16 dbid)
 	table_close(bbf_function_ext_rel, RowExclusiveLock);
 }
 
+
+/*****************************************
+ *			SCHEMA
+ *****************************************/
+
+static Oid
+get_bbf_schema_perms_oid()
+{
+	if (!OidIsValid(bbf_schema_perms_oid))
+		bbf_schema_perms_oid = get_relname_relid(BBF_SCHEMA_PERMS_TABLE_NAME,
+								get_namespace_oid("sys", false));
+	return bbf_schema_perms_oid;
+}
+
+static Oid
+get_bbf_schema_perms_idx_oid()
+{
+	if (!OidIsValid(bbf_schema_perms_idx_oid))
+		bbf_schema_perms_idx_oid = get_relname_relid(BBF_SCHEMA_PERMS_IDX_NAME,
+									get_namespace_oid("sys", false));
+	return bbf_schema_perms_idx_oid;
+}
+
 /*****************************************
  *			DOMAIN MAPPING
  *****************************************/
@@ -1534,6 +1569,8 @@ static Datum get_user_rolname(HeapTuple tuple, TupleDesc dsc);
 static Datum get_database_name(HeapTuple tuple, TupleDesc dsc);
 static Datum get_function_nspname(HeapTuple tuple, TupleDesc dsc);
 static Datum get_function_name(HeapTuple tuple, TupleDesc dsc);
+static Datum get_perms_schema_name(HeapTuple tuple, TupleDesc dsc);
+static Datum get_perms_grantee_name(HeapTuple tuple, TupleDesc dsc);
 static Datum get_server_name(HeapTuple tuple, TupleDesc dsc);
 
 /* Condition function declaration */
@@ -1558,6 +1595,9 @@ static void alter_guest_schema_for_db(const char *dbname);
 /* Helper function Rename BBF catalog update*/
 static void rename_view_update_bbf_catalog(RenameStmt *stmt);
 static void rename_procfunc_update_bbf_catalog(RenameStmt *stmt);
+static void rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_type);
+
+static int get_privilege_of_object(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
 
 /*****************************************
  * 			Catalog Extra Info
@@ -1676,6 +1716,14 @@ Rule		must_match_rules_function[] =
 	"pg_proc", "proname", NULL, get_function_name, NULL, check_exist, NULL}
 };
 
+/* babelfish_schema_permissions */
+Rule		must_match_rules_schema_permission[] =
+{
+	{"<schema_name> in babelfish_schema_permissions must also exist in babelfish_namespace_ext",
+	"babelfish_namespace_ext", "nspname", NULL, get_perms_schema_name, NULL, check_exist, NULL},
+	{"<grantee> in babelfish_schema_permissions must also exist in pg_authid",
+	"pg_authid", "rolname", NULL, get_perms_grantee_name, NULL, check_exist, NULL}
+};
 
 /* babelfish_server_options */
 Rule		must_match_rules_srv_options[] =
@@ -1773,6 +1821,7 @@ metadata_inconsistency_check(Tuplestorestate *res_tupstore, TupleDesc res_tupdes
 	size_t		num_must_match_rules_login = sizeof(must_match_rules_login) / sizeof(must_match_rules_login[0]);
 	size_t		num_must_match_rules_user = sizeof(must_match_rules_user) / sizeof(must_match_rules_user[0]);
 	size_t		num_must_match_rules_function = sizeof(must_match_rules_function) / sizeof(must_match_rules_function[0]);
+	size_t		num_must_match_rules_schema_permission = sizeof(must_match_rules_schema_permission) / sizeof(must_match_rules_schema_permission[0]);
 	size_t		num_must_match_rules_srv_options = sizeof(must_match_rules_srv_options) / sizeof(must_match_rules_srv_options[0]);
 
 	/* Initialize the catalog_data array to fetch catalog info */
@@ -1802,6 +1851,9 @@ metadata_inconsistency_check(Tuplestorestate *res_tupstore, TupleDesc res_tupdes
 		||
 		!(check_must_match_rules(must_match_rules_function, num_must_match_rules_function,
 								 bbf_function_ext_oid, res_tupstore, res_tupdesc))
+		||
+		!(check_must_match_rules(must_match_rules_schema_permission, num_must_match_rules_schema_permission,
+								 bbf_schema_perms_oid, res_tupstore, res_tupdesc))
 		||
 		!(check_must_match_rules(must_match_rules_srv_options, num_must_match_rules_srv_options,
 								 bbf_servers_def_oid, res_tupstore, res_tupdesc))
@@ -2088,6 +2140,31 @@ get_function_name(HeapTuple tuple, TupleDesc dsc)
 	Form_bbf_function_ext func = ((Form_bbf_function_ext) GETSTRUCT(tuple));
 
 	return NameGetDatum(&(func->funcname));
+}
+
+static Datum
+get_perms_schema_name(HeapTuple tuple, TupleDesc dsc)
+{
+	bool		isNull;
+	Datum		schema_name = heap_getattr(tuple, Anum_bbf_schema_perms_schema_name, dsc, &isNull);
+
+	if (isNull)
+		ereport(ERROR,
+					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					errmsg("schema name should not be null.")));
+	return schema_name;
+}
+
+static Datum
+get_perms_grantee_name(HeapTuple tuple, TupleDesc dsc)
+{
+	bool		isNull;
+	Datum		grantee_name = heap_getattr(tuple, Anum_bbf_schema_perms_grantee, dsc, &isNull);
+	if (isNull)
+		ereport(ERROR,
+					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					errmsg("grantee name should not be null.")));
+	return grantee_name;
 }
 
 static Datum
@@ -2602,16 +2679,28 @@ rename_update_bbf_catalog(RenameStmt *stmt)
 {
 	switch (stmt->renameType)
 	{
+		/*
+		 * In case of renaming a table, view, procedure and function, modify the object
+		 * names present in all the Babelfish catalogs which stores these object names to
+		 * have consistency with the new names.
+		 *
+		 * List of catalogs which are updated here:
+		 * babelfish_schema_permissions, babelfish_function_ext, babelfish_view_def
+		 */
 		case OBJECT_TABLE:
+			rename_object_update_bbf_schema_permission_catalog(stmt, stmt->renameType);
 			break;
 		case OBJECT_VIEW:
 			rename_view_update_bbf_catalog(stmt);
+			rename_object_update_bbf_schema_permission_catalog(stmt, stmt->renameType);
 			break;
 		case OBJECT_PROCEDURE:
 			rename_procfunc_update_bbf_catalog(stmt);
+			rename_object_update_bbf_schema_permission_catalog(stmt, stmt->renameType);
 			break;
 		case OBJECT_FUNCTION:
 			rename_procfunc_update_bbf_catalog(stmt);
+			rename_object_update_bbf_schema_permission_catalog(stmt, stmt->renameType);
 			break;
 		case OBJECT_SEQUENCE:
 			break;
@@ -2624,6 +2713,124 @@ rename_update_bbf_catalog(RenameStmt *stmt)
 		default:
 			break;
 	}
+}
+
+/*
+ * rename_object_update_bbf_schema_permission_catalog
+ *
+ * In case of renaming a table, view, procedure and function, modify the 'object_name' in
+ * 'babelfish_schema_permissions' to have consistency with the new names.
+ */
+static void
+rename_object_update_bbf_schema_permission_catalog(RenameStmt *stmt, int rename_type)
+{
+	/* Update 'object_name' in 'babelfish_schema_permissions' */
+	Relation	bbf_schema_rel;
+	TupleDesc	bbf_schema_dsc;
+	ScanKeyData key[4];
+	HeapTuple	tuple_bbf_schema;
+	HeapTuple	new_tuple;
+	SysScanDesc scan;
+	Datum		new_record_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {0};
+	bool		new_record_nulls_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {false};
+	bool		new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS] = {false};
+	char		*logical_schema_name = NULL;
+	char		*physical_schema_name = NULL;
+	char		*object_name = NULL;
+	const char	*object_type = NULL;
+	int16		dbid = get_cur_db_id();
+	ObjectWithArgs *objwargs;
+
+	/* open the catalog table */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(), RowExclusiveLock);
+	/* get the description of the table */
+	bbf_schema_dsc = RelationGetDescr(bbf_schema_rel);
+
+	if (rename_type == OBJECT_TABLE || rename_type == OBJECT_VIEW)
+	{
+		logical_schema_name = (char *) get_logical_schema_name(stmt->relation->schemaname, false);
+		object_name = stmt->relation->relname;
+		object_type = OBJ_RELATION;
+	}
+	else
+	{
+		if (rename_type == OBJECT_PROCEDURE)
+			object_type = OBJ_PROCEDURE;
+		else if (rename_type == OBJECT_FUNCTION)
+			object_type = OBJ_FUNCTION;
+		objwargs = (ObjectWithArgs *) stmt->object;
+		DeconstructQualifiedName(objwargs->objname, &physical_schema_name, &object_name);
+		logical_schema_name = (char *) get_logical_schema_name(physical_schema_name, false);
+	}
+
+	/* search for the row for update => build the key */
+	ScanKeyInit(&key[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&key[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ, CStringGetTextDatum(logical_schema_name));
+	ScanKeyEntryInitialize(&key[2], 0,
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber, InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ, CStringGetTextDatum(object_name));
+	ScanKeyEntryInitialize(&key[3], 0,
+				Anum_bbf_schema_perms_object_type,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(object_type));
+
+	/* scan */
+	scan = systable_beginscan(bbf_schema_rel,
+			get_bbf_schema_perms_oid(),
+			false, NULL, 4, key);
+
+	/* get the scan result -> original tuple */
+	tuple_bbf_schema = systable_getnext(scan);
+
+	/*
+	 * If a permission on the same object is granted to multiple grantees,
+	 * there can be multiple rows in the catalog corresponding to each grantee name.
+	 * All such rows need to be updated with the new name.
+	 *
+	 * It is OK to not throw an error if an entry is not found in 'babelfish_schema_permissions'.
+	 * Explaination: An entry is added to 'babelfish_schema_permissions' only if an object has an explicit GRANT on it.
+	 * It is not necessary that each RENAME on an object has a GRANT of that object too.
+	 * Hence, there can be missing entries.
+	 */
+	while (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		/* create new tuple to substitute */
+		new_record_bbf_schema[Anum_bbf_schema_perms_object_name - 1] = CStringGetTextDatum(stmt->newname);
+		new_record_repl_bbf_schema[Anum_bbf_schema_perms_object_name - 1] = true;
+
+		new_tuple = heap_modify_tuple(tuple_bbf_schema,
+									bbf_schema_dsc,
+									new_record_bbf_schema,
+									new_record_nulls_bbf_schema,
+									new_record_repl_bbf_schema);
+
+		CatalogTupleUpdate(bbf_schema_rel, &new_tuple->t_self, new_tuple);
+
+		heap_freetuple(new_tuple);
+		tuple_bbf_schema = systable_getnext(scan);
+	}
+
+	if (physical_schema_name != NULL)
+		pfree(physical_schema_name);
+	if (logical_schema_name != NULL)
+		pfree(logical_schema_name);
+	if (object_name != NULL)
+		pfree(object_name);
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
 }
 
 static void
@@ -2806,6 +3013,719 @@ rename_procfunc_update_bbf_catalog(RenameStmt *stmt)
 
 	table_endscan(tblscan);
 	table_close(bbf_func_ext_rel, RowExclusiveLock);
+}
+
+/*
+ * Add an entry to catalog BABELFISH_SCHEMA_PERMISSIONS.
+ */
+void
+add_entry_to_bbf_schema_perms(const char *schema_name,
+				const char *object_name,
+				int permission,
+				const char *grantee,
+				const char *object_type,
+				const char *func_args)
+{
+	Relation	bbf_schema_rel;
+	TupleDesc	bbf_schema_dsc;
+	HeapTuple	tuple_bbf_schema;
+	Datum		new_record_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+	bool		new_record_nulls_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+	int16	dbid = get_cur_db_id();
+	char	*user = GetUserNameFromId(GetUserId(), false);
+
+	/* Immediately return, if grantee is NULL or PUBLIC. */
+	if ((grantee == NULL) || (strcmp(grantee, PUBLIC_ROLE_NAME) == 0))
+		return;
+
+	/* Fetch the relation */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									RowExclusiveLock);
+	bbf_schema_dsc = RelationGetDescr(bbf_schema_rel);
+
+	/* Build a tuple to insert */
+	MemSet(new_record_bbf_schema, 0, sizeof(new_record_bbf_schema));
+	MemSet(new_record_nulls_bbf_schema, false, sizeof(new_record_nulls_bbf_schema));
+
+	new_record_bbf_schema[Anum_bbf_schema_perms_dbid - 1] = Int16GetDatum(dbid);
+	new_record_bbf_schema[Anum_bbf_schema_perms_schema_name - 1] = CStringGetTextDatum(pstrdup(schema_name));
+	new_record_bbf_schema[Anum_bbf_schema_perms_object_name - 1] = CStringGetTextDatum(pstrdup(object_name));
+	new_record_bbf_schema[Anum_bbf_schema_perms_permission - 1] = Int32GetDatum(permission);
+	new_record_bbf_schema[Anum_bbf_schema_perms_grantee - 1] = CStringGetTextDatum(pstrdup(grantee));
+	new_record_bbf_schema[Anum_bbf_schema_perms_object_type - 1] = CStringGetTextDatum(pstrdup(object_type));
+	if (func_args)
+		new_record_bbf_schema[Anum_bbf_schema_perms_function_args - 1] = CStringGetTextDatum(func_args);
+	else
+		new_record_nulls_bbf_schema[Anum_bbf_schema_perms_function_args - 1] = true;
+	new_record_bbf_schema[Anum_bbf_schema_perms_grantor - 1] = CStringGetTextDatum(pstrdup(user));
+
+	tuple_bbf_schema = heap_form_tuple(bbf_schema_dsc,
+									new_record_bbf_schema,
+									new_record_nulls_bbf_schema);
+
+	/* Insert new record in the bbf_authid_user_ext table */
+	CatalogTupleInsert(bbf_schema_rel, tuple_bbf_schema);
+
+	/* Close bbf_authid_user_ext, but keep lock till commit */
+	table_close(bbf_schema_rel, RowExclusiveLock);
+
+	/* make sure later steps can see the entry added here */
+	CommandCounterIncrement();
+}
+
+/*
+ * Updates the permission column for a particular row in BABELFISH_SCHEMA_PERMISSIONS table.
+ */
+void
+update_privileges_of_object(const char *schema_name,
+				const char *object_name,
+				int new_permission,
+				const char *grantee,
+				const char *object_type,
+				bool is_grant)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	TupleDesc	bbf_schema_dsc;
+	HeapTuple	new_tuple;
+	ScanKeyData scanKey[5];
+	SysScanDesc scan;
+	int16	dbid = get_cur_db_id();
+	int old_permission = 0;
+	int current_permission = 0;
+	Datum		new_record_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+	bool		new_record_nulls_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+	bool		new_record_repl_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
+
+	/* Immediately return false, if SCHEMA name is NULL or it's a shared schema. */
+	if (schema_name == NULL || is_shared_schema(schema_name))
+		return;
+
+	/* Immediately return, if grantee is NULL or PUBLIC. */
+	if ((grantee == NULL) || (strcmp(grantee, PUBLIC_ROLE_NAME) == 0))
+		return;
+
+	/* Get existing privilege of an object. */
+	old_permission = get_privilege_of_object(schema_name, object_name, grantee, object_type);
+
+	if (is_grant)
+	{
+		/*
+		 * In case of GRANT, we add the new privilege along with the previous privilege in the column.
+		 */
+		current_permission = old_permission | new_permission;
+	}
+	else
+	{
+		/*
+		 * In case of REVOKE, we remove the new privilege and keep the previous privilege as it is.
+		 */
+		current_permission = old_permission & ~new_permission;
+	}
+
+	if (current_permission == 0)
+	{
+		remove_entry_from_bbf_schema_perms(schema_name, object_name, grantee, object_type);
+		return;
+	}
+
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+							RowExclusiveLock);
+
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&scanKey[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(schema_name));
+	ScanKeyEntryInitialize(&scanKey[2], 0,
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(object_name));
+	ScanKeyInit(&scanKey[3],
+				Anum_bbf_schema_perms_permission,
+				BTEqualStrategyNumber, F_INT4EQ,
+				Int32GetDatum(old_permission));
+	ScanKeyEntryInitialize(&scanKey[4], 0,
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(grantee));
+
+	scan = systable_beginscan(bbf_schema_rel,
+				get_bbf_schema_perms_idx_oid(),
+				false, NULL, 5, scanKey);
+
+	tuple_bbf_schema = systable_getnext(scan);
+	if (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		bbf_schema_dsc = RelationGetDescr(bbf_schema_rel);
+		/* Build a tuple to insert */
+		MemSet(new_record_bbf_schema, 0, sizeof(new_record_bbf_schema));
+		MemSet(new_record_nulls_bbf_schema, false, sizeof(new_record_nulls_bbf_schema));
+		MemSet(new_record_repl_bbf_schema, false, sizeof(new_record_repl_bbf_schema));
+
+		new_record_bbf_schema[Anum_bbf_schema_perms_permission - 1] = Int32GetDatum(current_permission);
+		new_record_repl_bbf_schema[Anum_bbf_schema_perms_permission - 1] = true;
+
+		new_tuple = heap_modify_tuple(tuple_bbf_schema,
+									bbf_schema_dsc,
+									new_record_bbf_schema,
+									new_record_nulls_bbf_schema,
+									new_record_repl_bbf_schema);
+
+		CatalogTupleUpdate(bbf_schema_rel, &new_tuple->t_self, new_tuple);
+		heap_freetuple(new_tuple);
+	}
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
+
+	/* make sure later steps can see the entry updated here */
+	CommandCounterIncrement();
+}
+
+/*
+ * Checks if a particular privilege exists in catalog BABELFISH_SCHEMA_PERMISSIONS.
+ */
+bool
+privilege_exists_in_bbf_schema_permissions(const char *schema_name,
+							const char *object_name,
+							const char *grantee)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	SysScanDesc	scan;
+	bool	catalog_entry_exists = false;
+	int16	dbid = get_cur_db_id();
+
+	/* Immediately return false, if SCHEMA name is NULL or it's a shared schema. */
+	if (schema_name == NULL || is_shared_schema(schema_name))
+		return false;
+
+	if (grantee != NULL)
+	{
+		ScanKeyData	scanKey[4];
+		/* Immediately return false, if grantee is PUBLIC. */
+		if (strcmp(grantee, PUBLIC_ROLE_NAME) == 0)
+			return false;
+
+		bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+										AccessShareLock);
+		ScanKeyInit(&scanKey[0],
+					Anum_bbf_schema_perms_dbid,
+					BTEqualStrategyNumber, F_INT2EQ,
+					Int16GetDatum(dbid));
+		ScanKeyEntryInitialize(&scanKey[1], 0,
+					Anum_bbf_schema_perms_schema_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(schema_name));
+		ScanKeyEntryInitialize(&scanKey[2], 0,
+					Anum_bbf_schema_perms_object_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(object_name));
+		ScanKeyEntryInitialize(&scanKey[3], 0,
+					Anum_bbf_schema_perms_grantee,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(grantee));
+		scan = systable_beginscan(bbf_schema_rel,
+					get_bbf_schema_perms_idx_oid(),
+					true, NULL, 4, scanKey);
+	}
+	else
+	{
+		ScanKeyData	scanKey[3];
+		bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+										AccessShareLock);
+		ScanKeyInit(&scanKey[0],
+					Anum_bbf_schema_perms_dbid,
+					BTEqualStrategyNumber, F_INT2EQ,
+					Int16GetDatum(dbid));
+		ScanKeyEntryInitialize(&scanKey[1], 0,
+					Anum_bbf_schema_perms_schema_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(schema_name));
+		ScanKeyEntryInitialize(&scanKey[2], 0,
+					Anum_bbf_schema_perms_object_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(object_name));
+
+		scan = systable_beginscan(bbf_schema_rel,
+					get_bbf_schema_perms_idx_oid(),
+					true, NULL, 3, scanKey);
+	}
+
+	tuple_bbf_schema = systable_getnext(scan);
+	if (HeapTupleIsValid(tuple_bbf_schema))
+		catalog_entry_exists = true;
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, AccessShareLock);
+	return catalog_entry_exists;
+}
+
+/*
+ * Get the value of permission column from BABELFISH_SCHEMA_PERMISSIONS table.
+ */
+static int
+get_privilege_of_object(const char *schema_name,
+					const char *object_name,
+					const char *grantee,
+					const char *object_type)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	ScanKeyData	scanKey[5];
+	SysScanDesc	scan;
+	int16	dbid = get_cur_db_id();
+	int permission = 0;
+
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									AccessShareLock);
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&scanKey[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(schema_name));
+	ScanKeyEntryInitialize(&scanKey[2], 0,
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(object_name));
+	ScanKeyEntryInitialize(&scanKey[3], 0,
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(grantee));
+	ScanKeyEntryInitialize(&scanKey[4], 0,
+				Anum_bbf_schema_perms_object_type,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(object_type));
+	scan = systable_beginscan(bbf_schema_rel,
+				get_bbf_schema_perms_idx_oid(),
+				true, NULL, 5, scanKey);
+	tuple_bbf_schema = systable_getnext(scan);
+
+	if (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		Datum datum;
+		bool isnull;
+		datum = heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_permission, RelationGetDescr(bbf_schema_rel), &isnull);
+		permission = DatumGetInt32(datum);
+	}
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, AccessShareLock);
+	return permission;
+}
+
+/*
+ * Removes a row from the catalog BABELFISH_SCHEMA_PERMISSIONS.
+ */
+void
+remove_entry_from_bbf_schema_perms(const char *schema_name,
+				  const char *object_name,
+				  const char *grantee,
+				  const char *object_type)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	ScanKeyData scanKey[5];
+	SysScanDesc scan;
+	int16	dbid = get_cur_db_id();
+
+	/* Immediately return false, if SCHEMA name is NULL or it's a shared schema. */
+	if (schema_name == NULL || is_shared_schema(schema_name))
+		return;
+
+	/* Immediately return, if grantee is NULL or PUBLIC. */
+	if ((grantee == NULL) || (strcmp(grantee, PUBLIC_ROLE_NAME) == 0))
+		return;
+
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									RowExclusiveLock);
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&scanKey[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(schema_name));
+	ScanKeyEntryInitialize(&scanKey[2], 0,
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(object_name));
+	ScanKeyEntryInitialize(&scanKey[3], 0,
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(grantee));
+	ScanKeyEntryInitialize(&scanKey[4], 0,
+				Anum_bbf_schema_perms_object_type,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(object_type));
+	scan = systable_beginscan(bbf_schema_rel,
+				get_bbf_schema_perms_idx_oid(),
+				true, NULL, 5, scanKey);
+
+	tuple_bbf_schema = systable_getnext(scan);
+
+	if (HeapTupleIsValid(tuple_bbf_schema))
+		CatalogTupleDelete(bbf_schema_rel, &tuple_bbf_schema->t_self);
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
+}
+
+/*
+ * Add an entry to BABELFISH_SCHEMA_PERMISSIONS table, if it doesn't exist already.
+ * If exists, updates the PERMISSION column in the table.
+ */
+void
+add_or_update_object_in_bbf_schema(const char *schema_name,
+				const char *object_name,
+				int new_permission,
+				const char *grantee,
+				const char *object_type,
+				bool is_grant,
+				const char *func_args)
+{
+	if (!privilege_exists_in_bbf_schema_permissions(schema_name, object_name, grantee))
+		add_entry_to_bbf_schema_perms(schema_name, object_name, new_permission, grantee, object_type, func_args);
+	else
+		update_privileges_of_object(schema_name, object_name, new_permission, grantee, object_type, is_grant);
+}
+
+/*
+ * Removes all the rows corresponding to an OBJECT/SCHEMA from the catalog BABELFISH_SCHEMA_PERMISSIONS.
+ */
+void
+clean_up_bbf_schema_permissions(const char *schema_name,
+				  const char *object_name,
+				  bool is_schema)
+{
+	SysScanDesc scan;
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	int16	dbid = get_cur_db_id();
+
+	/* Immediately return false, if SCHEMA name is NULL or it's a shared schema. */
+	if (schema_name == NULL || is_shared_schema(schema_name))
+		return;
+
+	/* Fetch the relation */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									RowExclusiveLock);
+
+	if (is_schema)
+	{
+		ScanKeyData scanKey[2];
+		ScanKeyInit(&scanKey[0],
+					Anum_bbf_schema_perms_dbid,
+					BTEqualStrategyNumber, F_INT2EQ,
+					Int16GetDatum(dbid));
+		ScanKeyEntryInitialize(&scanKey[1], 0,
+					Anum_bbf_schema_perms_schema_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(schema_name));
+		scan = systable_beginscan(bbf_schema_rel,
+					get_bbf_schema_perms_idx_oid(),
+					true, NULL, 2, scanKey);
+	}
+	else
+	{
+		ScanKeyData scanKey[3];
+		ScanKeyInit(&scanKey[0],
+					Anum_bbf_schema_perms_dbid,
+					BTEqualStrategyNumber, F_INT2EQ,
+					Int16GetDatum(dbid));
+		ScanKeyEntryInitialize(&scanKey[1], 0,
+					Anum_bbf_schema_perms_schema_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(schema_name));
+		ScanKeyEntryInitialize(&scanKey[2], 0,
+					Anum_bbf_schema_perms_object_name,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(object_name));
+		scan = systable_beginscan(bbf_schema_rel,
+					get_bbf_schema_perms_idx_oid(),
+					true, NULL, 3, scanKey);
+	}
+
+	while ((tuple_bbf_schema = systable_getnext(scan)) != NULL)
+	{
+		if (HeapTupleIsValid(tuple_bbf_schema))
+			CatalogTupleDelete(bbf_schema_rel,
+							   &tuple_bbf_schema->t_self);
+	}
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
+}
+
+/*
+ * For all objects belonging to a schema which has OBJECT level permission,
+ * It grants the permission explicitly when REVOKE has been executed on that
+ * specific schema.
+ */
+void
+grant_perms_to_objects_in_schema(const char *schema_name,
+				  int permission,
+				  const char *grantee)
+{
+	SysScanDesc scan;
+	Relation	bbf_schema_rel;
+	TupleDesc	dsc;
+	HeapTuple	tuple_bbf_schema;
+	ScanKeyData scanKey[3];
+	int16		dbid = get_cur_db_id();
+	const char *db_name = get_cur_db_name();
+
+	/* Fetch the relation */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									AccessShareLock);
+	dsc = RelationGetDescr(bbf_schema_rel);
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&scanKey[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(schema_name));
+	ScanKeyEntryInitialize(&scanKey[2], 0,
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(grantee));
+
+	scan = systable_beginscan(bbf_schema_rel, get_bbf_schema_perms_idx_oid(),
+							true, NULL, 3, scanKey);
+	tuple_bbf_schema = systable_getnext(scan);
+
+	while (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		bool isnull;
+		Datum datum;
+		const char	*object_name;
+		const char	*object_type;
+		const char	*func_args = NULL;
+		int		current_permission;
+		object_name = TextDatumGetCString(heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_object_name, dsc, &isnull));
+		object_type = TextDatumGetCString(heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_object_type, dsc, &isnull));
+		current_permission = DatumGetInt32(heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_permission, dsc, &isnull));
+		datum = heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_function_args, dsc, &isnull);
+		if (!isnull)
+			func_args = TextDatumGetCString(datum);
+		/* For each object, grant the permission explicitly. */
+		if (strcmp(object_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA) != 0)
+		{
+			const char	*query = NULL;
+			char			*schema;
+			List			*res;
+			GrantStmt		*grant;
+			PlannedStmt		*wrapper;
+			const char		*priv_name;
+
+			schema = get_physical_schema_name((char *)db_name, schema_name);
+			/* Check if the permission to be REVOKED on SCHEMA exists on the OBJECT. */
+
+			if (current_permission & permission)
+			{
+				priv_name = privilege_to_string(permission);
+				if (strcmp(object_type, OBJ_RELATION) == 0)
+					query = psprintf("GRANT %s ON [%s].[%s] TO %s", priv_name, schema, object_name, grantee);
+				else if (strcmp(object_type, OBJ_FUNCTION) == 0)
+					query = psprintf("GRANT %s ON FUNCTION [%s].[%s](%s) TO %s", priv_name, schema, object_name, func_args, grantee);
+				else if (strcmp(object_type, OBJ_PROCEDURE) == 0)
+					query = psprintf("GRANT %s ON PROCEDURE [%s].[%s](%s) TO %s", priv_name, schema, object_name, func_args, grantee);
+				res = raw_parser(query, RAW_PARSE_DEFAULT);
+				grant = (GrantStmt *) parsetree_nth_stmt(res, 0);
+
+				/* need to make a wrapper PlannedStmt */
+				wrapper = makeNode(PlannedStmt);
+				wrapper->commandType = CMD_UTILITY;
+				wrapper->canSetTag = false;
+				wrapper->utilityStmt = (Node *) grant;
+				wrapper->stmt_location = 0;
+				wrapper->stmt_len = 1;
+
+				/* do this step */
+				ProcessUtility(wrapper,
+							"(GRANT STATEMENT )",
+							false,
+							PROCESS_UTILITY_SUBCOMMAND,
+							NULL,
+							NULL,
+							None_Receiver,
+							NULL);
+			}
+		}
+		tuple_bbf_schema = systable_getnext(scan);
+	}
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, AccessShareLock);
+}
+
+/*
+ * For a new object(function/procedure) belonging to a schema where EXECUTE privilege has been
+ * granted explicitly to any user, this function grants the EXECUTE permission to those users
+ * implicitly at the time of CREATE function/procedure.
+ */
+void
+exec_internal_grant_on_function(const char *logicalschema,
+								const char *object_name,
+								const char *object_type)
+{
+	SysScanDesc scan;
+	Relation	bbf_schema_rel;
+	TupleDesc	dsc;
+	HeapTuple	tuple_bbf_schema;
+	const char	*grantee = NULL;
+	int			current_permission;
+	ScanKeyData scanKey[3];
+	int16		dbid = get_cur_db_id();
+	const char *db_name = get_cur_db_name();
+
+	/* Fetch the relation */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									AccessShareLock);
+	dsc = RelationGetDescr(bbf_schema_rel);
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	ScanKeyEntryInitialize(&scanKey[1], 0,
+				Anum_bbf_schema_perms_schema_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(logicalschema));
+	ScanKeyEntryInitialize(&scanKey[2], 0,
+				Anum_bbf_schema_perms_object_name,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA));
+
+	scan = systable_beginscan(bbf_schema_rel, get_bbf_schema_perms_idx_oid(),
+							true, NULL, 3, scanKey);
+	tuple_bbf_schema = systable_getnext(scan);
+
+	while (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		bool isnull;
+		Datum datum;
+		current_permission = DatumGetInt32(heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_permission, dsc, &isnull));
+		datum = heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_grantee, dsc, &isnull);
+		if (!isnull)
+			grantee = TextDatumGetCString(datum);
+		/* For each object, grant the permission explicitly. */
+		if (current_permission & ALL_PERMISSIONS_ON_FUNCTION)
+		{
+			const char	*query = NULL;
+			char			*schema;
+			List			*res;
+			GrantStmt		*grant;
+			PlannedStmt		*wrapper;
+
+			schema = get_physical_schema_name((char *)db_name, logicalschema);
+
+			if (strcmp(object_type, OBJ_FUNCTION) == 0)
+				query = psprintf("GRANT EXECUTE ON FUNCTION [%s].[%s] TO %s", schema, object_name, grantee);
+			else if (strcmp(object_type, OBJ_PROCEDURE) == 0)
+				query = psprintf("GRANT EXECUTE ON PROCEDURE [%s].[%s] TO %s", schema, object_name, grantee);
+			res = raw_parser(query, RAW_PARSE_DEFAULT);
+			grant = (GrantStmt *) parsetree_nth_stmt(res, 0);
+
+			/* need to make a wrapper PlannedStmt */
+			wrapper = makeNode(PlannedStmt);
+			wrapper->commandType = CMD_UTILITY;
+			wrapper->canSetTag = false;
+			wrapper->utilityStmt = (Node *) grant;
+			wrapper->stmt_location = 0;
+			wrapper->stmt_len = 1;
+
+			/* do this step */
+			ProcessUtility(wrapper,
+						"(GRANT STATEMENT )",
+						false,
+						PROCESS_UTILITY_SUBCOMMAND,
+						NULL,
+						NULL,
+						None_Receiver,
+						NULL);
+		}
+		tuple_bbf_schema = systable_getnext(scan);
+	}
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, AccessShareLock);
 }
 
 PG_FUNCTION_INFO_V1(update_user_catalog_for_guest_schema);

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -281,6 +281,58 @@ typedef struct FormData_bbf_function_ext
 typedef FormData_bbf_function_ext *Form_bbf_function_ext;
 
 /*****************************************
+ *			SCHEMA_PERMISSIONS
+ *****************************************/
+#define BBF_SCHEMA_PERMS_TABLE_NAME "babelfish_schema_permissions"
+#define BBF_SCHEMA_PERMS_IDX_NAME "babelfish_schema_permissions_pkey"
+#define BBF_SCHEMA_PERMS_NUM_OF_COLS 8
+#define Anum_bbf_schema_perms_dbid 1
+#define Anum_bbf_schema_perms_schema_name 2
+#define Anum_bbf_schema_perms_object_name 3
+#define Anum_bbf_schema_perms_permission 4
+#define Anum_bbf_schema_perms_grantee 5
+#define Anum_bbf_schema_perms_object_type 6
+#define Anum_bbf_schema_perms_function_args 7
+#define Anum_bbf_schema_perms_grantor 8
+
+#define PUBLIC_ROLE_NAME "public"
+#define PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA "ALL"
+#define ALL_PERMISSIONS_ON_RELATION 47 /* last 6 bits as 101111 represents ALL privileges on a relation. */
+#define ALL_PERMISSIONS_ON_FUNCTION 128 /* last 8 bits as 10000000 represents ALL privileges on a procedure/function. */
+#define OBJ_SCHEMA "s"
+#define OBJ_RELATION "r"
+#define OBJ_PROCEDURE "p"
+#define OBJ_FUNCTION "f"
+#define NUMBER_OF_PERMISSIONS 6
+
+extern int permissions[];
+
+extern Oid bbf_schema_perms_oid;
+extern Oid bbf_schema_perms_idx_oid;
+
+typedef struct FormData_bbf_schema_perms
+{
+	int16		dbid;
+	VarChar	schema_name;
+	VarChar	object_name;
+	int32		permission;
+	VarChar	grantee;
+	char	object_type;
+	text	function_args;
+} FormData_bbf_schema_perms;
+
+typedef FormData_bbf_schema_perms *Form_bbf_schema_perms;
+
+extern void add_entry_to_bbf_schema_perms(const char *schema_name, const char *object_name, int permission, const char *grantee, const char *object_type, const char *func_args);
+extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee);
+extern void update_privileges_of_object(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant);
+extern void remove_entry_from_bbf_schema_perms(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
+extern void add_or_update_object_in_bbf_schema(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant, const char *func_args);
+extern void clean_up_bbf_schema_permissions(const char *schema_name, const char *object_name, bool is_schema);
+extern void grant_perms_to_objects_in_schema(const char *schema_name, int permission, const char *grantee);
+extern void exec_internal_grant_on_function(const char *logicalschema, const char *object_name, const char *object_type);
+
+/*****************************************
  *			DOMAIN MAPPING
  *****************************************/
 #define BBF_DOMAIN_MAPPING_TABLE_NAME "babelfish_domain_mapping"

--- a/contrib/babelfishpg_tsql/src/codegen.c
+++ b/contrib/babelfishpg_tsql/src/codegen.c
@@ -302,6 +302,7 @@ stmt_default_act(Walker_context *ctx, PLtsql_stmt *stmt)
 		case PLTSQL_STMT_GRANTDB:
 		case PLTSQL_STMT_CHANGE_DBOWNER:
 		case PLTSQL_STMT_FULLTEXTINDEX:
+		case PLTSQL_STMT_GRANTSCHEMA:
 		case PLTSQL_STMT_INSERT_BULK:
 		case PLTSQL_STMT_DBCC:
 		case PLTSQL_STMT_SET_EXPLAIN_MODE:

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -133,7 +133,7 @@ gen_createdb_subcmds(const char *schema, const char *dbo, const char *db_owner, 
 	update_CreateRoleStmt(stmt, dbo, NULL, db_owner);
 
 	stmt = parsetree_nth_stmt(res, i++);
-	update_GrantStmt(stmt, get_database_name(MyDatabaseId), NULL, dbo);
+	update_GrantStmt(stmt, get_database_name(MyDatabaseId), NULL, dbo, NULL);
 
 	if (guest)
 	{
@@ -240,7 +240,7 @@ gen_dropdb_subcmds(const char *schema,
 	update_DropOwnedStmt(stmt, list_make2(pstrdup(db_owner), pstrdup(dbo)));
 
 	stmt = parsetree_nth_stmt(stmt_list, i++);
-	update_GrantStmt(stmt, get_database_name(MyDatabaseId), NULL, dbo);
+	update_GrantStmt(stmt, get_database_name(MyDatabaseId), NULL, dbo, NULL);
 	
 	stmt = parsetree_nth_stmt(stmt_list, i++);
 	update_DropRoleStmt(stmt, db_owner);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -200,7 +200,6 @@ static void logicalrep_modify_slot(Relation rel, EState *estate, TupleTableSlot 
 static object_access_hook_type prev_object_access_hook = NULL;
 static void bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int subId, void *arg);
 static void revoke_func_permission_from_public(Oid objectId);
-static char *gen_func_arg_list(Oid objectId);
 
 /*****************************************
  * 			Planner Hook
@@ -2815,7 +2814,7 @@ revoke_func_permission_from_public(Oid objectId)
 	/* Command Counter will be increased by validator */
 }
 
-static char *
+char *
 gen_func_arg_list(Oid objectId)
 {
 	Oid		   *argtypes;
@@ -4597,7 +4596,8 @@ fill_missing_values_in_copyfrom(Relation rel, Datum *values, bool *nulls)
 	if (relid == sysdatabases_oid ||
 		relid == namespace_ext_oid ||
 		relid == bbf_view_def_oid ||
-		relid == bbf_extended_properties_oid)
+		relid == bbf_extended_properties_oid ||
+		relid == bbf_schema_perms_oid)
 	{
 		AttrNumber	attnum;
 

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -18,6 +18,7 @@ pg_locale_t *collation_cache_entry_hook_function(Oid ,pg_locale_t *);
 extern bool output_update_transformation;
 extern bool output_into_insert_transformation;
 extern char *extract_identifier(const char *start);
+extern char *gen_func_arg_list(Oid objectId);
 extern void pltsql_store_func_default_positions(ObjectAddress address,
                                                 List *parameters,
                                                 const char *queryString,

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -809,6 +809,9 @@ dispatch_stmt(PLtsql_execstate *estate, PLtsql_stmt *stmt)
 			}
 			exec_stmt_change_dbowner(estate, (PLtsql_stmt_change_dbowner *) stmt);
 			break;
+		case PLTSQL_STMT_GRANTSCHEMA:
+			exec_stmt_grantschema(estate, (PLtsql_stmt_grantschema *) stmt);
+			break;
 		case PLTSQL_STMT_FULLTEXTINDEX:
 			if (pltsql_explain_only)
 			{

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3750,7 +3750,7 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 						errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", grantee_name)));
 		}
 
-		if ((strcmp(rolname, user) == 0) || (!is_public && pg_namespace_ownercheck(schemaOid, role_oid)) || is_member_of_role(role_oid, get_sysadmin_oid()))
+		if ((strcmp(rolname, user) == 0) || (!is_public && object_ownercheck(NamespaceRelationId, schemaOid, role_oid)) || is_member_of_role(role_oid, get_sysadmin_oid()))
 			ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					errmsg("Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.")));
@@ -3759,7 +3759,7 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 		 * If the login is not the db owner or the login is not the member of
 		 * sysadmin or login is not the schema owner, then it doesn't have the permission to GRANT/REVOKE.
 		 */
-		if (!is_member_of_role(GetSessionUserId(), get_sysadmin_oid()) && !login_is_db_owner && !pg_namespace_ownercheck(schemaOid, GetUserId()))
+		if (!is_member_of_role(GetSessionUserId(), get_sysadmin_oid()) && !login_is_db_owner && !object_ownercheck(NamespaceRelationId, schemaOid, GetUserId()))
 			ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					errmsg("Cannot find the schema \"%s\", because it does not exist or you do not have permission.", stmt->schema_name)));

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -55,6 +55,7 @@ static int	exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt);
 static int	exec_stmt_usedb_explain(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt, bool shouldRestoreDb);
 static int	exec_stmt_grantdb(PLtsql_execstate *estate, PLtsql_stmt_grantdb *stmt);
 static int	exec_stmt_fulltextindex(PLtsql_execstate *estate, PLtsql_stmt_fulltextindex *stmt);
+static int	exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt);
 static int	exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *expr);
 static int	exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *expr);
 static int	exec_stmt_dbcc(PLtsql_execstate *estate, PLtsql_stmt_dbcc *stmt);
@@ -3686,6 +3687,116 @@ int
 get_insert_bulk_kilobytes_per_batch()
 {
 	return insert_bulk_kilobytes_per_batch;
+}
+
+static int
+exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
+{
+	char		*dbname = get_cur_db_name();
+	char		*login = GetUserNameFromId(GetSessionUserId(), false);
+	bool		login_is_db_owner;
+	char		*schema_name;
+	ListCell	*lc;
+	Oid		schemaOid;
+	char		*user = GetUserNameFromId(GetUserId(), false);
+	const char	*db_owner = get_owner_of_db(dbname);
+
+	login_is_db_owner = 0 == strcmp(login, db_owner);
+	schema_name = get_physical_schema_name(dbname, stmt->schema_name);
+
+	if(schema_name)
+	{
+		/* Return immediately for shared schema. */
+		if(is_shared_schema(schema_name))
+			return PLTSQL_RC_OK;
+
+		schemaOid = LookupExplicitNamespace(schema_name, false);
+	}
+	else
+	{
+		ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_SCHEMA),
+					 errmsg("An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as \"\" or [] are not allowed. Change the alias to a valid name.")));
+	}
+
+	foreach(lc, stmt->grantees)
+	{
+		int i;
+		char	*rolname = NULL;
+		char	*grantee_name = (char *) lfirst(lc);
+		Oid	role_oid;
+		bool	is_public = 0 == strcmp(grantee_name, PUBLIC_ROLE_NAME);
+		if (!is_public)
+			rolname	= get_physical_user_name(dbname, grantee_name);
+		else
+			rolname = pstrdup(PUBLIC_ROLE_NAME);
+		role_oid = get_role_oid(rolname, true);
+
+		/* Special database roles should throw an error. */
+		if (strcmp(grantee_name, "db_owner") == 0)
+			ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("Cannot grant, deny or revoke permissions to or from special roles.")));
+
+		if (!is_public && !OidIsValid(role_oid))
+		{
+			/* sys or information_schema roles should throw an error. */
+			if ((strcmp(grantee_name, "sys") == 0) || (strcmp(grantee_name, "information_schema") == 0))
+				ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						errmsg("Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.")));
+			else
+				ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", grantee_name)));
+		}
+
+		if ((strcmp(rolname, user) == 0) || (!is_public && pg_namespace_ownercheck(schemaOid, role_oid)) || is_member_of_role(role_oid, get_sysadmin_oid()))
+			ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					errmsg("Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.")));
+
+		/*
+		 * If the login is not the db owner or the login is not the member of
+		 * sysadmin or login is not the schema owner, then it doesn't have the permission to GRANT/REVOKE.
+		 */
+		if (!is_member_of_role(GetSessionUserId(), get_sysadmin_oid()) && !login_is_db_owner && !pg_namespace_ownercheck(schemaOid, GetUserId()))
+			ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					errmsg("Cannot find the schema \"%s\", because it does not exist or you do not have permission.", stmt->schema_name)));
+
+		/* Execute the GRANT SCHEMA subcommands. */
+		for (i = 0; i < NUMBER_OF_PERMISSIONS; i++)
+		{
+			if (stmt->privileges & permissions[i])
+				exec_grantschema_subcmds(schema_name, rolname, stmt->is_grant, stmt->with_grant_option, permissions[i]);
+		}
+
+		if (stmt->is_grant)
+		{
+			/* For GRANT statement, add or update privileges in the catalog. */
+			add_or_update_object_in_bbf_schema(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, stmt->privileges, rolname, OBJ_SCHEMA, true, NULL);
+		}
+		else
+		{
+			/* For REVOKE statement, update privileges in the catalog. */
+			if (privilege_exists_in_bbf_schema_permissions(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rolname))
+			{
+				/* If any object in the schema has the OBJECT level permission. Then, internally grant that permission back. */
+				for (i = 0; i < NUMBER_OF_PERMISSIONS; i++)
+				{
+					if (stmt->privileges & permissions[i])
+						grant_perms_to_objects_in_schema(stmt->schema_name, permissions[i], rolname);
+				}
+				update_privileges_of_object(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, stmt->privileges, rolname, OBJ_SCHEMA, false);
+			}
+		}
+		pfree(rolname);
+	}
+	pfree(user);
+	pfree(schema_name);
+	pfree(dbname);
+	pfree(login);
+	return PLTSQL_RC_OK;
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_funcs-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_funcs-2.c
@@ -485,6 +485,7 @@ free_stmt2(PLtsql_stmt *stmt)
 		case PLTSQL_STMT_GRANTDB:
 		case PLTSQL_STMT_CHANGE_DBOWNER:
 		case PLTSQL_STMT_FULLTEXTINDEX:
+		case PLTSQL_STMT_GRANTSCHEMA:
 		case PLTSQL_STMT_SET_EXPLAIN_MODE:
 			{
 				/* Nothing to free */

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -128,6 +128,14 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 							   QueryEnvironment *queryEnv,
 							   DestReceiver *dest,
 							   QueryCompletion *qc);
+static void call_prev_ProcessUtility(PlannedStmt *pstmt,
+						 const char *queryString,
+						 bool readOnlyTree,
+						 ProcessUtilityContext context,
+						 ParamListInfo params,
+						 QueryEnvironment *queryEnv,
+						 DestReceiver *dest,
+						 QueryCompletion *qc);
 static void set_pgtype_byval(List *name, bool byval);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
@@ -518,7 +526,8 @@ pltsql_pre_parse_analyze(ParseState *pstate, RawStmt *parseTree)
 				if (relid == sysdatabases_oid ||
 					relid == namespace_ext_oid ||
 					relid == bbf_view_def_oid ||
-					relid == bbf_extended_properties_oid)
+					relid == bbf_extended_properties_oid ||
+					relid == bbf_schema_perms_oid)
 				{
 					ResTarget	*col = NULL;
 					A_Const 	*dbidValue = NULL;
@@ -3486,6 +3495,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					List	   *res;
 					GrantStmt  *stmt;
 					PlannedStmt *wrapper;
+					RoleSpec *rolspec = create_schema->authrole;
 
 					if (strcmp(queryString, "(CREATE LOGICAL DATABASE )") == 0
 						&& context == PROCESS_UTILITY_SUBCOMMAND)
@@ -3534,7 +3544,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								   NULL);
 
 					CommandCounterIncrement();
-
+					/* Grant ALL schema privileges to the user.*/
+					if (rolspec && strcmp(queryString, "(CREATE LOGICAL DATABASE )") != 0)
+					{
+						int i;
+						for (i = 0; i < NUMBER_OF_PERMISSIONS; i++)
+						{
+							/* Execute the GRANT SCHEMA subcommands. */
+							exec_grantschema_subcmds(create_schema->schemaname, rolspec->rolename, true, false, permissions[i]);
+						}
+					}
 					return;
 				}
 				else
@@ -3548,7 +3567,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				{
 					if (sql_dialect == SQL_DIALECT_TSQL)
 						bbf_ExecDropStmt(drop_stmt);
-
 					break;
 				}
 
@@ -3560,10 +3578,11 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					 * database command.
 					 */
 					const char *schemaname = strVal(lfirst(list_head(drop_stmt->objects)));
+					char	   *cur_db = get_cur_db_name();
+					const char	*logicalschema = get_logical_schema_name(schemaname, true);
 
 					if (strcmp(queryString, "(DROP DATABASE )") != 0)
 					{
-						char	   *cur_db = get_cur_db_name();
 						char	   *guest_schema_name = get_physical_schema_name(cur_db, "guest");
 
 						if (strcmp(schemaname, guest_schema_name) == 0)
@@ -3576,6 +3595,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 					bbf_ExecDropStmt(drop_stmt);
 					del_ns_ext_info(schemaname, drop_stmt->missing_ok);
+					clean_up_bbf_schema_permissions(logicalschema, NULL, true);
 
 					if (prev_ProcessUtility)
 						prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
@@ -3819,16 +3839,221 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				}
 				break;
 			}
+		case T_GrantStmt:
+			{
+				GrantStmt *grant = (GrantStmt *) parsetree;
+				char	   *dbname = get_cur_db_name();
+				const char *current_user = GetUserNameFromId(GetUserId(), false);
+				/* Ignore when GRANT statement has no specific named object. */
+				if (sql_dialect != SQL_DIALECT_TSQL || grant->targtype != ACL_TARGET_OBJECT)
+					break;
+				Assert(list_length(grant->objects) == 1);
+				if (grant->objtype == OBJECT_SCHEMA)
+						break;
+				else if (grant->objtype == OBJECT_TABLE && strcmp("(CREATE LOGICAL DATABASE )", queryString) != 0)
+				{
+					/*
+					 * Ignore GRANT statements that are executed implicitly as a part of
+					 * CREATE database statements. Refer: create_bbf_db_internal().
+					 * These GRANT statement are just executed at the end, without checking any
+					 * schema permission or adding catalog entry.
+					 */
+					RangeVar   *rv = (RangeVar *) linitial(grant->objects);
+					const char *logical_schema = NULL;
+					char	   *obj = rv->relname;
+					bool exec_pg_command = false;
+					ListCell   *lc;
+					ListCell	*lc1;
+					if (rv->schemaname != NULL)
+						logical_schema = get_logical_schema_name(rv->schemaname, true);
+					else
+						logical_schema = get_authid_user_ext_schema_name(dbname, current_user);
+
+					/* If ALL PRIVILEGES is granted/revoked. */
+					if (list_length(grant->privileges) == 0)
+					{
+						if (grant->is_grant)
+						{
+							foreach(lc, grant->grantees)
+							{
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+								add_or_update_object_in_bbf_schema(logical_schema, obj, ALL_PERMISSIONS_ON_RELATION, rol_spec->rolename, OBJ_RELATION, true, NULL);
+							}
+						}
+						else
+						{
+							foreach(lc, grant->grantees)
+							{
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+								/*
+								 * 1. If permission on schema exists, don't revoke any permission from the object.
+								 * 2. If permission on object exists, update the privilege in the catalog and revoke permission.
+								 */
+								update_privileges_of_object(logical_schema, obj, ALL_PERMISSIONS_ON_RELATION, rol_spec->rolename, OBJ_RELATION, false);
+								if (privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+									return;
+							}
+						}
+						exec_pg_command = true;
+					}
+					foreach(lc1, grant->privileges)
+					{
+						AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+						AclMode privilege = string_to_privilege(ap->priv_name);
+						if (grant->is_grant)
+						{
+							exec_pg_command = true;
+							/* Don't add/update an entry, if the permission is granted on column list.*/
+							if (ap->cols == NULL)
+							{
+								foreach(lc, grant->grantees)
+								{
+									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+									add_or_update_object_in_bbf_schema(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, true, NULL);
+								}
+							}
+						}
+						else
+						{
+							/* Don't update an entry, if the permission is granted on column list.*/
+							if (ap->cols == NULL)
+							{
+								foreach(lc, grant->grantees)
+								{
+									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+									/*
+									 * If permission on schema exists, don't revoke any permission from the object.
+									 */
+									if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+										exec_pg_command = true;
+
+									update_privileges_of_object(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, false);
+								}
+							}
+						}
+					}
+					if (exec_pg_command)
+						call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc);
+					return;
+				}
+				else if ((grant->objtype == OBJECT_PROCEDURE) || (grant->objtype == OBJECT_FUNCTION))
+				{
+					ObjectWithArgs  *ob = (ObjectWithArgs *) linitial(grant->objects);
+					ListCell   *lc;
+					ListCell	*lc1;
+					bool exec_pg_command = false;
+					const char *logicalschema = NULL;
+					char *funcname = NULL;
+					const char *obj_type = NULL;
+					Oid func_oid = LookupFuncWithArgs(OBJECT_ROUTINE, ob, true);
+					const char *func_args = NULL;
+					if (OidIsValid(func_oid))
+						func_args = gen_func_arg_list(func_oid);
+					if (grant->objtype == OBJECT_FUNCTION)
+						obj_type = OBJ_FUNCTION;
+					else
+						obj_type = OBJ_PROCEDURE;
+					if (list_length(ob->objname) == 1)
+					{
+						Node *func = (Node *) linitial(ob->objname);
+						funcname = strVal(func);
+						logicalschema = get_authid_user_ext_schema_name(dbname, current_user);
+					}
+					else
+					{
+						Node *schema = (Node *) linitial(ob->objname);
+						char *schemaname = strVal(schema);
+						Node *func = (Node *) lsecond(ob->objname);
+						logicalschema = get_logical_schema_name(schemaname, true);
+						funcname = strVal(func);
+					}
+
+					/* If ALL PRIVILEGES is granted/revoked. */
+					if (list_length(grant->privileges) == 0)
+					{
+						/*
+						 * Case: When ALL PRIVILEGES is revoked internally during create function.
+						 * pstmt->stmt_len = 0 means it is an implicit REVOKE statement issued at the time of create function/procedure.
+						 * For more details, please refer revoke_func_permission_from_public().
+						 * If schema entry exists in the catalog, implicitly grant permission on the new object to the user.
+						 */
+						if ((pstmt->stmt_len == 0) && privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, NULL))
+						{
+							call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc);
+							exec_internal_grant_on_function(logicalschema, funcname, obj_type);
+							return;
+						}
+
+						if (grant->is_grant)
+						{
+							foreach(lc, grant->grantees)
+							{
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+								add_or_update_object_in_bbf_schema(logicalschema, funcname, ALL_PERMISSIONS_ON_FUNCTION, rol_spec->rolename, obj_type, true, func_args);
+							}
+						}
+						else
+						{
+							foreach(lc, grant->grantees)
+							{
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+								/*
+								 * 1. If permission on schema exists, don't revoke any permission from the object.
+								 * 2. If permission on object exists, update the privilege in the catalog and revoke permission.
+								 */
+								update_privileges_of_object(logicalschema, funcname, ALL_PERMISSIONS_ON_FUNCTION, rol_spec->rolename, obj_type, false);
+								if (privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+									return;
+							}
+						}
+						exec_pg_command = true;
+					}
+					foreach(lc1, grant->privileges)
+					{
+						AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+						AclMode privilege = string_to_privilege(ap->priv_name);
+						if (grant->is_grant)
+						{
+							exec_pg_command = true;
+							if (strcmp("(GRANT STATEMENT )", queryString) != 0)
+							{
+								/*
+								 * If it is an implicit GRANT issued by exec_internal_grant_on_function, then we should not add catalog
+								 * entry. Catalog entry is supposed to be added only by explicit GRANTs.
+								 */
+								foreach(lc, grant->grantees)
+								{
+									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+									add_or_update_object_in_bbf_schema(logicalschema, funcname, privilege, rol_spec->rolename, obj_type, true, func_args);
+								}
+							}
+						}
+						else
+						{
+							foreach(lc, grant->grantees)
+							{
+								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+
+								/*
+								 * If permission on schema exists, don't revoke any permission from the object.
+								 */
+								if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+									exec_pg_command = true;
+								/* Update the privilege in the catalog. */
+								update_privileges_of_object(logicalschema, funcname, privilege, rol_spec->rolename, obj_type, false);
+							}
+						}
+					}
+					if (exec_pg_command)
+						call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc);
+					return;
+				}
+			}
 		default:
 			break;
 	}
 
-	if (prev_ProcessUtility)
-		prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-							queryEnv, dest, qc);
-	else
-		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
-								queryEnv, dest, qc);
+	call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc);
 
 	/* Cleanup babelfish_server_options catalog when tds_fdw extension is dropped */
 	if (sql_dialect == SQL_DIALECT_PG && nodeTag(parsetree) == T_DropStmt)
@@ -3843,6 +4068,24 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 			}
 		}
 	}
+}
+
+static void
+call_prev_ProcessUtility(PlannedStmt *pstmt,
+						 const char *queryString,
+						 bool readOnlyTree,
+						 ProcessUtilityContext context,
+						 ParamListInfo params,
+						 QueryEnvironment *queryEnv,
+						 DestReceiver *dest,
+						 QueryCompletion *qc)
+{
+	if (prev_ProcessUtility)
+		prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+							queryEnv, dest, qc);
+	else
+		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+								queryEnv, dest, qc);
 }
 
 /*
@@ -5940,6 +6183,7 @@ bbf_ExecDropStmt(DropStmt *stmt)
 	Relation		relation = NULL;
 	Oid				schema_oid;
 	ListCell		*cell;
+	const char *logicalschema = NULL;
 
 	db_id = get_cur_db_id();
 
@@ -5980,6 +6224,8 @@ bbf_ExecDropStmt(DropStmt *stmt)
 			schema_oid = get_object_namespace(&address);
 			if (OidIsValid(schema_oid))
 				schema_name = get_namespace_name(schema_oid);
+			if (schema_name != NULL)
+				logicalschema = get_logical_schema_name(schema_name, true);
 
 			if (schema_name && major_name)
 			{
@@ -6005,6 +6251,7 @@ bbf_ExecDropStmt(DropStmt *stmt)
 											 major_name, NULL);
 				}
 			}
+			clean_up_bbf_schema_permissions(logicalschema, major_name, false);
 		}
 	}
 	else if (stmt->removeType == OBJECT_PROCEDURE ||
@@ -6048,6 +6295,8 @@ bbf_ExecDropStmt(DropStmt *stmt)
 			schema_oid = get_object_namespace(&address);
 			if (OidIsValid(schema_oid))
 				schema_name = get_namespace_name(schema_oid);
+			if (schema_name != NULL)
+				logicalschema = get_logical_schema_name(schema_name, true);
 
 			if (schema_name && major_name)
 			{
@@ -6061,6 +6310,7 @@ bbf_ExecDropStmt(DropStmt *stmt)
 				delete_extended_property(db_id, type, schema_name, major_name,
 										 NULL);
 			}
+			clean_up_bbf_schema_permissions(logicalschema, major_name, false);
 		}
 	}
 }

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -197,6 +197,7 @@ typedef enum PLtsql_stmt_type
 	PLTSQL_STMT_CHANGE_DBOWNER,
 	PLTSQL_STMT_DBCC,
 	PLTSQL_STMT_FULLTEXTINDEX,
+	PLTSQL_STMT_GRANTSCHEMA
 } PLtsql_stmt_type;
 
 /*
@@ -1067,6 +1068,20 @@ typedef struct PLtsql_stmt_fulltextindex
 	char		*db_name;      /* database name */
 	bool		is_create;     /* flag for create index */		
 } PLtsql_stmt_fulltextindex;
+
+/*
+ *	Grant on schema stmt
+ */
+typedef struct PLtsql_stmt_grantschema
+{
+	PLtsql_stmt_type cmd_type;
+	int			lineno;
+	bool		is_grant;
+	int		privileges;
+	List		*grantees;		/* list of users */
+	bool 		with_grant_option;
+	char		*schema_name;	/* schema name */
+} PLtsql_stmt_grantschema;
 
 /*
  * ASSERT statement
@@ -1989,6 +2004,8 @@ extern void pltsql_exec_get_datum_type_info(PLtsql_execstate *estate,
 extern int	get_insert_bulk_rows_per_batch(void);
 extern int	get_insert_bulk_kilobytes_per_batch(void);
 extern char *get_original_query_string(void);
+extern AclMode string_to_privilege(const char *privname);
+extern const char *privilege_to_string(AclMode privilege);
 
 /*
  * Functions for namespace handling in pl_funcs.c
@@ -2051,6 +2068,7 @@ extern const char *gen_schema_name_for_fulltext_index(const char *schema_name);
 extern bool check_fulltext_exist(const char *schema_name, const char *table_name);
 extern char *replace_special_chars_fts_impl(char *input_str);
 extern bool is_unique_index(Oid relid, const char *index_name);
+extern void exec_grantschema_subcmds(const char *schema, const char *rolname, bool is_grant, bool with_grant_option, AclMode privilege);
 extern int	TsqlUTF8LengthInUTF16(const void *vin, int len);
 extern void TsqlCheckUTF16Length_bpchar(const char *s, int32 len, int32 maxlen, int charlen, bool isExplicit);
 extern void TsqlCheckUTF16Length_varchar(const char *s, int32 len, int32 maxlen, bool isExplicit);
@@ -2089,7 +2107,7 @@ extern void update_DropOwnedStmt(Node *n, List *role_list);
 extern void update_DropRoleStmt(Node *n, const char *role);
 extern void update_DropStmt(Node *n, const char *object);
 extern void update_GrantRoleStmt(Node *n, List *privs, List *roles);
-extern void update_GrantStmt(Node *n, const char *object, const char *obj_schema, const char *grantee);
+extern void update_GrantStmt(Node *n, const char *object, const char *obj_schema, const char *grantee, const char *priv);
 extern void update_RenameStmt(Node *n, const char *old_name, const char *new_name);
 extern void update_ViewStmt(Node *n, const char *view_schema);
 extern void pltsql_check_or_set_default_typmod(TypeName *typeName, int32 *typmod, bool is_cast);

--- a/contrib/babelfishpg_tsql/src/stmt_walker.c
+++ b/contrib/babelfishpg_tsql/src/stmt_walker.c
@@ -110,6 +110,7 @@ stmt_walker(PLtsql_stmt *stmt, WalkerFunc walker, void *context)
 		case PLTSQL_STMT_CHANGE_DBOWNER:
 		case PLTSQL_STMT_FULLTEXTINDEX:
 		case PLTSQL_STMT_DBCC:
+		case PLTSQL_STMT_GRANTSCHEMA:
 			break;
 			/* TSQL-only executable node */
 		case PLTSQL_STMT_SAVE_CTX:
@@ -211,6 +212,7 @@ general_walker_func(PLtsql_stmt *stmt, void *context)
 				DISPATCH(CHANGE_DBOWNER, change_dbowner)
 				DISPATCH(DBCC, dbcc)
 				DISPATCH(FULLTEXTINDEX, fulltextindex)
+				DISPATCH(GRANTSCHEMA, grantschema)
 
 			/* TSQL-only executable node */
 				DISPATCH(SAVE_CTX, save_ctx)

--- a/contrib/babelfishpg_tsql/src/stmt_walker.h
+++ b/contrib/babelfishpg_tsql/src/stmt_walker.h
@@ -90,6 +90,7 @@ typedef bool (*Stmt_grantdb_act) ACTION_SIGNITURE(grantdb);
 typedef bool (*Stmt_change_dbowner_act) ACTION_SIGNITURE(change_dbowner);
 typedef bool (*Stmt_dbcc_act) ACTION_SIGNITURE(dbcc);
 typedef bool (*Stmt_fulltextindex_act) ACTION_SIGNITURE(fulltextindex);
+typedef bool (*Stmt_grantschema_act) ACTION_SIGNITURE(grantschema);
 
  /* TSQL-only executable node */
 typedef bool (*Stmt_save_ctx) ACTION_SIGNITURE(save_ctx);
@@ -143,6 +144,7 @@ typedef struct Walker_context
 	Stmt_change_dbowner_act change_dbowner_act;
 	Stmt_dbcc_act dbcc_act;
 	Stmt_fulltextindex_act fulltextindex_act;
+	Stmt_grantschema_act grantschema_act;
 
 	/* TSQL-only executable node */
 	Stmt_save_ctx save_ctx_act;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -25,6 +25,7 @@
 #define JOIN_HINTS_INFO_VECTOR_SIZE 6
 
 #define RAISE_ERROR_PARAMS_LIMIT 20
+#define PUBLIC_ROLE_NAME "public"
 
 
 #pragma GCC diagnostic push
@@ -1890,32 +1891,80 @@ public:
 	
 	void exitSecurity_statement(TSqlParser::Security_statementContext *ctx) override
 	{
-		if (ctx->grant_statement() && ctx->grant_statement()->TO() && !ctx->grant_statement()->permission_object()
-								&& ctx->grant_statement()->permissions())
+		if (ctx->grant_statement())
 		{
-			for (auto perm : ctx->grant_statement()->permissions()->permission())
+			auto grant = ctx->grant_statement();
+			if (!grant->permission_object() && grant->permissions())
 			{
-				auto single_perm = perm->single_permission();
-				if (single_perm->CONNECT())
+				for (auto perm : grant->permissions()->permission())
 				{
-					clear_rewritten_query_fragment();
-					return;
+					auto single_perm = perm->single_permission();
+					if (single_perm->CONNECT())
+					{
+						clear_rewritten_query_fragment();
+						return;
+					}
+				}
+			}
+			else if (grant->ON() && grant->permission_object() && grant->permission_object()->object_type() && grant->permission_object()->object_type()->SCHEMA())
+			{
+				if (grant->principals() && grant->permissions())
+				{
+					for (auto perm: grant->permissions()->permission())
+					{
+						auto single_perm = perm->single_permission();
+						if (single_perm->EXECUTE()
+							|| single_perm->EXEC()
+							|| single_perm->SELECT()
+							|| single_perm->INSERT()
+							|| single_perm->UPDATE()
+							|| single_perm->DELETE()
+							|| single_perm->REFERENCES())
+						{
+							return;
+						}
+					}
 				}
 			}
 		}
-		else if (ctx->revoke_statement() && ctx->revoke_statement()->FROM() && !ctx->revoke_statement()->permission_object()
-										&& ctx->revoke_statement()->permissions())
+		else if (ctx->revoke_statement())
 		{
-			for (auto perm : ctx->revoke_statement()->permissions()->permission())
+			auto revoke = ctx->revoke_statement();
+			if (!revoke->permission_object() && revoke->permissions())
 			{
-				auto single_perm = perm->single_permission();
-				if (single_perm->CONNECT())
+				for (auto perm : revoke->permissions()->permission())
 				{
-					clear_rewritten_query_fragment();
-					return;
+					auto single_perm = perm->single_permission();
+					if (single_perm->CONNECT())
+					{
+						clear_rewritten_query_fragment();
+						return;
+					}
+				}
+			}
+
+			else if (revoke->ON() && revoke->permission_object() && revoke->permission_object()->object_type() && revoke->permission_object()->object_type()->SCHEMA())
+			{
+				if (revoke->principals() && revoke->permissions())
+				{
+					for (auto perm: revoke->permissions()->permission())
+					{
+						auto single_perm = perm->single_permission();
+						if (single_perm->EXECUTE()
+							|| single_perm->EXEC()
+							|| single_perm->SELECT()
+							|| single_perm->INSERT()
+							|| single_perm->UPDATE()
+							|| single_perm->DELETE()
+							|| single_perm->REFERENCES())
+						{
+							return;
+						}
+					}
 				}
 			}
 		}
+
 		PLtsql_stmt_execsql *stmt = (PLtsql_stmt_execsql *) getPLtsql_fragment(ctx);
 		Assert(stmt);
 
@@ -5719,61 +5768,190 @@ makeKillStatement(TSqlParser::Kill_statementContext *ctx)
 PLtsql_stmt *
 makeGrantdbStatement(TSqlParser::Security_statementContext *ctx)
 {
-	if (ctx->grant_statement() && ctx->grant_statement()->TO() && !ctx->grant_statement()->permission_object()
-								&& ctx->grant_statement()->permissions())
+	if (ctx->grant_statement())
 	{
-		for (auto perm : ctx->grant_statement()->permissions()->permission())
+		auto grant = ctx->grant_statement();
+		if (!grant->permission_object() && grant->permissions())
 		{
-			auto single_perm = perm->single_permission();
-			if (single_perm->CONNECT())
+			for (auto perm : grant->permissions()->permission())
 			{
-				PLtsql_stmt_grantdb *result = (PLtsql_stmt_grantdb *) palloc0(sizeof(PLtsql_stmt_grantdb));
-				result->cmd_type = PLTSQL_STMT_GRANTDB;
-				result->lineno = getLineNo(ctx->grant_statement());
+				auto single_perm = perm->single_permission();
+				if (single_perm->CONNECT())
+				{
+					PLtsql_stmt_grantdb *result = (PLtsql_stmt_grantdb *) palloc0(sizeof(PLtsql_stmt_grantdb));
+					result->cmd_type = PLTSQL_STMT_GRANTDB;
+					result->lineno = getLineNo(grant);
+					result->is_grant = true;
+					List *grantee_list = NIL;
+					for (auto prin : grant->principals()->principal_id())
+					{
+						if (prin->id())
+						{
+							std::string id_str = ::getFullText(prin->id());
+							char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
+							grantee_list = lappend(grantee_list, grantee_name);
+						}
+						if (prin->PUBLIC())
+						{
+							char *grantee_name = pstrdup(PUBLIC_ROLE_NAME);
+							grantee_list = lappend(grantee_list, grantee_name);
+						}
+					}
+					result->grantees = grantee_list;
+					return (PLtsql_stmt *) result;
+				}
+			}
+		}
+		else if (grant->ON() && grant->permission_object() && grant->permission_object()->object_type() && grant->permission_object()->object_type()->SCHEMA())
+		{
+			if (grant->principals() && grant->permissions())
+			{
+				PLtsql_stmt_grantschema *result = (PLtsql_stmt_grantschema *) palloc0(sizeof(PLtsql_stmt_grantschema));
+				result->cmd_type = PLTSQL_STMT_GRANTSCHEMA;
+				result->lineno = getLineNo(grant);
 				result->is_grant = true;
+				std::string schema_name;
+				if (grant->permission_object()->full_object_name()->object_name)
+				{
+					schema_name = stripQuoteFromId(grant->permission_object()->full_object_name()->object_name);
+					if (string_matches(schema_name.c_str(), "information_schema"))
+						schema_name = "information_schema_tsql";
+					result->schema_name = pstrdup(downcase_truncate_identifier(schema_name.c_str(), schema_name.length(), true));
+				}
 				List *grantee_list = NIL;
-				for (auto prin : ctx->grant_statement()->principals()->principal_id())
+				for (auto prin : grant->principals()->principal_id())
 				{
 					if (prin->id())
 					{
-						std::string id_str = ::getFullText(prin->id());
+						std::string id_str = stripQuoteFromId(prin->id());
 						char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
 						grantee_list = lappend(grantee_list, grantee_name);
 					}
+					if (prin->PUBLIC())
+					{
+						char *grantee_name = pstrdup(PUBLIC_ROLE_NAME);
+						grantee_list = lappend(grantee_list, grantee_name);
+					}
 				}
+				int privileges = 0;
+				for (auto perm: grant->permissions()->permission())
+				{
+					auto single_perm = perm->single_permission();
+					if (single_perm->EXECUTE())
+						privileges |= ACL_EXECUTE;
+					if (single_perm->EXEC())
+						privileges |= ACL_EXECUTE;
+					if (single_perm->SELECT())
+						privileges |= ACL_SELECT;
+					if (single_perm->INSERT())
+						privileges |= ACL_INSERT;
+					if (single_perm->UPDATE())
+						privileges |= ACL_UPDATE;
+					if (single_perm->DELETE())
+						privileges |= ACL_DELETE;
+					if (single_perm->REFERENCES())
+						privileges |= ACL_REFERENCES;
+				}
+				result->privileges = privileges;
+				if (grant->WITH())
+					result->with_grant_option = true;
 				result->grantees = grantee_list;
 				return (PLtsql_stmt *) result;
 			}
 		}
 	}
-	if (ctx->revoke_statement() && ctx->revoke_statement()->FROM() && !ctx->revoke_statement()->permission_object()
-								&& ctx->revoke_statement()->permissions())
-	{
-		for (auto perm : ctx->revoke_statement()->permissions()->permission())
-		{
-			auto single_perm = perm->single_permission();
-			if (single_perm->CONNECT())
-			{
-				PLtsql_stmt_grantdb *result = (PLtsql_stmt_grantdb *) palloc0(sizeof(PLtsql_stmt_grantdb));
-				result->cmd_type = PLTSQL_STMT_GRANTDB;
-				result->lineno = getLineNo(ctx->revoke_statement());
-				result->is_grant = false;
-				List *grantee_list = NIL;
 
-				for (auto prin : ctx->revoke_statement()->principals()->principal_id())
+	else if (ctx->revoke_statement())
+	{
+		auto revoke = ctx->revoke_statement();
+		if (!revoke->permission_object() && revoke->permissions())
+		{
+			for (auto perm : revoke->permissions()->permission())
+			{
+				auto single_perm = perm->single_permission();
+				if (single_perm->CONNECT())
+				{
+					PLtsql_stmt_grantdb *result = (PLtsql_stmt_grantdb *) palloc0(sizeof(PLtsql_stmt_grantdb));
+					result->cmd_type = PLTSQL_STMT_GRANTDB;
+					result->lineno = getLineNo(revoke);
+					result->is_grant = false;
+					List *grantee_list = NIL;
+
+					for (auto prin : revoke->principals()->principal_id())
+					{
+						if (prin->id())
+						{
+							std::string id_str = ::getFullText(prin->id());
+							char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
+							grantee_list = lappend(grantee_list, grantee_name);
+						}
+						if (prin->PUBLIC())
+						{
+							char *grantee_name = pstrdup(PUBLIC_ROLE_NAME);
+							grantee_list = lappend(grantee_list, grantee_name);
+						}
+					}
+					result->grantees = grantee_list;
+					return (PLtsql_stmt *) result;
+				}
+			}
+		}
+
+		else if (revoke->ON() && revoke->permission_object() && revoke->permission_object()->object_type() && revoke->permission_object()->object_type()->SCHEMA())
+		{
+			if (revoke->principals() && revoke->permissions())
+			{
+				PLtsql_stmt_grantschema *result = (PLtsql_stmt_grantschema *) palloc0(sizeof(PLtsql_stmt_grantschema));
+				result->cmd_type = PLTSQL_STMT_GRANTSCHEMA;
+				result->lineno = getLineNo(revoke);
+				result->is_grant = false;
+				std::string schema_name;
+				if (revoke->permission_object()->full_object_name()->object_name)
+				{
+					schema_name = stripQuoteFromId(revoke->permission_object()->full_object_name()->object_name);
+					result->schema_name = pstrdup(downcase_truncate_identifier(schema_name.c_str(), schema_name.length(), true));
+				}
+				List *grantee_list = NIL;
+				for (auto prin : revoke->principals()->principal_id())
 				{
 					if (prin->id())
 					{
-						std::string id_str = ::getFullText(prin->id());
+						std::string id_str = stripQuoteFromId(prin->id());
 						char *grantee_name = pstrdup(downcase_truncate_identifier(id_str.c_str(), id_str.length(), true));
 						grantee_list = lappend(grantee_list, grantee_name);
 					}
+					if (prin->PUBLIC())
+					{
+						char *grantee_name = pstrdup(PUBLIC_ROLE_NAME);
+						grantee_list = lappend(grantee_list, grantee_name);
+					}
 				}
+				int privileges = 0;
+				for (auto perm: revoke->permissions()->permission())
+				{
+					auto single_perm = perm->single_permission();
+					if (single_perm->EXECUTE())
+						privileges |= ACL_EXECUTE;
+					if (single_perm->EXEC())
+						privileges |= ACL_EXECUTE;
+					if (single_perm->SELECT())
+						privileges |= ACL_SELECT;
+					if (single_perm->INSERT())
+						privileges |= ACL_INSERT;
+					if (single_perm->UPDATE())
+						privileges |= ACL_UPDATE;
+					if (single_perm->DELETE())
+						privileges |= ACL_DELETE;
+					if (single_perm->REFERENCES())
+						privileges |= ACL_REFERENCES;
+				}
+				result->privileges = privileges;
 				result->grantees = grantee_list;
 				return (PLtsql_stmt *) result;
 			}
 		}
 	}
+
 	PLtsql_stmt *result;
 	result = makeExecSql(ctx);
 	attachPLtsql_fragment(ctx, result);

--- a/contrib/babelfishpg_tsql/src/tsqlNodes.h
+++ b/contrib/babelfishpg_tsql/src/tsqlNodes.h
@@ -52,6 +52,7 @@ typedef enum pltsql_stmt_type
 	PLTSQL_STMT_CHANGE_DBOWNER,
 	PLTSQL_STMT_DBCC,
 	PLTSQL_STMT_FULLTEXTINDEX
+	PLTSQL_STMT_GRANTSCHEMA
 } PLtsql_stmt_type;
 
 typedef struct PLtsql_expr

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1108,7 +1108,6 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 	 || ctx->create_fulltext_index()
 	 || ctx->create_index()
 	 || ctx->create_login()
-	 || ctx->create_schema()
 	 || ctx->create_sequence()
 	 || (ctx->create_server_role() && pltsql_allow_antlr_to_unsupported_grammar_for_testing)
 	 || ctx->create_table()
@@ -1136,6 +1135,20 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitDdl_statement(TSqlParser::
 	 )
 	{
 		// supported DDL or DDL which need special handling
+		return visitChildren(ctx);
+	}
+
+	if (ctx->create_schema())
+	{
+		auto create_schema = ctx->create_schema();
+		if (create_schema->grant_statement().size() > 0)
+		{
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "GRANT inside CREATE SCHEMA is not yet supported in Babelfish.", getLineAndPos(ctx));
+		}
+		if (create_schema->revoke_statement().size() > 0)
+		{
+			throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE inside CREATE SCHEMA is not yet supported in Babelfish.", getLineAndPos(ctx));
+		}
 		return visitChildren(ctx);
 	}
 
@@ -1763,10 +1776,10 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedGrantStmt(TSqlParser::Gran
 				continue;
 			else
 			{
-				unsupported_feature = "GRANT PERMISSION " + perm->getText();
+				unsupported_feature = "GRANT PERMISSION " + ::getFullText(single_perm);
+				std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 				handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(perm));
 			}
-
 		}
 	}
 
@@ -1774,9 +1787,17 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedGrantStmt(TSqlParser::Gran
 	{
 		auto perm_obj = grant->permission_object();
 		auto obj_type = perm_obj->object_type();
-		if (obj_type && !obj_type->OBJECT())
+		if (obj_type && obj_type->SCHEMA())
+		{
+			if (grant->ALL())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(grant));
+			if (grant->WITH())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "GRANT on SCHEMA .. WITH GRANT OPTION is not yet supported in Babelfish.", getLineAndPos(grant));
+		}
+		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{
 			unsupported_feature = "GRANT ON " + obj_type->getText();
+			std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 			handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(obj_type));
 		}
 	}
@@ -1856,10 +1877,10 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Rev
 				continue;
 			else
 			{
-				unsupported_feature = "REVOKE PERMISSION " + perm->getText();
+				unsupported_feature = "REVOKE PERMISSION " + ::getFullText(single_perm);
+				std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 				handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(perm));
 			}
-
 		}
 	}
 
@@ -1867,9 +1888,19 @@ void TsqlUnsupportedFeatureHandlerImpl::checkSupportedRevokeStmt(TSqlParser::Rev
 	{
 		auto perm_obj = revoke->permission_object();
 		auto obj_type = perm_obj->object_type();
-		if (obj_type && !obj_type->OBJECT())
+		if (obj_type && obj_type->SCHEMA())
+		{
+			if (revoke->ALL())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "The all permission has been deprecated and is not available for this class of entity.", getLineAndPos(revoke));
+			if (revoke->CASCADE())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE on SCHEMA .. CASCADE is not yet supported in Babelfish.", getLineAndPos(revoke));
+			if (revoke->GRANT())
+				throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "REVOKE GRANT OPTION FOR .. on SCHEMA is not yet supported in Babelfish.", getLineAndPos(revoke));
+		}
+		if (obj_type && !(obj_type->OBJECT() || obj_type->SCHEMA()))
 		{
 			unsupported_feature = "REVOKE ON " + obj_type->getText();
+			std::transform(unsupported_feature.begin(), unsupported_feature.end(), unsupported_feature.begin(), ::toupper);
 			handle(INSTR_UNSUPPORTED_TSQL_REVOKE_STMT, unsupported_feature.c_str(), getLineAndPos(obj_type));
 		}
 	}

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
@@ -1,0 +1,67 @@
+-- tsql
+
+-- Cleanup
+drop table babel_4768_t1_new
+go
+
+drop table babel_4768_s1.babel_4768_t1_new
+go
+
+drop view babel_4768_v1_new
+go
+
+drop view babel_4768_s1.babel_4768_v1_new
+go
+
+drop proc babel_4768_p1_new
+go
+
+drop proc babel_4768_s1.babel_4768_p1_new
+go
+
+drop proc babel_4768_p2_new
+go
+
+drop proc babel_4768_s1.babel_4768_p2_new
+go
+
+drop FUNCTION babel_4768_f1_new
+go
+
+drop FUNCTION babel_4768_s1.babel_4768_f1_new
+go
+
+drop FUNCTION babel_4768_f2_new
+go
+
+drop FUNCTION babel_4768_s1.babel_4768_f2_new
+go
+
+drop schema babel_4768_s1;
+go
+
+drop user babel_4768_u1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4768_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login babel_4768_l1;
+go

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
@@ -1,0 +1,118 @@
+-- tsql
+create schema babel_4768_s1
+go
+
+create login babel_4768_l1 with password = '12345678'
+go
+
+create user babel_4768_u1 for login babel_4768_l1
+go
+
+create table babel_4768_t1(a int, b int);
+go
+
+create table babel_4768_s1.babel_4768_t1(a int, b int);
+go
+
+create view babel_4768_v1 as select 1;
+go
+
+create view babel_4768_s1.babel_4768_v1 as select 2;
+go
+
+create proc babel_4768_p1 as select 1;
+go
+
+create proc babel_4768_s1.babel_4768_p1 as select 1;
+go
+
+create proc babel_4768_p2 @l datetimeoffset(2) as select 1;
+go
+
+create proc babel_4768_s1.babel_4768_p2 @l datetimeoffset(2) as select 1;
+go
+
+CREATE FUNCTION babel_4768_f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4768_s1.babel_4768_f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4768_f2(@l int) returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4768_s1.babel_4768_f2(@l int) returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql
+-- GRANT individual object access to babel_4768_u1
+GRANT SELECT ON dbo.babel_4768_t1 TO babel_4768_u1
+go
+
+GRANT SELECT ON babel_4768_s1.babel_4768_t1 TO babel_4768_u1
+go
+
+GRANT SELECT ON dbo.babel_4768_v1 TO babel_4768_u1
+go
+
+GRANT SELECT ON babel_4768_s1.babel_4768_v1 TO babel_4768_u1
+go
+
+GRANT EXECUTE ON dbo.babel_4768_p1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_p1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON dbo.babel_4768_p2 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_p2 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON dbo.babel_4768_f1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_f1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON dbo.babel_4768_f2 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_f2 TO babel_4768_u1
+GO
+
+GRANT SELECT, EXECUTE ON SCHEMA::dbo TO babel_4768_u1
+GO
+
+GRANT SELECT, EXECUTE ON SCHEMA::babel_4768_s1 TO babel_4768_u1
+GO
+
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
+babel_4768_s1#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
+babel_4768_s1#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
+babel_4768_s1#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
+babel_4768_s1#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
+babel_4768_s1#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+babel_4768_s1#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+~~END~~
+
+
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
+dbo#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
+dbo#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
+dbo#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
+dbo#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
+dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+~~END~~
+

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -1,0 +1,189 @@
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
+babel_4768_s1#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
+babel_4768_s1#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
+babel_4768_s1#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
+babel_4768_s1#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
+babel_4768_s1#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+babel_4768_s1#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+~~END~~
+
+
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
+dbo#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
+dbo#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
+dbo#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
+dbo#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
+dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+~~END~~
+
+
+-- tsql
+-- rename the objects where permissions are already granted
+sp_rename 'babel_4768_s1.babel_4768_t1', 'babel_4768_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_v1', 'babel_4768_v1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_p1', 'babel_4768_p1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_p2', 'babel_4768_p2_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_f1', 'babel_4768_f1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_f2', 'babel_4768_f2_new', 'OBJECT';
+go
+
+sp_rename 'babel_4768_t1', 'babel_4768_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_v1', 'babel_4768_v1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_p1', 'babel_4768_p1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_p2', 'babel_4768_p2_new', 'OBJECT';
+go
+sp_rename 'babel_4768_f1', 'babel_4768_f1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_f2', 'babel_4768_f2_new', 'OBJECT';
+go
+
+-- psql
+-- catalog should show new object names
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text
+babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>
+babel_4768_s1#!#babel_4768_f1_new#!#128#!#master_babel_4768_u1#!#f#!#
+babel_4768_s1#!#babel_4768_f2_new#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4
+babel_4768_s1#!#babel_4768_p1_new#!#128#!#master_babel_4768_u1#!#p#!#
+babel_4768_s1#!#babel_4768_p2_new#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset
+babel_4768_s1#!#babel_4768_t1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+babel_4768_s1#!#babel_4768_v1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+~~END~~
+
+
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text
+dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>
+dbo#!#babel_4768_f1_new#!#128#!#master_babel_4768_u1#!#f#!#
+dbo#!#babel_4768_f2_new#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4
+dbo#!#babel_4768_p1_new#!#128#!#master_babel_4768_u1#!#p#!#
+dbo#!#babel_4768_p2_new#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset
+dbo#!#babel_4768_t1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+dbo#!#babel_4768_v1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+~~END~~
+
+
+-- psql
+-- This is needed so that MVU passes
+DO $$
+BEGIN 
+    IF EXISTS (SELECT 1 FROM
+information_schema.tables WHERE
+table_name = 'tbl_creation_should_succeed' AND
+table_schema = 'master_dbo') THEN
+        EXECUTE 'GRANT ALL ON
+master_dbo.tbl_creation_should_succeed TO master_dbo';
+    END IF;
+END $$;
+GO
+
+-- tsql
+REVOKE SELECT, EXECUTE ON SCHEMA::dbo FROM babel_4768_u1
+GO
+
+REVOKE SELECT, EXECUTE ON SCHEMA::babel_4768_s1 FROM babel_4768_u1
+GO
+
+-- psql
+-- catalog entry ALL should be gone now
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text
+babel_4768_s1#!#babel_4768_f1_new#!#128#!#master_babel_4768_u1#!#f#!#
+babel_4768_s1#!#babel_4768_f2_new#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4
+babel_4768_s1#!#babel_4768_p1_new#!#128#!#master_babel_4768_u1#!#p#!#
+babel_4768_s1#!#babel_4768_p2_new#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset
+babel_4768_s1#!#babel_4768_t1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+babel_4768_s1#!#babel_4768_v1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+~~END~~
+
+
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text
+dbo#!#babel_4768_f1_new#!#128#!#master_babel_4768_u1#!#f#!#
+dbo#!#babel_4768_f2_new#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4
+dbo#!#babel_4768_p1_new#!#128#!#master_babel_4768_u1#!#p#!#
+dbo#!#babel_4768_p2_new#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset
+dbo#!#babel_4768_t1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+dbo#!#babel_4768_v1_new#!#2#!#master_babel_4768_u1#!#r#!#<NULL>
+~~END~~
+
+
+-- tsql
+-- REVOKE individual object access from babel_4768_u1
+REVOKE SELECT ON dbo.babel_4768_t1_new FROM babel_4768_u1
+go
+
+REVOKE SELECT ON babel_4768_s1.babel_4768_t1_new FROM babel_4768_u1
+go
+
+REVOKE SELECT ON dbo.babel_4768_v1_new FROM babel_4768_u1
+go
+
+REVOKE SELECT ON babel_4768_s1.babel_4768_v1_new FROM babel_4768_u1
+go
+
+REVOKE EXECUTE ON babel_4768_p1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_p1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_p2_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_p2_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_f1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_f1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_f2_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_f2_new FROM babel_4768_u1
+GO
+
+-- psql
+-- catalog should be empty now
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text
+~~END~~
+
+
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text
+~~END~~
+

--- a/test/JDBC/expected/AUTO_ANALYZE-vu-prepare.out
+++ b/test/JDBC/expected/AUTO_ANALYZE-vu-prepare.out
@@ -22,6 +22,7 @@ babelfish_extended_properties
 babelfish_function_ext
 babelfish_helpcollation
 babelfish_namespace_ext
+babelfish_schema_permissions
 babelfish_server_options
 babelfish_sysdatabases
 babelfish_syslanguages

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -370,6 +370,12 @@ USE master;
 GO
 
 -- tsql
+USE db1;
+GO
+
+REVOKE SELECT ON dbo.db1_t1 FROM db1_janedoe;
+GO
+
 USE MASTER;
 GO
 
@@ -522,6 +528,12 @@ DROP PROCEDURE p1
 GO
 
 -- tsql
+USE db1;
+GO
+
+DROP TABLE db1_t1;
+GO
+
 USE master;
 GO
 

--- a/test/JDBC/expected/BABEL-GRANT.out
+++ b/test/JDBC/expected/BABEL-GRANT.out
@@ -20,6 +20,10 @@ GO
 ---
 ---  Prepare Objects
 ---
+---- SCHEMA
+CREATE SCHEMA scm;
+GO
+
 ---- TABLE
 CREATE TABLE t1 ( a int, b int);
 GO
@@ -57,6 +61,18 @@ GO
 ---
 ---  Basic Grant / Revoke
 ---
+GRANT SELECT ON SCHEMA::scm TO guest;
+GO
+
+GRANT SELECT ON SCHEMA::scm TO PUBLIC;
+GO
+
+REVOKE SELECT ON SCHEMA::scm FROM PUBLIC;
+GO
+
+GRANT INSERT ON SCHEMA::scm TO guest;
+GO
+
 GRANT ALL ON OBJECT::t1 TO guest WITH GRANT OPTION;
 GO
 
@@ -155,7 +171,10 @@ GO
 ~~ERROR (Message: 'REVOKE ALL on Database' is not currently supported in Babelfish)~~
 
 
-GRANT SHOWPLAN ON OBJECT::t1 TO guest;  -- unsupported permission
+REVOKE SELECT ON SCHEMA::scm FROM guest;
+GO
+
+GRANT showplan ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -169,18 +188,46 @@ GO
 ~~ERROR (Message: 'REVOKE PERMISSION SHOWPLAN' is not currently supported in Babelfish)~~
 
 
-GRANT ALL ON SCHEMA::scm TO guest;  -- unsupported class
+GRANT ALL ON SCHEMA::scm TO guest;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'GRANT ON SCHEMA' is not currently supported in Babelfish)~~
+~~ERROR (Message: The all permission has been deprecated and is not available for this class of entity.)~~
 
 
-REVOKE ALL ON SCHEMA::scm TO guest; -- unsupported class
+REVOKE ALL ON SCHEMA::scm TO guest;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'REVOKE ON SCHEMA' is not currently supported in Babelfish)~~
+~~ERROR (Message: The all permission has been deprecated and is not available for this class of entity.)~~
+
+
+GRANT create table ON OBJECT::t1 TO guest;  -- unsupported permission
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'GRANT PERMISSION CREATE TABLE' is not currently supported in Babelfish)~~
+
+
+REVOKE create table ON OBJECT::t2 FROM alogin;  -- unsupported permission
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'REVOKE PERMISSION CREATE TABLE' is not currently supported in Babelfish)~~
+
+
+GRANT SELECT ON table::t1 TO guest; -- unsupported object
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'GRANT ON TABLE' is not currently supported in Babelfish)~~
+
+
+REVOKE SELECT ON table::t1 FROM guest; -- unsupported object
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'REVOKE ON TABLE' is not currently supported in Babelfish)~~
 
 
 GRANT ALL ON OBJECT::t1 TO guest WITH GRANT OPTION AS superuser;
@@ -213,6 +260,9 @@ GO
 ---
 ---  Clean Up
 ---
+DROP SCHEMA scm;
+GO
+
 DROP VIEW IF EXISTS my_view;
 GO
 

--- a/test/JDBC/expected/BABEL-SESSION.out
+++ b/test/JDBC/expected/BABEL-SESSION.out
@@ -153,6 +153,21 @@ USE master;
 GO
 
 -- tsql
+USE db1;
+GO
+
+DROP TABLE tb1;
+GO
+
+DROP TABLE janedoe_schema.t1;
+GO
+
+DROP SCHEMA janedoe_schema;
+GO
+
+USE master;
+go
+
 DROP DATABASE db1;
 GO
 

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -785,6 +785,20 @@ GO
 DROP TABLE t_unsupported_ft2;
 GO
 
+CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish.)~~
+
+
+CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish.)~~
+
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~

--- a/test/JDBC/expected/GRANT_SCHEMA-before-15_7-16_3-vu-cleanup.out
+++ b/test/JDBC/expected/GRANT_SCHEMA-before-15_7-16_3-vu-cleanup.out
@@ -1,0 +1,75 @@
+-- tsql
+-- Drop objects
+use grant_schema_d1;
+go
+
+drop table grant_schema_s1.grant_schema_t1;
+go
+
+drop table grant_schema_s1.grant_schema_t2;
+go
+
+drop table grant_schema_s1.grant_schema_t3;
+go
+
+drop view grant_schema_s1.grant_schema_v1;
+go
+
+drop view grant_schema_s1.grant_schema_v2;
+go
+
+drop proc grant_schema_s1.grant_schema_p1;
+go
+
+drop proc grant_schema_s1.grant_schema_p2;
+go
+
+drop function grant_schema_s1.grant_schema_f1;
+go
+
+drop function grant_schema_s1.grant_schema_f2;
+go
+
+drop schema grant_schema_s1;
+go
+
+drop table grant_schema_s2.grant_schema_t1;
+go
+
+drop table grant_schema_s2.grant_schema_t2;
+go
+
+drop schema grant_schema_s2;
+go
+
+drop user grant_schema_u1;
+go
+
+use master;
+go
+
+drop database grant_schema_d1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'grant_schema_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login grant_schema_l1;
+go

--- a/test/JDBC/expected/GRANT_SCHEMA-before-15_7-16_3-vu-prepare.out
+++ b/test/JDBC/expected/GRANT_SCHEMA-before-15_7-16_3-vu-prepare.out
@@ -1,0 +1,74 @@
+-- tsql
+-- create objects
+create database grant_schema_d1;
+go
+
+use grant_schema_d1;
+go
+
+create login grant_schema_l1 with password = '12345678'
+go
+
+create user grant_schema_u1 for login grant_schema_l1;
+go
+
+create schema grant_schema_s1;
+go
+
+create table grant_schema_s1.grant_schema_t1(a int);
+go
+
+create table grant_schema_s1.grant_schema_t2(b int);
+go
+
+create table grant_schema_s1.grant_schema_t3(c int);
+go
+
+create view grant_schema_s1.grant_schema_v1 as select 2;
+go
+
+create view grant_schema_s1.grant_schema_v2 as select 2;
+go
+
+create proc grant_schema_s1.grant_schema_p1 as select 2;
+go
+
+create proc grant_schema_s1.grant_schema_p2 as select 2;
+go
+
+CREATE FUNCTION grant_schema_s1.grant_schema_f1() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
+go
+
+CREATE FUNCTION grant_schema_s1.grant_schema_f2() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
+go
+
+create schema grant_schema_s2;
+go
+
+create table grant_schema_s2.grant_schema_t1(a int);
+go
+
+create table grant_schema_s2.grant_schema_t2(a int);
+go
+
+-- GRANT OBJECT privilege
+grant select on grant_schema_s1.grant_schema_t1 to grant_schema_u1;
+go
+grant select on grant_schema_s1.grant_schema_t3 to grant_schema_u1;
+go
+grant select on grant_schema_s1.grant_schema_v1 to grant_schema_u1;
+go
+grant select on grant_schema_s1.grant_schema_v2 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_p1 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_p2 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_f1 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_f2 to grant_schema_u1;
+go
+grant select on grant_schema_s2.grant_schema_t1 to grant_schema_u1;
+go
+grant select on grant_schema_s2.grant_schema_t2 to grant_schema_u1;
+go

--- a/test/JDBC/expected/GRANT_SCHEMA-before-15_7-16_3-vu-verify.out
+++ b/test/JDBC/expected/GRANT_SCHEMA-before-15_7-16_3-vu-verify.out
@@ -1,0 +1,291 @@
+-- tsql user=grant_schema_l1 password=12345678
+-- User has OBJECT privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t1;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_t2; -- case 1: has no permission
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table grant_schema_t2)~~
+
+
+select * from grant_schema_s1.grant_schema_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+exec grant_schema_s1.grant_schema_p1;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_f1();
+go
+~~START~~
+int
+10
+~~END~~
+
+
+-- tsql
+-- REVOKE OBJECT privilege
+use grant_schema_d1;
+go
+revoke select on grant_schema_s1.grant_schema_t1 from grant_schema_u1;
+go
+revoke select on grant_schema_s1.grant_schema_v1 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_p1 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_f1 from grant_schema_u1;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+-- User has no privileges, should not be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table grant_schema_t1)~~
+
+
+select * from grant_schema_s1.grant_schema_v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view grant_schema_v1)~~
+
+
+exec grant_schema_s1.grant_schema_p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure grant_schema_p1)~~
+
+
+select * from grant_schema_s1.grant_schema_f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function grant_schema_f1)~~
+
+
+-- tsql
+-- GRANT SCHEMA privilege
+use grant_schema_d1;
+go
+grant select, execute on schema::grant_schema_s1 to grant_schema_u1;
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+-- User has SCHEMA privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t1;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_t2;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+exec grant_schema_s1.grant_schema_p1;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_f1();
+go
+~~START~~
+int
+11
+~~END~~
+
+
+-- User has OBJECT and SCHEMA privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t3;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_v2;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+exec grant_schema_s1.grant_schema_p2;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_f2();
+go
+~~START~~
+int
+11
+~~END~~
+
+
+-- tsql
+-- Case 6: User has SCHEMA privilege, REVOKE OBJECT privilege
+use grant_schema_d1;
+go
+revoke select on grant_schema_s1.grant_schema_t3 from grant_schema_u1;
+go
+revoke select on grant_schema_s1.grant_schema_v2 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_p2 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_f2 from grant_schema_u1;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+-- User has SCHEMA privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t3;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_v2;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+exec grant_schema_s1.grant_schema_p2;
+go
+~~START~~
+int
+2
+~~END~~
+
+
+select * from grant_schema_s1.grant_schema_f2();
+go
+~~START~~
+int
+11
+~~END~~
+
+
+-- tsql
+-- User has OBJECT privilege, REVOKE OBJECT privilege
+-- case 7: User has no privileges, should not be accessible. 
+use grant_schema_d1;
+go
+revoke select on grant_schema_s2.grant_schema_t2 from grant_schema_u1;
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+use grant_schema_d1;
+go
+
+select * from grant_schema_s2.grant_schema_t2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table grant_schema_t2)~~
+
+
+-- tsql
+-- User has OBJECT privilege, REVOKE SCHEMA privilege
+-- case 8: User has OBJECT privileges, would not be accessible. 
+use grant_schema_d1;
+go
+revoke select on schema::grant_schema_s2 from grant_schema_u1; 
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+use grant_schema_d1;
+go
+
+select * from grant_schema_s2.grant_schema_t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table grant_schema_t1)~~
+
+
+-- tsql
+-- User has OBJECT privilege, GRANT and REVOKE SCHEMA privilege
+-- case 5: User has OBJECT privileges, would not be accessible. 
+use grant_schema_d1;
+go
+grant  select on schema::grant_schema_s2 to grant_schema_u1;
+go
+
+revoke select on schema::grant_schema_s2 from grant_schema_u1; 
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+use grant_schema_d1;
+go
+
+select * from grant_schema_s2.grant_schema_t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table grant_schema_t1)~~
+
+

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -1,0 +1,4555 @@
+-- tsql
+-- create objects
+create database babel_4344_d1;
+go
+
+use babel_4344_d1;
+go
+
+create login babel_4344_l1 with password = '12345678'
+go
+
+create user babel_4344_u1 for login babel_4344_l1;
+go
+
+create login αιώνια with password = '12345678'
+go
+
+create user αιώνια for login αιώνια;
+go
+
+create login ログイン with password = '12345678'
+go
+
+create user ログイン for login ログイン;
+go
+
+create schema babel_4344_s1;
+go
+
+create schema "BAbel_4344 S1";
+go
+
+create table "babel_4344 s1"."babel_4344 t1"(a int);
+go
+
+create schema αγάπη;
+go
+
+create schema スキーマ;
+go
+
+create schema babel_4344_s2 authorization babel_4344_u1;
+go
+
+create table babel_4344_t1(a int);
+go
+
+create table babel_4344_s1.babel_4344_t1(a int);
+go
+
+create table babel_4344_s2.babel_4344_t1(a int);
+go
+
+create table αγάπη.abc(a int);
+go
+
+create table スキーマ.abc(a int);
+go
+
+create table babel_4344_t3(a int, b int);
+go
+
+create table babel_4344_s1.babel_4344_t3(a int, b int);
+go
+
+create schema "update pg_class set oid = 0 where relname = 'babel_4344_t1'";
+go
+
+create view babel_4344_v1 as select 1;
+go
+
+create view babel_4344_s1.babel_4344_v1 as select 2;
+go
+
+create proc babel_4344_p1 as select 1;
+go
+
+create proc babel_4344_s1.babel_4344_p1 as select 2;
+go
+
+create proc babel_4344_s1.babel_4344_p3 as select 3;
+go
+
+CREATE FUNCTION babel_4344_f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4344_s1.babel_4344_f1() returns int begin declare @a int; set @a = 1; return @a; END
+go
+
+-- tests with greek character (one byte) and japanese character (muti bytes)
+grant SELECT on schema::babel_4344_S1 to public, αιώνια, ログイン;
+go
+
+grant select on schema::αγάπη to αιώνια, ログイン;
+go
+
+grant select on schema::スキーマ to ログイン, αιώνια;
+go
+
+-- test special database roles
+grant SELECT on schema::babel_4344_S1 to db_owner; -- throws an error
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny or revoke permissions to or from special roles.)~~
+
+
+grant SELECT on schema::babel_4344_S1 to sys; -- throws an error
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+
+
+grant SELECT on schema::babel_4344_S1 to information_schema; -- throws an error
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+
+
+grant SELECT on schema::babel_4344_S1 to dbo; -- throws an error
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+
+
+-- tsql user=ログイン password=12345678 
+use babel_4344_d1;
+go
+
+select * from αγάπη.abc;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from スキーマ.abc;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from babel_4344_S1.babel_4344_t1;
+go
+~~START~~
+int
+~~END~~
+
+
+use master;
+go
+
+-- tsql user=αιώνια password=12345678 
+use babel_4344_d1;
+go
+
+select * from αγάπη.abc;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from スキーマ.abc;
+go
+~~START~~
+int
+~~END~~
+
+
+select * from babel_4344_S1.babel_4344_t1;
+go
+~~START~~
+int
+~~END~~
+
+
+use master;
+go
+
+-- tsql user=babel_4344_l1 password=12345678 
+use babel_4344_d1;
+go
+
+-- User has select privileges, tables and views be accessible
+select * from babel_4344_s1.babel_4344_t1
+go
+~~START~~
+int
+~~END~~
+
+select * from babel_4344_s1.babel_4344_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+use master;
+go
+
+-- tsql
+-- object names having more than 64 bytes
+create schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
+go
+
+create table abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz(a int);
+go
+
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+-- unsupported features
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 with grant option;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: GRANT on SCHEMA .. WITH GRANT OPTION is not yet supported in Babelfish.)~~
+
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 cascade;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE on SCHEMA .. CASCADE is not yet supported in Babelfish.)~~
+
+
+revoke grant option for select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE GRANT OPTION FOR .. on SCHEMA is not yet supported in Babelfish.)~~
+
+
+grant select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+revoke select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz from babel_4344_u1;
+go
+
+drop table abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
+go
+
+drop schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
+go
+
+use babel_4344_d1;
+go
+revoke select on schema::babel_4344_s1 from public, αιώνια, ログイン;
+go
+
+-- tsql user=babel_4344_l1 password=12345678 
+use babel_4344_d1;
+go
+
+-- User doesn't have any privileges, objects should not be accessible
+select * from babel_4344_t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t1)~~
+
+select * from babel_4344_s1.babel_4344_t1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t1)~~
+
+insert into babel_4344_s1.babel_4344_t1 values(1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t1)~~
+
+select * from babel_4344_v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_4344_v1)~~
+
+select * from babel_4344_s1.babel_4344_v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_4344_v1)~~
+
+exec babel_4344_p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure babel_4344_p1)~~
+
+exec babel_4344_s1.babel_4344_p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure babel_4344_p1)~~
+
+select * from babel_4344_f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_4344_f1)~~
+
+select * from babel_4344_s1.babel_4344_f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_4344_f1)~~
+
+use master;
+go
+
+-- tsql
+-- GRANT OBJECT privilege
+use babel_4344_d1;
+go
+grant SELECT on schema::"bAbel_4344 s1" to BABEL_4344_U1;
+go
+grant SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" to BABEL_4344_U1;
+go
+grant SELECT on "babel_4344_t1" to BABEL_4344_U1;
+go
+grant SELECT on "babel_4344_s1".babel_4344_t1 to babel_4344_u1;
+go
+grant all on babel_4344_s1.babel_4344_t1 to "babel_4344_u1";
+go
+grant select on babel_4344_t3(a) to babel_4344_u1; -- column privilege
+go
+grant select on babel_4344_s1.babel_4344_t3(a) to babel_4344_u1; -- column privilege
+go
+grant select on babel_4344_v1 to babel_4344_u1;
+go
+grant select on babel_4344_s1.babel_4344_v1 to babel_4344_u1;
+go
+grant execute on babel_4344_p1 to babel_4344_u1;
+go
+grant execute on babel_4344_s1.babel_4344_p1 to babel_4344_u1;
+go
+-- inside a transaction, permission will not be granted since it is rolled back
+begin transaction;
+exec sp_executesql N'grant execute on babel_4344_s1.babel_4344_p3 to babel_4344_u1;';
+rollback transaction;
+go
+
+-- Mixed case
+grant Execute on Babel_4344_F1 to Babel_4344_u1;
+go
+grant execute on BABEL_4344_s1.babel_4344_f1 to babEL_4344_u1;
+go
+-- Grant schema permission to its owner, should fail
+grant select on schema::babel_4344_s2 to babel_4344_u1; -- should fail
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+
+grant select on schema::babel_4344_s2 to jdbc_user; -- should fail
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'jdbc_user', because it does not exist or you do not have permission.)~~
+
+grant SELECT on schema::"babel_4344_s2" to guest; -- should pass 
+go
+grant select on schema::"" to guest; -- should fail 
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
+
+grant select on schema::non_existing_schema to guest; -- should fail 
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "non_existing_schema" does not exist)~~
+
+-- grant statement via a procedure
+create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
+go
+exec grant_perm_proc; -- should fail, invalid GRANT statement
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
+
+-- non-existing role
+grant SELECT on schema::dbo to guest, babel_4344_u3; -- should fail
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'babel_4344_u3', because it does not exist or you do not have permission.)~~
+
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has OBJECT privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_t1;
+go
+~~START~~
+int
+~~END~~
+
+select * from babel_4344_s1.babel_4344_t1
+go
+~~START~~
+int
+~~END~~
+
+insert into babel_4344_s1.babel_4344_t1 values(2);
+go
+~~ROW COUNT: 1~~
+
+select * from babel_4344_t3; -- not accessible, only column privilege is granted
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t3)~~
+
+select * from babel_4344_s1.babel_4344_t3 -- not accessible, only column privilege is granted
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t3)~~
+
+select * from babel_4344_v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_4344_s1.babel_4344_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec babel_4344_p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec babel_4344_s1.babel_4344_p1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec babel_4344_s1.babel_4344_p3; -- should fail, grant statement was rolled back
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure babel_4344_p3)~~
+
+select * from BABEl_4344_f1();
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from babEL_4344_s1.babel_4344_f1();
+go
+~~START~~
+int
+1
+~~END~~
+
+-- Grant schema permission to its owner
+grant select on schema::babel_4344_s2 to babel_4344_u1; -- should fail
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+
+grant select on schema::babel_4344_s2 to guest; -- should pass 
+go
+grant select on schema::babel_4344_s1 to babel_4344_u1; -- should fail
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot grant, deny, or revoke permissions to sa, dbo, entity owner, information_schema, sys, or yourself.)~~
+
+use master;
+go
+
+-- tsql
+-- GRANT SCHEMA privilege
+use babel_4344_d1;
+go
+grant control on schema::babel_4344_s1 to babel_4344_u1; -- should fail, 'control' is not supported
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'GRANT PERMISSION CONTROL' is not currently supported in Babelfish)~~
+
+grant select, insert, execute on schema::babel_4344_s1 to babel_4344_u1;
+go
+use master;
+go
+
+-- psql
+-- GRANT statement add an entry to the catalog
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where schema_name = 'babel_4344_s1' collate "C" order by permission; -- and object_name = 'ALL' collate "C"
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
+~~END~~
+
+
+-- tsql
+-- GRANT SCHEMA privilege again
+use babel_4344_d1;
+go
+grant select, insert, execute on schema::babel_4344_s1 to babel_4344_u1;
+go
+-- GRANT OBJECT privilege again
+grant select on babel_4344_s1.babel_4344_v1 to babel_4344_u1;
+go
+use master;
+go
+
+-- psql
+-- check the consistency of catalog
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where schema_name = 'babel_4344_s1' collate "C" order by permission;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
+~~END~~
+
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has OBJECT and SCHEMA privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1
+go
+~~START~~
+int
+2
+~~END~~
+
+insert into babel_4344_s1.babel_4344_t1 values(3);
+go
+~~ROW COUNT: 1~~
+
+select * from babel_4344_s1.babel_4344_t3
+go
+~~START~~
+int#!#int
+~~END~~
+
+select * from babel_4344_s1.babel_4344_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec babel_4344_s1.babel_4344_p1;
+go
+~~START~~
+int
+2
+~~END~~
+
+select * from babel_4344_s1.babel_4344_f1();
+go
+~~START~~
+int
+1
+~~END~~
+
+use master;
+go
+
+-- tsql
+-- REVOKE SCHEMA privilege
+use babel_4344_d1;
+go
+revoke select, insert, execute on schema::babel_4344_s1 from babel_4344_u1;
+go
+use master;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has OBJECT privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1
+go
+~~START~~
+int
+2
+3
+~~END~~
+
+insert into babel_4344_s1.babel_4344_t1 values(3); 
+go
+~~ROW COUNT: 1~~
+
+select * from babel_4344_s1.babel_4344_t3 -- not accessible
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t3)~~
+
+select * from babel_4344_s1.babel_4344_v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec babel_4344_s1.babel_4344_p1;
+go
+~~START~~
+int
+2
+~~END~~
+
+select * from babel_4344_s1.babel_4344_f1();
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_4344_s2.babel_4344_t1;
+go
+~~START~~
+int
+~~END~~
+
+use master;
+go
+
+-- tsql
+-- create new objects in same schema
+use babel_4344_d1;
+go
+-- Grant the permissions again
+grant select, insert, execute on schema::babel_4344_s1 to babel_4344_u1;
+go
+grant select, insert, execute on schema::information_schema to babel_4344_u1;
+go
+create table babel_4344_s1.babel_4344_t2(a int);
+go
+create view babel_4344_s1.babel_4344_v2 as select 2;
+go
+create proc babel_4344_s1.babel_4344_p2 as select 2;
+go
+CREATE FUNCTION babel_4344_s1.babel_4344_f2() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
+go
+use master;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has SCHEMA privileges,objects should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t2
+go
+~~START~~
+int
+~~END~~
+
+insert into babel_4344_s1.babel_4344_t1 values(4);
+go
+~~ROW COUNT: 1~~
+
+select * from babel_4344_s1.babel_4344_v2;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec babel_4344_s1.babel_4344_p2;
+go
+~~START~~
+int
+2
+~~END~~
+
+select * from babel_4344_s1.babel_4344_f2();
+go
+~~START~~
+int
+16
+~~END~~
+
+select * from "bAbel_4344 s1"."bAbel_4344 t1";
+go
+~~START~~
+int
+~~END~~
+
+use master;
+go
+
+-- tsql
+-- REVOKE OBJECT privileges
+use babel_4344_d1;
+go
+
+REVOKE SELECT on schema::"bAbel_4344 s1" from "BABEL_4344_U1";
+go
+REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
+go
+GRANT SELECT on babel_4344_t1 to BABEL_4344_U1;
+go
+
+-- psql
+-- should show original object names
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
+~~END~~
+
+
+-- tsql
+-- rename the objects where permissions are already granted
+sp_rename 'babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_t3', 'babel_4344_t3_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_v1', 'babel_4344_v1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_p1', 'babel_4344_p1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_f1', 'babel_4344_f1_new', 'OBJECT';
+go
+
+-- psql
+-- should show renamed objects
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_f1_new#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_p1_new#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_t1_new#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_v1_new#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
+~~END~~
+
+
+-- tsql
+-- permissions are transferred to the new objects 
+-- Revoke permissions from the new objects
+REVOKE all on babel_4344_s1.babel_4344_t1_new FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_t3_new(a) FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_v1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_p1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
+go
+REVOKE all on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has SCHEMA privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_t1_new;
+go
+~~START~~
+int
+~~END~~
+
+select * from babel_4344_s1.babel_4344_t1_new
+go
+~~START~~
+int
+2
+3
+3
+4
+~~END~~
+
+insert into babel_4344_s1.babel_4344_t1_new values(5);
+go
+~~ROW COUNT: 1~~
+
+select * from babel_4344_s1.babel_4344_t3_new;
+go
+~~START~~
+int#!#int
+~~END~~
+
+select * from babel_4344_s1.babel_4344_v1_new;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec babel_4344_s1.babel_4344_p1_new;
+go
+~~START~~
+int
+2
+~~END~~
+
+select * from babel_4344_s1.babel_4344_f1_new();
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_4344_s2.babel_4344_t1;
+go
+~~START~~
+int
+~~END~~
+
+use master;
+go
+
+-- tsql
+-- REVOKE SCHEMA privileges
+use babel_4344_d1;
+go
+revoke select, insert, execute on schema::babel_4344_s1 from babel_4344_u1;
+go
+use master;
+go
+
+-- psql
+-- REVOKE on schema removes the entry from the catalog
+select * from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+~~END~~
+
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has no privileges, shouldn't be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1_new;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t1_new)~~
+
+insert into babel_4344_s1.babel_4344_t1_new values(5);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t1_new)~~
+
+select * from babel_4344_s1.babel_4344_t3_new;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t3_new)~~
+
+select * from babel_4344_s1.babel_4344_v1_new;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_4344_v1_new)~~
+
+exec babel_4344_s1.babel_4344_p1_new;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure babel_4344_p1_new)~~
+
+select * from babel_4344_s1.babel_4344_f1_new();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_4344_f1_new)~~
+
+use master;
+go
+
+-- psql
+-- grant object permission
+grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
+go
+
+-- tsql
+-- grant schema permission
+use babel_4344_d1;
+go
+grant select on schema::babel_4344_s1 to babel_4344_u1;
+go
+use master
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1_new; -- accessible
+go
+~~START~~
+int
+2
+3
+3
+4
+5
+~~END~~
+
+use master
+go
+
+-- psql
+-- revoke schema permission
+revoke select on all tables in schema babel_4344_s1 from babel_4344_d1_babel_4344_u1;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1_new; -- not accessible
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_4344_t1_new)~~
+
+use master
+go
+
+-- tsql
+-- Drop objects
+use babel_4344_d1;
+go
+
+drop schema "update pg_class set oid = 0 where relname = 'babel_4344_t1'";
+go
+
+drop table babel_4344_t1_new;
+go
+
+drop table babel_4344_s1.babel_4344_t1_new;
+go
+
+drop table babel_4344_t3;
+go
+
+drop table babel_4344_s1.babel_4344_t3_new;
+go
+
+drop table babel_4344_s1.babel_4344_t2;
+go
+
+drop view babel_4344_v1;
+go
+
+drop view babel_4344_s1.babel_4344_v1_new;
+go
+
+drop view babel_4344_s1.babel_4344_v2;
+go
+
+drop proc babel_4344_p1;
+go
+
+drop proc babel_4344_s1.babel_4344_p1_new;
+go
+
+drop proc babel_4344_s1.babel_4344_p2;
+go
+
+drop proc babel_4344_s1.babel_4344_p3;
+go
+
+drop function babel_4344_f1;
+go
+
+drop function babel_4344_s1.babel_4344_f1_new;
+go
+
+drop function babel_4344_s1.babel_4344_f2;
+go
+
+drop schema babel_4344_s1;
+go
+
+drop table babel_4344_s2.babel_4344_t1;
+go
+
+drop schema babel_4344_s2;
+go
+
+drop table αγάπη.abc;
+go
+
+drop schema αγάπη;
+go
+
+drop table スキーマ.abc;
+go
+
+drop schema スキーマ;
+go
+
+drop table "babel_4344 s1"."babel_4344 t1";
+go
+
+drop schema "BAbel_4344 s1";
+go
+
+drop user babel_4344_u1;
+go
+
+drop user αιώνια;
+go
+
+drop user ログイン;
+go
+
+use master;
+go
+
+drop database babel_4344_d1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4344_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login babel_4344_l1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'αιώνια' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login αιώνια;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'ログイン' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login ログイン;
+go
+
+-- tsql
+-- Test group 1 [guest users and dbo schema]
+-- create objects
+create login l1 with password = '12345678'
+go
+create table t1(a int);
+go
+create view v1 as select 2;
+go
+create proc p1 as select 1;
+go
+create function f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have no permission
+select current_user;
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+select * from dbo.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from dbo.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec dbo.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from dbo.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+grant select, execute on schema::dbo to guest;
+go
+create function f2() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have select and EXECUTE permission
+select current_user;
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+select * from dbo.t1;
+go
+~~START~~
+int
+~~END~~
+
+select * from dbo.v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec dbo.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from dbo.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from dbo.f2()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+grant select on dbo.t1 to guest;
+go
+grant execute on dbo.f1 to guest;
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have select and EXECUTE permission
+select current_user;
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+select * from dbo.t1;
+go
+~~START~~
+int
+~~END~~
+
+select * from dbo.v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec dbo.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from dbo.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from dbo.f2()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+revoke select on dbo.t1 from guest;
+go
+revoke execute on dbo.f1 from guest;
+go
+revoke select, execute on schema::dbo to guest;
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have no permission
+select current_user;
+go
+~~START~~
+varchar
+guest
+~~END~~
+
+select * from dbo.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from dbo.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec dbo.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from dbo.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select * from dbo.f2()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+-- drop objects
+drop table t1;
+go
+drop view v1;
+go
+drop procedure p1;
+go
+drop function f1;
+go
+drop function f2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login l1;
+go
+
+-- tsql
+-- Create objects for tests in a user defined schema
+create schema s1;
+go
+create login l1 with password = '123';
+go
+create user u1 for login l1;
+go
+create login l2 with password = '123';
+go
+create user u2 for login l2;
+go
+create table s1.t1(a int);
+go
+create view s1.v1 as select 1;
+go
+create procedure s1.p1 as select 1;
+go
+create function s1.f1() returns int begin declare @a int; set @a = 1; return @a; end
+go
+create trigger s1.tr1 ON s1.t1 for insert as begin 
+select 'insert successful' end
+go
+create trigger s1.tr2 ON s1.t1 for insert as begin 
+grant select on s1.t1 to u1 end
+go
+create sequence s1.sq1 start with 1 increment by 1 ;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 2 [users have no default permission]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+grant select on schema::s1 to u1;
+go
+grant insert on schema::s1 to u1;
+go
+grant delete on schema::s1 to u1;
+go
+grant update on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 3 [user u1 has select, insert, update, delete privilege on the schema]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+delete from s1.t1 where a = 2;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+grant execute on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 4 [user u1 has select, insert, update, delete and execute privilege on the schema]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+delete from s1.t1 where a = 2;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+-- create new objects in the schema s1
+create table s1.t2(a int);
+go
+create view s1.v2 as select 1;
+go
+create procedure s1.p2 as select 1;
+go
+create function s1.f2() returns int begin declare @a int; set @a = 1; return @a; end
+go
+
+-- tsql user=l1 password=123
+-- Test Group 5 [u1 has select, insert, update, delete and execute privilege on the schema]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t2;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t2 values (1);
+go
+~~ROW COUNT: 1~~
+
+update s1.t2 set a = 2 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+delete from s1.t2 where a = 2;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v2;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p2;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f2()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+insert into s1.t2 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+update s1.t2 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+delete from s1.t2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+select * from s1.v2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+exec s1.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select * from s1.f2()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+revoke select on schema::s1 from u1;
+go
+revoke insert on schema::s1 from u1;
+go
+revoke delete on schema::s1 from u1;
+go
+revoke update on schema::s1 from u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 6 
+-- [user u1 has execute privilege on the schema, u1 has select privilege on s1.t1 via trigger]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.t2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+insert into s1.t2 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+delete from s1.t2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+select * from s1.v2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+exec s1.p2;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f2()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select * from s1.t2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+insert into s1.t2 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+delete from s1.t2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+select * from s1.v2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+exec s1.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select * from s1.f2()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+revoke execute on schema::s1 from u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 7
+-- [user u1 and u2 have no privilege on the schema, u1 has select privilege on table s1.t1 via trigger]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select * from s1.t2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+insert into s1.t2 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+delete from s1.t2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+select * from s1.v2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+exec s1.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select * from s1.f2()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select * from s1.t2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+insert into s1.t2 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+delete from s1.t2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t2)~~
+
+select * from s1.v2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+exec s1.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select * from s1.f2()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+grant select on s1.t1 to u1;
+go
+grant insert on s1.t1 to u1;
+go
+grant delete on s1.t1 to u1;
+go
+grant select on s1.v1 to u1;
+go
+grant execute on s1.p1 to u1;
+go
+grant execute on s1.f1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 8 [user u1 has select, insert, delete, execute privilege on these objects]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+grant select on s1.t1 to PUBLIC;
+go
+grant insert, delete on s1.t1 to PUBLIC;
+go
+grant select on s1.v1 to PUBLIC;
+go
+grant execute on s1.p1 to PUBLIC;
+go
+grant execute on s1.f1 to PUBLIC;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 9 [select, insert, execute privilege on these objects to PUBLIC]
+-- [Also, u1 has select, insert and execute privilege on these objects]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+revoke select on s1.t1 from u1;
+go
+revoke insert, delete on s1.t1 from u1;
+go
+revoke select on s1.v1 from u1;
+go
+revoke execute on s1.p1 from u1;
+go
+revoke execute on s1.f1 from u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 10 [select, insert, delete, execute privilege on these objects to PUBLIC]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+grant select on s1.t1 to u1;
+go
+grant insert on s1.t1 to u1;
+go
+grant delete on s1.t1 to u1;
+go
+grant select on s1.v1 to u1;
+go
+grant execute on s1.p1 to u1;
+go
+grant execute on s1.f1 to u1;
+go
+revoke select on s1.t1 from public;
+go
+revoke insert, delete on s1.t1 from public;
+go
+revoke select on s1.v1 from public;
+go
+revoke execute on s1.p1 from public;
+go
+revoke execute on s1.f1 from public;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 11 [select, insert, delete, execute privilege on these objects to u1]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+grant select, insert, delete, execute on schema::s1 to public;
+go
+grant select, insert, delete, execute on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 12
+-- [select, insert, delete, execute privilege on these objects to u1]
+-- [select, insert, delete, execute privilege on schema to public, u1]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+revoke select, insert, delete, execute on schema::s1 from u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 13
+-- [select, insert, delete, execute privilege on these objects to u1]
+-- [select, insert, delete, execute privilege on schema to public]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+revoke select on s1.t1 from u1;
+go
+revoke insert, delete on s1.t1 from u1;
+go
+revoke select on s1.v1 from u1;
+go
+revoke execute on s1.p1 from u1;
+go
+revoke execute on s1.f1 from u1;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 14
+-- [select, insert, delete, execute privilege on schema to public]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+insert into s1.t1 values (1);
+go
+~~START~~
+varchar
+insert successful
+~~END~~
+
+~~ROW COUNT: 1~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence sq1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+select * from s1.v1;
+go
+~~START~~
+int
+1
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select * from s1.f1()
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+revoke select, insert, delete, execute on schema::s1 from public;
+go
+
+-- tsql user=l1 password=123
+-- Test Group 15 [No privilege on these objects]
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql user=l2 password=123
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+update s1.t1 set a = 2 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+delete from s1.t1 where a = 1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from s1.f1()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+-- Test Group 16 [Cross database queries]
+create database db1;
+go
+use db1
+go
+create user u1 for login l1;
+go
+
+-- create objects in db1 database
+create schema s1;
+go
+create table s1.t1(a int);
+go
+create view s1.v1 as select 2;
+go
+create proc s1.p1 as select 1;
+go
+create function s1.f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql user=l1 password=123
+-- try to access the objects which belong to db1
+use master
+go
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from db1.s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from db1.s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec db1.s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from db1.s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+use db1
+go
+grant select on schema::s1 to u1;
+go
+grant execute on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- try to access the objects which belong to db1
+use master
+go
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from db1.s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+select * from db1.s1.v1;
+go
+~~START~~
+int
+2
+~~END~~
+
+exec db1.s1.p1;
+go
+~~START~~
+int
+1
+~~END~~
+
+select db1.s1.f1(); -- Needs fix [BABEL-4841]
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+revoke select on schema::s1 to u1;
+go
+revoke execute on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- try to access the objects which belong to db1
+use master
+go
+select current_user;
+go
+~~START~~
+varchar
+u1
+~~END~~
+
+select * from db1.s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select * from db1.s1.v1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec db1.s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+select * from db1.s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+
+-- tsql
+-- drop objects
+use db1
+go
+drop table s1.t1;
+go
+drop view s1.v1
+go
+drop procedure s1.p1
+go
+drop function s1.f1
+go
+drop schema s1;
+go
+drop user u1;
+go
+
+use master
+go
+drop database db1
+go
+drop trigger s1.tr1;
+go
+drop trigger s1.tr2;
+go
+drop sequence s1.sq1;
+go
+drop table s1.t1;
+go
+drop table s1.t2;
+go
+drop view s1.v1;
+go
+drop view s1.v2;
+go
+drop procedure s1.p1;
+go
+drop procedure s1.p2;
+go
+drop function s1.f1;
+go
+drop function s1.f2;
+go
+drop schema s1;
+go
+drop user u1;
+go
+drop user u2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login l1;
+go
+
+drop login l2;
+go
+
+-- tsql
+-- Test group 17 [nested tests]
+-- create objects
+create schema s1;
+go
+create schema s2;
+go
+create login l3 with password = '123'
+go
+create user u3 for login l3
+go
+create login l4 with password = '123'
+go
+create user u4 for login l4
+go
+create table s1.t1(a int);
+go
+create view s2.v1 as select a from s1.t1; -- table inside a view
+go
+create proc s2.p1 as select a from s1.t1; -- table inside a proc
+go
+create function s2.f1() returns table as return (select * from s1.t1); -- table inside a function
+go
+create proc s1.p1 as select * from s2.v1; -- view inside a proc
+go
+create function s1.f1() returns table as return (select * from s2.v1); -- view inside a function
+go
+-- calling a user defined stored proc inside a view is not allowed
+-- calling a user defined stored proc inside a function is not allowed
+create view s2.v2 as select * from s1.f1(); -- function inside a view
+go
+create proc s2.p2 as select * from s1.f1(); -- function inside a proc
+go
+create view s1.v3 as select * from s2.v1; -- view inside a view
+go
+create proc s2.p3 as begin exec s1.p1 end; -- procedure inside a procedure
+go
+create function s1.f2() returns int as begin declare @a int set @a = 1 return @a end
+go
+create function s2.f2() returns int as begin declare @a int set @a = (select s1.f2()) return @a end -- function inside a function
+go
+
+-- tsql user=l3 password=123
+-- [u3 and u4 have no privilege]
+select current_user;
+go
+~~START~~
+varchar
+u3
+~~END~~
+
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql user=l4 password=123
+select current_user;
+go
+~~START~~
+varchar
+u4
+~~END~~
+
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+grant select on schema::s1 to u3;
+go
+grant execute on schema::s1 to u3;
+go
+
+-- tsql user=l3 password=123
+-- u3 has select and execute privilege on s1
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~START~~
+int
+~~END~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql user=l4 password=123
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+revoke select on schema::s1 to u3;
+go
+revoke execute on schema::s1 to u3;
+go
+grant select on schema::s2 to u3;
+go
+grant execute on schema::s2 to u3;
+go
+
+-- tsql user=l3 password=123
+-- u3 has select and execute privilege on s2
+select * from s2.v1
+go
+~~START~~
+int
+~~END~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+select s2.f2();
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql user=l4 password=123
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+grant select on schema::s1 to u3;
+go
+grant execute on schema::s1 to u3;
+go
+
+-- tsql user=l3 password=123
+-- u3 has select and execute privilege on s1 and s2
+select * from s2.v1
+go
+~~START~~
+int
+~~END~~
+
+select * from s2.v2
+go
+~~START~~
+int
+~~END~~
+
+select * from s1.v3
+go
+~~START~~
+int
+~~END~~
+
+exec s2.p3;
+go
+~~START~~
+int
+~~END~~
+
+exec s1.p1;
+go
+~~START~~
+int
+~~END~~
+
+exec s2.p1;
+go
+~~START~~
+int
+~~END~~
+
+exec s2.p2;
+go
+~~START~~
+int
+~~END~~
+
+select s1.f1();
+go
+~~START~~
+int
+~~END~~
+
+select s2.f1();
+go
+~~START~~
+int
+~~END~~
+
+select s2.f2();
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql user=l4 password=123
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+revoke select on schema::s2 to u3;
+go
+revoke execute on schema::s2 to u3;
+go
+revoke select on schema::s1 to u3;
+go
+revoke execute on schema::s1 to u3;
+go
+
+-- tsql user=l3 password=123
+-- [u3 and u4 have no privilege]
+select current_user;
+go
+~~START~~
+varchar
+u3
+~~END~~
+
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql user=l4 password=123
+select current_user;
+go
+~~START~~
+varchar
+u4
+~~END~~
+
+select * from s2.v1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v1)~~
+
+select * from s2.v2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v2)~~
+
+select * from s1.v3
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view v3)~~
+
+exec s2.p3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p3)~~
+
+exec s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+
+exec s2.p2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p2)~~
+
+select s1.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f1();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f1)~~
+
+select s2.f2();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function f2)~~
+
+
+-- tsql
+-- drop objects
+use master
+go
+drop view s1.v3;
+go
+drop view s2.v1;
+go
+drop procedure s1.p1;
+go
+drop procedure s2.p1;
+go
+drop view s2.v2;
+go
+drop table s1.t1;
+go
+drop function s1.f1;
+go
+drop function s2.f1;
+go
+drop function s1.f2;
+go
+drop function s2.f2;
+go
+drop procedure s2.p2;
+go
+drop procedure s2.p3;
+go
+drop schema s1;
+go
+drop schema s2;
+go
+drop user u3;
+go
+drop user u4;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l3' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l4' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login l3;
+go
+
+drop login l4;
+go
+
+-- tsql
+-- Test Group 18 [Where grantor is dbo, but it doesn’t have sysadmin role]
+create login l5 with password = '123';
+go
+create login l6 with password = '123';
+go
+alter role sysadmin add member l5;
+go
+
+-- tsql user=l5 password=123
+create database db1
+go
+use db1
+go
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+create schema s1;
+go
+create table s1.t1(a int);
+go
+use master
+go
+
+-- tsql
+alter role sysadmin drop member l5;
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+grant select on schema::s1 to guest;
+go
+use master
+go
+
+-- tsql user=l6 password=123
+use db1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The server principal "l6" is not able to access the database "db1" under the current security context)~~
+
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+grant connect to guest;
+go
+use master
+go
+
+-- tsql user=l6 password=123
+-- connect permission on database, select permission on schema
+use db1
+go
+select * from s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+use master
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+revoke select on schema::s1 from guest
+go
+use master
+go
+
+-- tsql user=l6 password=123
+-- only connect permission on database
+use db1
+go
+select * from s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+use master
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+revoke connect from guest
+go
+use master
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+drop table s1.t1;
+go
+drop schema s1;
+go
+use master
+go
+
+-- tsql
+use master
+go
+drop database db1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l5' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l6' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+drop login l5;
+go
+drop login l6;
+go

--- a/test/JDBC/expected/babel_datatype.out
+++ b/test/JDBC/expected/babel_datatype.out
@@ -3074,3 +3074,7 @@ drop table testing6;
 GO
 drop table test_sysname;
 GO
+drop table s1.test1;
+GO
+drop schema s1;
+GO

--- a/test/JDBC/expected/babelfish_integrity_checker-vu-verify.out
+++ b/test/JDBC/expected/babelfish_integrity_checker-vu-verify.out
@@ -36,6 +36,7 @@ babelfish_domain_mapping
 babelfish_extended_properties
 babelfish_function_ext
 babelfish_namespace_ext
+babelfish_schema_permissions
 babelfish_server_options
 babelfish_sysdatabases
 babelfish_view_def

--- a/test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__14_6__BABEL-guest-before-14_7-or-15_2-vu-verify.out
@@ -54,4 +54,9 @@ guest
 ~~END~~
 
 
+-- tsql
+use babel_2571_db_guest;
+go
 
+drop table guest.babel_2571_table_t1;
+go

--- a/test/JDBC/expected/master__preparation__BABEL-4206-vu-prepare.out
+++ b/test/JDBC/expected/master__preparation__BABEL-4206-vu-prepare.out
@@ -70,3 +70,15 @@ babel_4206_vu_prepare_role1#!#R#!#babel_4206_vu_prepare_user1#!#S
 babel_4206_vu_prepare_role2#!#R#!#babel_4206_vu_prepare_user2#!#S
 ~~END~~
 
+
+GRANT EXECUTE ON babel_4206_vu_prepare_user_ext TO babel_4206_vu_prepare_user2;
+GO
+
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4206_vu_prepare_user2' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+dbo#!#babel_4206_vu_prepare_user_ext#!#128#!#master_babel_4206_vu_prepare_user2#!#p#!##!#master_dbo
+~~END~~
+

--- a/test/JDBC/expected/master__verification_cleanup__BABEL-4206-vu-verify.out
+++ b/test/JDBC/expected/master__verification_cleanup__BABEL-4206-vu-verify.out
@@ -60,3 +60,16 @@ master_babel_4206_vu_prepare_user1#!#babel_4206_vu_prepare_login1#!#S#!#babel_42
 master_babel_4206_vu_prepare_user2#!#babel_4206_vu_prepare_login2#!#S#!#babel_4206_vu_prepare_user2#!#master
 ~~END~~
 
+
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4206_vu_prepare_user2' collate sys.database_default order by object_name;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+dbo#!#babel_4206_vu_prepare_user_ext#!#128#!#master_babel_4206_vu_prepare_user2#!#p#!##!#master_dbo
+~~END~~
+
+
+-- tsql
+REVOKE EXECUTE ON babel_4206_vu_prepare_user_ext FROM babel_4206_vu_prepare_user2;
+GO

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -793,6 +793,20 @@ GO
 DROP TABLE t_unsupported_ft2;
 GO
 
+CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: GRANT inside CREATE SCHEMA is not yet supported in Babelfish.)~~
+
+
+CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: REVOKE inside CREATE SCHEMA is not yet supported in Babelfish.)~~
+
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 ~~START~~

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_datatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_datatype.out
@@ -3074,3 +3074,7 @@ drop table testing6;
 GO
 drop table test_sysname;
 GO
+drop table s1.test1;
+GO
+drop schema s1;
+GO

--- a/test/JDBC/expected/sys-has_perms_by_name-vu-prepare.out
+++ b/test/JDBC/expected/sys-has_perms_by_name-vu-prepare.out
@@ -87,24 +87,3 @@ GO
 
 CREATE USER user_perms_by_name FOR LOGIN user_perms_by_name;
 GO
-
-GRANT ALL ON t_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON [.t perms.by.name.] TO user_perms_by_name;
-GO
-
-GRANT ALL ON [ t.perms by name ] TO user_perms_by_name;
-GO
-
-GRANT ALL ON v_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON scalar_function_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON table_function_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON proc_perms_by_name TO user_perms_by_name;
-GO

--- a/test/JDBC/expected/sys-has_perms_by_name-vu-verify.out
+++ b/test/JDBC/expected/sys-has_perms_by_name-vu-verify.out
@@ -3,6 +3,30 @@
 ALTER LOGIN user_perms_by_name WITH PASSWORD='test';
 GO
 
+USE db_perms_by_name;
+GO
+
+GRANT ALL ON t_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON [.t perms.by.name.] TO user_perms_by_name;
+GO
+
+GRANT ALL ON [ t.perms by name ] TO user_perms_by_name;
+GO
+
+GRANT ALL ON v_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON table_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON proc_perms_by_name TO user_perms_by_name;
+GO
+
 -- tsql user=user_perms_by_name password=test
 USE db_perms_by_name;
 GO
@@ -2866,3 +2890,27 @@ int
 ~~END~~
 
 
+-- tsql
+USE db_perms_by_name;
+GO
+
+REVOKE ALL ON t_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON [.t perms.by.name.] FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON [ t.perms by name ] FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON v_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON scalar_function_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON table_function_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON proc_perms_by_name FROM user_perms_by_name;
+GO

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
@@ -1,0 +1,58 @@
+-- tsql
+-- Cleanup
+
+drop table babel_4768_t1_new
+go
+
+drop table babel_4768_s1.babel_4768_t1_new
+go
+
+drop view babel_4768_v1_new
+go
+
+drop view babel_4768_s1.babel_4768_v1_new
+go
+
+drop proc babel_4768_p1_new
+go
+
+drop proc babel_4768_s1.babel_4768_p1_new
+go
+
+drop proc babel_4768_p2_new
+go
+
+drop proc babel_4768_s1.babel_4768_p2_new
+go
+
+drop FUNCTION babel_4768_f1_new
+go
+
+drop FUNCTION babel_4768_s1.babel_4768_f1_new
+go
+
+drop FUNCTION babel_4768_f2_new
+go
+
+drop FUNCTION babel_4768_s1.babel_4768_f2_new
+go
+
+drop schema babel_4768_s1;
+go
+
+drop user babel_4768_u1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4768_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login babel_4768_l1;
+go

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
@@ -1,0 +1,96 @@
+-- tsql
+create schema babel_4768_s1
+go
+
+create login babel_4768_l1 with password = '12345678'
+go
+
+create user babel_4768_u1 for login babel_4768_l1
+go
+
+create table babel_4768_t1(a int, b int);
+go
+
+create table babel_4768_s1.babel_4768_t1(a int, b int);
+go
+
+create view babel_4768_v1 as select 1;
+go
+
+create view babel_4768_s1.babel_4768_v1 as select 2;
+go
+
+create proc babel_4768_p1 as select 1;
+go
+
+create proc babel_4768_s1.babel_4768_p1 as select 1;
+go
+
+create proc babel_4768_p2 @l datetimeoffset(2) as select 1;
+go
+
+create proc babel_4768_s1.babel_4768_p2 @l datetimeoffset(2) as select 1;
+go
+
+CREATE FUNCTION babel_4768_f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4768_s1.babel_4768_f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4768_f2(@l int) returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4768_s1.babel_4768_f2(@l int) returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql
+-- GRANT individual object access to babel_4768_u1
+GRANT SELECT ON dbo.babel_4768_t1 TO babel_4768_u1
+go
+
+GRANT SELECT ON babel_4768_s1.babel_4768_t1 TO babel_4768_u1
+go
+
+GRANT SELECT ON dbo.babel_4768_v1 TO babel_4768_u1
+go
+
+GRANT SELECT ON babel_4768_s1.babel_4768_v1 TO babel_4768_u1
+go
+
+GRANT EXECUTE ON dbo.babel_4768_p1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_p1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON dbo.babel_4768_p2 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_p2 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON dbo.babel_4768_f1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_f1 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON dbo.babel_4768_f2 TO babel_4768_u1
+GO
+
+GRANT EXECUTE ON babel_4768_s1.babel_4768_f2 TO babel_4768_u1
+GO
+
+GRANT SELECT, EXECUTE ON SCHEMA::dbo TO babel_4768_u1
+GO
+
+GRANT SELECT, EXECUTE ON SCHEMA::babel_4768_s1 TO babel_4768_u1
+GO
+
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default order by object_name;
+go
+
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
@@ -1,0 +1,117 @@
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+-- tsql
+-- rename the objects where permissions are already granted
+sp_rename 'babel_4768_s1.babel_4768_t1', 'babel_4768_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_v1', 'babel_4768_v1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_p1', 'babel_4768_p1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_p2', 'babel_4768_p2_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_f1', 'babel_4768_f1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_s1.babel_4768_f2', 'babel_4768_f2_new', 'OBJECT';
+go
+
+sp_rename 'babel_4768_t1', 'babel_4768_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_v1', 'babel_4768_v1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_p1', 'babel_4768_p1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_p2', 'babel_4768_p2_new', 'OBJECT';
+go
+sp_rename 'babel_4768_f1', 'babel_4768_f1_new', 'OBJECT';
+go
+sp_rename 'babel_4768_f2', 'babel_4768_f2_new', 'OBJECT';
+go
+
+-- psql
+-- catalog should show new object names
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+-- psql
+-- This is needed so that MVU passes
+DO $$
+BEGIN 
+    IF EXISTS (SELECT 1 FROM
+information_schema.tables WHERE
+table_name = 'tbl_creation_should_succeed' AND
+table_schema = 'master_dbo') THEN
+        EXECUTE 'GRANT ALL ON
+master_dbo.tbl_creation_should_succeed TO master_dbo';
+    END IF;
+END $$;
+GO
+
+-- tsql
+REVOKE SELECT, EXECUTE ON SCHEMA::dbo FROM babel_4768_u1
+GO
+
+REVOKE SELECT, EXECUTE ON SCHEMA::babel_4768_s1 FROM babel_4768_u1
+GO
+
+-- psql
+-- catalog entry ALL should be gone now
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+-- tsql
+-- REVOKE individual object access from babel_4768_u1
+REVOKE SELECT ON dbo.babel_4768_t1_new FROM babel_4768_u1
+go
+
+REVOKE SELECT ON babel_4768_s1.babel_4768_t1_new FROM babel_4768_u1
+go
+
+REVOKE SELECT ON dbo.babel_4768_v1_new FROM babel_4768_u1
+go
+
+REVOKE SELECT ON babel_4768_s1.babel_4768_v1_new FROM babel_4768_u1
+go
+
+REVOKE EXECUTE ON babel_4768_p1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_p1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_p2_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_p2_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_f1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_f1_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_f2_new FROM babel_4768_u1
+GO
+
+REVOKE EXECUTE ON babel_4768_s1.babel_4768_f2_new FROM babel_4768_u1
+GO
+
+-- psql
+-- catalog should be empty now
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go
+
+select schema_name, object_name, permission, grantee, object_type, function_args from sys.babelfish_schema_permissions where schema_name = 'dbo' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
+go

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -224,6 +224,12 @@ USE master;
 GO
 
 -- tsql
+USE db1;
+GO
+
+REVOKE SELECT ON dbo.db1_t1 FROM db1_janedoe;
+GO
+
 USE MASTER;
 GO
 
@@ -338,6 +344,12 @@ DROP PROCEDURE p1
 GO
 
 -- tsql
+USE db1;
+GO
+
+DROP TABLE db1_t1;
+GO
+
 USE master;
 GO
 

--- a/test/JDBC/input/BABEL-GRANT.sql
+++ b/test/JDBC/input/BABEL-GRANT.sql
@@ -20,6 +20,10 @@ GO
 ---  Prepare Objects
 ---
 
+---- SCHEMA
+CREATE SCHEMA scm;
+GO
+
 ---- TABLE
 CREATE TABLE t1 ( a int, b int);
 GO
@@ -54,6 +58,18 @@ GO
 ---
 ---  Basic Grant / Revoke
 ---
+
+GRANT SELECT ON SCHEMA::scm TO guest;
+GO
+
+GRANT SELECT ON SCHEMA::scm TO PUBLIC;
+GO
+
+REVOKE SELECT ON SCHEMA::scm FROM PUBLIC;
+GO
+
+GRANT INSERT ON SCHEMA::scm TO guest;
+GO
 
 GRANT ALL ON OBJECT::t1 TO guest WITH GRANT OPTION;
 GO
@@ -145,16 +161,31 @@ GO
 REVOKE ALL TO alogin; -- database permission
 GO
 
-GRANT SHOWPLAN ON OBJECT::t1 TO guest;  -- unsupported permission
+REVOKE SELECT ON SCHEMA::scm FROM guest;
+GO
+
+GRANT showplan ON OBJECT::t1 TO guest;  -- unsupported permission
 GO
 
 REVOKE SHOWPLAN ON OBJECT::t2 TO alogin;  -- unsupported permission
 GO
 
-GRANT ALL ON SCHEMA::scm TO guest;  -- unsupported class
+GRANT ALL ON SCHEMA::scm TO guest;
 GO
 
-REVOKE ALL ON SCHEMA::scm TO guest; -- unsupported class
+REVOKE ALL ON SCHEMA::scm TO guest;
+GO
+
+GRANT create table ON OBJECT::t1 TO guest;  -- unsupported permission
+GO
+
+REVOKE create table ON OBJECT::t2 FROM alogin;  -- unsupported permission
+GO
+
+GRANT SELECT ON table::t1 TO guest; -- unsupported object
+GO
+
+REVOKE SELECT ON table::t1 FROM guest; -- unsupported object
 GO
 
 GRANT ALL ON OBJECT::t1 TO guest WITH GRANT OPTION AS superuser;
@@ -178,6 +209,9 @@ GO
 ---
 ---  Clean Up
 ---
+
+DROP SCHEMA scm;
+GO
 
 DROP VIEW IF EXISTS my_view;
 GO

--- a/test/JDBC/input/BABEL-SESSION.mix
+++ b/test/JDBC/input/BABEL-SESSION.mix
@@ -99,6 +99,21 @@ USE master;
 GO
 
 -- tsql
+USE db1;
+GO
+
+DROP TABLE tb1;
+GO
+
+DROP TABLE janedoe_schema.t1;
+GO
+
+DROP SCHEMA janedoe_schema;
+GO
+
+USE master;
+go
+
 DROP DATABASE db1;
 GO
 

--- a/test/JDBC/input/BABEL-UNSUPPORTED.sql
+++ b/test/JDBC/input/BABEL-UNSUPPORTED.sql
@@ -488,6 +488,12 @@ GO
 DROP TABLE t_unsupported_ft2;
 GO
 
+CREATE SCHEMA t_unsupported_schema GRANT SELECT on schema::t_unsupported_schema TO guest;
+GO
+
+CREATE SCHEMA t_unsupported_schema REVOKE SELECT on schema::t_unsupported_schema TO guest;
+GO
+
 SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO
 

--- a/test/JDBC/input/GRANT_SCHEMA-before-15_7-16_3-vu-cleanup.mix
+++ b/test/JDBC/input/GRANT_SCHEMA-before-15_7-16_3-vu-cleanup.mix
@@ -1,0 +1,66 @@
+-- tsql
+-- Drop objects
+use grant_schema_d1;
+go
+
+drop table grant_schema_s1.grant_schema_t1;
+go
+
+drop table grant_schema_s1.grant_schema_t2;
+go
+
+drop table grant_schema_s1.grant_schema_t3;
+go
+
+drop view grant_schema_s1.grant_schema_v1;
+go
+
+drop view grant_schema_s1.grant_schema_v2;
+go
+
+drop proc grant_schema_s1.grant_schema_p1;
+go
+
+drop proc grant_schema_s1.grant_schema_p2;
+go
+
+drop function grant_schema_s1.grant_schema_f1;
+go
+
+drop function grant_schema_s1.grant_schema_f2;
+go
+
+drop schema grant_schema_s1;
+go
+
+drop table grant_schema_s2.grant_schema_t1;
+go
+
+drop table grant_schema_s2.grant_schema_t2;
+go
+
+drop schema grant_schema_s2;
+go
+
+drop user grant_schema_u1;
+go
+
+use master;
+go
+
+drop database grant_schema_d1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'grant_schema_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login grant_schema_l1;
+go

--- a/test/JDBC/input/GRANT_SCHEMA-before-15_7-16_3-vu-prepare.mix
+++ b/test/JDBC/input/GRANT_SCHEMA-before-15_7-16_3-vu-prepare.mix
@@ -1,0 +1,74 @@
+-- tsql
+-- create objects
+create database grant_schema_d1;
+go
+
+use grant_schema_d1;
+go
+
+create login grant_schema_l1 with password = '12345678'
+go
+
+create user grant_schema_u1 for login grant_schema_l1;
+go
+
+create schema grant_schema_s1;
+go
+
+create table grant_schema_s1.grant_schema_t1(a int);
+go
+
+create table grant_schema_s1.grant_schema_t2(b int);
+go
+
+create table grant_schema_s1.grant_schema_t3(c int);
+go
+
+create view grant_schema_s1.grant_schema_v1 as select 2;
+go
+
+create view grant_schema_s1.grant_schema_v2 as select 2;
+go
+
+create proc grant_schema_s1.grant_schema_p1 as select 2;
+go
+
+create proc grant_schema_s1.grant_schema_p2 as select 2;
+go
+
+CREATE FUNCTION grant_schema_s1.grant_schema_f1() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
+go
+
+CREATE FUNCTION grant_schema_s1.grant_schema_f2() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
+go
+
+create schema grant_schema_s2;
+go
+
+create table grant_schema_s2.grant_schema_t1(a int);
+go
+
+create table grant_schema_s2.grant_schema_t2(a int);
+go
+
+-- GRANT OBJECT privilege
+grant select on grant_schema_s1.grant_schema_t1 to grant_schema_u1;
+go
+grant select on grant_schema_s1.grant_schema_t3 to grant_schema_u1;
+go
+grant select on grant_schema_s1.grant_schema_v1 to grant_schema_u1;
+go
+grant select on grant_schema_s1.grant_schema_v2 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_p1 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_p2 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_f1 to grant_schema_u1;
+go
+grant execute on grant_schema_s1.grant_schema_f2 to grant_schema_u1;
+go
+grant select on grant_schema_s2.grant_schema_t1 to grant_schema_u1;
+go
+grant select on grant_schema_s2.grant_schema_t2 to grant_schema_u1;
+go

--- a/test/JDBC/input/GRANT_SCHEMA-before-15_7-16_3-vu-verify.mix
+++ b/test/JDBC/input/GRANT_SCHEMA-before-15_7-16_3-vu-verify.mix
@@ -1,0 +1,179 @@
+-- tsql user=grant_schema_l1 password=12345678
+-- User has OBJECT privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t1;
+go
+
+select * from grant_schema_s1.grant_schema_t2; -- case 1: has no permission
+go
+
+select * from grant_schema_s1.grant_schema_v1;
+go
+
+exec grant_schema_s1.grant_schema_p1;
+go
+
+select * from grant_schema_s1.grant_schema_f1();
+go
+
+-- tsql
+-- REVOKE OBJECT privilege
+use grant_schema_d1;
+go
+revoke select on grant_schema_s1.grant_schema_t1 from grant_schema_u1;
+go
+revoke select on grant_schema_s1.grant_schema_v1 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_p1 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_f1 from grant_schema_u1;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+-- User has no privileges, should not be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t1;
+go
+
+select * from grant_schema_s1.grant_schema_v1;
+go
+
+exec grant_schema_s1.grant_schema_p1;
+go
+
+select * from grant_schema_s1.grant_schema_f1();
+go
+
+-- tsql
+-- GRANT SCHEMA privilege
+use grant_schema_d1;
+go
+grant select, execute on schema::grant_schema_s1 to grant_schema_u1;
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+-- User has SCHEMA privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t1;
+go
+
+select * from grant_schema_s1.grant_schema_t2;
+go
+
+select * from grant_schema_s1.grant_schema_v1;
+go
+
+exec grant_schema_s1.grant_schema_p1;
+go
+
+select * from grant_schema_s1.grant_schema_f1();
+go
+
+-- User has OBJECT and SCHEMA privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t3;
+go
+
+select * from grant_schema_s1.grant_schema_v2;
+go
+
+exec grant_schema_s1.grant_schema_p2;
+go
+
+select * from grant_schema_s1.grant_schema_f2();
+go
+
+-- tsql
+-- Case 6: User has SCHEMA privilege, REVOKE OBJECT privilege
+use grant_schema_d1;
+go
+revoke select on grant_schema_s1.grant_schema_t3 from grant_schema_u1;
+go
+revoke select on grant_schema_s1.grant_schema_v2 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_p2 from grant_schema_u1;
+go
+revoke execute on grant_schema_s1.grant_schema_f2 from grant_schema_u1;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+-- User has SCHEMA privileges, should be accessible.
+use grant_schema_d1;
+go
+
+select * from grant_schema_s1.grant_schema_t3;
+go
+
+select * from grant_schema_s1.grant_schema_v2;
+go
+
+exec grant_schema_s1.grant_schema_p2;
+go
+
+select * from grant_schema_s1.grant_schema_f2();
+go
+
+-- tsql
+-- User has OBJECT privilege, REVOKE OBJECT privilege
+-- case 7: User has no privileges, should not be accessible. 
+use grant_schema_d1;
+go
+revoke select on grant_schema_s2.grant_schema_t2 from grant_schema_u1;
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+use grant_schema_d1;
+go
+
+select * from grant_schema_s2.grant_schema_t2;
+go
+
+-- tsql
+-- User has OBJECT privilege, REVOKE SCHEMA privilege
+-- case 8: User has OBJECT privileges, would not be accessible. 
+use grant_schema_d1;
+go
+revoke select on schema::grant_schema_s2 from grant_schema_u1; 
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+use grant_schema_d1;
+go
+
+select * from grant_schema_s2.grant_schema_t1;
+go
+
+-- tsql
+-- User has OBJECT privilege, GRANT and REVOKE SCHEMA privilege
+-- case 5: User has OBJECT privileges, would not be accessible. 
+use grant_schema_d1;
+go
+grant  select on schema::grant_schema_s2 to grant_schema_u1;
+go
+
+revoke select on schema::grant_schema_s2 from grant_schema_u1; 
+go
+use master;
+go
+
+-- tsql user=grant_schema_l1 password=12345678
+use grant_schema_d1;
+go
+
+select * from grant_schema_s2.grant_schema_t1;
+go
+

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -1,0 +1,2274 @@
+-- tsql
+-- create objects
+create database babel_4344_d1;
+go
+
+use babel_4344_d1;
+go
+
+create login babel_4344_l1 with password = '12345678'
+go
+
+create user babel_4344_u1 for login babel_4344_l1;
+go
+
+create login αιώνια with password = '12345678'
+go
+
+create user αιώνια for login αιώνια;
+go
+
+create login ログイン with password = '12345678'
+go
+
+create user ログイン for login ログイン;
+go
+
+create schema babel_4344_s1;
+go
+
+create schema "BAbel_4344 S1";
+go
+
+create table "babel_4344 s1"."babel_4344 t1"(a int);
+go
+
+create schema αγάπη;
+go
+
+create schema スキーマ;
+go
+
+create schema babel_4344_s2 authorization babel_4344_u1;
+go
+
+create table babel_4344_t1(a int);
+go
+
+create table babel_4344_s1.babel_4344_t1(a int);
+go
+
+create table babel_4344_s2.babel_4344_t1(a int);
+go
+
+create table αγάπη.abc(a int);
+go
+
+create table スキーマ.abc(a int);
+go
+
+create table babel_4344_t3(a int, b int);
+go
+
+create table babel_4344_s1.babel_4344_t3(a int, b int);
+go
+
+create schema "update pg_class set oid = 0 where relname = 'babel_4344_t1'";
+go
+
+create view babel_4344_v1 as select 1;
+go
+
+create view babel_4344_s1.babel_4344_v1 as select 2;
+go
+
+create proc babel_4344_p1 as select 1;
+go
+
+create proc babel_4344_s1.babel_4344_p1 as select 2;
+go
+
+create proc babel_4344_s1.babel_4344_p3 as select 3;
+go
+
+CREATE FUNCTION babel_4344_f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+CREATE FUNCTION babel_4344_s1.babel_4344_f1() returns int begin declare @a int; set @a = 1; return @a; END
+go
+
+-- tests with greek character (one byte) and japanese character (muti bytes)
+grant SELECT on schema::babel_4344_S1 to public, αιώνια, ログイン;
+go
+
+grant select on schema::αγάπη to αιώνια, ログイン;
+go
+
+grant select on schema::スキーマ to ログイン, αιώνια;
+go
+
+-- test special database roles
+grant SELECT on schema::babel_4344_S1 to db_owner; -- throws an error
+go
+
+grant SELECT on schema::babel_4344_S1 to sys; -- throws an error
+go
+
+grant SELECT on schema::babel_4344_S1 to information_schema; -- throws an error
+go
+
+grant SELECT on schema::babel_4344_S1 to dbo; -- throws an error
+go
+
+-- tsql user=ログイン password=12345678 
+use babel_4344_d1;
+go
+
+select * from αγάπη.abc;
+go
+
+select * from スキーマ.abc;
+go
+
+select * from babel_4344_S1.babel_4344_t1;
+go
+
+use master;
+go
+
+-- tsql user=αιώνια password=12345678 
+use babel_4344_d1;
+go
+
+select * from αγάπη.abc;
+go
+
+select * from スキーマ.abc;
+go
+
+select * from babel_4344_S1.babel_4344_t1;
+go
+
+use master;
+go
+
+-- tsql user=babel_4344_l1 password=12345678 
+use babel_4344_d1;
+go
+
+-- User has select privileges, tables and views be accessible
+select * from babel_4344_s1.babel_4344_t1
+go
+select * from babel_4344_s1.babel_4344_v1;
+go
+use master;
+go
+
+-- tsql
+-- object names having more than 64 bytes
+create schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
+go
+
+create table abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz(a int);
+go
+
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+-- unsupported features
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 with grant option;
+go
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1 cascade;
+go
+
+revoke grant option for select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+grant select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+go
+
+revoke select on abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz from babel_4344_u1;
+go
+
+drop table abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
+go
+
+drop schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
+go
+
+use babel_4344_d1;
+go
+revoke select on schema::babel_4344_s1 from public, αιώνια, ログイン;
+go
+
+-- tsql user=babel_4344_l1 password=12345678 
+use babel_4344_d1;
+go
+
+-- User doesn't have any privileges, objects should not be accessible
+select * from babel_4344_t1;
+go
+select * from babel_4344_s1.babel_4344_t1
+go
+insert into babel_4344_s1.babel_4344_t1 values(1);
+go
+select * from babel_4344_v1;
+go
+select * from babel_4344_s1.babel_4344_v1;
+go
+exec babel_4344_p1;
+go
+exec babel_4344_s1.babel_4344_p1;
+go
+select * from babel_4344_f1();
+go
+select * from babel_4344_s1.babel_4344_f1();
+go
+use master;
+go
+
+-- tsql
+-- GRANT OBJECT privilege
+use babel_4344_d1;
+go
+grant SELECT on schema::"bAbel_4344 s1" to BABEL_4344_U1;
+go
+grant SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" to BABEL_4344_U1;
+go
+grant SELECT on "babel_4344_t1" to BABEL_4344_U1;
+go
+grant SELECT on "babel_4344_s1".babel_4344_t1 to babel_4344_u1;
+go
+grant all on babel_4344_s1.babel_4344_t1 to "babel_4344_u1";
+go
+grant select on babel_4344_t3(a) to babel_4344_u1; -- column privilege
+go
+grant select on babel_4344_s1.babel_4344_t3(a) to babel_4344_u1; -- column privilege
+go
+grant select on babel_4344_v1 to babel_4344_u1;
+go
+grant select on babel_4344_s1.babel_4344_v1 to babel_4344_u1;
+go
+grant execute on babel_4344_p1 to babel_4344_u1;
+go
+grant execute on babel_4344_s1.babel_4344_p1 to babel_4344_u1;
+go
+-- inside a transaction, permission will not be granted since it is rolled back
+begin transaction;
+exec sp_executesql N'grant execute on babel_4344_s1.babel_4344_p3 to babel_4344_u1;';
+rollback transaction;
+go
+
+-- Mixed case
+grant Execute on Babel_4344_F1 to Babel_4344_u1;
+go
+grant execute on BABEL_4344_s1.babel_4344_f1 to babEL_4344_u1;
+go
+-- Grant schema permission to its owner, should fail
+grant select on schema::babel_4344_s2 to babel_4344_u1; -- should fail
+go
+grant select on schema::babel_4344_s2 to jdbc_user; -- should fail
+go
+grant SELECT on schema::"babel_4344_s2" to guest; -- should pass 
+go
+grant select on schema::"" to guest; -- should fail 
+go
+grant select on schema::non_existing_schema to guest; -- should fail 
+go
+-- grant statement via a procedure
+create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
+go
+exec grant_perm_proc; -- should fail, invalid GRANT statement
+go
+-- non-existing role
+grant SELECT on schema::dbo to guest, babel_4344_u3; -- should fail
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has OBJECT privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_t1;
+go
+select * from babel_4344_s1.babel_4344_t1
+go
+insert into babel_4344_s1.babel_4344_t1 values(2);
+go
+select * from babel_4344_t3; -- not accessible, only column privilege is granted
+go
+select * from babel_4344_s1.babel_4344_t3 -- not accessible, only column privilege is granted
+go
+select * from babel_4344_v1;
+go
+select * from babel_4344_s1.babel_4344_v1;
+go
+exec babel_4344_p1;
+go
+exec babel_4344_s1.babel_4344_p1;
+go
+exec babel_4344_s1.babel_4344_p3; -- should fail, grant statement was rolled back
+go
+select * from BABEl_4344_f1();
+go
+select * from babEL_4344_s1.babel_4344_f1();
+go
+-- Grant schema permission to its owner
+grant select on schema::babel_4344_s2 to babel_4344_u1; -- should fail
+go
+grant select on schema::babel_4344_s2 to guest; -- should pass 
+go
+grant select on schema::babel_4344_s1 to babel_4344_u1; -- should fail
+go
+use master;
+go
+
+-- tsql
+-- GRANT SCHEMA privilege
+use babel_4344_d1;
+go
+grant control on schema::babel_4344_s1 to babel_4344_u1; -- should fail, 'control' is not supported
+go
+grant select, insert, execute on schema::babel_4344_s1 to babel_4344_u1;
+go
+use master;
+go
+
+-- psql
+-- GRANT statement add an entry to the catalog
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where schema_name = 'babel_4344_s1' collate "C" order by permission; -- and object_name = 'ALL' collate "C"
+go
+
+-- tsql
+-- GRANT SCHEMA privilege again
+use babel_4344_d1;
+go
+grant select, insert, execute on schema::babel_4344_s1 to babel_4344_u1;
+go
+-- GRANT OBJECT privilege again
+grant select on babel_4344_s1.babel_4344_v1 to babel_4344_u1;
+go
+use master;
+go
+
+-- psql
+-- check the consistency of catalog
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where schema_name = 'babel_4344_s1' collate "C" order by permission;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has OBJECT and SCHEMA privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1
+go
+insert into babel_4344_s1.babel_4344_t1 values(3);
+go
+select * from babel_4344_s1.babel_4344_t3
+go
+select * from babel_4344_s1.babel_4344_v1;
+go
+exec babel_4344_s1.babel_4344_p1;
+go
+select * from babel_4344_s1.babel_4344_f1();
+go
+use master;
+go
+
+-- tsql
+-- REVOKE SCHEMA privilege
+use babel_4344_d1;
+go
+revoke select, insert, execute on schema::babel_4344_s1 from babel_4344_u1;
+go
+use master;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has OBJECT privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1
+go
+insert into babel_4344_s1.babel_4344_t1 values(3); 
+go
+select * from babel_4344_s1.babel_4344_t3 -- not accessible
+go
+select * from babel_4344_s1.babel_4344_v1;
+go
+exec babel_4344_s1.babel_4344_p1;
+go
+select * from babel_4344_s1.babel_4344_f1();
+go
+select * from babel_4344_s2.babel_4344_t1;
+go
+use master;
+go
+
+-- tsql
+-- create new objects in same schema
+use babel_4344_d1;
+go
+-- Grant the permissions again
+grant select, insert, execute on schema::babel_4344_s1 to babel_4344_u1;
+go
+grant select, insert, execute on schema::information_schema to babel_4344_u1;
+go
+create table babel_4344_s1.babel_4344_t2(a int);
+go
+create view babel_4344_s1.babel_4344_v2 as select 2;
+go
+create proc babel_4344_s1.babel_4344_p2 as select 2;
+go
+CREATE FUNCTION babel_4344_s1.babel_4344_f2() RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM sys.objects) END
+go
+use master;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has SCHEMA privileges,objects should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t2
+go
+insert into babel_4344_s1.babel_4344_t1 values(4);
+go
+select * from babel_4344_s1.babel_4344_v2;
+go
+exec babel_4344_s1.babel_4344_p2;
+go
+select * from babel_4344_s1.babel_4344_f2();
+go
+select * from "bAbel_4344 s1"."bAbel_4344 t1";
+go
+use master;
+go
+
+-- tsql
+-- REVOKE OBJECT privileges
+use babel_4344_d1;
+go
+
+REVOKE SELECT on schema::"bAbel_4344 s1" from "BABEL_4344_U1";
+go
+REVOKE SELECT on schema::"update pg_class set oid = 0 where relname = 'babel_4344_t1'" from BABEL_4344_U1;
+go
+GRANT SELECT on babel_4344_t1 to BABEL_4344_U1;
+go
+
+-- psql
+-- should show original object names
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+
+-- tsql
+-- rename the objects where permissions are already granted
+sp_rename 'babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_t1', 'babel_4344_t1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_t3', 'babel_4344_t3_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_v1', 'babel_4344_v1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_p1', 'babel_4344_p1_new', 'OBJECT';
+go
+sp_rename 'babel_4344_s1.babel_4344_f1', 'babel_4344_f1_new', 'OBJECT';
+go
+
+-- psql
+-- should show renamed objects
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default order by object_name;
+go
+
+-- tsql
+-- permissions are transferred to the new objects 
+-- Revoke permissions from the new objects
+REVOKE all on babel_4344_s1.babel_4344_t1_new FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_t3_new(a) FROM babel_4344_u1;
+go
+REVOKE select on babel_4344_s1.babel_4344_v1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_p1_new FROM babel_4344_u1;
+go
+REVOKE execute on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
+go
+REVOKE all on babel_4344_s1.babel_4344_f1_new FROM babel_4344_u1;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has SCHEMA privileges, should be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_t1_new;
+go
+select * from babel_4344_s1.babel_4344_t1_new
+go
+insert into babel_4344_s1.babel_4344_t1_new values(5);
+go
+select * from babel_4344_s1.babel_4344_t3_new;
+go
+select * from babel_4344_s1.babel_4344_v1_new;
+go
+exec babel_4344_s1.babel_4344_p1_new;
+go
+select * from babel_4344_s1.babel_4344_f1_new();
+go
+select * from babel_4344_s2.babel_4344_t1;
+go
+use master;
+go
+
+-- tsql
+-- REVOKE SCHEMA privileges
+use babel_4344_d1;
+go
+revoke select, insert, execute on schema::babel_4344_s1 from babel_4344_u1;
+go
+use master;
+go
+
+-- psql
+-- REVOKE on schema removes the entry from the catalog
+select * from sys.babelfish_schema_permissions where schema_name = 'babel_4344_s1' collate sys.database_default;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+-- User has no privileges, shouldn't be accessible.
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1_new;
+go
+insert into babel_4344_s1.babel_4344_t1_new values(5);
+go
+select * from babel_4344_s1.babel_4344_t3_new;
+go
+select * from babel_4344_s1.babel_4344_v1_new;
+go
+exec babel_4344_s1.babel_4344_p1_new;
+go
+select * from babel_4344_s1.babel_4344_f1_new();
+go
+use master;
+go
+
+-- psql
+-- grant object permission
+grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
+go
+
+-- tsql
+-- grant schema permission
+use babel_4344_d1;
+go
+grant select on schema::babel_4344_s1 to babel_4344_u1;
+go
+use master
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1_new; -- accessible
+go
+use master
+go
+
+-- psql
+-- revoke schema permission
+revoke select on all tables in schema babel_4344_s1 from babel_4344_d1_babel_4344_u1;
+go
+
+-- tsql user=babel_4344_l1 password=12345678
+use babel_4344_d1;
+go
+select * from babel_4344_s1.babel_4344_t1_new; -- not accessible
+go
+use master
+go
+
+-- tsql
+-- Drop objects
+use babel_4344_d1;
+go
+
+drop schema "update pg_class set oid = 0 where relname = 'babel_4344_t1'";
+go
+
+drop table babel_4344_t1_new;
+go
+
+drop table babel_4344_s1.babel_4344_t1_new;
+go
+
+drop table babel_4344_t3;
+go
+
+drop table babel_4344_s1.babel_4344_t3_new;
+go
+
+drop table babel_4344_s1.babel_4344_t2;
+go
+
+drop view babel_4344_v1;
+go
+
+drop view babel_4344_s1.babel_4344_v1_new;
+go
+
+drop view babel_4344_s1.babel_4344_v2;
+go
+
+drop proc babel_4344_p1;
+go
+
+drop proc babel_4344_s1.babel_4344_p1_new;
+go
+
+drop proc babel_4344_s1.babel_4344_p2;
+go
+
+drop proc babel_4344_s1.babel_4344_p3;
+go
+
+drop function babel_4344_f1;
+go
+
+drop function babel_4344_s1.babel_4344_f1_new;
+go
+
+drop function babel_4344_s1.babel_4344_f2;
+go
+
+drop schema babel_4344_s1;
+go
+
+drop table babel_4344_s2.babel_4344_t1;
+go
+
+drop schema babel_4344_s2;
+go
+
+drop table αγάπη.abc;
+go
+
+drop schema αγάπη;
+go
+
+drop table スキーマ.abc;
+go
+
+drop schema スキーマ;
+go
+
+drop table "babel_4344 s1"."babel_4344 t1";
+go
+
+drop schema "BAbel_4344 s1";
+go
+
+drop user babel_4344_u1;
+go
+
+drop user αιώνια;
+go
+
+drop user ログイン;
+go
+
+use master;
+go
+
+drop database babel_4344_d1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4344_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login babel_4344_l1;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'αιώνια' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login αιώνια;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'ログイン' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login ログイン;
+go
+
+-- Test group 1 [guest users and dbo schema]
+-- tsql
+-- create objects
+create login l1 with password = '12345678'
+go
+create table t1(a int);
+go
+create view v1 as select 2;
+go
+create proc p1 as select 1;
+go
+create function f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have no permission
+select current_user;
+go
+select * from dbo.t1;
+go
+select * from dbo.v1;
+go
+exec dbo.p1;
+go
+select * from dbo.f1()
+go
+
+-- tsql
+grant select, execute on schema::dbo to guest;
+go
+create function f2() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have select and EXECUTE permission
+select current_user;
+go
+select * from dbo.t1;
+go
+select * from dbo.v1;
+go
+exec dbo.p1;
+go
+select * from dbo.f1()
+go
+select * from dbo.f2()
+go
+
+-- tsql
+grant select on dbo.t1 to guest;
+go
+grant execute on dbo.f1 to guest;
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have select and EXECUTE permission
+select current_user;
+go
+select * from dbo.t1;
+go
+select * from dbo.v1;
+go
+exec dbo.p1;
+go
+select * from dbo.f1()
+go
+select * from dbo.f2()
+go
+
+-- tsql
+revoke select on dbo.t1 from guest;
+go
+revoke execute on dbo.f1 from guest;
+go
+revoke select, execute on schema::dbo to guest;
+go
+
+-- tsql user=l1 password=12345678
+-- guest user should have no permission
+select current_user;
+go
+select * from dbo.t1;
+go
+select * from dbo.v1;
+go
+exec dbo.p1;
+go
+select * from dbo.f1()
+go
+select * from dbo.f2()
+go
+
+-- tsql
+-- drop objects
+drop table t1;
+go
+drop view v1;
+go
+drop procedure p1;
+go
+drop function f1;
+go
+drop function f2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login l1;
+go
+
+-- Create objects for tests in a user defined schema
+-- tsql
+create schema s1;
+go
+create login l1 with password = '123';
+go
+create user u1 for login l1;
+go
+create login l2 with password = '123';
+go
+create user u2 for login l2;
+go
+create table s1.t1(a int);
+go
+create view s1.v1 as select 1;
+go
+create procedure s1.p1 as select 1;
+go
+create function s1.f1() returns int begin declare @a int; set @a = 1; return @a; end
+go
+create trigger s1.tr1 ON s1.t1 for insert as begin 
+select 'insert successful' end
+go
+create trigger s1.tr2 ON s1.t1 for insert as begin 
+grant select on s1.t1 to u1 end
+go
+create sequence s1.sq1 start with 1 increment by 1 ;
+go
+
+-- Test Group 2 [users have no default permission]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+grant select on schema::s1 to u1;
+go
+grant insert on schema::s1 to u1;
+go
+grant delete on schema::s1 to u1;
+go
+grant update on schema::s1 to u1;
+go
+
+-- Test Group 3 [user u1 has select, insert, update, delete privilege on the schema]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 2;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+grant execute on schema::s1 to u1;
+go
+
+-- Test Group 4 [user u1 has select, insert, update, delete and execute privilege on the schema]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 2;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+-- create new objects in the schema s1
+create table s1.t2(a int);
+go
+create view s1.v2 as select 1;
+go
+create procedure s1.p2 as select 1;
+go
+create function s1.f2() returns int begin declare @a int; set @a = 1; return @a; end
+go
+
+-- Test Group 5 [u1 has select, insert, update, delete and execute privilege on the schema]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t2;
+go
+insert into s1.t2 values (1);
+go
+update s1.t2 set a = 2 where a = 1;
+go
+delete from s1.t2 where a = 2;
+go
+select * from s1.v2;
+go
+exec s1.p2;
+go
+select * from s1.f2()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t2;
+go
+insert into s1.t2 values (1);
+go
+update s1.t2 set a = 2 where a = 1;
+go
+delete from s1.t2 where a = 1;
+go
+select * from s1.v2;
+go
+exec s1.p2;
+go
+select * from s1.f2()
+go
+
+-- tsql
+revoke select on schema::s1 from u1;
+go
+revoke insert on schema::s1 from u1;
+go
+revoke delete on schema::s1 from u1;
+go
+revoke update on schema::s1 from u1;
+go
+
+-- Test Group 6 
+-- [user u1 has execute privilege on the schema, u1 has select privilege on s1.t1 via trigger]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 2;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+select * from s1.t2;
+go
+insert into s1.t2 values (1);
+go
+delete from s1.t2 where a = 1;
+go
+select * from s1.v2;
+go
+exec s1.p2;
+go
+select * from s1.f2()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+select * from s1.t2;
+go
+insert into s1.t2 values (1);
+go
+delete from s1.t2 where a = 1;
+go
+select * from s1.v2;
+go
+exec s1.p2;
+go
+select * from s1.f2()
+go
+
+-- tsql
+revoke execute on schema::s1 from u1;
+go
+
+-- Test Group 7
+-- [user u1 and u2 have no privilege on the schema, u1 has select privilege on table s1.t1 via trigger]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+select * from s1.t2;
+go
+insert into s1.t2 values (1);
+go
+delete from s1.t2 where a = 1;
+go
+select * from s1.v2;
+go
+exec s1.p2;
+go
+select * from s1.f2()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+select * from s1.t2;
+go
+insert into s1.t2 values (1);
+go
+delete from s1.t2 where a = 1;
+go
+select * from s1.v2;
+go
+exec s1.p2;
+go
+select * from s1.f2()
+go
+
+-- tsql
+grant select on s1.t1 to u1;
+go
+grant insert on s1.t1 to u1;
+go
+grant delete on s1.t1 to u1;
+go
+grant select on s1.v1 to u1;
+go
+grant execute on s1.p1 to u1;
+go
+grant execute on s1.f1 to u1;
+go
+
+-- Test Group 8 [user u1 has select, insert, delete, execute privilege on these objects]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+grant select on s1.t1 to PUBLIC;
+go
+grant insert, delete on s1.t1 to PUBLIC;
+go
+grant select on s1.v1 to PUBLIC;
+go
+grant execute on s1.p1 to PUBLIC;
+go
+grant execute on s1.f1 to PUBLIC;
+go
+
+-- Test Group 9 [select, insert, execute privilege on these objects to PUBLIC]
+-- [Also, u1 has select, insert and execute privilege on these objects]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+revoke select on s1.t1 from u1;
+go
+revoke insert, delete on s1.t1 from u1;
+go
+revoke select on s1.v1 from u1;
+go
+revoke execute on s1.p1 from u1;
+go
+revoke execute on s1.f1 from u1;
+go
+
+-- Test Group 10 [select, insert, delete, execute privilege on these objects to PUBLIC]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+grant select on s1.t1 to u1;
+go
+grant insert on s1.t1 to u1;
+go
+grant delete on s1.t1 to u1;
+go
+grant select on s1.v1 to u1;
+go
+grant execute on s1.p1 to u1;
+go
+grant execute on s1.f1 to u1;
+go
+revoke select on s1.t1 from public;
+go
+revoke insert, delete on s1.t1 from public;
+go
+revoke select on s1.v1 from public;
+go
+revoke execute on s1.p1 from public;
+go
+revoke execute on s1.f1 from public;
+go
+
+-- Test Group 11 [select, insert, delete, execute privilege on these objects to u1]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+grant select, insert, delete, execute on schema::s1 to public;
+go
+grant select, insert, delete, execute on schema::s1 to u1;
+go
+
+-- Test Group 12
+-- [select, insert, delete, execute privilege on these objects to u1]
+-- [select, insert, delete, execute privilege on schema to public, u1]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+revoke select, insert, delete, execute on schema::s1 from u1;
+go
+
+-- Test Group 13
+-- [select, insert, delete, execute privilege on these objects to u1]
+-- [select, insert, delete, execute privilege on schema to public]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+revoke select on s1.t1 from u1;
+go
+revoke insert, delete on s1.t1 from u1;
+go
+revoke select on s1.v1 from u1;
+go
+revoke execute on s1.p1 from u1;
+go
+revoke execute on s1.f1 from u1;
+go
+
+-- Test Group 14
+-- [select, insert, delete, execute privilege on schema to public]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql
+revoke select, insert, delete, execute on schema::s1 from public;
+go
+
+-- Test Group 15 [No privilege on these objects]
+-- tsql user=l1 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- tsql user=l2 password=123
+select current_user;
+go
+select * from s1.t1;
+go
+insert into s1.t1 values (1);
+go
+insert into s1.t1 (a) values (next value for s1.sq1);
+go
+update s1.t1 set a = 2 where a = 1;
+go
+delete from s1.t1 where a = 1;
+go
+select * from s1.v1;
+go
+exec s1.p1;
+go
+select * from s1.f1()
+go
+
+-- Test Group 16 [Cross database queries]
+-- tsql
+create database db1;
+go
+use db1
+go
+create user u1 for login l1;
+go
+
+-- create objects in db1 database
+create schema s1;
+go
+create table s1.t1(a int);
+go
+create view s1.v1 as select 2;
+go
+create proc s1.p1 as select 1;
+go
+create function s1.f1() returns int begin declare @a int; set @a = 1; return @a; end 
+go
+
+-- tsql user=l1 password=123
+-- try to access the objects which belong to db1
+use master
+go
+select current_user;
+go
+select * from db1.s1.t1;
+go
+select * from db1.s1.v1;
+go
+exec db1.s1.p1;
+go
+select * from db1.s1.f1();
+go
+
+-- tsql
+use db1
+go
+grant select on schema::s1 to u1;
+go
+grant execute on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- try to access the objects which belong to db1
+use master
+go
+select current_user;
+go
+select * from db1.s1.t1;
+go
+select * from db1.s1.v1;
+go
+exec db1.s1.p1;
+go
+select db1.s1.f1(); -- Needs fix [BABEL-4841]
+go
+
+-- tsql
+revoke select on schema::s1 to u1;
+go
+revoke execute on schema::s1 to u1;
+go
+
+-- tsql user=l1 password=123
+-- try to access the objects which belong to db1
+use master
+go
+select current_user;
+go
+select * from db1.s1.t1;
+go
+select * from db1.s1.v1;
+go
+exec db1.s1.p1;
+go
+select * from db1.s1.f1();
+go
+
+-- tsql
+-- drop objects
+use db1
+go
+drop table s1.t1;
+go
+drop view s1.v1
+go
+drop procedure s1.p1
+go
+drop function s1.f1
+go
+drop schema s1;
+go
+drop user u1;
+go
+
+use master
+go
+drop database db1
+go
+drop trigger s1.tr1;
+go
+drop trigger s1.tr2;
+go
+drop sequence s1.sq1;
+go
+drop table s1.t1;
+go
+drop table s1.t2;
+go
+drop view s1.v1;
+go
+drop view s1.v2;
+go
+drop procedure s1.p1;
+go
+drop procedure s1.p2;
+go
+drop function s1.f1;
+go
+drop function s1.f2;
+go
+drop schema s1;
+go
+drop user u1;
+go
+drop user u2;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login l1;
+go
+
+drop login l2;
+go
+
+-- Test group 17 [nested tests]
+-- create objects
+-- tsql
+create schema s1;
+go
+create schema s2;
+go
+create login l3 with password = '123'
+go
+create user u3 for login l3
+go
+create login l4 with password = '123'
+go
+create user u4 for login l4
+go
+create table s1.t1(a int);
+go
+create view s2.v1 as select a from s1.t1; -- table inside a view
+go
+create proc s2.p1 as select a from s1.t1; -- table inside a proc
+go
+create function s2.f1() returns table as return (select * from s1.t1); -- table inside a function
+go
+create proc s1.p1 as select * from s2.v1; -- view inside a proc
+go
+create function s1.f1() returns table as return (select * from s2.v1); -- view inside a function
+go
+-- calling a user defined stored proc inside a view is not allowed
+-- calling a user defined stored proc inside a function is not allowed
+create view s2.v2 as select * from s1.f1(); -- function inside a view
+go
+create proc s2.p2 as select * from s1.f1(); -- function inside a proc
+go
+create view s1.v3 as select * from s2.v1; -- view inside a view
+go
+create proc s2.p3 as begin exec s1.p1 end; -- procedure inside a procedure
+go
+create function s1.f2() returns int as begin declare @a int set @a = 1 return @a end
+go
+create function s2.f2() returns int as begin declare @a int set @a = (select s1.f2()) return @a end -- function inside a function
+go
+
+-- [u3 and u4 have no privilege]
+-- tsql user=l3 password=123
+select current_user;
+go
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql user=l4 password=123
+select current_user;
+go
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql
+grant select on schema::s1 to u3;
+go
+grant execute on schema::s1 to u3;
+go
+
+-- u3 has select and execute privilege on s1
+-- tsql user=l3 password=123
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql user=l4 password=123
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql
+revoke select on schema::s1 to u3;
+go
+revoke execute on schema::s1 to u3;
+go
+grant select on schema::s2 to u3;
+go
+grant execute on schema::s2 to u3;
+go
+
+-- u3 has select and execute privilege on s2
+-- tsql user=l3 password=123
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql user=l4 password=123
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql
+grant select on schema::s1 to u3;
+go
+grant execute on schema::s1 to u3;
+go
+
+-- u3 has select and execute privilege on s1 and s2
+-- tsql user=l3 password=123
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql user=l4 password=123
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql
+revoke select on schema::s2 to u3;
+go
+revoke execute on schema::s2 to u3;
+go
+revoke select on schema::s1 to u3;
+go
+revoke execute on schema::s1 to u3;
+go
+
+-- [u3 and u4 have no privilege]
+-- tsql user=l3 password=123
+select current_user;
+go
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql user=l4 password=123
+select current_user;
+go
+select * from s2.v1
+go
+select * from s2.v2
+go
+select * from s1.v3
+go
+exec s2.p3;
+go
+exec s1.p1;
+go
+exec s2.p1;
+go
+exec s2.p2;
+go
+select s1.f1();
+go
+select s2.f1();
+go
+select s2.f2();
+go
+
+-- tsql
+-- drop objects
+use master
+go
+drop view s1.v3;
+go
+drop view s2.v1;
+go
+drop procedure s1.p1;
+go
+drop procedure s2.p1;
+go
+drop view s2.v2;
+go
+drop table s1.t1;
+go
+drop function s1.f1;
+go
+drop function s2.f1;
+go
+drop function s1.f2;
+go
+drop function s2.f2;
+go
+drop procedure s2.p2;
+go
+drop procedure s2.p3;
+go
+drop schema s1;
+go
+drop schema s2;
+go
+drop user u3;
+go
+drop user u4;
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l3' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l4' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login l3;
+go
+
+drop login l4;
+go
+
+-- Test Group 18 [Where grantor is dbo, but it doesn’t have sysadmin role]
+-- tsql
+create login l5 with password = '123';
+go
+create login l6 with password = '123';
+go
+alter role sysadmin add member l5;
+go
+
+-- tsql user=l5 password=123
+create database db1
+go
+use db1
+go
+select current_user
+go
+create schema s1;
+go
+create table s1.t1(a int);
+go
+use master
+go
+
+-- tsql
+alter role sysadmin drop member l5;
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+grant select on schema::s1 to guest;
+go
+use master
+go
+
+-- tsql user=l6 password=123
+use db1
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+grant connect to guest;
+go
+use master
+go
+
+-- connect permission on database, select permission on schema
+-- tsql user=l6 password=123
+use db1
+go
+select * from s1.t1;
+go
+use master
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+revoke select on schema::s1 from guest
+go
+use master
+go
+
+-- only connect permission on database
+-- tsql user=l6 password=123
+use db1
+go
+select * from s1.t1;
+go
+use master
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+select current_user
+go
+revoke connect from guest
+go
+use master
+go
+
+-- tsql user=l5 password=123
+use db1
+go
+drop table s1.t1;
+go
+drop schema s1;
+go
+use master
+go
+
+-- tsql
+use master
+go
+drop database db1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l5' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'l6' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+
+-- tsql
+drop login l5;
+go
+drop login l6;
+go

--- a/test/JDBC/input/babel_datatype.sql
+++ b/test/JDBC/input/babel_datatype.sql
@@ -1209,3 +1209,7 @@ drop table testing6;
 GO
 drop table test_sysname;
 GO
+drop table s1.test1;
+GO
+drop schema s1;
+GO

--- a/test/JDBC/input/functions/sys-has_perms_by_name-vu-prepare.mix
+++ b/test/JDBC/input/functions/sys-has_perms_by_name-vu-prepare.mix
@@ -87,24 +87,3 @@ GO
 
 CREATE USER user_perms_by_name FOR LOGIN user_perms_by_name;
 GO
-
-GRANT ALL ON t_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON [.t perms.by.name.] TO user_perms_by_name;
-GO
-
-GRANT ALL ON [ t.perms by name ] TO user_perms_by_name;
-GO
-
-GRANT ALL ON v_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON scalar_function_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON table_function_perms_by_name TO user_perms_by_name;
-GO
-
-GRANT ALL ON proc_perms_by_name TO user_perms_by_name;
-GO

--- a/test/JDBC/input/functions/sys-has_perms_by_name-vu-verify.mix
+++ b/test/JDBC/input/functions/sys-has_perms_by_name-vu-verify.mix
@@ -4,6 +4,30 @@
 ALTER LOGIN user_perms_by_name WITH PASSWORD='test';
 GO
 
+USE db_perms_by_name;
+GO
+
+GRANT ALL ON t_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON [.t perms.by.name.] TO user_perms_by_name;
+GO
+
+GRANT ALL ON [ t.perms by name ] TO user_perms_by_name;
+GO
+
+GRANT ALL ON v_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON scalar_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON table_function_perms_by_name TO user_perms_by_name;
+GO
+
+GRANT ALL ON proc_perms_by_name TO user_perms_by_name;
+GO
+
 -- tsql user=user_perms_by_name password=test
 USE db_perms_by_name;
 GO
@@ -1317,3 +1341,27 @@ GO
 SELECT HAS_PERMS_BY_NAME('".non existent.schema.".[non .. existent table]', 'OBJECT', 'SELECT', '[. non. existent.column]', 'COLUMN');
 GO
 
+-- tsql
+USE db_perms_by_name;
+GO
+
+REVOKE ALL ON t_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON [.t perms.by.name.] FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON [ t.perms by name ] FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON v_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON scalar_function_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON table_function_perms_by_name FROM user_perms_by_name;
+GO
+
+REVOKE ALL ON proc_perms_by_name FROM user_perms_by_name;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -43,6 +43,9 @@ ignore#!#sys-types-before-dep-vu-cleanup
 ignore#!#sys-table_types-before-dep-vu-prepare
 ignore#!#sys-table_types-before-dep-vu-verify
 ignore#!#sys-table_types-before-dep-vu-cleanup
+ignore#!#GRANT_SCHEMA-before-15_7-16_3-vu-prepare
+ignore#!#GRANT_SCHEMA-before-15_7-16_3-vu-verify
+ignore#!#GRANT_SCHEMA-before-15_7-16_3-vu-cleanup
 ignore#!#BABEL_4553-vu-prepare
 ignore#!#BABEL_4553-vu-verify
 

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -335,3 +335,5 @@ BABEL-2999
 drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
+babel-4517

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -334,3 +334,4 @@ drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
 babel-4517
+GRANT_SCHEMA-before-15_7-16_3

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -426,6 +426,7 @@ sys-parsename-before-15_6-or-16_1
 permission_restrictions_from_pg
 BABEL-4529-before-15_6-or-14_11
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
 babel-4475
 babel-3254
 babel-4517

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -351,4 +351,5 @@ BABEL-2999
 drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
 babel-4517

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -366,4 +366,5 @@ BABEL-2999
 drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
 babel-4517

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -401,4 +401,5 @@ BABEL-2999
 drop_index-before-15_6-or-16_2
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
 babel-4517

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -430,5 +430,6 @@ BABEL-4606
 BABEL-4672
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
 babel-4475
 babel-4517

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -465,4 +465,5 @@ BABEL-4606
 BABEL-4672
 permission_restrictions_from_pg
 BABEL-730-before-15_6-or-16_1
+GRANT_SCHEMA-before-15_7-16_3
 babel-4517

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -496,3 +496,4 @@ BABEL-730-before-15_6-or-16_1
 babel-3254
 babel-4517
 BABEL-492-before-15_6
+GRANT_SCHEMA-before-15_7-16_3

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -506,3 +506,4 @@ sys_availability_replicas
 BABEL-730
 babel-4475
 babel-4517
+GRANT_SCHEMA-before-15_7-16_3

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -498,3 +498,4 @@ BABEL-730-before-15_6-or-16_1
 babel-4475
 babel-4517
 BABEL_4553
+GRANT_SCHEMA-before-15_7-16_3

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -513,3 +513,4 @@ BABEL-730
 babel-4475
 babel-3254
 babel-4517
+GRANT_SCHEMA-before-15_7-16_3

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -514,3 +514,4 @@ BABEL-730
 babel-4475
 babel-3254
 babel-4517
+1_GRANT_SCHEMA

--- a/test/JDBC/upgrade/latest/verification_cleanup/14_6/BABEL-guest-before-14_7-or-15_2-vu-verify.mix
+++ b/test/JDBC/upgrade/latest/verification_cleanup/14_6/BABEL-guest-before-14_7-or-15_2-vu-verify.mix
@@ -35,4 +35,9 @@ go
 select schema_name()
 go
 
+-- tsql
+use babel_2571_db_guest;
+go
 
+drop table guest.babel_2571_table_t1;
+go

--- a/test/JDBC/upgrade/master/preparation/BABEL-4206-vu-prepare.mix
+++ b/test/JDBC/upgrade/master/preparation/BABEL-4206-vu-prepare.mix
@@ -55,3 +55,10 @@ GO
 -- show role membership
 EXEC babel_4206_vu_prepare_role_members;
 GO
+
+GRANT EXECUTE ON babel_4206_vu_prepare_user_ext TO babel_4206_vu_prepare_user2;
+GO
+
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4206_vu_prepare_user2' collate sys.database_default order by object_name;
+go

--- a/test/JDBC/upgrade/master/verification_cleanup/BABEL-4206-vu-verify.mix
+++ b/test/JDBC/upgrade/master/verification_cleanup/BABEL-4206-vu-verify.mix
@@ -31,3 +31,11 @@ GO
 -- again check updated users
 EXEC babel_4206_vu_prepare_user_ext;
 GO
+
+-- psql
+select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4206_vu_prepare_user2' collate sys.database_default order by object_name;
+go
+
+-- tsql
+REVOKE EXECUTE ON babel_4206_vu_prepare_user_ext FROM babel_4206_vu_prepare_user2;
+GO


### PR DESCRIPTION
## Description
Supported GRANT/REVOKE .. ON SCHEMA .. in Babelfish 
Supported syntax GRANT ON SCHEMA::<schema_name> TO <user_name> 
Supported syntax REVOKE ON SCHEMA::<schema_name> TO/FROM <user_name>

We have introduced a catalog sys.babelfish_schema_permission to hold the information about objects and its permissions.

GRANT on schema/objects add/update a row in the catalog table if does not exist already. 
REVOKE on schema/objects removes/update the corresponding row in the catalog table if it exists already. 
Drop statement for OBJECT/SCHEMA removes all the relevant object entries from the catalog.

sp_rename updates the object name in sys.babelfish_schema_permission catalog so that the permission is tracked correctly in the catalogs

Added metadata check for schema permissions catalog

GRANT/REVOKE ... ON ... SCHEMA ... WITH GRANT OPTION/CASCADE does not work as expected -> Throw unsupported error 
CREATE SCHEMA ... GRANT ... ON ... SCHEMA throws syntax error -> Throw unsupported error 
REVOKE GRANT OPTION FOR ... ON SCHEMA should be unsupported in Babelfish

Specific to Upgrade: The catalogs will not track the permissions granted on the OBJECTs on the earlier versions.

## Issues Resolved
Task: BABEL-4344, BABEL-4775, BABEL-4485, BABEL-4739, BABEL-4738, BABEL-4758

Signed-off-by: Shalini Lohia lshalini@amazon.com

