### PR TITLE
Add test for column level constraint for LIKE for AI collations

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -369,7 +369,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 	patt = (Const *) rightop;
 
 	/* extract pattern */
-	pstatus = pattern_fixed_prefix_wrapper(patt, 1, server_collation_oid,
+	pstatus = pattern_fixed_prefix_wrapper(patt, 1, coll_info_of_inputcollid.oid,
 											&prefix, NULL);
 
 	/* If there is no constant prefix then there's nothing more to do */
@@ -391,7 +391,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 
 		ret = (Node *) (make_op_with_func(oprid(optup), BOOLOID, false,
 											(Expr *) leftop, (Expr *) prefix,
-											InvalidOid, server_collation_oid, oprfuncid(optup)));
+											InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup)));
 
 		ReleaseSysCache(optup);
 	}
@@ -410,10 +410,10 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 			return node;
 		greater_equal = make_op_with_func(oprid(optup), BOOLOID, false,
 											(Expr *) leftop, (Expr *) prefix,
-											InvalidOid, server_collation_oid, oprfuncid(optup));
+											InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		ReleaseSysCache(optup);
 		/* construct pattern||E'\uFFFF' */
-		highest_sort_key = makeConst(TEXTOID, -1, server_collation_oid, -1,
+		highest_sort_key = makeConst(TEXTOID, -1, coll_info_of_inputcollid.oid, -1,
 										PointerGetDatum(cstring_to_text(SORT_KEY_STR)), false, false);
 
 		optup = compatible_oper(NULL, list_make1(makeString("||")), rtypeId, rtypeId,
@@ -422,7 +422,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 			return node;
 		concat_expr = make_op_with_func(oprid(optup), rtypeId, false,
 										(Expr *) prefix, (Expr *) highest_sort_key,
-										InvalidOid, server_collation_oid, oprfuncid(optup));
+										InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		ReleaseSysCache(optup);
 		/* construct leftop < pattern */
 		optup = compatible_oper(NULL, list_make1(makeString("<")), ltypeId, ltypeId,
@@ -432,7 +432,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 
 		less_equal = make_op_with_func(oprid(optup), BOOLOID, false,
 										(Expr *) leftop, (Expr *) concat_expr,
-										InvalidOid, server_collation_oid, oprfuncid(optup));
+										InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		constant_suffix = make_and_qual((Node *) greater_equal, (Node *) less_equal);
 		if (like_entry.is_not_match)
 		{

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -415,6 +415,9 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 		/* construct pattern||E'\uFFFF' */
 		highest_sort_key = makeConst(TEXTOID, -1, coll_info_of_inputcollid.oid, -1,
 										PointerGetDatum(cstring_to_text(SORT_KEY_STR)), false, false);
+		
+		/* Set the collation explicitly for the Const node */
+		highest_sort_key->constcollid = coll_info_of_inputcollid.oid;
 
 		optup = compatible_oper(NULL, list_make1(makeString("||")), rtypeId, rtypeId,
 								true, -1);

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -2257,6 +2257,43 @@ TEññiȘ#!#No Match
 
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 ~~START~~
@@ -4421,7 +4458,59 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 ~~START~~

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -2256,6 +2256,19 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
+
+
 
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -4405,6 +4418,16 @@ película#!#Match
 canapé#!#No Match
 chaptéR#!#No Match
 TEññiȘ#!#No Match
+~~END~~
+
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+10#!#Ądam
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -2257,43 +2257,6 @@ TEññiȘ#!#No Match
 
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ROW COUNT: 1~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 ~~START~~
@@ -4458,59 +4421,7 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
-
 -- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
-GO
-~~ROW COUNT: 1~~
-
-
--- these will fail - CS_AI
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 ~~START~~

--- a/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
@@ -11,6 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
+
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO
@@ -27,6 +30,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_cs;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CS_AI;
+GO
 
 -- GENERIC --
 DROP TABLE test_like_for_AI_prepare_escape;

--- a/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
@@ -11,9 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
-DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
-GO
 
+-- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO

--- a/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
@@ -11,9 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
 
--- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
--- GO
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -116,43 +116,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
 );
 GO
 
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ROW COUNT: 1~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -315,58 +278,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
         CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
 );
 GO
-
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
-GO
-~~ROW COUNT: 1~~
-
-
--- these will fail - CS_AI
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
 
 
 --- ADDITIONAL CORNER CASE TESTING ---

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -106,16 +106,16 @@ GO
 ~~ROW COUNT: 13~~
 
 
-
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
--- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
---     id INT PRIMARY KEY,
---     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
---     CONSTRAINT check_name_starts_with_a 
---         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
--- );
--- GO
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
+
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -106,6 +106,53 @@ GO
 ~~ROW COUNT: 13~~
 
 
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -257,6 +304,67 @@ VALUES
 ,(null);
 GO
 ~~ROW COUNT: 29~~
+
+
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CS_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
 
 
 

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -106,16 +106,16 @@ GO
 ~~ROW COUNT: 13~~
 
 
+
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
-CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
-    id INT PRIMARY KEY,
-    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
-    CONSTRAINT check_name_starts_with_a 
-        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
-);
-GO
-
+-- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+--     id INT PRIMARY KEY,
+--     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+--     CONSTRAINT check_name_starts_with_a 
+--         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+-- );
+-- GO
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2257,6 +2257,43 @@ TEññiȘ#!#No Match
 
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 ~~START~~
@@ -4421,7 +4458,59 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 ~~START~~

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2256,6 +2256,19 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
+
+
 
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -4405,6 +4418,16 @@ película#!#Match
 canapé#!#No Match
 chaptéR#!#No Match
 TEññiȘ#!#No Match
+~~END~~
+
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+10#!#Ądam
 ~~END~~
 
 

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2256,30 +2256,57 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
 
 
 
-
--- -- CASE 21: COLUMN LEVEL CONSTRAINT
--- -- Test the constraint
--- -- This insert will succeed
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
--- GO
--- -- This insert will fail due to the check constraint
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
--- GO
--- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
--- GO
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 select 1 where 'cantáis' like 'cá%' collate Latin1_General_CS_AI;

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2256,57 +2256,30 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
--- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ROW COUNT: 1~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-
-SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
-GO
-~~START~~
-int#!#nvarchar
-1#!#Adam
-2#!#ådAm
-3#!#ädam
-4#!#adam
-5#!#ædam
-~~END~~
 
 
 
+
+-- -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- -- Test the constraint
+-- -- This insert will succeed
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+-- GO
+-- -- This insert will fail due to the check constraint
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+-- GO
+-- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 select 1 where 'cantáis' like 'cá%' collate Latin1_General_CS_AI;

--- a/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
@@ -11,8 +11,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
--- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
--- GO
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
 
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;

--- a/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
@@ -11,6 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
+
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO
@@ -27,6 +30,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_cs;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CS_AI;
+GO
 
 -- GENERIC --
 DROP TABLE test_like_for_AI_prepare_escape;

--- a/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
@@ -11,8 +11,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
-DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
-GO
+-- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -106,25 +106,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
 );
 GO
 
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -275,30 +256,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
         CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
 );
 GO
-
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
-GO
-
--- these will fail - CS_AI
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
-GO
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
-GO
-
 
 --- ADDITIONAL CORNER CASE TESTING ---
 

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -98,13 +98,13 @@ GO
 
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
--- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
---     id INT PRIMARY KEY,
---     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
---     CONSTRAINT check_name_starts_with_a 
---         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
--- );
--- GO
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
 
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -96,6 +96,35 @@ INSERT INTO test_like_for_AI_prepare_t13_2_ci VALUES
   (null);
 GO
 
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -235,6 +264,39 @@ VALUES
 ,('My[valid]String')
 ,(null);
 
+GO
+
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CS_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
 GO
 
 

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -98,13 +98,13 @@ GO
 
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
-CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
-    id INT PRIMARY KEY,
-    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
-    CONSTRAINT check_name_starts_with_a 
-        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
-);
-GO
+-- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+--     id INT PRIMARY KEY,
+--     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+--     CONSTRAINT check_name_starts_with_a 
+--         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+-- );
+-- GO
 
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -793,28 +793,28 @@ SELECT col,
 FROM test_like_for_AI_prepare_t1_ci;
 GO
 
--- -- CASE 21: COLUMN LEVEL CONSTRAINT
--- -- Test the constraint
--- -- This insert will succeed
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
--- GO
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
 
--- -- This insert will fail due to the check constraint
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
--- GO
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
 
--- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
--- GO
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
 
 
 ------------------- CS_AI ----------------------

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -793,6 +793,10 @@ SELECT col,
 FROM test_like_for_AI_prepare_t1_ci;
 GO
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+
 
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -1584,6 +1588,10 @@ SELECT col,
            ELSE 'No Match' 
        END AS extracted_substring
 FROM test_like_for_AI_prepare_t1_ci;
+GO
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 
 --- ADDITIONAL CORNER CASE TESTING ---

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -793,28 +793,28 @@ SELECT col,
 FROM test_like_for_AI_prepare_t1_ci;
 GO
 
--- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
+-- -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- -- Test the constraint
+-- -- This insert will succeed
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+-- GO
 
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
+-- -- This insert will fail due to the check constraint
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+-- GO
 
-SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
-GO
+-- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 
 
 ------------------- CS_AI ----------------------

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -794,6 +794,25 @@ FROM test_like_for_AI_prepare_t1_ci;
 GO
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 
@@ -1591,6 +1610,30 @@ FROM test_like_for_AI_prepare_t1_ci;
 GO
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -514,3 +514,4 @@ babel_test_int4_numeric_oper_before_16_3
 babel_test_int8_numeric_oper_before_16_3
 babel_test_int2_numeric_oper_before_16_3
 BABEL_3571
+test_like_for_AI


### PR DESCRIPTION
### Description
This commit adds JDBC tests for column level constrains using CHECK while inserting value into a table. If the CHECK condition is not met, user won't be able to insert data into table
Upgrade test for 15_latest to 16_latest has also been added.


### Issues Resolved

BABEL-4931
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).