### PR TITLE
Update collation Oid for CI_AI and Add tests for column level constraint for LIKE for AI collations

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -415,9 +415,6 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 		/* construct pattern||E'\uFFFF' */
 		highest_sort_key = makeConst(TEXTOID, -1, coll_info_of_inputcollid.oid, -1,
 										PointerGetDatum(cstring_to_text(SORT_KEY_STR)), false, false);
-		
-		/* Set the collation explicitly for the Const node */
-		highest_sort_key->constcollid = coll_info_of_inputcollid.oid;
 
 		optup = compatible_oper(NULL, list_make1(makeString("||")), rtypeId, rtypeId,
 								true, -1);

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -369,7 +369,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 	patt = (Const *) rightop;
 
 	/* extract pattern */
-	pstatus = pattern_fixed_prefix_wrapper(patt, 1, server_collation_oid,
+	pstatus = pattern_fixed_prefix_wrapper(patt, 1, coll_info_of_inputcollid.oid,
 											&prefix, NULL);
 
 	/* If there is no constant prefix then there's nothing more to do */
@@ -391,7 +391,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 
 		ret = (Node *) (make_op_with_func(oprid(optup), BOOLOID, false,
 											(Expr *) leftop, (Expr *) prefix,
-											InvalidOid, server_collation_oid, oprfuncid(optup)));
+											InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup)));
 
 		ReleaseSysCache(optup);
 	}
@@ -410,10 +410,10 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 			return node;
 		greater_equal = make_op_with_func(oprid(optup), BOOLOID, false,
 											(Expr *) leftop, (Expr *) prefix,
-											InvalidOid, server_collation_oid, oprfuncid(optup));
+											InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		ReleaseSysCache(optup);
 		/* construct pattern||E'\uFFFF' */
-		highest_sort_key = makeConst(TEXTOID, -1, server_collation_oid, -1,
+		highest_sort_key = makeConst(TEXTOID, -1, coll_info_of_inputcollid.oid, -1,
 										PointerGetDatum(cstring_to_text(SORT_KEY_STR)), false, false);
 
 		optup = compatible_oper(NULL, list_make1(makeString("||")), rtypeId, rtypeId,
@@ -422,7 +422,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 			return node;
 		concat_expr = make_op_with_func(oprid(optup), rtypeId, false,
 										(Expr *) prefix, (Expr *) highest_sort_key,
-										InvalidOid, server_collation_oid, oprfuncid(optup));
+										InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		ReleaseSysCache(optup);
 		/* construct leftop < pattern */
 		optup = compatible_oper(NULL, list_make1(makeString("<")), ltypeId, ltypeId,
@@ -432,7 +432,7 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 
 		less_equal = make_op_with_func(oprid(optup), BOOLOID, false,
 										(Expr *) leftop, (Expr *) concat_expr,
-										InvalidOid, server_collation_oid, oprfuncid(optup));
+										InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		constant_suffix = make_and_qual((Node *) greater_equal, (Node *) less_equal);
 		if (like_entry.is_not_match)
 		{

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -415,6 +415,9 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 		/* construct pattern||E'\uFFFF' */
 		highest_sort_key = makeConst(TEXTOID, -1, coll_info_of_inputcollid.oid, -1,
 										PointerGetDatum(cstring_to_text(SORT_KEY_STR)), false, false);
+		
+		/* Set the collation explicitly for the Const node */
+		highest_sort_key->constcollid = coll_info_of_inputcollid.oid;
 
 		optup = compatible_oper(NULL, list_make1(makeString("||")), rtypeId, rtypeId,
 								true, -1);

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
@@ -1,0 +1,4836 @@
+-- tsql
+
+------------------- CI_AI ----------------------
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+select 1 where 'cantáis' like 'Cá%' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS text) like CAST('Cá%' AS text) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS ntext) like CAST('Cá%' AS ntext) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS varchar) like CAST('Cá%' AS varchar) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS nvarchar) like CAST('Cá%' AS nvarchar) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS char) like 'Cá%' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS nchar) like 'Cá%' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'shaEpéD' like '%Æ%e%' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'BleȘȘing' like '%nĜ' collate Latin1_General_CI_AI
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+select 1 where 'cOntáis' collate Latin1_General_CI_AI like 'CŐ%';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'shaEpüD' collate Latin1_General_CI_AI like '%Æ%ú%';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS text) collate Latin1_General_CI_AI like CAST('%Æ%ú%' AS text);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS ntext) collate Latin1_General_CI_AI like CAST('%Æ%ú%' AS ntext);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS varchar) collate Latin1_General_CI_AI like CAST('%Æ%ú%' AS varchar);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS nvarchar) collate Latin1_General_CI_AI like CAST('%Æ%ú%' AS nvarchar);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS char) collate Latin1_General_CI_AI like '%Æ%ú%';
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS nchar) collate Latin1_General_CI_AI like '%Æ%ú%';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'BleȘȘing' collate Latin1_General_CI_AI like '%ŝ%nĜ';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+select 1 where 'cOntáis' collate Latin1_General_CI_AI like 'CŐ%' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'shaEpüD' collate Latin1_General_CI_AI like '%Æ%ú%' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'BleȘȘing' collate Latin1_General_CI_AI like '%ŝ%nĜ' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS text) collate Latin1_General_CI_AI like CAST('%ŝ%nĜ' AS text) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS ntext) collate Latin1_General_CI_AI like CAST('%ŝ%nĜ' AS ntext) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS varchar) collate Latin1_General_CI_AI like CAST('%ŝ%nĜ' AS varchar) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS nvarchar) collate Latin1_General_CI_AI like CAST('%ŝ%nĜ' AS nvarchar) collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS char) collate Latin1_General_CI_AI like '%ŝ%nĜ' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS nchar) collate Latin1_General_CI_AI like '%ŝ%nĜ' collate Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'jalapeno';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 're%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%n%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'TELefONO';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'resume';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'movie';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'naïve';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'Piñata';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%é%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%é%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ia%s';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'orange';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'jalapen%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'e%ito';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'c%eR';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_ci with ñ 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_ci with ü
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ú%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+~~END~~
+
+
+-- different datatypes
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_v LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_v LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_v LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_v LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_t LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_t LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_t LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_t LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_ntext LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_ntext LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_ntext LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_ntext LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_c LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_c LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_c LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_c LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_nchar LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_nchar LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_nchar LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col_nchar LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'cafe' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'jalapeno' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 're%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%n%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'TELefONO' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'resume' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'movie' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'naïve' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'Piñata' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%é%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ñ%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'ch%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%is' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%é%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ia%s' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'orange' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'jalapen%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'e%ito' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'c%eR' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_ci with ñ 
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ñ%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_ci with ü
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%ú%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+~~END~~
+
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT * FROM test_like_for_AI_prepare_t6_ci WHERE a LIKE b
+GO
+~~START~~
+nvarchar#!#nvarchar
+Ŭwmed#!#uŴɱêÐ
+Æmed#!#aeMéD
+Șpain#!#SPÅǏn
+THazmEEm#!#%z%
+Ŭwmed#!#Uw%
+Æmed#!#%éd
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'cafe';
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'jalapeno';
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 're%';
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%n%';
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'TELefONO';
+GO
+~~START~~
+nvarchar
+TELÉFONO
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'resume';
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'movie';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'naïve';
+GO
+~~START~~
+nvarchar
+naïve
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'Piñata';
+GO
+~~START~~
+nvarchar
+Piñata
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'ch%';
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%is';
+GO
+~~START~~
+nvarchar
+TEññiȘ
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%é%';
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+TELÉFONO
+película
+canapé
+chaptéR
+TEññiȘ
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ia%s';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'orange';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'jalapen%';
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'e%ito';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'c%eR';
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_ci with ñ 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ñ%';
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_ci with ü
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ú%';
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'cafe' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'jalapeno' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 're%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%n%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'TELefONO' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+TELÉFONO
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'resume' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'movie' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'naïve' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+naïve
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'Piñata' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+Piñata
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%é%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+TELÉFONO
+película
+canapé
+chaptéR
+TEññiȘ
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ñ%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'ch%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%is' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+TEññiȘ
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%é%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+TELÉFONO
+película
+canapé
+chaptéR
+TEññiȘ
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ia%s' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'orange' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'jalapen%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'e%ito' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE 'c%eR' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_ci with ñ 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ñ%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_ci with ü
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%ú%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const)
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE 'cafe' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE 'jalapeno' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE SUBSTRING(col, 1, 3) COLLATE Latin1_General_CI_AI LIKE 're%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE '%n%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE 'TELefONO' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+TELÉFONO
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE 'resume' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(LOWER(col)) COLLATE Latin1_General_CI_AI LIKE 'movie' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(LOWER(col)) COLLATE Latin1_General_CI_AI LIKE 'naïve' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+naïve
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(UPPER(col)) COLLATE Latin1_General_CI_AI LIKE 'Piñata' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+Piñata
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE SUBSTRING(UPPER(LOWER(col)), 1, 3) COLLATE Latin1_General_CI_AI LIKE '%é%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+TELÉFONO
+película
+TEññiȘ
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE '%ñ%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE SUBSTRING(col, 1, 3) COLLATE Latin1_General_CI_AI LIKE 'ch%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE '%is' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+TEññiȘ
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE '%é%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+TELÉFONO
+película
+canapé
+chaptéR
+TEññiȘ
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE '%ia%s' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE UPPER(col) COLLATE Latin1_General_CI_AI LIKE 'orange' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE 'jalapen%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE 'e%ito' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE 'c%eR' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_ci with ñ 
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE '%ñ%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_ci with ü
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE LOWER(col) COLLATE Latin1_General_CI_AI LIKE '%ú%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+-- same experiments as above with column collated with Latin1_General_CI_AI
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE LOWER(col) LIKE 'c%eR';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE LOWER(col) LIKE 'jalapen%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE UPPER(col) LIKE '%ia%s';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE SUBSTRING(col, 1, 3) LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- CASE 10: T_ReLabelType(T_Param) LIKE T_ReLabelType(T_Param)
+declare @a varchar='RaŊdom';
+declare @b varchar='Ra%';
+SELECT 1 WHERE @a LIKE @b COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- number of chars > 8000
+DECLARE @var VARCHAR(MAX);
+SET @var = REPLICATE('A', 8005);
+SELECT 1 WHERE @var COLLATE Latin1_General_CI_AI LIKE '%a%'
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 11: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Param)
+declare @c varchar(51)='e%ito';
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE @c;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+declare @c varchar(51)='c%eR';
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE @c;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+declare @d varchar(51)='%ú%';
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col LIKE @d COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+-- CASE 12: LIKE inside CASE
+SELECT CASE WHEN col COLLATE Latin1_General_CI_AI LIKE 'jalapen%' THEN 1 ELSE 2 END FROM test_like_for_AI_prepare_t7_ci;
+GO
+~~START~~
+int
+2
+1
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+~~END~~
+
+
+SELECT CASE WHEN col LIKE '%is' COLLATE Latin1_General_CI_AI THEN 1 ELSE 2 END FROM test_like_for_AI_prepare_t7_ci;
+GO
+~~START~~
+int
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+1
+2
+~~END~~
+
+
+
+-- CASE 13: SUBQUERY
+-- SIMPLE SUBQUERY (LIKE OPERATOR AS SUBQUERY)
+-- returns 1 row
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_ci WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_ci WHERE col LIKE 'Àb%');
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- returns 2 rows
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_ci WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_ci WHERE col LIKE '%aŖ%l%');
+GO
+~~START~~
+nvarchar
+Piñata
+Año Nuevo
+~~END~~
+
+
+-- returns 1 rows
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_ci WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_ci WHERE col LIKE '%ţÕ');
+GO
+~~START~~
+nvarchar
+canapé
+~~END~~
+
+
+-- COMPLEX SUBQUERY (LIKE OPERATOR CONRTAINING SUBQUERY)
+-- returns 1 row
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'shaEpéD' LIKE 'Ș%' COLLATE Latin1_General_CI_AI) = 1 THEN 'TEñ%' ELSE 'ár%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+TEññiȘ#!#patín
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'naïve' LIKE 'Ș%' COLLATE Latin1_General_CI_AI) = 1 THEN 'TEñ%' ELSE 'ár%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+árbol#!#difícil
+~~END~~
+
+
+-- returns 4 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE (CASE WHEN 1 = 1 THEN '%I%' ELSE '%t%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+naïve#!#cuídate
+Piñata#!#gárgola
+película#!#réquiem
+TEññiȘ#!#patín
+lúdico#!#lúdico
+~~END~~
+
+
+-- rerurns 4 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE (CASE WHEN 2 = 1 THEN '%I%' ELSE '%t%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+Piñata#!#gárgola
+TELÉFONO#!#núcleo
+chaptéR#!#enérgetico
+TEññiȘ#!#patín
+~~END~~
+
+
+-- returns 2 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'shaEpéD' LIKE 'Ș%' COLLATE Latin1_General_CI_AI) = 1 THEN '%a' ELSE '%é' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+Piñata#!#gárgola
+película#!#réquiem
+~~END~~
+
+
+-- returns 4 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'naïve' LIKE 'Ș%' COLLATE Latin1_General_CI_AI) = 1 THEN '%a' ELSE '%é' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+café#!#prójimo
+résumé#!#críquet
+naïve#!#cuídate
+canapé#!#crédito
+~~END~~
+
+
+-- returns 1 row
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 IN (SELECT col1 FROM test_like_for_AI_prepare_t13_1_ci t1 JOIN test_like_for_AI_prepare_t13_2_ci t2 ON t1.col1 LIKE 'r%' AND t2.col LIKE 'r%');
+GO
+~~START~~
+nvarchar#!#nvarchar
+résumé#!#críquet
+~~END~~
+
+
+-- returns 1 row
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_ci WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_ci WHERE col LIKE test_like_for_AI_prepare_t13_1_ci.col1);
+GO
+~~START~~
+nvarchar
+lúdico
+~~END~~
+
+
+-- CASE 14: DIFFERENT WILDCARDS
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'ca_e';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'c[ĥżâ]%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%[^oa]ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%[i-s]';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+árbol#!#árbol#!#árbol#!#árbol#!#árbol                                             #!#árbol                                             
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- CASE 15: LIKE CLAUSE AS FUNCTION ARGUMENT - works when LIKE returns one row (expected)
+SELECT SUM(10 + (SELECT 90 WHERE 'cantáis' like 'Cá%' collate Latin1_General_CI_AI));
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+SELECT CONCAT('Hi ', (SELECT col FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE 'ca_e'));
+GO
+~~START~~
+text
+Hi café
+~~END~~
+
+
+SELECT UPPER((SELECT col FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE '%oNo'));
+GO
+~~START~~
+text
+TELÉFONO
+~~END~~
+
+
+-- CASE 16: JOIN
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci JOIN test_like_for_AI_prepare_t13_2_ci on test_like_for_AI_prepare_t13_1_ci.col2 LIKE test_like_for_AI_prepare_t13_2_ci.col
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+jalapeño#!#aburrí#!#aburrí
+Piñata#!#gárgola#!#gárgola
+Año Nuevo#!#gárgola#!#gárgola
+lúdico#!#lúdico#!#lúdico
+canapé#!#crédito#!#crédito
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci t1 JOIN test_like_for_AI_prepare_t13_2_ci t2 ON t1.col1 LIKE 'r%' AND t2.col LIKE 'r%';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+résumé#!#críquet#!#résumen
+résumé#!#críquet#!#reísteis
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci t1 JOIN test_like_for_AI_prepare_t13_2_ci t2 ON t1.col1 LIKE '%a%' AND t2.col LIKE '%a%';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+café#!#prójimo#!#aburrí
+jalapeño#!#aburrí#!#aburrí
+naïve#!#cuídate#!#aburrí
+Piñata#!#gárgola#!#aburrí
+Año Nuevo#!#gárgola#!#aburrí
+película#!#réquiem#!#aburrí
+árbol#!#difícil#!#aburrí
+canapé#!#crédito#!#aburrí
+chaptéR#!#enérgetico#!#aburrí
+café#!#prójimo#!#brújula
+jalapeño#!#aburrí#!#brújula
+naïve#!#cuídate#!#brújula
+Piñata#!#gárgola#!#brújula
+Año Nuevo#!#gárgola#!#brújula
+película#!#réquiem#!#brújula
+árbol#!#difícil#!#brújula
+canapé#!#crédito#!#brújula
+chaptéR#!#enérgetico#!#brújula
+café#!#prójimo#!#calabacín
+jalapeño#!#aburrí#!#calabacín
+naïve#!#cuídate#!#calabacín
+Piñata#!#gárgola#!#calabacín
+Año Nuevo#!#gárgola#!#calabacín
+película#!#réquiem#!#calabacín
+árbol#!#difícil#!#calabacín
+canapé#!#crédito#!#calabacín
+chaptéR#!#enérgetico#!#calabacín
+café#!#prójimo#!#gárgola
+jalapeño#!#aburrí#!#gárgola
+naïve#!#cuídate#!#gárgola
+Piñata#!#gárgola#!#gárgola
+Año Nuevo#!#gárgola#!#gárgola
+película#!#réquiem#!#gárgola
+árbol#!#difícil#!#gárgola
+canapé#!#crédito#!#gárgola
+chaptéR#!#enérgetico#!#gárgola
+café#!#prójimo#!#ácaro
+jalapeño#!#aburrí#!#ácaro
+naïve#!#cuídate#!#ácaro
+Piñata#!#gárgola#!#ácaro
+Año Nuevo#!#gárgola#!#ácaro
+película#!#réquiem#!#ácaro
+árbol#!#difícil#!#ácaro
+canapé#!#crédito#!#ácaro
+chaptéR#!#enérgetico#!#ácaro
+café#!#prójimo#!#gígabyte
+jalapeño#!#aburrí#!#gígabyte
+naïve#!#cuídate#!#gígabyte
+Piñata#!#gárgola#!#gígabyte
+Año Nuevo#!#gárgola#!#gígabyte
+película#!#réquiem#!#gígabyte
+árbol#!#difícil#!#gígabyte
+canapé#!#crédito#!#gígabyte
+chaptéR#!#enérgetico#!#gígabyte
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_ci t1 JOIN test_like_for_AI_prepare_t13_2_ci t2 ON t1.col2 LIKE '%o' AND t2.col LIKE '%o';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+café#!#prójimo#!#lúdico
+TELÉFONO#!#núcleo#!#lúdico
+canapé#!#crédito#!#lúdico
+chaptéR#!#enérgetico#!#lúdico
+lúdico#!#lúdico#!#lúdico
+café#!#prójimo#!#ácaro
+TELÉFONO#!#núcleo#!#ácaro
+canapé#!#crédito#!#ácaro
+chaptéR#!#enérgetico#!#ácaro
+lúdico#!#lúdico#!#ácaro
+café#!#prójimo#!#crédito
+TELÉFONO#!#núcleo#!#crédito
+canapé#!#crédito#!#crédito
+chaptéR#!#enérgetico#!#crédito
+lúdico#!#lúdico#!#crédito
+café#!#prójimo#!#ídolo
+TELÉFONO#!#núcleo#!#ídolo
+canapé#!#crédito#!#ídolo
+chaptéR#!#enérgetico#!#ídolo
+lúdico#!#lúdico#!#ídolo
+~~END~~
+
+
+-- CASE 17: PREPARED STATEMENTS
+DECLARE @prefix NVARCHAR(50) = 'ár';
+EXEC sp_executesql N'SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE @prefix + ''%'';', N'@prefix NVARCHAR(50)', @prefix;
+GO
+~~START~~
+nvarchar#!#nvarchar
+árbol#!#difícil
+~~END~~
+
+
+DECLARE @pattern NVARCHAR(50) = '%bo%';
+EXEC sp_executesql N'SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE @pattern + ''%'';', N'@pattern NVARCHAR(50)', @pattern;
+GO
+~~START~~
+nvarchar#!#nvarchar
+árbol#!#difícil
+~~END~~
+
+
+DECLARE @suffix NVARCHAR(50) = 'éR';
+EXEC sp_executesql N'SELECT * FROM test_like_for_AI_prepare_t13_1_ci WHERE col1 LIKE ''%'' + @suffix;', N'@suffix NVARCHAR(50)', @suffix;
+GO
+~~START~~
+nvarchar#!#nvarchar
+chaptéR#!#enérgetico
+~~END~~
+
+
+-- CASE 18: LIKE OBJECT_NAME()
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE 1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) LIKE '%Blah%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE 1=1 AND OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) LIKE '%AI_prepãr%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE 1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) LIKE 'Blah%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE 1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) LIKE '%Blah' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE NOT 1>1 AND ((NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) LIKE '%Blah%' COLLATE Latin1_General_CI_AI) AND (OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) COLLATE Latin1_General_CI_AI LIKE '%like_for_AI%'))
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE 1>1 OR ((NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) COLLATE Latin1_General_CI_AI LIKE '%Blah%') AND (NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) LIKE '%Blâh%' COLLATE Latin1_General_CI_AI))
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_ci WHERE (1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) COLLATE Latin1_General_CI_AI LIKE '%Blah%') OR ((NOT 2<1) AND (NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_ci')) COLLATE Latin1_General_CI_AI LIKE '%Blâh%'))
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+-- CASE 19: ESCAPE WITH LIKE
+--15% off using ESCAPE; should return rows 19
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CI_AI LIKE '15/% %' ESCAPE '/' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+19#!#15% off
+~~END~~
+
+
+--15% off using a different ESCAPE character; should return rows 19
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CI_AI LIKE '15!% %' ESCAPE '!' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+19#!#15% off
+~~END~~
+
+
+--15 % off ; should return rows 21
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CI_AI LIKE '15 /%___' ESCAPE '/' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+21#!#15 %off
+~~END~~
+
+
+--Searching for the escape character itself; should return rows 23
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CI_AI LIKE '15 [%] //off' ESCAPE '/' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+23#!#15 % /off
+~~END~~
+
+
+--As above, but also allow for "[". Should return 3-18, 24
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CI_AI NOT LIKE '%[^a-zA-ZåÅäÄöÖ.[?[]%' ESCAPE '?' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+3#!#Andersson
+4#!#Bertilsson
+5#!#Carlson
+6#!#Davidsson
+7#!#Eriksson
+8#!#Fredriksson
+9#!#F
+10#!#F.
+11#!#Göransson
+12#!#Karlsson
+13#!#KarlsTon
+14#!#Karlson
+15#!#Persson
+16#!#Uarlson
+17#!#McDonalds
+18#!#MacDonalds
+24#!#My[String
+~~END~~
+
+
+SELECT 1 WHERE 'a[abc]b' COLLATE Latin1_General_CI_AI LIKE 'a\[abc]b' escape '\'  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+declare @v varchar = 'a[bc'
+SELECT 1 WHERE @v COLLATE Latin1_General_CI_AI LIKE '%[%' escape '~' OR @v COLLATE Latin1_General_CI_AI LIKE '%]%'                -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+declare @v varchar = 'a[bc'
+SELECT 1 WHERE @v COLLATE Latin1_General_CI_AI LIKE '%~[%' escape '~' OR @v COLLATE Latin1_General_CI_AI LIKE '%~]%' escape '~'   -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+declare @v varchar = 'a[bc'
+set @v = 'a]bc'
+SELECT 1 WHERE @v COLLATE Latin1_General_CI_AI LIKE '%[%' escape '~' OR @v COLLATE Latin1_General_CI_AI LIKE '%]%'                -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+
+declare @v varchar = 'a[bc'
+set @v = 'a]bc'
+SELECT 1 WHERE @v LIKE '%~[%' COLLATE Latin1_General_CI_AI escape '~' OR @v LIKE '%~]%' escape '~'  COLLATE Latin1_General_CI_AI -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+declare @v varchar(20), @p varchar(20), @esc char(1)
+set @v = 'a[abc]b'set @p = 'a\[abc]b' set @esc = '\' -- 1
+SELECT 1 WHERE @v COLLATE Latin1_General_CI_AI LIKE @p escape @esc 
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE '_ab' COLLATE Latin1_General_CI_AI LIKE '\_ab'  escape '\'         -- 1 
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT 1 WHERE '%AAABBB%' COLLATE Latin1_General_CI_AI LIKE '\%AAA%' escape '\'   -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' COLLATE Latin1_General_CI_AI LIKE 'AB~[C]D' ESCAPE '~'  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB\[C]D' COLLATE Latin1_General_CI_AI ESCAPE '\'  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB\[C]D' ESCAPE '\'  COLLATE Latin1_General_CI_AI  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB [C]D' COLLATE Latin1_General_CI_AI ESCAPE ' '  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB[C]D' COLLATE Latin1_General_CI_AI ESCAPE 'B'   -- no row
+GO
+~~START~~
+int
+~~END~~
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'ABB[C]D' COLLATE Latin1_General_CI_AI ESCAPE 'B'  -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'ABZ[C]D' ESCAPE 'Z' COLLATE Latin1_General_CI_AI -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT 1 WHERE 'AB[C]D' COLLATE Latin1_General_CI_AI LIKE 'ABZ[C]D' ESCAPE 'z'  -- no row! Note: SQL Server treats the escape as case-sensitive!
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null like null COLLATE Latin1_General_CI_AI escape null -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null COLLATE Latin1_General_CI_AI like null escape null -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null COLLATE Latin1_General_CI_AI like null COLLATE Latin1_General_CI_AI escape null -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null like null escape null COLLATE Latin1_General_CI_AI  -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE 'ABCD' LIKE 'AB[C]D' COLLATE Latin1_General_CI_AI ESCAPE ''  -- should raise error , BABEL-4271
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+SELECT 1 WHERE 'ABCD' COLLATE Latin1_General_CI_AI LIKE 'AB[C]D' ESCAPE 'xy'  -- raise error
+GO
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+SELECT 1 WHERE 'ABCD' COLLATE Latin1_General_CI_AI LIKE 'AB[C]D' ESCAPE null;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 20: LIKE IN TARGET LIST
+SELECT col, CASE WHEN col LIKE 'ch%' THEN 'Prefix Match' ELSE 'No Match' END AS match_status FROM test_like_for_AI_prepare_t1_ci;
+GO
+~~START~~
+nvarchar#!#text
+café#!#No Match
+jalapeño#!#No Match
+résumé#!#No Match
+naïve#!#No Match
+Piñata#!#No Match
+Año Nuevo#!#No Match
+TELÉFONO#!#No Match
+película#!#No Match
+árbol#!#No Match
+canapé#!#No Match
+chaptéR#!#Prefix Match
+TEññiȘ#!#No Match
+~~END~~
+
+
+SELECT col,
+       CASE 
+           WHEN col LIKE 'prefix%' THEN 'Prefix Match'
+           WHEN col LIKE '%ONO' THEN 'Suffix Match'
+           ELSE 'No Match' 
+       END AS match_category
+FROM test_like_for_AI_prepare_t1_ci;
+GO
+~~START~~
+nvarchar#!#text
+café#!#No Match
+jalapeño#!#No Match
+résumé#!#No Match
+naïve#!#No Match
+Piñata#!#No Match
+Año Nuevo#!#No Match
+TELÉFONO#!#Suffix Match
+película#!#No Match
+árbol#!#No Match
+canapé#!#No Match
+chaptéR#!#No Match
+TEññiȘ#!#No Match
+~~END~~
+
+
+SELECT col,
+       CASE 
+           WHEN col LIKE 'prefix%' THEN 'Prefix Match'
+           WHEN col LIKE '%suffix' THEN 'Suffix Match'
+           WHEN col LIKE '%íc%' THEN 'Match'
+           ELSE 'No Match' 
+       END AS extracted_substring
+FROM test_like_for_AI_prepare_t1_ci;
+GO
+~~START~~
+nvarchar#!#text
+café#!#No Match
+jalapeño#!#No Match
+résumé#!#No Match
+naïve#!#No Match
+Piñata#!#No Match
+Año Nuevo#!#No Match
+TELÉFONO#!#No Match
+película#!#Match
+árbol#!#No Match
+canapé#!#No Match
+chaptéR#!#No Match
+TEññiȘ#!#No Match
+~~END~~
+
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
+
+
+
+------------------- CS_AI ----------------------
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+select 1 where 'cantáis' like 'cá%' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('cantáis' AS text) like CAST('Cá%' AS text) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('cantáis' AS ntext) like CAST('Cá%' AS ntext) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('cantáis' AS varchar) like CAST('Cá%' AS varchar) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('cantáis' AS nvarchar) like CAST('Cá%' AS nvarchar) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('cantáis' AS char) like 'Cá%' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('cantáis' AS nchar) like 'Cá%' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where 'shaEpéD' like '%ǣ%e%' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where 'BleȘȘing' like '%nĝ' collate Latin1_General_CS_AI
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+select 1 where 'cOntáis' collate Latin1_General_CS_AI like 'cŐ%';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'shaEpüD' collate Latin1_General_CS_AI like '%ǣ%ú%';
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS text) collate Latin1_General_CS_AI like CAST('%Æ%ú%' AS text);
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS ntext) collate Latin1_General_CS_AI like CAST('%Æ%ú%' AS ntext);
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS varchar) collate Latin1_General_CS_AI like CAST('%Æ%ú%' AS varchar);
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS nvarchar) collate Latin1_General_CS_AI like CAST('%Æ%ú%' AS nvarchar);
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS char) collate Latin1_General_CS_AI like '%Æ%ú%';
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('shaEpüD' AS nchar) collate Latin1_General_CS_AI like '%Æ%ú%';
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where 'BlesȘing' collate Latin1_General_CS_AI like '%ŝ%nĝ';
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+select 1 where 'cOntáis' collate Latin1_General_CS_AI like 'cŐ%' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where 'shaEpüD' collate Latin1_General_CS_AI like '%ǣ%ú%' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where 'BleȘsing' collate Latin1_General_CS_AI like '%ŝ%ng' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS text) collate Latin1_General_CS_AI like CAST('%ŝ%nĜ' AS text) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS ntext) collate Latin1_General_CS_AI like CAST('%ŝ%nĜ' AS ntext) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS varchar) collate Latin1_General_CS_AI like CAST('%ŝ%nĜ' AS varchar) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS nvarchar) collate Latin1_General_CS_AI like CAST('%ŝ%nĜ' AS nvarchar) collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS char) collate Latin1_General_CS_AI like '%ŝ%nĜ' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+select 1 where CAST('BleȘȘing' AS nchar) collate Latin1_General_CS_AI like '%ŝ%nĜ' collate Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'jalapeno';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 're%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%n%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'TELefONO';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'resume';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'movie';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'naïve';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'Piñata';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%é%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%é%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ia%s';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'orange';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'jalapen%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'e%ito';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'c%eR';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_cs with ñ 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_cs with ü
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ú%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+~~END~~
+
+
+-- different datatypes
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_v LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_v LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_v LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_v LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_t LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_t LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_t LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_t LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_ntext LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_ntext LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_ntext LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_ntext LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_c LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_c LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_c LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_c LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_nchar LIKE 'cafe';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_nchar LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_nchar LIKE '%ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col_nchar LIKE '%is';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'cafe' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'jalapeno' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 're%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%n%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'TELefONO' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'resume' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'movie' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'naïve' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'Piñata' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%é%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ñ%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'ch%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%is' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%é%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ia%s' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'orange' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'jalapen%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'e%ito' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'c%eR' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_cs with ñ 
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ñ%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+naïve#!#naïve#!#naïve#!#naïve#!#naïve                                             #!#naïve                                             
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+
+-- test_like_for_AI_prepare_t1_cs with ü
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%ú%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+résumé#!#résumé#!#résumé#!#résumé#!#résumé                                            #!#résumé                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+película#!#película#!#película#!#película#!#película                                          #!#película                                          
+~~END~~
+
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT * FROM test_like_for_AI_prepare_t6_cs WHERE a LIKE b
+GO
+~~START~~
+nvarchar#!#nvarchar
+THazmEEm#!#%z%
+Ŭwmed#!#Uw%
+Æmed#!#%éd
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'cafe';
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'jalapeno';
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 're%';
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%n%';
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'TELefONO';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'resume';
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'movie';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'naïve';
+GO
+~~START~~
+nvarchar
+naïve
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'Piñata';
+GO
+~~START~~
+nvarchar
+Piñata
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'ch%';
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%is';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%é%';
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+película
+canapé
+chaptéR
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ia%s';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'orange';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'jalapen%';
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'e%ito';
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'c%eR';
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_cs with ñ 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ñ%';
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+canapé
+TEññiȘ
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_cs with ü
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ú%';
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'cafe' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'jalapeno' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 're%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%n%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'TELefONO' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'resume' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'movie' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'naïve' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+naïve
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'Piñata' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+Piñata
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%é%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+película
+canapé
+chaptéR
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ñ%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'ch%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%is' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%é%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+résumé
+naïve
+Año Nuevo
+película
+canapé
+chaptéR
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ia%s' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'orange' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'jalapen%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'e%ito' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE 'c%eR' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_cs with ñ 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ñ%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+canapé
+TEññiȘ
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_cs with ü
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE '%ú%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const)
+-- Simple matches
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE 'cafe' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE 'jalapeno' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Wildcards
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE SUBSTRING(col, 1, 3) COLLATE Latin1_General_CS_AI LIKE 're%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+résumé
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE '%n%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- Case insensitive
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE 'TELefONO' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Accents variations 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE 'resume' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(LOWER(col)) COLLATE Latin1_General_CS_AI LIKE 'movie' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple accented characters
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(LOWER(col)) COLLATE Latin1_General_CS_AI LIKE 'naïve' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(UPPER(col)) COLLATE Latin1_General_CS_AI LIKE 'Piñata' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Different positions
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE SUBSTRING(UPPER(LOWER(col)), 1, 3) COLLATE Latin1_General_CS_AI LIKE '%é%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE '%ñ%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+
+-- Wildcard start
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE SUBSTRING(col, 1, 3) COLLATE Latin1_General_CS_AI LIKE 'ch%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+-- Wildcard end 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE '%is' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Wildcard middle
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE '%é%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Multiple wildcards 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE '%ia%s' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- No match
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE UPPER(col) COLLATE Latin1_General_CS_AI LIKE 'orange' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- Diacritic variations
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE 'jalapen%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- Different accented vowels
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE 'e%ito' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE 'c%eR' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_cs with ñ 
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE '%ñ%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+jalapeño
+naïve
+Piñata
+Año Nuevo
+TELÉFONO
+canapé
+TEññiȘ
+~~END~~
+
+
+-- test_like_for_AI_prepare_t7_cs with ü
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE LOWER(col) COLLATE Latin1_General_CS_AI LIKE '%ú%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+-- same experiments as above with column collated with Latin1_General_CS_AI
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE LOWER(col) LIKE 'c%eR';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE LOWER(col) LIKE 'jalapen%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE UPPER(col) LIKE '%ia%s';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE SUBSTRING(col, 1, 3) LIKE 'ch%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+
+-- CASE 10: T_ReLabelType(T_Param) LIKE T_ReLabelType(T_Param)
+declare @a varchar='RaŊdom';
+declare @b varchar='ra%';
+SELECT 1 WHERE @a LIKE @b COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+int
+~~END~~
+
+
+-- number of chars > 8000
+DECLARE @var VARCHAR(MAX);
+SET @var = REPLICATE('A', 8005);
+SELECT 1 WHERE @var COLLATE Latin1_General_CS_AI LIKE '%A%'
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 11: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Param)
+declare @c varchar(51)='e%ito';
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE @c;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+declare @c varchar(51)='c%eR';
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE @c;
+GO
+~~START~~
+nvarchar
+chaptéR
+~~END~~
+
+
+declare @d varchar(51)='%ú%';
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col LIKE @d COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+nvarchar
+résumé
+Año Nuevo
+película
+~~END~~
+
+
+-- CASE 12: LIKE inside CASE
+SELECT CASE WHEN col COLLATE Latin1_General_CS_AI LIKE 'jalapen%' THEN 1 ELSE 2 END FROM test_like_for_AI_prepare_t7_cs;
+GO
+~~START~~
+int
+2
+1
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+~~END~~
+
+
+SELECT CASE WHEN col LIKE '%is' COLLATE Latin1_General_CS_AI THEN 1 ELSE 2 END FROM test_like_for_AI_prepare_t7_cs;
+GO
+~~START~~
+int
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+~~END~~
+
+
+
+-- CASE 13: SUBQUERY
+-- SIMPLE SUBQUERY (LIKE OPERATOR AS SUBQUERY)
+-- returns 1 row
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_cs WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_cs WHERE col LIKE 'áb%');
+GO
+~~START~~
+nvarchar
+jalapeño
+~~END~~
+
+
+-- returns 2 rows
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_cs WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_cs WHERE col LIKE '%ar%l%');
+GO
+~~START~~
+nvarchar
+Piñata
+Año Nuevo
+~~END~~
+
+
+-- returns 1 rows
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_cs WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_cs WHERE col LIKE '%ţö');
+GO
+~~START~~
+nvarchar
+canapé
+~~END~~
+
+
+-- COMPLEX SUBQUERY (LIKE OPERATOR CONRTAINING SUBQUERY)
+-- returns 1 row
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'ShaEpéD' LIKE 'Ș%' COLLATE Latin1_General_CS_AI) = 1 THEN 'TEñ%' ELSE 'ár%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+TEññiȘ#!#patín
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'naïve' LIKE 'Ș%' COLLATE Latin1_General_CS_AI) = 1 THEN 'TEñ%' ELSE 'ár%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+árbol#!#difícil
+~~END~~
+
+
+-- returns 4 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE (CASE WHEN 1 = 1 THEN '%i%' ELSE '%t%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+naïve#!#cuídate
+Piñata#!#gárgola
+película#!#réquiem
+TEññiȘ#!#patín
+lúdico#!#lúdico
+~~END~~
+
+
+-- rerurns 2 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE (CASE WHEN 2 = 1 THEN '%i%' ELSE '%t%' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+Piñata#!#gárgola
+chaptéR#!#enérgetico
+~~END~~
+
+
+-- returns 2 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'ShaEpéD' LIKE 'Ș%' COLLATE Latin1_General_CS_AI) = 1 THEN '%a' ELSE '%é' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+Piñata#!#gárgola
+película#!#réquiem
+~~END~~
+
+
+-- returns 4 rows
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE (CASE WHEN (SELECT 1 WHERE 'naïve' LIKE 'Ș%' COLLATE Latin1_General_CS_AI) = 1 THEN '%a' ELSE '%é' END);
+GO
+~~START~~
+nvarchar#!#nvarchar
+café#!#prójimo
+résumé#!#críquet
+naïve#!#cuídate
+canapé#!#crédito
+~~END~~
+
+
+-- returns 1 row
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 IN (SELECT col1 FROM test_like_for_AI_prepare_t13_1_cs t1 JOIN test_like_for_AI_prepare_t13_2_cs t2 ON t1.col1 LIKE 'r%' AND t2.col LIKE 'r%');
+GO
+~~START~~
+nvarchar#!#nvarchar
+résumé#!#críquet
+~~END~~
+
+
+-- returns 1 row
+SELECT col1 FROM test_like_for_AI_prepare_t13_1_cs WHERE col2 IN (SELECT col FROM test_like_for_AI_prepare_t13_2_cs WHERE col LIKE test_like_for_AI_prepare_t13_1_cs.col1);
+GO
+~~START~~
+nvarchar
+lúdico
+~~END~~
+
+
+-- CASE 14: DIFFERENT WILDCARDS
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'ca_e';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'c[ĥżâ]%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+café#!#café#!#café#!#café#!#café                                              #!#café                                              
+canapé#!#canapé#!#canapé#!#canapé#!#canapé                                            #!#canapé                                            
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%[^oa]ñ%';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+Piñata#!#Piñata#!#Piñata#!#Piñata#!#Piñata                                            #!#Piñata                                            
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TEññiȘ#!#TEññi?#!#TEññi?#!#TEññiȘ#!#TEññi?                                            #!#TEññiȘ                                            
+~~END~~
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%[i-s]';
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+jalapeño#!#jalapeño#!#jalapeño#!#jalapeño#!#jalapeño                                          #!#jalapeño                                          
+Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo#!#Año Nuevo                                         #!#Año Nuevo                                         
+TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO#!#TELÉFONO                                          #!#TELÉFONO                                          
+árbol#!#árbol#!#árbol#!#árbol#!#árbol                                             #!#árbol                                             
+chaptéR#!#chaptéR#!#chaptéR#!#chaptéR#!#chaptéR                                           #!#chaptéR                                           
+~~END~~
+
+
+-- CASE 15: LIKE CLAUSE AS FUNCTION ARGUMENT - works when LIKE returns one row (expected)
+SELECT SUM(10 + (SELECT 90 WHERE 'Cantáis' like 'Cá%' collate Latin1_General_CS_AI));
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+SELECT CONCAT('Hi ', (SELECT col FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE 'ca_e'));
+GO
+~~START~~
+text
+Hi café
+~~END~~
+
+
+SELECT UPPER((SELECT col FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE '%no'));
+GO
+~~START~~
+text
+JALAPEÑO
+~~END~~
+
+
+-- CASE 16: JOIN
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs JOIN test_like_for_AI_prepare_t13_2_cs on test_like_for_AI_prepare_t13_1_cs.col2 LIKE test_like_for_AI_prepare_t13_2_cs.col
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+jalapeño#!#aburrí#!#aburrí
+Piñata#!#gárgola#!#gárgola
+Año Nuevo#!#gárgola#!#gárgola
+lúdico#!#lúdico#!#lúdico
+canapé#!#crédito#!#crédito
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs t1 JOIN test_like_for_AI_prepare_t13_2_cs t2 ON t1.col1 LIKE 'r%' AND t2.col LIKE 'r%';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+résumé#!#críquet#!#résumen
+résumé#!#críquet#!#reísteis
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs t1 JOIN test_like_for_AI_prepare_t13_2_cs t2 ON t1.col1 LIKE '%a%' AND t2.col LIKE '%a%';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+café#!#prójimo#!#aburrí
+jalapeño#!#aburrí#!#aburrí
+naïve#!#cuídate#!#aburrí
+Piñata#!#gárgola#!#aburrí
+película#!#réquiem#!#aburrí
+árbol#!#difícil#!#aburrí
+canapé#!#crédito#!#aburrí
+chaptéR#!#enérgetico#!#aburrí
+café#!#prójimo#!#brújula
+jalapeño#!#aburrí#!#brújula
+naïve#!#cuídate#!#brújula
+Piñata#!#gárgola#!#brújula
+película#!#réquiem#!#brújula
+árbol#!#difícil#!#brújula
+canapé#!#crédito#!#brújula
+chaptéR#!#enérgetico#!#brújula
+café#!#prójimo#!#calabacín
+jalapeño#!#aburrí#!#calabacín
+naïve#!#cuídate#!#calabacín
+Piñata#!#gárgola#!#calabacín
+película#!#réquiem#!#calabacín
+árbol#!#difícil#!#calabacín
+canapé#!#crédito#!#calabacín
+chaptéR#!#enérgetico#!#calabacín
+café#!#prójimo#!#gárgola
+jalapeño#!#aburrí#!#gárgola
+naïve#!#cuídate#!#gárgola
+Piñata#!#gárgola#!#gárgola
+película#!#réquiem#!#gárgola
+árbol#!#difícil#!#gárgola
+canapé#!#crédito#!#gárgola
+chaptéR#!#enérgetico#!#gárgola
+café#!#prójimo#!#ácaro
+jalapeño#!#aburrí#!#ácaro
+naïve#!#cuídate#!#ácaro
+Piñata#!#gárgola#!#ácaro
+película#!#réquiem#!#ácaro
+árbol#!#difícil#!#ácaro
+canapé#!#crédito#!#ácaro
+chaptéR#!#enérgetico#!#ácaro
+café#!#prójimo#!#gígabyte
+jalapeño#!#aburrí#!#gígabyte
+naïve#!#cuídate#!#gígabyte
+Piñata#!#gárgola#!#gígabyte
+película#!#réquiem#!#gígabyte
+árbol#!#difícil#!#gígabyte
+canapé#!#crédito#!#gígabyte
+chaptéR#!#enérgetico#!#gígabyte
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t13_1_cs t1 JOIN test_like_for_AI_prepare_t13_2_cs t2 ON t1.col2 LIKE '%o' AND t2.col LIKE '%o';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar
+café#!#prójimo#!#lúdico
+TELÉFONO#!#núcleo#!#lúdico
+canapé#!#crédito#!#lúdico
+chaptéR#!#enérgetico#!#lúdico
+lúdico#!#lúdico#!#lúdico
+café#!#prójimo#!#ácaro
+TELÉFONO#!#núcleo#!#ácaro
+canapé#!#crédito#!#ácaro
+chaptéR#!#enérgetico#!#ácaro
+lúdico#!#lúdico#!#ácaro
+café#!#prójimo#!#crédito
+TELÉFONO#!#núcleo#!#crédito
+canapé#!#crédito#!#crédito
+chaptéR#!#enérgetico#!#crédito
+lúdico#!#lúdico#!#crédito
+café#!#prójimo#!#ídolo
+TELÉFONO#!#núcleo#!#ídolo
+canapé#!#crédito#!#ídolo
+chaptéR#!#enérgetico#!#ídolo
+lúdico#!#lúdico#!#ídolo
+~~END~~
+
+
+-- CASE 17: PREPARED STATEMENTS
+DECLARE @prefix NVARCHAR(50) = 'ár';
+EXEC sp_executesql N'SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE @prefix + ''%'';', N'@prefix NVARCHAR(50)', @prefix;
+GO
+~~START~~
+nvarchar#!#nvarchar
+árbol#!#difícil
+~~END~~
+
+
+DECLARE @pattern NVARCHAR(50) = '%bo%';
+EXEC sp_executesql N'SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE @pattern + ''%'';', N'@pattern NVARCHAR(50)', @pattern;
+GO
+~~START~~
+nvarchar#!#nvarchar
+árbol#!#difícil
+~~END~~
+
+
+DECLARE @suffix NVARCHAR(50) = 'éR';
+EXEC sp_executesql N'SELECT * FROM test_like_for_AI_prepare_t13_1_cs WHERE col1 LIKE ''%'' + @suffix;', N'@suffix NVARCHAR(50)', @suffix;
+GO
+~~START~~
+nvarchar#!#nvarchar
+chaptéR#!#enérgetico
+~~END~~
+
+
+-- CASE 18: LIKE OBJECT_NAME()
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE 1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) LIKE '%Blah%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE 1=1 AND OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) LIKE '%AI_prepãr%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE 1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) LIKE 'Blah%' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE 1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) LIKE '%Blah' COLLATE Latin1_General_CS_AI;
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE NOT 1>1 AND ((NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) LIKE '%Blah%' COLLATE Latin1_General_CS_AI) AND (OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) COLLATE Latin1_General_CS_AI LIKE '%like_for_AI%'))
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE 1>1 OR ((NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) COLLATE Latin1_General_CS_AI LIKE '%Blah%') AND (NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) LIKE '%Blâh%' COLLATE Latin1_General_CS_AI))
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+SELECT COUNT(*) FROM test_like_for_AI_prepare_t13_1_cs WHERE (1=1 AND NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) COLLATE Latin1_General_CS_AI LIKE '%Blah%') OR ((NOT 2<1) AND (NOT OBJECT_NAME(OBJECT_ID('test_like_for_AI_prepare_t13_1_cs')) COLLATE Latin1_General_CS_AI LIKE '%Blâh%'))
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+-- CASE 19: ESCAPE WITH LIKE
+--15% off using ESCAPE; should return rows 19
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CS_AI LIKE '15/% %' ESCAPE '/' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+19#!#15% off
+~~END~~
+
+
+--15% off using a different ESCAPE character; should return rows 19
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CS_AI LIKE '15!% %' ESCAPE '!' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+19#!#15% off
+~~END~~
+
+
+--15 % off ; should return rows 21
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CS_AI LIKE '15 /%___' ESCAPE '/' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+21#!#15 %off
+~~END~~
+
+
+--Searching for the escape character itself; should return rows 23
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CS_AI LIKE '15 [%] //off' ESCAPE '/' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+23#!#15 % /off
+~~END~~
+
+
+--As above, but also allow for "[". Should return 3-18, 24
+SELECT * FROM test_like_for_AI_prepare_escape WHERE string COLLATE Latin1_General_CS_AI NOT LIKE '%[^a-zA-ZåÅäÄöÖ.[?[]%' ESCAPE '?' ORDER BY c1
+GO
+~~START~~
+int#!#nvarchar
+3#!#Andersson
+4#!#Bertilsson
+5#!#Carlson
+6#!#Davidsson
+7#!#Eriksson
+8#!#Fredriksson
+9#!#F
+10#!#F.
+11#!#Göransson
+12#!#Karlsson
+13#!#KarlsTon
+14#!#Karlson
+15#!#Persson
+16#!#Uarlson
+17#!#McDonalds
+18#!#MacDonalds
+24#!#My[String
+~~END~~
+
+
+SELECT 1 WHERE 'a[abc]b' COLLATE Latin1_General_CS_AI LIKE 'a\[abc]b' escape '\'  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+declare @v varchar = 'a[bc'
+SELECT 1 WHERE @v COLLATE Latin1_General_CS_AI LIKE '%[%' escape '~' OR @v COLLATE Latin1_General_CS_AI LIKE '%]%'                -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+declare @v varchar = 'a[bc'
+SELECT 1 WHERE @v COLLATE Latin1_General_CS_AI LIKE '%~[%' escape '~' OR @v COLLATE Latin1_General_CS_AI LIKE '%~]%' escape '~'   -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+declare @v varchar = 'a[bc'
+set @v = 'a]bc'
+SELECT 1 WHERE @v COLLATE Latin1_General_CS_AI LIKE '%[%' escape '~' OR @v COLLATE Latin1_General_CS_AI LIKE '%]%'                -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+
+declare @v varchar = 'a[bc'
+set @v = 'a]bc'
+SELECT 1 WHERE @v LIKE '%~[%' COLLATE Latin1_General_CS_AI escape '~' OR @v LIKE '%~]%' escape '~'  COLLATE Latin1_General_CS_AI -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+declare @v varchar(20), @p varchar(20), @esc char(1)
+set @v = 'a[abc]b'set @p = 'a\[abc]b' set @esc = '\' -- 1
+SELECT 1 WHERE @v COLLATE Latin1_General_CS_AI LIKE @p escape @esc 
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE '_ab' COLLATE Latin1_General_CS_AI LIKE '\_ab'  escape '\'         -- 1 
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT 1 WHERE '%AAABBB%' COLLATE Latin1_General_CS_AI LIKE '\%AAA%' escape '\'   -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' COLLATE Latin1_General_CS_AI LIKE 'AB~[C]D' ESCAPE '~'  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB\[C]D' COLLATE Latin1_General_CS_AI ESCAPE '\'  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB\[C]D' ESCAPE '\'  COLLATE Latin1_General_CS_AI  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB [C]D' COLLATE Latin1_General_CS_AI ESCAPE ' '  -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'AB[C]D' COLLATE Latin1_General_CS_AI ESCAPE 'B'   -- no row
+GO
+~~START~~
+int
+~~END~~
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'ABB[C]D' COLLATE Latin1_General_CS_AI ESCAPE 'B'  -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE 'AB[C]D' LIKE 'ABZ[C]D' ESCAPE 'Z' COLLATE Latin1_General_CS_AI -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT 1 WHERE 'AB[C]D' COLLATE Latin1_General_CS_AI LIKE 'ABZ[C]D' ESCAPE 'z'  -- no row! Note: SQL Server treats the escape as case-sensitive!
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null like null COLLATE Latin1_General_CS_AI escape null -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null COLLATE Latin1_General_CS_AI like null escape null -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null COLLATE Latin1_General_CS_AI like null COLLATE Latin1_General_CS_AI escape null -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE null like null escape null COLLATE Latin1_General_CS_AI  -- no row
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT 1 WHERE 'ABCD' LIKE 'AB[C]D' COLLATE Latin1_General_CS_AI ESCAPE ''  -- should raise error , BABEL-4271
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The invalid escape character "" was specified in a LIKE predicate.)~~
+
+SELECT 1 WHERE 'ABCD' COLLATE Latin1_General_CS_AI LIKE 'AB[C]D' ESCAPE 'xy'  -- raise error
+GO
+~~ERROR (Code: 506)~~
+
+~~ERROR (Message: invalid escape string)~~
+
+
+SELECT 1 WHERE 'ABCD' COLLATE Latin1_General_CS_AI LIKE 'AB[C]D' ESCAPE null;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- CASE 20: LIKE IN TARGET LIST
+SELECT col, CASE WHEN col LIKE 'ch%' THEN 'Prefix Match' ELSE 'No Match' END AS match_status FROM test_like_for_AI_prepare_t1_ci;
+GO
+~~START~~
+nvarchar#!#text
+café#!#No Match
+jalapeño#!#No Match
+résumé#!#No Match
+naïve#!#No Match
+Piñata#!#No Match
+Año Nuevo#!#No Match
+TELÉFONO#!#No Match
+película#!#No Match
+árbol#!#No Match
+canapé#!#No Match
+chaptéR#!#Prefix Match
+TEññiȘ#!#No Match
+~~END~~
+
+
+SELECT col,
+       CASE 
+           WHEN col LIKE 'prefix%' THEN 'Prefix Match'
+           WHEN col LIKE '%ONO' THEN 'Suffix Match'
+           ELSE 'No Match' 
+       END AS match_category
+FROM test_like_for_AI_prepare_t1_ci;
+GO
+~~START~~
+nvarchar#!#text
+café#!#No Match
+jalapeño#!#No Match
+résumé#!#No Match
+naïve#!#No Match
+Piñata#!#No Match
+Año Nuevo#!#No Match
+TELÉFONO#!#Suffix Match
+película#!#No Match
+árbol#!#No Match
+canapé#!#No Match
+chaptéR#!#No Match
+TEññiȘ#!#No Match
+~~END~~
+
+
+SELECT col,
+       CASE 
+           WHEN col LIKE 'prefix%' THEN 'Prefix Match'
+           WHEN col LIKE '%suffix' THEN 'Suffix Match'
+           WHEN col LIKE '%íc%' THEN 'Match'
+           ELSE 'No Match' 
+       END AS extracted_substring
+FROM test_like_for_AI_prepare_t1_ci;
+GO
+~~START~~
+nvarchar#!#text
+café#!#No Match
+jalapeño#!#No Match
+résumé#!#No Match
+naïve#!#No Match
+Piñata#!#No Match
+Año Nuevo#!#No Match
+TELÉFONO#!#No Match
+película#!#Match
+árbol#!#No Match
+canapé#!#No Match
+chaptéR#!#No Match
+TEññiȘ#!#No Match
+~~END~~
+
+
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+10#!#Ądam
+~~END~~
+
+
+
+--- ADDITIONAL CORNER CASE TESTING ---
+-- different collation on both arguments
+SELECT 1 WHERE 'cantáis' COLLATE Latin1_General_CS_AI LIKE 'Cá%' COLLATE Latin1_General_CI_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: collation mismatch between explicit collations "bbf_unicode_cp1_cs_ai" and "bbf_unicode_cp1_ci_ai")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col COLLATE Latin1_General_CI_AI LIKE '%a%' COLLATE Latin1_General_CS_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: collation mismatch between explicit collations "bbf_unicode_cp1_ci_ai" and "bbf_unicode_cp1_cs_ai")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col COLLATE Latin1_General_CS_AI LIKE'%a%' COLLATE Latin1_General_CI_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: collation mismatch between explicit collations "bbf_unicode_cp1_cs_ai" and "bbf_unicode_cp1_ci_ai")~~
+
+
+
+-- NON-Latin based collation 
+select 1 where 'cantáis' like 'Cá%' collate Chinese_PRC_CI_AI
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "chinese_prc_ci_ai")~~
+
+
+-- should throw error as bbf_unicode_cp1258_ci_ai is related with code page 1258 which contains vietnamese chars
+select 1 where 'cantáis' like 'Cá%' collate bbf_unicode_cp1258_ci_ai
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "bbf_unicode_cp1258_ci_ai")~~
+
+
+select 1 where '幸福' like '幸福%' collate Chinese_PRC_CI_AI
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "chinese_prc_ci_ai")~~
+
+
+
+SELECT * FROM test_like_for_AI_prepare_chinese WHERE a LIKE '中%' COLLATE Chinese_PRC_CI_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "chinese_prc_ci_ai")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_chinese WHERE a LIKE '微笑' COLLATE Chinese_PRC_CI_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "chinese_prc_ci_ai")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_chinese WHERE a LIKE '%谢%' COLLATE Chinese_PRC_CI_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "chinese_prc_ci_ai")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_chinese WHERE a LIKE '%笑' COLLATE Chinese_PRC_CI_AI;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: LIKE operator is not supported for "chinese_prc_ci_ai")~~
+
+
+-- col LIKE NULL
+SELECT * FROM test_like_for_AI_prepare_t1_ci WHERE col LIKE NULL;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t1_cs WHERE col LIKE NULL;
+GO
+~~START~~
+nvarchar#!#varchar#!#text#!#ntext#!#char#!#nchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_ci WHERE col COLLATE Latin1_General_CI_AI LIKE NULL;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+SELECT * FROM test_like_for_AI_prepare_t7_cs WHERE col COLLATE Latin1_General_CS_AI LIKE NULL;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- test cases which would test our restriction on capacity of removing accents
+SELECT count(*) FROM test_like_for_AI_prepare_max_test WHERE a LIKE '%ae%' COLLATE Latin1_General_CI_AI;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT count(*) FROM test_like_for_AI_prepare_max_test WHERE a COLLATE Latin1_General_CI_AI LIKE '%Áe%'
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- TESTS FOR INDEX SCAN 
+select set_config('enable_seqscan','off','false');
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+-- psql
+ANALYZE master_dbo.test_like_for_AI_prepare_index;
+GO
+
+-- tsql
+SET babelfish_showplan_all ON;
+GO
+-- for CI_AI
+select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'; -- this gets converted to '='
+GO
+~~START~~
+text
+Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE "default")
+~~END~~
+
+
+select c1 from test_like_for_AI_prepare_index where c1 LIKE 'Jon%';
+GO
+~~START~~
+text
+Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'Jon%'
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text))
+~~END~~
+
+
+select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jone_';
+GO
+~~START~~
+text
+Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jone_'
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text))
+~~END~~
+
+
+select c1 from test_like_for_AI_prepare_index where c1 LIKE '_one_';
+GO
+~~START~~
+text
+Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '_one_'
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE "default")
+~~END~~
+
+
+select c1 from test_like_for_AI_prepare_index where c1 LIKE '%on%s';
+GO
+~~START~~
+text
+Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '%on%s'
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE "default")
+~~END~~
+
+
+-- for CS_AI
+select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'; -- this does not get converted to '=' as we are not using optimization for CS_AI
+GO
+~~START~~
+text
+Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ 'jones'::text)
+~~END~~
+
+
+select c2 from test_like_for_AI_prepare_index where c2 LIKE 'Jon%';
+GO
+~~START~~
+text
+Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'Jon%'
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ 'Jon%'::text)
+~~END~~
+
+
+select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jone_';
+GO
+~~START~~
+text
+Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jone_'
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ 'jone_'::text)
+~~END~~
+
+
+select c2 from test_like_for_AI_prepare_index where c2 LIKE '_one_';
+GO
+~~START~~
+text
+Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE '_one_'
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ '_one_'::text)
+~~END~~
+
+
+select c2 from test_like_for_AI_prepare_index where c2 LIKE '%on%s';
+GO
+~~START~~
+text
+Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE '%on%s'
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ '%on%s'::text)
+~~END~~
+
+
+SET babelfish_showplan_all OFF;
+GO
+
+
+-- TESTS for remove_accents_internal
+-- function
+SELECT test_like_for_AI_prepare_function('ǪǞǛ');
+GO
+~~START~~
+nvarchar
+OAU
+~~END~~
+
+
+SELECT test_like_for_AI_prepare_function('ĵķżƁ');
+GO
+~~START~~
+nvarchar
+jkzB
+~~END~~
+
+
+SELECT test_like_for_AI_prepare_function('ȌÆß');
+GO
+~~START~~
+nvarchar
+OAEss
+~~END~~
+
+
+-- view
+SELECT * FROM test_like_for_AI_prepare_view;
+GO
+~~START~~
+nvarchar
+cafe
+jalapeno
+resume
+naive
+Pinata
+Ano Nuevo
+TELEFONO
+pelicula
+arbol
+canape
+chapteR
+TEnniS
+~~END~~
+
+
+-- procedure
+EXEC test_like_for_AI_prepare_procedure @input_text = 'ǪǞǛ';
+GO
+~~START~~
+nvarchar
+OAU
+~~END~~
+
+
+EXEC test_like_for_AI_prepare_procedure @input_text = 'ĵķżƁ';
+GO
+~~START~~
+nvarchar
+jkzB
+~~END~~
+
+
+EXEC test_like_for_AI_prepare_procedure @input_text = 'ȌÆß';
+GO
+~~START~~
+nvarchar
+OAEss
+~~END~~
+

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -2257,6 +2257,43 @@ TEññiȘ#!#No Match
 
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 ~~START~~
@@ -4421,7 +4458,59 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 ~~START~~

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -2256,6 +2256,19 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
+
+
 
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -4405,6 +4418,16 @@ película#!#Match
 canapé#!#No Match
 chaptéR#!#No Match
 TEññiȘ#!#No Match
+~~END~~
+
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+10#!#Ądam
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -2257,43 +2257,6 @@ TEññiȘ#!#No Match
 
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ROW COUNT: 1~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 ~~START~~
@@ -4458,59 +4421,7 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
-
 -- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
-GO
-~~ROW COUNT: 1~~
-
-
--- these will fail - CS_AI
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 ~~START~~

--- a/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
@@ -11,6 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
+
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO
@@ -27,6 +30,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_cs;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CS_AI;
+GO
 
 -- GENERIC --
 DROP TABLE test_like_for_AI_prepare_escape;

--- a/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
@@ -11,9 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
-DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
-GO
 
+-- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO

--- a/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-cleanup.out
@@ -11,9 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
 
--- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
--- GO
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -116,43 +116,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
 );
 GO
 
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ROW COUNT: 1~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -315,58 +278,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
         CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
 );
 GO
-
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
-GO
-~~ROW COUNT: 1~~
-
-
--- these will fail - CS_AI
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
-
-
 
 
 --- ADDITIONAL CORNER CASE TESTING ---

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -106,16 +106,16 @@ GO
 ~~ROW COUNT: 13~~
 
 
-
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
--- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
---     id INT PRIMARY KEY,
---     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
---     CONSTRAINT check_name_starts_with_a 
---         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
--- );
--- GO
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
+
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -106,6 +106,53 @@ GO
 ~~ROW COUNT: 13~~
 
 
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -257,6 +304,67 @@ VALUES
 ,(null);
 GO
 ~~ROW COUNT: 29~~
+
+
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CS_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
 
 
 

--- a/test/JDBC/expected/test_like_for_AI-vu-prepare.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-prepare.out
@@ -106,16 +106,16 @@ GO
 ~~ROW COUNT: 13~~
 
 
+
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
-CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
-    id INT PRIMARY KEY,
-    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
-    CONSTRAINT check_name_starts_with_a 
-        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
-);
-GO
-
+-- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+--     id INT PRIMARY KEY,
+--     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+--     CONSTRAINT check_name_starts_with_a 
+--         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+-- );
+-- GO
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2257,6 +2257,43 @@ TEññiȘ#!#No Match
 
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 ~~START~~
@@ -4421,7 +4458,59 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_cs_ai" violates check constraint "check_name_starts_with_atest_li9c0556d54bbcccb196d33f13188c8740")~~
+
+
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 ~~START~~

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2256,6 +2256,19 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
+
+
 
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -4405,6 +4418,16 @@ película#!#Match
 canapé#!#No Match
 chaptéR#!#No Match
 TEññiȘ#!#No Match
+~~END~~
+
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+10#!#Ądam
 ~~END~~
 
 

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2256,30 +2256,57 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+~~ROW COUNT: 1~~
+
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
+
+
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+~~START~~
+int#!#nvarchar
+1#!#Adam
+2#!#ådAm
+3#!#ädam
+4#!#adam
+5#!#ædam
+~~END~~
 
 
 
-
--- -- CASE 21: COLUMN LEVEL CONSTRAINT
--- -- Test the constraint
--- -- This insert will succeed
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
--- GO
--- -- This insert will fail due to the check constraint
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
--- GO
--- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
--- GO
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 select 1 where 'cantáis' like 'cá%' collate Latin1_General_CS_AI;

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -2256,57 +2256,30 @@ TEññiȘ#!#No Match
 ~~END~~
 
 
--- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-~~ROW COUNT: 1~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-~~ROW COUNT: 1~~
-
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "test_like_for_ai_prepare_employee_ci_ai" violates check constraint "check_name_starts_with_atest_liecd1958c3e7903956f04af7a57787ee2")~~
-
-
-SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
-GO
-~~START~~
-int#!#nvarchar
-1#!#Adam
-2#!#ådAm
-3#!#ädam
-4#!#adam
-5#!#ædam
-~~END~~
 
 
 
+
+-- -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- -- Test the constraint
+-- -- This insert will succeed
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+-- GO
+-- -- This insert will fail due to the check constraint
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+-- GO
+-- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 select 1 where 'cantáis' like 'cá%' collate Latin1_General_CS_AI;

--- a/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
@@ -11,8 +11,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
--- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
--- GO
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
 
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;

--- a/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
@@ -11,6 +11,9 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+GO
+
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;
 GO
@@ -27,6 +30,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_cs;
 GO
 
+DROP TABLE test_like_for_AI_prepare_employee_CS_AI;
+GO
 
 -- GENERIC --
 DROP TABLE test_like_for_AI_prepare_escape;

--- a/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-cleanup.sql
@@ -11,8 +11,8 @@ GO
 DROP TABLE test_like_for_AI_prepare_t13_2_ci;
 GO
 
-DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
-GO
+-- DROP TABLE test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 
 ------------------- CS_AI ----------------------
 DROP TABLE test_like_for_AI_prepare_t1_cs;

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -106,25 +106,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
 );
 GO
 
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
-
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -275,30 +256,6 @@ CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
         CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
 );
 GO
-
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
-GO
-
--- these will fail - CS_AI
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
-GO
-
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
-GO
-
 
 --- ADDITIONAL CORNER CASE TESTING ---
 

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -98,13 +98,13 @@ GO
 
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
--- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
---     id INT PRIMARY KEY,
---     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
---     CONSTRAINT check_name_starts_with_a 
---         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
--- );
--- GO
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
 
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -96,6 +96,35 @@ INSERT INTO test_like_for_AI_prepare_t13_2_ci VALUES
   (null);
 GO
 
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (
     col NVARCHAR(50) COLLATE Latin1_General_CS_AI,
@@ -235,6 +264,39 @@ VALUES
 ,('My[valid]String')
 ,(null);
 
+GO
+
+-- TESTS FOR COLUMN LEVEL CONSTRAINTS
+-- Create the employee table with the computed column and check constraint
+CREATE TABLE test_like_for_AI_prepare_employee_CS_AI (
+    id INT PRIMARY KEY,
+    name NVARCHAR(MAX) COLLATE Latin1_General_CS_AI,
+    CONSTRAINT check_name_starts_with_a 
+        CHECK (name COLLATE Latin1_General_CS_AI LIKE 'A%')
+);
+GO
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
 GO
 
 

--- a/test/JDBC/input/test_like_for_AI-vu-prepare.sql
+++ b/test/JDBC/input/test_like_for_AI-vu-prepare.sql
@@ -98,13 +98,13 @@ GO
 
 -- TESTS FOR COLUMN LEVEL CONSTRAINTS
 -- Create the employee table with the computed column and check constraint
-CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
-    id INT PRIMARY KEY,
-    name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
-    CONSTRAINT check_name_starts_with_a 
-        CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
-);
-GO
+-- CREATE TABLE test_like_for_AI_prepare_employee_CI_AI (
+--     id INT PRIMARY KEY,
+--     name NVARCHAR(MAX) COLLATE Latin1_General_CI_AI,
+--     CONSTRAINT check_name_starts_with_a 
+--         CHECK (name COLLATE Latin1_General_CI_AI LIKE 'A%')
+-- );
+-- GO
 
 ------------------- CS_AI ----------------------
 CREATE TABLE test_like_for_AI_prepare_t1_cs (

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -793,28 +793,28 @@ SELECT col,
 FROM test_like_for_AI_prepare_t1_ci;
 GO
 
--- -- CASE 21: COLUMN LEVEL CONSTRAINT
--- -- Test the constraint
--- -- This insert will succeed
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
--- GO
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
 
--- -- This insert will fail due to the check constraint
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
--- GO
--- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
--- GO
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
 
--- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
--- GO
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
 
 
 ------------------- CS_AI ----------------------

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -793,6 +793,10 @@ SELECT col,
 FROM test_like_for_AI_prepare_t1_ci;
 GO
 
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+GO
+
 
 ------------------- CS_AI ----------------------
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -1584,6 +1588,10 @@ SELECT col,
            ELSE 'No Match' 
        END AS extracted_substring
 FROM test_like_for_AI_prepare_t1_ci;
+GO
+
+-- CASE 21: COLUMN LEVEL CONSTRAINT
+SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 
 --- ADDITIONAL CORNER CASE TESTING ---

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -793,28 +793,28 @@ SELECT col,
 FROM test_like_for_AI_prepare_t1_ci;
 GO
 
--- CASE 21: COLUMN LEVEL CONSTRAINT
--- Test the constraint
--- This insert will succeed
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
-GO
+-- -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- -- Test the constraint
+-- -- This insert will succeed
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+-- GO
 
--- This insert will fail due to the check constraint
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
-GO
-INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
-GO
+-- -- This insert will fail due to the check constraint
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+-- GO
+-- INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+-- GO
 
-SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
-GO
+-- SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
+-- GO
 
 
 ------------------- CS_AI ----------------------

--- a/test/JDBC/input/test_like_for_AI-vu-verify.mix
+++ b/test/JDBC/input/test_like_for_AI-vu-verify.mix
@@ -794,6 +794,25 @@ FROM test_like_for_AI_prepare_t1_ci;
 GO
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CI_AI (id, name) VALUES (7, 'ôob');
+GO
+
 SELECT * FROM test_like_for_AI_prepare_employee_CI_AI;
 GO
 
@@ -1591,6 +1610,30 @@ FROM test_like_for_AI_prepare_t1_ci;
 GO
 
 -- CASE 21: COLUMN LEVEL CONSTRAINT
+
+-- Test the constraint
+-- This insert will succeed
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (1, 'Adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (10, 'Ądam');
+GO
+
+-- these will fail - CS_AI
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (2, 'ådAm');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (3, 'ädam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (4, 'adam');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (5, 'ædam');
+GO
+
+-- This insert will fail due to the check constraint
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (6, 'Bob');
+GO
+INSERT INTO test_like_for_AI_prepare_employee_CS_AI (id, name) VALUES (7, 'ôob');
+GO
+
 SELECT * FROM test_like_for_AI_prepare_employee_CS_AI;
 GO
 

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -514,3 +514,4 @@ babel_test_int4_numeric_oper_before_16_3
 babel_test_int8_numeric_oper_before_16_3
 babel_test_int2_numeric_oper_before_16_3
 BABEL_3571
+test_like_for_AI


### PR DESCRIPTION
### Description
This commit adds JDBC tests for column level constrains using CHECK while inserting value into a table. If the CHECK condition is not met, user won't be able to insert data into table.
Updated the collation oid for AI inside ```transform_from_ci_as_for_likenode``` function as initially we were using ```server_collation_oid```. Because of previous behaviour, the upgrade from 15 -> 16 will fail as there will be collation mismatch if LIKE for CI_AI is used in DDL. 
Had to add expected output file for test_like_for_AI-vu-verify when server_collation is japanese_ci_as during upgrade test as there was an expected diff.
Related PR (for 3_X): https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2556


### Issues Resolved

BABEL-4931
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).