### PR TITLE
Fix BBF PIVOT cannot use CTE as source table (PG15)

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -1616,16 +1616,19 @@ simple_select:
 			| tsql_values_clause							{ $$ = $1; }
 			;
 
-tsql_pivot_expr: TSQL_PIVOT '(' func_application FOR columnref IN_P in_expr ')'
+tsql_pivot_expr: TSQL_PIVOT '(' func_name '(' columnref ')' FOR columnref IN_P '(' columnList ')' ')'
 				{						
 					ColumnRef 		*a_star;
+					ColumnRef		*agg_col;
 					ResTarget 		*a_star_restarget;
 					RangeSubselect 	*range_sub_select;
 					Alias 			*temptable_alias;
-					List    *ret;
-					List    *value_col_strlist = NULL;
-					List	*subsel_valuelists = NULL;
-					String 	*pivot_colstr;
+					String 			*pivot_colstr;
+					String 			*agg_colstr;
+					List    		*ret;
+					List 			*column_list;
+					List			*column_const_list;
+					ListCell 		*lc;
 					
 					SelectStmt 	*category_sql = makeNode(SelectStmt);
 					SelectStmt 	*valuelists_sql = makeNode(SelectStmt);
@@ -1640,42 +1643,45 @@ tsql_pivot_expr: TSQL_PIVOT '(' func_application FOR columnref IN_P in_expr ')'
 					a_star_restarget->indirection = NIL;
 					a_star_restarget->val = (Node *) a_star;
 					a_star_restarget->location = -1;
-					
 
 					/* prepare aggregation function for pivot source sql */
+					agg_col = (ColumnRef *)$5;
 					restarget_aggfunc->name = NULL;
 					restarget_aggfunc->name_location = -1;
 					restarget_aggfunc->indirection = NIL;
-					restarget_aggfunc->val = (Node *) $3;
+					restarget_aggfunc->val = (Node *) makeFuncCall($3, list_make1(agg_col),
+																   COERCE_EXPLICIT_CALL,
+																   @3);
 					restarget_aggfunc->location = -1;
-					
-					if (IsA((List *)$7, List))
+
+					agg_colstr = list_nth_node(String, agg_col->fields, ((List *)agg_col->fields)->length - 1);
+					column_list = (List *)$11;
+					column_const_list = NIL;
+
+					foreach(lc ,column_list)
 					{
-						for (int i = 0; i < ((List *)$7)->length; i++)
-						{
-							ColumnRef	*tempRef = list_nth((List *)$7, i);
-							String		*s = list_nth(tempRef->fields, 0);
-							Node		*n = makeStringConst(s->sval, -1);
-							List 		*l = list_make1(copyObject(n));
-							if (value_col_strlist == NULL || subsel_valuelists == NULL)
-							{
-								value_col_strlist = list_make1(s->sval);
-								subsel_valuelists = list_make1(l);
-							}else
-							{
-								value_col_strlist = lappend(value_col_strlist, s->sval);
-								subsel_valuelists = lappend(subsel_valuelists, l);
-							}
-						}
+						Node 	*column_const;
+						String 	*column_str;
+
+						column_str = (String *)lfirst(lc);
+
+						if (column_str != NULL && strcmp(column_str->sval, agg_colstr->sval) == 0)
+							ereport(ERROR,
+									(errcode(ERRCODE_SYNTAX_ERROR),
+										errmsg("The column name \"%s\" specified in the PIVOT operator conflicts with the existing column name in the PIVOT argument.", agg_colstr->sval),
+										parser_errposition(@5)));
+
+						column_const = makeStringConst(pstrdup(column_str->sval), -1);
+						column_const_list = lappend(column_const_list, list_make1(column_const));
 					}
 
 					temptable_alias = makeNode(Alias);
 					temptable_alias->aliasname = "pivotTempTable";
 					/* get the column name from the columnref*/
-					pivot_colstr = llast(((ColumnRef *)$5)->fields);
+					pivot_colstr = llast(((ColumnRef *)$8)->fields);
 					temptable_alias->colnames = list_make1(copyObject(pivot_colstr));
 					
-					valuelists_sql->valuesLists = subsel_valuelists;
+					valuelists_sql->valuesLists = column_const_list;
 
 					range_sub_select = makeNode(RangeSubselect);
 					range_sub_select->subquery = (Node *) valuelists_sql;
@@ -1684,7 +1690,7 @@ tsql_pivot_expr: TSQL_PIVOT '(' func_application FOR columnref IN_P in_expr ')'
 					category_sql->targetList = list_make1(a_star_restarget);
 					category_sql->fromClause = list_make1(range_sub_select);
 
-					ret = list_make4($5, restarget_aggfunc, category_sql, value_col_strlist);
+					ret = list_make4($8, restarget_aggfunc, category_sql, column_list);
 					$$ = (Node*) ret; 
 				} 
 			;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4598,6 +4598,7 @@ transform_pivot_clause(ParseState *pstate, SelectStmt *stmt)
 	RawStmt			*s_sql;
 	RawStmt			*c_sql;
 	FuncCall 		*pivot_func;
+	WithClause		*with_clause;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
@@ -4607,10 +4608,25 @@ transform_pivot_clause(ParseState *pstate, SelectStmt *stmt)
 	src_sql_groupbylist = NIL;
 	src_sql_sortbylist = NIL;
 
+	with_clause = copyObject(stmt->withClause);
 	pivot_src_sql =  makeNode(SelectStmt);
 	pivot_src_sql->fromClause = copyObject(stmt->srcSql->fromClause);
+	pivot_src_sql->withClause = copyObject(with_clause);
+
+	((SelectStmt *)stmt->srcSql)->withClause = copyObject(with_clause);
+	stmt->withClause = NULL;
+	
 	src_sql_fromClause_copy = copyObject(stmt->srcSql->fromClause);
-	/* transform temporary src_sql */
+	
+	/*
+	 * During pre_transform_target_entry, we only rewrote object references in pivot wrapper sql 
+	 * and skipped stmt->srcSql rewriting. Here we rewrite srcSql to correct the right reference 
+	 * for object with schema name
+	 */
+	if (enable_schema_mapping())
+		rewrite_object_refs((Node *)stmt->srcSql);
+
+	/* We execute first parse_sub_analyze to get the correct pivot_src_sql targetlist */
 	temp_src_query = parse_sub_analyze((Node *) stmt->srcSql, pstate, NULL,
 										false,
 										false);
@@ -4647,13 +4663,20 @@ transform_pivot_clause(ParseState *pstate, SelectStmt *stmt)
 		
 		new_pivot_aliaslist = lappend(new_pivot_aliaslist, tempColDef);
 	}
-	/* source_sql: non-pivot column + pivot colunm+ agg(value_col) */
-	/* complete src_sql's targetList*/	
+
+   	/* pivot_src_sql: non-pivot column + pivot colunm+ agg(value_col)*/	
 	new_src_sql_targetist = lappend(new_src_sql_targetist, make_restarget_from_cstr_list(stmt->pivotCol->fields));
 	new_src_sql_targetist = lappend(new_src_sql_targetist, (ResTarget *)stmt->aggFunc);
-	((SelectStmt *)stmt->srcSql)->targetList = new_src_sql_targetist;
 	pivot_src_sql->targetList = copyObject(new_src_sql_targetist);
-	/* complete src_sql's groupby*/
+
+	/*
+	 *  We need second round of parse_sub_analyze to get the output type of 
+	 *  pivot aggregation function, and therefore we can create correct alias
+	 *  column names and datatypes for wrapper/outer sql.
+	 */
+	((SelectStmt *)stmt->srcSql)->targetList = new_src_sql_targetist;
+	
+	/* complete src_sql's groupby */
 	for (int i = 0; i < new_src_sql_targetist->length - 1; i++)
 	{
 		A_Const		*tempAConst = makeNode(A_Const);
@@ -4676,9 +4699,15 @@ transform_pivot_clause(ParseState *pstate, SelectStmt *stmt)
 	pivot_src_sql->groupClause = copyObject(src_sql_groupbylist);
 	pivot_src_sql->sortClause = copyObject(src_sql_sortbylist);
 	
-	/* use the copy of the orgininal fromClause to prevent double analyzing fromClause */
+	/* use the copy of the orgininal fromClause and withClause to prevent double analyzing fromClause */
 	((SelectStmt *)stmt->srcSql)->fromClause = src_sql_fromClause_copy;
-	/* Transform the new src_sql & get the output type of that agg function*/
+	((SelectStmt *)stmt->srcSql)->withClause = with_clause;
+
+	/* we rewrite srcSql object refereces again because we used a new copy of fromClause */
+	if (enable_schema_mapping())
+		rewrite_object_refs((Node *)stmt->srcSql);
+
+	/* transform src_sql and get the output datatype of that agg function */
 	temp_src_query = parse_sub_analyze((Node *) stmt->srcSql, pstate, NULL,
 									false,
 									false);
@@ -4696,7 +4725,7 @@ transform_pivot_clause(ParseState *pstate, SelectStmt *stmt)
 	for(int i = 0; i < stmt->value_col_strlist->length; i++)
 	{
 		ColumnDef	*tempColDef;
-		tempColDef = makeColumnDef((char *) list_nth(stmt->value_col_strlist, i),
+		tempColDef = makeColumnDef(((String *) list_nth(stmt->value_col_strlist, i))->sval,
 									((Aggref *)aggfunc_te->expr)->aggtype, 
 									-1,
 									((Aggref *)aggfunc_te->expr)->aggcollid

--- a/test/JDBC/expected/pivot-vu-cleanup.out
+++ b/test/JDBC/expected/pivot-vu-cleanup.out
@@ -41,6 +41,18 @@ GO
 drop table StoreReceipt;
 GO
 
+drop table orders;
+GO
+
+drop table products;
+GO
+
+drop table pivot_schema.products_sch;
+GO
+
+drop schema pivot_schema;
+GO
+
 use master;
 GO
 

--- a/test/JDBC/expected/pivot-vu-prepare.out
+++ b/test/JDBC/expected/pivot-vu-prepare.out
@@ -618,6 +618,73 @@ GO
 ~~ROW COUNT: 1~~
 
 
+CREATE TABLE orders (
+    orderId INT PRIMARY KEY,
+    productId INT,
+    employeeName VARCHAR(4),
+    employeeCode VARBINARY(30),
+    date DATE);
+GO
+
+
+CREATE TABLE products (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+INSERT INTO products VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+~~ROW COUNT: 5~~
+
+
+INSERT INTO orders VALUES
+    (101, 5,'empA', 0x656D7041, '2024-05-01'),
+    (102, 3,'empA', 0x656D7041, '2024-05-01'),
+    (103, 1,'empA', 0x656D7041, '2024-05-01'),
+    (104, 2,'empA', 0x656D7041, '2024-05-01'),
+    (105, 1,'empB', 0x656D7042, '2024-05-01'),
+    (106, 2,'empB', 0x656D7042, '2024-05-01'),
+    (110, 3,'empB', 0x656D7042, '2024-05-01'),
+    (109, 4,'empB', 0x656D7042, '2024-05-01'),
+    (108, 5,'empB', 0x656D7042, '2024-05-01'),
+    (107, 5,'empB', 0x656D7042, '2024-05-01'),
+    (111, 1,'empC', 0x656D7043, '2024-05-01'),
+    (113, 1,'empC', 0x656D7043, '2024-05-01'),
+    (115, 1,'empC', 0x656D7043, '2024-05-01'),
+    (119, 1,'empC', 0x656D7043, '2024-05-01'),
+    (201, 2,'empC', 0x656D7043, '2024-05-01'),
+    (223, 2,'empC', 0x656D7043, '2024-05-01'),
+    (224, 5,'empD', 0x656D7044, '2024-05-01'),
+    (202, 3,'empD', 0x656D7044, '2024-05-01'),
+    (190, 1,'empD', 0x656D7044, '2024-05-01');
+GO
+~~ROW COUNT: 19~~
+
+
+create schema pivot_schema;
+GO
+
+CREATE TABLE pivot_schema.products_sch (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+GO
+
+INSERT INTO pivot_schema.products_sch VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+~~ROW COUNT: 5~~
+
 
 create table pivot_insert_into(ManufactureID int, EmployeeID int, p1 int, p2 int, p3 int, p4 int, p5 int);
 GO

--- a/test/JDBC/expected/pivot-vu-verify.out
+++ b/test/JDBC/expected/pivot-vu-verify.out
@@ -1124,7 +1124,6 @@ Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000
 ~~END~~
 
 
-
 -- CTE test 2
 WITH
 SalesTotal AS
@@ -1235,8 +1234,97 @@ Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000#!#4535.0000#!#23425.00
 ~~END~~
 
 
+-- Test stmt of CTE table and PIVOT stmt in different level 
+WITH
+SalesTotal AS
+(
+    SELECT FruitType,
+        [2023] AS [2023_Total],
+        [2024] AS [2024_Total]
+    FROM #FruitSales
+    PIVOT(SUM(FruitSales)
+    FOR SalesYear IN([2023], [2024])
+    ) AS PivotSales
+)
+SELECT st.FruitType, st.[2023_Total], sa.[2023_Avg],
+  st.[2024_Total], sa.[2024_Avg]
+FROM SalesTotal AS st
+JOIN (
+    SELECT FruitType,
+        [2023] AS [2023_Avg],
+        [2024] AS [2024_Avg]
+    FROM #FruitSales
+    PIVOT(AVG(FruitSales)
+    FOR SalesYear IN([2023], [2024])
+    ) AS PivotSales
+) sa ON st.FruitType = sa.FruitType;
+GO
+~~START~~
+varchar#!#money#!#money#!#money#!#money
+Banana#!#31201.0000#!#15600.5000#!#51381.0000#!#25690.5000
+Orange#!#17025.0000#!#8512.5000#!#77659.0000#!#38829.5000
+~~END~~
+
+
 DROP TABlE IF EXISTS #FruitSales
 GO
+
+-- PIVOT with CTE as source table
+WITH cte_table AS (
+    SELECT [p].productName, [o].[employeeName]
+    FROM orders [o] JOIN products AS [p] on (o.productId = p.productId)
+)
+SELECT CAST('COUNT' AS VARCHAR(10)), [mac],[ipad],[charger] FROM cte_table
+PIVOT (
+    COUNT(employeeName)
+    FOR productName IN (mac, [iphone], [ipad], [charger])
+) as pvt
+GO
+~~START~~
+varchar#!#int#!#int#!#int
+COUNT#!#7#!#4#!#1
+~~END~~
+
+
+-- string is not allowed in PIVOT column value list
+WITH cte_table AS (
+    SELECT o.[orderId], o.[productId], [p].productName,
+        [p].productPrice, [o].[employeeName], [o].employeeCode, [o].date
+    FROM orders [o] JOIN products AS [p] on (o.productId = p.productId)
+)
+SELECT * FROM cte_table
+PIVOT (
+    COUNT(orderId)
+    FOR productName IN ('mac', 'iphone', 'ipad', 'charger')
+) as p
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "'mac'")~~
+
+
+-- aggregate column in PIVOT column value list is not allowed
+WITH cte_table AS
+(
+  SELECT
+    CAST('COUNT' AS VARCHAR(10)) AS COUNT,
+    [mac], [ipad], [charger], [employeeName]
+  FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM orders [o] JOIN products AS [p] on ([o].productId = [p].productId)
+  ) AS dervied_table
+PIVOT
+  (
+      COUNT(employeeName)
+      FOR productName IN ([mac], [employeeName], [iphone], [ipad], [charger])
+  ) as pvt
+)
+SELECT * FROM cte_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The column name "employeename" specified in the PIVOT operator conflicts with the existing column name in the PIVOT argument.)~~
+
 
 -- Join stmts inside PIVOT statment (BABEL-4558)
 SELECT Oid, [1] AS TYPE1, [2] AS TYPE2, [3] AS TYPE3
@@ -1819,5 +1907,39 @@ varchar#!#varchar#!#varchar
 SEAT1#!#LEFT#!#RIGHT
 SEAT2#!#LEFT#!#<NULL>
 SEAT3#!#LEFT#!#RIGHT
+~~END~~
+
+
+-- test pivot with table in different schemas 1
+SELECT CAST('COUNT' AS VARCHAR(10)) AS COUNT, [mac], [ipad], [charger]
+FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM dbo.orders [o] JOIN products AS [p] on ([o].productId = [p].productId)
+) AS dervied_table
+PIVOT(
+     COUNT(employeeName)
+     FOR productName IN ([mac], [iphone], [ipad], [charger])
+) as pvt
+GO
+~~START~~
+varchar#!#int#!#int#!#int
+COUNT#!#7#!#4#!#1
+~~END~~
+
+
+-- test pivot with table in different schemas 2
+SELECT CAST('COUNT' AS VARCHAR(10)) AS COUNT, [mac], [ipad], [charger]
+FROM (
+    SELECT [o].employeeName, [p].productName
+    FROM dbo.orders [o] JOIN pivot_schema.products_sch AS [p] on ([o].productId = [p].productId)
+) AS dervied_table
+PIVOT(
+     COUNT(employeeName)
+     FOR productName IN ([mac], [iphone], [ipad], [charger])
+) as pvt
+GO
+~~START~~
+varchar#!#int#!#int#!#int
+COUNT#!#7#!#4#!#1
 ~~END~~
 

--- a/test/JDBC/input/pivot-vu-cleanup.sql
+++ b/test/JDBC/input/pivot-vu-cleanup.sql
@@ -37,6 +37,18 @@ GO
 drop table StoreReceipt;
 GO
 
+drop table orders;
+GO
+
+drop table products;
+GO
+
+drop table pivot_schema.products_sch;
+GO
+
+drop schema pivot_schema;
+GO
+
 use master;
 GO
 

--- a/test/JDBC/input/pivot-vu-prepare.sql
+++ b/test/JDBC/input/pivot-vu-prepare.sql
@@ -218,6 +218,67 @@ insert into StoreReceipt (OrderID, ItemID, Price, EmployeeID, StoreID, Manufactu
 insert into StoreReceipt (OrderID, ItemID, Price, EmployeeID, StoreID, ManufactureID, PurchaseDate) values (200, 2084, 735.91, 223, 5, 1221, '2023-10-30');
 GO
 
+CREATE TABLE orders (
+    orderId INT PRIMARY KEY,
+    productId INT,
+    employeeName VARCHAR(4),
+    employeeCode VARBINARY(30),
+    date DATE);
+GO
+
+CREATE TABLE products (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+
+INSERT INTO products VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
+
+INSERT INTO orders VALUES
+    (101, 5,'empA', 0x656D7041, '2024-05-01'),
+    (102, 3,'empA', 0x656D7041, '2024-05-01'),
+    (103, 1,'empA', 0x656D7041, '2024-05-01'),
+    (104, 2,'empA', 0x656D7041, '2024-05-01'),
+    (105, 1,'empB', 0x656D7042, '2024-05-01'),
+    (106, 2,'empB', 0x656D7042, '2024-05-01'),
+    (110, 3,'empB', 0x656D7042, '2024-05-01'),
+    (109, 4,'empB', 0x656D7042, '2024-05-01'),
+    (108, 5,'empB', 0x656D7042, '2024-05-01'),
+    (107, 5,'empB', 0x656D7042, '2024-05-01'),
+    (111, 1,'empC', 0x656D7043, '2024-05-01'),
+    (113, 1,'empC', 0x656D7043, '2024-05-01'),
+    (115, 1,'empC', 0x656D7043, '2024-05-01'),
+    (119, 1,'empC', 0x656D7043, '2024-05-01'),
+    (201, 2,'empC', 0x656D7043, '2024-05-01'),
+    (223, 2,'empC', 0x656D7043, '2024-05-01'),
+    (224, 5,'empD', 0x656D7044, '2024-05-01'),
+    (202, 3,'empD', 0x656D7044, '2024-05-01'),
+    (190, 1,'empD', 0x656D7044, '2024-05-01');
+GO
+
+create schema pivot_schema;
+GO
+
+CREATE TABLE pivot_schema.products_sch (
+    productId int PRIMARY KEY,
+    productName VARCHAR(30),
+    productPrice INT
+)
+GO
+
+INSERT INTO pivot_schema.products_sch VALUES
+    (1, 'mac', 250000),
+    (2, 'iphone', 80000),
+    (3, 'airpods', 20000),
+    (4, 'charger', 2900),
+    (5, 'ipad', 50000)
+GO
 
 create table pivot_insert_into(ManufactureID int, EmployeeID int, p1 int, p2 int, p3 int, p4 int, p5 int);
 GO


### PR DESCRIPTION
### Description

  Fixed BBF PIVOT stmt cannot use CTE as source table.
  Fixed string in pivot clumn value list caused crash
  Fixed conflicting column name is allowed in BBF PIVOT clause


### Issues Resolved

BABEL-4958, BABEL-4959, BABEL-4960, BABEL-4977

### Test Scenarios Covered ###
* **Use case based -**
    - string in PIVOT column value list (BABEL-4958)
    - PIVOT with CTE as source table
    - aggregate column in PIVOT column value list
    - completely qualified name (dbname.schema_name.table_name.column_name)
    - PIVOT  in different stmt level (within and out of CTE)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).