### PR TITLE
Revert "Add ANTLR parsing time to EXPLAIN info (#2597)"

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_explain.c
+++ b/contrib/babelfishpg_tsql/src/pl_explain.c
@@ -21,8 +21,6 @@ int			pltsql_explain_format = EXPLAIN_FORMAT_TEXT;
 
 static ExplainInfo *get_last_explain_info();
 
-instr_time	antlr_parse_time;
-
 bool
 is_explain_analyze_mode()
 {
@@ -159,7 +157,6 @@ append_explain_info(QueryDesc *queryDesc, const char *queryString)
 		{
 			PLtsql_execstate *time_state = get_current_tsql_estate();
 
-			ExplainPropertyFloat("ANTLR Parsing Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(antlr_parse_time), 3, es);
 			ExplainPropertyFloat("Planning Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(time_state->planning_end), 3, es);
 			INSTR_TIME_SET_CURRENT(time_state->execution_end);
 			INSTR_TIME_SUBTRACT(time_state->execution_end, time_state->execution_start);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -88,9 +88,6 @@ extern "C"
 	extern bool check_fulltext_exist(const char *schema_name, const char *table_name);
 
 	extern int escape_hatch_showplan_all;
-
-	/* To store the time spent in ANTLR parsing for the current batch */
-	extern instr_time antlr_parse_time;
 }
 
 static void toDotRecursive(ParseTree *t, const std::vector<std::string> &ruleNames, const std::string &sourceText);
@@ -3207,7 +3204,6 @@ antlr_parser_cpp(const char *sourceText)
 	instr_time	parseStart;
 	instr_time	parseEnd;
 	INSTR_TIME_SET_CURRENT(parseStart);
-	INSTR_TIME_SET_ZERO(antlr_parse_time);
 
 	// special handling for empty sourceText
 	if (strlen(sourceText) == 0)
@@ -3249,9 +3245,6 @@ antlr_parser_cpp(const char *sourceText)
 	INSTR_TIME_SET_CURRENT(parseEnd);
 	INSTR_TIME_SUBTRACT(parseEnd, parseStart);
 	elog(DEBUG1, "ANTLR Query Parse Time for query: %s | %f ms", sourceText, 1000.0 * INSTR_TIME_GET_DOUBLE(parseEnd));
-
-	/* And store time spent in ANTLR parsing so that we can emit it for EXPLAIN info if required */
-	antlr_parse_time = parseEnd;
 
 	return result;
 }


### PR DESCRIPTION
This reverts commit 4330bab8492e17645e5dc2081ee30d1ea4132164.

Commit details of 4330bab8492e17645e5dc2081ee30d1ea4132164 - 

    Add ANTLR parsing time to EXPLAIN info (#2597)
    
    This commit adds support to show ANTLR parsing time info with EXPLAIN info. With this change, query plan would look like following:
    ```
    QUERY PLAN
    
    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    Query Text: select 'abc'
    
    Result  (cost=0.00..0.01 rows=1 width=32) (actual time=0.004..0.005 rows=1 loops=1)
    
    ANTLR Parsing Time: 34.469 ms
    
    Planning Time: 0.016 ms
    
    Execution Time: 0.057 ms
    ```
    This capabilities will help us diagnosing the performance issue to understand where most of the time being consumed.

Task: BABEL-3650
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).