### PR TITLE
Support profiling backend memory usage in JDBC tests

### DIFF
--- a/test/JDBC/src/main/java/com/sqlsamples/BackendMemoryProfiler.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/BackendMemoryProfiler.java
@@ -1,0 +1,92 @@
+package com.sqlsamples;
+
+import org.apache.logging.log4j.Logger;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.newBufferedWriter;
+
+public class BackendMemoryProfiler implements Runnable {
+
+    private static final Pattern VM_RSS_REGEX = Pattern.compile("^VmRSS:\\s+(\\d+)\\s+kB$");
+    private final Logger logger;
+    private final int pid;
+    private final Path outputFilePath;
+
+    public BackendMemoryProfiler(Connection conn_bbl, String testFilePath, String outputDirPath, Logger logger) {
+        int pid = getBackendPid(conn_bbl);
+        String testNameFull = Paths.get(testFilePath).getFileName().toString();
+        String testName = testNameFull.substring(0, testNameFull.lastIndexOf("."));
+        String outputFileName = testName + "_mprof.txt";
+
+        this.logger = logger;
+        this.pid = pid;
+        this.outputFilePath = Paths.get(outputDirPath, outputFileName);
+    }
+
+    @Override
+    public void run() {
+        long start = currentTimeMillis();
+        try (Writer writer = newBufferedWriter(outputFilePath, UTF_8)) {
+            logger.error("Memory profiler thread started, backend pid: " + pid + ", " +
+                    "output file: " + outputFilePath.getFileName());
+            writer.write("# This file contains recorded RSS values, to create a plot run the following from JDBC directory:\n");
+            writer.write("# gnuplot -p -e \"set grid; set xlabel 'Elapsed time (millis)'; set ylabel 'Backend RSS for pid: " + pid + " (KB)'; plot './output/" + outputFilePath.getFileName() + "' with linespoints\"\n");
+            for (;;) {
+                long cur = currentTimeMillis();
+                long elapsed = cur - start;
+                int rss = readRSS();
+                writer.write(elapsed + " " + rss + "\n");
+                writer.flush();
+                long delay = currentTimeMillis() - cur;
+                if (delay < 100) {
+                    Thread.sleep(100 - delay);
+                }
+            }
+        } catch (NoSuchFileException e) {
+            // backend process exited
+        } catch (Throwable e) {
+            logger.error(e, e);
+        } finally {
+            logger.error("Memory profiler thread shut down, backend pid: " + pid + ", " +
+                    "output file: " + outputFilePath.getFileName());
+        }
+    }
+
+    private int readRSS() throws IOException {
+        Path status = Paths.get("/proc/" + pid + "/status");
+        List<String> lines = Files.readAllLines(status, UTF_8);
+        for (String ln : lines) {
+            if (ln.startsWith("VmRSS")) {
+                Matcher matcher = VM_RSS_REGEX.matcher(ln);
+                if (matcher.matches()) {
+                    return Integer.parseInt(matcher.group(1));
+                }
+            }
+        }
+        throw new IOException("Error reading VmRSS from /proc/pid/status");
+    }
+
+    private static int getBackendPid(Connection conn_bbl) {
+        try (Statement stmt = conn_bbl.createStatement()) {
+            ResultSet rs = stmt.executeQuery("select pg_backend_pid()");
+            rs.next();
+            return rs.getInt(1);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
@@ -17,7 +17,7 @@ import static com.sqlsamples.Config.checkParallelQueryExpected;
 public class batch_run {
 
     // method that iterates through an input file and writes output to corresponding .out file.
-    static void batch_run_sql(Connection con_bbl, BufferedWriter bw, String testFilePath, Logger logger) {
+    static void batch_run_sql(Connection con_bbl, BufferedWriter bw, String testFilePath, String outputDirPath, Logger logger) {
 
         boolean isSQLFile = testFilePath.contains(".sql");
         boolean isCrossDialectFile = false;
@@ -221,7 +221,7 @@ public class batch_run {
                     String filePath = new File(result[1]).getAbsolutePath();
 
                     // Run the iterative parse and compare loop for test file
-                    batch_run_sql(con_bbl, bw, filePath, logger);
+                    batch_run_sql(con_bbl, bw, filePath, outputDirPath, logger);
 
                 } else if (strLine.startsWith("insertbulk")) {
                     bw.write(strLine);
@@ -292,6 +292,15 @@ public class batch_run {
                         checkParallelQueryExpected = true;
                         continue;
                     }
+
+                    if (strLine.toLowerCase().startsWith("-- backend_memory_profile")){
+                        BackendMemoryProfiler mprof = new BackendMemoryProfiler(con_bbl, testFilePath, outputDirPath, logger);
+                        Thread th = new Thread(mprof);
+                        th.setDaemon(false);
+                        th.start();
+                        continue;
+                    }
+
                     // execute statement as a normal SQL statement
                     if (isSQLFile) {
                         if (!strLine.equalsIgnoreCase("GO")) {

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -427,7 +427,7 @@ public class TestQueryFile {
             JDBCTempTable.runTest(bw, logger);
             sla = defaultSLA*1000000L * 2; /* Increase SLA to avoid flakiness */
         } else {
-            batch_run.batch_run_sql(connection_bbl, bw, testFilePath, logger);
+            batch_run.batch_run_sql(connection_bbl, bw, testFilePath, outputFilesDirectoryPath, logger);
         }
         bw.close();
         if(sla == 0){


### PR DESCRIPTION
### Description

This patch contains an enhancement to JDBC test harness. It adds support for `-- backend_memory_profile` command. When this command is read in `batch_run`, it fetches backend pid for current open JDBC connection and spawns a new thread with `BackendMemoryProfiler` worker. This thread reads `VmRSS` value from `/proc/<backend_pid>/status` every 100 milliseconds and writes these values to output file. The thread exits when the backend process exits.

For example, if we add `-- backend_memory_profile` on top of `babel_function.sql` (or some other `.sql` or `.txt` test) and run `mvn test`, then additional file `babel_function_mprof.txt` will be written to output directory next to `babel_function.out` file. This new file contains the following (where first column is elapsed millis and second column is RSS):

```
# This file contains recorded RSS values, to create a plot run the following from JDBC directory:
# gnuplot -p -e "set grid; set xlabel 'Elapsed time (millis)'; set ylabel 'Backend RSS for pid: 70794 (KB)'; plot './output/babel_function_mprof.txt' with linespoints"
2 43648
102 46976
202 48512
302 51712
402 51712
502 52352
602 60800
702 68200
802 71272
902 74832
1002 75216
1102 75216
1202 75728
1302 76240
1402 76624
1502 76868
1603 77764
1703 78660
1804 79132
1904 79900
2005 80540
2105 80668
2205 84380
2305 84380
2405 85148
2505 86172
2605 87068
```

Running the [gnuplot](http://gnuplot.info/) command from the top of the file (expected to be only run manually) will display a chart like this:

![mprof](https://github.com/babelfish-for-postgresql/babelfish_extensions/assets/9497509/ac81f58e-dc7d-4055-9980-abe9a4368588)
 
This profiling can only work when tests are run on the same machine where server is running. It is intended to be used only in local dev environment, when `-- backend_memory_profile` can be temporary added on top of any test.

I've only tested this on Fedora, but it is expected to work on any recent Linux.

### Issues Resolved

No related issue.

### Test Scenarios Covered ###

This is test harness enhancement.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>