### PR TITLE
Free heap allocated Datums after the flush

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -721,19 +721,22 @@ SetBulkLoadRowData(TDSRequestBulkLoad request, StringInfo message)
 							case TDS_TYPE_CHAR:
 							case TDS_TYPE_VARCHAR:
 								rowData->columnValues[i] = TdsTypeVarcharToDatum(temp, colmetadata[i].encoding, colmetadata[i].columnTdsType);
-								rowData->isAllocated[i] = true;
 								break;
 							case TDS_TYPE_NCHAR:
 							case TDS_TYPE_NVARCHAR:
 								rowData->columnValues[i] = TdsTypeNCharToDatum(temp);
-								rowData->isAllocated[i] = true;
 								break;
 							case TDS_TYPE_BINARY:
 							case TDS_TYPE_VARBINARY:
 								rowData->columnValues[i] = TdsTypeVarbinaryToDatum(temp);
-								rowData->isAllocated[i] = true;
 								break;
 						}
+
+						/*
+						 * All three of Varchar, NChar and Varbinary conversions allocate
+						 * their results with palloc.
+						 */
+						rowData->isAllocated[i] = true;
 
 						/*
 						 * Free temp->data only if this was created as part of
@@ -801,17 +804,20 @@ SetBulkLoadRowData(TDSRequestBulkLoad request, StringInfo message)
 						{
 							case TDS_TYPE_TEXT:
 								rowData->columnValues[i] = TdsTypeVarcharToDatum(temp, colmetadata[i].encoding, colmetadata[i].columnTdsType);
-								rowData->isAllocated[i] = true;
 								break;
 							case TDS_TYPE_NTEXT:
 								rowData->columnValues[i] = TdsTypeNCharToDatum(temp);
-								rowData->isAllocated[i] = true;
 								break;
 							case TDS_TYPE_IMAGE:
 								rowData->columnValues[i] = TdsTypeVarbinaryToDatum(temp);
-								rowData->isAllocated[i] = true;
 								break;
 						}
+
+						/*
+						 * All three of Varchar, NChar and Varbinary conversions allocate
+						 * their results with palloc.
+						 */
+						rowData->isAllocated[i] = true;
 
 						offset += len;
 						request->currentBatchSize += len;

--- a/contrib/babelfishpg_tds/src/include/tds_typeio.h
+++ b/contrib/babelfishpg_tds/src/include/tds_typeio.h
@@ -273,7 +273,17 @@ typedef struct BulkLoadRowData
 	/* Array of length col count, holds value of each column in that row. */
 	Datum	   *columnValues;
 
+	/* 
+	 * Array of length col count, holds true value if corresponding column is
+	 * null in that row.
+	 */
 	bool	   *isNull;
+
+	/* 
+	 * Array of length col count, holds true value if corresponding column's
+	 * Datum in that row was allocated on heap with palloc.
+	 */
+	bool	   *isAllocated;
 } BulkLoadRowData;
 
 /* Map TVP to its underlying table, either by relid or by table name. */

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3530,7 +3530,7 @@ void exec_stmt_dbcc_checkident(PLtsql_stmt_dbcc *stmt)
 
 uint64
 execute_bulk_load_insert(int ncol, int nrow,
-						 Datum *Values, bool *Nulls)
+						 Datum *Values, bool *Nulls, bool *ValueAllocFlags)
 {
 	uint64		retValue = -1;
 	Snapshot	snap;
@@ -3544,7 +3544,7 @@ execute_bulk_load_insert(int ncol, int nrow,
 		/* Cleanup all the pointers. */
 		if (cstmt)
 		{
-			EndBulkCopy(cstmt->cstate);
+			EndBulkCopy(cstmt->cstate, cstmt->ncol);
 			if (cstmt->attlist)
 				list_free_deep(cstmt->attlist);
 			if (cstmt->relation)
@@ -3573,6 +3573,7 @@ execute_bulk_load_insert(int ncol, int nrow,
 		cstmt->ncol = ncol;
 		cstmt->Values = Values;
 		cstmt->Nulls = Nulls;
+		cstmt->ValueAllocFlags = ValueAllocFlags;
 
 		snap = GetTransactionSnapshot();
 		PushActiveSnapshot(snap);

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1727,7 +1727,7 @@ typedef struct PLtsql_protocol_plugin
 	int		   *(*get_mapped_tsql_error_code_list) (void);
 
 	uint64		(*bulk_load_callback) (int ncol, int nrow,
-									   Datum *Values, bool *Nulls);
+									   Datum *Values, bool *Nulls, bool *ValueAllocFlags);
 
 	int			(*pltsql_get_generic_typmod) (Oid funcid, int nargs, Oid declared_oid);
 
@@ -1980,7 +1980,7 @@ extern Datum sp_unprepare(PG_FUNCTION_ARGS);
 extern bool pltsql_support_tsql_transactions(void);
 extern bool pltsql_sys_function_pop(void);
 extern uint64 execute_bulk_load_insert(int ncol, int nrow,
-									   Datum *Values, bool *Nulls);
+									   Datum *Values, bool *Nulls, bool *ValueAllocFlags);
 
 /*
  * Functions in pl_exec.c

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -633,7 +633,7 @@ ExecuteBulkCopy(BulkCopyState cstate, int rowCount, int colCount,
 	for (int i = 0; i < rowCount * colCount; i++)
 	{
 		cstate->bufferedValues = lappend(cstate->bufferedValues, (void *) Values[i]);
-		cstate->bufferedValueAllocFlags = lappend_int(cstate->bufferedValueAllocFlags, ValueAllocFlags[i] ? 1 : 0);
+		cstate->bufferedValueAllocFlags = lappend_int(cstate->bufferedValueAllocFlags, ValueAllocFlags[i]);
 	}
 
 	ExecOpenIndices(cstate->resultRelInfo, false);


### PR DESCRIPTION
### Description

When BCP import is performed, `Datums` are created for all non-NULL incoming fields. Some of these `Datums` are [allocated on heap](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/b26029536061182f8b2b216d4a149922606040e9/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c#L1449). These `Datums` need to be kept in memory until the call to `table_multi_insert`.

It seems to be not possible to distinguish between heap-allocated `Datums` and passed-by-value `Datums` using only the pointer to such `Datum`. The proposed patch attempts to keep track of all heap-allocated `Datums` (in a similar manner, like `isNull` is tracked) so they can be freed immediately after the flush.

Pointers to `Datums` and `isAllocated` flags are kept in `BulkCopyStateData` in growing lists. Pointers from incoming batch are appended there before processing. And these `Datums` are freed and lists are trimmed after each flush.

There are also 2 unrelated memory cleanup changes included: freeing of `TDSRequestBulkLoadData->rowData` contents on TDS side and freeing of `attnums` list on TSQL side. `attnums` is created for every batch (I assume this is needed for error-checking), but only used for the first incoming batch.

Memory usage when importing 1 million of `varchars` (see details in linked issue), without the patch:

![Figure_1](https://github.com/babelfish-for-postgresql/babelfish_extensions/assets/9497509/24881ef1-f313-4bbf-9b2d-8d100b7e0e35)

With patch applied:

![Figure_2](https://github.com/babelfish-for-postgresql/babelfish_extensions/assets/9497509/752cf613-2170-41ba-88de-a3019674aa7c)

### Issues Resolved

#2468

### Test Scenarios Covered ###

There are no functional changes, so no new tests.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>