### PR TITLE
Fix searchpath handling for tsql udfs inside fmgr (#2536)

### DIFF
--- a/test/JDBC/expected/BABEL_4877.out
+++ b/test/JDBC/expected/BABEL_4877.out
@@ -1,0 +1,491 @@
+-- tsql
+CREATE SCHEMA babel_4877_s1
+GO
+
+CREATE FUNCTION babel_4877_s1.babel_4877_f1() RETURNS INT
+AS
+BEGIN
+    DECLARE @babel_4877_tablevar TABLE (id INT)
+    INSERT INTO @babel_4877_tablevar SELECT id FROM babel_4877_t;
+    RETURN (SELECT id FROM @babel_4877_tablevar)
+END
+GO
+
+CREATE PROC babel_4877_s1.babel_4877_p
+AS
+    SELECT babel_4877_s1.babel_4877_f1()
+GO
+
+CREATE TABLE dbo.babel_4877_t (id INT)
+GO
+INSERT INTO dbo.babel_4877_t VALUES (10)
+GO
+~~ROW COUNT: 1~~
+
+
+-- func in s1 should see dbo table
+EXEC babel_4877_s1.babel_4877_p
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+CREATE TABLE babel_4877_s1.babel_4877_t (id INT)
+GO
+INSERT INTO babel_4877_s1.babel_4877_t VALUES (20)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Now func in s1 should select unspecified objects from s1 first then dbo
+EXEC babel_4877_s1.babel_4877_p
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+SELECT babel_4877_s1.babel_4877_f1()
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+DROP TABLE babel_4877_s1.babel_4877_t, dbo.babel_4877_t
+GO
+DROP PROC babel_4877_s1.babel_4877_p
+GO
+DROP FUNCTION babel_4877_s1.babel_4877_f1
+GO
+DROP SCHEMA babel_4877_s1
+GO
+
+
+-- psql
+CREATE PROCEDURE master_dbo.babel_4877_reset_search_path() AS
+$$ BEGIN
+RESET search_path;
+END $$
+LANGUAGE plpgsql;
+GO
+
+-- tsql
+CREATE SCHEMA babel_4877_s1
+GO
+CREATE FUNCTION babel_4877_s1.babel_4877_f1() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (SELECT set_config('search_path','master_babel_4877_s1, sys, pg_catalog', false));
+END
+GO
+CREATE TABLE babel_4877_t1 (id INT);
+GO
+INSERT INTO babel_4877_t1 VALUES (generate_series(1,10));
+GO
+~~ROW COUNT: 10~~
+
+
+-- user set commands should persists even after the function call ends
+CREATE PROC babel_4877_s1.babel_4877_p1 AS
+    SELECT 'before search path ====> ', current_setting('search_path');
+    SELECT babel_4877_s1.babel_4877_f1() FROM babel_4877_t1;
+    SELECT 'after search path ====> ', current_setting('search_path');
+GO
+
+EXEC babel_4877_s1.babel_4877_p1
+GO
+~~START~~
+varchar#!#text
+before search path ====> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+varchar
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+master_babel_4877_s1, sys, pg_catalog
+~~END~~
+
+~~START~~
+varchar#!#text
+after search path ====> #!#master_babel_4877_s1, sys, pg_catalog
+~~END~~
+
+
+DROP FUNCTION babel_4877_s1.babel_4877_f1
+GO
+
+EXEC dbo.babel_4877_reset_search_path
+GO
+
+
+-- now search path = reset val 
+CREATE FUNCTION babel_4877_s1.babel_4877_f1() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (SELECT current_setting('search_path'));
+END
+GO
+
+-- internal temp  override of serach path should not exists after function ends
+EXEC babel_4877_s1.babel_4877_p1
+GO
+~~START~~
+varchar#!#text
+before search path ====> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+varchar
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+master_babel_4877_s1, master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+varchar#!#text
+after search path ====> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+DROP FUNCTION babel_4877_s1.babel_4877_f1
+GO
+DROP PROC babel_4877_s1.babel_4877_p1, dbo.babel_4877_reset_search_path
+GO
+DROP TABLE babel_4877_t1
+GO
+DROP SCHEMA babel_4877_s1
+GO
+
+-- check if check hook for search path is pltsql_called
+CREATE SCHEMA babel_4877_s
+GO
+CREATE FUNCTION babel_4877_s.babel_4877_f1() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (1);
+END
+GO
+CREATE PROC babel_4877_p AS SELECT babel_4877_s.babel_4877_f1(); select set_config('search_path','sys master_dbo',false);
+GO
+CREATE PROC babel_4877_s.babel_4877_p AS SELECT babel_4877_s.babel_4877_f1(); select set_config('search_path','sys master_dbo',false);
+GO
+EXEC babel_4877_p
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+~~START~~
+text
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid value for parameter "search_path": "sys master_dbo")~~
+
+EXEC babel_4877_s.babel_4877_p
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+~~START~~
+text
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid value for parameter "search_path": "sys master_dbo")~~
+
+DROP PROC babel_4877_s.babel_4877_p, babel_4877_p
+GO
+CREATE FUNCTION babel_4877_s.babel_4877_f2() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (select set_config('search_path','sys master_dbo',false));
+END
+GO
+SELECT babel_4877_s.babel_4877_f2();
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid value for parameter "search_path": "sys master_dbo")~~
+
+DROP FUNCTION babel_4877_s.babel_4877_f2, babel_4877_s.babel_4877_f1
+GO
+
+-- test error case
+CREATE TABLE babel_4877_s.babel_4877_t (id BIGINT)
+GO
+INSERT INTO babel_4877_s.babel_4877_t VALUES (99999999999999999)
+GO
+~~ROW COUNT: 1~~
+
+CREATE FUNCTION babel_4877_s.babel_4877_f2() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (SELECT CAST(id AS INT) FROM babel_4877_t);
+END
+GO
+
+CREATE PROC babel_4877_s.babel_4877_p AS
+    SELECT babel_4877_s.babel_4877_f2()
+GO
+
+SELECT current_setting('search_path');
+GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+SELECT babel_4877_s.babel_4877_f2();
+GO
+~~START~~
+varchar
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+SELECT current_setting('search_path');
+GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+EXEC babel_4877_s.babel_4877_p
+GO
+~~START~~
+varchar
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+SELECT current_setting('search_path');
+GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+-- Statement terminating error
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+before search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+EXEC babel_4877_s.babel_4877_p
+GO
+~~START~~
+varchar
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+SELECT 'after error search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+after error search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+COMMIT
+GO
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+after tran search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+before search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+SELECT babel_4877_s.babel_4877_f2();
+GO
+~~START~~
+varchar
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+SELECT 'after error search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+after error search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+COMMIT
+GO
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+after tran search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+BEGIN TRAN
+SELECT 'before search_path  ----> ', current_setting('search_path');
+SELECT babel_4877_s.babel_4877_f2();
+SELECT 'after error search_path  ----> ', current_setting('search_path');
+COMMIT
+GO
+~~START~~
+varchar#!#text
+before search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+varchar
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~START~~
+varchar#!#text
+after error search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+-- txn aborting error
+CREATE FUNCTION babel_4877_s.babel_4877_f3() RETURNS INT
+AS
+BEGIN
+    RETURN (CAST('a' as INT));
+END
+GO
+
+CREATE PROC babel_4877_s.babel_4877_p2 AS
+    SELECT babel_4877_s.babel_4877_f3()
+GO
+
+-- TXN aborting error
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+before search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+EXEC babel_4877_s.babel_4877_p2
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "a")~~
+
+COMMIT
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+after tran search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+before search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+SELECT babel_4877_s.babel_4877_f3();
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "a")~~
+
+COMMIT
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+~~START~~
+varchar#!#text
+after tran search_path  ----> #!#master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+
+
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+DROP TABLE babel_4877_s.babel_4877_t
+GO
+DROP PROCEDURE babel_4877_s.babel_4877_p, babel_4877_s.babel_4877_p2
+GO
+DROP FUNCTION babel_4877_s.babel_4877_f2, babel_4877_s.babel_4877_f3
+GO
+DROP SCHEMA babel_4877_s
+GO

--- a/test/JDBC/input/BABEL_4877.mix
+++ b/test/JDBC/input/BABEL_4877.mix
@@ -1,0 +1,257 @@
+-- tsql
+CREATE SCHEMA babel_4877_s1
+GO
+
+CREATE FUNCTION babel_4877_s1.babel_4877_f1() RETURNS INT
+AS
+BEGIN
+    DECLARE @babel_4877_tablevar TABLE (id INT)
+    INSERT INTO @babel_4877_tablevar SELECT id FROM babel_4877_t;
+    RETURN (SELECT id FROM @babel_4877_tablevar)
+END
+GO
+
+CREATE PROC babel_4877_s1.babel_4877_p
+AS
+    SELECT babel_4877_s1.babel_4877_f1()
+GO
+
+CREATE TABLE dbo.babel_4877_t (id INT)
+GO
+INSERT INTO dbo.babel_4877_t VALUES (10)
+GO
+
+-- func in s1 should see dbo table
+EXEC babel_4877_s1.babel_4877_p
+GO
+
+CREATE TABLE babel_4877_s1.babel_4877_t (id INT)
+GO
+INSERT INTO babel_4877_s1.babel_4877_t VALUES (20)
+GO
+
+-- Now func in s1 should select unspecified objects from s1 first then dbo
+EXEC babel_4877_s1.babel_4877_p
+GO
+
+SELECT babel_4877_s1.babel_4877_f1()
+GO
+
+DROP TABLE babel_4877_s1.babel_4877_t, dbo.babel_4877_t
+GO
+DROP PROC babel_4877_s1.babel_4877_p
+GO
+DROP FUNCTION babel_4877_s1.babel_4877_f1
+GO
+DROP SCHEMA babel_4877_s1
+GO
+
+
+-- psql
+CREATE PROCEDURE master_dbo.babel_4877_reset_search_path() AS
+$$ BEGIN
+RESET search_path;
+END $$
+LANGUAGE plpgsql;
+GO
+
+-- tsql
+CREATE SCHEMA babel_4877_s1
+GO
+CREATE FUNCTION babel_4877_s1.babel_4877_f1() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (SELECT set_config('search_path','master_babel_4877_s1, sys, pg_catalog', false));
+END
+GO
+CREATE TABLE babel_4877_t1 (id INT);
+GO
+INSERT INTO babel_4877_t1 VALUES (generate_series(1,10));
+GO
+
+-- user set commands should persists even after the function call ends
+CREATE PROC babel_4877_s1.babel_4877_p1 AS
+    SELECT 'before search path ====> ', current_setting('search_path');
+    SELECT babel_4877_s1.babel_4877_f1() FROM babel_4877_t1;
+    SELECT 'after search path ====> ', current_setting('search_path');
+GO
+
+EXEC babel_4877_s1.babel_4877_p1
+GO
+
+DROP FUNCTION babel_4877_s1.babel_4877_f1
+GO
+
+EXEC dbo.babel_4877_reset_search_path
+GO
+
+-- now search path = reset val 
+
+CREATE FUNCTION babel_4877_s1.babel_4877_f1() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (SELECT current_setting('search_path'));
+END
+GO
+
+-- internal temp  override of serach path should not exists after function ends
+EXEC babel_4877_s1.babel_4877_p1
+GO
+
+DROP FUNCTION babel_4877_s1.babel_4877_f1
+GO
+DROP PROC babel_4877_s1.babel_4877_p1, dbo.babel_4877_reset_search_path
+GO
+DROP TABLE babel_4877_t1
+GO
+DROP SCHEMA babel_4877_s1
+GO
+
+-- check if check hook for search path is pltsql_called
+CREATE SCHEMA babel_4877_s
+GO
+CREATE FUNCTION babel_4877_s.babel_4877_f1() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (1);
+END
+GO
+CREATE PROC babel_4877_p AS SELECT babel_4877_s.babel_4877_f1(); select set_config('search_path','sys master_dbo',false);
+GO
+CREATE PROC babel_4877_s.babel_4877_p AS SELECT babel_4877_s.babel_4877_f1(); select set_config('search_path','sys master_dbo',false);
+GO
+EXEC babel_4877_p
+GO
+EXEC babel_4877_s.babel_4877_p
+GO
+DROP PROC babel_4877_s.babel_4877_p, babel_4877_p
+GO
+CREATE FUNCTION babel_4877_s.babel_4877_f2() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (select set_config('search_path','sys master_dbo',false));
+END
+GO
+SELECT babel_4877_s.babel_4877_f2();
+GO
+DROP FUNCTION babel_4877_s.babel_4877_f2, babel_4877_s.babel_4877_f1
+GO
+
+-- test error case
+CREATE TABLE babel_4877_s.babel_4877_t (id BIGINT)
+GO
+INSERT INTO babel_4877_s.babel_4877_t VALUES (99999999999999999)
+GO
+CREATE FUNCTION babel_4877_s.babel_4877_f2() RETURNS VARCHAR(100)
+AS
+BEGIN
+    RETURN (SELECT CAST(id AS INT) FROM babel_4877_t);
+END
+GO
+
+CREATE PROC babel_4877_s.babel_4877_p AS
+    SELECT babel_4877_s.babel_4877_f2()
+GO
+
+SELECT current_setting('search_path');
+GO
+
+SELECT babel_4877_s.babel_4877_f2();
+GO
+
+SELECT current_setting('search_path');
+GO
+
+EXEC babel_4877_s.babel_4877_p
+GO
+
+SELECT current_setting('search_path');
+GO
+
+-- Statement terminating error
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+EXEC babel_4877_s.babel_4877_p
+GO
+SELECT 'after error search_path  ----> ', current_setting('search_path');
+GO
+COMMIT
+GO
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+SELECT babel_4877_s.babel_4877_f2();
+GO
+SELECT 'after error search_path  ----> ', current_setting('search_path');
+GO
+COMMIT
+GO
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+
+BEGIN TRAN
+SELECT 'before search_path  ----> ', current_setting('search_path');
+SELECT babel_4877_s.babel_4877_f2();
+SELECT 'after error search_path  ----> ', current_setting('search_path');
+COMMIT
+GO
+
+
+SELECT @@trancount
+GO
+
+
+-- txn aborting error
+CREATE FUNCTION babel_4877_s.babel_4877_f3() RETURNS INT
+AS
+BEGIN
+    RETURN (CAST('a' as INT));
+END
+GO
+
+CREATE PROC babel_4877_s.babel_4877_p2 AS
+    SELECT babel_4877_s.babel_4877_f3()
+GO
+
+-- TXN aborting error
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+EXEC babel_4877_s.babel_4877_p2
+GO
+COMMIT
+GO
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+
+BEGIN TRAN
+GO
+SELECT 'before search_path  ----> ', current_setting('search_path');
+GO
+SELECT babel_4877_s.babel_4877_f3();
+GO
+COMMIT
+GO
+SELECT 'after tran search_path  ----> ', current_setting('search_path');
+GO
+
+
+SELECT @@trancount
+GO
+
+
+DROP TABLE babel_4877_s.babel_4877_t
+GO
+DROP PROCEDURE babel_4877_s.babel_4877_p, babel_4877_s.babel_4877_p2
+GO
+DROP FUNCTION babel_4877_s.babel_4877_f2, babel_4877_s.babel_4877_f3
+GO
+DROP SCHEMA babel_4877_s
+GO


### PR DESCRIPTION
### Description

#### Cherry Picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2536

Currently we override the search_path for pltsql UDFs directly using the GUC variable & avoid set_config.
This leads to crash if there was another set_config('search_path... when we were in this overridden state.
Reason for crash is that the new set_config call may push the current value (the one we set in fmgr) onto
GUC stack. Now it pssoble that we exit the function call and released fcache, but fcache->prosearchpath
is still referenced in GUC stack.

To fix this we fallback to using set_config for setting the search_path & skip the check hook for search path
when setting from inside fmgr which helps with performance.
Also increase the GUC nest level since GUC_ACTION_SAVE is not possible on top of GUC_ACTION_SET
(user set), which is possible in this case. New nest level also means that we do not have to reset the search
path at the end of execution and let AtEOXact_GUC(commit=true) handle it.

We also move the set search path block in fmgr inside TRY, to ensure we reset the skip check search path
variable in case of errors.

### Issues Resolved

[BABEL-4877]

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/357
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2552

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).