### PR TITLE
Ensure accurate metadata inconsistency checks (#2609)

### DIFF
--- a/.github/composite-actions/check-babelfish-inconsistency/action.yml
+++ b/.github/composite-actions/check-babelfish-inconsistency/action.yml
@@ -6,6 +6,36 @@ runs:
     - name: Check Babelfish metadata inconsistency
       id: check-babelfish-inconsistency
       run: |
-        output=$(sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT sys.check_for_inconsistent_metadata() GO" | tail -n +2)
-        echo "check_result=$output" >> "$GITHUB_OUTPUT"
+        # Check if the function exists
+        function_exists=$(sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "
+        SELECT CASE WHEN COUNT(*) > 0 THEN 'exists' ELSE 'not_exists' END
+        FROM pg_proc
+        WHERE proname = 'check_for_inconsistent_metadata';" | grep -o 'exists\|not_exists')
+
+        echo "::set-output name=function_exists::$function_exists"
+        echo "Check Babelfish metadata inconsistency function exists: $function_exists"
+        
+        # If the function exists, run the metadata inconsistency check
+        if [[ "$function_exists" == "exists" ]]; then
+          output=$(sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT 'check_result=', sys.check_for_inconsistent_metadata() GO" | grep 'check_result' | sed 's/[[:blank:]]//g')
+          check_result=$(echo "$output" | grep -oP 'check_result=\K.+')
+          echo "Check Babelfish metadata inconsistency result: $check_result"
+          
+          if [[ "$check_result" == "1" ]]; then
+            echo "Check Babelfish metadata inconsistency failed"
+            
+            # Fetch and print the detailed inconsistent rules
+            inconsistent_rules=$(sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "
+            SELECT DISTINCT object_type, schema_name, object_name, detail::text
+            FROM sys.babelfish_inconsistent_metadata();")
+
+            echo "Babelfish Inconsistent Metadata failing rules:"
+            echo "$inconsistent_rules"
+            exit 1
+          else
+            echo "Check Babelfish metadata inconsistency succeeded"
+          fi
+        else
+          echo "The function check_for_inconsistent_metadata does not exist, skipping metadata check."
+        fi
       shell: bash

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -227,8 +227,15 @@ runs:
         python3 upgrade_validation.py
       shell: bash
 
+    - name: Run Babelfish metadata inconsistency check
+      id: check-babelfish-inconsistency
+      if: always() && steps.run-dependency-check.outcome == 'success'
+      uses: ./.github/composite-actions/check-babelfish-inconsistency
+      
     - name: Upload artifacts
-      if: always() && steps.run-dependency-check.outcome == 'failure'
+      if: |
+        always() && (steps.run-dependency-check.outcome == 'failure'
+        || steps.check-babelfish-inconsistency.outcome == 'failure')
       run: |
         mkdir -p ~/upgrade
         cp test/python/output/upgrade_validation/* ~/upgrade

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -197,9 +197,8 @@ jobs:
       - name: Run pg_upgrade
         id: run-pg_upgrade
         if: |
-          always() && steps.setup-new-datadir.outcome == 'success' 
-          && steps.check-babelfish-inconsistency.outcome == 'success' 
-          && steps.check-babelfish-inconsistency.outputs.check_result == 0
+          always() && steps.setup-new-datadir.outcome == 'success'
+          && steps.check-babelfish-inconsistency.outcome == 'success'
         uses: ./.github/composite-actions/run-pg-upgrade
 
       - name: Disable TDS fault injection tests in release mode

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -33,8 +33,7 @@ jobs:
         id: upgrade-and-verify
         if: |
           always() && steps.setup-base-version.outcome == 'success' 
-          && steps.check-babelfish-inconsistency.outcome == 'success' 
-          && steps.check-babelfish-inconsistency.outputs.check_result == 0
+          && steps.check-babelfish-inconsistency.outcome == 'success'
         uses: ./.github/composite-actions/major-version-upgrade-util
         with:
           engine_branch: latest


### PR DESCRIPTION
### Description

This commit addresses metadata inconsistency checks, ensuring they occur in the appropriate places. Additionally, steps have been added to verify the existence of the inconsistency checker function before performing the metadata checks.

This is a cherry-pick commit of [858698](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/858698e693d33af1b6212119c6db72aab6029142).

### Issues Resolved

Task: BABEL-4139

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).