### PR TITLE
fix unique constraint on nullable column for table variable & nulls ordering for primary key indexes

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -5134,7 +5134,12 @@ is_function_pg_stat_valid(FunctionCallInfo fcinfo, PgStat_FunctionCallUsage *fcu
 static SortByNulls
 unique_constraint_nulls_ordering(ConstrType constraint_type, SortByDir ordering)
 {
-	if (constraint_type == CONSTR_UNIQUE)
+	/*
+	 * Ordering is only allowed when index has amcanorder = true (eg: btree)
+	 * PRIMARY KEY and UNIQUE constraints currently only use btree indexes
+	 * so we can be sure that setting nulls_order here is okay
+	 */
+	if (constraint_type == CONSTR_UNIQUE || constraint_type == CONSTR_PRIMARY)
 	{
 		switch (ordering)
 		{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -3522,6 +3522,25 @@ rewriteBatchLevelStatement(
 				if (all_removed)
 					removeTokenStringFromQuery(expr, cctx->WITH(), ctx);
 			}
+
+			if (cctx->table_type_definition() && cctx->table_type_definition()->column_def_table_constraints())
+			{
+				for (auto cdtctx : cctx->table_type_definition()->column_def_table_constraints()->column_def_table_constraint())
+				{
+					if (cdtctx->table_constraint() && cdtctx->table_constraint()->UNIQUE())
+						rewritten_query_fragment.emplace(std::make_pair(cdtctx->table_constraint()->UNIQUE()->getSymbol()->getStopIndex()+1 , std::make_pair("", " NULLS NOT DISTINCT")));
+
+					if (cdtctx->column_definition() && !cdtctx->column_definition()->column_constraint().empty())
+					{
+						for (auto actx: cdtctx->column_definition()->column_constraint())
+						{
+							if (actx->UNIQUE())
+								rewritten_query_fragment.emplace(std::make_pair(actx->UNIQUE()->getSymbol()->getStopIndex()+1 , std::make_pair("", " NULLS NOT DISTINCT")));
+						}
+					}
+
+				}
+			}
 		}
 		else if (ctx->create_or_alter_function()->func_body_returns_scalar()) /* CREATE FUNCTON ... RETURNS INT RETURN ... */
 		{
@@ -7243,6 +7262,19 @@ post_process_declare_table_statement(PLtsql_stmt_decl_table *stmt, TSqlParser::T
 				std::string rewritten_text = "timestamp " + ::getFullText(tctx);
 				rewritten_query_fragment.emplace(std::make_pair(tctx->getSymbol()->getStartIndex(), std::make_pair(::getFullText(tctx), rewritten_text)));
 			}
+
+			if (cdtctx->table_constraint() && cdtctx->table_constraint()->UNIQUE())
+				rewritten_query_fragment.emplace(std::make_pair(cdtctx->table_constraint()->UNIQUE()->getSymbol()->getStopIndex()+1 , std::make_pair("", " NULLS NOT DISTINCT")));
+
+			if (cdtctx->column_definition() && !cdtctx->column_definition()->column_constraint().empty())
+			{
+				for (auto actx: cdtctx->column_definition()->column_constraint())
+				{
+					if (actx->UNIQUE())
+						rewritten_query_fragment.emplace(std::make_pair(actx->UNIQUE()->getSymbol()->getStopIndex()+1 , std::make_pair("", " NULLS NOT DISTINCT")));
+				}
+			}
+
 		}
 
 		/*

--- a/test/JDBC/expected/BABEL_3571.out
+++ b/test/JDBC/expected/BABEL_3571.out
@@ -419,10 +419,10 @@ GO
 text
 CREATE UNIQUE INDEX babel_3571_1_id1_key ON master_dbo.babel_3571_1 USING btree (id1 NULLS FIRST) NULLS NOT DISTINCT
 CREATE UNIQUE INDEX babel_3571_1_id2_key ON master_dbo.babel_3571_1 USING btree (id2 NULLS FIRST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3 NULLS FIRST)
 CREATE UNIQUE INDEX babel_3571_2_id1_id2_key ON master_dbo.babel_3571_2 USING btree (id1 NULLS FIRST, id2 DESC NULLS LAST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3)
-CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3 NULLS FIRST)
+CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3 NULLS FIRST)
 CREATE UNIQUE INDEX babel_3571_3_unique_idxbabel_35df79da2a42216884edca5a4a798829ce ON master_dbo.babel_3571_3 USING btree (id1 DESC NULLS LAST, id2 NULLS FIRST) NULLS NOT DISTINCT
 ~~END~~
 
@@ -549,10 +549,10 @@ GO
 text
 CREATE UNIQUE INDEX babel_3571_1_id1_key ON master_dbo.babel_3571_1 USING btree (id1 NULLS FIRST) NULLS NOT DISTINCT
 CREATE UNIQUE INDEX babel_3571_1_id2_key ON master_dbo.babel_3571_1 USING btree (id2 NULLS FIRST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3 NULLS FIRST)
 CREATE UNIQUE INDEX babel_3571_2_id1_id2_key ON master_dbo.babel_3571_2 USING btree (id1 NULLS FIRST, id2 DESC NULLS LAST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3)
-CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3 NULLS FIRST)
+CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3 NULLS FIRST)
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL_4928.out
+++ b/test/JDBC/expected/BABEL_4928.out
@@ -1,0 +1,362 @@
+-- UNIQUE CONSTRAINT ON TABLE VARIABLES
+-- column constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int UNIQUE);
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_0_id_key")~~
+
+
+-- multiple column constraint on table variable
+DECLARE @babel_4928 TABLE(id int UNIQUE, id1 int UNIQUE, id2 INT PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (NULL, 1, 2);
+INSERT INTO @babel_4928 VALUES (NULL, 2, 20);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_0_id_key")~~
+
+
+DECLARE @babel_4928 TABLE(id int UNIQUE, id1 int UNIQUE, id2 INT PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (1, NULL, 2);
+INSERT INTO @babel_4928 VALUES (2, NULL, 20);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_0_id1_key")~~
+
+
+DECLARE @babel_4928 TABLE(id int UNIQUE, id1 int UNIQUE, id2 INT PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (1, 2, NULL);
+INSERT INTO @babel_4928 VALUES (2, 1, NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id2" of relation "@babel_4928_0" violates not-null constraint)~~
+
+
+-- table constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int , UNIQUE(id));
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_0_id_key")~~
+
+
+-- UNIQUE CONSTRAINT ON TABLE RETURNING FUNCTIONS VARIABLES
+-- column constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT UNIQUE)
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+~~START~~
+int
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_1_id_key")~~
+
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- table constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT, UNIQUE(id))
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+~~START~~
+int
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_1_id_key")~~
+
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- temp tables with unique column constraints
+CREATE TABLE #babel_4928_temp_table (id INT UNIQUE);
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#babel_4928_temp_table_id_key")~~
+
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- temp tables with unique table constraints
+CREATE TABLE #babel_4928_temp_table (id INT, UNIQUE(id));
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#babel_4928_temp_table_id_key")~~
+
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- test table type with uniqe constraint
+CREATE TYPE babel_4928_table_type AS TABLE(id INT UNIQUE)
+GO
+CREATE TYPE babel_4928_table_type_2 AS TABLE(id INT, UNIQUE(id))
+GO
+DECLARE @babel_4928 babel_4928_table_type;
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_0_id_key")~~
+
+
+-- multiple column constraint on table variable
+DECLARE @babel_4928 babel_4928_table_type_2;
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "@babel_4928_0_id_key")~~
+
+
+DROP TYPE babel_4928_table_type
+GO
+DROP TYPE babel_4928_table_type_2
+GO
+
+-- SAME TESTS AS ABOVE BUT WITH TIMESTAMP TYPE SINCE WE HAVE DIFFERENT GRAMMER RULE FOR TIMESTAMP
+sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion','ignore'
+GO
+
+DECLARE @babel_4928 TABLE(id TIMESTAMP UNIQUE);
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unique constraint is not supported on a timestamp column.)~~
+
+
+-- table constraint on tbale variable
+DECLARE @babel_4928 TABLE(id TIMESTAMP , UNIQUE(id));
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unique constraint is not supported on a timestamp column.)~~
+
+
+-- UNIQUE CONSTRAINT ON TABLE RETURNING FUNCTIONS VARIABLES
+-- column constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id TIMESTAMP UNIQUE)
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+~~START~~
+binary
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot insert an explicit value into a timestamp column.)~~
+
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- table constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id TIMESTAMP, UNIQUE(id))
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+~~START~~
+binary
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot insert an explicit value into a timestamp column.)~~
+
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- temp tables with unique column constraints
+CREATE TABLE #babel_4928_temp_table (id TIMESTAMP UNIQUE);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unique constraint is not supported on a timestamp column.)~~
+
+
+-- temp tables with unique table constraints
+CREATE TABLE #babel_4928_temp_table (id TIMESTAMP, UNIQUE(id));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Unique constraint is not supported on a timestamp column.)~~
+
+
+
+
+-- without UNIQUE keyword in sql to check if parser conditions are written properly
+-- column constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "@babel_4928_0" violates not-null constraint)~~
+
+
+-- table constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int , PRIMARY KEY(id));
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "@babel_4928_0" violates not-null constraint)~~
+
+
+-- column constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT PRIMARY KEY)
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+~~START~~
+int
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "@babel_4928_1" violates not-null constraint)~~
+
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- table constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT, PRIMARY KEY(id))
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+~~START~~
+int
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "@babel_4928_1" violates not-null constraint)~~
+
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- temp tables with PRIMARY KEY column constraints
+CREATE TABLE #babel_4928_temp_table (id INT PRIMARY KEY);
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "#babel_4928_temp_table" violates not-null constraint)~~
+
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- temp tables with PRIMARY KEY table constraints
+CREATE TABLE #babel_4928_temp_table (id INT, PRIMARY KEY(id));
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "#babel_4928_temp_table" violates not-null constraint)~~
+
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- test table type with PRIMARY KEY
+CREATE TYPE babel_4928_table_type AS TABLE(id INT PRIMARY KEY)
+GO
+CREATE TYPE babel_4928_table_type_2 AS TABLE(id INT, PRIMARY KEY(id))
+GO
+DECLARE @babel_4928 babel_4928_table_type;
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "@babel_4928_0" violates not-null constraint)~~
+
+
+-- column constraint on table variable
+DECLARE @babel_4928 babel_4928_table_type_2;
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id" of relation "@babel_4928_0" violates not-null constraint)~~
+
+
+DROP TYPE babel_4928_table_type
+GO
+DROP TYPE babel_4928_table_type_2
+GO

--- a/test/JDBC/expected/BABEL_4940.out
+++ b/test/JDBC/expected/BABEL_4940.out
@@ -1,0 +1,379 @@
+-- check if primary key index is used for query with order by clause
+SET NOCOUNT ON
+GO
+-- column constraint
+CREATE TABLE babel_4940_t1(id INT PRIMARY KEY)
+GO
+INSERT INTO babel_4940_t1 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint
+CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id))
+GO
+INSERT INTO babel_4940_t2 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint multiple column
+CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1))
+GO
+SET NOCOUNT ON
+DECLARE @i INT=0;
+WHILE (@i<1000)
+BEGIN
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+3)
+    SET @i = @i + 1;
+END
+GO
+
+
+-- same test as above but create primary key using alter table add constraints
+-- column constraint
+CREATE TABLE babel_4940_t4(id INT PRIMARY KEY)
+GO
+ALTER TABLE babel_4940_t4 DROP COLUMN id
+GO
+ALTER TABLE babel_4940_t4 ADD id INT PRIMARY KEY
+GO
+INSERT INTO babel_4940_t4 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint
+CREATE TABLE babel_4940_t5(id INT)
+GO
+ALTER TABLE babel_4940_t5 ADD CONSTRAINT c PRIMARY KEY (id)
+GO
+INSERT INTO babel_4940_t5 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint multiple column
+CREATE TABLE babel_4940_t6(id INT, id1 INT)
+GO
+ALTER TABLE babel_4940_t6 ADD CONSTRAINT c PRIMARY KEY(id, id1 DESC)
+GO
+DECLARE @i INT=0;
+WHILE (@i<1000)
+BEGIN
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+3)
+    SET @i = @i + 1;
+END
+GO
+
+-- All these queries should use primary key index
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SET BABELFISH_STATISTICS PROFILE ON;
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id 
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
+GO
+~~START~~
+int#!#int
+0#!#1
+0#!#2
+0#!#3
+1#!#2
+1#!#3
+1#!#4
+2#!#3
+2#!#4
+2#!#5
+3#!#4
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
+GO
+~~START~~
+int#!#int
+999#!#1002
+999#!#1001
+999#!#1000
+998#!#1001
+998#!#1000
+998#!#999
+997#!#1000
+997#!#999
+997#!#998
+996#!#999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id 
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan using cbabel_4940_t54a8a08f09d37b73795649038408b5f33 on babel_4940_t5 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan Backward using cbabel_4940_t54a8a08f09d37b73795649038408b5f33 on babel_4940_t5 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
+GO
+~~START~~
+int#!#int
+0#!#3
+0#!#2
+0#!#1
+1#!#4
+1#!#3
+1#!#2
+2#!#5
+2#!#4
+2#!#3
+3#!#6
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan using cbabel_4940_t64a8a08f09d37b73795649038408b5f33 on babel_4940_t6 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
+GO
+~~START~~
+int#!#int
+999#!#1000
+999#!#1001
+999#!#1002
+998#!#999
+998#!#1000
+998#!#1001
+997#!#998
+997#!#999
+997#!#1000
+996#!#997
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
+Limit (actual rows=10 loops=1)
+  ->  Index Only Scan Backward using cbabel_4940_t64a8a08f09d37b73795649038408b5f33 on babel_4940_t6 (actual rows=10 loops=1)
+        Heap Fetches: 10
+~~END~~
+
+
+
+SET BABELFISH_STATISTICS PROFILE OFF;
+DROP TABLE babel_4940_t1, babel_4940_t2, babel_4940_t3, babel_4940_t4, babel_4940_t5, babel_4940_t6
+GO

--- a/test/JDBC/expected/babel_ddl.out
+++ b/test/JDBC/expected/babel_ddl.out
@@ -63,12 +63,12 @@ t1_idx1t18e881e6977bd6b8cbb78725b3a8ac988#!#CREATE INDEX t1_idx1t18e881e6977bd6b
 t1_idx2t117dbbb74ced1fe936cdf7cd7baeff266#!#CREATE INDEX t1_idx2t117dbbb74ced1fe936cdf7cd7baeff266 ON master_dbo.t1 USING btree (a NULLS FIRST)
 t1_idx3t19eceb46c036c3c1bd6895a34ec3c93f1#!#CREATE INDEX t1_idx3t19eceb46c036c3c1bd6895a34ec3c93f1 ON master_dbo.t1 USING btree (a NULLS FIRST)
 t1_idx4t1fb4b953a652720bfa47919dff09b172e#!#CREATE INDEX t1_idx4t1fb4b953a652720bfa47919dff09b172e ON master_dbo.t1 USING btree (a NULLS FIRST)
-t2_pkey#!#CREATE UNIQUE INDEX t2_pkey ON master_dbo.t2 USING btree (a)
-t3_pkey#!#CREATE UNIQUE INDEX t3_pkey ON master_dbo.t3 USING btree (a)
+t2_pkey#!#CREATE UNIQUE INDEX t2_pkey ON master_dbo.t2 USING btree (a NULLS FIRST)
+t3_pkey#!#CREATE UNIQUE INDEX t3_pkey ON master_dbo.t3 USING btree (a NULLS FIRST)
 t4_a_key#!#CREATE UNIQUE INDEX t4_a_key ON master_dbo.t4 USING btree (a NULLS FIRST) NULLS NOT DISTINCT
 t5_a_key#!#CREATE UNIQUE INDEX t5_a_key ON master_dbo.t5 USING btree (a NULLS FIRST) NULLS NOT DISTINCT
-t6_pkey#!#CREATE UNIQUE INDEX t6_pkey ON master_dbo.t6 USING btree (a)
-t7_pkey#!#CREATE UNIQUE INDEX t7_pkey ON master_dbo.t7 USING btree (a)
+t6_pkey#!#CREATE UNIQUE INDEX t6_pkey ON master_dbo.t6 USING btree (a NULLS FIRST)
+t7_pkey#!#CREATE UNIQUE INDEX t7_pkey ON master_dbo.t7 USING btree (a NULLS FIRST)
 t8_a_key#!#CREATE UNIQUE INDEX t8_a_key ON master_dbo.t8 USING btree (a NULLS FIRST) NULLS NOT DISTINCT
 t9_a_key#!#CREATE UNIQUE INDEX t9_a_key ON master_dbo.t9 USING btree (a NULLS FIRST) NULLS NOT DISTINCT
 ~~END~~

--- a/test/JDBC/expected/parallel_query/BABEL_3571.out
+++ b/test/JDBC/expected/parallel_query/BABEL_3571.out
@@ -431,10 +431,10 @@ GO
 text
 CREATE UNIQUE INDEX babel_3571_1_id1_key ON master_dbo.babel_3571_1 USING btree (id1 NULLS FIRST) NULLS NOT DISTINCT
 CREATE UNIQUE INDEX babel_3571_1_id2_key ON master_dbo.babel_3571_1 USING btree (id2 NULLS FIRST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3 NULLS FIRST)
 CREATE UNIQUE INDEX babel_3571_2_id1_id2_key ON master_dbo.babel_3571_2 USING btree (id1 NULLS FIRST, id2 DESC NULLS LAST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3)
-CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3 NULLS FIRST)
+CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3 NULLS FIRST)
 CREATE UNIQUE INDEX babel_3571_3_unique_idxbabel_35df79da2a42216884edca5a4a798829ce ON master_dbo.babel_3571_3 USING btree (id1 DESC NULLS LAST, id2 NULLS FIRST) NULLS NOT DISTINCT
 ~~END~~
 
@@ -573,10 +573,10 @@ GO
 text
 CREATE UNIQUE INDEX babel_3571_1_id1_key ON master_dbo.babel_3571_1 USING btree (id1 NULLS FIRST) NULLS NOT DISTINCT
 CREATE UNIQUE INDEX babel_3571_1_id2_key ON master_dbo.babel_3571_1 USING btree (id2 NULLS FIRST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_1_pkey ON master_dbo.babel_3571_1 USING btree (id3 NULLS FIRST)
 CREATE UNIQUE INDEX babel_3571_2_id1_id2_key ON master_dbo.babel_3571_2 USING btree (id1 NULLS FIRST, id2 DESC NULLS LAST) NULLS NOT DISTINCT
-CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3)
-CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3)
+CREATE UNIQUE INDEX babel_3571_2_pkey ON master_dbo.babel_3571_2 USING btree (id3 NULLS FIRST)
+CREATE UNIQUE INDEX babel_3571_3_pkeybabel_3571_34773fbee6e7b68a5cb6b0b6273b17de0 ON master_dbo.babel_3571_3 USING btree (id3 NULLS FIRST)
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/BABEL_4940.out
+++ b/test/JDBC/expected/parallel_query/BABEL_4940.out
@@ -1,0 +1,427 @@
+-- check if primary key index is used for query with order by clause
+SET NOCOUNT ON
+GO
+-- column constraint
+CREATE TABLE babel_4940_t1(id INT PRIMARY KEY)
+GO
+INSERT INTO babel_4940_t1 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint
+CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id))
+GO
+INSERT INTO babel_4940_t2 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint multiple column
+CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1))
+GO
+SET NOCOUNT ON
+DECLARE @i INT=0;
+WHILE (@i<1000)
+BEGIN
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+3)
+    SET @i = @i + 1;
+END
+GO
+
+
+-- same test as above but create primary key using alter table add constraints
+-- column constraint
+CREATE TABLE babel_4940_t4(id INT PRIMARY KEY)
+GO
+ALTER TABLE babel_4940_t4 DROP COLUMN id
+GO
+ALTER TABLE babel_4940_t4 ADD id INT PRIMARY KEY
+GO
+INSERT INTO babel_4940_t4 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint
+CREATE TABLE babel_4940_t5(id INT)
+GO
+ALTER TABLE babel_4940_t5 ADD CONSTRAINT c PRIMARY KEY (id)
+GO
+INSERT INTO babel_4940_t5 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint multiple column
+CREATE TABLE babel_4940_t6(id INT, id1 INT)
+GO
+ALTER TABLE babel_4940_t6 ADD CONSTRAINT c PRIMARY KEY(id, id1 DESC)
+GO
+DECLARE @i INT=0;
+WHILE (@i<1000)
+BEGIN
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+3)
+    SET @i = @i + 1;
+END
+GO
+
+-- All these queries should use primary key index
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SET BABELFISH_STATISTICS PROFILE ON;
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id 
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
+GO
+~~START~~
+int#!#int
+0#!#1
+0#!#2
+0#!#3
+1#!#2
+1#!#3
+1#!#4
+2#!#3
+2#!#4
+2#!#5
+3#!#4
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
+GO
+~~START~~
+int#!#int
+999#!#1002
+999#!#1001
+999#!#1000
+998#!#1001
+998#!#1000
+998#!#999
+997#!#1000
+997#!#999
+997#!#998
+996#!#999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id 
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan using cbabel_4940_t54a8a08f09d37b73795649038408b5f33 on babel_4940_t5 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
+GO
+~~START~~
+int
+100000
+99999
+99998
+99997
+99996
+99995
+99994
+99993
+99992
+99991
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan Backward using cbabel_4940_t54a8a08f09d37b73795649038408b5f33 on babel_4940_t5 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
+GO
+~~START~~
+int#!#int
+0#!#3
+0#!#2
+0#!#1
+1#!#4
+1#!#3
+1#!#2
+2#!#5
+2#!#4
+2#!#3
+3#!#6
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan using cbabel_4940_t64a8a08f09d37b73795649038408b5f33 on babel_4940_t6 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
+GO
+~~START~~
+int#!#int
+999#!#1000
+999#!#1001
+999#!#1002
+998#!#999
+998#!#1000
+998#!#1001
+997#!#998
+997#!#999
+997#!#1000
+996#!#997
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
+Gather (actual rows=10 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Limit (actual rows=10 loops=1)
+        ->  Index Only Scan Backward using cbabel_4940_t64a8a08f09d37b73795649038408b5f33 on babel_4940_t6 (actual rows=10 loops=1)
+              Heap Fetches: 10
+~~END~~
+
+
+
+SET BABELFISH_STATISTICS PROFILE OFF;
+DROP TABLE babel_4940_t1, babel_4940_t2, babel_4940_t3, babel_4940_t4, babel_4940_t5, babel_4940_t6
+GO

--- a/test/JDBC/input/BABEL_4928.sql
+++ b/test/JDBC/input/BABEL_4928.sql
@@ -1,0 +1,234 @@
+-- UNIQUE CONSTRAINT ON TABLE VARIABLES
+-- column constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int UNIQUE);
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- multiple column constraint on table variable
+DECLARE @babel_4928 TABLE(id int UNIQUE, id1 int UNIQUE, id2 INT PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (NULL, 1, 2);
+INSERT INTO @babel_4928 VALUES (NULL, 2, 20);
+GO
+
+DECLARE @babel_4928 TABLE(id int UNIQUE, id1 int UNIQUE, id2 INT PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (1, NULL, 2);
+INSERT INTO @babel_4928 VALUES (2, NULL, 20);
+GO
+
+DECLARE @babel_4928 TABLE(id int UNIQUE, id1 int UNIQUE, id2 INT PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (1, 2, NULL);
+INSERT INTO @babel_4928 VALUES (2, 1, NULL);
+GO
+
+-- table constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int , UNIQUE(id));
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- UNIQUE CONSTRAINT ON TABLE RETURNING FUNCTIONS VARIABLES
+-- column constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT UNIQUE)
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- table constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT, UNIQUE(id))
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- temp tables with unique column constraints
+CREATE TABLE #babel_4928_temp_table (id INT UNIQUE);
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- temp tables with unique table constraints
+CREATE TABLE #babel_4928_temp_table (id INT, UNIQUE(id));
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- test table type with uniqe constraint
+CREATE TYPE babel_4928_table_type AS TABLE(id INT UNIQUE)
+GO
+CREATE TYPE babel_4928_table_type_2 AS TABLE(id INT, UNIQUE(id))
+GO
+DECLARE @babel_4928 babel_4928_table_type;
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- multiple column constraint on table variable
+DECLARE @babel_4928 babel_4928_table_type_2;
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+DROP TYPE babel_4928_table_type
+GO
+DROP TYPE babel_4928_table_type_2
+GO
+
+-- SAME TESTS AS ABOVE BUT WITH TIMESTAMP TYPE SINCE WE HAVE DIFFERENT GRAMMER RULE FOR TIMESTAMP
+sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion','ignore'
+GO
+
+DECLARE @babel_4928 TABLE(id TIMESTAMP UNIQUE);
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- table constraint on tbale variable
+DECLARE @babel_4928 TABLE(id TIMESTAMP , UNIQUE(id));
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- UNIQUE CONSTRAINT ON TABLE RETURNING FUNCTIONS VARIABLES
+-- column constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id TIMESTAMP UNIQUE)
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- table constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id TIMESTAMP, UNIQUE(id))
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- temp tables with unique column constraints
+CREATE TABLE #babel_4928_temp_table (id TIMESTAMP UNIQUE);
+GO
+
+-- temp tables with unique table constraints
+CREATE TABLE #babel_4928_temp_table (id TIMESTAMP, UNIQUE(id));
+GO
+
+
+-- without UNIQUE keyword in sql to check if parser conditions are written properly
+
+-- column constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int PRIMARY KEY);
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- table constraint on tbale variable
+DECLARE @babel_4928 TABLE(id int , PRIMARY KEY(id));
+INSERT INTO @babel_4928 VALUES (NULL);
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- column constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT PRIMARY KEY)
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- table constraint on table returning funciton
+CREATE FUNCTION babel_4928_f() RETURNS @babel_4928 TABLE(id INT, PRIMARY KEY(id))
+AS
+BEGIN
+    INSERT INTO @babel_4928 VALUES (NULL);
+    INSERT INTO @babel_4928 VALUES (NULL);
+END
+GO
+
+SELECT * FROM babel_4928_f();
+GO
+
+DROP FUNCTION babel_4928_f
+GO
+
+-- temp tables with PRIMARY KEY column constraints
+CREATE TABLE #babel_4928_temp_table (id INT PRIMARY KEY);
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- temp tables with PRIMARY KEY table constraints
+CREATE TABLE #babel_4928_temp_table (id INT, PRIMARY KEY(id));
+GO
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+INSERT INTO #babel_4928_temp_table VALUES (NULL);
+GO
+DROP TABLE #babel_4928_temp_table
+GO
+
+-- test table type with PRIMARY KEY
+CREATE TYPE babel_4928_table_type AS TABLE(id INT PRIMARY KEY)
+GO
+CREATE TYPE babel_4928_table_type_2 AS TABLE(id INT, PRIMARY KEY(id))
+GO
+DECLARE @babel_4928 babel_4928_table_type;
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+-- column constraint on table variable
+DECLARE @babel_4928 babel_4928_table_type_2;
+INSERT INTO @babel_4928 VALUES (NULL);
+GO
+
+DROP TYPE babel_4928_table_type
+GO
+DROP TYPE babel_4928_table_type_2
+GO

--- a/test/JDBC/input/BABEL_4940.sql
+++ b/test/JDBC/input/BABEL_4940.sql
@@ -1,0 +1,101 @@
+-- parallel_query_expected
+-- check if primary key index is used for query with order by clause
+SET NOCOUNT ON
+GO
+-- column constraint
+CREATE TABLE babel_4940_t1(id INT PRIMARY KEY)
+GO
+INSERT INTO babel_4940_t1 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint
+CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id))
+GO
+INSERT INTO babel_4940_t2 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint multiple column
+CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1))
+GO
+SET NOCOUNT ON
+DECLARE @i INT=0;
+WHILE (@i<1000)
+BEGIN
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t3 VALUES(@i,@i+3)
+    SET @i = @i + 1;
+END
+GO
+
+
+-- same test as above but create primary key using alter table add constraints
+-- column constraint
+CREATE TABLE babel_4940_t4(id INT PRIMARY KEY)
+GO
+ALTER TABLE babel_4940_t4 DROP COLUMN id
+GO
+ALTER TABLE babel_4940_t4 ADD id INT PRIMARY KEY
+GO
+INSERT INTO babel_4940_t4 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint
+CREATE TABLE babel_4940_t5(id INT)
+GO
+ALTER TABLE babel_4940_t5 ADD CONSTRAINT c PRIMARY KEY (id)
+GO
+INSERT INTO babel_4940_t5 VALUES(generate_series(1,100000))
+GO
+
+-- table constraint multiple column
+CREATE TABLE babel_4940_t6(id INT, id1 INT)
+GO
+ALTER TABLE babel_4940_t6 ADD CONSTRAINT c PRIMARY KEY(id, id1 DESC)
+GO
+DECLARE @i INT=0;
+WHILE (@i<1000)
+BEGIN
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t6 VALUES(@i,@i+3)
+    SET @i = @i + 1;
+END
+GO
+
+-- All these queries should use primary key index
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SET BABELFISH_STATISTICS PROFILE ON;
+GO
+
+SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
+GO
+SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
+GO
+SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id 
+GO
+SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
+GO
+SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
+GO
+SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
+GO
+SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
+GO
+SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
+GO
+SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id 
+GO
+SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
+GO
+SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
+GO
+SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
+GO
+
+SET BABELFISH_STATISTICS PROFILE OFF;
+
+DROP TABLE babel_4940_t1, babel_4940_t2, babel_4940_t3, babel_4940_t4, babel_4940_t5, babel_4940_t6
+GO


### PR DESCRIPTION
### Description

UNIQUE constraints declared on pltsql table variables should only allow one null value by using the postgres nulls not distinct behaviour.

For other relations we already fixed this behaviour here https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2392

Also fixed the default nulls ordering for pltsql primary key constraints to ASC NULLS FIRSTS & DESC NULLS LAST.

### Cherry Picked From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2562

### Issues Resolved

[BABEL-4928] [BABEL-4940]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).