### PR TITLE
Fix BBF PIVOT cannot use CTE as source table

### DIFF
--- a/test/JDBC/expected/pivot-vu-cleanup.out
+++ b/test/JDBC/expected/pivot-vu-cleanup.out
@@ -47,6 +47,12 @@ GO
 drop table products;
 GO
 
+drop table pivot_schema.products_sch;
+GO
+
+drop schema pivot_schema;
+GO
+
 use master;
 GO
 

--- a/test/JDBC/expected/pivot-vu-cleanup.out
+++ b/test/JDBC/expected/pivot-vu-cleanup.out
@@ -41,6 +41,12 @@ GO
 drop table StoreReceipt;
 GO
 
+drop table orders;
+GO
+
+drop table products;
+GO
+
 use master;
 GO
 

--- a/test/JDBC/expected/pivot-vu-prepare.out
+++ b/test/JDBC/expected/pivot-vu-prepare.out
@@ -666,6 +666,26 @@ GO
 ~~ROW COUNT: 19~~
 
 
+create schema pivot_schema;
+GO
+
+CREATE TABLE pivot_schema.products_sch (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+GO
+
+INSERT INTO pivot_schema.products_sch VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+~~ROW COUNT: 5~~
+
+
 create table pivot_insert_into(ManufactureID int, EmployeeID int, p1 int, p2 int, p3 int, p4 int, p5 int);
 GO
 

--- a/test/JDBC/expected/pivot-vu-prepare.out
+++ b/test/JDBC/expected/pivot-vu-prepare.out
@@ -618,6 +618,53 @@ GO
 ~~ROW COUNT: 1~~
 
 
+CREATE TABLE orders (
+    orderId INT PRIMARY KEY,
+    productId INT,
+    employeeName VARCHAR(4),
+    employeeCode VARBINARY(30),
+    date DATE);
+GO
+
+
+CREATE TABLE products (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+INSERT INTO products VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+~~ROW COUNT: 5~~
+
+
+INSERT INTO orders VALUES
+    (101, 5,'empA', 0x656D7041, '2024-05-01'),
+    (102, 3,'empA', 0x656D7041, '2024-05-01'),
+    (103, 1,'empA', 0x656D7041, '2024-05-01'),
+    (104, 2,'empA', 0x656D7041, '2024-05-01'),
+    (105, 1,'empB', 0x656D7042, '2024-05-01'),
+    (106, 2,'empB', 0x656D7042, '2024-05-01'),
+    (110, 3,'empB', 0x656D7042, '2024-05-01'),
+    (109, 4,'empB', 0x656D7042, '2024-05-01'),
+    (108, 5,'empB', 0x656D7042, '2024-05-01'),
+    (107, 5,'empB', 0x656D7042, '2024-05-01'),
+    (111, 1,'empC', 0x656D7043, '2024-05-01'),
+    (113, 1,'empC', 0x656D7043, '2024-05-01'),
+    (115, 1,'empC', 0x656D7043, '2024-05-01'),
+    (119, 1,'empC', 0x656D7043, '2024-05-01'),
+    (201, 2,'empC', 0x656D7043, '2024-05-01'),
+    (223, 2,'empC', 0x656D7043, '2024-05-01'),
+    (224, 5,'empD', 0x656D7044, '2024-05-01'),
+    (202, 3,'empD', 0x656D7044, '2024-05-01'),
+    (190, 1,'empD', 0x656D7044, '2024-05-01');
+GO
+~~ROW COUNT: 19~~
+
 
 create table pivot_insert_into(ManufactureID int, EmployeeID int, p1 int, p2 int, p3 int, p4 int, p5 int);
 GO

--- a/test/JDBC/expected/pivot-vu-verify.out
+++ b/test/JDBC/expected/pivot-vu-verify.out
@@ -1238,6 +1238,63 @@ Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000#!#4535.0000#!#23425.00
 DROP TABlE IF EXISTS #FruitSales
 GO
 
+-- PIVOT with CTE as source table
+WITH cte_table AS (
+    SELECT [p].productName, [o].[employeeName]
+    FROM orders [o] JOIN products AS [p] on (o.productId = p.productId)
+)
+SELECT CAST('COUNT' AS VARCHAR(10)), [mac],[ipad],[charger] FROM cte_table
+PIVOT (
+    COUNT(employeeName)
+    FOR productName IN (mac, [iphone], [ipad], [charger])
+) as pvt
+GO
+~~START~~
+varchar#!#int#!#int#!#int
+COUNT#!#7#!#4#!#1
+~~END~~
+
+
+-- string is not allowed in PIVOT column value list
+WITH cte_table AS (
+    SELECT o.[orderId], o.[productId], [p].productName,
+        [p].productPrice, [o].[employeeName], [o].employeeCode, [o].date
+    FROM orders [o] JOIN products AS [p] on (o.productId = p.productId)
+)
+SELECT * FROM cte_table
+PIVOT (
+    COUNT(orderId)
+    FOR productName IN ('mac', 'iphone', 'ipad', 'charger')
+) as p
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "'mac'")~~
+
+
+-- aggregate column in PIVOT column value list is not allowed
+WITH cte_table AS
+(
+  SELECT
+    CAST('COUNT' AS VARCHAR(10)) AS COUNT,
+    [mac], [ipad], [charger], [employeeName]
+  FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM orders [o] JOIN products AS [p] on ([o].productId = [p].productId)
+  ) AS dervied_table
+PIVOT
+  (
+      COUNT(employeeName)
+      FOR productName IN ([mac], [employeeName], [iphone], [ipad], [charger])
+  ) as pvt
+)
+SELECT * FROM cte_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The column name "employeename" specified in the PIVOT operator conflicts with the existing column name in the PIVOT argument.)~~
+
+
 -- Join stmts inside PIVOT statment (BABEL-4558)
 SELECT Oid, [1] AS TYPE1, [2] AS TYPE2, [3] AS TYPE3
 FROM (SELECT OSTable.Oid, STable.Scode, STable.Type

--- a/test/JDBC/expected/pivot-vu-verify.out
+++ b/test/JDBC/expected/pivot-vu-verify.out
@@ -1124,7 +1124,6 @@ Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000
 ~~END~~
 
 
-
 -- CTE test 2
 WITH
 SalesTotal AS
@@ -1232,6 +1231,38 @@ GO
 varchar#!#money#!#money#!#money#!#money#!#money#!#money
 Banana#!#31201.0000#!#15600.5000#!#51381.0000#!#25690.5000#!#6547.0000#!#5636.0000
 Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000#!#4535.0000#!#23425.0000
+~~END~~
+
+
+-- Test stmt of CTE table and PIVOT stmt in different level 
+WITH
+SalesTotal AS
+(
+    SELECT FruitType,
+        [2023] AS [2023_Total],
+        [2024] AS [2024_Total]
+    FROM #FruitSales
+    PIVOT(SUM(FruitSales)
+    FOR SalesYear IN([2023], [2024])
+    ) AS PivotSales
+)
+SELECT st.FruitType, st.[2023_Total], sa.[2023_Avg],
+  st.[2024_Total], sa.[2024_Avg]
+FROM SalesTotal AS st
+JOIN (
+    SELECT FruitType,
+        [2023] AS [2023_Avg],
+        [2024] AS [2024_Avg]
+    FROM #FruitSales
+    PIVOT(AVG(FruitSales)
+    FOR SalesYear IN([2023], [2024])
+    ) AS PivotSales
+) sa ON st.FruitType = sa.FruitType;
+GO
+~~START~~
+varchar#!#money#!#money#!#money#!#money
+Banana#!#31201.0000#!#15600.5000#!#51381.0000#!#25690.5000
+Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000
 ~~END~~
 
 
@@ -1876,5 +1907,39 @@ varchar#!#varchar#!#varchar
 SEAT1#!#LEFT#!#RIGHT
 SEAT2#!#LEFT#!#<NULL>
 SEAT3#!#LEFT#!#RIGHT
+~~END~~
+
+
+-- test pivot with table in different schemas 1
+SELECT CAST('COUNT' AS VARCHAR(10)) AS COUNT, [mac], [ipad], [charger]
+FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM dbo.orders [o] JOIN products AS [p] on ([o].productId = [p].productId)
+) AS dervied_table
+PIVOT(
+     COUNT(employeeName)
+     FOR productName IN ([mac], [iphone], [ipad], [charger])
+) as pvt
+GO
+~~START~~
+varchar#!#int#!#int#!#int
+COUNT#!#7#!#4#!#1
+~~END~~
+
+
+-- test pivot with table in different schemas 2
+SELECT CAST('COUNT' AS VARCHAR(10)) AS COUNT, [mac], [ipad], [charger]
+FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM dbo.orders [o] JOIN pivot_schema.products_sch AS [p] on ([o].productId = [p].productId)
+) AS dervied_table
+PIVOT(
+     COUNT(employeeName)
+     FOR productName IN ([mac], [iphone], [ipad], [charger])
+) as pvt
+GO
+~~START~~
+varchar#!#int#!#int#!#int
+COUNT#!#7#!#4#!#1
 ~~END~~
 

--- a/test/JDBC/input/pivot-vu-cleanup.sql
+++ b/test/JDBC/input/pivot-vu-cleanup.sql
@@ -43,6 +43,12 @@ GO
 drop table products;
 GO
 
+drop table pivot_schema.products_sch;
+GO
+
+drop schema pivot_schema;
+GO
+
 use master;
 GO
 

--- a/test/JDBC/input/pivot-vu-cleanup.sql
+++ b/test/JDBC/input/pivot-vu-cleanup.sql
@@ -37,6 +37,12 @@ GO
 drop table StoreReceipt;
 GO
 
+drop table orders;
+GO
+
+drop table products;
+GO
+
 use master;
 GO
 

--- a/test/JDBC/input/pivot-vu-prepare.sql
+++ b/test/JDBC/input/pivot-vu-prepare.sql
@@ -262,6 +262,24 @@ INSERT INTO orders VALUES
     (190, 1,'empD', 0x656D7044, '2024-05-01');
 GO
 
+create schema pivot_schema;
+GO
+
+CREATE TABLE pivot_schema.products_sch (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+GO
+
+INSERT INTO pivot_schema.products_sch VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+
 create table pivot_insert_into(ManufactureID int, EmployeeID int, p1 int, p2 int, p3 int, p4 int, p5 int);
 GO
 

--- a/test/JDBC/input/pivot-vu-prepare.sql
+++ b/test/JDBC/input/pivot-vu-prepare.sql
@@ -218,6 +218,49 @@ insert into StoreReceipt (OrderID, ItemID, Price, EmployeeID, StoreID, Manufactu
 insert into StoreReceipt (OrderID, ItemID, Price, EmployeeID, StoreID, ManufactureID, PurchaseDate) values (200, 2084, 735.91, 223, 5, 1221, '2023-10-30');
 GO
 
+CREATE TABLE orders (
+    orderId INT PRIMARY KEY,
+    productId INT,
+    employeeName VARCHAR(4),
+    employeeCode VARBINARY(30),
+    date DATE);
+GO
+
+CREATE TABLE products (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+
+INSERT INTO products VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+
+INSERT INTO orders VALUES
+    (101, 5,'empA', 0x656D7041, '2024-05-01'),
+    (102, 3,'empA', 0x656D7041, '2024-05-01'),
+    (103, 1,'empA', 0x656D7041, '2024-05-01'),
+    (104, 2,'empA', 0x656D7041, '2024-05-01'),
+    (105, 1,'empB', 0x656D7042, '2024-05-01'),
+    (106, 2,'empB', 0x656D7042, '2024-05-01'),
+    (110, 3,'empB', 0x656D7042, '2024-05-01'),
+    (109, 4,'empB', 0x656D7042, '2024-05-01'),
+    (108, 5,'empB', 0x656D7042, '2024-05-01'),
+    (107, 5,'empB', 0x656D7042, '2024-05-01'),
+    (111, 1,'empC', 0x656D7043, '2024-05-01'),
+    (113, 1,'empC', 0x656D7043, '2024-05-01'),
+    (115, 1,'empC', 0x656D7043, '2024-05-01'),
+    (119, 1,'empC', 0x656D7043, '2024-05-01'),
+    (201, 2,'empC', 0x656D7043, '2024-05-01'),
+    (223, 2,'empC', 0x656D7043, '2024-05-01'),
+    (224, 5,'empD', 0x656D7044, '2024-05-01'),
+    (202, 3,'empD', 0x656D7044, '2024-05-01'),
+    (190, 1,'empD', 0x656D7044, '2024-05-01');
+GO
 
 create table pivot_insert_into(ManufactureID int, EmployeeID int, p1 int, p2 int, p3 int, p4 int, p5 int);
 GO

--- a/test/JDBC/input/pivot-vu-verify.sql
+++ b/test/JDBC/input/pivot-vu-verify.sql
@@ -427,6 +427,50 @@ GO
 DROP TABlE IF EXISTS #FruitSales
 GO
 
+-- PIVOT with CTE as source table
+WITH cte_table AS (
+    SELECT [p].productName, [o].[employeeName]
+    FROM orders [o] JOIN products AS [p] on (o.productId = p.productId)
+)
+SELECT CAST('COUNT' AS VARCHAR(10)), [mac],[ipad],[charger] FROM cte_table
+PIVOT (
+    COUNT(employeeName)
+    FOR productName IN (mac, [iphone], [ipad], [charger])
+) as pvt
+GO
+
+-- string is not allowed in PIVOT column value list
+WITH cte_table AS (
+    SELECT o.[orderId], o.[productId], [p].productName,
+        [p].productPrice, [o].[employeeName], [o].employeeCode, [o].date
+    FROM orders [o] JOIN products AS [p] on (o.productId = p.productId)
+)
+SELECT * FROM cte_table
+PIVOT (
+    COUNT(orderId)
+    FOR productName IN ('mac', 'iphone', 'ipad', 'charger')
+) as p
+GO
+
+-- aggregate column in PIVOT column value list is not allowed
+WITH cte_table AS
+(
+  SELECT
+    CAST('COUNT' AS VARCHAR(10)) AS COUNT,
+    [mac], [ipad], [charger], [employeeName]
+  FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM orders [o] JOIN products AS [p] on ([o].productId = [p].productId)
+  ) AS dervied_table
+PIVOT
+  (
+      COUNT(employeeName)
+      FOR productName IN ([mac], [employeeName], [iphone], [ipad], [charger])
+  ) as pvt
+)
+SELECT * FROM cte_table
+GO
+
 -- Join stmts inside PIVOT statment (BABEL-4558)
 SELECT Oid, [1] AS TYPE1, [2] AS TYPE2, [3] AS TYPE3
 FROM (SELECT OSTable.Oid, STable.Scode, STable.Type


### PR DESCRIPTION
### Description

  Fixed BBF PIVOT stmt cannot use CTE as source table.
  Fixed string in pivot clumn value list caused crash
  Fixed conflicting column name is allowed in BBF PIVOT clause


### Issues Resolved

BABEL-4958, BABEL-4959, BABEL-4960, BABEL-4977

### Test Scenarios Covered ###
* **Use case based -**
    - string in PIVOT column value list (BABEL-4958)
    - PIVOT with CTE as source table
    - aggregate column in PIVOT column value list





### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).