### PR TITLE
Add upgrade path files for 2.7.0 to 3.0.0 and 3.5.0 to 4.0.0 in babelfishpg_common

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.7.0--3.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--2.7.0--3.0.0.sql
@@ -1,0 +1,16 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '3.0.0'" to load this file. \quit
+
+SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+/* This helper function would only be useful and strictly be used during 1.x->2.3 and 2.3->3.0 upgrade. */
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+SELECT sys.babelfish_update_server_collation_name();
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- Reset search_path to not affect any subsequent scripts
+SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.5.0--4.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.5.0--4.0.0.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '4.0.0'" to load this file. \quit

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -510,7 +510,7 @@ babel-4517
 BABEL-4815
 BABEL-4641
 BABEL-4863
-babel_test_int4_numeric_oper_before_16_3
-babel_test_int8_numeric_oper_before_16_3
-babel_test_int2_numeric_oper_before_16_3
+babel_test_int4_numeric_oper
+babel_test_int8_numeric_oper
+babel_test_int2_numeric_oper
 BABEL_3571

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -14,6 +14,7 @@ Unexpected drop found for function sys.babelfish_update_server_collation_name in
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.4.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.5.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.6.0--3.0.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_common--2.7.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.0.0--2.1.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.3.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.4.0--3.0.0.sql


### PR DESCRIPTION
### Description

This commit introduces upgrade path file for upgrading version from `2.7.0` to `3.0.0` and from version `3.5.0` to `4.0.0` in `babelfishpg_common` module.

This issue was introduced by #2460 

### Issues Resolved

BABEL-3385

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).