### PR TITLE
Fix issues with TVFs which use identifiers longer than 63 characters

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -3913,7 +3913,7 @@ tsql_CreateFunctionStmt:
 								 parser_errposition(@1)));
 
 					tbltyp = list_truncate(tbltyp, list_length(tbltyp) - 1);
-					tbltyp = lappend(tbltyp, makeString(tbltyp_name));
+					tbltyp = lappend(tbltyp, makeString(downcase_truncate_identifier(tbltyp_name, strlen(tbltyp_name), true)));
 					n1->relation = makeRangeVarFromAnyName(tbltyp, @4, yyscanner);
 					n1->tableElts = $10;
 					n1->inhRelations = NIL;

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1366,6 +1366,21 @@ exec_stmt_decl_table(PLtsql_execstate *estate, PLtsql_stmt_decl_table *stmt)
 		}
 
 		tblname = psprintf("%s_%d", var->refname, estate->nestlevel);
+
+		/*
+		 * If the original refname was already >=63 characters (the max limit of PG identifiers),
+		 * then the above construction of tblname will be >63 characters, which will violate the
+		 * max length of PG identiefiers and cause issues down the road. Fix this by truncating
+		 * tblname so that adding the "_<@@nestlevel>" suffix will be exactly 63 characters.
+		 */
+		if (strlen(tblname) >= NAMEDATALEN)
+		{
+			// truncate tblname to fit the "_#" nestlevel suffix
+			tblname[(NAMEDATALEN-1)-(strlen(tblname)-(NAMEDATALEN-1))] = '\0';
+			// previous palloc of tblname will be cleaned up with the memory context
+			tblname = psprintf("%s_%d", tblname, estate->nestlevel);
+		}
+		
 		if (stmt->tbltypname)
 			query = psprintf("CREATE TEMPORARY TABLE IF NOT EXISTS %s (like %s including all)",
 							 tblname, stmt->tbltypname);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2126,13 +2126,8 @@ bbf_table_var_lookup(const char *relname, Oid relnamespace)
 			continue;
 
 		tbl = (PLtsql_tbl *) estate->datums[n];
-		if (strcmp(relname, tbl->refname) == 0)
+		if (strcmp(relname, tbl->refname) == 0 && tbl->tblname)
 		{
-			if (!tbl->tblname)	/* FIXME: throwing an error instead of a crash
-								 * until table-type is supported in ANTLR
-								 * parser */
-				ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-								errmsg("table variable underlying typename is NULL. refname: %s", tbl->refname)));
 			return get_relname_relid(tbl->tblname, relnamespace);
 		}
 	}

--- a/test/JDBC/expected/babel_table_type-vu-prepare.out
+++ b/test/JDBC/expected/babel_table_type-vu-prepare.out
@@ -1,0 +1,56 @@
+
+-- BABEL-3311 TVF name truncation
+-- function name longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_very_long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(@id INT)
+RETURNS @a_short_table_name TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_short_table_name
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- table name longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_short_function_name(@id INT)
+RETURNS @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- both function name and table name longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_very_long_function_name_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(@id INT)
+RETURNS @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- each shorter than 63 characters, but combined are longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_medium_function_name_aaaaaaaaaaaaaaaaa(@id INT)
+RETURNS @a_medium_table_name_aaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_medium_table_name_aaaaaaaaaaaaaaaaaaaa
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- nesting TVFs using the same long table variable name
+CREATE FUNCTION babel_table_type_vu_a_nested_function(@id INT)
+RETURNS @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		SELECT result FROM babel_table_type_vu_a_short_function_name(@id);
+	RETURN;
+END;
+GO

--- a/test/JDBC/expected/babel_table_type-vu-verify.out
+++ b/test/JDBC/expected/babel_table_type-vu-verify.out
@@ -1,0 +1,51 @@
+SELECT * FROM babel_table_type_vu_a_very_long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM babel_table_type_vu_a_short_function_name(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM babel_table_type_vu_a_very_long_function_name_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM babel_table_type_vu_a_medium_function_name_aaaaaaaaaaaaaaaaa(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM babel_table_type_vu_a_nested_function(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- cleanup
+DROP FUNCTION babel_table_type_vu_a_nested_function;
+GO
+DROP FUNCTION babel_table_type_vu_a_very_long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+GO
+DROP FUNCTION babel_table_type_vu_a_short_function_name;
+GO
+DROP FUNCTION babel_table_type_vu_a_very_long_function_name_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+GO
+DROP FUNCTION babel_table_type_vu_a_medium_function_name_aaaaaaaaaaaaaaaaa;
+GO

--- a/test/JDBC/expected/parallel_query/table-variable-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/table-variable-vu-verify.out
@@ -274,5 +274,5 @@ go
 int
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: table variable underlying typename is NULL. refname: @t)~~
+~~ERROR (Message: relation "@t" does not exist)~~
 

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -271,5 +271,5 @@ go
 int
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: table variable underlying typename is NULL. refname: @t)~~
+~~ERROR (Message: relation "@t" does not exist)~~
 

--- a/test/JDBC/input/babel_table_type-vu-prepare.sql
+++ b/test/JDBC/input/babel_table_type-vu-prepare.sql
@@ -1,0 +1,56 @@
+-- BABEL-3311 TVF name truncation
+
+-- function name longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_very_long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(@id INT)
+RETURNS @a_short_table_name TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_short_table_name
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- table name longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_short_function_name(@id INT)
+RETURNS @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- both function name and table name longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_very_long_function_name_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(@id INT)
+RETURNS @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- each shorter than 63 characters, but combined are longer than 63 characters
+CREATE FUNCTION babel_table_type_vu_a_medium_function_name_aaaaaaaaaaaaaaaaa(@id INT)
+RETURNS @a_medium_table_name_aaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_medium_table_name_aaaaaaaaaaaaaaaaaaaa
+		SELECT @id;
+	RETURN;
+END;
+GO
+
+-- nesting TVFs using the same long table variable name
+CREATE FUNCTION babel_table_type_vu_a_nested_function(@id INT)
+RETURNS @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TABLE (result INT)
+AS
+BEGIN
+	INSERT INTO @a_very_long_table_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		SELECT result FROM babel_table_type_vu_a_short_function_name(@id);
+	RETURN;
+END;
+GO

--- a/test/JDBC/input/babel_table_type-vu-verify.sql
+++ b/test/JDBC/input/babel_table_type-vu-verify.sql
@@ -1,0 +1,26 @@
+SELECT * FROM babel_table_type_vu_a_very_long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(1);
+GO
+
+SELECT * FROM babel_table_type_vu_a_short_function_name(1);
+GO
+
+SELECT * FROM babel_table_type_vu_a_very_long_function_name_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(1);
+GO
+
+SELECT * FROM babel_table_type_vu_a_medium_function_name_aaaaaaaaaaaaaaaaa(1);
+GO
+
+SELECT * FROM babel_table_type_vu_a_nested_function(1);
+GO
+
+-- cleanup
+DROP FUNCTION babel_table_type_vu_a_nested_function;
+GO
+DROP FUNCTION babel_table_type_vu_a_very_long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+GO
+DROP FUNCTION babel_table_type_vu_a_short_function_name;
+GO
+DROP FUNCTION babel_table_type_vu_a_very_long_function_name_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+GO
+DROP FUNCTION babel_table_type_vu_a_medium_function_name_aaaaaaaaaaaaaaaaa;
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -515,6 +515,7 @@ babel-4475
 babel-3254
 babel-4517
 alter-procedure
+babel_table_type
 1_GRANT_SCHEMA
 BABEL-4707
 BABEL_4817


### PR DESCRIPTION
### Description

In Table-valued functions which return data into a table variable, we create a temporary table in which to return the data. The name of this temporary table is generated as a combination of the table variable and function name. If this combination exceeds 63 characters (the limit of identifiers in postgresql), then we can run into issues trying to refer back to the temporary table to insert the data while executing the function, as the name used to access it will be different than what is stored in the postgres catalog due to truncation.

Fix this by utilizing the pre-existing `downcase_truncate_identifier()` function to ensure that the new identifier is within the postgresql character limit. Additionally, truncate the temporary table name (which normally tries to append the @@nest_level to the end) to 63 characters to prevent issues there.


### Issues Resolved

BABEL-3311

### Test Scenarios Covered ###
* **Use case based -**
Nested TVFs which use the same (long) table variable name

* **Boundary conditions -**
function name >63 characters
table variable name >63 characters
both function name and table variable name >63 characters
both function name and table variable name <63 characters, but combined are >63 characters

* **Arbitrary inputs -**
N/A

* **Negative test cases -**
N/A

* **Minor version upgrade tests -**
N/A

* **Major version upgrade tests -**
N/A

* **Performance tests -**
N/A

* **Tooling impact -**
N/A

* **Client tests -**
N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).