### PR TITLE
Do not reset SysCacheRelationOidSize and SysCacheSupportingRelOidSize

### DIFF
--- a/test/JDBC/expected/vacuum.out
+++ b/test/JDBC/expected/vacuum.out
@@ -1,0 +1,35 @@
+
+
+-- psql
+-- BABEL-4119
+VACUUM FULL pg_index;
+GO
+
+-- psql currentSchema=master_dbo,public
+VACUUM FULL pg_index;
+GO
+
+-- psql currentSchema=sys
+-- Confirm we are able to connect still
+SELECT oid, relname FROM pg_class WHERE oid=2679;
+GO
+~~START~~
+oid#!#name
+2679#!#pg_index_indexrelid_index
+~~END~~
+
+
+-- psql
+-- vacuum full all tables
+VACUUM FULL;
+GO
+
+-- psql currentSchema=sys
+SELECT oid, relname FROM pg_class WHERE oid=2679;
+GO
+~~START~~
+oid#!#name
+2679#!#pg_index_indexrelid_index
+~~END~~
+
+

--- a/test/JDBC/input/vacuum.mix
+++ b/test/JDBC/input/vacuum.mix
@@ -1,0 +1,25 @@
+
+-- BABEL-4119
+
+-- psql
+VACUUM FULL pg_index;
+GO
+
+-- psql currentSchema=master_dbo,public
+VACUUM FULL pg_index;
+GO
+
+-- Confirm we are able to connect still
+-- psql currentSchema=sys
+SELECT oid, relname FROM pg_class WHERE oid=2679;
+GO
+
+-- vacuum full all tables
+-- psql
+VACUUM FULL;
+GO
+
+-- psql currentSchema=sys
+SELECT oid, relname FROM pg_class WHERE oid=2679;
+GO
+


### PR DESCRIPTION
Do not reset SysCacheRelationOidSize and SysCacheSupportingRelOidSize in InitExtensionCatalogCache. Otherwise any invalidation on catalog tables that happened on the babelfish database will not be reported causing inconsistency issues.

The code change is in the engine, this commit includes testcase only.

Task: BABEL-4119


