### PR TITLE
Add typmod validation in [VAR]BINARY input function

### DIFF
--- a/contrib/babelfishpg_common/src/varbinary.c
+++ b/contrib/babelfishpg_common/src/varbinary.c
@@ -196,6 +196,14 @@ varbinaryin(PG_FUNCTION_ARGS)
 		 */
 		int			bc = (len - 1) / 2 + VARHDRSZ;	/* maximum possible length */
 
+		if (typmod >= (int32) VARHDRSZ && bc > typmod)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
+					 errmsg("String or binary data would be truncated.\n"
+							"The statement has been terminated.")));
+		}
+
 		result = palloc(bc);
 		bc = babelfish_hex_decode_allow_odd_digits(inputText + 2, len - 2, VARDATA(result));
 		SET_VARSIZE(result, bc + VARHDRSZ); /* actual length */

--- a/test/JDBC/expected/BABEL-4956.out
+++ b/test/JDBC/expected/BABEL-4956.out
@@ -1,6 +1,6 @@
 -- tsql
 -- Test typmod for BINARY datatype
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_binary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     BINARY(4) NOT NULL)
 GO
@@ -8,30 +8,32 @@ GO
 -- tsql port=8199
 -- typmod of binary column is kept less in this table
 -- compared to source table to test typmod compatibility.
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_binary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     BINARY(3) NOT NULL)
 GO
 
 -- psql
 -- Add table to publication
-ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+CREATE PUBLICATION my_pub1 FOR TABLE master_dbo.babel_4956_tab_binary;
 GO
 
 -- psql port=5433
--- Refresh the subscription
+-- Add publication and refresh the subscription
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub1;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
 -- tsql
 -- Insert a 4 byte binary value with last trailing byte as 0 in the
 -- source table so that it fits into 3 byte in target table's column.
-INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(1, 0x11223300);
 GO
 ~~ROW COUNT: 1~~
 
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 ~~START~~
 int#!#binary
@@ -51,7 +53,7 @@ void
 
 -- tsql port=8199
 -- data should have replicated to target table
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 ~~START~~
 int#!#binary
@@ -62,12 +64,12 @@ int#!#binary
 -- tsql
 -- Now insert a 4 byte binary value with no trailing zero bytes in the
 -- source table so that it does not fit into 3 byte in target table's column.
-INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(2, 0x11223344);
 GO
 ~~ROW COUNT: 1~~
 
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 ~~START~~
 int#!#binary
@@ -88,7 +90,7 @@ void
 
 -- tsql port=8199
 -- we should not see the new row in target table
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 ~~START~~
 int#!#binary
@@ -96,26 +98,28 @@ int#!#binary
 ~~END~~
 
 
--- psql
--- Cleanup
-ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
-GO
-
 -- psql port=5433
+-- Cleanup
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub1;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
+-- psql
+DROP PUBLICATION my_pub1;
+GO
+
 -- tsql
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_binary;
 GO
 
 -- tsql port=8199
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_binary;
 GO
 
 -- tsql
 -- Test typmod for VARBINARY datatype
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_varbinary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     VARBINARY(4) NOT NULL)
 GO
@@ -123,30 +127,32 @@ GO
 -- tsql port=8199
 -- typmod of varbinary columns is kept less in this table
 -- compared to source table to test typmod compatibility.
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_varbinary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     VARBINARY(3) NOT NULL)
 GO
 
 -- psql
 -- Add table to publication
-ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+CREATE PUBLICATION my_pub2 FOR TABLE master_dbo.babel_4956_tab_varbinary;
 GO
 
 -- psql port=5433
--- Refresh the subscription
+-- Add publication and refresh the subscription
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub2;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
 -- tsql
 -- Insert a 4 byte varbinary value with last trailing byte as 0 in the
 -- source table so that it fits into 3 byte in target table's column.
-INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(1, 0x11223300);
 GO
 ~~ROW COUNT: 1~~
 
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 ~~START~~
 int#!#varbinary
@@ -166,7 +172,7 @@ void
 
 -- tsql port=8199
 -- data should have replicated to target table
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 ~~START~~
 int#!#varbinary
@@ -177,12 +183,12 @@ int#!#varbinary
 -- tsql
 -- Now insert a 4 byte varbinary value with no trailing zero bytes in the
 -- source table so that it does not fit into 3 byte in target table's column.
-INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(2, 0x11223344);
 GO
 ~~ROW COUNT: 1~~
 
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 ~~START~~
 int#!#varbinary
@@ -203,7 +209,7 @@ void
 
 -- tsql port=8199
 -- we should not see the new row in target table
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 ~~START~~
 int#!#varbinary
@@ -211,19 +217,25 @@ int#!#varbinary
 ~~END~~
 
 
--- psql
--- Cleanup
-ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
-GO
-
 -- psql port=5433
+-- Cleanup
+SET client_min_messages TO ERROR;
+GO
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub2;
+GO
+RESET client_min_messages;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
+-- psql
+DROP PUBLICATION my_pub2;
+GO
+
 -- tsql
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_varbinary;
 GO
 
 -- tsql port=8199
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_varbinary;
 GO

--- a/test/JDBC/expected/BABEL-4956.out
+++ b/test/JDBC/expected/BABEL-4956.out
@@ -1,0 +1,229 @@
+-- tsql
+-- Test typmod for BINARY datatype
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of binary column is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(3) NOT NULL)
+GO
+
+-- psql
+-- Add table to publication
+ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+GO
+
+-- psql port=5433
+-- Refresh the subscription
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+-- Insert a 4 byte binary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#binary
+1#!#11223300
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- data should have replicated to target table
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#binary
+1#!#112233
+~~END~~
+
+
+-- tsql
+-- Now insert a 4 byte binary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#binary
+1#!#11223300
+2#!#11223344
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- we should not see the new row in target table
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#binary
+1#!#112233
+~~END~~
+
+
+-- psql
+-- Cleanup
+ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
+GO
+
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+DROP TABLE babel_4956_t1;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_t1;
+GO
+
+-- tsql
+-- Test typmod for VARBINARY datatype
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of varbinary columns is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(3) NOT NULL)
+GO
+
+-- psql
+-- Add table to publication
+ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+GO
+
+-- psql port=5433
+-- Refresh the subscription
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+-- Insert a 4 byte varbinary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#varbinary
+1#!#11223300
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- data should have replicated to target table
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#varbinary
+1#!#112233
+~~END~~
+
+
+-- tsql
+-- Now insert a 4 byte varbinary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#varbinary
+1#!#11223300
+2#!#11223344
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- we should not see the new row in target table
+SELECT * FROM babel_4956_t1;
+GO
+~~START~~
+int#!#varbinary
+1#!#112233
+~~END~~
+
+
+-- psql
+-- Cleanup
+ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
+GO
+
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+DROP TABLE babel_4956_t1;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_t1;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,8 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-#all
-BABEL-4956
+all
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,8 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+#all
+BABEL-4956
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/replication/BABEL-4956.mix
+++ b/test/JDBC/replication/BABEL-4956.mix
@@ -1,6 +1,6 @@
 -- Test typmod for BINARY datatype
 -- tsql
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_binary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     BINARY(4) NOT NULL)
 GO
@@ -8,28 +8,30 @@ GO
 -- tsql port=8199
 -- typmod of binary column is kept less in this table
 -- compared to source table to test typmod compatibility.
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_binary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     BINARY(3) NOT NULL)
 GO
 
 -- Add table to publication
 -- psql
-ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+CREATE PUBLICATION my_pub1 FOR TABLE master_dbo.babel_4956_tab_binary;
 GO
 
--- Refresh the subscription
+-- Add publication and refresh the subscription
 -- psql port=5433
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub1;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
 -- Insert a 4 byte binary value with last trailing byte as 0 in the
 -- source table so that it fits into 3 byte in target table's column.
 -- tsql
-INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(1, 0x11223300);
 GO
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 
 -- Wait for data to get replicated
@@ -39,16 +41,16 @@ GO
 
 -- data should have replicated to target table
 -- tsql port=8199
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 
 -- Now insert a 4 byte binary value with no trailing zero bytes in the
 -- source table so that it does not fit into 3 byte in target table's column.
 -- tsql
-INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(2, 0x11223344);
 GO
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 
 -- Wait for data to get replicated
@@ -58,29 +60,31 @@ GO
 
 -- we should not see the new row in target table
 -- tsql port=8199
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_binary;
 GO
 
 -- Cleanup
--- psql
-ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
-GO
-
 -- psql port=5433
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub1;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
+-- psql
+DROP PUBLICATION my_pub1;
+GO
+
 -- tsql
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_binary;
 GO
 
 -- tsql port=8199
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_binary;
 GO
 
 -- Test typmod for VARBINARY datatype
 -- tsql
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_varbinary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     VARBINARY(4) NOT NULL)
 GO
@@ -88,28 +92,30 @@ GO
 -- tsql port=8199
 -- typmod of varbinary columns is kept less in this table
 -- compared to source table to test typmod compatibility.
-CREATE TABLE babel_4956_t1 (
+CREATE TABLE babel_4956_tab_varbinary (
     c1  INT  NOT NULL PRIMARY KEY
     , c2     VARBINARY(3) NOT NULL)
 GO
 
 -- Add table to publication
 -- psql
-ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+CREATE PUBLICATION my_pub2 FOR TABLE master_dbo.babel_4956_tab_varbinary;
 GO
 
--- Refresh the subscription
+-- Add publication and refresh the subscription
 -- psql port=5433
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub2;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
 -- Insert a 4 byte varbinary value with last trailing byte as 0 in the
 -- source table so that it fits into 3 byte in target table's column.
 -- tsql
-INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(1, 0x11223300);
 GO
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 
 -- Wait for data to get replicated
@@ -119,16 +125,16 @@ GO
 
 -- data should have replicated to target table
 -- tsql port=8199
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 
 -- Now insert a 4 byte varbinary value with no trailing zero bytes in the
 -- source table so that it does not fit into 3 byte in target table's column.
 -- tsql
-INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(2, 0x11223344);
 GO
 
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 
 -- Wait for data to get replicated
@@ -138,22 +144,28 @@ GO
 
 -- we should not see the new row in target table
 -- tsql port=8199
-SELECT * FROM babel_4956_t1;
+SELECT * FROM babel_4956_tab_varbinary;
 GO
 
 -- Cleanup
--- psql
-ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
-GO
-
 -- psql port=5433
+SET client_min_messages TO ERROR;
+GO
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub2;
+GO
+RESET client_min_messages;
+GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
+-- psql
+DROP PUBLICATION my_pub2;
+GO
+
 -- tsql
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_varbinary;
 GO
 
 -- tsql port=8199
-DROP TABLE babel_4956_t1;
+DROP TABLE babel_4956_tab_varbinary;
 GO

--- a/test/JDBC/replication/BABEL-4956.mix
+++ b/test/JDBC/replication/BABEL-4956.mix
@@ -1,0 +1,159 @@
+-- Test typmod for BINARY datatype
+-- tsql
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of binary column is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(3) NOT NULL)
+GO
+
+-- Add table to publication
+-- psql
+ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+GO
+
+-- Refresh the subscription
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- Insert a 4 byte binary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+GO
+
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- data should have replicated to target table
+-- tsql port=8199
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Now insert a 4 byte binary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+GO
+
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- we should not see the new row in target table
+-- tsql port=8199
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Cleanup
+-- psql
+ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
+GO
+
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+DROP TABLE babel_4956_t1;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_t1;
+GO
+
+-- Test typmod for VARBINARY datatype
+-- tsql
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of varbinary columns is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_t1 (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(3) NOT NULL)
+GO
+
+-- Add table to publication
+-- psql
+ALTER PUBLICATION my_pub ADD TABLE master_dbo.babel_4956_t1;
+GO
+
+-- Refresh the subscription
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- Insert a 4 byte varbinary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_t1(c1, c2) VALUES(1, 0x11223300);
+GO
+
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- data should have replicated to target table
+-- tsql port=8199
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Now insert a 4 byte varbinary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_t1(c1, c2) VALUES(2, 0x11223344);
+GO
+
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- we should not see the new row in target table
+-- tsql port=8199
+SELECT * FROM babel_4956_t1;
+GO
+
+-- Cleanup
+-- psql
+ALTER PUBLICATION my_pub DROP TABLE master_dbo.babel_4956_t1;
+GO
+
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+DROP TABLE babel_4956_t1;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_t1;
+GO


### PR DESCRIPTION
### Description
(Var)binary input function does not check if input string is bigger than the
desired typmod. This is problematic as it is possible to insert a binary value
larger than typmod into a column. Although, the issue is not there for normal
inserts into a table as there exists typmod coercion functions for binary and
varbinary datatypes which are always called along with input function to adjust
the value length according to given typmod.

But the issue exists for logical replication and dump/restore in which the value
is coming from a remote server possibly with a different typmod. In these cases
typmod coercion functions are not called so no checks are performed on size of
input value.
To fix the issue, this commit adds a check in the (var)binary input function to
validate input string with typmod and throw error if the value is larger than typmod
similar to (var)char datatype.

Task: BABEL-4956
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).