### PR TITLE
Metadata consistency check keeps failing for babelfish_schema_permissions

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2172,7 +2172,8 @@ get_perms_grantee_name(HeapTuple tuple, TupleDesc dsc)
 {
 	bool		isNull;
 	Datum		grantee_datum = heap_getattr(tuple, Anum_bbf_schema_perms_grantee, dsc, &isNull);
-	const char *grantee_name = pstrdup(TextDatumGetCString(grantee_datum));
+	char *grantee_name = pstrdup(TextDatumGetCString(grantee_datum));
+	truncate_identifier(grantee_name, strlen(grantee_name), false);
 
 	return CStringGetDatum(grantee_name);
 }

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -4008,6 +4008,14 @@ grant select on schema::s1 to u3;
 go
 grant execute on schema::s1 to u3;
 go
+-- check for inconsistent metadata
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
+~~START~~
+int
+0
+~~END~~
+
 
 -- tsql user=l3 password=123
 -- u3 has select and execute privilege on s1 and s2

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -12,6 +12,12 @@ go
 create user babel_4344_u1 for login babel_4344_l1;
 go
 
+create login abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz with password = '12345678'
+go
+
+create user abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz for login abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
+go
+
 create login αιώνια with password = '12345678'
 go
 
@@ -211,10 +217,25 @@ go
 create table abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz(a int);
 go
 
-grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
 go
 
-revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+-- check for inconsistent metadata
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
+~~START~~
+int
+0
+~~END~~
+
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
+go
+
+drop user abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
+go
+
+drop login abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
 go
 
 -- unsupported features

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -1975,6 +1975,9 @@ grant select on schema::s1 to u3;
 go
 grant execute on schema::s1 to u3;
 go
+-- check for inconsistent metadata
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
 
 -- u3 has select and execute privilege on s1 and s2
 -- tsql user=l3 password=123

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -12,6 +12,12 @@ go
 create user babel_4344_u1 for login babel_4344_l1;
 go
 
+create login abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz with password = '12345678'
+go
+
+create user abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz for login abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
+go
+
 create login αιώνια with password = '12345678'
 go
 
@@ -162,10 +168,20 @@ go
 create table abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz(a int);
 go
 
-grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+grant select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
 go
 
-revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to babel_4344_u1;
+-- check for inconsistent metadata
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
+
+revoke select on schema::abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz to abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
+go
+
+drop user abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
+go
+
+drop login abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz;
 go
 
 -- unsupported features


### PR DESCRIPTION
### Description

Fix Metadata inconsistency for babelfish_schema_permissions catalog.

### Issues Resolved

Task: BABEL-4980
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Added metadata consistency check


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
