### PR TITLE
Support CHECK CONSTRAINTS options and Fix Error aborting Cycle in TSQL Bulk Copy

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsbulkload.c
@@ -1006,9 +1006,6 @@ ProcessBCPRequest(TDSRequest request)
 
 				RESUME_CANCEL_INTERRUPTS();
 
-				/* Using Same callback function to do the clean-up. */
-				pltsql_plugin_handler_ptr->bulk_load_callback(0, 0, NULL, NULL);
-
 				if (ret < 0)
 					TdsErrorContext->err_text = "EOF on TDS socket while fetching For Bulk Load Request";
 

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -99,10 +99,12 @@ BulkCopyStmt *cstmt = NULL;
 int			insert_bulk_rows_per_batch = DEFAULT_INSERT_BULK_ROWS_PER_BATCH;
 int			insert_bulk_kilobytes_per_batch = DEFAULT_INSERT_BULK_PACKET_SIZE;
 bool		insert_bulk_keep_nulls = false;
+bool		insert_bulk_check_constraints = false;
 
 static int	prev_insert_bulk_rows_per_batch = DEFAULT_INSERT_BULK_ROWS_PER_BATCH;
 static int	prev_insert_bulk_kilobytes_per_batch = DEFAULT_INSERT_BULK_PACKET_SIZE;
 static bool prev_insert_bulk_keep_nulls = false;
+static bool prev_insert_bulk_check_constraints = false;
 
 /* return a underlying node if n is implicit casting and underlying node is a certain type of node */
 static Node *get_underlying_node_from_implicit_casting(Node *n, NodeTag underlying_nodetype);
@@ -2976,6 +2978,11 @@ exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *stmt)
 		prev_insert_bulk_keep_nulls = insert_bulk_keep_nulls;
 		insert_bulk_keep_nulls = true;
 	}
+	if (stmt->check_constraints)
+	{
+		prev_insert_bulk_check_constraints = insert_bulk_check_constraints;
+		insert_bulk_check_constraints = true;
+	}
 	return PLTSQL_RC_OK;
 }
 
@@ -2995,7 +3002,7 @@ execute_bulk_load_insert(int ncol, int nrow,
 		/* Cleanup all the pointers. */
 		if (cstmt)
 		{
-			EndBulkCopy(cstmt->cstate);
+			EndBulkCopy(cstmt->cstate, false);
 			if (cstmt->attlist)
 				list_free_deep(cstmt->attlist);
 			if (cstmt->relation)
@@ -3011,6 +3018,7 @@ execute_bulk_load_insert(int ncol, int nrow,
 
 		/* Reset Insert-Bulk Options. */
 		insert_bulk_keep_nulls = prev_insert_bulk_keep_nulls;
+		insert_bulk_check_constraints = prev_insert_bulk_check_constraints;
 		insert_bulk_rows_per_batch = prev_insert_bulk_rows_per_batch;
 		insert_bulk_kilobytes_per_batch = prev_insert_bulk_kilobytes_per_batch;
 
@@ -3041,6 +3049,9 @@ execute_bulk_load_insert(int ncol, int nrow,
 		 */
 		MemoryContext oldcontext;
 
+		/* Cleanup cstate. */
+		EndBulkCopy(cstmt->cstate, true);
+
 		if (ActiveSnapshotSet() && GetActiveSnapshot() == snap)
 			PopActiveSnapshot();
 		oldcontext = CurrentMemoryContext;
@@ -3060,6 +3071,7 @@ execute_bulk_load_insert(int ncol, int nrow,
 
 		/* Reset Insert-Bulk Options. */
 		insert_bulk_keep_nulls = prev_insert_bulk_keep_nulls;
+		insert_bulk_check_constraints = prev_insert_bulk_check_constraints;
 		insert_bulk_rows_per_batch = prev_insert_bulk_rows_per_batch;
 		insert_bulk_kilobytes_per_batch = prev_insert_bulk_kilobytes_per_batch;
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -928,6 +928,7 @@ typedef struct PLtsql_stmt_insert_bulk
 	char	   *kilobytes_per_batch;
 	char	   *rows_per_batch;
 	bool		keep_nulls;
+	bool		check_constraints;
 } PLtsql_stmt_insert_bulk;
 
 /*
@@ -1823,6 +1824,7 @@ extern char *bulk_load_table_name;
 extern int	insert_bulk_rows_per_batch;
 extern int	insert_bulk_kilobytes_per_batch;
 extern bool insert_bulk_keep_nulls;
+extern bool insert_bulk_check_constraints;
 
 /**********************************************************************
  * Function declarations

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.h
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.h
@@ -49,7 +49,6 @@ typedef struct BulkCopyStateData
 	int 		seq_index; 		/* index for an identity column */
 	Oid			seqid; 			/* oid of the sequence for an identity column */
 	int			rv_index;		/* index for a rowversion datatype column */
-
 } BulkCopyStateData;
 
 /* ----------------------
@@ -76,5 +75,4 @@ typedef struct BulkCopyStmt
 } BulkCopyStmt;
 
 extern void BulkCopy(BulkCopyStmt *stmt, uint64 *processed);
-extern void EndBulkCopy(BulkCopyState cstate);
-
+extern void EndBulkCopy(BulkCopyState cstate, bool aborted);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4521,8 +4521,9 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 					stmt->keep_nulls = true;
 
 				else if (pg_strcasecmp("CHECK_CONSTRAINTS", ::getFullText(option_list[i]->id()).c_str()) == 0)
-					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option check_constraints is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
-
+				{
+					stmt->check_constraints = true;
+				}
 				else if (pg_strcasecmp("FIRE_TRIGGERS", ::getFullText(option_list[i]->id()).c_str()) == 0)
 					throw PGErrorWrapperException(ERROR, ERRCODE_FEATURE_NOT_SUPPORTED, "insert bulk option fire_triggers is not yet supported in babelfish", getLineAndPos(bulk_ctx->WITH()));
 

--- a/test/dotnet/ExpectedOutput/bcp.out
+++ b/test/dotnet/ExpectedOutput/bcp.out
@@ -660,3 +660,72 @@ bcp#!#in#!#bcp_source#!#destinationTable
 #!##!#
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Create table sourceTable (a int);
+#Q#Create table destinationTable(a int, check (a < 2))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1);
+#Q#INSERT INTO sourceTable values (2);
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select count(*) from sourceTable
+#D#int
+1001
+#Q#select count(*) from destinationTable
+#D#int
+1001
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable (a int);
+#Q#Create table destinationTable(a int)
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1500, 1);
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select count(*) from sourceTable
+#D#int
+1500
+#Q#select count(*) from destinationTable
+#D#int
+1500
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+#Q#INSERT INTO destinationTable VALUES(1000, 'Foo')
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select count(*) from sourceTable
+#D#int
+1000
+#Q#select count(*) from destinationTable
+#D#int
+1
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable (a int);
+#Q#Create table destinationTable(a int, check (a < 2))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1);
+#Q#INSERT INTO sourceTable values (2);
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp -h "CHECK_CONSTRAINTS"#!#in#!#bcp_source#!#destinationTable
+#Q#Select count(*) from sourceTable
+#D#int
+1001
+#Q#select count(*) from destinationTable
+#D#int
+0
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+#Q#INSERT INTO destinationTable VALUES(1000, 'Foo')
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp -h "CHECK_CONSTRAINTS"#!#in#!#bcp_source#!#destinationTable
+#Q#Select count(*) from sourceTable
+#D#int
+1000
+#Q#select count(*) from destinationTable
+#D#int
+1
+#Q#drop table sourceTable
+#Q#drop table destinationTable

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -223,6 +223,9 @@ bcp -h "CHECK_CONSTRAINTS"#!#in#!#bcp_source#!#destinationTable2
 1#!#1
 2#!#2
 #Q#Select * from destinationTable2
+#D#bigint#!#bigint
+1#!#1
+2#!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
 #Q#drop table destinationTable2
@@ -499,23 +502,3 @@ bcp#!#in#!#bcp_source#!#destinationTable
 01/01/2000 00:00:00#!#01/01/2060 00:00:00
 #Q#drop table sourceTable
 #Q#drop table destinationTable
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
-#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
-#E#invalid insert bulk option hello
-#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
-#D#text
-ignore
-#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
-#E#insert bulk option tablock is not yet supported in babelfish
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
-#E#insert bulk option fire_triggers is not yet supported in babelfish
-#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
-#E#insert bulk option tablock is not yet supported in babelfish
-#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
-#E#invalid insert bulk option hello
-#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -499,3 +499,23 @@ bcp#!#in#!#bcp_source#!#destinationTable
 01/01/2000 00:00:00#!#01/01/2060 00:00:00
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+#E#invalid insert bulk option hello
+#Q#SELECT current_setting('babelfishpg_tsql.escape_hatch_insert_bulk_options');
+#D#text
+ignore
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'strict';
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(tablock);
+#E#insert bulk option tablock is not yet supported in babelfish
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(check_constraints);
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(fire_triggers);
+#E#insert bulk option fire_triggers is not yet supported in babelfish
+#Q#insert bulk dbo.ct_depreciacao_gerencial_valores ([r_e_c_n_o_] Int, [acumulado] Decimal(19,6), [centro_custo] VarChar(20) COLLATE SQL_Latin1_General_CP1_CI_AS, [data] VarChar(8) COLLATE SQL_Latin1_General_CP1_CI_AS, [diasdeprec] Decimal(19,6), [fator] Decimal(19,6), [grupo_bem] Int, [nlanc] Int, [percentual] Decimal(19,6), [recno_bem] Int, [taxa_grupo] Decimal(19,6), [valor] Decimal(19,6), [valorresidual] Decimal(19,6), [manual] VarChar(1) COLLATE SQL_Latin1_General_CP1_CI_AS, [credito_pis] Decimal(19,2), [credito_cofins] Decimal(19,2), [id] UniqueIdentifier) with (KEEP_NULLS, TABLOCK);
+#E#insert bulk option tablock is not yet supported in babelfish
+#Q#Insert Bulk destinationTable ([a] bigint,[b] bigint) with(hello);
+#E#invalid insert bulk option hello
+#Q#EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_insert_bulk_options', 'ignore';

--- a/test/dotnet/ExpectedOutput/insertBulk.out
+++ b/test/dotnet/ExpectedOutput/insertBulk.out
@@ -407,3 +407,38 @@ hello#!#jello
 10#!#hello
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Create table sourceTable (a int);
+#Q#Create table destinationTable(a int, check (a < 2))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1);
+#Q#INSERT INTO sourceTable values (2);
+#Q#Select count(*) from sourceTable
+#D#int
+1001
+#Q#select count(*) from destinationTable
+#D#int
+1001
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable (a int);
+#Q#Create table destinationTable(a int)
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1500, 1);
+#Q#Select count(*) from sourceTable
+#D#int
+1500
+#Q#select count(*) from destinationTable
+#D#int
+1500
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+#Q#INSERT INTO destinationTable VALUES(1000, 'Foo')
+#Q#Select count(*) from sourceTable
+#D#int
+1000
+#Q#select count(*) from destinationTable
+#D#int
+1
+#Q#drop table sourceTable
+#Q#drop table destinationTable

--- a/test/dotnet/input/InsertBulk/insertBulk.txt
+++ b/test/dotnet/input/InsertBulk/insertBulk.txt
@@ -318,3 +318,33 @@ Select * from sourceTable
 Select * from destinationTable
 drop table sourceTable
 drop table destinationTable
+
+
+Create table sourceTable (a int);
+Create table destinationTable(a int, check (a < 2))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1);
+INSERT INTO sourceTable values (2);
+insertbulk#!#sourceTable#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable (a int);
+Create table destinationTable(a int)
+INSERT INTO sourceTable SELECT generate_series(1, 1500, 1);
+insertbulk#!#sourceTable#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+INSERT INTO destinationTable VALUES(1000, 'Foo')
+insertbulk#!#sourceTable#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable

--- a/test/dotnet/input/bcp.txt
+++ b/test/dotnet/input/bcp.txt
@@ -470,3 +470,57 @@ Select * from sourceTable
 select * from destinationTable
 drop table sourceTable
 drop table destinationTable
+
+Create table sourceTable (a int);
+Create table destinationTable(a int, check (a < 2))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1);
+INSERT INTO sourceTable values (2);
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable (a int);
+Create table destinationTable(a int)
+INSERT INTO sourceTable SELECT generate_series(1, 1500, 1);
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+INSERT INTO destinationTable VALUES(1000, 'Foo')
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable (a int);
+Create table destinationTable(a int, check (a < 2))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1);
+INSERT INTO sourceTable values (2);
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp -h "CHECK_CONSTRAINTS"#!#in#!#bcp_source#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+INSERT INTO destinationTable VALUES(1000, 'Foo')
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp -h "CHECK_CONSTRAINTS"#!#in#!#bcp_source#!#destinationTable
+Select count(*) from sourceTable
+select count(*) from destinationTable
+drop table sourceTable
+drop table destinationTable


### PR DESCRIPTION
This commit has the following changes:

1. Fix Permissions checking missed in d95b7ad
2. Fix the error handling behaviour in Bulk Copy. While processing a batch of inserts, if there are unexpected errors then the current design aborts the insert and later tries to cleanup the stale buffers. During cleanup we were not checking for aborted phase and thus flushing buffers even when we didnt have to. With this commit we fix this by not flushing during cleanup in the abort phase.
3. Also supported CHECK_CONSTRAINTS insert bulk options with this commit. The ideal behaviour is to not check any constraints unless user passes the CHECK_CONSTRAINTS options. We have now implemented the same for Babelfish.

Issues Resolved
BABEL-4200, BABEL-4991

Authored-by: Kushaal Shroff kushaal@amazon.com
Signed-off-by: Kushaal Shroff kushaal@amazon.com


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).