### PR TITLE
Fix metadata inconsisteny workflow check

### DIFF
--- a/.github/composite-actions/check-babelfish-inconsistency/action.yml
+++ b/.github/composite-actions/check-babelfish-inconsistency/action.yml
@@ -6,6 +6,6 @@ runs:
     - name: Check Babelfish metadata inconsistency
       id: check-babelfish-inconsistency
       run: |
-        output=$(sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT sys.check_for_inconsistent_metadata() GO" | tail -n +2)
-        echo "check_result=$output" >> "$GITHUB_OUTPUT"
+        output=$(sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT 'check_result=',sys.check_for_inconsistent_metadata() GO" | grep 'check_result' | sed 's/[[:blank:]]//g')
+        echo "$output" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
### Description

This commit fixes the failure that arises during the metadata inconsistency check during major version upgrades. Handling of multiline strings in github seems to be inconsistent.

This issue was introduced by #2554 

### Issues Resolved

BABEL-4139

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).