### PR TITLE
Fix crash when trying to delete a trigger on a temp table.

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2338,6 +2338,12 @@ get_tsql_trigger_oid(List *object, const char *tsql_trigger_name, bool object_fr
 			reloid = pg_trigger->tgrelid;
 			relation = RelationIdGetRelation(reloid);
 			pg_trigger_physical_schema = get_namespace_name(get_rel_namespace(pg_trigger->tgrelid));
+			if (pg_trigger_physical_schema == NULL)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("error while trying to look up trigger")));
+			}
 			if (strcasecmp(pg_trigger_physical_schema, cur_physical_schema) == 0)
 			{
 				trigger_rel_oid = reloid;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -2340,9 +2340,7 @@ get_tsql_trigger_oid(List *object, const char *tsql_trigger_name, bool object_fr
 			pg_trigger_physical_schema = get_namespace_name(get_rel_namespace(pg_trigger->tgrelid));
 			if (pg_trigger_physical_schema == NULL)
 			{
-				ereport(ERROR,
-						(errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("error while trying to look up trigger")));
+				return InvalidOid;
 			}
 			if (strcasecmp(pg_trigger_physical_schema, cur_physical_schema) == 0)
 			{

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -214,7 +214,6 @@ ignore#!#load_road
 ignore#!#load_tenk
 ignore#!#load_stud_emp
 ignore#!#load_student
-ignore#!#temp_table_jdbc
 ignore#!#temp_tables_concurrent-vu-cleanup
 ignore#!#temp_tables_concurrent-vu-prepare
 ignore#!#temp_tables_concurrent-vu-verify

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCTempTable.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCTempTable.java
@@ -328,7 +328,7 @@ public class JDBCTempTable {
         try {
             s.execute(queryString);
         } catch (Exception e) {
-            if (!e.getMessage().equals("error while trying to look up trigger")) {
+            if (!e.getMessage().equals("trigger \"bar\" does not exist")) {
                 bw.write(e.getMessage());
                 bw.newLine();
             }


### PR DESCRIPTION
Instead, raise an error.

Task: BABEL-4867

### Description

Triggers do not have visibility into temp tables from other sessions. In particular, if a trigger is created on a temp table, and then a separate session attempts to drop that trigger, the reference temp table  will not be visible within the second session, and a null OID reference will be passed through the internal code. Currently this causes a segmentation fault, so fix it by detecting for this case and erroring out instead.

### Issues Resolved

BABEL-4867

### Test Scenarios Covered ###
* **Use case based -**
Java test which replicates the error scenario by creating a trigger on a temp table in one session and then attempting to drop the trigger in another session. Due to requiring two simultaneous sessions to be tested, this currently can only be tested in the Java file and cannot be tested in upgrade scenarios.

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).