### PR TITLE
Update TDS error handling to support special characters

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2618,7 +2618,7 @@ TdsSendInfoOrError(int token, int number, int state, int class,
 	int			messageLen = strlen(message);
 	int			serverNameLen = strlen(serverName);
 	int			procNameLen = strlen(procName);
-	int16_t		messageLen_16 = pg_mbstrlen(message);
+	int16_t		messageLen_16;
 	int32_t		number_32 = (int32_t) number;
 	int32_t		lineNo_32 = (int32_t) lineNo;
 	int16_t		totalLen;
@@ -2641,6 +2641,8 @@ TdsSendInfoOrError(int token, int number, int state, int class,
 	TdsUTF8toUTF16StringInfo(&messageUtf16, message, messageLen);
 	TdsUTF8toUTF16StringInfo(&serverNameUtf16, serverName, serverNameLen);
 	TdsUTF8toUTF16StringInfo(&procNameUtf16, procName, procNameLen);
+
+	messageLen_16 = messageUtf16.len / 2;
 
 	SendPendingDone(true);
 

--- a/test/JDBC/expected/BABEL-4792.out
+++ b/test/JDBC/expected/BABEL-4792.out
@@ -1,0 +1,137 @@
+-- Initialize Procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+
+-- Expect error for duplicate procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
+
+
+-- Expect error for duplicate function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
+
+
+-- Cleanup
+drop proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Expect error for duplicate function 
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
+
+
+-- Cleanup
+drop function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize View
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+
+-- Expect error for duplicate view
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~
+
+
+-- Expect error for duplicate relation
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~
+
+
+-- Cleanup
+drop view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Expect error for duplicate table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~
+
+
+-- Cleanup
+drop table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+create table t1 (
+    col1 int
+);
+go
+
+-- Initialize Trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+
+-- Expect error for duplicate trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: trigger "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" for relation "t1" already exists)~~
+
+
+-- Cleanup
+drop trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+drop table t1
+go

--- a/test/JDBC/input/BABEL-4792.sql
+++ b/test/JDBC/input/BABEL-4792.sql
@@ -1,0 +1,109 @@
+-- Initialize Procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+
+-- Expect error for duplicate procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+
+-- Expect error for duplicate function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Cleanup
+drop proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Expect error for duplicate function 
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Cleanup
+drop function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize View
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+
+-- Expect error for duplicate view
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+
+-- Expect error for duplicate relation
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Cleanup
+drop view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Expect error for duplicate table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Cleanup
+drop table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+create table t1 (
+    col1 int
+);
+go
+
+-- Initialize Trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+
+-- Expect error for duplicate trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+
+-- Cleanup
+drop trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+drop table t1
+go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -530,3 +530,4 @@ babel_test_int2_numeric_oper
 login_token-dep
 test_like_for_AI
 BABEL-4869
+BABEL-4792

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -530,4 +530,3 @@ babel_test_int2_numeric_oper
 login_token-dep
 test_like_for_AI
 BABEL-4869
-BABEL-4792


### PR DESCRIPTION
### Description

1. This commit modifies TDS error message handling to add support for special characters such as emojis
2. An earlier commit introduced error handling when users attempt to create a procedure / function with the same name as one that is already defined. In recent testing, we found that if a user attempts to recreate an existing procedure that contains certain special characters, there will be a TDS error.
3. We are relying on pg_mbstrlen to calculate the error string length ([code link](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_4_X_DEV/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c#L2621)). This pg_mbstrlen would calculate length of certain characters such as emoji and others as a 1 whereas it should be counted as 2 in UTF16. Hence, for given error string, pg_mbstrlen is calculating the length of error string as 91 whereas it should be 93 characters in UTF16. So we need to update this logic to compute messageLen_16 to use messageUtf16.len / 2 instead of using pg_mbstrlen. 


### Issues Resolved
Task: BABEL-4972

### Test Scenarios Covered ###
* **Use case based -**

```
-- Initialize Procedure
create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
go

-- Expect error for duplicate procedure
create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
go
~~ERROR (Code: 2714)~~

~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~


-- Expect error for duplicate function
create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
returns varchar(250)
as begin
    return "test"
end
go
~~ERROR (Code: 2714)~~

~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
```

```
-- Initialize View
create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
as
    select 1
go

-- Expect error for duplicate view
create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
as
    select 1
go
~~ERROR (Code: 2714)~~

~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~


create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
    col1 int
);
go
~~ERROR (Code: 2714)~~

~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~


-- Cleanup
drop view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
go
```


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).