### PR TITLE
User Defined Scalar function in first column does not rewrite properly

### DIFF
--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -769,11 +769,13 @@ select_json_modify(SelectStmt *stmt)
 				FuncCall   *json_mod_fc = (FuncCall *) rt->val;
 				SelectStmt *from_sel_stmt = (SelectStmt *) rs->subquery;
 
-				rewrite_plain_name(json_mod_fc->funcname);
 				if (is_json_modify(json_mod_fc->funcname) && is_select_for_json(from_sel_stmt))
 				{
-					Node	   *n = lfourth(json_mod_fc->args);
-					A_Const    *escape = (A_Const *) n;
+
+					Node	   *n1 = lfourth(json_mod_fc->args);
+					A_Const    *escape = (A_Const *) n1;
+					
+					rewrite_plain_name(json_mod_fc->funcname);
 
 					escape->val.boolval.boolval = true;
 				}

--- a/test/JDBC/expected/BABEL-3697-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3697-vu-cleanup.out
@@ -24,3 +24,24 @@ GO
 
 DROP VIEW babel_3697_multi_function
 GO
+
+DROP FUNCTION [dbo].[o7getcodevaluedesc] 
+GO
+
+drop function babel_4793_schema.babel_4793_func
+GO
+
+drop table babel_4793;
+GO
+
+drop procedure babel_4793_pro1
+GO
+
+drop procedure babel_4793_pro2
+GO
+
+drop procedure babel_4793_pro3
+GO
+
+drop schema babel_4793_schema
+GO

--- a/test/JDBC/expected/BABEL-3697-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3697-vu-prepare.out
@@ -45,3 +45,47 @@ create view babel_3697_multi_function as
 SELECT JSON_MODIFY(JSON_MODIFY(JSON_MODIFY('{"name":"John","skills":["C#","SQL"]}','$.name','Mike'),'$.surname','Smith'),'append $.skills','Azure') AS mf_1, 
        JSON_MODIFY(JSON_MODIFY('{"price":49.99}','$.Price',CAST(JSON_VALUE('{"price":49.99}','$.price') AS NUMERIC(4,2))),'$.price',NULL) AS mf_2;
 go
+
+CREATE  FUNCTION [dbo].[o7getcodevaluedesc] ()
+returns nvarchar(256)
+as BEGIN
+   return "ddd"
+end;
+GO
+
+create table babel_4793(a int , b int)
+GO
+
+create schema babel_4793_schema
+GO
+
+CREATE  FUNCTION babel_4793_schema.babel_4793_func ()
+returns int 
+as BEGIN
+    return 1;
+end;
+GO
+
+create procedure babel_4793_pro1
+as begin
+   select kk , dd, dbo.o7getcodevaluedesc() from (
+      select a as kk, count(b) as dd from babel_4793  group by a 
+   ) as drived
+end;
+go
+
+create procedure babel_4793_pro2
+as begin
+   select dbo.o7getcodevaluedesc() , kk , dd from (
+      select a as kk, count(b) as dd from babel_4793  group by a 
+   ) as drived
+end;
+go
+
+create procedure babel_4793_pro3
+as begin
+   select babel_4793_schema.babel_4793_func() , kk , dd from (
+      select a as kk, count(b) as dd from babel_4793  group by a 
+   ) as drived
+end;
+go

--- a/test/JDBC/expected/BABEL-3697-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3697-vu-verify.out
@@ -71,3 +71,45 @@ nvarchar#!#nvarchar
 {"name": "Mike", "skills": ["C#", "SQL", "Azure"], "surname": "Smith"}#!#{"Price": 49.99}
 ~~END~~
 
+
+select kk , dd, dbo.o7getcodevaluedesc() from (
+   select a as kk, count(b) as dd from babel_4793  group by a 
+) as drived
+GO
+~~START~~
+int#!#int#!#nvarchar
+~~END~~
+
+
+select dbo.o7getcodevaluedesc() , kk , dd from (
+   select a as kk, count(b) as dd from babel_4793  group by a 
+) as drived
+GO
+~~START~~
+nvarchar#!#int#!#int
+~~END~~
+
+
+select babel_4793_schema.babel_4793_func() , kk , dd from (
+   select a as kk, count(b) as dd from babel_4793  group by a 
+) as drived
+GO
+~~START~~
+int#!#int#!#int
+~~END~~
+
+
+EXEC babel_4793_pro1
+GO
+~~START~~
+int#!#int#!#nvarchar
+~~END~~
+
+
+EXEC babel_4793_pro2
+GO
+~~START~~
+nvarchar#!#int#!#int
+~~END~~
+
+

--- a/test/JDBC/input/json_modify/BABEL-3697-vu-cleanup.sql
+++ b/test/JDBC/input/json_modify/BABEL-3697-vu-cleanup.sql
@@ -24,3 +24,24 @@ GO
 
 DROP VIEW babel_3697_multi_function
 GO
+
+DROP FUNCTION [dbo].[o7getcodevaluedesc] 
+GO
+
+drop function babel_4793_schema.babel_4793_func
+GO
+
+drop table babel_4793;
+GO
+
+drop procedure babel_4793_pro1
+GO
+
+drop procedure babel_4793_pro2
+GO
+
+drop procedure babel_4793_pro3
+GO
+
+drop schema babel_4793_schema
+GO

--- a/test/JDBC/input/json_modify/BABEL-3697-vu-prepare.sql
+++ b/test/JDBC/input/json_modify/BABEL-3697-vu-prepare.sql
@@ -45,3 +45,47 @@ create view babel_3697_multi_function as
 SELECT JSON_MODIFY(JSON_MODIFY(JSON_MODIFY('{"name":"John","skills":["C#","SQL"]}','$.name','Mike'),'$.surname','Smith'),'append $.skills','Azure') AS mf_1, 
        JSON_MODIFY(JSON_MODIFY('{"price":49.99}','$.Price',CAST(JSON_VALUE('{"price":49.99}','$.price') AS NUMERIC(4,2))),'$.price',NULL) AS mf_2;
 go
+
+CREATE  FUNCTION [dbo].[o7getcodevaluedesc] ()
+returns nvarchar(256)
+as BEGIN
+   return "ddd"
+end;
+GO
+
+create table babel_4793(a int , b int)
+GO
+
+create schema babel_4793_schema
+GO
+
+CREATE  FUNCTION babel_4793_schema.babel_4793_func ()
+returns int 
+as BEGIN
+    return 1;
+end;
+GO
+
+create procedure babel_4793_pro1
+as begin
+   select kk , dd, dbo.o7getcodevaluedesc() from (
+      select a as kk, count(b) as dd from babel_4793  group by a 
+   ) as drived
+end;
+go
+
+create procedure babel_4793_pro2
+as begin
+   select dbo.o7getcodevaluedesc() , kk , dd from (
+      select a as kk, count(b) as dd from babel_4793  group by a 
+   ) as drived
+end;
+go
+
+create procedure babel_4793_pro3
+as begin
+   select babel_4793_schema.babel_4793_func() , kk , dd from (
+      select a as kk, count(b) as dd from babel_4793  group by a 
+   ) as drived
+end;
+go

--- a/test/JDBC/input/json_modify/BABEL-3697-vu-verify.sql
+++ b/test/JDBC/input/json_modify/BABEL-3697-vu-verify.sql
@@ -24,3 +24,27 @@ GO
 
 SELECT * FROM babel_3697_multi_function
 GO
+
+select kk , dd, dbo.o7getcodevaluedesc() from (
+   select a as kk, count(b) as dd from babel_4793  group by a 
+) as drived
+GO
+
+select dbo.o7getcodevaluedesc() , kk , dd from (
+   select a as kk, count(b) as dd from babel_4793  group by a 
+) as drived
+GO
+
+select babel_4793_schema.babel_4793_func() , kk , dd from (
+   select a as kk, count(b) as dd from babel_4793  group by a 
+) as drived
+GO
+
+EXEC babel_4793_pro1
+GO
+
+EXEC babel_4793_pro2
+GO
+
+EXEC babel_4793_pro3
+GO 


### PR DESCRIPTION

In json_modify rewrite, it should only rewrite json_modify function.

Task: BABEL-4793
Sign-off-by: Zhibai Song <szh@amazon.com>


cherry-pick to APG 15 as it's a bugfix

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).