### PR TITLE
Free buffer early when converting numerics 2x

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -1069,7 +1069,8 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 	Numeric		res;
 	int			len,
 				sign;
-	char	   *decString;
+	char	   *decString,
+				*decStringOrig;
 	int			temp1,
 				temp2;
 	uint128		num = 0;
@@ -1088,6 +1089,7 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 	}
 
 	decString = (char *) palloc0(sizeof(char) * 40);
+	decStringOrig = decString;
 
 	if (num != 0)
 		Integer2String(num, decString);
@@ -1118,8 +1120,10 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 		 * index during shifting the scale part of the string.
 		 */
 		decString = psprintf("-%s%s.", zeros, tempString + 1);
+		decStringOrig = decString;
 		len = strlen(decString) - 1;
 		pfree(tempString);
+		pfree(zeros);
 	}
 	if (num != 0)
 	{
@@ -1146,6 +1150,7 @@ TdsTypeNumericToDatum(StringInfo buf, int scale)
 		decString++;
 
 	res = TdsSetVarFromStrWrapper(decString);
+	pfree(decStringOrig);
 	PG_RETURN_NUMERIC(res);
 }
 


### PR DESCRIPTION
### Description

Backport of #2456 to 2x.

### Issues Resolved

#2455

### Test Scenarios Covered ###

No functional changes, no new tests.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>