### PR TITLE
Fix the issue that insert exec not correctly resolve schema name (#2438)

### DIFF
--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -90,11 +90,22 @@ rewrite_object_refs(Node *stmt)
 		case T_DeleteStmt:
 		case T_InsertStmt:
 			{
+				/*
+				 * For INSERT ... EXECUTE, rewrite the schema name
+				*/
+				if ((nodeTag(stmt) == T_InsertStmt && ((InsertStmt *)stmt)->execStmt)
+					&& nodeTag(((InsertStmt *)stmt)->execStmt) == T_CallStmt)
+				{
+					CallStmt   *call = (CallStmt *) ((InsertStmt *)stmt)->execStmt;
+					call->funccall->funcname = rewrite_plain_name(call->funccall->funcname);
+				}
+
 				/* walker supported stmts */
 				raw_expression_tree_walker(stmt,
 										   rewrite_relation_walker,
 										   (void *) NULL);
 				break;
+
 			}
 		case T_AlterTableStmt:
 			{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1689,6 +1689,29 @@ public:
 			ctx->insert_statement()->insert_statement_value() &&
 			ctx->insert_statement()->insert_statement_value()->execute_statement();
 
+		if (stmt->insert_exec)
+		{
+			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
+			TSqlParser::Execute_bodyContext *body = nullptr;
+
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			body = ctxES->execute_body();
+			Assert(body);
+			
+			ctx_name       = body->func_proc_name_server_database_schema();
+			if (ctx_name) 
+			{				
+				if (ctx_name->database)
+				{
+					db_name = stripQuoteFromId(ctx_name->database);
+					if (!string_matches(db_name.c_str(), get_cur_db_name()))
+					{
+						is_cross_db = true;
+					}
+				}
+			}
+		}
+
 		// record whether stmt is cross-db
 		if (is_cross_db)
 			stmt->is_cross_db = true;

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
@@ -161,9 +161,7 @@ GO
 INSERT INTO dbo.babel_cross_db_vu_prepare_db1_t1 (a)
 EXECUTE master.dbo.babel_cross_db_vu_prepare_master_p1;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cross-database references are not implemented: master.dbo.babel_cross_db_vu_prepare_master_p1)~~
+~~ROW COUNT: 4~~
 
 
 EXECUTE master.dbo.babel_cross_db_vu_prepare_master_p1;

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -210,9 +210,7 @@ GO
 INSERT INTO dbo.db1_t1 (a)
 EXECUTE master.dbo.master_p1;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cross-database references are not implemented: master.dbo.master_p1)~~
+~~ROW COUNT: 4~~
 
 
 EXECUTE master.dbo.master_p1;

--- a/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
@@ -702,6 +702,49 @@ int
 ~~END~~
 
 
+create schema user_defined_sch;
+go
+
+create type user_defined_sch.test_tbl_type as table (a int, b varchar(10))
+go
+
+create table user_defined_sch.test_tbl (a int, b varchar(10))
+go
+
+insert into user_defined_sch.test_tbl values (1, 'AAA'), (2, 'Bbb');
+go
+~~ROW COUNT: 2~~
+
+
+create procedure user_defined_sch.test_proc
+as
+begin
+    select * from user_defined_sch.test_tbl;
+end;
+go
+
+exec user_defined_sch.test_proc
+go
+~~START~~
+int#!#varchar
+1#!#AAA
+2#!#Bbb
+~~END~~
+
+
+declare @tbl_var user_defined_sch.test_tbl_type
+insert into @tbl_var (a,b) exec user_defined_sch.test_proc
+select * from @tbl_var
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#varchar
+1#!#AAA
+2#!#Bbb
+~~END~~
+
+
 -- clean up
 drop table t1
 go
@@ -729,4 +772,12 @@ go
 drop procedure sp_select_mismatch_after_subtran
 go
 drop procedure sp_select_param
+go
+drop procedure user_defined_sch.test_proc
+go
+drop table user_defined_sch.test_tbl
+go
+drop type user_defined_sch.test_tbl_type
+go
+drop schema user_defined_sch
 go

--- a/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
@@ -242,6 +242,33 @@ insert into @a execute('select * from t1; select 3');
 select * from @a;
 go
 
+create schema user_defined_sch;
+go
+
+create type user_defined_sch.test_tbl_type as table (a int, b varchar(10))
+go
+
+create table user_defined_sch.test_tbl (a int, b varchar(10))
+go
+
+insert into user_defined_sch.test_tbl values (1, 'AAA'), (2, 'Bbb');
+go
+
+create procedure user_defined_sch.test_proc
+as
+begin
+    select * from user_defined_sch.test_tbl;
+end;
+go
+
+exec user_defined_sch.test_proc
+go
+
+declare @tbl_var user_defined_sch.test_tbl_type
+insert into @tbl_var (a,b) exec user_defined_sch.test_proc
+select * from @tbl_var
+go
+
 -- clean up
 drop table t1
 go
@@ -269,4 +296,12 @@ go
 drop procedure sp_select_mismatch_after_subtran
 go
 drop procedure sp_select_param
+go
+drop procedure user_defined_sch.test_proc
+go
+drop table user_defined_sch.test_tbl
+go
+drop type user_defined_sch.test_tbl_type
+go
+drop schema user_defined_sch
 go


### PR DESCRIPTION
In insert into exec, it can't correctly resolve user defined schema name, and the reason is pre analyze didn't visit the exec part of insert in resolve the correct schema name. This fix added the schema name resolve logic into pre analyze for insert .. exec .. .

Task: BABEL-4829

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).