### PR TITLE
Keep grantor column in the catalog babelfish_schema_permissions as NULL

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -25,7 +25,7 @@ CREATE TABLE sys.babelfish_schema_permissions (
   grantee sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
   object_type CHAR(1) NOT NULL COLLATE sys.database_default,
   function_args TEXT COLLATE "C",
-  grantor sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  grantor sys.NVARCHAR(128) COLLATE sys.database_default,
   PRIMARY KEY(dbid, schema_name, object_name, grantee, object_type)
 );
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS sys.babelfish_schema_permissions (
   grantee sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
   object_type CHAR(1) NOT NULL COLLATE sys.database_default,
   function_args TEXT COLLATE "C",
-  grantor sys.NVARCHAR(128) NOT NULL COLLATE sys.database_default,
+  grantor sys.NVARCHAR(128) COLLATE sys.database_default,
   PRIMARY KEY(dbid, schema_name, object_name, grantee, object_type)
 );
 

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -3059,7 +3059,6 @@ add_entry_to_bbf_schema_perms(const char *schema_name,
 	Datum		new_record_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
 	bool		new_record_nulls_bbf_schema[BBF_SCHEMA_PERMS_NUM_OF_COLS];
 	int16	dbid = get_cur_db_id();
-	char	*user = GetUserNameFromId(GetUserId(), false);
 
 	/* Immediately return, if grantee is NULL or PUBLIC. */
 	if ((grantee == NULL) || (strcmp(grantee, PUBLIC_ROLE_NAME) == 0))
@@ -3084,7 +3083,7 @@ add_entry_to_bbf_schema_perms(const char *schema_name,
 		new_record_bbf_schema[Anum_bbf_schema_perms_function_args - 1] = CStringGetTextDatum(func_args);
 	else
 		new_record_nulls_bbf_schema[Anum_bbf_schema_perms_function_args - 1] = true;
-	new_record_bbf_schema[Anum_bbf_schema_perms_grantor - 1] = CStringGetTextDatum(pstrdup(user));
+	new_record_nulls_bbf_schema[Anum_bbf_schema_perms_grantor - 1] = true;
 
 	tuple_bbf_schema = heap_form_tuple(bbf_schema_dsc,
 									new_record_bbf_schema,

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
@@ -93,13 +93,13 @@ select schema_name, object_name, permission, grantee, object_type, function_args
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
-babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
-babel_4768_s1#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
-babel_4768_s1#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
-babel_4768_s1#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
-babel_4768_s1#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
-babel_4768_s1#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
-babel_4768_s1#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#<NULL>
+babel_4768_s1#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#<NULL>
+babel_4768_s1#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#<NULL>
+babel_4768_s1#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#<NULL>
+babel_4768_s1#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#<NULL>
+babel_4768_s1#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
+babel_4768_s1#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
 ~~END~~
 
 
@@ -107,12 +107,12 @@ select schema_name, object_name, permission, grantee, object_type, function_args
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
-dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
-dbo#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
-dbo#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
-dbo#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
-dbo#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
-dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
-dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#<NULL>
+dbo#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#<NULL>
+dbo#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#<NULL>
+dbo#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#<NULL>
+dbo#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#<NULL>
+dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
+dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -3,13 +3,13 @@ select schema_name, object_name, permission, grantee, object_type, function_args
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
-babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
-babel_4768_s1#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
-babel_4768_s1#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
-babel_4768_s1#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
-babel_4768_s1#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
-babel_4768_s1#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
-babel_4768_s1#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+babel_4768_s1#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#<NULL>
+babel_4768_s1#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#<NULL>
+babel_4768_s1#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#<NULL>
+babel_4768_s1#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#<NULL>
+babel_4768_s1#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#<NULL>
+babel_4768_s1#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
+babel_4768_s1#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
 ~~END~~
 
 
@@ -17,13 +17,13 @@ select schema_name, object_name, permission, grantee, object_type, function_args
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
-dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#master_dbo
-dbo#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#master_dbo
-dbo#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#master_dbo
-dbo#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#master_dbo
-dbo#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#master_dbo
-dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
-dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#master_dbo
+dbo#!#ALL#!#130#!#master_babel_4768_u1#!#s#!#<NULL>#!#<NULL>
+dbo#!#babel_4768_f1#!#128#!#master_babel_4768_u1#!#f#!##!#<NULL>
+dbo#!#babel_4768_f2#!#128#!#master_babel_4768_u1#!#f#!#pg_catalog.int4#!#<NULL>
+dbo#!#babel_4768_p1#!#128#!#master_babel_4768_u1#!#p#!##!#<NULL>
+dbo#!#babel_4768_p2#!#128#!#master_babel_4768_u1#!#p#!#sys.datetimeoffset#!#<NULL>
+dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
+dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
 ~~END~~
 
 
@@ -92,9 +92,9 @@ BEGIN
     IF EXISTS (SELECT 1 FROM
 information_schema.tables WHERE
 table_name = 'tbl_creation_should_succeed' AND
-table_schema = 'master_dbo') THEN
+table_schema = '<NULL>') THEN
         EXECUTE 'GRANT ALL ON
-master_dbo.tbl_creation_should_succeed TO master_dbo';
+<NULL>.tbl_creation_should_succeed TO <NULL>';
     END IF;
 END $$;
 GO

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -92,9 +92,9 @@ BEGIN
     IF EXISTS (SELECT 1 FROM
 information_schema.tables WHERE
 table_name = 'tbl_creation_should_succeed' AND
-table_schema = '<NULL>') THEN
+table_schema = 'master_dbo') THEN
         EXECUTE 'GRANT ALL ON
-<NULL>.tbl_creation_should_succeed TO <NULL>';
+master_dbo.tbl_creation_should_succeed TO master_dbo';
     END IF;
 END $$;
 GO

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -519,11 +519,11 @@ where schema_name = 'babel_4344_s1' collate "C" order by permission; -- and obje
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
-babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#<NULL>
 ~~END~~
 
 
@@ -546,11 +546,11 @@ where schema_name = 'babel_4344_s1' collate "C" order by permission;
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
-babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#<NULL>
 ~~END~~
 
 
@@ -742,11 +742,11 @@ select schema_name, object_name, permission, grantee, grantor from sys.babelfish
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
-babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_f1#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_p1#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_t1#!#47#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_v1#!#2#!#babel_4344_d1_babel_4344_u1#!#<NULL>
 ~~END~~
 
 
@@ -771,11 +771,11 @@ select schema_name, object_name, permission, grantee, grantor from sys.babelfish
 go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
-babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_f1_new#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_p1_new#!#128#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_t1_new#!#47#!#babel_4344_d1_babel_4344_u1#!#dbo
-babel_4344_s1#!#babel_4344_v1_new#!#2#!#babel_4344_d1_babel_4344_u1#!#dbo
+babel_4344_s1#!#ALL#!#131#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_f1_new#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_p1_new#!#128#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_t1_new#!#47#!#babel_4344_d1_babel_4344_u1#!#<NULL>
+babel_4344_s1#!#babel_4344_v1_new#!#2#!#babel_4344_d1_babel_4344_u1#!#<NULL>
 ~~END~~
 
 


### PR DESCRIPTION
### Description

Keep `grantor` column in the catalog `babelfish_schema_permissions` as NULL


### Issues Resolved

Task: [BABEL-4904](https://jira.rds.a2z.com/browse/BABEL-4904)
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -Added**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).