### PR TITLE
Send env change token in tds when error abort transaction block

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -181,6 +181,7 @@ pe_tds_init(void)
 	pltsql_plugin_handler_ptr->send_info = &TdsSendInfo;
 	pltsql_plugin_handler_ptr->send_done = &TdsSendDone;
 	pltsql_plugin_handler_ptr->send_env_change = &TdsSendEnvChange;
+	pltsql_plugin_handler_ptr->send_env_change_binary = &TdsSendEnvChangeBinary;
 	pltsql_plugin_handler_ptr->get_tsql_error = &get_tsql_error_details;
 	pltsql_plugin_handler_ptr->stmt_beg = TDSStatementBeginCallback;
 	pltsql_plugin_handler_ptr->stmt_end = TDSStatementEndCallback;

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -7,6 +7,8 @@
 #include "dynastack.h"
 #include "table_variable_mvcc.h"
 
+#define ENVCHANGE_ROLLBACKTXN		0x0a
+
 /***************************************************************************************
  *                         Execution Actions
  **************************************************************************************/
@@ -31,6 +33,7 @@ static void read_throw_params(PLtsql_execstate *estate, List *params,
 static int	read_throw_params_explain(List *params);
 static char *get_proc_name(PLtsql_execstate *estate);
 static bool is_seterror_on(PLtsql_stmt *stmt);
+static void send_env_change_token_on_txn_abort(void);
 
 static void process_explain(PLtsql_execstate *estate);
 static void process_explain_analyze(PLtsql_execstate *estate);
@@ -1115,6 +1118,7 @@ handle_error(PLtsql_execstate *estate,
 		elog(DEBUG1, "TSQL TXN Mark transaction for rollback error mapping failed : %d", last_error_mapping_failed);
 		RESUME_INTERRUPTS();
 		AbortCurTransaction = true;
+		send_env_change_token_on_txn_abort();
 	}
 
 	/* Recreate evaluation context in case needed */
@@ -1987,4 +1991,14 @@ is_seterror_on(PLtsql_stmt *stmt)
 	if (!((PLtsql_stmt_raiserror *) stmt)->seterror)
 		return false;
 	return true;
+}
+
+static
+void
+send_env_change_token_on_txn_abort(void)
+{
+	uint64_t	txnId = (uint64_t) MyProc->lxid;
+
+	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change_binary)
+		((*pltsql_protocol_plugin_ptr)->send_env_change_binary) (ENVCHANGE_ROLLBACKTXN, NULL, 0, &txnId, sizeof(uint64_t));
 }

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1549,6 +1549,7 @@ typedef struct PLtsql_protocol_plugin
 	void		(*send_done) (int tag, int status,
 							  int curcmd, uint64_t nprocessed);
 	void		(*send_env_change) (int envid, const char *new_val, const char *old_val);
+	void		(*send_env_change_binary) (int envid, void *newValue, int newNbytes, void *oldValue, int oldNbytes);
 	bool		(*get_tsql_error) (ErrorData *edata,
 								   int *tsql_error_code,
 								   int *tsql_error_severity,

--- a/test/JDBC/expected/BABEL_4797.out
+++ b/test/JDBC/expected/BABEL_4797.out
@@ -1,0 +1,120 @@
+# BABEL-4797 does not affect JDBC driver
+# adding test cases just for assurance
+
+# txn#!#begin does not actually call begin tran
+# It simply sets autocommit to false
+# Changing autocommit send set implicit_transactions on to Server
+# the server now takes care of the transactions, unlike pyodbc
+
+CREATE TABLE babel_4794(ID INT);
+
+txn#!#begin
+~~SUCCESS~~
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+SELECT * FROM babel_4794
+~~START~~
+int
+~~END~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4794 VALUES (1)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4794 VALUES ('a')
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "a")~~
+
+INSERT INTO babel_4794 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4794 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+txn#!#rollback
+~~SUCCESS~~
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4794
+~~START~~
+int
+~~END~~
+
+
+# begin tran -> error (should rollback txn) -> driver should implicitly spawn new txn -> commit
+txn#!#begin
+~~SUCCESS~~
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4794 VALUES (1)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4794 VALUES ('a')
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "a")~~
+
+INSERT INTO babel_4794 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4794 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+txn#!#commit
+~~SUCCESS~~
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4794
+~~START~~
+int
+2
+3
+~~END~~
+
+
+DROP TABLE babel_4794;
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/input/BABEL_4797.txt
+++ b/test/JDBC/input/BABEL_4797.txt
@@ -1,0 +1,42 @@
+# BABEL-4797 does not affect JDBC driver
+# adding test cases just for assurance
+
+# txn#!#begin does not actually call begin tran
+# It simply sets autocommit to false
+# Changing autocommit send set implicit_transactions on to Server
+# the server now takes care of the transactions, unlike pyodbc
+
+CREATE TABLE babel_4794(ID INT);
+
+txn#!#begin
+SELECT @@trancount
+SELECT * FROM babel_4794
+SELECT @@trancount
+INSERT INTO babel_4794 VALUES (1)
+INSERT INTO babel_4794 VALUES ('a')
+INSERT INTO babel_4794 VALUES (2)
+INSERT INTO babel_4794 VALUES (3)
+SELECT @@trancount
+txn#!#rollback
+
+SELECT @@trancount
+
+SELECT * FROM babel_4794
+
+# begin tran -> error (should rollback txn) -> driver should implicitly spawn new txn -> commit
+txn#!#begin
+SELECT @@trancount
+INSERT INTO babel_4794 VALUES (1)
+INSERT INTO babel_4794 VALUES ('a')
+INSERT INTO babel_4794 VALUES (2)
+INSERT INTO babel_4794 VALUES (3)
+SELECT @@trancount
+txn#!#commit
+
+SELECT @@trancount
+
+SELECT * FROM babel_4794
+
+DROP TABLE babel_4794;
+
+SELECT @@trancount

--- a/test/python/expected/pyodbc/BABEL_4797.out
+++ b/test/python/expected/pyodbc/BABEL_4797.out
@@ -1,0 +1,276 @@
+CREATE TABLE babel_4797(ID INT);
+
+# default value of autcommit is false in python test framework
+# txn#!#begin does not actually run begin tran
+# instead it just set autocommit = false & let driver handle the txn
+
+# begin tran -> error (should rollback txn) -> driver should implicitly spawn new txn -> rollback
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4797 VALUES (1)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES ('a')
+~~ERROR (Code: 33557097)~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]invalid input syntax for type integer: "a" (33557097) (SQLExecDirectW))~~
+
+INSERT INTO babel_4797 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4797
+~~START~~
+int
+~~END~~
+
+
+# begin tran -> error (should rollback txn) -> driver should implicitly spawn new txn -> commit
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4797 VALUES (1)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES ('a')
+~~ERROR (Code: 33557097)~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]invalid input syntax for type integer: "a" (33557097) (SQLExecDirectW))~~
+
+INSERT INTO babel_4797 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4797
+~~START~~
+int
+2
+3
+~~END~~
+
+DELETE FROM babel_4797
+~~ROW COUNT: 2~~
+
+
+# begin tran -> error in proc (should rollback txn) -> driver should implicitly spawn new txn -> commit
+CREATE PROCEDURE babel_4797_p AS INSERT INTO babel_4797 VALUES (10); INSERT INTO babel_4797 VALUES ('a'); INSERT INTO babel_4797 VALUES (20);
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4797 VALUES (1)
+~~ROW COUNT: 1~~
+
+EXEC babel_4797_p
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]invalid input syntax for type integer: "a" (33557097) (SQLMoreResults))~~
+
+INSERT INTO babel_4797 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4797;
+~~START~~
+int
+2
+3
+~~END~~
+
+DELETE FROM babel_4797;
+~~ROW COUNT: 2~~
+
+
+DROP PROCEDURE babel_4797_p;
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+# begin tran -> error in proc (should rollback txn) -> driver should implicitly spawn new txn -> commit
+# Using a mapped transaction aborting error inside a procedure
+
+CREATE PROCEDURE babel_4797_p AS BEGIN TRY INSERT INTO babel_4797 VALUES (10); SET IDENTITY_INSERT babel_4797 ON; INSERT INTO babel_4797 VALUES (20); END TRY BEGIN CATCH SELECT 'in exception block'; END CATCH;
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4797 VALUES (1)
+~~ROW COUNT: 1~~
+
+EXEC babel_4797_p
+~~ROW COUNT: 1~~
+
+~~START~~
+str
+in exception block
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Uncommittable transaction is detected at the end of the batch. The transaction is rolled back. (33557097) (SQLMoreResults))~~
+
+INSERT INTO babel_4797 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4797
+~~START~~
+int
+2
+3
+~~END~~
+
+
+DELETE FROM babel_4797;
+~~ROW COUNT: 2~~
+
+
+DROP PROCEDURE babel_4797_p;
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+# begin tran -> error in proc (statement abort error) -> commit
+# Using a mapped statement aborting error inside a procedure
+
+CREATE PROCEDURE babel_4797_p AS BEGIN TRY INSERT INTO babel_4797 VALUES (10); SELECT 1/0; INSERT INTO babel_4797 VALUES (20); END TRY BEGIN CATCH SELECT 'in exception block'; END CATCH;
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO babel_4797 VALUES (1)
+~~ROW COUNT: 1~~
+
+EXEC babel_4797_p
+~~ROW COUNT: 1~~
+
+~~START~~
+str
+in exception block
+~~END~~
+
+INSERT INTO babel_4797 VALUES (2)
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_4797 VALUES (3)
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM babel_4797
+~~START~~
+int
+1
+10
+2
+3
+~~END~~
+
+
+DROP TABLE babel_4797;
+
+DROP PROCEDURE babel_4797_p;
+
+SELECT @@trancount
+~~START~~
+int
+0
+~~END~~
+

--- a/test/python/input/transactions/BABEL_4797.txt
+++ b/test/python/input/transactions/BABEL_4797.txt
@@ -1,0 +1,102 @@
+CREATE TABLE babel_4797(ID INT);
+
+# default value of autcommit is false in python test framework
+# txn#!#begin does not actually run begin tran
+# instead it just set autocommit = false & let driver handle the txn
+
+# begin tran -> error (should rollback txn) -> driver should implicitly spawn new txn -> rollback
+txn#!#begin
+SELECT @@trancount
+INSERT INTO babel_4797 VALUES (1)
+INSERT INTO babel_4797 VALUES ('a')
+INSERT INTO babel_4797 VALUES (2)
+INSERT INTO babel_4797 VALUES (3)
+SELECT @@trancount
+txn#!#rollback
+
+SELECT @@trancount
+
+SELECT * FROM babel_4797
+
+# begin tran -> error (should rollback txn) -> driver should implicitly spawn new txn -> commit
+txn#!#begin
+SELECT @@trancount
+INSERT INTO babel_4797 VALUES (1)
+INSERT INTO babel_4797 VALUES ('a')
+INSERT INTO babel_4797 VALUES (2)
+INSERT INTO babel_4797 VALUES (3)
+SELECT @@trancount
+txn#!#commit
+
+SELECT @@trancount
+
+SELECT * FROM babel_4797
+DELETE FROM babel_4797
+
+# begin tran -> error in proc (should rollback txn) -> driver should implicitly spawn new txn -> commit
+CREATE PROCEDURE babel_4797_p AS INSERT INTO babel_4797 VALUES (10); INSERT INTO babel_4797 VALUES ('a'); INSERT INTO babel_4797 VALUES (20);
+txn#!#begin
+SELECT @@trancount
+INSERT INTO babel_4797 VALUES (1)
+EXEC babel_4797_p
+INSERT INTO babel_4797 VALUES (2)
+INSERT INTO babel_4797 VALUES (3)
+SELECT @@trancount
+txn#!#commit
+
+SELECT @@trancount
+
+SELECT * FROM babel_4797;
+DELETE FROM babel_4797;
+
+DROP PROCEDURE babel_4797_p;
+
+SELECT @@trancount
+
+# begin tran -> error in proc (should rollback txn) -> driver should implicitly spawn new txn -> commit
+# Using a mapped transaction aborting error inside a procedure
+
+CREATE PROCEDURE babel_4797_p AS BEGIN TRY INSERT INTO babel_4797 VALUES (10); SET IDENTITY_INSERT babel_4797 ON; INSERT INTO babel_4797 VALUES (20); END TRY BEGIN CATCH SELECT 'in exception block'; END CATCH;
+
+txn#!#begin
+SELECT @@trancount
+INSERT INTO babel_4797 VALUES (1)
+EXEC babel_4797_p
+INSERT INTO babel_4797 VALUES (2)
+INSERT INTO babel_4797 VALUES (3)
+SELECT @@trancount
+txn#!#commit
+
+SELECT @@trancount
+
+SELECT * FROM babel_4797
+
+DELETE FROM babel_4797;
+
+DROP PROCEDURE babel_4797_p;
+
+SELECT @@trancount
+
+# begin tran -> error in proc (statement abort error) -> commit
+# Using a mapped statement aborting error inside a procedure
+
+CREATE PROCEDURE babel_4797_p AS BEGIN TRY INSERT INTO babel_4797 VALUES (10); SELECT 1/0; INSERT INTO babel_4797 VALUES (20); END TRY BEGIN CATCH SELECT 'in exception block'; END CATCH;
+
+txn#!#begin
+SELECT @@trancount
+INSERT INTO babel_4797 VALUES (1)
+EXEC babel_4797_p
+INSERT INTO babel_4797 VALUES (2)
+INSERT INTO babel_4797 VALUES (3)
+SELECT @@trancount
+txn#!#commit
+
+SELECT @@trancount
+
+SELECT * FROM babel_4797
+
+DROP TABLE babel_4797;
+
+DROP PROCEDURE babel_4797_p;
+
+SELECT @@trancount


### PR DESCRIPTION
### Description

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2401

In drivers which manage transaction automatically for the user, it is necessary to send the ENVCHANGE token on error which aborts a user transaction block. Other wise the driver will not be aware of this TRANSACTION ABORT.
For example consider this pyodbc case: (autocommit disabled, which also the default value in pyodbc)
```
cursor = cnxn.cursor()
cursor.execute("insert into t values (1)")
cursor.execute("insert into t values (2)")
try:
    cursor.execute("insert into t values ('aaaa')")
except:
    print("Let execution continue")
cursor.execute("insert into t values (3)")
cursor.execute("insert into t values (4)")
cnxn.rollback()
```
This currently gets executed as
```
BEGIN TRAN -- driver managed
INSERT INTO t VALUES (1)
INSERT INTO t VALUES (2)
INSERT INTO t VALUES ('aaaa') -- We hit an error here -- txn block aborted
INSERT INTO t VALUES (3)  -- No active transaction block -- auto commit behaviour
INSERT INTO t VALUES (4)  -- No active transaction block -- auto commit behaviour
ROLLBACK -- No transaction block active, we will get error
```
table 't' will contain values 3,4. Ideally this should have been empty since we are not committing any txn.
If we had notified driver about the transaction rollback on error, the execution would look like
```
BEGIN TRAN -- driver managed
INSERT INTO t VALUES (1)
INSERT INTO t VALUES (2)
INSERT INTO t VALUES ('aaaa') -- We hit an error here -- txn block aborted & driver notified
BEGIN TRAN -- since we notified the driver about the rollback
INSERT INTO t VALUES (3)  -- Active txn block, not yet committed
INSERT INTO t VALUES (4)  -- Active txn block, not yet committed
ROLLBACK -- txn block aborted
```
table 't' empty

### Issues Resolved

[BABEL-4797]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).