### PR TITLE
[OSS-ONLY] Remove extra check for helper functions for sp_describe_undeclared_parameters_internal

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -630,10 +630,10 @@ handle_where_clause_attnums(ParseState *pstate, Node *w_clause, List *target_att
 					if (attrno == InvalidAttrNumber)
 					{
 						ereport(ERROR,
-								(errcode(ERRCODE_UNDEFINED_COLUMN),
-									errmsg("column \"%s\" of relation \"%s\" does not exist",
-										name,
-										RelationGetRelationName(pstate->p_target_relation))));
+							(errcode(ERRCODE_UNDEFINED_COLUMN),
+				 			 errmsg("column \"%s\" of relation \"%s\" does not exist",
+								name,
+								RelationGetRelationName(pstate->p_target_relation))));
 					}
 					target_attnums = lappend_int(target_attnums, attrno);
 					break;
@@ -731,17 +731,16 @@ handle_where_clause_restargets_left(ParseState *pstate, Node *w_clause, List *ex
 					if (attrno == InvalidAttrNumber)
 					{
 						ereport(ERROR,
-								(errcode(ERRCODE_UNDEFINED_COLUMN),
-									errmsg("column \"%s\" of relation \"%s\" does not exist",
-										name,
-										RelationGetRelationName(pstate->p_target_relation))));
+						(errcode(ERRCODE_UNDEFINED_COLUMN),
+						 errmsg("column \"%s\" of relation \"%s\" does not exist",
+							name,
+							RelationGetRelationName(pstate->p_target_relation))));
 					}
 					res = (ResTarget *) palloc(sizeof(ResTarget));
 					res->type = ref->type;
 					res->name = field->val.str;
 					res->indirection = NIL; /* Unused for now */
-					res->val = (Node *) ref;	/* Store the ColumnRef
-													* here if needed */
+					res->val = (Node *) ref;	/* Store the ColumnRef here if needed */
 					res->location = ref->location;
 
 					extra_restargets = lappend(extra_restargets, res);
@@ -826,8 +825,7 @@ handle_where_clause_restargets_right(ParseState *pstate, Node *w_clause, List *e
 					res->type = ref->type;
 					res->name = field->val.str;
 					res->indirection = NIL; /* Unused for now */
-					res->val = (Node *) ref;	/* Store the ColumnRef
-													* here if needed */
+					res->val = (Node *) ref;	/* Store the ColumnRef here if needed */
 					res->location = ref->location;
 
 					extra_restargets = lappend(extra_restargets, res);

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -617,30 +617,11 @@ handle_where_clause_attnums(ParseState *pstate, Node *w_clause, List *target_att
 					xpr = (A_Expr *)arg;
 					if (nodeTag(xpr->lexpr) != T_ColumnRef)
 					{
-						xpr = (A_Expr *) arg;
-
-						if (nodeTag(xpr->lexpr) != T_ColumnRef)
+						if (is_sp_describe_undeclared_parameters)
 						{
-							if (is_sp_describe_undeclared_parameters)
-							{
-								is_supported_case_sp_describe_undeclared_parameters = false;
-								return target_attnums;
-							}
+							is_supported_case_sp_describe_undeclared_parameters = false;
+							return target_attnums;
 						}
-						ref = (ColumnRef *) xpr->lexpr;
-						field = linitial(ref->fields);
-						name = field->val.str;
-						attrno = attnameAttNum(pstate->p_target_relation, name, false);
-						if (attrno == InvalidAttrNumber)
-						{
-							ereport(ERROR,
-									(errcode(ERRCODE_UNDEFINED_COLUMN),
-									 errmsg("column \"%s\" of relation \"%s\" does not exist",
-											name,
-											RelationGetRelationName(pstate->p_target_relation))));
-						}
-						target_attnums = lappend_int(target_attnums, attrno);
-						break;
 					}
 					ref = (ColumnRef *) xpr->lexpr;
 					field = linitial(ref->fields);
@@ -649,10 +630,10 @@ handle_where_clause_attnums(ParseState *pstate, Node *w_clause, List *target_att
 					if (attrno == InvalidAttrNumber)
 					{
 						ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_COLUMN),
-						 errmsg("column \"%s\" of relation \"%s\" does not exist",
-								name,
-								RelationGetRelationName(pstate->p_target_relation))));
+								(errcode(ERRCODE_UNDEFINED_COLUMN),
+									errmsg("column \"%s\" of relation \"%s\" does not exist",
+										name,
+										RelationGetRelationName(pstate->p_target_relation))));
 					}
 					target_attnums = lappend_int(target_attnums, attrno);
 					break;
@@ -737,38 +718,11 @@ handle_where_clause_restargets_left(ParseState *pstate, Node *w_clause, List *ex
 
 					if (nodeTag(xpr->lexpr) != T_ColumnRef)
 					{
-						xpr = (A_Expr *) arg;
-
-						if (nodeTag(xpr->lexpr) != T_ColumnRef)
+						if (is_sp_describe_undeclared_parameters)
 						{
-							if (is_sp_describe_undeclared_parameters)
-							{
-								is_supported_case_sp_describe_undeclared_parameters = false;
-								return extra_restargets;
-							}
+							is_supported_case_sp_describe_undeclared_parameters = false;
+							return extra_restargets;
 						}
-						ref = (ColumnRef *) xpr->lexpr;
-						field = linitial(ref->fields);
-						name = field->val.str;
-						attrno = attnameAttNum(pstate->p_target_relation, name, false);
-						if (attrno == InvalidAttrNumber)
-						{
-							ereport(ERROR,
-									(errcode(ERRCODE_UNDEFINED_COLUMN),
-									 errmsg("column \"%s\" of relation \"%s\" does not exist",
-											name,
-											RelationGetRelationName(pstate->p_target_relation))));
-						}
-						res = (ResTarget *) palloc(sizeof(ResTarget));
-						res->type = ref->type;
-						res->name = field->val.str;
-						res->indirection = NIL; /* Unused for now */
-						res->val = (Node *) ref;	/* Store the ColumnRef
-													 * here if needed */
-						res->location = ref->location;
-
-						extra_restargets = lappend(extra_restargets, res);
-						break;
 					}
 					ref = (ColumnRef *) xpr->lexpr;
 					field = linitial(ref->fields);
@@ -777,16 +731,17 @@ handle_where_clause_restargets_left(ParseState *pstate, Node *w_clause, List *ex
 					if (attrno == InvalidAttrNumber)
 					{
 						ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_COLUMN),
-						 errmsg("column \"%s\" of relation \"%s\" does not exist",
-								name,
-								RelationGetRelationName(pstate->p_target_relation))));
+								(errcode(ERRCODE_UNDEFINED_COLUMN),
+									errmsg("column \"%s\" of relation \"%s\" does not exist",
+										name,
+										RelationGetRelationName(pstate->p_target_relation))));
 					}
 					res = (ResTarget *) palloc(sizeof(ResTarget));
 					res->type = ref->type;
 					res->name = field->val.str;
 					res->indirection = NIL; /* Unused for now */
-					res->val = (Node *) ref; /* Store the ColumnRef here if needed */
+					res->val = (Node *) ref;	/* Store the ColumnRef
+													* here if needed */
 					res->location = ref->location;
 
 					extra_restargets = lappend(extra_restargets, res);
@@ -859,28 +814,11 @@ handle_where_clause_restargets_right(ParseState *pstate, Node *w_clause, List *e
 
 					if (nodeTag(xpr->rexpr) != T_ColumnRef)
 					{
-						xpr = (A_Expr *) arg;
-
-						if (nodeTag(xpr->rexpr) != T_ColumnRef)
+						if (is_sp_describe_undeclared_parameters)
 						{
-							if (is_sp_describe_undeclared_parameters)
-							{
-								is_supported_case_sp_describe_undeclared_parameters = false;
-								return extra_restargets;
-							}
+							is_supported_case_sp_describe_undeclared_parameters = false;
+							return extra_restargets;
 						}
-						ref = (ColumnRef *) xpr->rexpr;
-						field = linitial(ref->fields);
-						res = (ResTarget *) palloc(sizeof(ResTarget));
-						res->type = ref->type;
-						res->name = field->val.str;
-						res->indirection = NIL; /* Unused for now */
-						res->val = (Node *) ref;	/* Store the ColumnRef
-													 * here if needed */
-						res->location = ref->location;
-
-						extra_restargets = lappend(extra_restargets, res);
-						break;
 					}
 					ref = (ColumnRef *) xpr->rexpr;
 					field = linitial(ref->fields);
@@ -888,7 +826,8 @@ handle_where_clause_restargets_right(ParseState *pstate, Node *w_clause, List *e
 					res->type = ref->type;
 					res->name = field->val.str;
 					res->indirection = NIL; /* Unused for now */
-					res->val = (Node *) ref; /* Store the ColumnRef here if needed */
+					res->val = (Node *) ref;	/* Store the ColumnRef
+													* here if needed */
 					res->location = ref->location;
 
 					extra_restargets = lappend(extra_restargets, res);


### PR DESCRIPTION
### Description
This commit removes the extra check (if condition) for helper functions for sp_describe_undeclared_parameters_internal which was introduced in this [commit](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/eda23eac1e40e8d6fd4453eb2d0d59c833008373). 

### Issues Resolved

BABEL-4869
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).