### PR TITLE
Skip replication of Babelfish catalog tables (#2398)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -2120,11 +2120,15 @@ END;
 $$ LANGUAGE 'pltsql';
 GRANT EXECUTE ON PROCEDURE sys.sp_linkedservers TO PUBLIC;
 
+SET allow_system_table_mods = on;
 ALTER TABLE sys.babelfish_authid_login_ext ADD COLUMN IF NOT EXISTS orig_loginname SYS.NVARCHAR(128);
+RESET allow_system_table_mods;
 
 UPDATE sys.babelfish_authid_login_ext SET orig_loginname = rolname WHERE orig_loginname IS NULL;
 
+SET allow_system_table_mods = on;
 ALTER TABLE sys.babelfish_authid_login_ext ALTER COLUMN orig_loginname SET NOT NULL;
+RESET allow_system_table_mods;
 
 CREATE OR REPLACE FUNCTION sys.DBTS()
 RETURNS sys.ROWVERSION AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -96,7 +96,9 @@ RETURNS date
 AS 'babelfishpg_tsql', 'EOMONTH'
 LANGUAGE C STABLE PARALLEL SAFE;
 
+SET allow_system_table_mods = on;
 ALTER TABLE sys.babelfish_server_options ADD COLUMN IF NOT EXISTS connect_timeout INT;
+RESET allow_system_table_mods;
 
 CREATE OR REPLACE VIEW sys.servers
 AS

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -13,6 +13,13 @@
  *****************************************/
 extern Datum init_catalog(PG_FUNCTION_ARGS);
 extern void rename_update_bbf_catalog(RenameStmt *stmt);
+#define BBF_ASSEMBLIES_TABLE_NAME "assemblies"
+#define BBF_CONFIGURATIONS_TABLE_NAME "babelfish_configurations"
+#define BBF_HELPCOLLATION_TABLE_NAME "babelfish_helpcollation"
+#define BBF_SYSLANGUAGES_TABLE_NAME "babelfish_syslanguages"
+#define BBF_SERVICE_SETTINGS_TABLE_NAME "service_settings"
+#define SPT_DATATYPE_INFO_TABLE_NAME "spt_datatype_info_table"
+#define BBF_VERSIONS_TABLE_NAME "versions"
 
 /*****************************************
  * 			Catalog Hooks

--- a/test/JDBC/expected/TEST_PUBLICATION.out
+++ b/test/JDBC/expected/TEST_PUBLICATION.out
@@ -1,0 +1,46 @@
+-- psql
+DO
+$$
+DECLARE
+    is_publishable BOOL = TRUE;
+    tab TEXT;
+    tab_names TEXT = '';
+BEGIN
+    FOR tab IN
+        SELECT relname FROM pg_class WHERE relnamespace = 'sys'::regnamespace AND relkind = 'r' ORDER BY relname
+    LOOP
+        BEGIN
+            is_publishable = TRUE;
+            EXECUTE 'CREATE PUBLICATION catalog_pub FOR TABLE sys.' || tab;
+        EXCEPTION WHEN invalid_parameter_value or insufficient_privilege THEN
+            tab_names = tab_names || E'\n' || 'sys.' || tab;
+            is_publishable = FALSE;
+        END;
+        IF is_publishable THEN
+            RAISE EXCEPTION 'Babelfish extended catalog table sys.% is not marked as a catalog relation.', tab;
+        END IF;
+    END LOOP;
+    RAISE WARNING 'cannot add relations to publication: %', tab_names;
+END $$;
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: cannot add relations to publication: 
+sys.assemblies
+sys.babelfish_authid_login_ext
+sys.babelfish_authid_user_ext
+sys.babelfish_configurations
+sys.babelfish_domain_mapping
+sys.babelfish_extended_properties
+sys.babelfish_function_ext
+sys.babelfish_helpcollation
+sys.babelfish_namespace_ext
+sys.babelfish_schema_permissions
+sys.babelfish_server_options
+sys.babelfish_sysdatabases
+sys.babelfish_syslanguages
+sys.babelfish_view_def
+sys.service_settings
+sys.spt_datatype_info_table
+sys.versions  Server SQLState: 01000)~~
+

--- a/test/JDBC/input/TEST_PUBLICATION.mix
+++ b/test/JDBC/input/TEST_PUBLICATION.mix
@@ -1,0 +1,25 @@
+-- psql
+DO
+$$
+DECLARE
+    is_publishable BOOL = TRUE;
+    tab TEXT;
+    tab_names TEXT = '';
+BEGIN
+    FOR tab IN
+        SELECT relname FROM pg_class WHERE relnamespace = 'sys'::regnamespace AND relkind = 'r' ORDER BY relname
+    LOOP
+        BEGIN
+            is_publishable = TRUE;
+            EXECUTE 'CREATE PUBLICATION catalog_pub FOR TABLE sys.' || tab;
+        EXCEPTION WHEN invalid_parameter_value or insufficient_privilege THEN
+            tab_names = tab_names || E'\n' || 'sys.' || tab;
+            is_publishable = FALSE;
+        END;
+        IF is_publishable THEN
+            RAISE EXCEPTION 'Babelfish extended catalog table sys.% is not marked as a catalog relation.', tab;
+        END IF;
+    END LOOP;
+    RAISE WARNING 'cannot add relations to publication: %', tab_names;
+END $$;
+GO


### PR DESCRIPTION
### Description
Babelfish has several extended catalogs in the form of normal PG tables, so it is
possible for customers to replicate them which could result in undefined behavior.
This commit addresses the above scenario by marking all such tables as catalog
tables.

Task: BABEL-4721
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/323

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).