### PR TITLE
Update default behavior of fulltext search escape hatch

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1234,7 +1234,7 @@ int			escape_hatch_login_password_must_change = EH_STRICT;
 int			escape_hatch_login_password_unlock = EH_STRICT;
 int			escape_hatch_login_misc_options = EH_STRICT;
 int			escape_hatch_compatibility_level = EH_IGNORE;
-int			escape_hatch_fulltext = EH_IGNORE;
+int			escape_hatch_fulltext = EH_STRICT;
 int			escape_hatch_schemabinding_function = EH_IGNORE;
 int			escape_hatch_schemabinding_trigger = EH_IGNORE;
 int			escape_hatch_schemabinding_procedure = EH_IGNORE;
@@ -1383,7 +1383,7 @@ define_escape_hatch_variables(void)
 							 gettext_noop("escape hatch for fulltext search"),
 							 NULL,
 							 &escape_hatch_fulltext,
-							 EH_IGNORE,
+							 EH_STRICT,
 							 escape_hatch_options,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/test/JDBC/expected/BABEL-4785-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4785-vu-cleanup.out
@@ -1,3 +1,13 @@
+-- tsql user=jdbc_user password=12345678
+-- enable FULLTEXT
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
+GO
+~~START~~
+text
+ignore
+~~END~~
+
+
 DROP FULLTEXT INDEX ON [fts.test].[table.test];
 GO
 
@@ -87,3 +97,12 @@ GO
 
 DROP DATABASE IF EXISTS "fts_test .db";
 GO
+
+-- disable FULLTEXT
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
+GO
+~~START~~
+text
+strict
+~~END~~
+

--- a/test/JDBC/expected/BABEL-4785-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4785-vu-prepare.out
@@ -1,3 +1,13 @@
+-- tsql user=jdbc_user password=12345678
+-- enable FULLTEXT
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
+GO
+~~START~~
+text
+ignore
+~~END~~
+
+
 -- Tests for database, schema and object name containing spaces and dots
 CREATE SCHEMA [fts.test]
 GO
@@ -109,3 +119,12 @@ GO
 
 CREATE FULLTEXT INDEX ON "fts_test .db".[fts_test  .schema with / {} special characters #$%]."fts test table with / {} special [] characters"(name) KEY INDEX fti_schema_test11;
 GO
+
+-- disable FULLTEXT
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
+GO
+~~START~~
+text
+strict
+~~END~~
+

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -717,6 +717,10 @@ strict
 -- 'strict' is default
 CREATE DATABASE db_unsupported_ft WITH DEFAULT_FULLTEXT_LANGUAGE = English;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DEFAULT_FULLTEXT_LANGUAGE' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_fulltext to ignore)~~
+
 
 CREATE TABLE t_unsupported_ft (a text);
 GO
@@ -725,7 +729,7 @@ CREATE FULLTEXT INDEX ON t_unsupported_ft(a) KEY INDEX ix_unsupported_ft;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: '"ix_unsupported_ft"' is not a valid index to enforce a full-text search key. A full-text search key must be a unique, non-nullable, single-column index which is not offline, is not defined on a non-deterministic or imprecise nonpersisted computed column, does not have a filter, and has maximum size of 900 bytes. Choose another index for the full-text key.)~~
+~~ERROR (Message: 'CREATE FULLTEXT INDEX' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_fulltext to ignore)~~
 
 
 DROP TABLE t_unsupported_ft;
@@ -741,10 +745,6 @@ ignore
 
 CREATE DATABASE db_unsupported_ft WITH DEFAULT_FULLTEXT_LANGUAGE = English;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Database 'db_unsupported_ft' already exists. Choose a different database name.)~~
-
 
 DROP DATABASE db_unsupported_ft;
 GO

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -725,6 +725,10 @@ strict
 -- 'strict' is default
 CREATE DATABASE db_unsupported_ft WITH DEFAULT_FULLTEXT_LANGUAGE = English;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DEFAULT_FULLTEXT_LANGUAGE' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_fulltext to ignore)~~
+
 
 CREATE TABLE t_unsupported_ft (a text);
 GO
@@ -733,7 +737,7 @@ CREATE FULLTEXT INDEX ON t_unsupported_ft(a) KEY INDEX ix_unsupported_ft;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: '"ix_unsupported_ft"' is not a valid index to enforce a full-text search key. A full-text search key must be a unique, non-nullable, single-column index which is not offline, is not defined on a non-deterministic or imprecise nonpersisted computed column, does not have a filter, and has maximum size of 900 bytes. Choose another index for the full-text key.)~~
+~~ERROR (Message: 'CREATE FULLTEXT INDEX' is not currently supported in Babelfish. please use babelfishpg_tsql.escape_hatch_fulltext to ignore)~~
 
 
 DROP TABLE t_unsupported_ft;
@@ -749,10 +753,6 @@ ignore
 
 CREATE DATABASE db_unsupported_ft WITH DEFAULT_FULLTEXT_LANGUAGE = English;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: Database 'db_unsupported_ft' already exists. Choose a different database name.)~~
-
 
 DROP DATABASE db_unsupported_ft;
 GO

--- a/test/JDBC/input/full_text_search/BABEL-4785-vu-cleanup.mix
+++ b/test/JDBC/input/full_text_search/BABEL-4785-vu-cleanup.mix
@@ -1,3 +1,8 @@
+-- enable FULLTEXT
+-- tsql user=jdbc_user password=12345678
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
+GO
+
 DROP FULLTEXT INDEX ON [fts.test].[table.test];
 GO
 
@@ -86,4 +91,8 @@ USE master;
 GO
 
 DROP DATABASE IF EXISTS "fts_test .db";
+GO
+
+-- disable FULLTEXT
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO

--- a/test/JDBC/input/full_text_search/BABEL-4785-vu-prepare.mix
+++ b/test/JDBC/input/full_text_search/BABEL-4785-vu-prepare.mix
@@ -1,3 +1,8 @@
+-- enable FULLTEXT
+-- tsql user=jdbc_user password=12345678
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'ignore', 'false')
+GO
+
 -- Tests for database, schema and object name containing spaces and dots
 CREATE SCHEMA [fts.test]
 GO
@@ -108,4 +113,8 @@ CREATE TABLE "fts_test .db".[fts_test  .schema with / {} special characters #$%]
 GO
 
 CREATE FULLTEXT INDEX ON "fts_test .db".[fts_test  .schema with / {} special characters #$%]."fts test table with / {} special [] characters"(name) KEY INDEX fti_schema_test11;
+GO
+
+-- disable FULLTEXT
+SELECT set_config('babelfishpg_tsql.escape_hatch_fulltext', 'strict', 'false')
 GO


### PR DESCRIPTION
### Description

In `3_X`, the escape hatch for fulltext search queries defaults to `strict`, although, in `4_X`, fulltext search feature is turned on by default i.e. this escape hatch is set to `ignore`. 

This commit sets the default behavior of the escape hatch `babelfishpg_tsql.escape_hatch_fulltext` to `strict` ensuring consistency throughout.

### Issues Resolved

Task: BABEL-4930

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).