### PR TITLE
Incorrect babelfish_schema_permissions catalog update after database drop

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -3549,6 +3549,42 @@ clean_up_bbf_schema_permissions(const char *schema_name,
 }
 
 /*
+ * Clean up babelfish_schema_permissions table for a given database
+ * when database is dropped.
+ */
+void
+drop_bbf_schema_permission_entries(int16 dbid)
+{
+	Relation	bbf_schema_rel;
+	HeapTuple	tuple_bbf_schema;
+	ScanKeyData scanKey[1];
+	SysScanDesc scan;
+
+	/* Fetch the relation */
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(), RowExclusiveLock);
+
+	/* Search and drop the entries */
+	ScanKeyInit(&scanKey[0],
+				Anum_bbf_schema_perms_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+
+	scan = systable_beginscan(bbf_schema_rel,
+							  get_bbf_schema_perms_idx_oid(),
+							  true, NULL, 1, scanKey);
+
+	while ((tuple_bbf_schema = systable_getnext(scan)) != NULL)
+	{
+		if (HeapTupleIsValid(tuple_bbf_schema))
+			CatalogTupleDelete(bbf_schema_rel,
+							   &tuple_bbf_schema->t_self);
+	}
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
+}
+
+/*
  * For all objects belonging to a schema which has OBJECT level permission,
  * It grants the permission explicitly when REVOKE has been executed on that
  * specific schema.

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -203,6 +203,7 @@ extern HeapTuple search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid,
 									 const char *logical_schema_name, const char *view_name);
 extern bool check_is_tsql_view(Oid relid);
 extern void clean_up_bbf_view_def(int16 dbid);
+extern void drop_bbf_schema_permission_entries(int16 dbid);
 
 typedef struct FormData_bbf_view_def
 {

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -759,6 +759,8 @@ drop_bbf_db(const char *dbname, bool missing_ok, bool force_drop)
 		drop_related_bbf_users(db_users_list);
 		/* delete extended property */
 		delete_extended_property(dbid, NULL, NULL, NULL, NULL);
+		/* clean up bbf schema permission catalog */
+		drop_bbf_schema_permission_entries(dbid);
 
 		/* Release the session-level exclusive lock */
 		UnlockLogicalDatabaseForSession(dbid, ExclusiveLock, true);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3339,8 +3339,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					const char *schemaname = strVal(lfirst(list_head(drop_stmt->objects)));
 					char	   *cur_db = get_cur_db_name();
 					const char	*logicalschema = get_logical_schema_name(schemaname, true);
+					bool	is_drop_db_statement = 0 == strcmp(queryString, "(DROP DATABASE )");
 
-					if (strcmp(queryString, "(DROP DATABASE )") != 0)
+					if (!is_drop_db_statement)
 					{
 						char	   *guest_schema_name = get_physical_schema_name(cur_db, "guest");
 
@@ -3354,7 +3355,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 					bbf_ExecDropStmt(drop_stmt);
 					del_ns_ext_info(schemaname, drop_stmt->missing_ok);
-					if (strcmp(queryString, "(DROP DATABASE )") != 0)
+					if (!is_drop_db_statement)
 					{
 						/*
 						 * Prevent cleaning up the catalog here if it is a part

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3357,7 +3357,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					if (strcmp(queryString, "(DROP DATABASE )") != 0)
 					{
 						/*
-						 * Prevent cleaning up the catalag here if it is a part
+						 * Prevent cleaning up the catalog here if it is a part
 						 * of drop database command.
 						 */
 						clean_up_bbf_schema_permissions(logicalschema, NULL, true);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3330,7 +3330,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					break;
 				}
 
-
 				if (sql_dialect == SQL_DIALECT_TSQL)
 				{
 					/*
@@ -3355,7 +3354,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 					bbf_ExecDropStmt(drop_stmt);
 					del_ns_ext_info(schemaname, drop_stmt->missing_ok);
-					clean_up_bbf_schema_permissions(logicalschema, NULL, true);
+					if (strcmp(queryString, "(DROP DATABASE )") != 0)
+					{
+						/*
+						 * Prevent cleaning up the catalag here if it is a part
+						 * of drop database command.
+						 */
+						clean_up_bbf_schema_permissions(logicalschema, NULL, true);
+					}
 
 					if (prev_ProcessUtility)
 						prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,

--- a/test/JDBC/expected/BABEL-3865.out
+++ b/test/JDBC/expected/BABEL-3865.out
@@ -136,6 +136,9 @@ GO
 ~~ERROR (Message: role "master_role_a" cannot be dropped because some objects depend on it)~~
 
 
+REVOKE ALL ON #temp_5 FROM role_a
+GO
+
 DROP TABLE #temp_5
 GO
 

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -4553,3 +4553,60 @@ drop login l5;
 go
 drop login l6;
 go
+
+-- tsql
+-- test drop database removes correct entries from the catalog
+create table babel_4344_t1(a int);
+go
+grant select on babel_4344_t1 to guest;
+go
+create database babel_4344_d1;
+go
+use babel_4344_d1;
+go
+create table babel_4344_t1(a int);
+go
+grant select on babel_4344_t1 to guest;
+go
+use master;
+go
+
+-- psql
+-- should have 2 entries for master and babel_4344_d1 databases
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
+dbo#!#babel_4344_t1#!#2#!#master_guest
+dbo#!#babel_4344_t1#!#2#!#babel_4344_d1_guest
+~~END~~
+
+
+-- tsql
+use master
+go
+drop database babel_4344_d1;
+go
+
+-- psql
+-- should have 1 entry for master database since babel_4344_d1 is dropped
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
+dbo#!#babel_4344_t1#!#2#!#master_guest
+~~END~~
+
+
+-- tsql
+drop table babel_4344_t1;
+go
+
+-- psql
+-- should have no entries since the table is dropped
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
+~~END~~
+

--- a/test/JDBC/input/BABEL-3865.sql
+++ b/test/JDBC/input/BABEL-3865.sql
@@ -106,6 +106,9 @@ GO
 DROP ROLE role_a
 GO
 
+REVOKE ALL ON #temp_5 FROM role_a
+GO
+
 DROP TABLE #temp_5
 GO
 

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -2272,3 +2272,45 @@ drop login l5;
 go
 drop login l6;
 go
+
+-- test drop database removes correct entries from the catalog
+-- tsql
+create table babel_4344_t1(a int);
+go
+grant select on babel_4344_t1 to guest;
+go
+create database babel_4344_d1;
+go
+use babel_4344_d1;
+go
+create table babel_4344_t1(a int);
+go
+grant select on babel_4344_t1 to guest;
+go
+use master;
+go
+
+-- psql
+-- should have 2 entries for master and babel_4344_d1 databases
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
+go
+
+-- tsql
+use master
+go
+drop database babel_4344_d1;
+go
+
+-- psql
+-- should have 1 entry for master database since babel_4344_d1 is dropped
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
+go
+
+-- tsql
+drop table babel_4344_t1;
+go
+
+-- psql
+-- should have no entries since the table is dropped
+select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
+go


### PR DESCRIPTION
### Description

Incorrect babelfish_schema_permissions catalog update after database drop

### Issues Resolved

Task: BABEL-4905
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Added


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).