### PR TITLE
Add typmod validation in [VAR]BINARY input function (#2570)

### DIFF
--- a/contrib/babelfishpg_common/src/varbinary.c
+++ b/contrib/babelfishpg_common/src/varbinary.c
@@ -194,6 +194,28 @@ varbinaryin(PG_FUNCTION_ARGS)
 		 */
 		int			bc = (len - 1) / 2 + VARHDRSZ;	/* maximum possible length */
 
+		if (typmod >= (int32) VARHDRSZ && bc > typmod)
+		{
+			/* Verify that extra bytes are zeros, and clip them off */
+			char	*temp_result;
+			size_t	i;
+
+			temp_result = palloc0(bc);
+			bc = babelfish_hex_decode_allow_odd_digits(inputText + 2, len - 2, temp_result);
+
+			for (i = (typmod - VARHDRSZ); i < bc; i++)
+			{
+				if (temp_result[i] != 0)
+					ereport(ERROR,
+							(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
+							errmsg("String or binary data would be truncated.\n"
+									"The statement has been terminated.")));
+			}
+			pfree(temp_result);
+			bc = typmod;
+			len = (typmod - VARHDRSZ) * 2 + 2;
+		}
+
 		result = palloc(bc);
 		bc = babelfish_hex_decode_allow_odd_digits(inputText + 2, len - 2, VARDATA(result));
 		SET_VARSIZE(result, bc + VARHDRSZ); /* actual length */

--- a/test/JDBC/expected/BABEL-4956.out
+++ b/test/JDBC/expected/BABEL-4956.out
@@ -25,6 +25,18 @@ GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
+-- terminate-tsql-conn
+-- terminate-tsql-conn port=8199
+
+-- psql
+select pg_sleep(5);
+GO
+~~START~~
+void
+
+~~END~~
+
+
 -- tsql
 -- Insert a 4 byte binary value with last trailing byte as 0 in the
 -- source table so that it fits into 3 byte in target table's column.
@@ -143,6 +155,18 @@ ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub2;
 GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
+
+-- terminate-tsql-conn
+-- terminate-tsql-conn port=8199
+
+-- psql
+select pg_sleep(5);
+GO
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
 -- Insert a 4 byte varbinary value with last trailing byte as 0 in the

--- a/test/JDBC/expected/BABEL-4956.out
+++ b/test/JDBC/expected/BABEL-4956.out
@@ -1,0 +1,241 @@
+-- tsql
+-- Test typmod for BINARY datatype
+CREATE TABLE babel_4956_tab_binary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of binary column is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_tab_binary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(3) NOT NULL)
+GO
+
+-- psql
+-- Add table to publication
+CREATE PUBLICATION my_pub1 FOR TABLE master_dbo.babel_4956_tab_binary;
+GO
+
+-- psql port=5433
+-- Add publication and refresh the subscription
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub1;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+-- Insert a 4 byte binary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(1, 0x11223300);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_tab_binary;
+GO
+~~START~~
+int#!#binary
+1#!#11223300
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- data should have replicated to target table
+SELECT * FROM babel_4956_tab_binary;
+GO
+~~START~~
+int#!#binary
+1#!#112233
+~~END~~
+
+
+-- tsql
+-- Now insert a 4 byte binary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(2, 0x11223344);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_tab_binary;
+GO
+~~START~~
+int#!#binary
+1#!#11223300
+2#!#11223344
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- we should not see the new row in target table
+SELECT * FROM babel_4956_tab_binary;
+GO
+~~START~~
+int#!#binary
+1#!#112233
+~~END~~
+
+
+-- psql port=5433
+-- Cleanup
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub1;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- psql
+DROP PUBLICATION my_pub1;
+GO
+
+-- tsql
+DROP TABLE babel_4956_tab_binary;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_tab_binary;
+GO
+
+-- tsql
+-- Test typmod for VARBINARY datatype
+CREATE TABLE babel_4956_tab_varbinary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of varbinary columns is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_tab_varbinary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(3) NOT NULL)
+GO
+
+-- psql
+-- Add table to publication
+CREATE PUBLICATION my_pub2 FOR TABLE master_dbo.babel_4956_tab_varbinary;
+GO
+
+-- psql port=5433
+-- Add publication and refresh the subscription
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub2;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- tsql
+-- Insert a 4 byte varbinary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(1, 0x11223300);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+~~START~~
+int#!#varbinary
+1#!#11223300
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- data should have replicated to target table
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+~~START~~
+int#!#varbinary
+1#!#112233
+~~END~~
+
+
+-- tsql
+-- Now insert a 4 byte varbinary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(2, 0x11223344);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+~~START~~
+int#!#varbinary
+1#!#11223300
+2#!#11223344
+~~END~~
+
+
+-- psql
+-- Wait for data to get replicated
+select pg_sleep(2);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql port=8199
+-- we should not see the new row in target table
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+~~START~~
+int#!#varbinary
+1#!#112233
+~~END~~
+
+
+-- psql port=5433
+-- Cleanup
+SET client_min_messages TO ERROR;
+GO
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub2;
+GO
+RESET client_min_messages;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- psql
+DROP PUBLICATION my_pub2;
+GO
+
+-- tsql
+DROP TABLE babel_4956_tab_varbinary;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_tab_varbinary;
+GO

--- a/test/JDBC/replication/BABEL-4956.mix
+++ b/test/JDBC/replication/BABEL-4956.mix
@@ -1,0 +1,171 @@
+-- Test typmod for BINARY datatype
+-- tsql
+CREATE TABLE babel_4956_tab_binary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of binary column is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_tab_binary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     BINARY(3) NOT NULL)
+GO
+
+-- Add table to publication
+-- psql
+CREATE PUBLICATION my_pub1 FOR TABLE master_dbo.babel_4956_tab_binary;
+GO
+
+-- Add publication and refresh the subscription
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub1;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- Insert a 4 byte binary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(1, 0x11223300);
+GO
+
+SELECT * FROM babel_4956_tab_binary;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- data should have replicated to target table
+-- tsql port=8199
+SELECT * FROM babel_4956_tab_binary;
+GO
+
+-- Now insert a 4 byte binary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_tab_binary(c1, c2) VALUES(2, 0x11223344);
+GO
+
+SELECT * FROM babel_4956_tab_binary;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- we should not see the new row in target table
+-- tsql port=8199
+SELECT * FROM babel_4956_tab_binary;
+GO
+
+-- Cleanup
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub1;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- psql
+DROP PUBLICATION my_pub1;
+GO
+
+-- tsql
+DROP TABLE babel_4956_tab_binary;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_tab_binary;
+GO
+
+-- Test typmod for VARBINARY datatype
+-- tsql
+CREATE TABLE babel_4956_tab_varbinary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(4) NOT NULL)
+GO
+
+-- tsql port=8199
+-- typmod of varbinary columns is kept less in this table
+-- compared to source table to test typmod compatibility.
+CREATE TABLE babel_4956_tab_varbinary (
+    c1  INT  NOT NULL PRIMARY KEY
+    , c2     VARBINARY(3) NOT NULL)
+GO
+
+-- Add table to publication
+-- psql
+CREATE PUBLICATION my_pub2 FOR TABLE master_dbo.babel_4956_tab_varbinary;
+GO
+
+-- Add publication and refresh the subscription
+-- psql port=5433
+ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub2;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- Insert a 4 byte varbinary value with last trailing byte as 0 in the
+-- source table so that it fits into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(1, 0x11223300);
+GO
+
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- data should have replicated to target table
+-- tsql port=8199
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+
+-- Now insert a 4 byte varbinary value with no trailing zero bytes in the
+-- source table so that it does not fit into 3 byte in target table's column.
+-- tsql
+INSERT INTO babel_4956_tab_varbinary(c1, c2) VALUES(2, 0x11223344);
+GO
+
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+
+-- Wait for data to get replicated
+-- psql
+select pg_sleep(2);
+GO
+
+-- we should not see the new row in target table
+-- tsql port=8199
+SELECT * FROM babel_4956_tab_varbinary;
+GO
+
+-- Cleanup
+-- psql port=5433
+SET client_min_messages TO ERROR;
+GO
+ALTER SUBSCRIPTION my_sub DROP PUBLICATION my_pub2;
+GO
+RESET client_min_messages;
+GO
+ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- psql
+DROP PUBLICATION my_pub2;
+GO
+
+-- tsql
+DROP TABLE babel_4956_tab_varbinary;
+GO
+
+-- tsql port=8199
+DROP TABLE babel_4956_tab_varbinary;
+GO

--- a/test/JDBC/replication/BABEL-4956.mix
+++ b/test/JDBC/replication/BABEL-4956.mix
@@ -25,6 +25,13 @@ GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
 GO
 
+-- terminate-tsql-conn
+-- terminate-tsql-conn port=8199
+
+-- psql
+select pg_sleep(5);
+GO
+
 -- Insert a 4 byte binary value with last trailing byte as 0 in the
 -- source table so that it fits into 3 byte in target table's column.
 -- tsql
@@ -107,6 +114,13 @@ GO
 ALTER SUBSCRIPTION my_sub ADD PUBLICATION my_pub2;
 GO
 ALTER SUBSCRIPTION my_sub REFRESH PUBLICATION;
+GO
+
+-- terminate-tsql-conn
+-- terminate-tsql-conn port=8199
+
+-- psql
+select pg_sleep(5);
 GO
 
 -- Insert a 4 byte varbinary value with last trailing byte as 0 in the


### PR DESCRIPTION
### Description
[VAR]BINARY input function does not check if input string is bigger than the
desired typmod. This is problematic as it is possible to insert a binary value
larger than typmod into a column. Although, the issue is not there for normal
inserts into a table as there exists typmod coercion functions for binary and
varbinary datatypes which are always called along with input function to adjust
the value length according to given typmod.

But the issue exists for logical replication and dump/restore in which the value
is coming from a remote server possibly with a different typmod. In these cases
typmod coercion functions are not called so no checks are performed on size of
input value.

To fix the issue, this commit adds a check in the [VAR]BINARY input function to
validate input string with typmod and throw error if the value is larger than typmod
similar to [VAR]CHAR datatypes.

Task: BABEL-4956
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).