### PR TITLE
Fix valgrind warnings related to source and destination overlap in strcpy in datetime, datetime2 and datetimeoffset related functions

### DIFF
--- a/contrib/babelfishpg_common/src/datetime.c
+++ b/contrib/babelfishpg_common/src/datetime.c
@@ -180,7 +180,7 @@ clean_input_str(char *str, bool *contains_extra_spaces, DateTimeContext context)
 		if (str[i] == '\0')
 			break;
 
-		if (j > MAXDATELEN)
+		if (j >= MAXDATELEN)
 		{
 			if (result)
 				pfree(result);
@@ -515,7 +515,7 @@ datetime_in_str(char *str)
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
 	bool		contains_extra_spaces = false;
 	bool		is_year_set = false;
-	char		*modified_str = str;
+	char		*modified_str;
 
 	/*
 	 * Set input to default '1900-01-01 00:00:00.000' if empty string
@@ -530,9 +530,7 @@ datetime_in_str(char *str)
 	tm->tm_mon = 0;
 	tm->tm_mday = 0;
 
-	strcpy(modified_str, str);
-
-	modified_str = clean_input_str(modified_str, &contains_extra_spaces, DATE_TIME);
+	modified_str = clean_input_str(str, &contains_extra_spaces, DATE_TIME);
 
 	dterr = ParseDateTime(modified_str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);

--- a/contrib/babelfishpg_common/src/datetime.c
+++ b/contrib/babelfishpg_common/src/datetime.c
@@ -158,7 +158,7 @@ check_regex_for_text_month(char *str, DateTimeContext context)
 char*
 clean_input_str(char *str, bool *contains_extra_spaces, DateTimeContext context)
 {
-	char *result = (char *) palloc(MAXDATELEN);
+	char *result = (char *) palloc(MAXDATELEN + 1);
 	int i = 0, j = 0;
 	int last_non_space = -1;
 	int num_colons = 0;

--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -267,7 +267,7 @@ datetime2_in_str(char *str, int32 typmod)
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
 	bool		contains_extra_spaces = false;
 	bool		is_year_set = false;
-	char		*modified_str = str;
+	char		*modified_str;
 
 	tm->tm_year = 0;
 	tm->tm_mon = 0;
@@ -282,7 +282,7 @@ datetime2_in_str(char *str, int32 typmod)
 		PG_RETURN_TIMESTAMP(result);
 	}
 
-	modified_str = clean_input_str(modified_str, &contains_extra_spaces, DATE_TIME_2);
+	modified_str = clean_input_str(str, &contains_extra_spaces, DATE_TIME_2);
 
 	dterr = ParseDateTime(modified_str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);

--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -94,7 +94,7 @@ datetimeoffset_in(PG_FUNCTION_ARGS)
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
 	bool		contains_extra_spaces = false, is_year_set = false;
-	char		*modified_str = str;
+	char		*modified_str;
 
 	datetimeoffset = (tsql_datetimeoffset *) palloc(DATETIMEOFFSET_LEN);
 
@@ -115,7 +115,7 @@ datetimeoffset_in(PG_FUNCTION_ARGS)
 		PG_RETURN_DATETIMEOFFSET(datetimeoffset);
 	}
 
-	modified_str = clean_input_str(modified_str, &contains_extra_spaces, DATE_TIME_OFFSET);
+	modified_str = clean_input_str(str, &contains_extra_spaces, DATE_TIME_OFFSET);
 
 	dterr = ParseDateTime(modified_str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);


### PR DESCRIPTION
### Description

In datetime_in_str function, we are unnecessarily using strcpy function which is also causing issues in valgrind as the source and the destination overlap. 

This commit removes this unnecessary strcpy call in datetime_in_str function. Also, we can directly send the original input string in clean_input_str() function rather than sending modified_str as we were doing before.

### Issues Resolved

BABEL-5034

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)

### Test Scenarios Covered ###
Tested locally with Valgrind
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).