### PR TITLE
remove call to get_guc_variables in pltsql_revert_guc

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -96,7 +96,6 @@ extern bool pltsql_recursive_triggers;
 extern bool restore_tsql_tabletype;
 extern bool babelfish_dump_restore;
 extern bool pltsql_nocount;
-static slist_head guc_stack_list;
 
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
@@ -250,6 +249,7 @@ int			text_size;
 Portal		pltsql_snapshot_portal = NULL;
 int			pltsql_non_tsql_proc_entry_count = 0;
 int			pltsql_sys_func_entry_count = 0;
+static 		slist_head guc_stack_list;
 static int	PltsqlGUCNestLevel = 0;
 static guc_push_old_value_hook_type prev_guc_push_old_value_hook = NULL;
 static validate_set_config_function_hook_type prev_validate_set_config_function_hook = NULL;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -96,6 +96,7 @@ extern bool pltsql_recursive_triggers;
 extern bool restore_tsql_tabletype;
 extern bool babelfish_dump_restore;
 extern bool pltsql_nocount;
+static slist_head guc_stack_list;
 
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
@@ -250,7 +251,6 @@ Portal		pltsql_snapshot_portal = NULL;
 int			pltsql_non_tsql_proc_entry_count = 0;
 int			pltsql_sys_func_entry_count = 0;
 static int	PltsqlGUCNestLevel = 0;
-static bool pltsql_guc_dirty;
 static guc_push_old_value_hook_type prev_guc_push_old_value_hook = NULL;
 static validate_set_config_function_hook_type prev_validate_set_config_function_hook = NULL;
 static void pltsql_guc_push_old_value(struct config_generic *gconf, GucAction action);
@@ -5671,7 +5671,6 @@ pltsql_guc_push_old_value(struct config_generic *gconf, GucAction action)
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("Set action not supported")));
 		}
-		Assert(pltsql_guc_dirty);
 		return;
 	}
 
@@ -5699,8 +5698,9 @@ pltsql_guc_push_old_value(struct config_generic *gconf, GucAction action)
 	stack->scontext = gconf->scontext;
 	guc_set_stack_value(gconf, &stack->prior);
 
+	if (gconf->session_stack == NULL)
+		slist_push_head(&guc_stack_list, &gconf->stack_link);
 	gconf->session_stack = stack;
-	pltsql_guc_dirty = true;
 }
 
 int
@@ -5712,25 +5712,14 @@ pltsql_new_guc_nest_level(void)
 void
 pltsql_revert_guc(int nest_level)
 {
-	bool		still_dirty;
-	int			i;
-	int			num_guc_variables;
-	struct config_generic **guc_variables;
+	slist_mutable_iter iter;
 
 	Assert(nest_level > 0 && nest_level == PltsqlGUCNestLevel);
 
-	/* Quick exit if nothing's changed in this procedure */
-	if (!pltsql_guc_dirty)
+	slist_foreach_modify(iter, &guc_stack_list)
 	{
-		PltsqlGUCNestLevel = nest_level - 1;
-		return;
-	}
-
-	still_dirty = false;
-	guc_variables = get_guc_variables(&num_guc_variables);
-	for (i = 0; i < num_guc_variables; i++)
-	{
-		struct config_generic *gconf = guc_variables[i];
+		struct config_generic *gconf = slist_container(struct config_generic,
+													   stack_link, iter.cur);
 		GucStack   *stack = gconf->session_stack;
 
 		if (stack != NULL && stack->nest_level == nest_level)
@@ -5852,19 +5841,14 @@ pltsql_revert_guc(int nest_level)
 			/* Finish popping the state stack */
 			gconf->session_stack = prev;
 
+			if (prev == NULL)
+				slist_delete_current(&iter);
 			pfree(stack);
 		}						/* end of stack-popping loop */
-
-		if (stack != NULL)
-			still_dirty = true;
 	}
-
-	/* If there are no remaining stack entries, we can reset guc_dirty */
-	pltsql_guc_dirty = still_dirty;
 
 	/* Update nesting level */
 	PltsqlGUCNestLevel = nest_level - 1;
-
 }
 
 static char *

--- a/test/JDBC/expected/BABEL_4881.out
+++ b/test/JDBC/expected/BABEL_4881.out
@@ -1,82 +1,109 @@
 CREATE PROCEDURE babel_4881_proc_3
 AS
 BEGIN
-    SELECT 'before setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'before setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     SET NOCOUNT ON
+    SET QUOTED_IDENTIFIER OFF;
     SET DATEFIRST 7
-    SET QUOTED_IDENTIFIER OFF
-    SELECT 'after setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'after setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
 END
 GO
 
 CREATE PROCEDURE babel_4881_proc_2
 AS
 BEGIN
-    SELECT 'before setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'before setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     SET NOCOUNT OFF
-    SET DATEFIRST 4
-    SET QUOTED_IDENTIFIER ON
-    SELECT 'after setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET QUOTED_IDENTIFIER ON;
+    SET ROWCOUNT 1000;
+    SELECT 'after setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     EXEC babel_4881_proc_3
-    SELECT 'end nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'end nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
 END
 GO
 
 CREATE PROCEDURE babel_4881_proc_1
 AS
 BEGIN
-    SELECT 'before setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'before setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     SET NOCOUNT ON
-    SET DATEFIRST 2
     SET QUOTED_IDENTIFIER OFF
-    SELECT 'after setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET DATEFIRST 4
+    SELECT 'after setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     EXEC babel_4881_proc_2
-    SELECT 'end nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'end nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
 END
 GO
+
+SET ROWCOUNT 999;
+SET DATEFIRST 2;
+SELECT 'DATEFIRST BEFORE EXEC ===>', current_setting('babelfishpg_tsql.datefirst')
+SELECT 'ROWCOUNT BEFORE EXEC ===>', current_setting('babelfishpg_tsql.rowcount')
+GO
+~~START~~
+varchar#!#text
+DATEFIRST BEFORE EXEC ===>#!#2
+~~END~~
+
+~~START~~
+varchar#!#text
+ROWCOUNT BEFORE EXEC ===>#!#999
+~~END~~
 
 EXEC babel_4881_proc_1
 GO
 ~~START~~
-varchar#!#text#!#text#!#text
-before setting GUC in nest level 1#!#off#!#on#!#7
+varchar#!#text#!#text#!#text#!#text
+before setting GUC in nest level 1#!#off#!#on#!#2#!#999
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-after setting GUC in nest level 1#!#on#!#off#!#2
+varchar#!#text#!#text#!#text#!#text
+after setting GUC in nest level 1#!#on#!#off#!#4#!#999
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-before setting GUC in nest level 2#!#on#!#off#!#2
+varchar#!#text#!#text#!#text#!#text
+before setting GUC in nest level 2#!#on#!#off#!#4#!#999
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-after setting GUC in nest level 2#!#off#!#on#!#4
+varchar#!#text#!#text#!#text#!#text
+after setting GUC in nest level 2#!#off#!#on#!#4#!#1000
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-before setting GUC in nest level 3#!#off#!#on#!#4
+varchar#!#text#!#text#!#text#!#text
+before setting GUC in nest level 3#!#off#!#on#!#4#!#1000
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-after setting GUC in nest level 3#!#on#!#off#!#7
+varchar#!#text#!#text#!#text#!#text
+after setting GUC in nest level 3#!#on#!#off#!#7#!#1000
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-end nest level 2#!#off#!#on#!#4
+varchar#!#text#!#text#!#text#!#text
+end nest level 2#!#off#!#on#!#4#!#1000
 ~~END~~
 
 ~~START~~
-varchar#!#text#!#text#!#text
-end nest level 1#!#on#!#off#!#2
+varchar#!#text#!#text#!#text#!#text
+end nest level 1#!#on#!#off#!#4#!#999
 ~~END~~
 
+SELECT 'DATEFIRST AFTER EXEC ===>', current_setting('babelfishpg_tsql.datefirst')
+SELECT 'ROWCOUNT BEFORE EXEC ===>', current_setting('babelfishpg_tsql.rowcount')
+GO
+~~START~~
+varchar#!#text
+DATEFIRST AFTER EXEC ===>#!#2
+~~END~~
+
+~~START~~
+varchar#!#text
+ROWCOUNT BEFORE EXEC ===>#!#999
+~~END~~
 
 DROP PROCEDURE babel_4881_proc_1, babel_4881_proc_2, babel_4881_proc_3
 GO

--- a/test/JDBC/expected/BABEL_4881.out
+++ b/test/JDBC/expected/BABEL_4881.out
@@ -1,0 +1,82 @@
+CREATE PROCEDURE babel_4881_proc_3
+AS
+BEGIN
+    SELECT 'before setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET NOCOUNT ON
+    SET DATEFIRST 7
+    SET QUOTED_IDENTIFIER OFF
+    SELECT 'after setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+END
+GO
+
+CREATE PROCEDURE babel_4881_proc_2
+AS
+BEGIN
+    SELECT 'before setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET NOCOUNT OFF
+    SET DATEFIRST 4
+    SET QUOTED_IDENTIFIER ON
+    SELECT 'after setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    EXEC babel_4881_proc_3
+    SELECT 'end nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+END
+GO
+
+CREATE PROCEDURE babel_4881_proc_1
+AS
+BEGIN
+    SELECT 'before setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET NOCOUNT ON
+    SET DATEFIRST 2
+    SET QUOTED_IDENTIFIER OFF
+    SELECT 'after setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    EXEC babel_4881_proc_2
+    SELECT 'end nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+END
+GO
+
+EXEC babel_4881_proc_1
+GO
+~~START~~
+varchar#!#text#!#text#!#text
+before setting GUC in nest level 1#!#off#!#on#!#7
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+after setting GUC in nest level 1#!#on#!#off#!#2
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+before setting GUC in nest level 2#!#on#!#off#!#2
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+after setting GUC in nest level 2#!#off#!#on#!#4
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+before setting GUC in nest level 3#!#off#!#on#!#4
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+after setting GUC in nest level 3#!#on#!#off#!#7
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+end nest level 2#!#off#!#on#!#4
+~~END~~
+
+~~START~~
+varchar#!#text#!#text#!#text
+end nest level 1#!#on#!#off#!#2
+~~END~~
+
+
+DROP PROCEDURE babel_4881_proc_1, babel_4881_proc_2, babel_4881_proc_3
+GO

--- a/test/JDBC/input/BABEL_4881.sql
+++ b/test/JDBC/input/BABEL_4881.sql
@@ -1,0 +1,42 @@
+CREATE PROCEDURE babel_4881_proc_3
+AS
+BEGIN
+    SELECT 'before setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET NOCOUNT ON
+    SET DATEFIRST 7
+    SET QUOTED_IDENTIFIER OFF
+    SELECT 'after setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+END
+GO
+
+CREATE PROCEDURE babel_4881_proc_2
+AS
+BEGIN
+    SELECT 'before setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET NOCOUNT OFF
+    SET DATEFIRST 4
+    SET QUOTED_IDENTIFIER ON
+    SELECT 'after setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    EXEC babel_4881_proc_3
+    SELECT 'end nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+END
+GO
+
+CREATE PROCEDURE babel_4881_proc_1
+AS
+BEGIN
+    SELECT 'before setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET NOCOUNT ON
+    SET DATEFIRST 2
+    SET QUOTED_IDENTIFIER OFF
+    SELECT 'after setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    EXEC babel_4881_proc_2
+    SELECT 'end nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+END
+GO
+
+EXEC babel_4881_proc_1
+GO
+
+DROP PROCEDURE babel_4881_proc_1, babel_4881_proc_2, babel_4881_proc_3
+GO

--- a/test/JDBC/input/BABEL_4881.sql
+++ b/test/JDBC/input/BABEL_4881.sql
@@ -1,42 +1,49 @@
 CREATE PROCEDURE babel_4881_proc_3
 AS
 BEGIN
-    SELECT 'before setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'before setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     SET NOCOUNT ON
+    SET QUOTED_IDENTIFIER OFF;
     SET DATEFIRST 7
-    SET QUOTED_IDENTIFIER OFF
-    SELECT 'after setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'after setting GUC in nest level 3', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
 END
 GO
 
 CREATE PROCEDURE babel_4881_proc_2
 AS
 BEGIN
-    SELECT 'before setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'before setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     SET NOCOUNT OFF
-    SET DATEFIRST 4
-    SET QUOTED_IDENTIFIER ON
-    SELECT 'after setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET QUOTED_IDENTIFIER ON;
+    SET ROWCOUNT 1000;
+    SELECT 'after setting GUC in nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     EXEC babel_4881_proc_3
-    SELECT 'end nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'end nest level 2', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
 END
 GO
 
 CREATE PROCEDURE babel_4881_proc_1
 AS
 BEGIN
-    SELECT 'before setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'before setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     SET NOCOUNT ON
-    SET DATEFIRST 2
     SET QUOTED_IDENTIFIER OFF
-    SELECT 'after setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SET DATEFIRST 4
+    SELECT 'after setting GUC in nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
     EXEC babel_4881_proc_2
-    SELECT 'end nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst');
+    SELECT 'end nest level 1', current_setting('babelfishpg_tsql.nocount'), current_setting('babelfishpg_tsql.quoted_identifier'), current_setting('babelfishpg_tsql.datefirst'), current_setting('babelfishpg_tsql.rowcount');
 END
 GO
 
+SET ROWCOUNT 999;
+SET DATEFIRST 2;
+SELECT 'DATEFIRST BEFORE EXEC ===>', current_setting('babelfishpg_tsql.datefirst')
+SELECT 'ROWCOUNT BEFORE EXEC ===>', current_setting('babelfishpg_tsql.rowcount')
+GO
 EXEC babel_4881_proc_1
 GO
-
+SELECT 'DATEFIRST AFTER EXEC ===>', current_setting('babelfishpg_tsql.datefirst')
+SELECT 'ROWCOUNT BEFORE EXEC ===>', current_setting('babelfishpg_tsql.rowcount')
+GO
 DROP PROCEDURE babel_4881_proc_1, babel_4881_proc_2, babel_4881_proc_3
 GO


### PR DESCRIPTION
### Description

Utility function get_guc_variables() was changed in PG 16 [commit](https://github.com/postgres/postgres/commit/3057465acfbea2f3dd7a914a1478064022c6eecd). Earlier it returned an already sorted array pointer containing the GUC list, where as now it does a seq scan on that hash table for GUC and then sort this list.
To fix this we use a GUC list containing all the pltsql GUCs with non empty stack so that during revert we only need to look at those GUCs avoiding the call to get_guc_variables(). This fix is similar to community fix for engine in this [commit](https://github.com/postgres/postgres/commit/f13b2088fa2d4455936e65459b77698a4452f932).

Perf Numbers
Create a procedure with only set statement to get the worst case scenario.
```CREATE PROC p AS SET NOCOUNT ON```

```
DECLARE @dt DATETIME = GETDATE();
DECLARE @i INT =0;
WHILE (@i<100000)
BEGIN
SET @i = @i + 1;
EXEC p
END
SELECT DATEDIFF(ms, @dt, GETDATE());
```
after ~ 4.2 sec       before ~ 26 sec

### Issues Resolved

[BABEL-4881]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).