### PR TITLE
Fix metadata consistency check of schema name for babelfish_schema_permissions catalog

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2173,10 +2173,20 @@ get_function_name(HeapTuple tuple, TupleDesc dsc)
 static Datum
 get_perms_schema_name(HeapTuple tuple, TupleDesc dsc)
 {
-	bool		isNull;
-	Datum		schema_name = heap_getattr(tuple, Anum_bbf_schema_perms_schema_name, dsc, &isNull);
-	Datum		dbid = heap_getattr(tuple, Anum_bbf_schema_perms_dbid, dsc, &isNull);
+	bool		schema_is_null, dbid_is_null;
+	Datum		schema_name = heap_getattr(tuple, Anum_bbf_schema_perms_schema_name, dsc, &schema_is_null);
+	Datum		dbid = heap_getattr(tuple, Anum_bbf_schema_perms_dbid, dsc, &dbid_is_null);
 	char		*physical_schema_name;
+
+	if (dbid_is_null)
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					errmsg("dbid should not be null in babelfish_schema_permissions catalog")));
+	if (schema_is_null)
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					errmsg("schema name should not be null in babelfish_schema_permissions catalog")));
+
 	/* get_physical_schema_name() itself handles truncation, no explicit truncation needed */
 	physical_schema_name = get_physical_schema_name(get_db_name(DatumGetInt16(dbid)), TextDatumGetCString(schema_name));
 

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
@@ -58,6 +58,26 @@ go
 DROP SCHEMA babel_4768_s2
 GO
 
+DROP TABLE babel_4768ログインαιώνια.t1
+go
+
+
+DROP TABLE "babel_4768 😎$chem@ #123 🌍rder".t1
+go
+
+DROP TABLE [babel_4768유니코드스키마👻].t1
+go
+
+DROP SCHEMA babel_4768ログインαιώνια
+GO
+
+DROP SCHEMA [babel_4768 😎$chem@ #123 🌍rder]
+GO
+
+DROP SCHEMA [babel_4768유니코드스키마👻]
+GO
+
+
 
 drop user babel_4768_u1;
 go

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
@@ -40,6 +40,25 @@ go
 drop schema babel_4768_s1;
 go
 
+drop table babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1
+go
+
+drop schema babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+go
+
+DROP TABLE babel_4768_s2.t1
+go
+
+DROP VIEW babel_4768_s2.v1
+go
+
+DROP PROC babel_4768_s2.p1
+go
+
+DROP SCHEMA babel_4768_s2
+GO
+
+
 drop user babel_4768_u1;
 go
 

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
@@ -151,6 +151,35 @@ go
 GRANT EXECUTE ON babel_4768_s2.p1 TO babel_4768_u1
 go
 
+-- to test consistency in case of special characters in schema name
+CREATE SCHEMA babel_4768ログインαιώνια
+GO
+
+CREATE SCHEMA [babel_4768 😎$chem@ #123 🌍rder]
+GO
+
+CREATE SCHEMA [babel_4768유니코드스키마👻]
+GO
+
+CREATE TABLE babel_4768ログインαιώνια.t1 (a int)
+go
+
+GRANT SELECT ON  babel_4768ログインαιώνια.t1 TO babel_4768_u1
+go
+
+CREATE TABLE "babel_4768 😎$chem@ #123 🌍rder".t1 (a int)
+go
+
+GRANT SELECT ON "babel_4768 😎$chem@ #123 🌍rder".t1 TO babel_4768_u1
+go
+
+CREATE TABLE [babel_4768유니코드스키마👻].t1 (a int)
+go
+
+GRANT SELECT ON  [babel_4768유니코드스키마👻].t1 TO babel_4768_u1
+go
+
+
 
 -- check for inconsistent metadata before upgrade
 select COUNT(*) FROM sys.babelfish_inconsistent_metadata();

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
@@ -116,3 +116,47 @@ dbo#!#babel_4768_t1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
 dbo#!#babel_4768_v1#!#2#!#master_babel_4768_u1#!#r#!#<NULL>#!#<NULL>
 ~~END~~
 
+
+-- tsql
+-- to test schema length truncation
+CREATE SCHEMA babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+go
+
+CREATE TABLE babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1 (a int)
+go
+
+GRANT SELECT ON babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1 TO babel_4768_u1
+go
+
+-- to test perms of multiple objects in same schema
+CREATE SCHEMA babel_4768_s2
+GO
+
+CREATE TABLE babel_4768_s2.t1 (a int)
+go
+
+create view babel_4768_s2.v1 as select 1;
+go
+
+create proc babel_4768_s2.p1 as select 1;
+go
+
+GRANT SELECT ON babel_4768_s2.t1 TO babel_4768_u1
+go
+
+GRANT SELECT ON babel_4768_s2.v1 TO babel_4768_u1
+go
+
+
+GRANT EXECUTE ON babel_4768_s2.p1 TO babel_4768_u1
+go
+
+
+-- check for inconsistent metadata before upgrade
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -195,6 +195,14 @@ go
 REVOKE EXECUTE ON babel_4768_s2.p1 FROM babel_4768_u1
 go
 
+REVOKE SELECT ON babel_4768ログインαιώνια.t1 FROM babel_4768_u1
+go
+
+REVOKE SELECT ON "babel_4768 😎$chem@ #123 🌍rder".t1 FROM babel_4768_u1
+go
+
+REVOKE SELECT ON [babel_4768유니코드스키마👻].t1 FROM babel_4768_u1
+go
 
 -- psql
 -- catalog should be empty now

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -1,3 +1,13 @@
+-- tsql
+-- check for inconsistent metadata after upgrade
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
+~~START~~
+int
+0
+~~END~~
+
+
 -- psql
 select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
 go
@@ -171,6 +181,20 @@ GO
 
 REVOKE EXECUTE ON babel_4768_s1.babel_4768_f2_new FROM babel_4768_u1
 GO
+
+REVOKE SELECT ON babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1 FROM babel_4768_u1
+go
+
+
+REVOKE SELECT ON babel_4768_s2.t1 FROM babel_4768_u1
+go
+
+REVOKE SELECT ON babel_4768_s2.v1 FROM babel_4768_u1
+go
+
+REVOKE EXECUTE ON babel_4768_s2.p1 FROM babel_4768_u1
+go
+
 
 -- psql
 -- catalog should be empty now

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
@@ -58,6 +58,26 @@ go
 DROP SCHEMA babel_4768_s2
 GO
 
+DROP TABLE babel_4768ログインαιώνια.t1
+go
+
+
+DROP TABLE "babel_4768 😎$chem@ #123 🌍rder".t1
+go
+
+DROP TABLE [babel_4768유니코드스키마👻].t1
+go
+
+DROP SCHEMA babel_4768ログインαιώνια
+GO
+
+DROP SCHEMA [babel_4768 😎$chem@ #123 🌍rder]
+GO
+
+DROP SCHEMA [babel_4768유니코드스키마👻]
+GO
+
+
 
 drop user babel_4768_u1;
 go

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
@@ -40,6 +40,25 @@ go
 drop schema babel_4768_s1;
 go
 
+drop table babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1
+go
+
+drop schema babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+go
+
+DROP TABLE babel_4768_s2.t1
+go
+
+DROP VIEW babel_4768_s2.v1
+go
+
+DROP PROC babel_4768_s2.p1
+go
+
+DROP SCHEMA babel_4768_s2
+GO
+
+
 drop user babel_4768_u1;
 go
 

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
@@ -129,6 +129,35 @@ go
 GRANT EXECUTE ON babel_4768_s2.p1 TO babel_4768_u1
 go
 
+-- to test consistency in case of special characters in schema name
+CREATE SCHEMA babel_4768ログインαιώνια
+GO
+
+CREATE SCHEMA [babel_4768 😎$chem@ #123 🌍rder]
+GO
+
+CREATE SCHEMA [babel_4768유니코드스키마👻]
+GO
+
+CREATE TABLE babel_4768ログインαιώνια.t1 (a int)
+go
+
+GRANT SELECT ON  babel_4768ログインαιώνια.t1 TO babel_4768_u1
+go
+
+CREATE TABLE "babel_4768 😎$chem@ #123 🌍rder".t1 (a int)
+go
+
+GRANT SELECT ON "babel_4768 😎$chem@ #123 🌍rder".t1 TO babel_4768_u1
+go
+
+CREATE TABLE [babel_4768유니코드스키마👻].t1 (a int)
+go
+
+GRANT SELECT ON  [babel_4768유니코드스키마👻].t1 TO babel_4768_u1
+go
+
+
 
 -- check for inconsistent metadata before upgrade
 select COUNT(*) FROM sys.babelfish_inconsistent_metadata();

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
@@ -94,3 +94,42 @@ go
 
 select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'dbo' and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
 go
+
+-- tsql
+-- to test schema length truncation
+CREATE SCHEMA babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+go
+
+CREATE TABLE babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1 (a int)
+go
+
+GRANT SELECT ON babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1 TO babel_4768_u1
+go
+
+-- to test perms of multiple objects in same schema
+CREATE SCHEMA babel_4768_s2
+GO
+
+CREATE TABLE babel_4768_s2.t1 (a int)
+go
+
+create view babel_4768_s2.v1 as select 1;
+go
+
+create proc babel_4768_s2.p1 as select 1;
+go
+
+GRANT SELECT ON babel_4768_s2.t1 TO babel_4768_u1
+go
+
+GRANT SELECT ON babel_4768_s2.v1 TO babel_4768_u1
+go
+
+
+GRANT EXECUTE ON babel_4768_s2.p1 TO babel_4768_u1
+go
+
+
+-- check for inconsistent metadata before upgrade
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
@@ -1,3 +1,8 @@
+-- tsql
+-- check for inconsistent metadata after upgrade
+select COUNT(*) FROM sys.babelfish_inconsistent_metadata();
+go
+
 -- psql
 select schema_name, object_name, permission, grantee, object_type, function_args, grantor from sys.babelfish_schema_permissions where schema_name = 'babel_4768_s1' collate sys.database_default and grantee like '%babel_4768_u1' collate sys.database_default order by object_name;
 go
@@ -107,6 +112,20 @@ GO
 
 REVOKE EXECUTE ON babel_4768_s1.babel_4768_f2_new FROM babel_4768_u1
 GO
+
+REVOKE SELECT ON babel_4768_schema_longer_than_64_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.t1 FROM babel_4768_u1
+go
+
+
+REVOKE SELECT ON babel_4768_s2.t1 FROM babel_4768_u1
+go
+
+REVOKE SELECT ON babel_4768_s2.v1 FROM babel_4768_u1
+go
+
+REVOKE EXECUTE ON babel_4768_s2.p1 FROM babel_4768_u1
+go
+
 
 -- psql
 -- catalog should be empty now

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
@@ -126,6 +126,14 @@ go
 REVOKE EXECUTE ON babel_4768_s2.p1 FROM babel_4768_u1
 go
 
+REVOKE SELECT ON babel_4768ログインαιώνια.t1 FROM babel_4768_u1
+go
+
+REVOKE SELECT ON "babel_4768 😎$chem@ #123 🌍rder".t1 FROM babel_4768_u1
+go
+
+REVOKE SELECT ON [babel_4768유니코드스키마👻].t1 FROM babel_4768_u1
+go
 
 -- psql
 -- catalog should be empty now


### PR DESCRIPTION
### Description
This commit fixes the metadata consistency check of schema name for babelfish_schema_permissions catalog which has been introduced as part Grant on Schema support. Earlier it used to keep failing because we were comparing logical schema name with physical schema name in the check.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

4X PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2593
### Issues Resolved

Task: BABEL-4985

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** NA


* **Negative test cases -**  NA


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).