### PR TITLE
Fix code coverage test failure issue

### DIFF
--- a/test/JDBC/expected/check_for_inconsistent_metadata-vu-verify.out
+++ b/test/JDBC/expected/check_for_inconsistent_metadata-vu-verify.out
@@ -3,24 +3,22 @@
 
 
 
--- Deleting one entry from pg_proc pg catalog so that metadata inconsistency fails during check against babelfish_function_ext babelfish catalog
-WITH r1 AS (
-    SELECT * FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func'
-)
-SELECT proname, prosrc FROM r1;
-DELETE FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
-SELECT proname, prosrc FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
-SELECT nspname, funcname FROM sys.babelfish_function_ext WHERE funcname = 'check_for_inconsistent_metadata_vu_prepare_func';
-GO
-~~START~~
-name#!#text
-check_for_inconsistent_metadata_vu_prepare_func#!#BEGIN<newline>RETURN (SELECT sys.check_for_inconsistent_metadata())<newline>END
-~~END~~
 
+-- Updating one entry from pg_proc pg catalog so that metadata inconsistency fails during check against babelfish_function_ext babelfish catalog
+UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
+SELECT proname, prosrc FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
+SELECT nspname, funcname FROM sys.babelfish_function_ext WHERE funcname = 'check_for_inconsistent_metadata_vu_prepare_func';
+-- should return true because of inconsistency
+SELECT sys.check_for_inconsistent_metadata();
+-- should return the inconsistent row data
+SELECT sys.babelfish_inconsistent_metadata();
+UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
+GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
 name#!#text
+check_for_inconsistent_metadata_vu_prepare_func_wrong#!#BEGIN<newline>RETURN (SELECT sys.check_for_inconsistent_metadata())<newline>END
 ~~END~~
 
 ~~START~~
@@ -28,28 +26,25 @@ name#!#name
 master_dbo#!#check_for_inconsistent_metadata_vu_prepare_func
 ~~END~~
 
-
-SELECT sys.check_for_inconsistent_metadata();
-GO
 ~~START~~
 bool
 t
 ~~END~~
 
-
-SELECT sys.babelfish_inconsistent_metadata()
-GO
 ~~START~~
 record
 (name,pg_catalog,proname,"{""Rule"": ""<funcname> in babelfish_function_ext must also exist in pg_proc""}")
 ~~END~~
 
+~~ROW COUNT: 1~~
+
 
 -- tsql
--- should fail since the function is removed from the catalog
+-- since data is consistent now, this should return 0
 SELECT check_for_inconsistent_metadata_vu_prepare_func()
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: function check_for_inconsistent_metadata_vu_prepare_func() does not exist)~~
+~~START~~
+bit
+0
+~~END~~
 

--- a/test/JDBC/input/check_for_inconsistent_metadata-vu-verify.mix
+++ b/test/JDBC/input/check_for_inconsistent_metadata-vu-verify.mix
@@ -1,25 +1,21 @@
--- Deleting one entry from pg_proc pg catalog so that metadata inconsistency fails during check against babelfish_function_ext babelfish catalog
+-- Updating one entry from pg_proc pg catalog so that metadata inconsistency fails during check against babelfish_function_ext babelfish catalog
 -- psql
-WITH r1 AS (
-    SELECT * FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func'
-)
+UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
 
-SELECT proname, prosrc FROM r1;
-
-DELETE FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
-
-SELECT proname, prosrc FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
+SELECT proname, prosrc FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
 
 SELECT nspname, funcname FROM sys.babelfish_function_ext WHERE funcname = 'check_for_inconsistent_metadata_vu_prepare_func';
-GO
 
+-- should return true because of inconsistency
 SELECT sys.check_for_inconsistent_metadata();
-GO
 
-SELECT sys.babelfish_inconsistent_metadata()
+-- should return the inconsistent row data
+SELECT sys.babelfish_inconsistent_metadata();
+
+UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
 GO
 
 -- tsql
--- should fail since the function is removed from the catalog
+-- since data is consistent now, this should return 0
 SELECT check_for_inconsistent_metadata_vu_prepare_func()
 GO


### PR DESCRIPTION
### Description
This commit addresses a code coverage test failure triggered by the introduction of test files for `check_for_inconsistent_metadata()`. Initially, we attempted to delete an entry from `pg_catalog`, causing inconsistency. However, during cleanup, Babelfish couldn't detect this deleted function in `pg_proc`, leading to failed code coverage test actions.

To resolve this, instead of deletion, we now modify the entry, inducing inconsistency for testing.

Initial PR - #2465 

### Issues Resolved

Task: BABEL-4139

### Test Scenarios Covered ###
* **Use case based -** Y


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).