### PR TITLE
Update PG_FINALLY to PG_CATCH for sp_describe_undeclared_parameters_internal

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1651,7 +1651,7 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 			SRF_RETURN_DONE(funcctx);
 		}
 	}
-	PG_FINALLY();
+	PG_CATCH();
 	{
 		is_supported_case_sp_describe_undeclared_parameters = true;
 		PG_RE_THROW();


### PR DESCRIPTION
### Description

This commit updates the PG_FINALLY to PG_CATCH for sp_describe_undeclared_parameters_internal as we should not PG_RE_THROW() from a PG_FINALLY block but we to return as the function is a non void returning function. Maybe it is safe to ```SRF_RETURN_DONE(funcctx);``` but in any unexpected case we may get. segfault as funcctx is initialised inside PG_TRY block. So better to use PG_CATCH

### Issues Resolved
BABEL-4869
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).