### PR TITLE
[TESTS UPDATE ONLY] fix flakiness in BABEL-4940 jdbc test

### DIFF
--- a/test/JDBC/expected/BABEL_4940.out
+++ b/test/JDBC/expected/BABEL_4940.out
@@ -2,27 +2,27 @@
 SET NOCOUNT ON
 GO
 -- column constraint
-CREATE TABLE babel_4940_t1(id INT PRIMARY KEY)
+CREATE TABLE babel_4940_t1(id INT PRIMARY KEY, c1 VARCHAR(5) DEFAULT 'a')
 GO
-INSERT INTO babel_4940_t1 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t1 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint
-CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id))
+CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id), c1 VARCHAR(5) DEFAULT 'a')
 GO
-INSERT INTO babel_4940_t2 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t2 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint multiple column
-CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1))
+CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1), c1 VARCHAR(5) DEFAULT 'a')
 GO
 SET NOCOUNT ON
 DECLARE @i INT=0;
 WHILE (@i<1000)
 BEGIN
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+1)
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+2)
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+3)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+3)
     SET @i = @i + 1;
 END
 GO
@@ -30,34 +30,34 @@ GO
 
 -- same test as above but create primary key using alter table add constraints
 -- column constraint
-CREATE TABLE babel_4940_t4(id INT PRIMARY KEY)
+CREATE TABLE babel_4940_t4(id INT PRIMARY KEY, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t4 DROP COLUMN id
 GO
 ALTER TABLE babel_4940_t4 ADD id INT PRIMARY KEY
 GO
-INSERT INTO babel_4940_t4 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t4 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint
-CREATE TABLE babel_4940_t5(id INT)
+CREATE TABLE babel_4940_t5(id INT, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t5 ADD CONSTRAINT c PRIMARY KEY (id)
 GO
-INSERT INTO babel_4940_t5 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t5 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint multiple column
-CREATE TABLE babel_4940_t6(id INT, id1 INT)
+CREATE TABLE babel_4940_t6(id INT, id1 INT, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t6 ADD CONSTRAINT c1 PRIMARY KEY(id, id1 DESC)
 GO
 DECLARE @i INT=0;
 WHILE (@i<1000)
 BEGIN
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+1)
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+2)
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+3)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+3)
     SET @i = @i + 1;
 END
 GO
@@ -99,289 +99,277 @@ off
 SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+int#!#varchar
+1#!#a
+2#!#a
+3#!#a
+4#!#a
+5#!#a
+6#!#a
+7#!#a
+8#!#a
+9#!#a
+10#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+int#!#varchar
+100000#!#a
+99999#!#a
+99998#!#a
+99997#!#a
+99996#!#a
+99995#!#a
+99994#!#a
+99993#!#a
+99992#!#a
+99991#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id 
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+int#!#varchar
+1#!#a
+2#!#a
+3#!#a
+4#!#a
+5#!#a
+6#!#a
+7#!#a
+8#!#a
+9#!#a
+10#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+int#!#varchar
+100000#!#a
+99999#!#a
+99998#!#a
+99997#!#a
+99996#!#a
+99995#!#a
+99994#!#a
+99993#!#a
+99992#!#a
+99991#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
 GO
 ~~START~~
-int#!#int
-0#!#1
-0#!#2
-0#!#3
-1#!#2
-1#!#3
-1#!#4
-2#!#3
-2#!#4
-2#!#5
-3#!#4
+int#!#int#!#varchar
+0#!#1#!#a
+0#!#2#!#a
+0#!#3#!#a
+1#!#2#!#a
+1#!#3#!#a
+1#!#4#!#a
+2#!#3#!#a
+2#!#4#!#a
+2#!#5#!#a
+3#!#4#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
 GO
 ~~START~~
-int#!#int
-999#!#1002
-999#!#1001
-999#!#1000
-998#!#1001
-998#!#1000
-998#!#999
-997#!#1000
-997#!#999
-997#!#998
-996#!#999
+int#!#int#!#varchar
+999#!#1002#!#a
+999#!#1001#!#a
+999#!#1000#!#a
+998#!#1001#!#a
+998#!#1000#!#a
+998#!#999#!#a
+997#!#1000#!#a
+997#!#999#!#a
+997#!#998#!#a
+996#!#999#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+varchar#!#int
+a#!#1
+a#!#2
+a#!#3
+a#!#4
+a#!#5
+a#!#6
+a#!#7
+a#!#8
+a#!#9
+a#!#10
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+varchar#!#int
+a#!#100000
+a#!#99999
+a#!#99998
+a#!#99997
+a#!#99996
+a#!#99995
+a#!#99994
+a#!#99993
+a#!#99992
+a#!#99991
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id 
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+int#!#varchar
+1#!#a
+2#!#a
+3#!#a
+4#!#a
+5#!#a
+6#!#a
+7#!#a
+8#!#a
+9#!#a
+10#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan using c on babel_4940_t5 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan using c on babel_4940_t5 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+int#!#varchar
+100000#!#a
+99999#!#a
+99998#!#a
+99997#!#a
+99996#!#a
+99995#!#a
+99994#!#a
+99993#!#a
+99992#!#a
+99991#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan Backward using c on babel_4940_t5 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan Backward using c on babel_4940_t5 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
 GO
 ~~START~~
-int#!#int
-0#!#3
-0#!#2
-0#!#1
-1#!#4
-1#!#3
-1#!#2
-2#!#5
-2#!#4
-2#!#3
-3#!#6
+int#!#int#!#varchar
+0#!#3#!#a
+0#!#2#!#a
+0#!#1#!#a
+1#!#4#!#a
+1#!#3#!#a
+1#!#2#!#a
+2#!#5#!#a
+2#!#4#!#a
+2#!#3#!#a
+3#!#6#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan using c1 on babel_4940_t6 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan using c1 on babel_4940_t6 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
 GO
 ~~START~~
-int#!#int
-999#!#1000
-999#!#1001
-999#!#1002
-998#!#999
-998#!#1000
-998#!#1001
-997#!#998
-997#!#999
-997#!#1000
-996#!#997
+int#!#int#!#varchar
+999#!#1000#!#a
+999#!#1001#!#a
+999#!#1002#!#a
+998#!#999#!#a
+998#!#1000#!#a
+998#!#1001#!#a
+997#!#998#!#a
+997#!#999#!#a
+997#!#1000#!#a
+996#!#997#!#a
 ~~END~~
 
 ~~START~~
 text
 Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
 Limit (actual rows=10 loops=1)
-  ->  Index Only Scan Backward using c1 on babel_4940_t6 (actual rows=10 loops=1)
-        Heap Fetches: 10
+  ->  Index Scan Backward using c1 on babel_4940_t6 (actual rows=10 loops=1)
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/BABEL_4940.out
+++ b/test/JDBC/expected/parallel_query/BABEL_4940.out
@@ -2,27 +2,27 @@
 SET NOCOUNT ON
 GO
 -- column constraint
-CREATE TABLE babel_4940_t1(id INT PRIMARY KEY)
+CREATE TABLE babel_4940_t1(id INT PRIMARY KEY, c1 VARCHAR(5) DEFAULT 'a')
 GO
-INSERT INTO babel_4940_t1 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t1 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint
-CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id))
+CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id), c1 VARCHAR(5) DEFAULT 'a')
 GO
-INSERT INTO babel_4940_t2 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t2 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint multiple column
-CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1))
+CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1), c1 VARCHAR(5) DEFAULT 'a')
 GO
 SET NOCOUNT ON
 DECLARE @i INT=0;
 WHILE (@i<1000)
 BEGIN
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+1)
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+2)
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+3)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+3)
     SET @i = @i + 1;
 END
 GO
@@ -30,34 +30,34 @@ GO
 
 -- same test as above but create primary key using alter table add constraints
 -- column constraint
-CREATE TABLE babel_4940_t4(id INT PRIMARY KEY)
+CREATE TABLE babel_4940_t4(id INT PRIMARY KEY, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t4 DROP COLUMN id
 GO
 ALTER TABLE babel_4940_t4 ADD id INT PRIMARY KEY
 GO
-INSERT INTO babel_4940_t4 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t4 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint
-CREATE TABLE babel_4940_t5(id INT)
+CREATE TABLE babel_4940_t5(id INT, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t5 ADD CONSTRAINT c PRIMARY KEY (id)
 GO
-INSERT INTO babel_4940_t5 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t5 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint multiple column
-CREATE TABLE babel_4940_t6(id INT, id1 INT)
+CREATE TABLE babel_4940_t6(id INT, id1 INT, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t6 ADD CONSTRAINT c1 PRIMARY KEY(id, id1 DESC)
 GO
 DECLARE @i INT=0;
 WHILE (@i<1000)
 BEGIN
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+1)
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+2)
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+3)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+3)
     SET @i = @i + 1;
 END
 GO
@@ -99,17 +99,17 @@ off
 SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+int#!#varchar
+1#!#a
+2#!#a
+3#!#a
+4#!#a
+5#!#a
+6#!#a
+7#!#a
+8#!#a
+9#!#a
+10#!#a
 ~~END~~
 
 ~~START~~
@@ -120,24 +120,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+int#!#varchar
+100000#!#a
+99999#!#a
+99998#!#a
+99997#!#a
+99996#!#a
+99995#!#a
+99994#!#a
+99993#!#a
+99992#!#a
+99991#!#a
 ~~END~~
 
 ~~START~~
@@ -148,24 +147,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id 
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+int#!#varchar
+1#!#a
+2#!#a
+3#!#a
+4#!#a
+5#!#a
+6#!#a
+7#!#a
+8#!#a
+9#!#a
+10#!#a
 ~~END~~
 
 ~~START~~
@@ -176,24 +174,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+int#!#varchar
+100000#!#a
+99999#!#a
+99998#!#a
+99997#!#a
+99996#!#a
+99995#!#a
+99994#!#a
+99993#!#a
+99992#!#a
+99991#!#a
 ~~END~~
 
 ~~START~~
@@ -204,24 +201,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
 GO
 ~~START~~
-int#!#int
-0#!#1
-0#!#2
-0#!#3
-1#!#2
-1#!#3
-1#!#4
-2#!#3
-2#!#4
-2#!#5
-3#!#4
+int#!#int#!#varchar
+0#!#1#!#a
+0#!#2#!#a
+0#!#3#!#a
+1#!#2#!#a
+1#!#3#!#a
+1#!#4#!#a
+2#!#3#!#a
+2#!#4#!#a
+2#!#5#!#a
+3#!#4#!#a
 ~~END~~
 
 ~~START~~
@@ -232,24 +228,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
 GO
 ~~START~~
-int#!#int
-999#!#1002
-999#!#1001
-999#!#1000
-998#!#1001
-998#!#1000
-998#!#999
-997#!#1000
-997#!#999
-997#!#998
-996#!#999
+int#!#int#!#varchar
+999#!#1002#!#a
+999#!#1001#!#a
+999#!#1000#!#a
+998#!#1001#!#a
+998#!#1000#!#a
+998#!#999#!#a
+997#!#1000#!#a
+997#!#999#!#a
+997#!#998#!#a
+996#!#999#!#a
 ~~END~~
 
 ~~START~~
@@ -260,24 +255,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+varchar#!#int
+a#!#1
+a#!#2
+a#!#3
+a#!#4
+a#!#5
+a#!#6
+a#!#7
+a#!#8
+a#!#9
+a#!#10
 ~~END~~
 
 ~~START~~
@@ -288,24 +282,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+varchar#!#int
+a#!#100000
+a#!#99999
+a#!#99998
+a#!#99997
+a#!#99996
+a#!#99995
+a#!#99994
+a#!#99993
+a#!#99992
+a#!#99991
 ~~END~~
 
 ~~START~~
@@ -316,24 +309,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id 
 GO
 ~~START~~
-int
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
+int#!#varchar
+1#!#a
+2#!#a
+3#!#a
+4#!#a
+5#!#a
+6#!#a
+7#!#a
+8#!#a
+9#!#a
+10#!#a
 ~~END~~
 
 ~~START~~
@@ -344,24 +336,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan using c on babel_4940_t5 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan using c on babel_4940_t5 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
 GO
 ~~START~~
-int
-100000
-99999
-99998
-99997
-99996
-99995
-99994
-99993
-99992
-99991
+int#!#varchar
+100000#!#a
+99999#!#a
+99998#!#a
+99997#!#a
+99996#!#a
+99995#!#a
+99994#!#a
+99993#!#a
+99992#!#a
+99991#!#a
 ~~END~~
 
 ~~START~~
@@ -372,24 +363,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan Backward using c on babel_4940_t5 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan Backward using c on babel_4940_t5 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
 GO
 ~~START~~
-int#!#int
-0#!#3
-0#!#2
-0#!#1
-1#!#4
-1#!#3
-1#!#2
-2#!#5
-2#!#4
-2#!#3
-3#!#6
+int#!#int#!#varchar
+0#!#3#!#a
+0#!#2#!#a
+0#!#1#!#a
+1#!#4#!#a
+1#!#3#!#a
+1#!#2#!#a
+2#!#5#!#a
+2#!#4#!#a
+2#!#3#!#a
+3#!#6#!#a
 ~~END~~
 
 ~~START~~
@@ -400,24 +390,23 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan using c1 on babel_4940_t6 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan using c1 on babel_4940_t6 (actual rows=10 loops=1)
 ~~END~~
 
 SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
 GO
 ~~START~~
-int#!#int
-999#!#1000
-999#!#1001
-999#!#1002
-998#!#999
-998#!#1000
-998#!#1001
-997#!#998
-997#!#999
-997#!#1000
-996#!#997
+int#!#int#!#varchar
+999#!#1000#!#a
+999#!#1001#!#a
+999#!#1002#!#a
+998#!#999#!#a
+998#!#1000#!#a
+998#!#1001#!#a
+997#!#998#!#a
+997#!#999#!#a
+997#!#1000#!#a
+996#!#997#!#a
 ~~END~~
 
 ~~START~~
@@ -428,8 +417,7 @@ Gather (actual rows=10 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
-        ->  Index Only Scan Backward using c1 on babel_4940_t6 (actual rows=10 loops=1)
-              Heap Fetches: 10
+        ->  Index Scan Backward using c1 on babel_4940_t6 (actual rows=10 loops=1)
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL_4940.sql
+++ b/test/JDBC/input/BABEL_4940.sql
@@ -3,27 +3,27 @@
 SET NOCOUNT ON
 GO
 -- column constraint
-CREATE TABLE babel_4940_t1(id INT PRIMARY KEY)
+CREATE TABLE babel_4940_t1(id INT PRIMARY KEY, c1 VARCHAR(5) DEFAULT 'a')
 GO
-INSERT INTO babel_4940_t1 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t1 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint
-CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id))
+CREATE TABLE babel_4940_t2(id INT, PRIMARY KEY(id), c1 VARCHAR(5) DEFAULT 'a')
 GO
-INSERT INTO babel_4940_t2 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t2 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint multiple column
-CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1))
+CREATE TABLE babel_4940_t3(id INT, id1 INT, PRIMARY KEY(id, id1), c1 VARCHAR(5) DEFAULT 'a')
 GO
 SET NOCOUNT ON
 DECLARE @i INT=0;
 WHILE (@i<1000)
 BEGIN
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+1)
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+2)
-    INSERT INTO babel_4940_t3 VALUES(@i,@i+3)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t3 (id, id1) VALUES(@i,@i+3)
     SET @i = @i + 1;
 END
 GO
@@ -31,34 +31,34 @@ GO
 
 -- same test as above but create primary key using alter table add constraints
 -- column constraint
-CREATE TABLE babel_4940_t4(id INT PRIMARY KEY)
+CREATE TABLE babel_4940_t4(id INT PRIMARY KEY, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t4 DROP COLUMN id
 GO
 ALTER TABLE babel_4940_t4 ADD id INT PRIMARY KEY
 GO
-INSERT INTO babel_4940_t4 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t4 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint
-CREATE TABLE babel_4940_t5(id INT)
+CREATE TABLE babel_4940_t5(id INT, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t5 ADD CONSTRAINT c PRIMARY KEY (id)
 GO
-INSERT INTO babel_4940_t5 VALUES(generate_series(1,100000))
+INSERT INTO babel_4940_t5 (id) VALUES(generate_series(1,100000))
 GO
 
 -- table constraint multiple column
-CREATE TABLE babel_4940_t6(id INT, id1 INT)
+CREATE TABLE babel_4940_t6(id INT, id1 INT, c1 VARCHAR(5) DEFAULT 'a')
 GO
 ALTER TABLE babel_4940_t6 ADD CONSTRAINT c1 PRIMARY KEY(id, id1 DESC)
 GO
 DECLARE @i INT=0;
 WHILE (@i<1000)
 BEGIN
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+1)
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+2)
-    INSERT INTO babel_4940_t6 VALUES(@i,@i+3)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+1)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+2)
+    INSERT INTO babel_4940_t6 (id, id1) VALUES(@i,@i+3)
     SET @i = @i + 1;
 END
 GO


### PR DESCRIPTION
### Description

Update test case BABEL-4940 to remove "heap fetches" from plan.

### Cherry Pick From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2632

### Issues Resolved

[NO JIRA]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).