### PR TITLE
Add tests for ENR temp table transactions

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1139,6 +1139,15 @@ define_custom_variables(void)
 							   GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							   check_babelfish_dump_restore_min_oid, NULL, NULL);
 
+	DefineCustomBoolVariable("babelfishpg_tsql.temp_table_xact_support",
+							 gettext_noop("Enable temp table changes to respect transactional behavior"),
+							 NULL,
+							 &temp_table_xact_support,
+							 true,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+
 	/* T-SQL Hint Mapping */
 	DefineCustomBoolVariable("babelfishpg_tsql.enable_hint_mapping",
 							 gettext_noop("Enables T-SQL hint mapping in ANTLR parser"),

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9693,14 +9693,10 @@ pltsql_xact_cb(XactEvent event, void *arg)
 	 */
 	if (event == XACT_EVENT_COMMIT || event == XACT_EVENT_PREPARE)
 	{
-		if (temp_table_xact_support)
-			ENRCommitChanges(currentQueryEnv);
 		txn_clean_estate(true);
 	}
 	else if (event == XACT_EVENT_ABORT)
 	{
-		if (temp_table_xact_support)
-			ENRRollbackChanges(currentQueryEnv);
 		simple_econtext_stack = NULL;
 		shared_simple_eval_estate = NULL;
 	}
@@ -9723,9 +9719,6 @@ pltsql_subxact_cb(SubXactEvent event, SubTransactionId mySubid,
 {
 	if (event == SUBXACT_EVENT_COMMIT_SUB || event == SUBXACT_EVENT_ABORT_SUB)
 	{
-		if (temp_table_xact_support && event == SUBXACT_EVENT_ABORT_SUB)
-			ENRRollbackSubtransaction(mySubid, currentQueryEnv);
-
 		while (simple_econtext_stack != NULL &&
 			   simple_econtext_stack->xact_subxid == mySubid)
 		{

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9693,10 +9693,14 @@ pltsql_xact_cb(XactEvent event, void *arg)
 	 */
 	if (event == XACT_EVENT_COMMIT || event == XACT_EVENT_PREPARE)
 	{
+		if (temp_table_xact_support)
+			ENRCommitChanges(currentQueryEnv);
 		txn_clean_estate(true);
 	}
 	else if (event == XACT_EVENT_ABORT)
 	{
+		if (temp_table_xact_support)
+			ENRRollbackChanges(currentQueryEnv);
 		simple_econtext_stack = NULL;
 		shared_simple_eval_estate = NULL;
 	}
@@ -9719,6 +9723,9 @@ pltsql_subxact_cb(SubXactEvent event, SubTransactionId mySubid,
 {
 	if (event == SUBXACT_EVENT_COMMIT_SUB || event == SUBXACT_EVENT_ABORT_SUB)
 	{
+		if (temp_table_xact_support && event == SUBXACT_EVENT_ABORT_SUB)
+			ENRRollbackSubtransaction(mySubid, currentQueryEnv);
+
 		while (simple_econtext_stack != NULL &&
 			   simple_econtext_stack->xact_subxid == mySubid)
 		{

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -757,8 +757,6 @@ void
 PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 {
 	elog(DEBUG2, "TSQL TXN Commit transaction %d", NestedTranCount);
-	if (temp_table_xact_support)
-		ENRCommitChanges(currentQueryEnv);
 	if (NestedTranCount <= 1)
 	{
 		RequireTransactionBlock(true, "COMMIT");
@@ -782,8 +780,6 @@ PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 void
 PLTsqlRollbackTransaction(char *txnName, QueryCompletion *qc, bool chain)
 {
-	if (temp_table_xact_support)
-		ENRRollbackChanges(currentQueryEnv);
 	if (IsTopTransactionName(txnName))
 	{
 		elog(DEBUG2, "TSQL TXN Rollback transaction");

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -19,7 +19,6 @@
 #include "utils/fmgroids.h"
 #include "utils/catcache.h"
 #include "utils/acl.h"
-#include "utils/queryenvironment.h"
 #include "access/table.h"
 #include "access/genam.h"
 #include "catalog.h"

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -756,8 +756,9 @@ PLTsqlStartTransaction(char *txnName)
 void
 PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 {
-	ENRCommitChanges(currentQueryEnv);
 	elog(DEBUG2, "TSQL TXN Commit transaction %d", NestedTranCount);
+	if (temp_table_xact_support)
+		ENRCommitChanges(currentQueryEnv);
 	if (NestedTranCount <= 1)
 	{
 		RequireTransactionBlock(true, "COMMIT");
@@ -781,7 +782,8 @@ PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 void
 PLTsqlRollbackTransaction(char *txnName, QueryCompletion *qc, bool chain)
 {
-	ENRRollbackChanges(currentQueryEnv);
+	if (temp_table_xact_support)
+		ENRRollbackChanges(currentQueryEnv);
 	if (IsTopTransactionName(txnName))
 	{
 		elog(DEBUG2, "TSQL TXN Rollback transaction");

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -19,6 +19,7 @@
 #include "utils/fmgroids.h"
 #include "utils/catcache.h"
 #include "utils/acl.h"
+#include "utils/queryenvironment.h"
 #include "access/table.h"
 #include "access/genam.h"
 #include "catalog.h"
@@ -755,6 +756,7 @@ PLTsqlStartTransaction(char *txnName)
 void
 PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 {
+	ENRCommitChanges(currentQueryEnv);
 	elog(DEBUG2, "TSQL TXN Commit transaction %d", NestedTranCount);
 	if (NestedTranCount <= 1)
 	{
@@ -779,6 +781,7 @@ PLTsqlCommitTransaction(QueryCompletion *qc, bool chain)
 void
 PLTsqlRollbackTransaction(char *txnName, QueryCompletion *qc, bool chain)
 {
+	ENRRollbackChanges(currentQueryEnv);
 	if (IsTopTransactionName(txnName))
 	{
 		elog(DEBUG2, "TSQL TXN Rollback transaction");

--- a/test/JDBC/expected/temp_table_mixed_rollback.out
+++ b/test/JDBC/expected/temp_table_mixed_rollback.out
@@ -1,0 +1,74 @@
+-- tsql
+
+CREATE PROCEDURE tsql_proc1
+AS
+    BEGIN TRAN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 VALUES (1)
+    SELECT * FROM #t1
+    ROLLBACK
+GO
+
+
+-- psql
+
+CREATE PROCEDURE pg_proc1()
+AS
+$$
+BEGIN
+    INSERT INTO my_table VALUES(1);    
+    ROLLBACK;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE pg_proc2()
+AS
+$$
+BEGIN
+    INSERT INTO my_table VALUES(2);    
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql 
+CREATE TABLE my_table(a int)
+GO
+
+EXEC tsql_proc1
+EXEC [public].pg_proc1
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+BEGIN TRAN
+EXEC [public].pg_proc2
+ROLLBACK
+GO
+
+SELECT * FROM my_table
+DROP TABLE my_table
+GO
+~~START~~
+int
+~~END~~
+
+
+
+-- tsql
+
+DROP PROCEDURE tsql_proc1;
+GO
+
+-- psql
+
+DROP PROCEDURE pg_proc1;
+GO
+
+DROP PROCEDURE pg_proc2;
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -1,2 +1,8 @@
 DROP VIEW enr_view
 GO
+
+DROP PROCEDURE test_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -1,6 +1,9 @@
 DROP VIEW enr_view
 GO
 
+DROP TYPE temp_table_type
+GO
+
 DROP PROCEDURE test_rollback_in_proc
 GO
 

--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -1,0 +1,2 @@
+DROP VIEW enr_view
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -9,3 +9,6 @@ GO
 
 DROP PROCEDURE implicit_rollback_in_proc
 GO
+
+DROP PROCEDURE tv_base_rollback
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -1,0 +1,9 @@
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -7,3 +7,49 @@ CREATE VIEW enr_view AS
         END AS relname
     FROM sys.babelfish_get_enr_list()
 GO
+
+
+CREATE PROCEDURE test_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1 ADD b varchar(50)
+        TRUNCATE TABLE #t1
+        INSERT INTO #t1 VALUES (1, 'two')
+        select * from #t1
+        DROP TABLE #t1
+        CREATE TABLE #t1(a varchar(100))
+        INSERT INTO #t1 VALUES ('three')
+        select * from #t1
+        CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+        INSERT INTO #t2 VALUES ('four')
+        SELECT * FROM #t2
+        DROP TABLE #t2
+    ROLLBACK;
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    CREATE TABLE #t1(a int)
+    ALTER TABLE #t1 ADD b varchar(50)
+    INSERT INTO #t1 VALUES (1, 'two')
+    select * from #t1
+    DROP TABLE #t1
+    CREATE TABLE #t1(a varchar(100))
+    INSERT INTO #t1 VALUES ('three')
+    select * from #t1
+    CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+    INSERT INTO #t2 VALUES ('four')
+    SELECT * FROM #t2
+    DROP TABLE #t2
+    INSERT INTO #t1 values (1, 2, 3)
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -8,6 +8,9 @@ CREATE VIEW enr_view AS
     FROM sys.babelfish_get_enr_list()
 GO
 
+CREATE TYPE temp_table_type FROM int
+GO
+
 
 CREATE PROCEDURE test_rollback_in_proc AS
 BEGIN

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -56,3 +56,11 @@ BEGIN
     SELECT * FROM #t2
 END
 GO
+
+CREATE PROCEDURE tv_base_rollback AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    INSERT INTO mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+END
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -60,7 +60,7 @@ GO
 CREATE PROCEDURE tv_base_rollback AS
 BEGIN
     DECLARE @tv TABLE (a int)
-    INSERT INTO mytab VALUES (1)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
     INSERT INTO @tv VALUES (1)
 END
 GO

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -853,16 +853,16 @@ four#!#1
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
 
-CREATE TABLE mytab(a int)
+CREATE TABLE temp_tab_rollback_mytab(a int)
 GO
 
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 INSERT INTO #t1 VALUES (1)
 EXEC tv_base_rollback
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 ROLLBACK
-SELECT * FROM mytab
+SELECT * FROM temp_tab_rollback_mytab
 GO
 ~~ROW COUNT: 1~~
 
@@ -875,7 +875,7 @@ int
 ~~END~~
 
 
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 GO
 
 -- Everything should be rolled back due to error

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -257,117 +257,6 @@ text
 ~~END~~
 
 
-----------------------------------------------------------
--- Nested transactions
-----------------------------------------------------------
-BEGIN TRANSACTION T1
-    CREATE TABLE #t1(a varchar(16))
-    INSERT INTO #t1 VALUES ('t1')
-    SAVE TRANSACTION T2
-        INSERT INTO #t1 VALUES ('t2')
-        SAVE TRANSACTION T3
-            INSERT INTO #t1 VALUES ('t3')
-            SAVE TRANSACTION T4
-                INSERT INTO #t1 VALUES ('t4')
-                SELECT * FROM #t1
-            ROLLBACK TRANSACTION T4
-            SELECT * FROM #t1
-        ROLLBACK TRANSACTION T3
-        SELECT * FROM #t1
-    ROLLBACK TRANSACTION T2
-    SELECT * FROM #t1
-ROLLBACK TRANSACTION T1
-SELECT * FROM #t1
-GO
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
-~~START~~
-varchar
-t1
-t2
-t3
-t4
-~~END~~
-
-~~START~~
-varchar
-t1
-t2
-t3
-~~END~~
-
-~~START~~
-varchar
-t1
-t2
-~~END~~
-
-~~START~~
-varchar
-t1
-~~END~~
-
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: relation "#t1" does not exist)~~
-
-
-
-
-
--- SELECT * FROM enr_view;
--- GO
--- BEGIN TRANSACTION T1
---     SAVE TRANSACTION S2
---         create table #t3(a int)
---         create table #t4(a int identity primary key, b varchar(50))
---         insert into #t3 values (5)
---         insert into #t4 values ('six')
---         SELECT * FROM #t3
---         SELECT * FROM #t4
---         SELECT * FROM enr_view;
---     ROLLBACK TRANSACTION S2
---     SELECT * FROM enr_view;
--- COMMIT
--- GO
-----------------------------------------------------------
--- Savepoint CREATE and DROP
-----------------------------------------------------------
-BEGIN TRANSACTION T1
-    CREATE TABLE #t1(a int primary key, b varchar(16))
-    SAVE TRANSACTION T2
-        INSERT INTO #t1 VALUES (1, 't2')
-        SAVE TRANSACTION T3
-            UPDATE #t1 SET a = 2 WHERE a = 1
-            SELECT * FROM #t1
-            SAVE TRANSACTION T4
-                DROP TABLE #t1
-            ROLLBACK TRANSACTION T4
-        ROLLBACK TRANSACTION T3
-        SELECT * FROM #t1
-    ROLLBACK TRANSACTION T2
-select * from enr_view
-GO
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
-~~START~~
-int#!#varchar
-2#!#t2
-~~END~~
-
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: relation "#t1" does not exist)~~
-
-
 
 ---------------------------------------------------------------------------
 -- Same temp table name in one transaction
@@ -454,11 +343,9 @@ GO
 CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
 GO
 
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
-        INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
-    ROLLBACK TRANSACTION S2
+BEGIN TRAN
+    CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+    INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
 COMMIT
 GO
 ~~ROW COUNT: 1~~
@@ -468,6 +355,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 ~~END~~
 
 
@@ -480,22 +368,32 @@ BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
 ROLLBACK
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
 ~~END~~
 
 
 CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
 ~~END~~
 
@@ -518,11 +416,9 @@ text
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
 
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
-        INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
-    ROLLBACK TRANSACTION S2
+BEGIN TRAN
+    DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+    INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
 COMMIT
 GO
 ~~ROW COUNT: 1~~
@@ -532,7 +428,9 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
+3#!#c#!#4#!#5
 ~~END~~
 
 
@@ -540,9 +438,27 @@ BEGIN TRAN
     DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
@@ -550,24 +466,18 @@ GO
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
 
--- Create and drop in transaction
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
-        DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
-    ROLLBACK TRANSACTION S2
-COMMIT
-GO
-
 SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
+3#!#c#!#4#!#5
 ~~END~~
 
 
-BEGIN TRAN T1
+-- Create and drop in transaction
+BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
     DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
 ROLLBACK
@@ -577,7 +487,9 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
+3#!#c#!#4#!#5
 ~~END~~
 
 
@@ -589,7 +501,9 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
+3#!#c#!#4#!#5
 ~~END~~
 
 
@@ -597,23 +511,7 @@ int#!#varchar#!#int#!#int
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
 GO
 
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
-        CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
-    ROLLBACK TRANSACTION S2
-COMMIT
-GO
-
-SELECT * FROM #temp_table_rollback_t5
-GO
-~~START~~
-int#!#varchar#!#int#!#int
-2#!#b#!#3#!#4
-~~END~~
-
-
-BEGIN TRAN T1
+BEGIN TRAN
     DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
     CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
 ROLLBACK
@@ -623,7 +521,9 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
+3#!#c#!#4#!#5
 ~~END~~
 
 
@@ -635,7 +535,9 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
 2#!#b#!#3#!#4
+3#!#c#!#4#!#5
 ~~END~~
 
 

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -703,6 +703,80 @@ text
 ~~END~~
 
 
+
+-- DELETE, TRUNCATE
+CREATE TABLE #t1(a int identity primary key, b int)
+INSERT INTO #t1 VALUES (0)
+INSERT INTO #t1 VALUES (1)
+INSERT INTO #t1 VALUES (2)
+INSERT INTO #t1 VALUES (3)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+    DELETE FROM #t1
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+~~END~~
+
+
+-- Truncate should reset IDENTITY. But it should be restored on ROLLBACK.
+BEGIN TRAN
+    TRUNCATE TABLE #t1
+    INSERT INTO #t1 VALUES (1)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+
+INSERT INTO #t1 VALUES (4)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+5#!#4
+~~END~~
+
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
@@ -778,6 +852,31 @@ four#!#1
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
+
+CREATE TABLE mytab(a int)
+GO
+
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+EXEC tv_base_rollback
+DROP TABLE mytab
+ROLLBACK
+SELECT * FROM mytab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+
+DROP TABLE mytab
+GO
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
@@ -1072,6 +1171,9 @@ int
 ~~END~~
 
 
+DROP TABLE #t1
+GO
+
 
 
 
@@ -1155,4 +1257,78 @@ int
 
 
 DROP TABLE perm_tab
+GO
+
+
+---------------------------------------------------------------------------
+-- Trigger (can't be created on temp tables)
+---------------------------------------------------------------------------
+CREATE TABLE basetab(a int, b int)
+GO
+
+CREATE TRIGGER basetrig_insert ON basetab 
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (1)
+GO
+
+CREATE TABLE #t1(a int)
+GO
+
+BEGIN TRAN
+    INSERT INTO basetab VALUES (1, 2)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM basetab
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+
+CREATE TRIGGER basetrig_rollback ON basetab
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (2)
+    ROLLBACK
+GO
+
+INSERT INTO basetab VALUES (3, 4)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 3609)~~
+
+~~ERROR (Message: The transaction ended in the trigger. The batch has been aborted.)~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int
+~~END~~
+
+
+DROP TRIGGER basetrig_insert
+GO
+
+DROP TABLE basetab
 GO

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -32,6 +32,73 @@ GO
 ~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
 
 
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t1(a int, b int)
+GO
+
+INSERT INTO #t1 VALUES (1, 1)
+INSERT INTO #t1 VALUES (2, 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #t1 VALUES (3, 1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
+BEGIN TRAN
+UPDATE #t1 SET a = a + 1 WHERE b = 1
+SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
 -----------------------------
 -- Temp Table DROP + ROLLBACK
 -----------------------------
@@ -196,6 +263,87 @@ text
 ~~END~~
 
 
+CREATE TABLE #t1(a int, b int)
+GO
+
+CREATE TABLE #t2(c varchar(20), d int)
+GO
+
+INSERT INTO #t1 VALUES (1, 1)
+INSERT INTO #t1 VALUES (2, 1)
+INSERT INTO #t2 VALUES ('abc', 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #t1 VALUES (3, 1)
+INSERT INTO #t2 VALUES ('def', 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
+BEGIN TRAN
+UPDATE #t1 SET a = a + 1 WHERE b = 1
+UPDATE #t2 SET c = 'qed' WHERE d = 1
+SELECT * FROM #t1
+SELECT * FROM #t2
+ROLLBACK
+GO
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+qed#!#1
+qed#!#1
+~~END~~
+
+
+SELECT * FROM #t1
+SELECT * FROM #t2
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+abc#!#1
+def#!#1
+~~END~~
+
+
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
 ----------------------------------------------------------
 -- Implicit rollback due to error
 ----------------------------------------------------------
@@ -349,7 +497,7 @@ GO
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
     INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
-COMMIT
+ROLLBACK
 GO
 ~~ROW COUNT: 1~~
 
@@ -358,7 +506,6 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
 ~~END~~
 
 
@@ -369,40 +516,49 @@ GO
 
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
-ROLLBACK
+    UPDATE #temp_table_rollback_t5 SET b = 'd' WHERE d = 4
+    SELECT * FROM #temp_table_rollback_t5
+COMMIT
 GO
-~~ERROR (Code: 2714)~~
+~~ROW COUNT: 1~~
 
-~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
-
-
-SELECT * FROM #temp_table_rollback_t5
-GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 ~~END~~
 
 
-CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+BEGIN TRAN
+    UPDATE #temp_table_rollback_t5 SET b = 'e' WHERE d = 4
+    SELECT * FROM #temp_table_rollback_t5
+ROLLBACK
 GO
-~~ERROR (Code: 2714)~~
+~~ROW COUNT: 1~~
 
-~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#e#!#3#!#4
+~~END~~
 
 
 SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 ~~END~~
 
 
 DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
 GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+~~END~~
+
 
 SELECT * FROM enr_view
 GO
@@ -431,8 +587,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -450,8 +605,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -473,8 +627,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -490,8 +643,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -504,8 +656,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -524,8 +675,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -538,8 +688,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -638,3 +787,372 @@ GO
 text
 ~~END~~
 
+
+---------------------------------------------------------------------------
+-- Mixed permanent, TV, temp tables in/out of ENR.
+---------------------------------------------------------------------------
+-- Mixed create rollback
+BEGIN TRAN
+    DECLARE @tv TABLE (a1 int)
+    CREATE TABLE #temp_table(a2 int)
+    CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+-- Mixed insert rollback
+DECLARE @tv TABLE (a1 int)
+CREATE TABLE perm_table(a2 int)
+CREATE TABLE #temp_table(a3 int)
+CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+BEGIN TRAN
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO perm_table VALUES(2)
+    INSERT INTO #temp_table VALUES(3)
+    INSERT INTO #temp_table_nonenr VALUES (4)
+    SELECT * FROM @tv
+    SELECT * FROM perm_table
+    SELECT * FROM #temp_table
+    SELECT * FROM #temp_table_nonenr
+ROLLBACK
+-- Unaffected by rollback
+SELECT * FROM @tv
+-- Correctly rolled back
+SELECT * FROM perm_table
+-- Correctly rolled back
+SELECT * FROM #temp_table
+SELECT * FROM #temp_table_nonenr
+SELECT * FROM enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+text
+@tv_0
+#temp_table
+~~END~~
+
+
+SELECT * FROM enr_view
+DROP TABLE #temp_table
+DROP TABLE #temp_table_nonenr
+DROP TABLE perm_table
+GO
+~~START~~
+text
+#temp_table
+~~END~~
+
+
+-- Mixed drop rollback
+CREATE TABLE #temp_table(a int)
+CREATE TABLE perm_table(a int)
+CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+GO
+
+BEGIN TRAN
+    DECLARE @tv TABLE(a int)
+    SELECT * FROM enr_view
+    DROP TABLE #temp_table
+    DROP TABLE perm_table
+    DROP TABLE #temp_table_nonenr
+    SELECT * FROM enr_view
+ROLLBACK
+GO
+~~START~~
+text
+#temp_table
+@tv_0
+~~END~~
+
+~~START~~
+text
+@tv_0
+~~END~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#temp_table
+~~END~~
+
+
+DROP TABLE #temp_table
+DROP TABLE perm_table
+DROP TABLE #temp_table_nonenr
+GO
+
+
+---------------------------------------------------------------------------
+-- Multiple COMMIT/ROLLBACK
+---------------------------------------------------------------------------
+CREATE TABLE #t1(a int)
+GO
+
+
+
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+COMMIT
+BEGIN TRAN
+UPDATE #t1 SET a = 2 WHERE a = 1
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+
+
+
+
+------------------------
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+COMMIT
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+CREATE TABLE #t2(a int identity primary key, b varchar)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+CREATE INDEX #t2_idx ON #t2(b)
+INSERT INTO #t2 VALUES ('a')
+ROLLBACK
+BEGIN TRAN
+CREATE INDEX #t2_idx ON #t2(b)
+INSERT INTO #t2 VALUES ('b')
+SELECT * FROM #t1
+SELECT * FROM #t2
+DROP TABLE #t1
+DROP TABLE #t2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#b
+~~END~~
+
+
+
+
+
+
+
+----------------------------
+BEGIN TRAN 
+CREATE TABLE #t1(a int)
+CREATE TABLE #t2(a int)
+ROLLBACK
+BEGIN TRAN
+CREATE TABLE #t1(a varchar)
+CREATE TABLE #t2(a varchar)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+DROP TABLE #t2
+COMMIT
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+CREATE TABLE #t2(a int)
+INSERT INTO #t1 VALUES (1)
+ROLLBACK
+SELECT * FROM enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+text
+~~END~~
+
+
+
+
+
+
+
+----------------------------
+BEGIN TRAN
+CREATE TABLE #t1 (a int)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1 
+ROLLBACK
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+SELECT * FROM #t1
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+---------------------------------------------------------------------------
+-- Cursor
+---------------------------------------------------------------------------
+-- Temp into permanent
+DECLARE @v int
+CREATE TABLE #t(a int)
+insert into #t values (1)
+insert into #t values (2)
+insert into #t values (3)
+CREATE TABLE perm_tab(a int)
+DECLARE cur CURSOR FOR (select a from #t)
+OPEN cur
+WHILE @@fetch_status = 0
+BEGIN
+    fetch cur into @v
+    insert into perm_tab values (@v)
+END
+CLOSE cur
+DEALLOCATE cur
+SELECT * FROM perm_tab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+~~END~~
+
+
+
+-- Permanent into temp
+DECLARE @v int
+CREATE TABLE #t2(b int)
+DECLARE cur CURSOR FOR (select a from perm_tab)
+OPEN cur
+WHILE @@fetch_status = 0
+BEGIN
+    fetch cur into @v
+    insert into #t2 values (@v)
+END
+CLOSE cur
+DEALLOCATE cur
+SELECT * FROM #t2
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+<NULL>
+~~END~~
+
+
+DROP TABLE perm_tab
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -1,0 +1,332 @@
+
+-- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
+-------------------------------
+-- Temp Table CREATE + ROLLBACK
+-------------------------------
+BEGIN TRAN
+CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
+select * from enr_view
+ROLLBACK
+GO
+~~START~~
+text
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#temp_table_rollback_t1_pkey
+~~END~~
+
+
+-- Should be empty
+select * from enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+-- Should not exist
+SELECT * FROM #temp_table_rollback_t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
+
+
+-----------------------------
+-- Temp Table DROP + ROLLBACK
+-----------------------------
+CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
+go
+
+INSERT INTO #temp_table_rollback_t1 VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+ROLLBACK
+go
+
+-- Should still exist
+select * from enr_view
+GO
+~~START~~
+text
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#temp_table_rollback_t1_pkey
+~~END~~
+
+
+-- Should show results
+BEGIN TRAN
+select * from #temp_table_rollback_t1
+COMMIT
+go
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+
+-- Should not error
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+COMMIT
+GO
+
+----------------------------------------------------------
+-- ALTER TABLE (should fail due to BABEL-4912)
+----------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t1 (a int, b int)
+GO
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
+ROLLBACK
+GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
+ROLLBACK
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
+COMMIT
+GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
+COMMIT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
+
+DROP TABLE #temp_table_rollback_t1
+GO
+
+----------------------------------------------------------
+-- Multiple tables in one transaction
+----------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int, c varchar)
+GO
+
+create table #temp_table_rollback_t2(a varchar)
+GO
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+DROP TABLE #temp_table_rollback_t2
+ROLLBACK
+GO
+
+-- Tables are still visible and usable
+select * from enr_view
+GO
+~~START~~
+text
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#temp_table_rollback_t1_pkey
+#temp_table_rollback_t2
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+~~END~~
+
+
+INSERT INTO #temp_table_rollback_t1 values (1, 'b')
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #temp_table_rollback_t2 values ('c')
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp_table_rollback_t1
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#b
+~~END~~
+
+
+SELECT * FROM #temp_table_rollback_t2
+GO
+~~START~~
+varchar
+c
+~~END~~
+
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+DROP TABLE #temp_table_rollback_t2
+COMMIT
+GO
+
+----------------------------------------------------------
+-- Implicit rollback due to error
+----------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t1(a int primary key, b int, c varchar)
+CREATE TABLE #temp_table_rollback_t2(a int)
+GO
+
+INSERT INTO #temp_table_rollback_t2 VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Transaction will error out
+BEGIN TRAN
+drop table #temp_table_rollback_t2
+insert into #temp_table_rollback_t1 values (1, 1, 1) -- Wrong should error out 
+GO
+~~ROW COUNT: 1~~
+
+
+-- Table + data should still exist, due to implicit rollback. 
+SELECT * FROM #temp_table_rollback_t2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t2" does not exist)~~
+
+
+-- Duplicate key doesn't cause implicit rollback, so the drop will succeed here. 
+BEGIN TRAN
+drop table #temp_table_rollback_t2
+insert into #temp_table_rollback_t1 values (1, 1, 'a')
+insert into #temp_table_rollback_t1 values (1, 1, 'a')
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#temp_table_rollback_t1_pkey")~~
+
+
+SELECT * FROM #temp_table_rollback_t2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t2" does not exist)~~
+
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+DROP TABLE #temp_table_rollback_t2
+COMMIT
+GO
+
+----------------------------------------------------------
+-- Nested transactions
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a varchar(16))
+    INSERT INTO #t1 VALUES ('t1')
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES ('t2')
+        SAVE TRANSACTION T3
+            INSERT INTO #t1 VALUES ('t3')
+            SAVE TRANSACTION T4
+                INSERT INTO #t1 VALUES ('t4')
+                SELECT * FROM #t1
+            ROLLBACK TRANSACTION T4
+            SELECT * FROM #t1
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+    SELECT * FROM #t1
+ROLLBACK TRANSACTION T1
+SELECT * FROM #t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+t1
+t2
+t3
+t4
+~~END~~
+
+~~START~~
+varchar
+t1
+t2
+t3
+~~END~~
+
+~~START~~
+varchar
+t1
+t2
+~~END~~
+
+~~START~~
+varchar
+t1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t1" does not exist)~~
+
+
+----------------------------------------------------------
+-- Savepoint CREATE and DROP
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a int primary key, b varchar(16))
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES (1, 't2')
+        SAVE TRANSACTION T3
+            UPDATE #t1 SET a = 2 WHERE a = 1
+            SELECT * FROM #t1
+            SAVE TRANSACTION T4
+                DROP TABLE #t1
+            ROLLBACK TRANSACTION T4
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+select * from enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#t2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t1" does not exist)~~
+

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -384,3 +384,229 @@ GO
 int#!#char
 ~~END~~
 
+
+DROP TABLE #temp_table_rollback_t4
+GO
+
+CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+GO
+
+
+
+BEGIN TRANSACTION T1
+ALTER TABLE #temp_table_rollback_t4 ADD C3 INT
+DROP TABLE #temp_table_rollback_t4
+CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+DROP  TABLE #temp_table_rollback_t4
+INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
+COMMIT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
+
+
+---------------------------------------------------------------------------
+-- Index creation
+---------------------------------------------------------------------------
+-- Created index in transaction
+CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+        INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+~~END~~
+
+
+INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
+GO
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+    CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t1
+#temp_table_rollback_t2
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t4
+#temp_table_rollback_t5
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+~~END~~
+
+
+
+-- Drop index in transaction
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+        INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+BEGIN TRAN
+    DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+-- Create and drop in transaction
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+        DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+BEGIN TRAN T1
+    CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+    DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+-- Drop - Create
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+        CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+BEGIN TRAN T1
+    DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+    CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+
+
+

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -184,6 +184,18 @@ DROP TABLE #temp_table_rollback_t2
 COMMIT
 GO
 
+BEGIN TRAN
+    CREATE TABLE #t1(a int)
+    ROLLBACK
+GO
+
+SELECT * FROM enr_view
+go
+~~START~~
+text
+~~END~~
+
+
 ----------------------------------------------------------
 -- Implicit rollback due to error
 ----------------------------------------------------------
@@ -237,6 +249,13 @@ DROP TABLE #temp_table_rollback_t1
 DROP TABLE #temp_table_rollback_t2
 COMMIT
 GO
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+~~END~~
+
 
 ----------------------------------------------------------
 -- Nested transactions
@@ -299,6 +318,24 @@ t1
 ~~ERROR (Message: relation "#t1" does not exist)~~
 
 
+
+
+
+-- SELECT * FROM enr_view;
+-- GO
+-- BEGIN TRANSACTION T1
+--     SAVE TRANSACTION S2
+--         create table #t3(a int)
+--         create table #t4(a int identity primary key, b varchar(50))
+--         insert into #t3 values (5)
+--         insert into #t4 values ('six')
+--         SELECT * FROM #t3
+--         SELECT * FROM #t4
+--         SELECT * FROM enr_view;
+--     ROLLBACK TRANSACTION S2
+--     SELECT * FROM enr_view;
+-- COMMIT
+-- GO
 ----------------------------------------------------------
 -- Savepoint CREATE and DROP
 ----------------------------------------------------------
@@ -406,6 +443,9 @@ GO
 ~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
 
 
+DROP TABLE #temp_table_rollback_t4
+GO
+
 
 ---------------------------------------------------------------------------
 -- Index creation
@@ -467,14 +507,6 @@ SELECT * FROM enr_view
 GO
 ~~START~~
 text
-#temp_table_rollback_t1_pkey
-#pg_toast_#oid_masked#_index
-#pg_toast_#oid_masked#
-#temp_table_rollback_t1
-#temp_table_rollback_t2
-#pg_toast_#oid_masked#_index
-#pg_toast_#oid_masked#
-#temp_table_rollback_t4
 #temp_table_rollback_t5
 #pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
@@ -607,6 +639,97 @@ int#!#varchar#!#int#!#int
 ~~END~~
 
 
+DROP TABLE #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
 
 
+---------------------------------------------------------------------------
+-- Procedures
+---------------------------------------------------------------------------
+exec test_rollback_in_proc
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t2" does not exist)~~
+
+
+BEGIN TRANSACTION
+    CREATE TABLE #outer_tab1(a int)
+    SELECT * FROM enr_view
+    exec implicit_rollback_in_proc
+    select * from #outer_tab1
+ROLLBACK
+GO
+~~START~~
+text
+#outer_tab1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+-- Everything should be rolled back due to error
+-- Nothing from the proc should be here either
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
 

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -53,9 +53,9 @@ select * from enr_view
 GO
 ~~START~~
 text
+#temp_table_rollback_t1_pkey
 #temp_table_rollback_t1_a_seq
 #temp_table_rollback_t1
-#temp_table_rollback_t1_pkey
 ~~END~~
 
 
@@ -141,14 +141,14 @@ select * from enr_view
 GO
 ~~START~~
 text
+#temp_table_rollback_t1_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
 #temp_table_rollback_t1_a_seq
 #temp_table_rollback_t1
-#pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
-#temp_table_rollback_t1_pkey
+#pg_toast_#oid_masked#
 #temp_table_rollback_t2
-#pg_toast_#oid_masked#
-#pg_toast_#oid_masked#_index
 ~~END~~
 
 
@@ -329,4 +329,58 @@ int#!#varchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: relation "#t1" does not exist)~~
+
+
+
+---------------------------------------------------------------------------
+-- Same temp table name in one transaction
+---------------------------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
+GO
+
+BEGIN TRANSACTION
+    ALTER TABLE #temp_table_rollback_t3 ADD C3 INT;
+    INSERT INTO #temp_table_rollback_t3 VALUES (1, 2, 3)
+    DROP TABLE #temp_table_rollback_t3
+    CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+
+DROP TABLE #temp_table_rollback_t3
+GO
+
+CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+GO
+
+
+
+BEGIN TRANSACTION
+    DROP TABLE #temp_table_rollback_t4
+    CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+    INSERT INTO #temp_table_rollback_t4 VALUES (1, 'one')
+    SELECT * FROM #temp_table_rollback_t4 -- should return 1, 'one'
+    DROP TABLE #temp_table_rollback_t4
+    INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
+    SELECT * FROM #temp_table_rollback_t4
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#char
+1#!#one       
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
+
+SELECT * FROM #temp_table_rollback_t4
+GO
+~~START~~
+int#!#char
+~~END~~
 

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -211,17 +211,20 @@ GO
 -- Transaction will error out
 BEGIN TRAN
 drop table #temp_table_rollback_t2
-insert into #temp_table_rollback_t1 values (1, 1, 1) -- Wrong should error out 
+insert into #temp_table_rollback_t1 values (1, 1, 1, 1) -- Too many columns, should error out
 GO
-~~ROW COUNT: 1~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
 
 
 -- Table + data should still exist, due to implicit rollback. 
 SELECT * FROM #temp_table_rollback_t2
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: relation "#temp_table_rollback_t2" does not exist)~~
+~~START~~
+int
+1
+~~END~~
 
 
 -- Duplicate key doesn't cause implicit rollback, so the drop will succeed here. 

--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -1,0 +1,49 @@
+-- psql 
+-- Session-local setting, so it will only apply to this test.
+show babelfishpg_tsql.temp_table_xact_support;
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+set babelfishpg_tsql.temp_table_xact_support = off;
+GO
+
+-- tsql 
+
+
+USE master;
+CREATE TABLE #temp_rollback_1(a int)
+GO
+
+INSERT INTO #temp_rollback_1 VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+BEGIN TRANSACTION
+DROP TABLE #temp_rollback_1
+ROLLBACK
+GO
+
+SELECT * FROM #temp_rollback_1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- psql
+set babelfishpg_tsql.temp_table_xact_support = on; 
+GO
+
+show babelfishpg_tsql.temp_table_xact_support;
+GO
+~~START~~
+text
+on
+~~END~~
+

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -62,7 +62,7 @@ GO
 CREATE PROCEDURE tv_base_rollback AS
 BEGIN
     DECLARE @tv TABLE (a int)
-    INSERT INTO mytab VALUES (1)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
     INSERT INTO @tv VALUES (1)
 END
 GO
@@ -921,16 +921,16 @@ four#!#1
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
 
-CREATE TABLE mytab(a int)
+CREATE TABLE temp_tab_rollback_mytab(a int)
 GO
 
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 INSERT INTO #t1 VALUES (1)
 EXEC tv_base_rollback
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 ROLLBACK
-SELECT * FROM mytab
+SELECT * FROM temp_tab_rollback_mytab
 GO
 ~~ROW COUNT: 1~~
 
@@ -943,7 +943,7 @@ int
 ~~END~~
 
 
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 GO
 
 -- Everything should be rolled back due to error

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -59,6 +59,14 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE tv_base_rollback AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    INSERT INTO mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -763,6 +771,80 @@ text
 ~~END~~
 
 
+
+-- DELETE, TRUNCATE
+CREATE TABLE #t1(a int identity primary key, b int)
+INSERT INTO #t1 VALUES (0)
+INSERT INTO #t1 VALUES (1)
+INSERT INTO #t1 VALUES (2)
+INSERT INTO #t1 VALUES (3)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+    DELETE FROM #t1
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+~~END~~
+
+
+-- Truncate should reset IDENTITY. But it should be restored on ROLLBACK.
+BEGIN TRAN
+    TRUNCATE TABLE #t1
+    INSERT INTO #t1 VALUES (1)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+
+INSERT INTO #t1 VALUES (4)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+5#!#4
+~~END~~
+
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
@@ -838,6 +920,31 @@ four#!#1
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
+
+CREATE TABLE mytab(a int)
+GO
+
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+EXEC tv_base_rollback
+DROP TABLE mytab
+ROLLBACK
+SELECT * FROM mytab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+
+DROP TABLE mytab
+GO
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
@@ -1132,6 +1239,9 @@ int
 ~~END~~
 
 
+DROP TABLE #t1
+GO
+
 
 
 
@@ -1216,6 +1326,80 @@ int
 
 DROP TABLE perm_tab
 GO
+
+
+---------------------------------------------------------------------------
+-- Trigger (can't be created on temp tables)
+---------------------------------------------------------------------------
+CREATE TABLE basetab(a int, b int)
+GO
+
+CREATE TRIGGER basetrig_insert ON basetab 
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (1)
+GO
+
+CREATE TABLE #t1(a int)
+GO
+
+BEGIN TRAN
+    INSERT INTO basetab VALUES (1, 2)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM basetab
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+
+CREATE TRIGGER basetrig_rollback ON basetab
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (2)
+    ROLLBACK
+GO
+
+INSERT INTO basetab VALUES (3, 4)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 3609)~~
+
+~~ERROR (Message: The transaction ended in the trigger. The batch has been aborted.)~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int
+~~END~~
+
+
+DROP TRIGGER basetrig_insert
+GO
+
+DROP TABLE basetab
+GO
 DROP VIEW enr_view
 GO
 
@@ -1226,4 +1410,7 @@ DROP PROCEDURE test_rollback_in_proc
 GO
 
 DROP PROCEDURE implicit_rollback_in_proc
+GO
+
+DROP PROCEDURE tv_base_rollback
 GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -1,5 +1,65 @@
--- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+CREATE TYPE temp_table_type FROM int
+GO
+
+
+CREATE PROCEDURE test_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1 ADD b varchar(50)
+        TRUNCATE TABLE #t1
+        INSERT INTO #t1 VALUES (1, 'two')
+        select * from #t1
+        DROP TABLE #t1
+        CREATE TABLE #t1(a varchar(100))
+        INSERT INTO #t1 VALUES ('three')
+        select * from #t1
+        CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+        INSERT INTO #t2 VALUES ('four')
+        SELECT * FROM #t2
+        DROP TABLE #t2
+    ROLLBACK;
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    CREATE TABLE #t1(a int)
+    ALTER TABLE #t1 ADD b varchar(50)
+    INSERT INTO #t1 VALUES (1, 'two')
+    select * from #t1
+    DROP TABLE #t1
+    CREATE TABLE #t1(a varchar(100))
+    INSERT INTO #t1 VALUES ('three')
+    select * from #t1
+    CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+    INSERT INTO #t2 VALUES ('four')
+    SELECT * FROM #t2
+    DROP TABLE #t2
+    INSERT INTO #t1 values (1, 2, 3)
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+-- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
 -------------------------------
@@ -8,14 +68,29 @@ CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
 select * from enr_view
 ROLLBACK
 GO
+~~START~~
+text
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#temp_table_rollback_t1_pkey
+~~END~~
+
 
 -- Should be empty
 select * from enr_view
 GO
+~~START~~
+text
+~~END~~
+
 
 -- Should not exist
 SELECT * FROM #temp_table_rollback_t1
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
+
 
 BEGIN TRAN
 CREATE TABLE #t1(a int)
@@ -23,6 +98,13 @@ INSERT INTO #t1 VALUES (1)
 SELECT * FROM #t1
 ROLLBACK
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
 
 CREATE TABLE #t1(a int, b int)
 GO
@@ -30,23 +112,52 @@ GO
 INSERT INTO #t1 VALUES (1, 1)
 INSERT INTO #t1 VALUES (2, 1)
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 INSERT INTO #t1 VALUES (3, 1)
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #t1
 GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
 
 BEGIN TRAN
 UPDATE #t1 SET a = a + 1 WHERE b = 1
 SELECT * FROM #t1
 ROLLBACK
 GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+
 
 SELECT * FROM #t1
-
 DROP TABLE #t1
 GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
 
 -----------------------------
 -- Temp Table DROP + ROLLBACK
@@ -56,6 +167,8 @@ go
 
 INSERT INTO #temp_table_rollback_t1 VALUES (1)
 GO
+~~ROW COUNT: 1~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -65,12 +178,24 @@ go
 -- Should still exist
 select * from enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+~~END~~
+
 
 -- Should show results
 BEGIN TRAN
 select * from #temp_table_rollback_t1
 COMMIT
 go
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
 
 -- Should not error
 BEGIN TRAN
@@ -88,21 +213,37 @@ BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
 ROLLBACK
 GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
 COMMIT
 GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
 COMMIT
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
 
 DROP TABLE #temp_table_rollback_t1
 GO
@@ -125,18 +266,44 @@ GO
 -- Tables are still visible and usable
 select * from enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t2
+~~END~~
+
 
 INSERT INTO #temp_table_rollback_t1 values (1, 'b')
 GO
+~~ROW COUNT: 1~~
+
 
 INSERT INTO #temp_table_rollback_t2 values ('c')
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t1
 GO
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#b
+~~END~~
+
 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+varchar
+c
+~~END~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -151,6 +318,10 @@ GO
 
 SELECT * FROM enr_view
 go
+~~START~~
+text
+~~END~~
+
 
 CREATE TABLE #t1(a int, b int)
 GO
@@ -162,13 +333,30 @@ INSERT INTO #t1 VALUES (1, 1)
 INSERT INTO #t1 VALUES (2, 1)
 INSERT INTO #t2 VALUES ('abc', 1)
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 INSERT INTO #t1 VALUES (3, 1)
 INSERT INTO #t2 VALUES ('def', 1)
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #t1
 GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
 
 BEGIN TRAN
 UPDATE #t1 SET a = a + 1 WHERE b = 1
@@ -177,10 +365,40 @@ SELECT * FROM #t1
 SELECT * FROM #t2
 ROLLBACK
 GO
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+qed#!#1
+qed#!#1
+~~END~~
+
 
 SELECT * FROM #t1
 SELECT * FROM #t2
 GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+abc#!#1
+def#!#1
+~~END~~
+
 
 DROP TABLE #t1
 DROP TABLE #t2
@@ -195,16 +413,27 @@ GO
 
 INSERT INTO #temp_table_rollback_t2 VALUES (1)
 GO
+~~ROW COUNT: 1~~
+
 
 -- Transaction will error out
 BEGIN TRAN
 drop table #temp_table_rollback_t2
 insert into #temp_table_rollback_t1 values (1, 1, 1, 1) -- Too many columns, should error out
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
 
 -- Table + data should still exist, due to implicit rollback. 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 -- Duplicate key doesn't cause implicit rollback, so the drop will succeed here. 
 BEGIN TRAN
@@ -212,9 +441,19 @@ drop table #temp_table_rollback_t2
 insert into #temp_table_rollback_t1 values (1, 1, 'a')
 insert into #temp_table_rollback_t1 values (1, 1, 'a')
 GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#temp_table_rollback_t1_pkey")~~
+
 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t2" does not exist)~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -224,11 +463,15 @@ GO
 
 SELECT * FROM enr_view;
 GO
+~~START~~
+text
+~~END~~
+
+
 
 ---------------------------------------------------------------------------
 -- Same temp table name in one transaction
 ---------------------------------------------------------------------------
-
 CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
 GO
 
@@ -239,6 +482,8 @@ BEGIN TRANSACTION
     CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 DROP TABLE #temp_table_rollback_t3
 GO
@@ -246,47 +491,66 @@ GO
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 GO
 
+
+
 BEGIN TRANSACTION
     DROP TABLE #temp_table_rollback_t4
-
     CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
     INSERT INTO #temp_table_rollback_t4 VALUES (1, 'one')
     SELECT * FROM #temp_table_rollback_t4 -- should return 1, 'one'
     DROP TABLE #temp_table_rollback_t4
-
     INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
     SELECT * FROM #temp_table_rollback_t4
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#char
+1#!#one       
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
 
 SELECT * FROM #temp_table_rollback_t4
 GO
+~~START~~
+int#!#char
+~~END~~
+
 
 DROP TABLE #temp_table_rollback_t4
 GO
 
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 GO
+
+
 
 BEGIN TRANSACTION T1
 ALTER TABLE #temp_table_rollback_t4 ADD C3 INT
 DROP TABLE #temp_table_rollback_t4
-
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 DROP  TABLE #temp_table_rollback_t4
-
 INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
 COMMIT
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
 
 DROP TABLE #temp_table_rollback_t4
 GO
+
 
 ---------------------------------------------------------------------------
 -- Index creation
 ---------------------------------------------------------------------------
 -- Created index in transaction
-
 CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
 GO
 
@@ -295,12 +559,20 @@ BEGIN TRAN
     INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
 ROLLBACK
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+~~END~~
+
 
 INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
 GO
+~~ROW COUNT: 1~~
+
 
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
@@ -308,27 +580,58 @@ BEGIN TRAN
     SELECT * FROM #temp_table_rollback_t5
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+~~END~~
+
 
 BEGIN TRAN
     UPDATE #temp_table_rollback_t5 SET b = 'e' WHERE d = 4
     SELECT * FROM #temp_table_rollback_t5
 ROLLBACK
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#e#!#3#!#4
+~~END~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
 GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+~~END~~
+
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t5
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+~~END~~
+
+
 
 -- Drop index in transaction
-
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
 
@@ -337,20 +640,42 @@ BEGIN TRAN
     INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 BEGIN TRAN
     DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
@@ -360,6 +685,12 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 -- Create and drop in transaction
 BEGIN TRAN
@@ -370,6 +701,12 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
 DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
@@ -377,6 +714,12 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 -- Drop - Create
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
@@ -390,6 +733,12 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
@@ -397,18 +746,60 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP TABLE #temp_table_rollback_t5
 GO
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+~~END~~
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
-
 exec test_rollback_in_proc
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t2" does not exist)~~
+
 
 BEGIN TRANSACTION
     CREATE TABLE #outer_tab1(a int)
@@ -417,11 +808,45 @@ BEGIN TRANSACTION
     select * from #outer_tab1
 ROLLBACK
 GO
+~~START~~
+text
+#outer_tab1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+~~END~~
+
 
 ---------------------------------------------------------------------------
 -- Mixed permanent, TV, temp tables in/out of ENR.
@@ -436,6 +861,10 @@ GO
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+~~END~~
+
 
 -- Mixed insert rollback
 DECLARE @tv TABLE (a1 int)
@@ -461,12 +890,68 @@ SELECT * FROM #temp_table
 SELECT * FROM #temp_table_nonenr
 SELECT * FROM enr_view
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+text
+@tv_0
+#temp_table
+~~END~~
+
 
 SELECT * FROM enr_view
 DROP TABLE #temp_table
 DROP TABLE #temp_table_nonenr
 DROP TABLE perm_table
 GO
+~~START~~
+text
+#temp_table
+~~END~~
+
 
 -- Mixed drop rollback
 CREATE TABLE #temp_table(a int)
@@ -483,56 +968,81 @@ BEGIN TRAN
     SELECT * FROM enr_view
 ROLLBACK
 GO
+~~START~~
+text
+#temp_table
+@tv_0
+~~END~~
+
+~~START~~
+text
+@tv_0
+~~END~~
+
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+#temp_table
+~~END~~
+
 
 DROP TABLE #temp_table
 DROP TABLE perm_table
 DROP TABLE #temp_table_nonenr
 GO
 
+
 ---------------------------------------------------------------------------
 -- Multiple COMMIT/ROLLBACK
 ---------------------------------------------------------------------------
-
 CREATE TABLE #t1(a int)
 GO
+
+
 
 BEGIN TRAN
 INSERT INTO #t1 VALUES (1)
 COMMIT
-
 BEGIN TRAN
 UPDATE #t1 SET a = 2 WHERE a = 1
 COMMIT
-
 BEGIN TRAN
 DROP TABLE #t1
 ROLLBACK
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #t1
 DROP TABLE #t1
 GO
+~~START~~
+int
+2
+~~END~~
+
+
+
+
+
 
 ------------------------
-
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 COMMIT
-
 BEGIN TRAN
 INSERT INTO #t1 VALUES (1)
 CREATE TABLE #t2(a int identity primary key, b varchar)
 COMMIT
-
 BEGIN TRAN
 DROP TABLE #t1
 CREATE INDEX #t2_idx ON #t2(b)
 INSERT INTO #t2 VALUES ('a')
 ROLLBACK
-
 BEGIN TRAN
 CREATE INDEX #t2_idx ON #t2(b)
 INSERT INTO #t2 VALUES ('b')
@@ -542,61 +1052,92 @@ DROP TABLE #t1
 DROP TABLE #t2
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#b
+~~END~~
+
+
+
+
+
+
 
 ----------------------------
-
 BEGIN TRAN 
 CREATE TABLE #t1(a int)
 CREATE TABLE #t2(a int)
 ROLLBACK
-
 BEGIN TRAN
 CREATE TABLE #t1(a varchar)
 CREATE TABLE #t2(a varchar)
 COMMIT
-
 BEGIN TRAN
 DROP TABLE #t1
 DROP TABLE #t2
 COMMIT
-
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 CREATE TABLE #t2(a int)
 INSERT INTO #t1 VALUES (1)
 ROLLBACK
-
 SELECT * FROM enr_view
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+text
+~~END~~
+
+
+
+
+
+
 
 ----------------------------
-
 BEGIN TRAN
 CREATE TABLE #t1 (a int)
 COMMIT
-
 BEGIN TRAN
 DROP TABLE #t1 
 ROLLBACK
-
 BEGIN TRAN
 DROP TABLE #t1
 ROLLBACK
-
 BEGIN TRAN
 DROP TABLE #t1
 ROLLBACK
-
 BEGIN TRAN
 INSERT INTO #t1 VALUES (1)
 SELECT * FROM #t1
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+
+
 
 ---------------------------------------------------------------------------
 -- Cursor
 ---------------------------------------------------------------------------
-
 -- Temp into permanent
 DECLARE @v int
 CREATE TABLE #t(a int)
@@ -604,7 +1145,6 @@ insert into #t values (1)
 insert into #t values (2)
 insert into #t values (3)
 CREATE TABLE perm_tab(a int)
-
 DECLARE cur CURSOR FOR (select a from #t)
 OPEN cur
 WHILE @@fetch_status = 0
@@ -614,9 +1154,31 @@ BEGIN
 END
 CLOSE cur
 DEALLOCATE cur
-
 SELECT * FROM perm_tab
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+~~END~~
+
+
 
 -- Permanent into temp
 DECLARE @v int
@@ -630,9 +1192,38 @@ BEGIN
 END
 CLOSE cur
 DEALLOCATE cur
-
 SELECT * FROM #t2
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+<NULL>
+~~END~~
+
 
 DROP TABLE perm_tab
+GO
+DROP VIEW enr_view
+GO
+
+DROP TYPE temp_table_type
+GO
+
+DROP PROCEDURE test_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
 GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -1,5 +1,62 @@
--- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
 
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+
+CREATE PROCEDURE test_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1 ADD b varchar(50)
+        TRUNCATE TABLE #t1
+        INSERT INTO #t1 VALUES (1, 'two')
+        select * from #t1
+        DROP TABLE #t1
+        CREATE TABLE #t1(a varchar(100))
+        INSERT INTO #t1 VALUES ('three')
+        select * from #t1
+        CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+        INSERT INTO #t2 VALUES ('four')
+        SELECT * FROM #t2
+        DROP TABLE #t2
+    ROLLBACK;
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    CREATE TABLE #t1(a int)
+    ALTER TABLE #t1 ADD b varchar(50)
+    INSERT INTO #t1 VALUES (1, 'two')
+    select * from #t1
+    DROP TABLE #t1
+    CREATE TABLE #t1(a varchar(100))
+    INSERT INTO #t1 VALUES ('three')
+    select * from #t1
+    CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+    INSERT INTO #t2 VALUES ('four')
+    SELECT * FROM #t2
+    DROP TABLE #t2
+    INSERT INTO #t1 values (1, 2, 3)
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+-- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
 -------------------------------
@@ -8,14 +65,29 @@ CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
 select * from enr_view
 ROLLBACK
 GO
+~~START~~
+text
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#temp_table_rollback_t1_pkey
+~~END~~
+
 
 -- Should be empty
 select * from enr_view
 GO
+~~START~~
+text
+~~END~~
+
 
 -- Should not exist
 SELECT * FROM #temp_table_rollback_t1
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
+
 
 -----------------------------
 -- Temp Table DROP + ROLLBACK
@@ -25,6 +97,8 @@ go
 
 INSERT INTO #temp_table_rollback_t1 VALUES (1)
 GO
+~~ROW COUNT: 1~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -34,12 +108,24 @@ go
 -- Should still exist
 select * from enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+~~END~~
+
 
 -- Should show results
 BEGIN TRAN
 select * from #temp_table_rollback_t1
 COMMIT
 go
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
 
 -- Should not error
 BEGIN TRAN
@@ -57,21 +143,37 @@ BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
 ROLLBACK
 GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
 COMMIT
 GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
 COMMIT
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
 
 DROP TABLE #temp_table_rollback_t1
 GO
@@ -94,18 +196,44 @@ GO
 -- Tables are still visible and usable
 select * from enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t2
+~~END~~
+
 
 INSERT INTO #temp_table_rollback_t1 values (1, 'b')
 GO
+~~ROW COUNT: 1~~
+
 
 INSERT INTO #temp_table_rollback_t2 values ('c')
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t1
 GO
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#b
+~~END~~
+
 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+varchar
+c
+~~END~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -120,6 +248,10 @@ GO
 
 SELECT * FROM enr_view
 go
+~~START~~
+text
+~~END~~
+
 
 ----------------------------------------------------------
 -- Implicit rollback due to error
@@ -130,16 +262,27 @@ GO
 
 INSERT INTO #temp_table_rollback_t2 VALUES (1)
 GO
+~~ROW COUNT: 1~~
+
 
 -- Transaction will error out
 BEGIN TRAN
 drop table #temp_table_rollback_t2
 insert into #temp_table_rollback_t1 values (1, 1, 1, 1) -- Too many columns, should error out
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
 
 -- Table + data should still exist, due to implicit rollback. 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 -- Duplicate key doesn't cause implicit rollback, so the drop will succeed here. 
 BEGIN TRAN
@@ -147,9 +290,19 @@ drop table #temp_table_rollback_t2
 insert into #temp_table_rollback_t1 values (1, 1, 'a')
 insert into #temp_table_rollback_t1 values (1, 1, 'a')
 GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#temp_table_rollback_t1_pkey")~~
+
 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t2" does not exist)~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -159,11 +312,15 @@ GO
 
 SELECT * FROM enr_view;
 GO
+~~START~~
+text
+~~END~~
+
+
 
 ---------------------------------------------------------------------------
 -- Same temp table name in one transaction
 ---------------------------------------------------------------------------
-
 CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
 GO
 
@@ -174,6 +331,8 @@ BEGIN TRANSACTION
     CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 DROP TABLE #temp_table_rollback_t3
 GO
@@ -181,47 +340,66 @@ GO
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 GO
 
+
+
 BEGIN TRANSACTION
     DROP TABLE #temp_table_rollback_t4
-
     CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
     INSERT INTO #temp_table_rollback_t4 VALUES (1, 'one')
     SELECT * FROM #temp_table_rollback_t4 -- should return 1, 'one'
     DROP TABLE #temp_table_rollback_t4
-
     INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
     SELECT * FROM #temp_table_rollback_t4
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#char
+1#!#one       
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
 
 SELECT * FROM #temp_table_rollback_t4
 GO
+~~START~~
+int#!#char
+~~END~~
+
 
 DROP TABLE #temp_table_rollback_t4
 GO
 
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 GO
+
+
 
 BEGIN TRANSACTION T1
 ALTER TABLE #temp_table_rollback_t4 ADD C3 INT
 DROP TABLE #temp_table_rollback_t4
-
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 DROP  TABLE #temp_table_rollback_t4
-
 INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
 COMMIT
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
 
 DROP TABLE #temp_table_rollback_t4
 GO
+
 
 ---------------------------------------------------------------------------
 -- Index creation
 ---------------------------------------------------------------------------
 -- Created index in transaction
-
 CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
 GO
 
@@ -230,35 +408,71 @@ BEGIN TRAN
     INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+~~END~~
+
 
 INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
 GO
+~~ROW COUNT: 1~~
+
 
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
 ROLLBACK
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+~~END~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
 GO
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t5
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+~~END~~
+
+
 
 -- Drop index in transaction
-
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
 
@@ -267,20 +481,44 @@ BEGIN TRAN
     INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 BEGIN TRAN
     DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
@@ -290,6 +528,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 -- Create and drop in transaction
 BEGIN TRAN
@@ -300,6 +545,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
 DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
@@ -307,6 +559,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 -- Drop - Create
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
@@ -320,6 +579,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
@@ -327,18 +593,61 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP TABLE #temp_table_rollback_t5
 GO
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+~~END~~
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
-
 exec test_rollback_in_proc
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t2" does not exist)~~
+
 
 BEGIN TRANSACTION
     CREATE TABLE #outer_tab1(a int)
@@ -347,8 +656,50 @@ BEGIN TRANSACTION
     select * from #outer_tab1
 ROLLBACK
 GO
+~~START~~
+text
+#outer_tab1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
 SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+DROP VIEW enr_view
+GO
+
+DROP PROCEDURE test_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
 GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -62,7 +62,7 @@ GO
 CREATE PROCEDURE tv_base_rollback AS
 BEGIN
     DECLARE @tv TABLE (a int)
-    INSERT INTO mytab VALUES (1)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
     INSERT INTO @tv VALUES (1)
 END
 GO
@@ -921,16 +921,16 @@ four#!#1
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
 
-CREATE TABLE mytab(a int)
+CREATE TABLE temp_tab_rollback_mytab(a int)
 GO
 
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 INSERT INTO #t1 VALUES (1)
 EXEC tv_base_rollback
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 ROLLBACK
-SELECT * FROM mytab
+SELECT * FROM temp_tab_rollback_mytab
 GO
 ~~ROW COUNT: 1~~
 
@@ -943,7 +943,7 @@ int
 ~~END~~
 
 
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 GO
 
 -- Everything should be rolled back due to error

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -10,6 +10,9 @@ CREATE VIEW enr_view AS
     FROM sys.babelfish_get_enr_list()
 GO
 
+CREATE TYPE temp_table_type FROM int
+GO
+
 
 CREATE PROCEDURE test_rollback_in_proc AS
 BEGIN
@@ -87,6 +90,73 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
+
+
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t1(a int, b int)
+GO
+
+INSERT INTO #t1 VALUES (1, 1)
+INSERT INTO #t1 VALUES (2, 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #t1 VALUES (3, 1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
+BEGIN TRAN
+UPDATE #t1 SET a = a + 1 WHERE b = 1
+SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
 
 
 -----------------------------
@@ -253,6 +323,87 @@ text
 ~~END~~
 
 
+CREATE TABLE #t1(a int, b int)
+GO
+
+CREATE TABLE #t2(c varchar(20), d int)
+GO
+
+INSERT INTO #t1 VALUES (1, 1)
+INSERT INTO #t1 VALUES (2, 1)
+INSERT INTO #t2 VALUES ('abc', 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #t1 VALUES (3, 1)
+INSERT INTO #t2 VALUES ('def', 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
+BEGIN TRAN
+UPDATE #t1 SET a = a + 1 WHERE b = 1
+UPDATE #t2 SET c = 'qed' WHERE d = 1
+SELECT * FROM #t1
+SELECT * FROM #t2
+ROLLBACK
+GO
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+qed#!#1
+qed#!#1
+~~END~~
+
+
+SELECT * FROM #t1
+SELECT * FROM #t2
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+abc#!#1
+def#!#1
+~~END~~
+
+
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
 ----------------------------------------------------------
 -- Implicit rollback due to error
 ----------------------------------------------------------
@@ -406,7 +557,7 @@ GO
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
     INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
-COMMIT
+ROLLBACK
 GO
 ~~ROW COUNT: 1~~
 
@@ -415,7 +566,6 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
 ~~END~~
 
 
@@ -426,40 +576,49 @@ GO
 
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
-ROLLBACK
+    UPDATE #temp_table_rollback_t5 SET b = 'd' WHERE d = 4
+    SELECT * FROM #temp_table_rollback_t5
+COMMIT
 GO
-~~ERROR (Code: 2714)~~
+~~ROW COUNT: 1~~
 
-~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
-
-
-SELECT * FROM #temp_table_rollback_t5
-GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 ~~END~~
 
 
-CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+BEGIN TRAN
+    UPDATE #temp_table_rollback_t5 SET b = 'e' WHERE d = 4
+    SELECT * FROM #temp_table_rollback_t5
+ROLLBACK
 GO
-~~ERROR (Code: 2714)~~
+~~ROW COUNT: 1~~
 
-~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#e#!#3#!#4
+~~END~~
 
 
 SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 ~~END~~
 
 
 DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
 GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+~~END~~
+
 
 SELECT * FROM enr_view
 GO
@@ -488,8 +647,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -507,8 +665,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -530,8 +687,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -547,8 +703,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -561,8 +716,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -581,8 +735,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -595,8 +748,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -695,7 +847,379 @@ GO
 text
 ~~END~~
 
+
+---------------------------------------------------------------------------
+-- Mixed permanent, TV, temp tables in/out of ENR.
+---------------------------------------------------------------------------
+-- Mixed create rollback
+BEGIN TRAN
+    DECLARE @tv TABLE (a1 int)
+    CREATE TABLE #temp_table(a2 int)
+    CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+-- Mixed insert rollback
+DECLARE @tv TABLE (a1 int)
+CREATE TABLE perm_table(a2 int)
+CREATE TABLE #temp_table(a3 int)
+CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+BEGIN TRAN
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO perm_table VALUES(2)
+    INSERT INTO #temp_table VALUES(3)
+    INSERT INTO #temp_table_nonenr VALUES (4)
+    SELECT * FROM @tv
+    SELECT * FROM perm_table
+    SELECT * FROM #temp_table
+    SELECT * FROM #temp_table_nonenr
+ROLLBACK
+-- Unaffected by rollback
+SELECT * FROM @tv
+-- Correctly rolled back
+SELECT * FROM perm_table
+-- Correctly rolled back
+SELECT * FROM #temp_table
+SELECT * FROM #temp_table_nonenr
+SELECT * FROM enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+text
+@tv_0
+#temp_table
+~~END~~
+
+
+SELECT * FROM enr_view
+DROP TABLE #temp_table
+DROP TABLE #temp_table_nonenr
+DROP TABLE perm_table
+GO
+~~START~~
+text
+#temp_table
+~~END~~
+
+
+-- Mixed drop rollback
+CREATE TABLE #temp_table(a int)
+CREATE TABLE perm_table(a int)
+CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+GO
+
+BEGIN TRAN
+    DECLARE @tv TABLE(a int)
+    SELECT * FROM enr_view
+    DROP TABLE #temp_table
+    DROP TABLE perm_table
+    DROP TABLE #temp_table_nonenr
+    SELECT * FROM enr_view
+ROLLBACK
+GO
+~~START~~
+text
+#temp_table
+@tv_0
+~~END~~
+
+~~START~~
+text
+@tv_0
+~~END~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#temp_table
+~~END~~
+
+
+DROP TABLE #temp_table
+DROP TABLE perm_table
+DROP TABLE #temp_table_nonenr
+GO
+
+
+---------------------------------------------------------------------------
+-- Multiple COMMIT/ROLLBACK
+---------------------------------------------------------------------------
+CREATE TABLE #t1(a int)
+GO
+
+
+
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+COMMIT
+BEGIN TRAN
+UPDATE #t1 SET a = 2 WHERE a = 1
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+
+
+
+
+------------------------
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+COMMIT
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+CREATE TABLE #t2(a int identity primary key, b varchar)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+CREATE INDEX #t2_idx ON #t2(b)
+INSERT INTO #t2 VALUES ('a')
+ROLLBACK
+BEGIN TRAN
+CREATE INDEX #t2_idx ON #t2(b)
+INSERT INTO #t2 VALUES ('b')
+SELECT * FROM #t1
+SELECT * FROM #t2
+DROP TABLE #t1
+DROP TABLE #t2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#b
+~~END~~
+
+
+
+
+
+
+
+----------------------------
+BEGIN TRAN 
+CREATE TABLE #t1(a int)
+CREATE TABLE #t2(a int)
+ROLLBACK
+BEGIN TRAN
+CREATE TABLE #t1(a varchar)
+CREATE TABLE #t2(a varchar)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+DROP TABLE #t2
+COMMIT
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+CREATE TABLE #t2(a int)
+INSERT INTO #t1 VALUES (1)
+ROLLBACK
+SELECT * FROM enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+text
+~~END~~
+
+
+
+
+
+
+
+----------------------------
+BEGIN TRAN
+CREATE TABLE #t1 (a int)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1 
+ROLLBACK
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+SELECT * FROM #t1
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+---------------------------------------------------------------------------
+-- Cursor
+---------------------------------------------------------------------------
+-- Temp into permanent
+DECLARE @v int
+CREATE TABLE #t(a int)
+insert into #t values (1)
+insert into #t values (2)
+insert into #t values (3)
+CREATE TABLE perm_tab(a int)
+DECLARE cur CURSOR FOR (select a from #t)
+OPEN cur
+WHILE @@fetch_status = 0
+BEGIN
+    fetch cur into @v
+    insert into perm_tab values (@v)
+END
+CLOSE cur
+DEALLOCATE cur
+SELECT * FROM perm_tab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+~~END~~
+
+
+
+-- Permanent into temp
+DECLARE @v int
+CREATE TABLE #t2(b int)
+DECLARE cur CURSOR FOR (select a from perm_tab)
+OPEN cur
+WHILE @@fetch_status = 0
+BEGIN
+    fetch cur into @v
+    insert into #t2 values (@v)
+END
+CLOSE cur
+DEALLOCATE cur
+SELECT * FROM #t2
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+<NULL>
+~~END~~
+
+
+DROP TABLE perm_tab
+GO
 DROP VIEW enr_view
+GO
+
+DROP TYPE temp_table_type
 GO
 
 DROP PROCEDURE test_rollback_in_proc

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -59,6 +59,14 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE tv_base_rollback AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    INSERT INTO mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -763,6 +771,80 @@ text
 ~~END~~
 
 
+
+-- DELETE, TRUNCATE
+CREATE TABLE #t1(a int identity primary key, b int)
+INSERT INTO #t1 VALUES (0)
+INSERT INTO #t1 VALUES (1)
+INSERT INTO #t1 VALUES (2)
+INSERT INTO #t1 VALUES (3)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+    DELETE FROM #t1
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+~~END~~
+
+
+-- Truncate should reset IDENTITY. But it should be restored on ROLLBACK.
+BEGIN TRAN
+    TRUNCATE TABLE #t1
+    INSERT INTO #t1 VALUES (1)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+
+INSERT INTO #t1 VALUES (4)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+5#!#4
+~~END~~
+
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
@@ -838,6 +920,31 @@ four#!#1
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
+
+CREATE TABLE mytab(a int)
+GO
+
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+EXEC tv_base_rollback
+DROP TABLE mytab
+ROLLBACK
+SELECT * FROM mytab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+
+DROP TABLE mytab
+GO
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
@@ -1132,6 +1239,9 @@ int
 ~~END~~
 
 
+DROP TABLE #t1
+GO
+
 
 
 
@@ -1216,6 +1326,80 @@ int
 
 DROP TABLE perm_tab
 GO
+
+
+---------------------------------------------------------------------------
+-- Trigger (can't be created on temp tables)
+---------------------------------------------------------------------------
+CREATE TABLE basetab(a int, b int)
+GO
+
+CREATE TRIGGER basetrig_insert ON basetab 
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (1)
+GO
+
+CREATE TABLE #t1(a int)
+GO
+
+BEGIN TRAN
+    INSERT INTO basetab VALUES (1, 2)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM basetab
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+
+CREATE TRIGGER basetrig_rollback ON basetab
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (2)
+    ROLLBACK
+GO
+
+INSERT INTO basetab VALUES (3, 4)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 3609)~~
+
+~~ERROR (Message: The transaction ended in the trigger. The batch has been aborted.)~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int
+~~END~~
+
+
+DROP TRIGGER basetrig_insert
+GO
+
+DROP TABLE basetab
+GO
 DROP VIEW enr_view
 GO
 
@@ -1226,4 +1410,7 @@ DROP PROCEDURE test_rollback_in_proc
 GO
 
 DROP PROCEDURE implicit_rollback_in_proc
+GO
+
+DROP PROCEDURE tv_base_rollback
 GO

--- a/test/JDBC/expected/temp_table_rollback_subxact-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback_subxact-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP VIEW enr_view;
+GO
+
+DROP PROCEDURE test_nested_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
+GO

--- a/test/JDBC/expected/temp_table_rollback_subxact-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback_subxact-vu-prepare.out
@@ -1,0 +1,70 @@
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+
+
+
+
+CREATE PROCEDURE test_nested_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1_proc1(a int)
+    INSERT INTO #t1_proc1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1_proc1 ADD b varchar(50)
+        TRUNCATE TABLE #t1_proc1
+        INSERT INTO #t1_proc1 VALUES (1, 'two')
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+        SAVE TRAN s1
+            DROP TABLE #t1_proc1
+            CREATE TABLE #t1_proc1(a varchar(100))
+            INSERT INTO #t1_proc1 VALUES ('three')
+            -- Should just be 'three'
+            select * from #t1_proc1
+        ROLLBACK TRAN s1
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+        CREATE TABLE #t2_proc1(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc1 VALUES ('four')
+        -- ('four', 1)
+        SELECT * FROM #t2_proc1
+        DROP TABLE #t2_proc1
+    ROLLBACK;
+    -- Should have just 6
+    SELECT * FROM #t1_proc1
+    -- Should not exist
+    SELECT * FROM #t2_proc1
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    BEGIN TRAN
+        SAVE TRAN S1
+        CREATE TABLE #t1_proc2(a int)
+        ALTER TABLE #t1_proc2 ADD b varchar(50)
+        INSERT INTO #t1_proc2 VALUES (1, 'two')
+        select * from #t1_proc2
+        DROP TABLE #t1_proc2
+        CREATE TABLE #t1_proc2(a varchar(100))
+        INSERT INTO #t1_proc2 VALUES ('three')
+        select * from #t1_proc2
+        CREATE TABLE #t2_proc2(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc2 VALUES ('four')
+        SELECT * FROM #t2_proc2
+        DROP TABLE #t2_proc2
+        INSERT INTO #t1_proc2 values (1, 2, 3, 4, 5)
+        SELECT * FROM #t1_proc2
+        SELECT * FROM #t2_proc2
+    COMMIT
+END
+GO

--- a/test/JDBC/expected/temp_table_rollback_subxact-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback_subxact-vu-verify.out
@@ -1,0 +1,729 @@
+----------------------------------------------------------
+-- Nested transactions
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a varchar(16))
+    INSERT INTO #t1 VALUES ('t1')
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES ('t2')
+        SAVE TRANSACTION T3
+            INSERT INTO #t1 VALUES ('t3')
+            SAVE TRANSACTION T4
+                INSERT INTO #t1 VALUES ('t4')
+                SELECT * FROM #t1
+            ROLLBACK TRANSACTION T4
+            SELECT * FROM #t1
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+    SELECT * FROM #t1
+ROLLBACK TRANSACTION T1
+SELECT * FROM #t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+t1
+t2
+t3
+t4
+~~END~~
+
+~~START~~
+varchar
+t1
+t2
+t3
+~~END~~
+
+~~START~~
+varchar
+t1
+t2
+~~END~~
+
+~~START~~
+varchar
+t1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t1" does not exist)~~
+
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+~~END~~
+
+
+BEGIN TRANSACTION T1
+    SAVE TRANSACTION S2
+        create table #t3(a int)
+        create table #t4(a int identity primary key, b varchar(50))
+        insert into #t3 values (5)
+        insert into #t4 values ('six')
+        SELECT * FROM #t3
+        SELECT * FROM #t4
+        SELECT * FROM enr_view;
+    ROLLBACK TRANSACTION S2
+    SELECT * FROM enr_view;
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+5
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#six
+~~END~~
+
+~~START~~
+text
+#t3
+#t4_a_seq
+#t4
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#t4_pkey
+~~END~~
+
+~~START~~
+text
+~~END~~
+
+
+----------------------------------------------------------
+-- General Subtransaction tests
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a int primary key, b varchar(16))
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES (1, 't2')
+        SAVE TRANSACTION T3
+            UPDATE #t1 SET a = 2 WHERE a = 1
+            SELECT * FROM #t1
+            SAVE TRANSACTION T4
+                DROP TABLE #t1
+            ROLLBACK TRANSACTION T4
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+    select * from enr_view
+    DROP TABLE #t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#t2
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#t2
+~~END~~
+
+~~START~~
+text
+#t1_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#t1
+~~END~~
+
+
+-- Simple nested savepoint rollback
+BEGIN TRAN
+    CREATE TABLE #t1_exists(a int)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int)
+        SAVE TRAN save2
+            CREATE TABLE #t3(a int)
+    ROLLBACK TRAN save1
+    CREATE TABLE #t2_exists(a int)
+COMMIT
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#t1_exists
+#t2_exists
+~~END~~
+
+
+DROP TABLE #t1_exists
+DROP TABLE #t2_exists
+GO
+
+-- Multiple savepoint rollback in one xact
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b varchar)
+        SAVE TRAN save2
+            DROP TABLE #t2
+            DROP TABLE #t1
+    ROLLBACK TRAN save1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        SAVE TRAN save4
+            DROP TABLE #t4
+            DROP TABLE #t3
+    ROLLBACK TRAN save3
+    CREATE TABLE #t5(a int)
+COMMIT
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#t1_pkey
+#t1_a_seq
+#t1
+#t3_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#t3_b_seq
+#t3
+#t5
+~~END~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * FROM #t3
+GO
+~~START~~
+varchar#!#int
+~~END~~
+
+
+SELECT * FROM #t5
+GO
+~~START~~
+int
+~~END~~
+
+
+DROP TABLE #t1
+DROP TABLE #t3
+DROP TABLE #t5
+GO
+
+
+-- Multiple savepoint rollback in one xact with entire rollback
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b varchar)
+        SAVE TRAN save2
+            DROP TABLE #t2
+            DROP TABLE #t1
+    ROLLBACK TRAN save1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        SAVE TRAN save4
+            DROP TABLE #t4
+            DROP TABLE #t3
+    ROLLBACK TRAN save3
+    CREATE TABLE #t5(a int)
+ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+
+-- Multiple savepoint rollback entire transaction to beginning
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b varchar)
+        SAVE TRAN save2
+            DROP TABLE #t2
+            DROP TABLE #t1
+    ROLLBACK TRAN save1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        SAVE TRAN save4
+            DROP TABLE #t4
+            DROP TABLE #t3
+    ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+
+
+----------------------------------------------------------
+-- Index CREATE/DROP in subtransaction
+----------------------------------------------------------
+-- CREATE TABLE
+CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+        INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+~~END~~
+
+
+INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
+GO
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+    CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#temp_table_rollback_t5
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+~~END~~
+
+
+
+-- DROP INDEX
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+        INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+BEGIN TRAN
+    DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+
+-- CREATE + DROP
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+        DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+BEGIN TRAN T1
+    CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+    DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+
+-- DROP + CREATE
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+        CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+BEGIN TRAN T1
+    DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+    CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#b#!#3#!#4
+~~END~~
+
+
+DROP TABLE #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+
+-- Nested index creation
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key, b int)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b int)
+        CREATE INDEX #idx1 ON #t1(b)
+        SAVE TRAN save2
+            CREATE INDEX #idx2 ON #t2(b)
+    ROLLBACK TRAN save1
+    SELECT * FROM #t1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        CREATE INDEX #idx3 ON #t3(b)
+        SAVE TRAN save4
+            CREATE INDEX #idx4 ON #t4(b)
+            DROP INDEX #idx4 ON #t4
+            DROP INDEX #idx3 ON #t3
+        ROLLBACK TRAN save4
+    ROLLBACK TRAN save3
+    COMMIT
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#t1_a_seq
+#t1
+#t1_pkey
+#t3_b_seq
+#t3
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#t3_pkey
+~~END~~
+
+
+DROP TABLE #t1
+DROP TABLE #t3
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+
+----------------------------------------------------------
+-- Subtransactions with procedures
+----------------------------------------------------------
+exec test_nested_rollback_in_proc
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t2_proc1" does not exist)~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+-- Implicit rollback to top level transaction
+BEGIN TRANSACTION
+    CREATE TABLE #outer_tab1(a int)
+    SELECT * FROM enr_view
+    exec implicit_rollback_in_proc
+COMMIT
+GO
+~~START~~
+text
+#outer_tab1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
+
+-- This table is rolled back due to error in procedure
+select * from #outer_tab1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#outer_tab1" does not exist)~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+----------------------------------------------------------
+-- implicit rollback with postgres builtin procedures
+----------------------------------------------------------
+BEGIN TRANSACTION
+    CREATE TABLE #t1(a int)
+    SELECT UPPER(abc) -- Should fail 
+COMMIT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "abc" does not exist)~~
+
+
+BEGIN TRANSACTION
+    CREATE TABLE #t2(a int)
+    SAVE TRAN s1
+        SELECT UPPER(abc)
+COMMIT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "abc" does not exist)~~
+
+
+CREATE PROCEDURE my_bad_proc AS
+BEGIN
+    SELECT UPPER(abc)
+END
+GO
+
+BEGIN TRANSACTION
+    CREATE TABLE #t3(a int)
+    SAVE TRAN s1
+        exec my_bad_proc
+COMMIT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "abc" does not exist)~~
+
+
+DROP PROCEDURE my_bad_proc
+GO
+
+SELECT * FROM #t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t1" does not exist)~~
+
+
+SELECT * FROM #t2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t2" does not exist)~~
+
+
+SELECT * FROM #t3
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t3" does not exist)~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+

--- a/test/JDBC/expected/temp_table_rollback_subxact_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_subxact_isolation_snapshot.out
@@ -1,3 +1,75 @@
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+
+
+
+
+CREATE PROCEDURE test_nested_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1_proc1(a int)
+    INSERT INTO #t1_proc1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1_proc1 ADD b varchar(50)
+        TRUNCATE TABLE #t1_proc1
+        INSERT INTO #t1_proc1 VALUES (1, 'two')
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+        SAVE TRAN s1
+            DROP TABLE #t1_proc1
+            CREATE TABLE #t1_proc1(a varchar(100))
+            INSERT INTO #t1_proc1 VALUES ('three')
+            -- Should just be 'three'
+            select * from #t1_proc1
+        ROLLBACK TRAN s1
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+        CREATE TABLE #t2_proc1(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc1 VALUES ('four')
+        -- ('four', 1)
+        SELECT * FROM #t2_proc1
+        DROP TABLE #t2_proc1
+    ROLLBACK;
+    -- Should have just 6
+    SELECT * FROM #t1_proc1
+    -- Should not exist
+    SELECT * FROM #t2_proc1
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    BEGIN TRAN
+        SAVE TRAN S1
+        CREATE TABLE #t1_proc2(a int)
+        ALTER TABLE #t1_proc2 ADD b varchar(50)
+        INSERT INTO #t1_proc2 VALUES (1, 'two')
+        select * from #t1_proc2
+        DROP TABLE #t1_proc2
+        CREATE TABLE #t1_proc2(a varchar(100))
+        INSERT INTO #t1_proc2 VALUES ('three')
+        select * from #t1_proc2
+        CREATE TABLE #t2_proc2(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc2 VALUES ('four')
+        SELECT * FROM #t2_proc2
+        DROP TABLE #t2_proc2
+        INSERT INTO #t1_proc2 values (1, 2, 3, 4, 5)
+        SELECT * FROM #t1_proc2
+        SELECT * FROM #t2_proc2
+    COMMIT
+END
+GO
 ----------------------------------------------------------
 -- Nested transactions
 ----------------------------------------------------------
@@ -800,3 +872,11 @@ text
 ~~END~~
 
 
+DROP VIEW enr_view;
+GO
+
+DROP PROCEDURE test_nested_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
+GO

--- a/test/JDBC/expected/temp_table_rollback_subxact_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_subxact_xact_abort_on.out
@@ -1,3 +1,75 @@
+SET xact_abort ON
+
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+
+
+
+
+CREATE PROCEDURE test_nested_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1_proc1(a int)
+    INSERT INTO #t1_proc1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1_proc1 ADD b varchar(50)
+        TRUNCATE TABLE #t1_proc1
+        INSERT INTO #t1_proc1 VALUES (1, 'two')
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+        SAVE TRAN s1
+            DROP TABLE #t1_proc1
+            CREATE TABLE #t1_proc1(a varchar(100))
+            INSERT INTO #t1_proc1 VALUES ('three')
+            -- Should just be 'three'
+            select * from #t1_proc1
+        ROLLBACK TRAN s1
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+        CREATE TABLE #t2_proc1(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc1 VALUES ('four')
+        -- ('four', 1)
+        SELECT * FROM #t2_proc1
+        DROP TABLE #t2_proc1
+    ROLLBACK;
+    -- Should have just 6
+    SELECT * FROM #t1_proc1
+    -- Should not exist
+    SELECT * FROM #t2_proc1
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    BEGIN TRAN
+        SAVE TRAN S1
+        CREATE TABLE #t1_proc2(a int)
+        ALTER TABLE #t1_proc2 ADD b varchar(50)
+        INSERT INTO #t1_proc2 VALUES (1, 'two')
+        select * from #t1_proc2
+        DROP TABLE #t1_proc2
+        CREATE TABLE #t1_proc2(a varchar(100))
+        INSERT INTO #t1_proc2 VALUES ('three')
+        select * from #t1_proc2
+        CREATE TABLE #t2_proc2(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc2 VALUES ('four')
+        SELECT * FROM #t2_proc2
+        DROP TABLE #t2_proc2
+        INSERT INTO #t1_proc2 values (1, 2, 3, 4, 5)
+        SELECT * FROM #t1_proc2
+        SELECT * FROM #t2_proc2
+    COMMIT
+END
+GO
 ----------------------------------------------------------
 -- Nested transactions
 ----------------------------------------------------------
@@ -800,3 +872,11 @@ text
 ~~END~~
 
 
+DROP VIEW enr_view;
+GO
+
+DROP PROCEDURE test_nested_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
+GO

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -62,7 +62,7 @@ GO
 CREATE PROCEDURE tv_base_rollback AS
 BEGIN
     DECLARE @tv TABLE (a int)
-    INSERT INTO mytab VALUES (1)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
     INSERT INTO @tv VALUES (1)
 END
 GO
@@ -922,16 +922,16 @@ four#!#1
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
 
-CREATE TABLE mytab(a int)
+CREATE TABLE temp_tab_rollback_mytab(a int)
 GO
 
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 INSERT INTO #t1 VALUES (1)
 EXEC tv_base_rollback
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 ROLLBACK
-SELECT * FROM mytab
+SELECT * FROM temp_tab_rollback_mytab
 GO
 ~~ROW COUNT: 1~~
 
@@ -944,7 +944,7 @@ int
 ~~END~~
 
 
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 GO
 
 -- Everything should be rolled back due to error

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -1,5 +1,62 @@
--- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
+SET xact_abort ON
 
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+
+CREATE PROCEDURE test_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1 ADD b varchar(50)
+        TRUNCATE TABLE #t1
+        INSERT INTO #t1 VALUES (1, 'two')
+        select * from #t1
+        DROP TABLE #t1
+        CREATE TABLE #t1(a varchar(100))
+        INSERT INTO #t1 VALUES ('three')
+        select * from #t1
+        CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+        INSERT INTO #t2 VALUES ('four')
+        SELECT * FROM #t2
+        DROP TABLE #t2
+    ROLLBACK;
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    CREATE TABLE #t1(a int)
+    ALTER TABLE #t1 ADD b varchar(50)
+    INSERT INTO #t1 VALUES (1, 'two')
+    select * from #t1
+    DROP TABLE #t1
+    CREATE TABLE #t1(a varchar(100))
+    INSERT INTO #t1 VALUES ('three')
+    select * from #t1
+    CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+    INSERT INTO #t2 VALUES ('four')
+    SELECT * FROM #t2
+    DROP TABLE #t2
+    INSERT INTO #t1 values (1, 2, 3)
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+-- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
 -------------------------------
@@ -8,14 +65,29 @@ CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
 select * from enr_view
 ROLLBACK
 GO
+~~START~~
+text
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#temp_table_rollback_t1_pkey
+~~END~~
+
 
 -- Should be empty
 select * from enr_view
 GO
+~~START~~
+text
+~~END~~
+
 
 -- Should not exist
 SELECT * FROM #temp_table_rollback_t1
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
+
 
 -----------------------------
 -- Temp Table DROP + ROLLBACK
@@ -25,6 +97,8 @@ go
 
 INSERT INTO #temp_table_rollback_t1 VALUES (1)
 GO
+~~ROW COUNT: 1~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -34,12 +108,24 @@ go
 -- Should still exist
 select * from enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+~~END~~
+
 
 -- Should show results
 BEGIN TRAN
 select * from #temp_table_rollback_t1
 COMMIT
 go
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
 
 -- Should not error
 BEGIN TRAN
@@ -57,21 +143,37 @@ BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
 ROLLBACK
 GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
 COMMIT
 GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop column b of table "#temp_table_rollback_t1" because other objects depend on it)~~
+
 
 BEGIN TRAN
 ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
 COMMIT
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: unexpected object depending on column: type "#temp_table_rollback_t1")~~
+
 
 DROP TABLE #temp_table_rollback_t1
 GO
@@ -94,18 +196,44 @@ GO
 -- Tables are still visible and usable
 select * from enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t1_pkey
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t1_a_seq
+#temp_table_rollback_t1
+#pg_toast_#oid_masked#_index
+#pg_toast_#oid_masked#
+#temp_table_rollback_t2
+~~END~~
+
 
 INSERT INTO #temp_table_rollback_t1 values (1, 'b')
 GO
+~~ROW COUNT: 1~~
+
 
 INSERT INTO #temp_table_rollback_t2 values ('c')
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t1
 GO
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#b
+~~END~~
+
 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+varchar
+c
+~~END~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -120,6 +248,10 @@ GO
 
 SELECT * FROM enr_view
 go
+~~START~~
+text
+~~END~~
+
 
 ----------------------------------------------------------
 -- Implicit rollback due to error
@@ -130,16 +262,27 @@ GO
 
 INSERT INTO #temp_table_rollback_t2 VALUES (1)
 GO
+~~ROW COUNT: 1~~
+
 
 -- Transaction will error out
 BEGIN TRAN
 drop table #temp_table_rollback_t2
 insert into #temp_table_rollback_t1 values (1, 1, 1, 1) -- Too many columns, should error out
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
 
 -- Table + data should still exist, due to implicit rollback. 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 -- Duplicate key doesn't cause implicit rollback, so the drop will succeed here. 
 BEGIN TRAN
@@ -147,9 +290,20 @@ drop table #temp_table_rollback_t2
 insert into #temp_table_rollback_t1 values (1, 1, 'a')
 insert into #temp_table_rollback_t1 values (1, 1, 'a')
 GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#temp_table_rollback_t1_pkey")~~
+
 
 SELECT * FROM #temp_table_rollback_t2
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 BEGIN TRAN
 DROP TABLE #temp_table_rollback_t1
@@ -159,11 +313,15 @@ GO
 
 SELECT * FROM enr_view;
 GO
+~~START~~
+text
+~~END~~
+
+
 
 ---------------------------------------------------------------------------
 -- Same temp table name in one transaction
 ---------------------------------------------------------------------------
-
 CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
 GO
 
@@ -174,6 +332,8 @@ BEGIN TRANSACTION
     CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 DROP TABLE #temp_table_rollback_t3
 GO
@@ -181,47 +341,66 @@ GO
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 GO
 
+
+
 BEGIN TRANSACTION
     DROP TABLE #temp_table_rollback_t4
-
     CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
     INSERT INTO #temp_table_rollback_t4 VALUES (1, 'one')
     SELECT * FROM #temp_table_rollback_t4 -- should return 1, 'one'
     DROP TABLE #temp_table_rollback_t4
-
     INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
     SELECT * FROM #temp_table_rollback_t4
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#char
+1#!#one       
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
 
 SELECT * FROM #temp_table_rollback_t4
 GO
+~~START~~
+int#!#char
+~~END~~
+
 
 DROP TABLE #temp_table_rollback_t4
 GO
 
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 GO
+
+
 
 BEGIN TRANSACTION T1
 ALTER TABLE #temp_table_rollback_t4 ADD C3 INT
 DROP TABLE #temp_table_rollback_t4
-
 CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
 DROP  TABLE #temp_table_rollback_t4
-
 INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
 COMMIT
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t4" does not exist)~~
+
 
 DROP TABLE #temp_table_rollback_t4
 GO
+
 
 ---------------------------------------------------------------------------
 -- Index creation
 ---------------------------------------------------------------------------
 -- Created index in transaction
-
 CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
 GO
 
@@ -230,35 +409,71 @@ BEGIN TRAN
     INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+~~END~~
+
 
 INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
 GO
+~~ROW COUNT: 1~~
+
 
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
 ROLLBACK
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+~~END~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
 GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
 GO
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+#temp_table_rollback_t5
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+~~END~~
+
+
 
 -- Drop index in transaction
-
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
 
@@ -267,20 +482,44 @@ BEGIN TRAN
     INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
 COMMIT
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 BEGIN TRAN
     DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 ROLLBACK
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index "#temp_table_rollback_t5_idx2#te2a202739f4e4dbd1ebea8195fe760b6f" does not exist)~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
@@ -290,6 +529,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 -- Create and drop in transaction
 BEGIN TRAN
@@ -300,6 +546,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
 DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
@@ -307,6 +560,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 -- Drop - Create
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
@@ -320,6 +580,13 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
@@ -327,18 +594,61 @@ GO
 
 SELECT * FROM #temp_table_rollback_t5
 GO
+~~START~~
+int#!#varchar#!#int#!#int
+1#!#a#!#2#!#3
+2#!#b#!#3#!#4
+3#!#c#!#4#!#5
+~~END~~
+
 
 DROP TABLE #temp_table_rollback_t5
 GO
 
 SELECT * FROM enr_view
 GO
+~~START~~
+text
+~~END~~
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
-
 exec test_rollback_in_proc
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#t2" does not exist)~~
+
 
 BEGIN TRANSACTION
     CREATE TABLE #outer_tab1(a int)
@@ -347,8 +657,50 @@ BEGIN TRANSACTION
     select * from #outer_tab1
 ROLLBACK
 GO
+~~START~~
+text
+#outer_tab1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT has more expressions than target columns)~~
+
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
 SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+DROP VIEW enr_view
+GO
+
+DROP PROCEDURE test_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
 GO

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -59,6 +59,14 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE tv_base_rollback AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    INSERT INTO mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -764,6 +772,80 @@ text
 ~~END~~
 
 
+
+-- DELETE, TRUNCATE
+CREATE TABLE #t1(a int identity primary key, b int)
+INSERT INTO #t1 VALUES (0)
+INSERT INTO #t1 VALUES (1)
+INSERT INTO #t1 VALUES (2)
+INSERT INTO #t1 VALUES (3)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+BEGIN TRAN
+    DELETE FROM #t1
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+~~END~~
+
+
+-- Truncate should reset IDENTITY. But it should be restored on ROLLBACK.
+BEGIN TRAN
+    TRUNCATE TABLE #t1
+    INSERT INTO #t1 VALUES (1)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+
+INSERT INTO #t1 VALUES (4)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#0
+2#!#1
+3#!#2
+4#!#3
+5#!#4
+~~END~~
+
+
+
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
@@ -839,6 +921,31 @@ four#!#1
 
 ~~ERROR (Message: INSERT has more expressions than target columns)~~
 
+
+CREATE TABLE mytab(a int)
+GO
+
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+EXEC tv_base_rollback
+DROP TABLE mytab
+ROLLBACK
+SELECT * FROM mytab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+
+DROP TABLE mytab
+GO
 
 -- Everything should be rolled back due to error
 -- Nothing from the proc should be here either
@@ -1133,6 +1240,9 @@ int
 ~~END~~
 
 
+DROP TABLE #t1
+GO
+
 
 
 
@@ -1217,6 +1327,80 @@ int
 
 DROP TABLE perm_tab
 GO
+
+
+---------------------------------------------------------------------------
+-- Trigger (can't be created on temp tables)
+---------------------------------------------------------------------------
+CREATE TABLE basetab(a int, b int)
+GO
+
+CREATE TRIGGER basetrig_insert ON basetab 
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (1)
+GO
+
+CREATE TABLE #t1(a int)
+GO
+
+BEGIN TRAN
+    INSERT INTO basetab VALUES (1, 2)
+    SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * FROM basetab
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+
+CREATE TRIGGER basetrig_rollback ON basetab
+    FOR INSERT, UPDATE, DELETE
+AS
+    INSERT INTO #t1 VALUES (2)
+    ROLLBACK
+GO
+
+INSERT INTO basetab VALUES (3, 4)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 3609)~~
+
+~~ERROR (Message: The transaction ended in the trigger. The batch has been aborted.)~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int
+~~END~~
+
+
+DROP TRIGGER basetrig_insert
+GO
+
+DROP TABLE basetab
+GO
 DROP VIEW enr_view
 GO
 
@@ -1227,4 +1411,7 @@ DROP PROCEDURE test_rollback_in_proc
 GO
 
 DROP PROCEDURE implicit_rollback_in_proc
+GO
+
+DROP PROCEDURE tv_base_rollback
 GO

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -10,6 +10,9 @@ CREATE VIEW enr_view AS
     FROM sys.babelfish_get_enr_list()
 GO
 
+CREATE TYPE temp_table_type FROM int
+GO
+
 
 CREATE PROCEDURE test_rollback_in_proc AS
 BEGIN
@@ -87,6 +90,73 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: relation "#temp_table_rollback_t1" does not exist)~~
+
+
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+INSERT INTO #t1 VALUES (1)
+SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t1(a int, b int)
+GO
+
+INSERT INTO #t1 VALUES (1, 1)
+INSERT INTO #t1 VALUES (2, 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #t1 VALUES (3, 1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
+BEGIN TRAN
+UPDATE #t1 SET a = a + 1 WHERE b = 1
+SELECT * FROM #t1
+ROLLBACK
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
 
 
 -----------------------------
@@ -253,6 +323,87 @@ text
 ~~END~~
 
 
+CREATE TABLE #t1(a int, b int)
+GO
+
+CREATE TABLE #t2(c varchar(20), d int)
+GO
+
+INSERT INTO #t1 VALUES (1, 1)
+INSERT INTO #t1 VALUES (2, 1)
+INSERT INTO #t2 VALUES ('abc', 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+INSERT INTO #t1 VALUES (3, 1)
+INSERT INTO #t2 VALUES ('def', 1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+
+BEGIN TRAN
+UPDATE #t1 SET a = a + 1 WHERE b = 1
+UPDATE #t2 SET c = 'qed' WHERE d = 1
+SELECT * FROM #t1
+SELECT * FROM #t2
+ROLLBACK
+GO
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+2#!#1
+3#!#1
+4#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+qed#!#1
+qed#!#1
+~~END~~
+
+
+SELECT * FROM #t1
+SELECT * FROM #t2
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+3#!#1
+~~END~~
+
+~~START~~
+varchar#!#int
+abc#!#1
+def#!#1
+~~END~~
+
+
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
 ----------------------------------------------------------
 -- Implicit rollback due to error
 ----------------------------------------------------------
@@ -407,7 +558,7 @@ GO
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
     INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
-COMMIT
+ROLLBACK
 GO
 ~~ROW COUNT: 1~~
 
@@ -416,7 +567,6 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
 ~~END~~
 
 
@@ -427,40 +577,49 @@ GO
 
 BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
-ROLLBACK
+    UPDATE #temp_table_rollback_t5 SET b = 'd' WHERE d = 4
+    SELECT * FROM #temp_table_rollback_t5
+COMMIT
 GO
-~~ERROR (Code: 2714)~~
+~~ROW COUNT: 1~~
 
-~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
-
-
-SELECT * FROM #temp_table_rollback_t5
-GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 ~~END~~
 
 
-CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+BEGIN TRAN
+    UPDATE #temp_table_rollback_t5 SET b = 'e' WHERE d = 4
+    SELECT * FROM #temp_table_rollback_t5
+ROLLBACK
 GO
-~~ERROR (Code: 2714)~~
+~~ROW COUNT: 1~~
 
-~~ERROR (Message: relation "#temp_table_rollback_t5_idx1#te079f8902c8b6d636ba730e03a1305617" already exists)~~
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#e#!#3#!#4
+~~END~~
 
 
 SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 ~~END~~
 
 
 DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
 GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+~~START~~
+int#!#varchar#!#int#!#int
+2#!#d#!#3#!#4
+~~END~~
+
 
 SELECT * FROM enr_view
 GO
@@ -489,8 +648,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -508,8 +666,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -531,8 +688,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -548,8 +704,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -562,8 +717,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -582,8 +736,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -596,8 +749,7 @@ SELECT * FROM #temp_table_rollback_t5
 GO
 ~~START~~
 int#!#varchar#!#int#!#int
-1#!#a#!#2#!#3
-2#!#b#!#3#!#4
+2#!#d#!#3#!#4
 3#!#c#!#4#!#5
 ~~END~~
 
@@ -696,7 +848,379 @@ GO
 text
 ~~END~~
 
+
+---------------------------------------------------------------------------
+-- Mixed permanent, TV, temp tables in/out of ENR.
+---------------------------------------------------------------------------
+-- Mixed create rollback
+BEGIN TRAN
+    DECLARE @tv TABLE (a1 int)
+    CREATE TABLE #temp_table(a2 int)
+    CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+~~END~~
+
+
+-- Mixed insert rollback
+DECLARE @tv TABLE (a1 int)
+CREATE TABLE perm_table(a2 int)
+CREATE TABLE #temp_table(a3 int)
+CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+BEGIN TRAN
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO perm_table VALUES(2)
+    INSERT INTO #temp_table VALUES(3)
+    INSERT INTO #temp_table_nonenr VALUES (4)
+    SELECT * FROM @tv
+    SELECT * FROM perm_table
+    SELECT * FROM #temp_table
+    SELECT * FROM #temp_table_nonenr
+ROLLBACK
+-- Unaffected by rollback
+SELECT * FROM @tv
+-- Correctly rolled back
+SELECT * FROM perm_table
+-- Correctly rolled back
+SELECT * FROM #temp_table
+SELECT * FROM #temp_table_nonenr
+SELECT * FROM enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+int
+~~END~~
+
+~~START~~
+text
+@tv_0
+#temp_table
+~~END~~
+
+
+SELECT * FROM enr_view
+DROP TABLE #temp_table
+DROP TABLE #temp_table_nonenr
+DROP TABLE perm_table
+GO
+~~START~~
+text
+#temp_table
+~~END~~
+
+
+-- Mixed drop rollback
+CREATE TABLE #temp_table(a int)
+CREATE TABLE perm_table(a int)
+CREATE TABLE #temp_table_nonenr(a3 temp_table_type)
+GO
+
+BEGIN TRAN
+    DECLARE @tv TABLE(a int)
+    SELECT * FROM enr_view
+    DROP TABLE #temp_table
+    DROP TABLE perm_table
+    DROP TABLE #temp_table_nonenr
+    SELECT * FROM enr_view
+ROLLBACK
+GO
+~~START~~
+text
+#temp_table
+@tv_0
+~~END~~
+
+~~START~~
+text
+@tv_0
+~~END~~
+
+
+SELECT * FROM enr_view
+GO
+~~START~~
+text
+#temp_table
+~~END~~
+
+
+DROP TABLE #temp_table
+DROP TABLE perm_table
+DROP TABLE #temp_table_nonenr
+GO
+
+
+---------------------------------------------------------------------------
+-- Multiple COMMIT/ROLLBACK
+---------------------------------------------------------------------------
+CREATE TABLE #t1(a int)
+GO
+
+
+
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+COMMIT
+BEGIN TRAN
+UPDATE #t1 SET a = 2 WHERE a = 1
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+DROP TABLE #t1
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+
+
+
+
+------------------------
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+COMMIT
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+CREATE TABLE #t2(a int identity primary key, b varchar)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+CREATE INDEX #t2_idx ON #t2(b)
+INSERT INTO #t2 VALUES ('a')
+ROLLBACK
+BEGIN TRAN
+CREATE INDEX #t2_idx ON #t2(b)
+INSERT INTO #t2 VALUES ('b')
+SELECT * FROM #t1
+SELECT * FROM #t2
+DROP TABLE #t1
+DROP TABLE #t2
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#b
+~~END~~
+
+
+
+
+
+
+
+----------------------------
+BEGIN TRAN 
+CREATE TABLE #t1(a int)
+CREATE TABLE #t2(a int)
+ROLLBACK
+BEGIN TRAN
+CREATE TABLE #t1(a varchar)
+CREATE TABLE #t2(a varchar)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1
+DROP TABLE #t2
+COMMIT
+BEGIN TRAN
+CREATE TABLE #t1(a int)
+CREATE TABLE #t2(a int)
+INSERT INTO #t1 VALUES (1)
+ROLLBACK
+SELECT * FROM enr_view
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+text
+~~END~~
+
+
+
+
+
+
+
+----------------------------
+BEGIN TRAN
+CREATE TABLE #t1 (a int)
+COMMIT
+BEGIN TRAN
+DROP TABLE #t1 
+ROLLBACK
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+BEGIN TRAN
+DROP TABLE #t1
+ROLLBACK
+BEGIN TRAN
+INSERT INTO #t1 VALUES (1)
+SELECT * FROM #t1
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+
+---------------------------------------------------------------------------
+-- Cursor
+---------------------------------------------------------------------------
+-- Temp into permanent
+DECLARE @v int
+CREATE TABLE #t(a int)
+insert into #t values (1)
+insert into #t values (2)
+insert into #t values (3)
+CREATE TABLE perm_tab(a int)
+DECLARE cur CURSOR FOR (select a from #t)
+OPEN cur
+WHILE @@fetch_status = 0
+BEGIN
+    fetch cur into @v
+    insert into perm_tab values (@v)
+END
+CLOSE cur
+DEALLOCATE cur
+SELECT * FROM perm_tab
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+~~END~~
+
+
+
+-- Permanent into temp
+DECLARE @v int
+CREATE TABLE #t2(b int)
+DECLARE cur CURSOR FOR (select a from perm_tab)
+OPEN cur
+WHILE @@fetch_status = 0
+BEGIN
+    fetch cur into @v
+    insert into #t2 values (@v)
+END
+CLOSE cur
+DEALLOCATE cur
+SELECT * FROM #t2
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+2
+3
+<NULL>
+<NULL>
+~~END~~
+
+
+DROP TABLE perm_tab
+GO
 DROP VIEW enr_view
+GO
+
+DROP TYPE temp_table_type
 GO
 
 DROP PROCEDURE test_rollback_in_proc

--- a/test/JDBC/input/temp_tables/temp_table_mixed_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_mixed_rollback.mix
@@ -1,0 +1,63 @@
+-- tsql
+
+CREATE PROCEDURE tsql_proc1
+AS
+    BEGIN TRAN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 VALUES (1)
+    SELECT * FROM #t1
+    ROLLBACK
+GO
+
+
+-- psql
+
+CREATE PROCEDURE pg_proc1()
+AS
+$$
+BEGIN
+    INSERT INTO my_table VALUES(1);    
+    ROLLBACK;
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+CREATE PROCEDURE pg_proc2()
+AS
+$$
+BEGIN
+    INSERT INTO my_table VALUES(2);    
+END
+$$ LANGUAGE PLPGSQL;
+GO
+
+-- tsql 
+CREATE TABLE my_table(a int)
+GO
+
+EXEC tsql_proc1
+EXEC [public].pg_proc1
+GO
+
+BEGIN TRAN
+EXEC [public].pg_proc2
+ROLLBACK
+GO
+
+SELECT * FROM my_table
+DROP TABLE my_table
+GO
+
+
+-- tsql
+
+DROP PROCEDURE tsql_proc1;
+GO
+
+-- psql
+
+DROP PROCEDURE pg_proc1;
+GO
+
+DROP PROCEDURE pg_proc2;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -1,2 +1,8 @@
 DROP VIEW enr_view
 GO
+
+DROP PROCEDURE test_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -1,6 +1,9 @@
 DROP VIEW enr_view
 GO
 
+DROP TYPE temp_table_type
+GO
+
 DROP PROCEDURE test_rollback_in_proc
 GO
 

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -1,0 +1,2 @@
+DROP VIEW enr_view
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -9,3 +9,6 @@ GO
 
 DROP PROCEDURE implicit_rollback_in_proc
 GO
+
+DROP PROCEDURE tv_base_rollback
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -1,0 +1,9 @@
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -8,6 +8,9 @@ CREATE VIEW enr_view AS
     FROM sys.babelfish_get_enr_list()
 GO
 
+CREATE TYPE temp_table_type FROM int
+GO
+
 CREATE PROCEDURE test_rollback_in_proc AS
 BEGIN
     CREATE TABLE #t1(a int)

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -56,3 +56,11 @@ BEGIN
     SELECT * FROM #t2
 END
 GO
+
+CREATE PROCEDURE tv_base_rollback AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    INSERT INTO mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+END
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -7,3 +7,49 @@ CREATE VIEW enr_view AS
         END AS relname
     FROM sys.babelfish_get_enr_list()
 GO
+
+CREATE PROCEDURE test_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1(a int)
+    INSERT INTO #t1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1 ADD b varchar(50)
+        TRUNCATE TABLE #t1
+        INSERT INTO #t1 VALUES (1, 'two')
+        select * from #t1
+        DROP TABLE #t1
+        CREATE TABLE #t1(a varchar(100))
+        INSERT INTO #t1 VALUES ('three')
+        select * from #t1
+
+        CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+        INSERT INTO #t2 VALUES ('four')
+        SELECT * FROM #t2
+        DROP TABLE #t2
+    ROLLBACK;
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    CREATE TABLE #t1(a int)
+    ALTER TABLE #t1 ADD b varchar(50)
+    INSERT INTO #t1 VALUES (1, 'two')
+    select * from #t1
+    DROP TABLE #t1
+    CREATE TABLE #t1(a varchar(100))
+    INSERT INTO #t1 VALUES ('three')
+    select * from #t1
+
+    CREATE TABLE #t2(b varchar(50), a int identity primary key, )
+    INSERT INTO #t2 VALUES ('four')
+    SELECT * FROM #t2
+    DROP TABLE #t2
+
+    INSERT INTO #t1 values (1, 2, 3)
+    SELECT * FROM #t1
+    SELECT * FROM #t2
+END
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -60,7 +60,7 @@ GO
 CREATE PROCEDURE tv_base_rollback AS
 BEGIN
     DECLARE @tv TABLE (a int)
-    INSERT INTO mytab VALUES (1)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
     INSERT INTO @tv VALUES (1)
 END
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -160,66 +160,6 @@ GO
 SELECT * FROM enr_view;
 GO
 
-----------------------------------------------------------
--- Nested transactions
-----------------------------------------------------------
-BEGIN TRANSACTION T1
-    CREATE TABLE #t1(a varchar(16))
-    INSERT INTO #t1 VALUES ('t1')
-    SAVE TRANSACTION T2
-        INSERT INTO #t1 VALUES ('t2')
-        SAVE TRANSACTION T3
-            INSERT INTO #t1 VALUES ('t3')
-            SAVE TRANSACTION T4
-                INSERT INTO #t1 VALUES ('t4')
-                SELECT * FROM #t1
-            ROLLBACK TRANSACTION T4
-            SELECT * FROM #t1
-        ROLLBACK TRANSACTION T3
-        SELECT * FROM #t1
-    ROLLBACK TRANSACTION T2
-    SELECT * FROM #t1
-ROLLBACK TRANSACTION T1
-SELECT * FROM #t1
-GO
-
--- SELECT * FROM enr_view;
--- GO
-
--- BEGIN TRANSACTION T1
---     SAVE TRANSACTION S2
---         create table #t3(a int)
---         create table #t4(a int identity primary key, b varchar(50))
---         insert into #t3 values (5)
---         insert into #t4 values ('six')
---         SELECT * FROM #t3
---         SELECT * FROM #t4
---         SELECT * FROM enr_view;
---     ROLLBACK TRANSACTION S2
---     SELECT * FROM enr_view;
--- COMMIT
--- GO
-
-
-----------------------------------------------------------
--- Savepoint CREATE and DROP
-----------------------------------------------------------
-BEGIN TRANSACTION T1
-    CREATE TABLE #t1(a int primary key, b varchar(16))
-    SAVE TRANSACTION T2
-        INSERT INTO #t1 VALUES (1, 't2')
-        SAVE TRANSACTION T3
-            UPDATE #t1 SET a = 2 WHERE a = 1
-            SELECT * FROM #t1
-            SAVE TRANSACTION T4
-                DROP TABLE #t1
-            ROLLBACK TRANSACTION T4
-        ROLLBACK TRANSACTION T3
-        SELECT * FROM #t1
-    ROLLBACK TRANSACTION T2
-select * from enr_view
-GO
-
 ---------------------------------------------------------------------------
 -- Same temp table name in one transaction
 ---------------------------------------------------------------------------
@@ -285,11 +225,9 @@ GO
 CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
 GO
 
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
-        INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
-    ROLLBACK TRANSACTION S2
+BEGIN TRAN
+    CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+    INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
 COMMIT
 GO
 
@@ -324,11 +262,9 @@ GO
 CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
 GO
 
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
-        INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
-    ROLLBACK TRANSACTION S2
+BEGIN TRAN
+    DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+    INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
 COMMIT
 GO
 
@@ -340,6 +276,9 @@ BEGIN TRAN
 ROLLBACK
 GO
 
+SELECT * FROM #temp_table_rollback_t5
+GO
+
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
 
@@ -349,19 +288,11 @@ GO
 DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
 GO
 
--- Create and drop in transaction
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
-        DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
-    ROLLBACK TRANSACTION S2
-COMMIT
-GO
-
 SELECT * FROM #temp_table_rollback_t5
 GO
 
-BEGIN TRAN T1
+-- Create and drop in transaction
+BEGIN TRAN
     CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
     DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
 ROLLBACK
@@ -381,18 +312,7 @@ GO
 CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
 GO
 
-BEGIN TRAN T1
-    SAVE TRANSACTION S2
-        DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
-        CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
-    ROLLBACK TRANSACTION S2
-COMMIT
-GO
-
-SELECT * FROM #temp_table_rollback_t5
-GO
-
-BEGIN TRAN T1
+BEGIN TRAN
     DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
     CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
 ROLLBACK

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -1,0 +1,192 @@
+-- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
+
+-------------------------------
+-- Temp Table CREATE + ROLLBACK
+-------------------------------
+BEGIN TRAN
+CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
+select * from enr_view
+ROLLBACK
+GO
+
+-- Should be empty
+select * from enr_view
+GO
+
+-- Should not exist
+SELECT * FROM #temp_table_rollback_t1
+GO
+
+-----------------------------
+-- Temp Table DROP + ROLLBACK
+-----------------------------
+CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int)
+go
+
+INSERT INTO #temp_table_rollback_t1 VALUES (1)
+GO
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+ROLLBACK
+go
+
+-- Should still exist
+select * from enr_view
+GO
+
+-- Should show results
+BEGIN TRAN
+select * from #temp_table_rollback_t1
+COMMIT
+go
+
+-- Should not error
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+COMMIT
+GO
+
+----------------------------------------------------------
+-- ALTER TABLE (should fail due to BABEL-4912)
+----------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t1 (a int, b int)
+GO
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
+ROLLBACK
+GO
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
+ROLLBACK
+GO
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 DROP COLUMN b
+COMMIT
+GO
+
+BEGIN TRAN
+ALTER TABLE #temp_table_rollback_t1 ALTER COLUMN b VARCHAR
+COMMIT
+GO
+
+DROP TABLE #temp_table_rollback_t1
+GO
+
+----------------------------------------------------------
+-- Multiple tables in one transaction
+----------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t1(a int identity primary key, b int, c varchar)
+GO
+
+create table #temp_table_rollback_t2(a varchar)
+GO
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+DROP TABLE #temp_table_rollback_t2
+ROLLBACK
+GO
+
+-- Tables are still visible and usable
+select * from enr_view
+GO
+
+INSERT INTO #temp_table_rollback_t1 values (1, 'b')
+GO
+
+INSERT INTO #temp_table_rollback_t2 values ('c')
+GO
+
+SELECT * FROM #temp_table_rollback_t1
+GO
+
+SELECT * FROM #temp_table_rollback_t2
+GO
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+DROP TABLE #temp_table_rollback_t2
+COMMIT
+GO
+
+----------------------------------------------------------
+-- Implicit rollback due to error
+----------------------------------------------------------
+CREATE TABLE #temp_table_rollback_t1(a int primary key, b int, c varchar)
+CREATE TABLE #temp_table_rollback_t2(a int)
+GO
+
+INSERT INTO #temp_table_rollback_t2 VALUES (1)
+GO
+
+-- Transaction will error out
+BEGIN TRAN
+drop table #temp_table_rollback_t2
+insert into #temp_table_rollback_t1 values (1, 1, 1) -- Wrong should error out 
+GO
+
+-- Table + data should still exist, due to implicit rollback. 
+SELECT * FROM #temp_table_rollback_t2
+GO
+
+-- Duplicate key doesn't cause implicit rollback, so the drop will succeed here. 
+BEGIN TRAN
+drop table #temp_table_rollback_t2
+insert into #temp_table_rollback_t1 values (1, 1, 'a')
+insert into #temp_table_rollback_t1 values (1, 1, 'a')
+GO
+
+SELECT * FROM #temp_table_rollback_t2
+GO
+
+BEGIN TRAN
+DROP TABLE #temp_table_rollback_t1
+DROP TABLE #temp_table_rollback_t2
+COMMIT
+GO
+
+----------------------------------------------------------
+-- Nested transactions
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a varchar(16))
+    INSERT INTO #t1 VALUES ('t1')
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES ('t2')
+        SAVE TRANSACTION T3
+            INSERT INTO #t1 VALUES ('t3')
+            SAVE TRANSACTION T4
+                INSERT INTO #t1 VALUES ('t4')
+                SELECT * FROM #t1
+            ROLLBACK TRANSACTION T4
+            SELECT * FROM #t1
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+    SELECT * FROM #t1
+ROLLBACK TRANSACTION T1
+SELECT * FROM #t1
+GO
+
+----------------------------------------------------------
+-- Savepoint CREATE and DROP
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a int primary key, b varchar(16))
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES (1, 't2')
+        SAVE TRANSACTION T3
+            UPDATE #t1 SET a = 2 WHERE a = 1
+            SELECT * FROM #t1
+            SAVE TRANSACTION T4
+                DROP TABLE #t1
+            ROLLBACK TRANSACTION T4
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+select * from enr_view
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -227,3 +227,163 @@ GO
 
 SELECT * FROM #temp_table_rollback_t4
 GO
+
+DROP TABLE #temp_table_rollback_t4
+GO
+
+CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+GO
+
+BEGIN TRANSACTION T1
+ALTER TABLE #temp_table_rollback_t4 ADD C3 INT
+DROP TABLE #temp_table_rollback_t4
+
+CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+DROP  TABLE #temp_table_rollback_t4
+
+INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
+COMMIT
+GO
+
+---------------------------------------------------------------------------
+-- Index creation
+---------------------------------------------------------------------------
+-- Created index in transaction
+
+CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+        INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
+GO
+
+BEGIN TRAN
+    CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+
+-- Drop index in transaction
+
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+        INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+BEGIN TRAN
+    DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+-- Create and drop in transaction
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+        DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+BEGIN TRAN T1
+    CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+    DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+-- Drop - Create
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+        CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+BEGIN TRAN T1
+    DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+    CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+---------------------------------------------------------------------------
+-- Triggers
+---------------------------------------------------------------------------
+
+-- TODO
+
+---------------------------------------------------------------------------
+-- Procedures
+---------------------------------------------------------------------------
+
+-- TODO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -452,19 +452,19 @@ BEGIN TRANSACTION
 ROLLBACK
 GO
 
-CREATE TABLE mytab(a int)
+CREATE TABLE temp_tab_rollback_mytab(a int)
 GO
 
 BEGIN TRAN
 CREATE TABLE #t1(a int)
 INSERT INTO #t1 VALUES (1)
 EXEC tv_base_rollback
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 ROLLBACK
-SELECT * FROM mytab
+SELECT * FROM temp_tab_rollback_mytab
 GO
 
-DROP TABLE mytab
+DROP TABLE temp_tab_rollback_mytab
 GO
 
 -- Everything should be rolled back due to error

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -190,3 +190,40 @@ BEGIN TRANSACTION T1
     ROLLBACK TRANSACTION T2
 select * from enr_view
 GO
+
+---------------------------------------------------------------------------
+-- Same temp table name in one transaction
+---------------------------------------------------------------------------
+
+CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
+GO
+
+BEGIN TRANSACTION
+    ALTER TABLE #temp_table_rollback_t3 ADD C3 INT;
+    INSERT INTO #temp_table_rollback_t3 VALUES (1, 2, 3)
+    DROP TABLE #temp_table_rollback_t3
+    CREATE TABLE #temp_table_rollback_t3(c1 INT, c2 INT)
+COMMIT
+GO
+
+DROP TABLE #temp_table_rollback_t3
+GO
+
+CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+GO
+
+BEGIN TRANSACTION
+    DROP TABLE #temp_table_rollback_t4
+
+    CREATE TABLE #temp_table_rollback_t4(c1 INT, c2 CHAR(10))
+    INSERT INTO #temp_table_rollback_t4 VALUES (1, 'one')
+    SELECT * FROM #temp_table_rollback_t4 -- should return 1, 'one'
+    DROP TABLE #temp_table_rollback_t4
+
+    INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
+    SELECT * FROM #temp_table_rollback_t4
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t4
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -113,6 +113,14 @@ DROP TABLE #temp_table_rollback_t2
 COMMIT
 GO
 
+BEGIN TRAN
+    CREATE TABLE #t1(a int)
+    ROLLBACK
+GO
+
+SELECT * FROM enr_view
+go
+
 ----------------------------------------------------------
 -- Implicit rollback due to error
 ----------------------------------------------------------
@@ -149,6 +157,9 @@ DROP TABLE #temp_table_rollback_t2
 COMMIT
 GO
 
+SELECT * FROM enr_view;
+GO
+
 ----------------------------------------------------------
 -- Nested transactions
 ----------------------------------------------------------
@@ -171,6 +182,24 @@ BEGIN TRANSACTION T1
 ROLLBACK TRANSACTION T1
 SELECT * FROM #t1
 GO
+
+-- SELECT * FROM enr_view;
+-- GO
+
+-- BEGIN TRANSACTION T1
+--     SAVE TRANSACTION S2
+--         create table #t3(a int)
+--         create table #t4(a int identity primary key, b varchar(50))
+--         insert into #t3 values (5)
+--         insert into #t4 values ('six')
+--         SELECT * FROM #t3
+--         SELECT * FROM #t4
+--         SELECT * FROM enr_view;
+--     ROLLBACK TRANSACTION S2
+--     SELECT * FROM enr_view;
+-- COMMIT
+-- GO
+
 
 ----------------------------------------------------------
 -- Savepoint CREATE and DROP
@@ -243,6 +272,9 @@ DROP  TABLE #temp_table_rollback_t4
 
 INSERT INTO #temp_table_rollback_t4 VALUES (2, 'two')
 COMMIT
+GO
+
+DROP TABLE #temp_table_rollback_t4
 GO
 
 ---------------------------------------------------------------------------
@@ -376,14 +408,27 @@ GO
 SELECT * FROM #temp_table_rollback_t5
 GO
 
----------------------------------------------------------------------------
--- Triggers
----------------------------------------------------------------------------
+DROP TABLE #temp_table_rollback_t5
+GO
 
--- TODO
-
+SELECT * FROM enr_view
+GO
 ---------------------------------------------------------------------------
 -- Procedures
 ---------------------------------------------------------------------------
 
--- TODO
+exec test_rollback_in_proc
+GO
+
+BEGIN TRANSACTION
+    CREATE TABLE #outer_tab1(a int)
+    SELECT * FROM enr_view
+    exec implicit_rollback_in_proc
+    select * from #outer_tab1
+ROLLBACK
+GO
+
+-- Everything should be rolled back due to error
+-- Nothing from the proc should be here either
+SELECT * FROM enr_view
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_rollback.mix
@@ -1,0 +1,32 @@
+-- Session-local setting, so it will only apply to this test.
+-- psql 
+show babelfishpg_tsql.temp_table_xact_support;
+GO
+
+set babelfishpg_tsql.temp_table_xact_support = off;
+GO
+
+-- tsql 
+
+USE master;
+
+CREATE TABLE #temp_rollback_1(a int)
+GO
+
+INSERT INTO #temp_rollback_1 VALUES (1)
+GO
+
+BEGIN TRANSACTION
+DROP TABLE #temp_rollback_1
+ROLLBACK
+GO
+
+SELECT * FROM #temp_rollback_1
+GO
+
+-- psql
+set babelfishpg_tsql.temp_table_xact_support = on; 
+GO
+
+show babelfishpg_tsql.temp_table_xact_support;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback_isolation_read_uncommitted.txt
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_isolation_read_uncommitted.txt
@@ -1,0 +1,5 @@
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+
+include#!#input/temp_tables/temp_table_rollback-vu-prepare.sql
+include#!#input/temp_tables/temp_table_rollback-vu-verify.sql
+include#!#input/temp_tables/temp_table_rollback-vu-cleanup.sql

--- a/test/JDBC/input/temp_tables/temp_table_rollback_isolation_snapshot.txt
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_isolation_snapshot.txt
@@ -1,0 +1,5 @@
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+include#!#input/temp_tables/temp_table_rollback-vu-prepare.sql
+include#!#input/temp_tables/temp_table_rollback-vu-verify.sql
+include#!#input/temp_tables/temp_table_rollback-vu-cleanup.sql

--- a/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP VIEW enr_view;
+GO
+
+DROP PROCEDURE test_nested_rollback_in_proc
+GO
+
+DROP PROCEDURE implicit_rollback_in_proc
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-prepare.sql
@@ -1,0 +1,70 @@
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
+CREATE PROCEDURE test_nested_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1_proc1(a int)
+    INSERT INTO #t1_proc1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1_proc1 ADD b varchar(50)
+        TRUNCATE TABLE #t1_proc1
+        INSERT INTO #t1_proc1 VALUES (1, 'two')
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+
+        SAVE TRAN s1
+            DROP TABLE #t1_proc1
+            CREATE TABLE #t1_proc1(a varchar(100))
+            INSERT INTO #t1_proc1 VALUES ('three')
+            -- Should just be 'three'
+            select * from #t1_proc1
+        ROLLBACK TRAN s1
+
+        -- Should just be (1, 'two')
+        select * from #t1_proc1
+
+        CREATE TABLE #t2_proc1(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc1 VALUES ('four')
+
+        -- ('four', 1)
+        SELECT * FROM #t2_proc1
+        DROP TABLE #t2_proc1
+    ROLLBACK;
+    -- Should have just 6
+    SELECT * FROM #t1_proc1
+    -- Should not exist
+    SELECT * FROM #t2_proc1
+END
+GO
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    BEGIN TRAN
+        SAVE TRAN S1
+        CREATE TABLE #t1_proc2(a int)
+        ALTER TABLE #t1_proc2 ADD b varchar(50)
+        INSERT INTO #t1_proc2 VALUES (1, 'two')
+        select * from #t1_proc2
+        DROP TABLE #t1_proc2
+        CREATE TABLE #t1_proc2(a varchar(100))
+        INSERT INTO #t1_proc2 VALUES ('three')
+        select * from #t1_proc2
+
+        CREATE TABLE #t2_proc2(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc2 VALUES ('four')
+        SELECT * FROM #t2_proc2
+        DROP TABLE #t2_proc2
+
+        INSERT INTO #t1_proc2 values (1, 2, 3, 4, 5)
+        SELECT * FROM #t1_proc2
+        SELECT * FROM #t2_proc2
+    COMMIT
+END
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-verify.sql
@@ -1,0 +1,405 @@
+----------------------------------------------------------
+-- Nested transactions
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a varchar(16))
+    INSERT INTO #t1 VALUES ('t1')
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES ('t2')
+        SAVE TRANSACTION T3
+            INSERT INTO #t1 VALUES ('t3')
+            SAVE TRANSACTION T4
+                INSERT INTO #t1 VALUES ('t4')
+                SELECT * FROM #t1
+            ROLLBACK TRANSACTION T4
+            SELECT * FROM #t1
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+    SELECT * FROM #t1
+ROLLBACK TRANSACTION T1
+SELECT * FROM #t1
+GO
+
+SELECT * FROM enr_view;
+GO
+
+BEGIN TRANSACTION T1
+    SAVE TRANSACTION S2
+        create table #t3(a int)
+        create table #t4(a int identity primary key, b varchar(50))
+        insert into #t3 values (5)
+        insert into #t4 values ('six')
+        SELECT * FROM #t3
+        SELECT * FROM #t4
+        SELECT * FROM enr_view;
+    ROLLBACK TRANSACTION S2
+    SELECT * FROM enr_view;
+COMMIT
+GO
+
+----------------------------------------------------------
+-- General Subtransaction tests
+----------------------------------------------------------
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a int primary key, b varchar(16))
+    SAVE TRANSACTION T2
+        INSERT INTO #t1 VALUES (1, 't2')
+        SAVE TRANSACTION T3
+            UPDATE #t1 SET a = 2 WHERE a = 1
+            SELECT * FROM #t1
+            SAVE TRANSACTION T4
+                DROP TABLE #t1
+            ROLLBACK TRANSACTION T4
+        ROLLBACK TRANSACTION T3
+        SELECT * FROM #t1
+    ROLLBACK TRANSACTION T2
+    select * from enr_view
+    DROP TABLE #t1
+GO
+
+-- Simple nested savepoint rollback
+BEGIN TRAN
+    CREATE TABLE #t1_exists(a int)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int)
+        SAVE TRAN save2
+            CREATE TABLE #t3(a int)
+    ROLLBACK TRAN save1
+    CREATE TABLE #t2_exists(a int)
+COMMIT
+GO
+
+SELECT * FROM enr_view
+GO
+
+DROP TABLE #t1_exists
+DROP TABLE #t2_exists
+GO
+
+-- Multiple savepoint rollback in one xact
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b varchar)
+        SAVE TRAN save2
+            DROP TABLE #t2
+            DROP TABLE #t1
+    ROLLBACK TRAN save1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        SAVE TRAN save4
+            DROP TABLE #t4
+            DROP TABLE #t3
+    ROLLBACK TRAN save3
+    CREATE TABLE #t5(a int)
+COMMIT
+GO
+
+SELECT * FROM enr_view
+GO
+
+SELECT * FROM #t1
+GO
+
+SELECT * FROM #t3
+GO
+
+SELECT * FROM #t5
+GO
+
+DROP TABLE #t1
+DROP TABLE #t3
+DROP TABLE #t5
+GO
+
+-- Multiple savepoint rollback in one xact with entire rollback
+
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b varchar)
+        SAVE TRAN save2
+            DROP TABLE #t2
+            DROP TABLE #t1
+    ROLLBACK TRAN save1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        SAVE TRAN save4
+            DROP TABLE #t4
+            DROP TABLE #t3
+    ROLLBACK TRAN save3
+    CREATE TABLE #t5(a int)
+ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+
+-- Multiple savepoint rollback entire transaction to beginning
+
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b varchar)
+        SAVE TRAN save2
+            DROP TABLE #t2
+            DROP TABLE #t1
+    ROLLBACK TRAN save1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        SAVE TRAN save4
+            DROP TABLE #t4
+            DROP TABLE #t3
+    ROLLBACK
+GO
+
+SELECT * FROM enr_view
+GO
+
+----------------------------------------------------------
+-- Index CREATE/DROP in subtransaction
+----------------------------------------------------------
+
+-- CREATE TABLE
+
+CREATE TABLE #temp_table_rollback_t5(a int, b varchar, c int, d int)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+        INSERT INTO #temp_table_rollback_t5 VALUES (1, 'a', 2, 3)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+INSERT INTO #temp_table_rollback_t5 VALUES (2, 'b', 3, 4)
+GO
+
+BEGIN TRAN
+    CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5(a)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx1 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+
+-- DROP INDEX
+
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+        INSERT INTO #temp_table_rollback_t5 VALUES (3, 'c', 4, 5)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+BEGIN TRAN
+    DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5(b)
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx2 ON #temp_table_rollback_t5
+GO
+
+-- CREATE + DROP
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+        DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+BEGIN TRAN T1
+    CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+    DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+CREATE INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5(c)
+DROP INDEX #temp_table_rollback_t5_idx3 ON #temp_table_rollback_t5
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+-- DROP + CREATE
+
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(d)
+GO
+
+BEGIN TRAN T1
+    SAVE TRANSACTION S2
+        DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+        CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+    ROLLBACK TRANSACTION S2
+COMMIT
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+BEGIN TRAN T1
+    DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+    CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+ROLLBACK
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+DROP INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5
+CREATE INDEX #temp_table_rollback_t5_idx4 ON #temp_table_rollback_t5(c)
+GO
+
+SELECT * FROM #temp_table_rollback_t5
+GO
+
+DROP TABLE #temp_table_rollback_t5
+GO
+
+SELECT * FROM enr_view
+GO
+
+-- Nested index creation
+
+BEGIN TRAN 
+    CREATE TABLE #t1(a int identity primary key, b int)
+    SAVE TRAN save1
+        CREATE TABLE #t2(a int identity primary key, b int)
+        CREATE INDEX #idx1 ON #t1(b)
+        SAVE TRAN save2
+            CREATE INDEX #idx2 ON #t2(b)
+    ROLLBACK TRAN save1
+    SELECT * FROM #t1
+    CREATE TABLE #t3(a varchar, b int identity primary key)
+    SAVE TRAN save3
+        CREATE TABLE #t4(a int identity primary key, b varchar)
+        CREATE INDEX #idx3 ON #t3(b)
+        SAVE TRAN save4
+            CREATE INDEX #idx4 ON #t4(b)
+            DROP INDEX #idx4 ON #t4
+            DROP INDEX #idx3 ON #t3
+        ROLLBACK TRAN save4
+    ROLLBACK TRAN save3
+    COMMIT
+GO
+
+SELECT * FROM enr_view
+GO
+
+DROP TABLE #t1
+DROP TABLE #t3
+GO
+
+SELECT * FROM enr_view
+GO
+
+----------------------------------------------------------
+-- Subtransactions with procedures
+----------------------------------------------------------
+
+exec test_nested_rollback_in_proc
+GO
+
+SELECT * FROM enr_view
+GO
+
+-- Implicit rollback to top level transaction
+BEGIN TRANSACTION
+    CREATE TABLE #outer_tab1(a int)
+    SELECT * FROM enr_view
+    exec implicit_rollback_in_proc
+COMMIT
+GO
+
+-- This table is rolled back due to error in procedure
+select * from #outer_tab1
+GO
+
+SELECT * FROM enr_view
+GO
+
+----------------------------------------------------------
+-- implicit rollback with postgres builtin procedures
+----------------------------------------------------------
+BEGIN TRANSACTION
+    CREATE TABLE #t1(a int)
+    SELECT UPPER(abc) -- Should fail 
+COMMIT
+GO
+
+BEGIN TRANSACTION
+    CREATE TABLE #t2(a int)
+    SAVE TRAN s1
+        SELECT UPPER(abc)
+COMMIT
+GO
+
+CREATE PROCEDURE my_bad_proc AS
+BEGIN
+    SELECT UPPER(abc)
+END
+GO
+
+BEGIN TRANSACTION
+    CREATE TABLE #t3(a int)
+    SAVE TRAN s1
+        exec my_bad_proc
+COMMIT
+GO
+
+DROP PROCEDURE my_bad_proc
+GO
+
+SELECT * FROM #t1
+GO
+
+SELECT * FROM #t2
+GO
+
+SELECT * FROM #t3
+GO
+
+SELECT * FROM enr_view
+GO
+

--- a/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_subxact-vu-verify.sql
@@ -38,6 +38,66 @@ BEGIN TRANSACTION T1
 COMMIT
 GO
 
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a int)
+    SAVE TRANSACTION S1
+        DROP TABLE #t1
+        CREATE TABLE #t2(a int)
+        SAVE TRANSACTION S2
+            DROP TABLE #t2
+            CREATE TABLE #t3(a int)
+            SAVE TRANSACTION S3
+            DROP TABLE #t3
+    ROLLBACK TRANSACTION S1
+COMMIT
+GO
+
+-- Should be just #t1. 
+SELECT * FROM enr_view;
+GO
+
+DROP TABLE #t1
+GO
+
+BEGIN TRANSACTION T1
+    CREATE TABLE #t1(a int)
+    SAVE TRANSACTION S1
+        DROP TABLE #t1
+        CREATE TABLE #t2(a int)
+        SAVE TRANSACTION S2
+            DROP TABLE #t2
+            CREATE TABLE #t3(a int)
+            SAVE TRANSACTION S3
+            DROP TABLE #t3
+    ROLLBACK TRANSACTION S1
+ROLLBACK
+GO
+
+-- Should be empty. 
+SELECT * FROM enr_view;
+GO
+
+CREATE TABLE #t1(a int)
+GO
+BEGIN TRANSACTION T1
+    SAVE TRANSACTION s1
+        DROP TABLE #t1
+        CREATE TABLE #t1(a int identity primary key)  
+        SAVE TRANSACTION s2
+            DROP TABLE #t1
+            CREATE TABLE #t1(a varchar(1000))
+            SAVE TRANSACTION S3
+                DROP TABLE #t1
+    ROLLBACK TRANSACTION s1
+COMMIT
+GO
+
+SELECT * FROM #t1
+GO
+
+DROP TABLE #t1
+GO
+
 ----------------------------------------------------------
 -- General Subtransaction tests
 ----------------------------------------------------------

--- a/test/JDBC/input/temp_tables/temp_table_rollback_subxact_isolation_snapshot.txt
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_subxact_isolation_snapshot.txt
@@ -1,0 +1,5 @@
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+include#!#input/temp_tables/temp_table_rollback_subxact-vu-prepare.sql
+include#!#input/temp_tables/temp_table_rollback_subxact-vu-verify.sql
+include#!#input/temp_tables/temp_table_rollback_subxact-vu-cleanup.sql

--- a/test/JDBC/input/temp_tables/temp_table_rollback_subxact_xact_abort_on.txt
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_subxact_xact_abort_on.txt
@@ -1,0 +1,5 @@
+SET xact_abort ON
+
+include#!#input/temp_tables/temp_table_rollback_subxact-vu-prepare.sql
+include#!#input/temp_tables/temp_table_rollback_subxact-vu-verify.sql
+include#!#input/temp_tables/temp_table_rollback_subxact-vu-cleanup.sql

--- a/test/JDBC/input/temp_tables/temp_table_rollback_xact_abort_on.txt
+++ b/test/JDBC/input/temp_tables/temp_table_rollback_xact_abort_on.txt
@@ -1,0 +1,5 @@
+SET xact_abort ON
+
+include#!#input/temp_tables/temp_table_rollback-vu-prepare.sql
+include#!#input/temp_tables/temp_table_rollback-vu-verify.sql
+include#!#input/temp_tables/temp_table_rollback-vu-cleanup.sql


### PR DESCRIPTION
### Description

ENR temp tables were not sensitive to transactional behavior. We add it here by introducing a new structure which will track uncommitted ENR tuples and process them accordingly, depending on if the active transaction is committed or rolled back.

This PR adds tests for babelfish-for-postgresql/postgresql_modified_for_babelfish#376

4x: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2522

### Issues Resolved

BABEL-4864


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).