### PR TITLE
Free buffer early when converting numerics

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -1112,7 +1112,8 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 	Numeric		res;
 	int			len,
 				sign;
-	char	   *decString;
+	char	   *decString,
+				*decStringOrig;
 	int			temp1,
 				temp2;
 	uint128		num = 0;
@@ -1131,6 +1132,7 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 	}
 
 	decString = (char *) palloc0(sizeof(char) * 40);
+	decStringOrig = decString;
 
 	if (num != 0)
 		Integer2String(num, decString);
@@ -1161,6 +1163,7 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 		 * index during shifting the scale part of the string.
 		 */
 		decString = psprintf("-%s%s.", zeros, tempString + 1);
+		decStringOrig = decString;
 		len = strlen(decString) - 1;
 		pfree(tempString);
 	}
@@ -1189,6 +1192,7 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 		decString++;
 
 	res = TdsSetVarFromStrWrapper(decString);
+	pfree(decStringOrig);
 	PG_RETURN_NUMERIC(res);
 }
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -1166,6 +1166,7 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 		decStringOrig = decString;
 		len = strlen(decString) - 1;
 		pfree(tempString);
+		pfree(zeros);
 	}
 	if (num != 0)
 	{


### PR DESCRIPTION
### Description

`TdsTypeNumericToDatum` [allocates a buffer](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/6606b1118978477186869c3dddd2c6d85fcc6387/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c#L1133) for parsing incoming numeric data, but does not release this buffer. So it remains in `MessageContext` until the end of BCP import call.

Proposed patch frees this buffer before exiting `TdsTypeNumericToDatum`.

Backend memory usage when importing 1 million decimals (see details in linked issue) without the patch:

![Figure_1](https://github.com/babelfish-for-postgresql/babelfish_extensions/assets/9497509/dbdb8147-3c62-4658-954e-a9018070f441)

With patch applied:

![Figure_2](https://github.com/babelfish-for-postgresql/babelfish_extensions/assets/9497509/f418b1f1-8166-4227-b38f-2c09cb4181ac)

### Issues Resolved

#2455

### Test Scenarios Covered ###

There are no functional changes, so no new tests.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>