### PR TITLE
Restrict SET/RESET ROLE/SESSION AUTHORISATION from TDS endpoint

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3832,6 +3832,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 					}
 				}
+
+				if(IS_TDS_CLIENT() &&
+				   (strcmp(variable_set->name, "session_authorization") == 0 ||
+					strcmp(variable_set->name, "role") == 0))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INTERNAL_ERROR),
+							 errmsg("SET/RESET %s not is not supported from TDS endpoint.",
+							        variable_set->name)));
+				}
 				break;
 			}
 		case T_GrantStmt:

--- a/test/JDBC/expected/set_reset_role.out
+++ b/test/JDBC/expected/set_reset_role.out
@@ -1,0 +1,205 @@
+-- tsql
+create login set_reset_login with password='12345678';
+GO
+
+create user set_reset_user for login set_reset_login;
+GO
+
+-- psql
+CREATE PROCEDURE master_dbo.set_role_proc()
+AS
+$$
+BEGIN
+  SET ROLE master_set_reset_user;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE master_dbo.reset_role_proc()
+AS
+$$
+BEGIN
+  RESET ROLE;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE FUNCTION master_dbo.set_role_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'SET ROLE master_set_reset_user';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE FUNCTION master_dbo.reset_role_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'RESET ROLE';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE PROCEDURE master_dbo.set_session_auth_proc()
+AS
+$$
+BEGIN
+  SET SESSION AUTHORIZATION master_set_reset_user;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE master_dbo.reset_session_auth_proc()
+AS
+$$
+BEGIN
+  RESET SESSION AUTHORIZATION;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE FUNCTION master_dbo.set_session_auth_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'SET SESSION AUTHORIZATION master_set_reset_user';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE FUNCTION master_dbo.reset_session_auth_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'RESET SESSION AUTHORIZATION';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+-- tsql
+select current_user;
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+exec set_role_proc;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET role not is not supported from TDS endpoint.)~~
+
+
+exec reset_role_proc;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET role not is not supported from TDS endpoint.)~~
+
+
+select set_role_func();
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET role not is not supported from TDS endpoint.)~~
+
+
+select reset_role_func();
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET role not is not supported from TDS endpoint.)~~
+
+
+select current_user;
+GO
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+select suser_name();
+GO
+~~START~~
+nvarchar
+jdbc_user
+~~END~~
+
+
+exec set_session_auth_proc;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET session_authorization not is not supported from TDS endpoint.)~~
+
+
+exec reset_session_auth_proc;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET session_authorization not is not supported from TDS endpoint.)~~
+
+
+select set_session_auth_func();
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET session_authorization not is not supported from TDS endpoint.)~~
+
+
+select reset_session_auth_func();
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET/RESET session_authorization not is not supported from TDS endpoint.)~~
+
+
+select suser_name();
+GO
+~~START~~
+nvarchar
+jdbc_user
+~~END~~
+
+
+-- tsql
+-- cleanup
+drop user set_reset_user;
+GO
+
+drop login set_reset_login;
+GO
+
+-- psql
+drop procedure master_dbo.set_role_proc;
+GO
+
+drop procedure master_dbo.reset_role_proc;
+GO
+
+drop function master_dbo.set_role_func();
+GO
+
+drop function master_dbo.reset_role_func();
+GO
+
+drop procedure master_dbo.set_session_auth_proc;
+GO
+
+drop procedure master_dbo.reset_session_auth_proc;
+GO
+
+drop function master_dbo.set_session_auth_func();
+GO
+
+drop function master_dbo.reset_session_auth_func();
+GO

--- a/test/JDBC/input/set_reset_role.mix
+++ b/test/JDBC/input/set_reset_role.mix
@@ -1,0 +1,145 @@
+-- tsql
+create login set_reset_login with password='12345678';
+GO
+
+create user set_reset_user for login set_reset_login;
+GO
+
+-- psql
+CREATE PROCEDURE master_dbo.set_role_proc()
+AS
+$$
+BEGIN
+  SET ROLE master_set_reset_user;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE master_dbo.reset_role_proc()
+AS
+$$
+BEGIN
+  RESET ROLE;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE FUNCTION master_dbo.set_role_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'SET ROLE master_set_reset_user';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE FUNCTION master_dbo.reset_role_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'RESET ROLE';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE PROCEDURE master_dbo.set_session_auth_proc()
+AS
+$$
+BEGIN
+  SET SESSION AUTHORIZATION master_set_reset_user;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE master_dbo.reset_session_auth_proc()
+AS
+$$
+BEGIN
+  RESET SESSION AUTHORIZATION;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE FUNCTION master_dbo.set_session_auth_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'SET SESSION AUTHORIZATION master_set_reset_user';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE FUNCTION master_dbo.reset_session_auth_func() RETURNS int AS $$
+BEGIN
+  EXECUTE 'RESET SESSION AUTHORIZATION';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+-- tsql
+select current_user;
+GO
+
+exec set_role_proc;
+GO
+
+exec reset_role_proc;
+GO
+
+select set_role_func();
+GO
+
+select reset_role_func();
+GO
+
+select current_user;
+GO
+
+select suser_name();
+GO
+
+exec set_session_auth_proc;
+GO
+
+exec reset_session_auth_proc;
+GO
+
+select set_session_auth_func();
+GO
+
+select reset_session_auth_func();
+GO
+
+select suser_name();
+GO
+
+-- cleanup
+-- tsql
+drop user set_reset_user;
+GO
+
+drop login set_reset_login;
+GO
+
+-- psql
+drop procedure master_dbo.set_role_proc;
+GO
+
+drop procedure master_dbo.reset_role_proc;
+GO
+
+drop function master_dbo.set_role_func();
+GO
+
+drop function master_dbo.reset_role_func();
+GO
+
+drop procedure master_dbo.set_session_auth_proc;
+GO
+
+drop procedure master_dbo.reset_session_auth_proc;
+GO
+
+drop function master_dbo.set_session_auth_func();
+GO
+
+drop function master_dbo.reset_session_auth_func();
+GO


### PR DESCRIPTION
### Description
Before this commit, SET/RESET ROLE/SESSION AUTHORISATION statement executed from TDS endpoint via function, procedure or trigger can change the current user and session user, leading to mess up the Babelfish security context setup.

This commit avoids above scenarios by blocking SET/RESET ROLE/SESSION AUTHORISATION from being executed from TDS endpoint.

### Issues Resolved
BABEL-4890

### Test Scenarios Covered ###
* **Use case based -**
- Function, Procedure with SET/RESET ROLE
- Function, Procedure with SET/RESET ROLE

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).