### PR TITLE
Enable coredump generation by default in dev-tools.sh

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -124,12 +124,12 @@ fi
 
 restart() {
     cd $1/postgres
-    bin/pg_ctl -D data/ -l logfile restart
+    bin/pg_ctl -c -D data/ -l logfile restart
 }
 
 stop() {
     cd $1/postgres
-    bin/pg_ctl -D data/ -l logfile stop
+    bin/pg_ctl -c -D data/ -l logfile stop
 }
 
 build_pg() {
@@ -162,7 +162,7 @@ init_db() {
         kill -9 $PID
     fi
     sleep 1
-    bin/pg_ctl -D data/ -l logfile start
+    bin/pg_ctl -c -D data/ -l logfile start
     cd data
     sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
     sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
@@ -384,7 +384,7 @@ elif [ "$1" == "pg_upgrade" ]; then
 
     ./delete_old_cluster.sh
     cd $TARGET_WS/postgres
-    bin/pg_ctl -D data/ -l logfile start
+    bin/pg_ctl -c -D data/ -l logfile start
 
     echo ""
     echo 'Updating babelfish extensions...'


### PR DESCRIPTION
### Description

Add the `-c` flag for `pg_ctl` in `dev-tools.sh` to enable coredump generation by default. So core files will be generated under `postgres/data/core.xxx`. 

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).