### PR TITLE
Fix upgrade script after sp_tables change

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
@@ -308,16 +308,6 @@ $$
 STRICT
 LANGUAGE plpgsql IMMUTABLE parallel safe;
 
--- Drops the temporary procedure used by the upgrade script.
--- Please have this be one of the last statements executed in this upgrade script.
-DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
-
--- After upgrade, always run analyze for all babelfish catalogs.
-CALL sys.analyze_babelfish_catalogs();
-
--- Reset search_path to not affect any subsequent scripts
-SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
-
 CREATE OR REPLACE FUNCTION sys.sp_tables_internal(
 	in_table_name sys.nvarchar(384) = '',
 	in_table_owner sys.nvarchar(384) = '', 
@@ -378,3 +368,13 @@ CREATE OR REPLACE FUNCTION sys.sp_tables_internal(
 	END;
 $$
 LANGUAGE plpgsql STABLE;
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
+
+-- After upgrade, always run analyze for all babelfish catalogs.
+CALL sys.analyze_babelfish_catalogs();
+
+-- Reset search_path to not affect any subsequent scripts
+SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);


### PR DESCRIPTION
### Description

Upgrade script was updated incorrectly in #2405, this patch fixes that moving the re-creation of `sp_tables` before the search path reset.

### Issues Resolved

None.

### Test Scenarios Covered ###

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>