### PR TITLE
Fix the logic of calculating the length of the named procedure to consider characters position instead of bytes

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -6102,6 +6102,7 @@ makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type)
 	int lineno = getLineNo(ctx);
 	int return_code_dno = -1;	
 	std::string execKeywd = "EXEC"; // DO NOT CHANGE!
+	int name_length = 0;
 		
 	// Use a boolean vor convenience
 	bool execute_statement = string_matches(call_type.c_str(), "execute_statement") ? true : false;
@@ -6135,6 +6136,7 @@ makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type)
 	{
 		// Get the name of procedure being executed, and split up in parts
 		name = ::getFullText(ctx_name);
+		name_length = ctx_name->stop->getStopIndex() - ctx_name->start->getStartIndex();
 		Assert(!name.empty());
 		
 		// Original position of the name
@@ -6288,7 +6290,7 @@ makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type)
 	ssPos += spacesNeeded;
 			
 	ss << name;
-	ssPos += name.length();
+	ssPos += name_length;
 	
 	if (func_proc_args) 
 	{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -6136,7 +6136,7 @@ makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type)
 	{
 		// Get the name of procedure being executed, and split up in parts
 		name = ::getFullText(ctx_name);
-		name_length = ctx_name->stop->getStopIndex() - ctx_name->start->getStartIndex();
+		name_length = ctx_name->stop->getStopIndex() - ctx_name->start->getStartIndex() + 1;
 		Assert(!name.empty());
 		
 		// Original position of the name

--- a/test/JDBC/expected/BABEL-4961.out
+++ b/test/JDBC/expected/BABEL-4961.out
@@ -1,0 +1,162 @@
+-- there's invisible space in front on procedure name
+create procedure [​babel_4961_proc1] as select 'with invisible space';
+GO
+
+-- no invisible space in front
+create procedure [babel_4961_proc1] as select 'without invisible space';
+GO
+
+create procedure [  babel_4961_proc2] as select 2;
+GO
+
+create table babel_4961_tbl (a int);
+GO
+
+insert into babel_4961_tbl values (1), (2), (3);
+GO
+~~ROW COUNT: 3~~
+
+
+create procedure babel_4961_proc3 @param int
+as
+    select * from babel_4961_tbl where a = @param;
+go
+
+exec [​babel_4961_proc1]
+GO
+~~START~~
+varchar
+with invisible space
+~~END~~
+
+
+exec [dbo].[​babel_4961_proc1]
+GO
+~~START~~
+varchar
+with invisible space
+~~END~~
+
+
+exec [dbo].​babel_4961_proc1
+GO
+~~START~~
+varchar
+with invisible space
+~~END~~
+
+
+exec dbo.[​babel_4961_proc1]
+GO
+~~START~~
+varchar
+with invisible space
+~~END~~
+
+
+exec [babel_4961_proc1]
+GO
+~~START~~
+varchar
+without invisible space
+~~END~~
+
+
+exec [dbo].[babel_4961_proc1]
+GO
+~~START~~
+varchar
+without invisible space
+~~END~~
+
+
+exec [dbo].babel_4961_proc1
+GO
+~~START~~
+varchar
+without invisible space
+~~END~~
+
+
+exec dbo.[babel_4961_proc1]
+GO
+~~START~~
+varchar
+without invisible space
+~~END~~
+
+
+exec [  babel_4961_proc2]
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+exec [dbo].[  babel_4961_proc2]
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- invisble space in front
+-- should throw an error that proc does not exist
+exec [​babel_4961_proc3] 3
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: procedure ​babel_4961_proc3(integer) does not exist)~~
+
+
+exec [babel_4961_proc3] 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+exec [dbo].[babel_4961_proc3] 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- dependent objects
+-- should not crash the server
+CREATE PROCEDURE [dbo].test_depend_proc AS EXEC [dbo].[​babel_4961_proc1];
+GO
+
+-- 
+CREATE FUNCTION test_depend_func(@param int) RETURNS INT AS 
+BEGIN 
+    EXEC [dbo].[​babel_4961_proc1]; 
+    RETURN (@i) 
+END;
+GO
+
+DROP PROCEDURE [dbo].test_depend_proc
+GO
+
+DROP FUNCTION test_depend_func(int);
+GO
+
+drop procedure [​babel_4961_proc1];
+GO
+
+drop procedure [babel_4961_proc1];
+GO
+
+drop procedure [  babel_4961_proc2]
+GO
+
+drop table babel_4961_tbl;
+GO
+
+drop procedure babel_4961_proc3
+GO

--- a/test/JDBC/input/BABEL-4961.sql
+++ b/test/JDBC/input/BABEL-4961.sql
@@ -1,0 +1,96 @@
+-- there's invisible space in front on procedure name
+create procedure [​babel_4961_proc1] as select 'with invisible space';
+GO
+
+-- no invisible space in front
+create procedure [babel_4961_proc1] as select 'without invisible space';
+GO
+
+create procedure [  babel_4961_proc2] as select 2;
+GO
+
+create table babel_4961_tbl (a int);
+GO
+
+insert into babel_4961_tbl values (1), (2), (3);
+GO
+
+create procedure babel_4961_proc3 @param int
+as
+    select * from babel_4961_tbl where a = @param;
+go
+
+exec [​babel_4961_proc1]
+GO
+
+exec [dbo].[​babel_4961_proc1]
+GO
+
+exec [dbo].​babel_4961_proc1
+GO
+
+exec dbo.[​babel_4961_proc1]
+GO
+
+exec [babel_4961_proc1]
+GO
+
+exec [dbo].[babel_4961_proc1]
+GO
+
+exec [dbo].babel_4961_proc1
+GO
+
+exec dbo.[babel_4961_proc1]
+GO
+
+exec [  babel_4961_proc2]
+GO
+
+exec [dbo].[  babel_4961_proc2]
+GO
+
+-- invisble space in front
+-- should throw an error that proc does not exist
+exec [​babel_4961_proc3] 3
+GO
+
+exec [babel_4961_proc3] 1
+GO
+
+exec [dbo].[babel_4961_proc3] 1
+GO
+
+-- dependent objects
+-- should not crash the server
+CREATE PROCEDURE [dbo].test_depend_proc AS EXEC [dbo].[​babel_4961_proc1];
+GO
+
+-- 
+CREATE FUNCTION test_depend_func(@param int) RETURNS INT AS 
+BEGIN 
+    EXEC [dbo].[​babel_4961_proc1]; 
+    RETURN (@i) 
+END;
+GO
+
+DROP PROCEDURE [dbo].test_depend_proc
+GO
+
+DROP FUNCTION test_depend_func(int);
+GO
+
+drop procedure [​babel_4961_proc1];
+GO
+
+drop procedure [babel_4961_proc1];
+GO
+
+drop procedure [  babel_4961_proc2]
+GO
+
+drop table babel_4961_tbl;
+GO
+
+drop procedure babel_4961_proc3
+GO


### PR DESCRIPTION
### Description

Previously, string.length() method was being used to calculate the length of named procedure inside
makeExecuteProcedure. This method calculates length in terms of bytes. For example, length of 
"ZERO WIDTH SPACE" with unicode point U+200B will be computed as 3 which was causing certain
assertion failure makeExecuteProcedure resulting in crash. But as far as parser and token's position
concerns, we should really care of character position instead of bytes position.

This commit aims to fix this issue by fixing logic of calculating the length of named procedure by using
getStartIndex() and getStopIndex() of the procedure token.

Task: BABEL-4961
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).