### PR TITLE
Support Babelfish schema-only and data-only dump/restore (#2426)

### DIFF
--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -29,6 +29,10 @@ inputs:
   dump_format:
     description: "Dump format (plain/custom/tar/directory)"
     required: true
+  type:
+    description: "Dump type full or combination of schema-only and data-only"
+    required: false
+    default: 'full'
 
 runs:
   using: "composite"
@@ -59,15 +63,24 @@ runs:
           export DUMP_OPTS=''
         fi
         export DUMP_OPTS="$DUMP_OPTS --format=${{ inputs.dump_format }}"
+        export DUMPALL_OPTS=""
 
-        if [[ '${{ inputs.logical_database }}' == 'null' ]];then
-          echo 'Starting to dump whole Babelfish physical database'
-          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --verbose --no-role-passwords -f pg_dump_globals.sql 2>>error.log
+        if [[ '${{ inputs.logical_database }}' != 'null' ]];then
+          export DUMP_OPTS="$DUMP_OPTS --bbf-database-name=${{ inputs.logical_database }}"
+          export DUMPALL_OPTS="$DUMPALL_OPTS --bbf-database-name=${{ inputs.logical_database }}"
+        fi
+
+        echo 'Starting to dump the Babelfish database'
+        if [[ '${{ inputs.type }}' == 'full' ]];then
+          # Perform the complete dump
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user $DUMPALL_OPTS --roles-only --quote-all-identifiers --verbose --no-role-passwords -f pg_dump_globals.sql 2>>error.log
           ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --verbose --file="pg_dump.archive" --dbname=jdbc_testdb 2>>error.log
         else
-          echo "Starting to dump Babelfish logical database ${{ inputs.logical_database }}"
-          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --verbose --no-role-passwords --bbf-database-name='${{ inputs.logical_database }}' -f pg_dump_globals.sql 2>>error.log
-          ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --verbose --bbf-database-name='${{ inputs.logical_database }}' --file="pg_dump.archive" --dbname=jdbc_testdb 2>>error.log
+          # First perform the schema-only dump and then perform the data-only dump to produce a complete dump
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user $DUMPALL_OPTS --roles-only --quote-all-identifiers --schema-only --verbose --no-role-passwords -f pg_dump_globals_so.sql 2>>error.log
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --verbose --file="pg_dump_so.archive" --dbname=jdbc_testdb 2>>error.log
+
+          ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --verbose --file="pg_dump_do.archive" --dbname=jdbc_testdb 2>>error.log
         fi
 
         # Stop old server and start the new.
@@ -78,14 +91,30 @@ runs:
 
         # Create and initialise Babelfish extensions in the new server to perform restore.
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -v tsql_port="1433" -f .github/scripts/create_extension.sql
-        echo 'Restoring from pg_dumpall'
-        sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump_globals.sql 2>> ~/upgrade/error.log
-        echo 'Restoring from pg_dump'
-        if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump.archive 2>> ~/upgrade/error.log
+
+        echo 'Starting to restore the Babelfish database'
+        if [[ '${{ inputs.type }}' == 'full' ]];then
+          echo 'Restoring from pg_dumpall'
+          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump_globals.sql 2>> ~/upgrade/error.log
+          echo 'Restoring from pg_dump'
+          if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
+            sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump.archive 2>> ~/upgrade/error.log
+          else
+            ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/pg_dump.archive 2>> ~/upgrade/error.log
+          fi
         else
-          ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/pg_dump.archive 2>> ~/upgrade/error.log
+          echo 'Restoring from pg_dumpall'
+          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump_globals_so.sql 2>> ~/upgrade/error.log
+          echo 'Restoring from pg_dump'
+          if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
+            sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump_so.archive 2>> ~/upgrade/error.log
+            sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/pg_dump_do.archive 2>> ~/upgrade/error.log
+          else
+            ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/pg_dump_so.archive 2>> ~/upgrade/error.log
+            ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/pg_dump_do.archive 2>> ~/upgrade/error.log
+          fi
         fi
+        echo 'Database restore complete.'
 
         export PATH=/opt/mssql-tools/bin:$PATH
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"

--- a/.github/composite-actions/setup-dump-restore-ca/action.yml
+++ b/.github/composite-actions/setup-dump-restore-ca/action.yml
@@ -49,12 +49,14 @@ runs:
           dump_data_as=$(yq $dump_data_as_var ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml)
           dump_format_var=".\"dump-restore-version\"[${{ matrix.upgrade-path.id }}][$i].\"dump-format\""
           dump_format=$(yq $dump_format_var ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml)
+          type_var=".\"dump-restore-version\"[${{ matrix.upgrade-path.id }}][$i].\"type\""
+          type=$(yq $type_var ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml)
 
           if [[ $logical_database == 'null' ]]
           then
-            printf "    - name: Dump and Restore to version $dump_restore_version\n      id: dump-restore-version-$i\n      if: always() $temp\n      uses: ${uses_file}\n      with: \n        engine_branch: ${engine_branch}\n        extension_branch: ${extension_branch}\n        is_final_ver: ${is_final_ver}\n        pg_old_dir: ${pg_old_dir}\n        pg_new_dir: ${pg_new_dir}\n        migration_mode: 'multi-db'\n        dump_data_as: ${dump_data_as}\n        dump_format: ${dump_format}\n\n"   >> $dump_restore_version_dir_path/action.yml
+            printf "    - name: Dump and Restore to version $dump_restore_version\n      id: dump-restore-version-$i\n      if: always() $temp\n      uses: ${uses_file}\n      with: \n        engine_branch: ${engine_branch}\n        extension_branch: ${extension_branch}\n        is_final_ver: ${is_final_ver}\n        pg_old_dir: ${pg_old_dir}\n        pg_new_dir: ${pg_new_dir}\n        migration_mode: 'multi-db'\n        dump_data_as: ${dump_data_as}\n        dump_format: ${dump_format}\n        type: ${type}\n\n"   >> $dump_restore_version_dir_path/action.yml
           else
-            printf "    - name: Dump and Restore to version $dump_restore_version\n      id: dump-restore-version-$i\n      if: always() $temp\n      uses: ${uses_file}\n      with: \n        engine_branch: ${engine_branch}\n        extension_branch: ${extension_branch}\n        is_final_ver: ${is_final_ver}\n        pg_old_dir: ${pg_old_dir}\n        pg_new_dir: ${pg_new_dir}\n        migration_mode: 'multi-db'\n        logical_database: ${logical_database}\n        dump_data_as: ${dump_data_as}\n        dump_format: ${dump_format}\n\n"   >> $dump_restore_version_dir_path/action.yml
+            printf "    - name: Dump and Restore to version $dump_restore_version\n      id: dump-restore-version-$i\n      if: always() $temp\n      uses: ${uses_file}\n      with: \n        engine_branch: ${engine_branch}\n        extension_branch: ${extension_branch}\n        is_final_ver: ${is_final_ver}\n        pg_old_dir: ${pg_old_dir}\n        pg_new_dir: ${pg_new_dir}\n        migration_mode: 'multi-db'\n        logical_database: ${logical_database}\n        dump_data_as: ${dump_data_as}\n        dump_format: ${dump_format}\n        type: ${type}\n\n"   >> $dump_restore_version_dir_path/action.yml
           fi
 
           previous_installed_version=$dump_restore_version

--- a/.github/configuration/dump-restore-test-configuration.yml
+++ b/.github/configuration/dump-restore-test-configuration.yml
@@ -3,13 +3,31 @@ dump-restore-version: [[
     version: source.latest,
     dump-data-as: copy,
     dump-format: plain,
-    logical-database: null
+    logical-database: null,
+    type: full
   },
   {
     version: target.latest,
     dump-data-as: copy,
     dump-format: plain,
-    logical-database: null
+    logical-database: null,
+    type: full
+  }
+],
+[
+  {
+    version: source.latest,
+    dump-data-as: copy,
+    dump-format: plain,
+    logical-database: null,
+    type: schema-cum-data-only
+  },
+  {
+    version: target.latest,
+    dump-data-as: copy,
+    dump-format: plain,
+    logical-database: null,
+    type: schema-cum-data-only
   }
 ],
 [
@@ -17,13 +35,15 @@ dump-restore-version: [[
     version: source.latest,
     dump-data-as: copy,
     dump-format: custom,
-    logical-database: master
+    logical-database: master,
+    type: full
   },
   {
     version: target.latest,
     dump-data-as: copy,
     dump-format: custom,
-    logical-database: master
+    logical-database: master,
+    type: full
   }
 ],
 [
@@ -31,13 +51,31 @@ dump-restore-version: [[
     version: source.latest,
     dump-data-as: inserts,
     dump-format: tar,
-    logical-database: null
+    logical-database: null,
+    type: full
   },
   {
     version: target.latest,
     dump-data-as: inserts,
     dump-format: tar,
-    logical-database: null
+    logical-database: null,
+    type: full
+  }
+],
+[
+  {
+    version: source.latest,
+    dump-data-as: inserts,
+    dump-format: custom,
+    logical-database: master,
+    type: schema-cum-data-only
+  },
+  {
+    version: target.latest,
+    dump-data-as: inserts,
+    dump-format: custom,
+    logical-database: master,
+    type: schema-cum-data-only
   }
 ],
 [
@@ -45,13 +83,15 @@ dump-restore-version: [[
     version: source.latest,
     dump-data-as: inserts,
     dump-format: directory,
-    logical-database: master
+    logical-database: master,
+    type: full
   },
   {
     version: target.latest,
     dump-data-as: inserts,
     dump-format: directory,
-    logical-database: master
+    logical-database: master,
+    type: full
   }
 ],
 [
@@ -59,12 +99,14 @@ dump-restore-version: [[
     version: source.latest,
     dump-data-as: copy,
     dump-format: plain,
-    logical-database: database_1
+    logical-database: database_1,
+    type: full
   },
   {
     version: target.latest,
     dump-data-as: copy,
     dump-format: plain,
-    logical-database: database_1
+    logical-database: database_1,
+    type: full
   }
 ]]

--- a/.github/workflows/pg_dump-restore-test.yml
+++ b/.github/workflows/pg_dump-restore-test.yml
@@ -20,7 +20,8 @@ jobs:
           title: (itm[itm.length - 1]['logical-database'] == null ? 'Instance-level-' : 'Database-level-' + '(' + itm[itm.length - 1]['logical-database'] + ')') + itm.map(i => i.version.toString().replace(/[.]/g, \"_\")).join(\"-\"), \
           last_version: itm[itm.length - 1].version.toString().replace(/[.]/g, \"_\"), \
           dump_method: itm[itm.length - 1]['dump-data-as'] == 'copy' ? 'COPY' : 'INSERTS', \
-          dump_format: itm[itm.length - 1]['dump-format']})); \
+          dump_format: itm[itm.length - 1]['dump-format'], \
+          type: itm[itm.length - 1]['type']})); \
           console.log(JSON.stringify(p));")
           echo "::set-output name=dump-restore-path-list::$DUMP_RESTORE_PATH_LIST"
 
@@ -30,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         upgrade-path: ${{ fromJson(needs.generate-dump-restore-tests.outputs.dump-restore-path-list) }}
-    name: Dump Restore Test using ${{ matrix.upgrade-path.dump_method }} for ${{ matrix.upgrade-path.title }} - format=${{ matrix.upgrade-path.dump_format }}
+    name: Dump Restore Test using ${{ matrix.upgrade-path.dump_method }} for ${{ matrix.upgrade-path.title }} - format=${{ matrix.upgrade-path.dump_format }} - type=${{ matrix.upgrade-path.type }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -135,7 +136,7 @@ jobs:
         if: always() && (steps.setup-base-version.outcome == 'failure' || steps.dump-restore-and-test.outcome == 'failure')
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade-logs-${{ matrix.upgrade-path.dump_method }}-${{ matrix.upgrade-path.title }}-${{ matrix.upgrade-path.dump_format }}
+          name: dump-restore-logs-${{ matrix.upgrade-path.dump_method }}-${{ matrix.upgrade-path.title }}-${{ matrix.upgrade-path.dump_format }}-${{ matrix.upgrade-path.type }}
           path: |
             ~/upgrade/*
             ~/psql*/data/logfile

--- a/test/JDBC/expected/binary-index-vu-prepare.out
+++ b/test/JDBC/expected/binary-index-vu-prepare.out
@@ -42,9 +42,6 @@ GO
 ~~ROW COUNT: 1~~
 
 
-create index ix_tab_binary_b on tab_varbinary (a)
-GO
-
 create procedure babel_3939_vu_prepare_p2 AS BEGIN
 select * from tab_varbinary where a = 0xBAADF00D;
 select * from tab_varbinary where a = cast(0xBAADF00D as binary);

--- a/test/JDBC/expected/binary-index-vu-verify.out
+++ b/test/JDBC/expected/binary-index-vu-verify.out
@@ -1,3 +1,6 @@
+create index ix_tab_binary_b on tab_varbinary (a)
+GO
+
 select set_config('enable_bitmapscan', 'off', false);
 GO
 ~~START~~

--- a/test/JDBC/expected/parallel_query/binary-index-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/binary-index-vu-verify.out
@@ -1,3 +1,6 @@
+create index ix_tab_binary_b on tab_varbinary (a)
+GO
+
 select set_config('enable_bitmapscan', 'off', false);
 GO
 ~~START~~

--- a/test/JDBC/input/binary-index-vu-prepare.mix
+++ b/test/JDBC/input/binary-index-vu-prepare.mix
@@ -34,9 +34,6 @@ insert into tab_varbinary
 values (0xBAADF00D, 1234)
 GO
 
-create index ix_tab_binary_b on tab_varbinary (a)
-GO
-
 create procedure babel_3939_vu_prepare_p2 AS BEGIN
 select * from tab_varbinary where a = 0xBAADF00D;
 select * from tab_varbinary where a = cast(0xBAADF00D as binary);

--- a/test/JDBC/input/binary-index-vu-verify.sql
+++ b/test/JDBC/input/binary-index-vu-verify.sql
@@ -1,4 +1,7 @@
 -- parallel_query_expected
+create index ix_tab_binary_b on tab_varbinary (a)
+GO
+
 select set_config('enable_bitmapscan', 'off', false);
 GO
 


### PR DESCRIPTION
### Description
This commit adds github actions to test Babelfish schema-only and data-only dump/restore.
Actual underlying issues are fixed in the engine.
Engine PR: babelfish-for-postgresql/postgresql_modified_for_babelfish#326

Tasks: BABEL-4764, BABEL-4765
Signed-off-by: Rishabh Tanwar ritanwar@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).