### PR TITLE
SET Volatility of helper functions used to convert string to date and time types to IMMUTABLE

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -686,7 +686,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_day NUMERIC,
@@ -768,7 +768,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_day TEXT,
@@ -784,7 +784,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_datetimeval TIMESTAMP WITHOUT TIME ZONE)
@@ -804,7 +804,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 -- Following function can be used to convert string literal to DATE, TIME and DATETIME2.
@@ -1453,7 +1453,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 -- Following function can be used to convert string literal to DATETIME and SMALLDATETIME
@@ -2117,7 +2117,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 -- Following function can be used to convert string literal to DATETIMEOFFSET
@@ -2202,7 +2202,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_time_to_string(IN p_datatype TEXT,
@@ -2478,7 +2478,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_get_int_part(IN p_srcnumber DOUBLE PRECISION)
@@ -2493,7 +2493,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_get_jobs ()
@@ -2698,7 +2698,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_get_monthnum_by_name(IN p_monthname TEXT,
@@ -9788,7 +9788,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_string_to_datetime_v2(IN p_datatype TEXT,
@@ -9807,7 +9807,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_string_to_datetimeoffset(IN p_datatype TEXT,
@@ -9826,7 +9826,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_time_to_string(IN p_datatype TEXT,
@@ -9866,7 +9866,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.VARCHAR,
                                                         IN try BOOL,
@@ -9879,7 +9879,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.NVARCHAR,
                                                         IN try BOOL,
@@ -9892,7 +9892,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.BPCHAR,
                                                         IN try BOOL,
@@ -9905,7 +9905,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.NCHAR,
                                                         IN try BOOL,
@@ -9918,7 +9918,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg anyelement,
                                                         IN try BOOL,
@@ -9946,7 +9946,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_date(IN arg anyelement)
 RETURNS DATE
@@ -9962,7 +9962,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 -- conversion to time
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
@@ -9989,7 +9989,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.VARCHAR,
@@ -10003,7 +10003,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.NVARCHAR,
@@ -10017,7 +10017,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.BPCHAR,
@@ -10031,7 +10031,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.NCHAR,
@@ -10045,7 +10045,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg anyelement,
@@ -10074,7 +10074,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_time(IN arg anyelement)
 RETURNS TIME
@@ -10090,7 +10090,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 -- conversion to datetime
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
@@ -10117,7 +10117,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -10131,7 +10131,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -10145,7 +10145,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -10159,7 +10159,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -10173,7 +10173,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -10202,7 +10202,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_datetime(IN arg anyelement)
 RETURNS sys.DATETIME
@@ -10218,7 +10218,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 -- conversion to datetime2
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
@@ -10245,7 +10245,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -10259,7 +10259,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -10273,7 +10273,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -10287,7 +10287,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -10301,7 +10301,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -10330,7 +10330,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_datetime2(IN arg anyelement)
 RETURNS sys.DATETIME2
@@ -10346,7 +10346,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 -- conversion to datetimeoffset
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
@@ -10373,7 +10373,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -10387,7 +10387,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -10401,7 +10401,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -10415,7 +10415,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -10429,7 +10429,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -10458,7 +10458,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_datetimeoffset(IN arg anyelement)
 RETURNS sys.DATETIMEOFFSET
@@ -10474,7 +10474,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 -- conversion to smalldatetime
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
@@ -10501,7 +10501,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -10515,7 +10515,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -10529,7 +10529,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -10543,7 +10543,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -10557,7 +10557,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -10586,7 +10586,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_smalldatetime(IN arg anyelement)
 RETURNS sys.SMALLDATETIME
@@ -10602,7 +10602,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 -- conversion to varchar
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_varchar(IN typename TEXT,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
@@ -913,7 +913,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_get_timeunit_from_string(IN p_timepart TEXT,
@@ -1670,7 +1670,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_string_to_datetime_v2(IN p_datatype TEXT,
@@ -2333,7 +2333,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_string_to_datetimeoffset(IN p_datatype TEXT,
@@ -2417,7 +2417,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_string_to_datetime2(IN p_datatype TEXT,
@@ -2436,7 +2436,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_string_to_datetime_v2(IN p_datatype TEXT,
@@ -2455,7 +2455,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_string_to_datetimeoffset(IN p_datatype TEXT,
@@ -2474,7 +2474,7 @@ EXCEPTION
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE
+IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg TEXT,
@@ -2492,7 +2492,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.VARCHAR,
                                                         IN try BOOL,
@@ -2505,7 +2505,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.NVARCHAR,
                                                         IN try BOOL,
@@ -2518,7 +2518,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.BPCHAR,
                                                         IN try BOOL,
@@ -2531,7 +2531,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg sys.NCHAR,
                                                         IN try BOOL,
@@ -2544,7 +2544,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_date(IN arg anyelement)
 RETURNS DATE
@@ -2560,7 +2560,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_date(IN arg anyelement,
                                                         IN try BOOL,
@@ -2588,7 +2588,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg TEXT,
@@ -2614,7 +2614,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.VARCHAR,
@@ -2628,7 +2628,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.NVARCHAR,
@@ -2642,7 +2642,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.BPCHAR,
@@ -2656,7 +2656,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg sys.NCHAR,
@@ -2670,7 +2670,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_time(IN arg anyelement)
 RETURNS TIME
@@ -2686,7 +2686,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_time(IN typmod INTEGER,
                                                         IN arg anyelement,
@@ -2715,7 +2715,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg TEXT,
@@ -2741,7 +2741,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -2755,7 +2755,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -2769,7 +2769,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -2783,7 +2783,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -2797,7 +2797,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_datetime(IN arg anyelement)
 RETURNS sys.DATETIME
@@ -2813,7 +2813,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -2842,7 +2842,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg TEXT,
@@ -2868,7 +2868,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -2882,7 +2882,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -2896,7 +2896,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -2910,7 +2910,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -2924,7 +2924,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_datetime2(IN arg anyelement)
 RETURNS sys.DATETIME2
@@ -2940,7 +2940,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetime2(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -2969,7 +2969,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg TEXT,
@@ -2995,7 +2995,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -3009,7 +3009,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -3023,7 +3023,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -3037,7 +3037,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -3051,7 +3051,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_datetimeoffset(IN arg anyelement)
 RETURNS sys.DATETIMEOFFSET
@@ -3067,7 +3067,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_datetimeoffset(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -3096,7 +3096,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg TEXT,
@@ -3122,7 +3122,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.VARCHAR,
@@ -3136,7 +3136,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.NVARCHAR,
@@ -3150,7 +3150,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.BPCHAR,
@@ -3164,7 +3164,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg sys.NCHAR,
@@ -3178,7 +3178,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_try_conv_to_smalldatetime(IN arg anyelement)
 RETURNS sys.SMALLDATETIME
@@ -3194,7 +3194,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_helper_to_smalldatetime(IN typmod INTEGER,
                                                             IN arg anyelement,
@@ -3223,7 +3223,7 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql
-STABLE;
+IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.babelfish_conv_datetime_to_string(IN p_datatype TEXT,
                                                                      IN p_src_datatype TEXT,
@@ -6024,6 +6024,13 @@ BEGIN
 END;
 $body$
 LANGUAGE plpgsql IMMUTABLE;
+
+ALTER FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_dateval DATE) IMMUTABLE;
+ALTER FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_day NUMERIC, IN p_month NUMERIC, IN p_year NUMERIC) IMMUTABLE;
+ALTER FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_day TEXT, IN p_month TEXT, IN p_year TEXT) IMMUTABLE;
+ALTER FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_datetimeval TIMESTAMP WITHOUT TIME ZONE) IMMUTABLE;
+ALTER FUNCTION sys.babelfish_get_full_year(IN p_short_year TEXT, IN p_base_century TEXT, IN p_year_cutoff NUMERIC) IMMUTABLE;
+ALTER FUNCTION sys.babelfish_get_int_part(IN p_srcnumber DOUBLE PRECISION) IMMUTABLE;
 
 CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'babelfish_try_conv_string_to_date');
 CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'babelfish_conv_string_to_date');

--- a/test/JDBC/expected/9809_1.out
+++ b/test/JDBC/expected/9809_1.out
@@ -1,0 +1,368 @@
+
+-- simple batch start
+GO
+
+
+SELECT CONVERT(DATE, '10-10-10', 140)
+GO
+~~ERROR (Code: 9809)~~
+
+~~ERROR (Message: The style 140 is not supported for conversions from varchar to date.)~~
+
+GO
+
+
+begin transaction
+GO
+GO
+
+
+SELECT CONVERT(DATE, '10-10-10', 140)
+GO
+~~ERROR (Code: 9809)~~
+
+~~ERROR (Message: The style 140 is not supported for conversions from varchar to date.)~~
+
+
+
+-- Below output is only applicable if query is special case. for example, CREATE/ALTER TRIGGER, CREATE/ALTER FUNCTION, CREATE/ALTER PROC, CREATE/ALTER VIEW etc
+if (@@trancount > 0) select cast('compile time error' as text) else select cast('runtime error' as text)
+GO
+~~START~~
+text
+compile time error
+~~END~~
+
+
+if (@@trancount > 0) rollback tran
+GO
+
+GO
+
+
+-- simple batch end
+GO
+
+create schema error_mapping;
+GO
+-- Next portion is to check if error is being raised during parse analysis phase
+GO
+
+create table error_mapping.temp1 (a int)
+GO
+
+GO
+
+
+create procedure error_mapping.ErrorHandling1 as
+begin
+insert into error_mapping.temp1 values(1)
+SELECT CONVERT(DATE, '10-10-10', 140)
+end
+GO
+
+GO
+
+
+create table error_mapping.temp2 (a int)
+GO
+
+GO
+
+
+insert into error_mapping.temp2 values(1)
+SELECT CONVERT(DATE, '10-10-10', 140)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 9809)~~
+
+~~ERROR (Message: The style 140 is not supported for conversions from varchar to date.)~~
+
+
+GO
+
+
+-- Here we are assuming that error_mapping.ErrorHandling1 is created with no error
+GO
+
+create table error_mapping.temp3 (a int)
+GO
+
+GO
+
+insert into error_mapping.temp3 values(1)
+exec error_mapping.ErrorHandling1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 9809)~~
+
+~~ERROR (Message: The style 140 is not supported for conversions from varchar to date.)~~
+
+
+GO
+
+
+if ((select count(*) from error_mapping.temp1) = 0 and (select count(*) from error_mapping.temp2) = 0 and (select count(*) from error_mapping.temp3) > 0) select cast('parse analysis phase error' as text)
+GO
+
+drop procedure error_mapping.ErrorHandling1;
+GO
+drop table error_mapping.temp1;
+drop table error_mapping.temp2;
+drop table error_mapping.temp3;
+GO
+
+-- Parse analysis phase end
+GO
+
+
+-- compile time error portion
+-- Executing test error_mapping.ErrorHandling1
+GO
+
+
+
+
+create procedure error_mapping.ErrorHandling1 as
+begin
+SELECT CONVERT(DATE, '10-10-10', 140)
+if @@error > 0 select cast('STATEMENT TERMINATING ERROR' as text);
+select @@trancount;
+end
+GO
+
+if @@error > 0 select cast('Compile time error' as text);
+if @@trancount > 0 rollback transaction;
+drop procedure error_mapping.ErrorHandling1;
+set xact_abort OFF;
+set implicit_transactions OFF;
+GO
+GO
+
+
+
+GO
+
+begin transaction
+GO
+
+
+-- Executing test error_mapping.ErrorHandling1
+create procedure error_mapping.ErrorHandling1 as
+begin
+SELECT CONVERT(DATE, '10-10-10', 140)
+if @@error > 0 select cast('STATEMENT TERMINATING ERROR' as text);
+end
+GO
+
+declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
+if @@trancount > 0 rollback transaction;
+drop procedure error_mapping.ErrorHandling1;
+set xact_abort OFF;
+set implicit_transactions OFF;
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "master_error_mapping.errorhandling1")~~
+
+
+GO
+GO
+
+
+
+-- Checking xact_abort_flag for compile time error --
+set xact_abort ON;
+GO
+GO
+
+begin transaction
+GO
+
+
+-- Executing test error_mapping.ErrorHandling1
+create procedure error_mapping.ErrorHandling1 as
+begin
+SELECT CONVERT(DATE, '10-10-10', 140)
+if @@error > 0 select cast('STATEMENT TERMINATING ERROR' as text);
+end
+GO
+
+declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
+if @@trancount > 0 rollback transaction;
+drop procedure error_mapping.ErrorHandling1;
+set xact_abort OFF;
+set implicit_transactions OFF;
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "master_error_mapping.errorhandling1")~~
+
+
+GO
+GO
+
+set xact_abort OFF;
+GO
+
+
+-- comiple time error portion end --
+-- Next portion is for runtime error --
+-- Executing test error_mapping.ErrorHandling10000000
+GO
+
+
+
+
+create procedure error_mapping.ErrorHandling1 as
+begin
+SELECT CONVERT(DATE, '10-10-10', 140)
+if @@error > 0 select cast('STATEMENT TERMINATING ERROR' as text);
+select @@trancount;
+end
+GO
+
+if @@error > 0 select cast('CURRENT BATCH TERMINATING ERROR' as text);
+GO
+
+create procedure error_mapping.ErrorHandling2 as
+begin
+exec error_mapping.ErrorHandling1;
+if @@error > 0 select cast('CURRENT BATCH TERMINATING ERROR' as text);
+end
+GO
+
+begin transaction;
+GO
+exec error_mapping.ErrorHandling2;
+GO
+~~ERROR (Code: 9809)~~
+
+~~ERROR (Message: The style 140 is not supported for conversions from varchar to date.)~~
+
+~~START~~
+text
+STATEMENT TERMINATING ERROR
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
+if @@trancount > 0 rollback transaction;
+drop procedure error_mapping.ErrorHandling1;
+drop procedure error_mapping.ErrorHandling2;
+set xact_abort OFF;
+set implicit_transactions OFF;
+GO
+GO
+
+
+
+set xact_abort ON;
+GO
+-- Executing test error_mapping.ErrorHandling10000000
+GO
+
+
+
+
+create procedure error_mapping.ErrorHandling1 as
+begin
+SELECT CONVERT(DATE, '10-10-10', 140)
+if @@error > 0 select cast('STATEMENT TERMINATING ERROR' as text);
+select @@trancount;
+end
+GO
+
+if @@error > 0 select cast('CURRENT BATCH TERMINATING ERROR' as text);
+GO
+
+create procedure error_mapping.ErrorHandling2 as
+begin
+exec error_mapping.ErrorHandling1;
+if @@error > 0 select cast('CURRENT BATCH TERMINATING ERROR' as text);
+end
+GO
+
+begin transaction;
+GO
+exec error_mapping.ErrorHandling2;
+GO
+~~ERROR (Code: 9809)~~
+
+~~ERROR (Message: The style 140 is not supported for conversions from varchar to date.)~~
+
+declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
+if @@trancount > 0 rollback transaction;
+drop procedure error_mapping.ErrorHandling1;
+drop procedure error_mapping.ErrorHandling2;
+set xact_abort OFF;
+set implicit_transactions OFF;
+GO
+~~START~~
+text
+BATCH TERMINATING\ txn rolledback
+~~END~~
+
+GO
+
+
+
+
+set xact_abort OFF;
+GO
+
+
+-- Error classification is done --
+-- Executing test error_mapping.ErrorHandling10000000
+GO
+
+
+
+
+begin try
+select 1
+SELECT CONVERT(DATE, '10-10-10', 140)
+end try
+begin catch
+	select xact_state();
+end catch
+if @@trancount > 0 rollback transaction;
+drop procedure error_mapping.ErrorHandling1;
+drop procedure error_mapping.ErrorHandling2;
+set xact_abort OFF;
+set implicit_transactions OFF;
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "master_error_mapping.errorhandling1")~~
+
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "master_error_mapping.errorhandling2")~~
+
+GO
+
+
+
+
+GO
+drop schema error_mapping;
+GO

--- a/test/JDBC/expected/ATTIMEZONE.out
+++ b/test/JDBC/expected/ATTIMEZONE.out
@@ -71,8 +71,6 @@ datetimeoffset
 
 Select '2022-10-29 20:01:00.000' AT TIME ZONE convert(datetime,'2022-10-29 20:01:00.000')
 Go
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Argument data type varchar is invalid for argument 1 of AT TIME ZONE function.)~~

--- a/test/JDBC/expected/BABEL-3614-before-16_3-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3614-before-16_3-vu-verify.out
@@ -181,8 +181,6 @@ GO
 
 EXEC BABEL_3614_vu_prepare_p7
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to datetime2 is not allowed.)~~

--- a/test/JDBC/expected/BABEL-3614-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3614-vu-verify.out
@@ -170,8 +170,6 @@ GO
 
 SELECT * FROM BABEL_3614_vu_prepare_v7
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to datetime2 is not allowed.)~~
@@ -181,8 +179,6 @@ GO
 
 EXEC BABEL_3614_vu_prepare_p7
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to datetime2 is not allowed.)~~

--- a/test/JDBC/expected/BABEL-5031-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5031-vu-verify.out
@@ -1,0 +1,106 @@
+-- Customer case
+CREATE TABLE [dbo].[babel_5031_MemberValues](
+    [Id] [uniqueidentifier] NOT NULL,
+    [PanelId] [uniqueidentifier] NOT NULL,
+    [EndEffectiveDate] [datetime2](7) NOT NULL
+);
+GO
+
+CREATE NONCLUSTERED INDEX [babel_5031_IDX_MBRVAL_SHARED_LATEST_FILT] ON [dbo].[babel_5031_MemberValues] ([PanelId] ASC)
+WHERE ([EndEffectiveDate]=CONVERT([datetime2](7),'9999-12-31 23:59:59.9999999'));
+GO
+
+DROP TABLE babel_5031_MemberValues
+GO
+
+-- Using convert function for converting from string to date/datetime/datetime2/datetimeoffset/smalldatetime/time 
+-- in computed column of table
+CREATE TABLE babel_5031_t1(col_string VARCHAR(100),
+                        col_date AS CONVERT(date, col_string),
+                        col_datetime AS CONVERT(datetime, col_string),
+                        col_datetime2 AS CONVERT(datetime2, col_string),
+                        col_dateoffset AS CONVERT(datetimeoffset, col_string),
+                        col_smalldatetime AS CONVERT(smalldatetime, col_string),
+                        col_time AS CONVERT(time, col_string));
+GO
+
+INSERT INTO babel_5031_t1 VALUES('2026-12-31 23:59:59.99');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_5031_t1 VALUES('11.12.2024');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_5031_t1 VALUES('2022-10-30T03:00:00.123');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_5031_t1 VALUES('20240129 03:00:00');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_5031_t1
+GO
+~~START~~
+varchar#!#date#!#datetime#!#datetime2#!#datetimeoffset#!#smalldatetime#!#time
+2026-12-31 23:59:59.99#!#2026-12-31#!#2026-12-31 23:59:59.99#!#2026-12-31 23:59:59.9900000#!#2026-12-31 23:59:59.9900000 +00:00#!#2027-01-01 00:00:00.0#!#23:59:59.9900000
+11.12.2024#!#2024-11-12#!#2024-11-12 00:00:00.0#!#2024-11-12 00:00:00.0000000#!#2024-11-12 00:00:00.0000000 +00:00#!#2024-11-12 00:00:00.0#!#00:00:00.0000000
+2022-10-30T03:00:00.123#!#2022-10-30#!#2022-10-30 03:00:00.123#!#2022-10-30 03:00:00.1230000#!#2022-10-30 03:00:00.1230000 +00:00#!#2022-10-30 03:00:00.0#!#03:00:00.1230000
+20240129 03:00:00#!#2024-01-29#!#2024-01-29 03:00:00.0#!#2024-01-29 03:00:00.0000000#!#2024-01-29 03:00:00.0000000 +00:00#!#2024-01-29 03:00:00.0#!#03:00:00.0000000
+~~END~~
+
+
+DROP TABLE babel_5031_t1
+GO
+
+-- Using convert function for converting from string to date/datetime/datetime2/datetimeoffset/smalldatetime/time 
+-- in check constraint of table
+CREATE TABLE babel_5031_t2(col_string VARCHAR(100),
+                        CHECK (CONVERT(date, col_string) > CONVERT(date, '03-05-2023')),
+                        CHECK (CONVERT(datetime, col_string) > CONVERT(datetime, '03-05-2023')),
+                        CHECK (CONVERT(datetime2, col_string) > CONVERT(datetime2, '03-05-2023')),
+                        CHECK (CONVERT(datetimeoffset, col_string) > CONVERT(datetimeoffset, '03-05-2023')),
+                        CHECK (CONVERT(smalldatetime, col_string) > CONVERT(smalldatetime, '03-05-2023')),
+                        CHECK (CONVERT(time, col_string) > CONVERT(time, '03-05-2023')));
+GO
+
+INSERT INTO babel_5031_t2 VALUES('2026-12-31 23:59:59.99');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO babel_5031_t2 VALUES('11.12.2024');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5031_t2" violates check constraint "babel_5031_t2_col_string_check5")~~
+
+
+INSERT INTO babel_5031_t2 VALUES('2022-10-30T03:00:00.123');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5031_t2" violates check constraint "babel_5031_t2_col_string_check")~~
+
+
+INSERT INTO babel_5031_t2 VALUES('20240129 03:00:00');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_5031_t2
+GO
+~~START~~
+varchar
+2026-12-31 23:59:59.99
+20240129 03:00:00
+~~END~~
+
+
+DROP TABLE babel_5031_t2
+GO

--- a/test/JDBC/expected/TestDatetime-numeric-dateaddfunction-vu-prepare.out
+++ b/test/JDBC/expected/TestDatetime-numeric-dateaddfunction-vu-prepare.out
@@ -48,32 +48,24 @@ GO
 -- Should all fail
 SELECT CONVERT(SMALLDATETIME, CAST(-2.5 as DECIMAL))
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Arithmetic overflow error converting expression to data type smalldatetime.)~~
 
 SELECT CONVERT(SMALLDATETIME, CAST(-2.5 as NUMERIC(30,8)))
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Arithmetic overflow error converting expression to data type smalldatetime.)~~
 
 SELECT CONVERT(SMALLDATETIME, CAST(-2.5 as FLOAT))
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Arithmetic overflow error converting expression to data type smalldatetime.)~~
 
 SELECT CONVERT(SMALLDATETIME, CAST(-2.5 as REAL))
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Arithmetic overflow error converting expression to data type smalldatetime.)~~
@@ -122,32 +114,24 @@ smalldatetime
 -- Should all fail
 SELECT CONVERT(DATETIME2, CAST(-2.5 as DECIMAL))
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to datetime2 is not allowed.)~~
 
 SELECT CONVERT(DATETIME2, CAST(-2.5 as NUMERIC(30,8)))
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type numeric to datetime2 is not allowed.)~~
 
 SELECT CONVERT(DATETIME2, CAST(-2.5 as FLOAT))
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type double precision to datetime2 is not allowed.)~~
 
 SELECT CONVERT(DATETIME2, CAST(-2.5 as REAL))
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type real to datetime2 is not allowed.)~~
@@ -196,32 +180,24 @@ datetime2
 -- Should all fail
 SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as DECIMAL))
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to datetimeoffset is not allowed.)~~
 
 SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as NUMERIC(30,8)))
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type numeric to datetimeoffset is not allowed.)~~
 
 SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as FLOAT))
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type double precision to datetimeoffset is not allowed.)~~
 
 SELECT CONVERT(DATETIMEOFFSET, CAST(-2.5 as REAL))
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type real to datetimeoffset is not allowed.)~~
@@ -270,32 +246,24 @@ datetimeoffset
 -- Should all fail
 SELECT CONVERT(DATE, CAST(-2.5 as DECIMAL))
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to date is not allowed.)~~
 
 SELECT CONVERT(DATE, CAST(-2.5 as NUMERIC(30,8)))
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type numeric to date is not allowed.)~~
 
 SELECT CONVERT(DATE, CAST(-2.5 as FLOAT))
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type double precision to date is not allowed.)~~
 
 SELECT CONVERT(DATE, CAST(-2.5 as REAL))
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type real to date is not allowed.)~~
@@ -344,32 +312,24 @@ date
 -- Should all fail
 SELECT CONVERT(TIME, CAST(-2.5 as DECIMAL))
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type "decimal" to time is not allowed.)~~
 
 SELECT CONVERT(TIME, CAST(-2.5 as NUMERIC(30,8)))
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type numeric to time is not allowed.)~~
 
 SELECT CONVERT(TIME, CAST(-2.5 as FLOAT))
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type double precision to time is not allowed.)~~
 
 SELECT CONVERT(TIME, CAST(-2.5 as REAL))
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type real to time is not allowed.)~~

--- a/test/JDBC/expected/TestDatetime-vu-verify.out
+++ b/test/JDBC/expected/TestDatetime-vu-verify.out
@@ -250,22 +250,16 @@ datetime
 ~~END~~
 
 select convert(datetime, '9999-12-31 23:59:59.999');
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
 
 select convert(datetime, '1752-12-31 23:59:59.997');
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
 
 select convert(datetime, '0000-00-00 00:00:00.000');
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~

--- a/test/JDBC/expected/TestDatetime.out
+++ b/test/JDBC/expected/TestDatetime.out
@@ -369,22 +369,16 @@ datetime
 ~~END~~
 
 select convert(datetime, '9999-12-31 23:59:59.999');
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
 
 select convert(datetime, '1752-12-31 23:59:59.997');
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
 
 select convert(datetime, '0000-00-00 00:00:00.000');
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~

--- a/test/JDBC/expected/babel_function.out
+++ b/test/JDBC/expected/babel_function.out
@@ -318,16 +318,12 @@ varchar
 -- Wrong conversions that return NULL
 select TRY_CONVERT(date, 123);
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
 
 select TRY_CONVERT(time, 123);
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_function.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_function.out
@@ -318,16 +318,12 @@ varchar
 -- Wrong conversions that return NULL
 select TRY_CONVERT(date, 123);
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
 
 select TRY_CONVERT(time, 123);
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_date-before-13_6-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_date-before-13_6-vu-verify.out
@@ -191,8 +191,6 @@ date
 
 SELECT CONVERT(DATE, '3-2024-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -200,8 +198,6 @@ date
 
 SELECT CONVERT(DATE, '11-2024-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -209,8 +205,6 @@ date
 
 SELECT CONVERT(DATE, '3 -           2024     -        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -242,8 +236,6 @@ date
 
 SELECT CONVERT(DATE, '3.2024.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -251,8 +243,6 @@ date
 
 SELECT CONVERT(DATE, '11.2024.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -260,8 +250,6 @@ date
 
 SELECT CONVERT(DATE, '3 .           2024     .        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -293,8 +281,6 @@ date
 
 SELECT CONVERT(DATE, '3/2024/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -302,8 +288,6 @@ date
 
 SELECT CONVERT(DATE, '11/2024/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -311,8 +295,6 @@ date
 
 SELECT CONVERT(DATE, '3 /           2024     /        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -490,8 +472,6 @@ date
 
 SELECT CONVERT(DATE, '12-2024-3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -499,8 +479,6 @@ date
 
 SELECT CONVERT(DATE, '12-2024-11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -508,8 +486,6 @@ date
 
 SELECT CONVERT(DATE, '12     -        2024 -           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -541,8 +517,6 @@ date
 
 SELECT CONVERT(DATE, '12.2024.3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -550,8 +524,6 @@ date
 
 SELECT CONVERT(DATE, '12.2024.11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -559,8 +531,6 @@ date
 
 SELECT CONVERT(DATE, '12     .        2024 .           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -592,8 +562,6 @@ date
 
 SELECT CONVERT(DATE, '12/2024/3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -601,8 +569,6 @@ date
 
 SELECT CONVERT(DATE, '12/2024/11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -610,8 +576,6 @@ date
 
 SELECT CONVERT(DATE, '12     /        2024 /           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -636,8 +600,6 @@ date
 
 SELECT CONVERT(DATE, '24-3-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -685,8 +647,6 @@ date
 
 SELECT CONVERT(DATE, '24.3.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -734,8 +694,6 @@ date
 
 SELECT CONVERT(DATE, '24/3/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -768,8 +726,6 @@ date
 -- invalid syntax
 SELECT CONVERT(DATE, '3 12 2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -777,8 +733,6 @@ date
 
 SELECT CONVERT(DATE, '3#12#2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -786,8 +740,6 @@ date
 
 SELECT CONVERT(DATE, '3/12.2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -844,8 +796,6 @@ date
 
 SELECT CONVERT(DATE, '22-03-2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -883,8 +833,6 @@ date
 
 SELECT CONVERT(DATE, '03-2024-22')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -903,8 +851,6 @@ date
 
 SELECT CONVERT(DATE, '22-2024-03')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -926,8 +872,6 @@ date
 -- For DATE as follows, it will always be treated as YMD DATEFORMAT as YDM is not supported.
 SELECT CONVERT(DATE, '2024-22-03')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -964,8 +908,6 @@ date
 
 SELECT CONVERT(DATE, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -997,8 +939,6 @@ date
 
 SELECT CONVERT(DATE, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1006,8 +946,6 @@ date
 
 SELECT CONVERT(DATE,'2022-10-00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1015,8 +953,6 @@ date
 
 SELECT CONVERT(DATE,'0000-10-01')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1024,8 +960,6 @@ date
 
 SELECT CONVERT(DATE,'2023-00-01')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1033,8 +967,6 @@ date
 
 SELECT CONVERT(DATE,'0000-00-00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1319,8 +1251,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 12,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1328,8 +1258,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1369,8 +1297,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 1,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1378,8 +1304,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1419,8 +1343,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr12,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1428,8 +1350,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1469,8 +1389,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr1,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1478,8 +1396,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1521,8 +1437,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 12,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1530,8 +1444,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 12', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1571,8 +1483,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 1,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1580,8 +1490,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 1', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1621,8 +1529,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم12,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1630,8 +1536,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم12', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1671,8 +1575,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم1,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1680,8 +1582,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم1', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2032,8 +1932,6 @@ date
 
 SELECT CONVERT(DATE, '12 Apr,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2041,8 +1939,6 @@ date
 
 SELECT CONVERT(DATE, '12 Apr')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2098,8 +1994,6 @@ date
 
 SELECT CONVERT(DATE, '12Apr,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2107,8 +2001,6 @@ date
 
 SELECT CONVERT(DATE, '12Apr')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2166,8 +2058,6 @@ date
 
 SELECT CONVERT(DATE, N'12 محرم,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2175,8 +2065,6 @@ date
 
 SELECT CONVERT(DATE, N'12 محرم', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2232,8 +2120,6 @@ date
 
 SELECT CONVERT(DATE, N'12محرم,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2241,8 +2127,6 @@ date
 
 SELECT CONVERT(DATE, N'12محرم', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2623,8 +2507,6 @@ date
 
 SELECT CONVERT(DATE, '2023-2-29')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -2656,8 +2538,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T3:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2753,8 +2633,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.1234567891')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2787,8 +2665,6 @@ date
 -- -- spaces are not allowed between any two tokens for ISO 8601
 SELECT CONVERT(DATE, '2022-10-22T13 :34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2796,8 +2672,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10 -22T13:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2805,8 +2679,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22 T 13:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2814,8 +2686,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.123 Z')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2823,8 +2693,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.123 -11:11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2904,8 +2772,6 @@ date
 
 SELECT CONVERT(DATE, '241329')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3011,8 +2877,6 @@ date
 -- -- hijri leap year only contains 29 days in 12th month (for style 130 and 131)
 SELECT CONVERT(DATE, '20241230', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3020,8 +2884,6 @@ date
 
 SELECT CONVERT(DATE, '20241230', 131)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3046,8 +2908,6 @@ date
 -- -- invalid syntax
 SELECT CONVERT(DATE, '0')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3055,8 +2915,6 @@ date
 
 SELECT CONVERT(DATE, '1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3064,8 +2922,6 @@ date
 
 SELECT CONVERT(DATE, '11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3073,8 +2929,6 @@ date
 
 SELECT CONVERT(DATE, '111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3082,8 +2936,6 @@ date
 
 SELECT CONVERT(DATE, '11111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3091,8 +2943,6 @@ date
 
 SELECT CONVERT(DATE, '1111111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3133,8 +2983,6 @@ date
 
 SELECT CONVERT(DATE, '2024-04-22-14:10')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3142,8 +2990,6 @@ date
 
 SELECT CONVERT(DATE, '2024-04-22+14:10')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3159,8 +3005,6 @@ date
 
 SELECT CONVERT(DATE, '24-04-22Z')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3202,8 +3046,6 @@ date
 
 SELECT CONVERT(DATE, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3549,8 +3391,6 @@ date
 
 SELECT CONVERT(DATE, N'22 April 1440 1:39:17.090', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3583,8 +3423,6 @@ date
 
 SELECT CONVERT(DATE, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3592,8 +3430,6 @@ date
 
 SELECT CONVERT(DATE, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3604,8 +3440,6 @@ SELECT CONVERT(DATE, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATE, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3613,8 +3447,6 @@ date
 
 SELECT CONVERT(DATE, '02001-04-22 16:23:51')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3630,8 +3462,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 14:30.00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3671,8 +3501,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3680,8 +3508,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3690,8 +3516,6 @@ date
 DECLARE @TM_ICLO TIME = '17:24:07.1766670'
 SELECT CONVERT(DATE, @TM_ICLO)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type time without time zone to date is not allowed.)~~
@@ -3854,16 +3678,12 @@ date
 
 SELECT * FROM test_conv_string_to_date_v8
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
 
 EXEC test_conv_string_to_date_p8
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
@@ -3901,8 +3721,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v10
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3910,8 +3728,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v11
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3919,8 +3735,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v12
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_date-before-16_3-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_date-before-16_3-vu-verify.out
@@ -191,8 +191,6 @@ date
 
 SELECT CONVERT(DATE, '3-2024-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -200,8 +198,6 @@ date
 
 SELECT CONVERT(DATE, '11-2024-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -209,8 +205,6 @@ date
 
 SELECT CONVERT(DATE, '3 -           2024     -        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -242,8 +236,6 @@ date
 
 SELECT CONVERT(DATE, '3.2024.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -251,8 +243,6 @@ date
 
 SELECT CONVERT(DATE, '11.2024.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -260,8 +250,6 @@ date
 
 SELECT CONVERT(DATE, '3 .           2024     .        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -293,8 +281,6 @@ date
 
 SELECT CONVERT(DATE, '3/2024/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -302,8 +288,6 @@ date
 
 SELECT CONVERT(DATE, '11/2024/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -311,8 +295,6 @@ date
 
 SELECT CONVERT(DATE, '3 /           2024     /        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -490,8 +472,6 @@ date
 
 SELECT CONVERT(DATE, '12-2024-3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -499,8 +479,6 @@ date
 
 SELECT CONVERT(DATE, '12-2024-11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -508,8 +486,6 @@ date
 
 SELECT CONVERT(DATE, '12     -        2024 -           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -541,8 +517,6 @@ date
 
 SELECT CONVERT(DATE, '12.2024.3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -550,8 +524,6 @@ date
 
 SELECT CONVERT(DATE, '12.2024.11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -559,8 +531,6 @@ date
 
 SELECT CONVERT(DATE, '12     .        2024 .           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -592,8 +562,6 @@ date
 
 SELECT CONVERT(DATE, '12/2024/3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -601,8 +569,6 @@ date
 
 SELECT CONVERT(DATE, '12/2024/11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -610,8 +576,6 @@ date
 
 SELECT CONVERT(DATE, '12     /        2024 /           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -636,8 +600,6 @@ date
 
 SELECT CONVERT(DATE, '24-3-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -685,8 +647,6 @@ date
 
 SELECT CONVERT(DATE, '24.3.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -734,8 +694,6 @@ date
 
 SELECT CONVERT(DATE, '24/3/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -768,8 +726,6 @@ date
 -- invalid syntax
 SELECT CONVERT(DATE, '3 12 2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -777,8 +733,6 @@ date
 
 SELECT CONVERT(DATE, '3#12#2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -786,8 +740,6 @@ date
 
 SELECT CONVERT(DATE, '3/12.2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -844,8 +796,6 @@ date
 
 SELECT CONVERT(DATE, '22-03-2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -883,8 +833,6 @@ date
 
 SELECT CONVERT(DATE, '03-2024-22')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -903,8 +851,6 @@ date
 
 SELECT CONVERT(DATE, '22-2024-03')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -926,8 +872,6 @@ date
 -- For DATE as follows, it will always be treated as YMD DATEFORMAT as YDM is not supported.
 SELECT CONVERT(DATE, '2024-22-03')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -964,8 +908,6 @@ date
 
 SELECT CONVERT(DATE, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -997,8 +939,6 @@ date
 
 SELECT CONVERT(DATE, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1006,8 +946,6 @@ date
 
 SELECT CONVERT(DATE,'2022-10-00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1015,8 +953,6 @@ date
 
 SELECT CONVERT(DATE,'0000-10-01')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1024,8 +960,6 @@ date
 
 SELECT CONVERT(DATE,'2023-00-01')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1033,8 +967,6 @@ date
 
 SELECT CONVERT(DATE,'0000-00-00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1319,8 +1251,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 12,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1328,8 +1258,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1369,8 +1297,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 1,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1378,8 +1304,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1419,8 +1343,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr12,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1428,8 +1350,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1469,8 +1389,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr1,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1478,8 +1396,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1521,8 +1437,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 12,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1530,8 +1444,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 12', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1571,8 +1483,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 1,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1580,8 +1490,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 1', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1621,8 +1529,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم12,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1630,8 +1536,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم12', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1671,8 +1575,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم1,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1680,8 +1582,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم1', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2032,8 +1932,6 @@ date
 
 SELECT CONVERT(DATE, '12 Apr,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2041,8 +1939,6 @@ date
 
 SELECT CONVERT(DATE, '12 Apr')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2098,8 +1994,6 @@ date
 
 SELECT CONVERT(DATE, '12Apr,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2107,8 +2001,6 @@ date
 
 SELECT CONVERT(DATE, '12Apr')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2166,8 +2058,6 @@ date
 
 SELECT CONVERT(DATE, N'12 محرم,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2175,8 +2065,6 @@ date
 
 SELECT CONVERT(DATE, N'12 محرم', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2232,8 +2120,6 @@ date
 
 SELECT CONVERT(DATE, N'12محرم,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2241,8 +2127,6 @@ date
 
 SELECT CONVERT(DATE, N'12محرم', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2623,8 +2507,6 @@ date
 
 SELECT CONVERT(DATE, '2023-2-29')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -2656,8 +2538,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T3:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2753,8 +2633,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.1234567891')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2787,8 +2665,6 @@ date
 -- -- spaces are not allowed between any two tokens for ISO 8601
 SELECT CONVERT(DATE, '2022-10-22T13 :34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2796,8 +2672,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10 -22T13:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2805,8 +2679,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22 T 13:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2814,8 +2686,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.123 Z')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2823,8 +2693,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.123 -11:11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2904,8 +2772,6 @@ date
 
 SELECT CONVERT(DATE, '241329')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3011,8 +2877,6 @@ date
 -- -- hijri leap year only contains 29 days in 12th month (for style 130 and 131)
 SELECT CONVERT(DATE, '20241230', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3020,8 +2884,6 @@ date
 
 SELECT CONVERT(DATE, '20241230', 131)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3046,8 +2908,6 @@ date
 -- -- invalid syntax
 SELECT CONVERT(DATE, '0')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3055,8 +2915,6 @@ date
 
 SELECT CONVERT(DATE, '1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3064,8 +2922,6 @@ date
 
 SELECT CONVERT(DATE, '11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3073,8 +2929,6 @@ date
 
 SELECT CONVERT(DATE, '111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3082,8 +2936,6 @@ date
 
 SELECT CONVERT(DATE, '11111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3091,8 +2943,6 @@ date
 
 SELECT CONVERT(DATE, '1111111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3133,8 +2983,6 @@ date
 
 SELECT CONVERT(DATE, '2024-04-22-14:10')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3142,8 +2990,6 @@ date
 
 SELECT CONVERT(DATE, '2024-04-22+14:10')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3159,8 +3005,6 @@ date
 
 SELECT CONVERT(DATE, '24-04-22Z')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3202,8 +3046,6 @@ date
 
 SELECT CONVERT(DATE, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3549,8 +3391,6 @@ date
 
 SELECT CONVERT(DATE, N'22 April 1440 1:39:17.090', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3583,8 +3423,6 @@ date
 
 SELECT CONVERT(DATE, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3592,8 +3430,6 @@ date
 
 SELECT CONVERT(DATE, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3604,8 +3440,6 @@ SELECT CONVERT(DATE, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATE, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3613,8 +3447,6 @@ date
 
 SELECT CONVERT(DATE, '02001-04-22 16:23:51')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3630,8 +3462,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 14:30.00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3671,8 +3501,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3680,8 +3508,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3690,8 +3516,6 @@ date
 DECLARE @TM_ICLO TIME = '17:24:07.1766670'
 SELECT CONVERT(DATE, @TM_ICLO)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type time without time zone to date is not allowed.)~~
@@ -3854,16 +3678,12 @@ date
 
 SELECT * FROM test_conv_string_to_date_v8
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
 
 EXEC test_conv_string_to_date_p8
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
@@ -3901,8 +3721,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v10
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3910,8 +3728,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v12
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_date-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_date-vu-verify.out
@@ -191,8 +191,6 @@ date
 
 SELECT CONVERT(DATE, '3-2024-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -200,8 +198,6 @@ date
 
 SELECT CONVERT(DATE, '11-2024-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -209,8 +205,6 @@ date
 
 SELECT CONVERT(DATE, '3 -           2024     -        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -242,8 +236,6 @@ date
 
 SELECT CONVERT(DATE, '3.2024.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -251,8 +243,6 @@ date
 
 SELECT CONVERT(DATE, '11.2024.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -260,8 +250,6 @@ date
 
 SELECT CONVERT(DATE, '3 .           2024     .        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -293,8 +281,6 @@ date
 
 SELECT CONVERT(DATE, '3/2024/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -302,8 +288,6 @@ date
 
 SELECT CONVERT(DATE, '11/2024/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -311,8 +295,6 @@ date
 
 SELECT CONVERT(DATE, '3 /           2024     /        12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -490,8 +472,6 @@ date
 
 SELECT CONVERT(DATE, '12-2024-3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -499,8 +479,6 @@ date
 
 SELECT CONVERT(DATE, '12-2024-11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -508,8 +486,6 @@ date
 
 SELECT CONVERT(DATE, '12     -        2024 -           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -541,8 +517,6 @@ date
 
 SELECT CONVERT(DATE, '12.2024.3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -550,8 +524,6 @@ date
 
 SELECT CONVERT(DATE, '12.2024.11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -559,8 +531,6 @@ date
 
 SELECT CONVERT(DATE, '12     .        2024 .           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -592,8 +562,6 @@ date
 
 SELECT CONVERT(DATE, '12/2024/3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -601,8 +569,6 @@ date
 
 SELECT CONVERT(DATE, '12/2024/11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -610,8 +576,6 @@ date
 
 SELECT CONVERT(DATE, '12     /        2024 /           3')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -636,8 +600,6 @@ date
 
 SELECT CONVERT(DATE, '24-3-12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -685,8 +647,6 @@ date
 
 SELECT CONVERT(DATE, '24.3.12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -734,8 +694,6 @@ date
 
 SELECT CONVERT(DATE, '24/3/12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -768,8 +726,6 @@ date
 -- invalid syntax
 SELECT CONVERT(DATE, '3 12 2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -777,8 +733,6 @@ date
 
 SELECT CONVERT(DATE, '3#12#2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -786,8 +740,6 @@ date
 
 SELECT CONVERT(DATE, '3/12.2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -844,8 +796,6 @@ date
 
 SELECT CONVERT(DATE, '22-03-2024')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -883,8 +833,6 @@ date
 
 SELECT CONVERT(DATE, '03-2024-22')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -903,8 +851,6 @@ date
 
 SELECT CONVERT(DATE, '22-2024-03')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -926,8 +872,6 @@ date
 -- For DATE as follows, it will always be treated as YMD DATEFORMAT as YDM is not supported.
 SELECT CONVERT(DATE, '2024-22-03')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -964,8 +908,6 @@ date
 
 SELECT CONVERT(DATE, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -997,8 +939,6 @@ date
 
 SELECT CONVERT(DATE, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1006,8 +946,6 @@ date
 
 SELECT CONVERT(DATE,'2022-10-00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1015,8 +953,6 @@ date
 
 SELECT CONVERT(DATE,'0000-10-01')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1024,8 +960,6 @@ date
 
 SELECT CONVERT(DATE,'2023-00-01')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1033,8 +967,6 @@ date
 
 SELECT CONVERT(DATE,'0000-00-00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -1319,8 +1251,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 12,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1328,8 +1258,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1369,8 +1297,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 1,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1378,8 +1304,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr 1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1419,8 +1343,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr12,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1428,8 +1350,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr12')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1469,8 +1389,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr1,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1478,8 +1396,6 @@ date
 
 SELECT CONVERT(DATE, 'Apr1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1521,8 +1437,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 12,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1530,8 +1444,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 12', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1571,8 +1483,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 1,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1580,8 +1490,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم 1', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1621,8 +1529,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم12,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1630,8 +1536,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم12', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1671,8 +1575,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم1,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1680,8 +1582,6 @@ date
 
 SELECT CONVERT(DATE, N'محرم1', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2032,8 +1932,6 @@ date
 
 SELECT CONVERT(DATE, '12 Apr,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2041,8 +1939,6 @@ date
 
 SELECT CONVERT(DATE, '12 Apr')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2098,8 +1994,6 @@ date
 
 SELECT CONVERT(DATE, '12Apr,')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2107,8 +2001,6 @@ date
 
 SELECT CONVERT(DATE, '12Apr')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2166,8 +2058,6 @@ date
 
 SELECT CONVERT(DATE, N'12 محرم,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2175,8 +2065,6 @@ date
 
 SELECT CONVERT(DATE, N'12 محرم', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2232,8 +2120,6 @@ date
 
 SELECT CONVERT(DATE, N'12محرم,', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2241,8 +2127,6 @@ date
 
 SELECT CONVERT(DATE, N'12محرم', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2623,8 +2507,6 @@ date
 
 SELECT CONVERT(DATE, '2023-2-29')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -2656,8 +2538,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T3:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2753,8 +2633,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.1234567891')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2787,8 +2665,6 @@ date
 -- -- spaces are not allowed between any two tokens for ISO 8601
 SELECT CONVERT(DATE, '2022-10-22T13 :34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2796,8 +2672,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10 -22T13:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2805,8 +2679,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22 T 13:34:12.123')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2814,8 +2686,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.123 Z')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2823,8 +2693,6 @@ date
 
 SELECT CONVERT(DATE, '2022-10-22T13:34:12.123 -11:11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2904,8 +2772,6 @@ date
 
 SELECT CONVERT(DATE, '241329')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3011,8 +2877,6 @@ date
 -- -- hijri leap year only contains 29 days in 12th month (for style 130 and 131)
 SELECT CONVERT(DATE, '20241230', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3020,8 +2884,6 @@ date
 
 SELECT CONVERT(DATE, '20241230', 131)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a date data type resulted in an out-of-range value.)~~
@@ -3046,8 +2908,6 @@ date
 -- -- invalid syntax
 SELECT CONVERT(DATE, '0')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3055,8 +2915,6 @@ date
 
 SELECT CONVERT(DATE, '1')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3064,8 +2922,6 @@ date
 
 SELECT CONVERT(DATE, '11')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3073,8 +2929,6 @@ date
 
 SELECT CONVERT(DATE, '111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3082,8 +2936,6 @@ date
 
 SELECT CONVERT(DATE, '11111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3091,8 +2943,6 @@ date
 
 SELECT CONVERT(DATE, '1111111')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3133,8 +2983,6 @@ date
 
 SELECT CONVERT(DATE, '2024-04-22-14:10')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3142,8 +2990,6 @@ date
 
 SELECT CONVERT(DATE, '2024-04-22+14:10')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3159,8 +3005,6 @@ date
 
 SELECT CONVERT(DATE, '24-04-22Z')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3202,8 +3046,6 @@ date
 
 SELECT CONVERT(DATE, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3549,8 +3391,6 @@ date
 
 SELECT CONVERT(DATE, N'22 April 1440 1:39:17.090', 130)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3583,8 +3423,6 @@ date
 
 SELECT CONVERT(DATE, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3592,8 +3430,6 @@ date
 
 SELECT CONVERT(DATE, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3604,8 +3440,6 @@ SELECT CONVERT(DATE, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATE, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3613,8 +3447,6 @@ date
 
 SELECT CONVERT(DATE, '02001-04-22 16:23:51')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3630,8 +3462,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 14:30.00')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3671,8 +3501,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3680,8 +3508,6 @@ date
 
 SELECT CONVERT(DATE, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3690,8 +3516,6 @@ date
 DECLARE @TM_ICLO TIME = '17:24:07.1766670'
 SELECT CONVERT(DATE, @TM_ICLO)
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type time without time zone to date is not allowed.)~~
@@ -3854,16 +3678,12 @@ date
 
 SELECT * FROM test_conv_string_to_date_v8
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
 
 EXEC test_conv_string_to_date_p8
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~
@@ -3901,8 +3721,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v10
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3910,8 +3728,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v11
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -3919,8 +3735,6 @@ date
 
 SELECT * FROM test_conv_string_to_date_v12
 GO
-~~START~~
-date
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to date is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetime-before-14_6-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetime-before-14_6-vu-verify.out
@@ -617,8 +617,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24-3-12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -666,8 +664,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24.3.12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -715,8 +711,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24/3/12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -782,8 +776,6 @@ datetime
 -- invalid syntax
 SELECT CONVERT(DATETIME, '3 12 2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -791,8 +783,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '3#12#2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -849,8 +839,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '22-03-2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -907,8 +895,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '22-2024-03')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -930,8 +916,6 @@ datetime
 -- For DATE as follows, it will always be treated as YMD DATEFORMAT as YDM is not supported.
 SELECT CONVERT(DATETIME, '2024-22-03')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1172,8 +1156,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 12, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1181,8 +1163,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1222,8 +1202,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 1, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1231,8 +1209,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 1 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1272,8 +1248,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr12, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1281,8 +1255,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1322,8 +1294,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr1, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1331,8 +1301,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr1 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1342,8 +1310,6 @@ datetime
 -- this is only applicable for datetime and smalldatetime, for other datatypes error will be thrown
 SELECT CONVERT(DATETIME, N'محرم 12, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1351,8 +1317,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1360,8 +1324,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1369,8 +1331,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1378,8 +1338,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1387,8 +1345,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1396,8 +1352,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1405,8 +1359,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1414,8 +1366,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1423,8 +1373,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1432,8 +1380,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1441,8 +1387,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1450,8 +1394,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1459,8 +1401,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1468,8 +1408,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1477,8 +1415,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1486,8 +1422,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1495,8 +1429,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1504,8 +1436,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1513,8 +1443,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1522,8 +1450,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1531,8 +1457,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1540,8 +1464,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1549,8 +1471,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1901,8 +1821,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12 Apr, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1910,8 +1828,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12 Apr 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1967,8 +1883,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12Apr, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1976,8 +1890,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12Apr 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2003,8 +1915,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2012,8 +1922,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2021,8 +1929,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2030,8 +1936,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2039,8 +1943,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2048,8 +1950,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2073,8 +1973,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2082,8 +1980,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2091,8 +1987,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2100,8 +1994,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2109,8 +2001,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2118,8 +2008,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2170,8 +2058,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 24 محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2187,8 +2073,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 24محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2502,8 +2386,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-1-22T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2511,8 +2393,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-2T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2520,8 +2400,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T3:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2529,8 +2407,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:4:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2538,8 +2414,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:34:1.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2571,8 +2445,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:34:12.1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2589,8 +2461,6 @@ datetime
 -- -- spaces are not allowed between any two tokens for ISO 8601
 SELECT CONVERT(DATETIME, '2022-10-22T13 :34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2598,8 +2468,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10 -22T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2607,8 +2475,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22 T 13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2625,8 +2491,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '20241329')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2642,8 +2506,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '241329')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2659,8 +2521,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '0001')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2676,8 +2536,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '20241329 03:00:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2693,8 +2551,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '241329 03:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2710,8 +2566,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '0001 03:00:00.421')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2720,8 +2574,6 @@ datetime
 -- -- invalid syntax
 SELECT CONVERT(DATETIME, '0')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2729,8 +2581,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2738,8 +2588,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '11')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2747,8 +2595,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2756,8 +2602,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '11111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2765,8 +2609,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1111111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2791,8 +2633,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '4:12:12:1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2800,8 +2640,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '4:12:12.1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2875,8 +2713,6 @@ datetime
 -- -- hijri leap year
 SELECT CONVERT(DATETIME, '20241230', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2966,8 +2802,6 @@ datetime
 -- DATETIME with typmod
 SELECT CONVERT(DATETIME(1), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2975,8 +2809,6 @@ datetime
 
 SELECT CONVERT(DATETIME(2), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2984,8 +2816,6 @@ datetime
 
 SELECT CONVERT(DATETIME(3), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2994,8 +2824,6 @@ datetime
 -- boundary tests
 SELECT CONVERT(DATETIME, '9999-12-31 23:59:59.999')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3012,8 +2840,6 @@ datetime
 -- -- out of bound values
 SELECT CONVERT(DATETIME,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3021,8 +2847,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3030,8 +2854,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3039,8 +2861,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3048,8 +2868,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'1742-10-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3202,8 +3020,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '02/12/21 15:13:14 PM', 22)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3211,8 +3027,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2021-02-12', 23)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3220,8 +3034,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2021-02-12 15:13:14.123', 25)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3414,8 +3226,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3423,8 +3233,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3435,8 +3243,6 @@ SELECT CONVERT(DATETIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3444,8 +3250,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3453,8 +3257,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1900-05-06 13:59:29.050 -8:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3502,8 +3304,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3511,8 +3311,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetime-before-16_3-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetime-before-16_3-vu-verify.out
@@ -617,8 +617,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24-3-12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -666,8 +664,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24.3.12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -715,8 +711,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24/3/12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -782,8 +776,6 @@ datetime
 -- invalid syntax
 SELECT CONVERT(DATETIME, '3 12 2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -791,8 +783,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '3#12#2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -849,8 +839,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '22-03-2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -907,8 +895,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '22-2024-03')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -930,8 +916,6 @@ datetime
 -- For DATE as follows, it will always be treated as YMD DATEFORMAT as YDM is not supported.
 SELECT CONVERT(DATETIME, '2024-22-03')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1172,8 +1156,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 12, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1181,8 +1163,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1222,8 +1202,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 1, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1231,8 +1209,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 1 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1272,8 +1248,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr12, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1281,8 +1255,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1322,8 +1294,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr1, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1331,8 +1301,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr1 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1342,8 +1310,6 @@ datetime
 -- this is only applicable for datetime and smalldatetime, for other datatypes error will be thrown
 SELECT CONVERT(DATETIME, N'محرم 12, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1351,8 +1317,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1360,8 +1324,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1369,8 +1331,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1378,8 +1338,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1387,8 +1345,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1396,8 +1352,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1405,8 +1359,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1414,8 +1366,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1423,8 +1373,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1432,8 +1380,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1441,8 +1387,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1450,8 +1394,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1459,8 +1401,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1468,8 +1408,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1477,8 +1415,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1486,8 +1422,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1495,8 +1429,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1504,8 +1436,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1513,8 +1443,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1522,8 +1450,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1531,8 +1457,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1540,8 +1464,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1549,8 +1471,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1901,8 +1821,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12 Apr, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1910,8 +1828,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12 Apr 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1967,8 +1883,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12Apr, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1976,8 +1890,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12Apr 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2003,8 +1915,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2012,8 +1922,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2021,8 +1929,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2030,8 +1936,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2039,8 +1943,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2048,8 +1950,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2073,8 +1973,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2082,8 +1980,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2091,8 +1987,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2100,8 +1994,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2109,8 +2001,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2118,8 +2008,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2170,8 +2058,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 24 محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2187,8 +2073,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 24محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2502,8 +2386,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-1-22T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2511,8 +2393,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-2T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2520,8 +2400,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T3:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2529,8 +2407,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:4:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2538,8 +2414,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:34:1.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2571,8 +2445,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:34:12.1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2589,8 +2461,6 @@ datetime
 -- -- spaces are not allowed between any two tokens for ISO 8601
 SELECT CONVERT(DATETIME, '2022-10-22T13 :34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2598,8 +2468,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10 -22T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2607,8 +2475,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22 T 13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2625,8 +2491,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '20241329')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2642,8 +2506,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '241329')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2659,8 +2521,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '0001')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2676,8 +2536,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '20241329 03:00:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2693,8 +2551,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '241329 03:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2710,8 +2566,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '0001 03:00:00.421')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2720,8 +2574,6 @@ datetime
 -- -- invalid syntax
 SELECT CONVERT(DATETIME, '0')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2729,8 +2581,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2738,8 +2588,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '11')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2747,8 +2595,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2756,8 +2602,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '11111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2765,8 +2609,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1111111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2791,8 +2633,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '4:12:12:1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2800,8 +2640,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '4:12:12.1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2875,8 +2713,6 @@ datetime
 -- -- hijri leap year
 SELECT CONVERT(DATETIME, '20241230', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2966,8 +2802,6 @@ datetime
 -- DATETIME with typmod
 SELECT CONVERT(DATETIME(1), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2975,8 +2809,6 @@ datetime
 
 SELECT CONVERT(DATETIME(2), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2984,8 +2816,6 @@ datetime
 
 SELECT CONVERT(DATETIME(3), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2994,8 +2824,6 @@ datetime
 -- boundary tests
 SELECT CONVERT(DATETIME, '9999-12-31 23:59:59.999')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3012,8 +2840,6 @@ datetime
 -- -- out of bound values
 SELECT CONVERT(DATETIME,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3021,8 +2847,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3030,8 +2854,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3039,8 +2861,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3048,8 +2868,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'1742-10-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3202,8 +3020,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '02/12/21 15:13:14 PM', 22)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3211,8 +3027,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2021-02-12', 23)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3220,8 +3034,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2021-02-12 15:13:14.123', 25)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3414,8 +3226,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3423,8 +3233,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3435,8 +3243,6 @@ SELECT CONVERT(DATETIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3444,8 +3250,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3453,8 +3257,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1900-05-06 13:59:29.050 -8:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3502,8 +3304,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3511,8 +3311,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetime-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetime-vu-verify.out
@@ -617,8 +617,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24-3-12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -666,8 +664,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24.3.12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -715,8 +711,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '24/3/12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -782,8 +776,6 @@ datetime
 -- invalid syntax
 SELECT CONVERT(DATETIME, '3 12 2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -791,8 +783,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '3#12#2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -849,8 +839,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '22-03-2024')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -907,8 +895,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '22-2024-03')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -930,8 +916,6 @@ datetime
 -- For DATE as follows, it will always be treated as YMD DATEFORMAT as YDM is not supported.
 SELECT CONVERT(DATETIME, '2024-22-03')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1172,8 +1156,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 12, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1181,8 +1163,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1222,8 +1202,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 1, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1231,8 +1209,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr 1 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1272,8 +1248,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr12, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1281,8 +1255,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr12 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1322,8 +1294,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr1, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1331,8 +1301,6 @@ datetime
 
 SELECT CONVERT(DATETIME, 'Apr1 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1342,8 +1310,6 @@ datetime
 -- this is only applicable for datetime and smalldatetime, for other datatypes error will be thrown
 SELECT CONVERT(DATETIME, N'محرم 12, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1351,8 +1317,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1360,8 +1324,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1369,8 +1331,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1378,8 +1338,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1387,8 +1345,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 12  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1396,8 +1352,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1405,8 +1359,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1414,8 +1366,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1423,8 +1373,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1432,8 +1380,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1441,8 +1387,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم 1  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1450,8 +1394,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1459,8 +1401,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1468,8 +1408,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1477,8 +1415,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1486,8 +1422,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1495,8 +1429,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم12  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1504,8 +1436,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1513,8 +1443,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1522,8 +1450,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1531,8 +1457,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -1540,8 +1464,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1549,8 +1471,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'محرم1  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1901,8 +1821,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12 Apr, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1910,8 +1828,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12 Apr 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1967,8 +1883,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12Apr, 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1976,8 +1890,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '12Apr 14:30')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2003,8 +1915,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2012,8 +1922,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2021,8 +1929,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2030,8 +1936,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2039,8 +1943,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2048,8 +1950,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2073,8 +1973,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم, 24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2082,8 +1980,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم24  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2091,8 +1987,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم, 4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2100,8 +1994,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم4  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2109,8 +2001,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم,  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2118,8 +2008,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2170,8 +2058,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 24 محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2187,8 +2073,6 @@ datetime
 
 SELECT CONVERT(DATETIME, N'12 24محرم  14:30', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2502,8 +2386,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-1-22T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2511,8 +2393,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-2T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2520,8 +2400,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T3:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2529,8 +2407,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:4:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2538,8 +2414,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:34:1.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2571,8 +2445,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22T13:34:12.1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2589,8 +2461,6 @@ datetime
 -- -- spaces are not allowed between any two tokens for ISO 8601
 SELECT CONVERT(DATETIME, '2022-10-22T13 :34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2598,8 +2468,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10 -22T13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2607,8 +2475,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2022-10-22 T 13:34:12.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2625,8 +2491,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '20241329')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2642,8 +2506,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '241329')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2659,8 +2521,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '0001')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2676,8 +2536,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '20241329 03:00:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2693,8 +2551,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '241329 03:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2710,8 +2566,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '0001 03:00:00.421')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2720,8 +2574,6 @@ datetime
 -- -- invalid syntax
 SELECT CONVERT(DATETIME, '0')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2729,8 +2581,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2738,8 +2588,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '11')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2747,8 +2595,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2756,8 +2602,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '11111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2765,8 +2609,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1111111')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2791,8 +2633,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '4:12:12:1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2800,8 +2640,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '4:12:12.1234')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2875,8 +2713,6 @@ datetime
 -- -- hijri leap year
 SELECT CONVERT(DATETIME, '20241230', 130)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -2966,8 +2802,6 @@ datetime
 -- DATETIME with typmod
 SELECT CONVERT(DATETIME(1), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2975,8 +2809,6 @@ datetime
 
 SELECT CONVERT(DATETIME(2), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2984,8 +2816,6 @@ datetime
 
 SELECT CONVERT(DATETIME(3), '01/01/98 23:59:59.123')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'datetime')~~
@@ -2994,8 +2824,6 @@ datetime
 -- boundary tests
 SELECT CONVERT(DATETIME, '9999-12-31 23:59:59.999')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3012,8 +2840,6 @@ datetime
 -- -- out of bound values
 SELECT CONVERT(DATETIME,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3021,8 +2847,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3030,8 +2854,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3039,8 +2861,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3048,8 +2868,6 @@ datetime
 
 SELECT CONVERT(DATETIME,'1742-10-01 23:59:59.990')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime data type resulted in an out-of-range value.)~~
@@ -3202,8 +3020,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '02/12/21 15:13:14 PM', 22)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3211,8 +3027,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2021-02-12', 23)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3220,8 +3034,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2021-02-12 15:13:14.123', 25)
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3414,8 +3226,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3423,8 +3233,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3435,8 +3243,6 @@ SELECT CONVERT(DATETIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3444,8 +3250,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3453,8 +3257,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '1900-05-06 13:59:29.050 -8:00')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3502,8 +3304,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3511,8 +3311,6 @@ datetime
 
 SELECT CONVERT(DATETIME, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -3728,8 +3526,6 @@ datetime
 
 SELECT * FROM test_conv_string_to_datetime_v10
 GO
-~~START~~
-datetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetime2-before-14_5-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetime2-before-14_5-vu-verify.out
@@ -147,8 +147,6 @@ datetime2
 -- invalid syntax
 SELECT CONVERT(DATETIME2, '3 12 2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -156,8 +154,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '3#12#2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -165,8 +161,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '3/12.2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -383,8 +377,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr,24 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -448,8 +440,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, Apr, 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -465,8 +455,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, Apr 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -474,8 +462,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, Apr, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -483,8 +469,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024 Apr, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -492,8 +476,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, Apr 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -501,8 +483,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 12, 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -518,8 +498,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 12 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -527,8 +505,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 2024, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -536,8 +512,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr 2024, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -545,8 +519,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 2024 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -554,8 +526,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, 2024, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -563,8 +533,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12 2024, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -572,8 +540,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, 2024 Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -581,8 +547,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, 12, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -590,8 +554,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024 12, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -599,8 +561,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, 12 Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -649,8 +609,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -658,8 +616,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10 -30T03: 00:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -675,8 +631,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00:00:123')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -684,8 +638,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00:00:12345')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -702,8 +654,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '20241329')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -719,8 +669,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '241329')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -752,8 +700,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '20241329 03:00:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -769,8 +715,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '241329 03:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -795,8 +739,6 @@ datetime2
 -- -- invalid syntax
 SELECT CONVERT(DATETIME2, '0')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -804,8 +746,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '1')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -813,8 +753,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '11')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -822,8 +760,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -831,8 +767,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '11111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -840,8 +774,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '1111111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -866,8 +798,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '4:12:12:1234')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -932,8 +862,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -966,8 +894,6 @@ datetime2
 -- -- hijri leap year
 SELECT CONVERT(DATETIME2, '20241230', 130)
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1130,8 +1056,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1163,8 +1087,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1173,8 +1095,6 @@ datetime2
 -- -- out of bound values
 SELECT CONVERT(DATETIME2,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1182,8 +1102,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1191,8 +1109,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1200,8 +1116,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1563,8 +1477,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1572,8 +1484,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1584,8 +1494,6 @@ SELECT CONVERT(DATETIME2, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIME2, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1593,8 +1501,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1610,8 +1516,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 14:30.00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1651,8 +1555,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1660,8 +1562,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1854,8 +1754,6 @@ GO
 
 EXEC test_conv_string_to_datetime2_p8
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetime2 is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetime2-before-16_3-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetime2-before-16_3-vu-verify.out
@@ -147,8 +147,6 @@ datetime2
 -- invalid syntax
 SELECT CONVERT(DATETIME2, '3 12 2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -156,8 +154,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '3#12#2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -165,8 +161,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '3/12.2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -383,8 +377,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr,24 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -448,8 +440,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, Apr, 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -465,8 +455,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, Apr 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -474,8 +462,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, Apr, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -483,8 +469,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024 Apr, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -492,8 +476,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, Apr 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -501,8 +483,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 12, 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -518,8 +498,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 12 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -527,8 +505,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 2024, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -536,8 +512,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr 2024, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -545,8 +519,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 2024 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -554,8 +526,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, 2024, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -563,8 +533,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12 2024, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -572,8 +540,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, 2024 Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -581,8 +547,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, 12, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -590,8 +554,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024 12, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -599,8 +561,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, 12 Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -649,8 +609,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -658,8 +616,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10 -30T03: 00:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -675,8 +631,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00:00:123')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -684,8 +638,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00:00:12345')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -702,8 +654,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '20241329')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -719,8 +669,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '241329')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -752,8 +700,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '20241329 03:00:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -769,8 +715,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '241329 03:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -795,8 +739,6 @@ datetime2
 -- -- invalid syntax
 SELECT CONVERT(DATETIME2, '0')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -804,8 +746,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '1')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -813,8 +753,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '11')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -822,8 +760,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -831,8 +767,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '11111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -840,8 +774,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '1111111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -866,8 +798,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '4:12:12:1234')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -932,8 +862,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -966,8 +894,6 @@ datetime2
 -- -- hijri leap year
 SELECT CONVERT(DATETIME2, '20241230', 130)
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1130,8 +1056,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1163,8 +1087,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1173,8 +1095,6 @@ datetime2
 -- -- out of bound values
 SELECT CONVERT(DATETIME2,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1182,8 +1102,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1191,8 +1109,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1200,8 +1116,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1563,8 +1477,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1572,8 +1484,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1584,8 +1494,6 @@ SELECT CONVERT(DATETIME2, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIME2, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1593,8 +1501,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1610,8 +1516,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 14:30.00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1651,8 +1555,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1660,8 +1562,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1854,8 +1754,6 @@ GO
 
 EXEC test_conv_string_to_datetime2_p8
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetime2 is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetime2-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetime2-vu-verify.out
@@ -147,8 +147,6 @@ datetime2
 -- invalid syntax
 SELECT CONVERT(DATETIME2, '3 12 2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -156,8 +154,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '3#12#2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -165,8 +161,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '3/12.2024')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -383,8 +377,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr,24 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -448,8 +440,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, Apr, 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -465,8 +455,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, Apr 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -474,8 +462,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, Apr, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -483,8 +469,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024 Apr, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -492,8 +476,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, Apr 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -501,8 +483,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 12, 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -518,8 +498,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 12 2024 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -527,8 +505,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 2024, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -536,8 +512,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr 2024, 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -545,8 +519,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, 'Apr, 2024 12 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -554,8 +526,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, 2024, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -563,8 +533,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12 2024, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -572,8 +540,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '12, 2024 Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -581,8 +547,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, 12, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -590,8 +554,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024 12, Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -599,8 +561,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2024, 12 Apr 14:30')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -649,8 +609,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -658,8 +616,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10 -30T03: 00:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -675,8 +631,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00:00:123')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -684,8 +638,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2022-10-30T03:00:00:12345')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -702,8 +654,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '20241329')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -719,8 +669,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '241329')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -752,8 +700,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '20241329 03:00:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -769,8 +715,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '241329 03:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -795,8 +739,6 @@ datetime2
 -- -- invalid syntax
 SELECT CONVERT(DATETIME2, '0')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -804,8 +746,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '1')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -813,8 +753,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '11')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -822,8 +760,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -831,8 +767,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '11111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -840,8 +774,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '1111111')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -866,8 +798,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '4:12:12:1234')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -932,8 +862,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -966,8 +894,6 @@ datetime2
 -- -- hijri leap year
 SELECT CONVERT(DATETIME2, '20241230', 130)
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1130,8 +1056,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1163,8 +1087,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1173,8 +1095,6 @@ datetime2
 -- -- out of bound values
 SELECT CONVERT(DATETIME2,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1182,8 +1102,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1191,8 +1109,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1200,8 +1116,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetime2 data type resulted in an out-of-range value.)~~
@@ -1563,8 +1477,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1572,8 +1484,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1584,8 +1494,6 @@ SELECT CONVERT(DATETIME2, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIME2, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1593,8 +1501,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1610,8 +1516,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 14:30.00')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1651,8 +1555,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1660,8 +1562,6 @@ datetime2
 
 SELECT CONVERT(DATETIME2, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1848,16 +1748,12 @@ datetime2
 
 SELECT * FROM test_conv_string_to_datetime2_v8
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetime2 is not allowed.)~~
 
 EXEC test_conv_string_to_datetime2_p8
 GO
-~~START~~
-datetime2
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetime2 is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetimeoffset-before-16_3-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetimeoffset-before-16_3-vu-verify.out
@@ -147,8 +147,6 @@ datetimeoffset
 -- invalid syntax
 SELECT CONVERT(DATETIMEOFFSET, '3 12 2024 +8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -156,8 +154,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '3#12#2024 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -165,8 +161,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '3/12.2024 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -383,8 +377,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr,24 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -448,8 +440,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, Apr, 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -465,8 +455,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, Apr 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -474,8 +462,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, Apr, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -483,8 +469,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024 Apr, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -492,8 +476,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, Apr 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -501,8 +483,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 12, 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -518,8 +498,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 12 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -527,8 +505,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 2024, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -536,8 +512,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr 2024, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -545,8 +519,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 2024 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -554,8 +526,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, 2024, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -563,8 +533,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12 2024, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -572,8 +540,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, 2024 Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -581,8 +547,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, 12, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -590,8 +554,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024 12, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -599,8 +561,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, 12 Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -609,8 +569,6 @@ datetimeoffset
 -- W3C XML
 SELECT CONVERT(DATETIMEOFFSET, '2023-11-27-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -619,8 +577,6 @@ datetimeoffset
 -- ISO 8601	
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -628,8 +584,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.123-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -653,8 +607,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -662,8 +614,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10 -30T03: 00:00-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -671,8 +621,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.12345-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -680,8 +628,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:123-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -689,8 +635,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:12345-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -698,8 +642,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2023-11-27+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -707,8 +649,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -716,8 +656,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.123+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -741,8 +679,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -750,8 +686,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10 -30T03: 00:00+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -759,8 +693,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.12345+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -768,8 +700,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:123+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -777,8 +707,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:12345+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -826,8 +754,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -835,8 +761,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10 -30T03: 00:00Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -852,8 +776,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:123Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -861,8 +783,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:12345Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -872,8 +792,6 @@ datetimeoffset
 -- Unseparated
 SELECT CONVERT(DATETIMEOFFSET, '20240129 +8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -881,8 +799,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '20241329 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -890,8 +806,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '240129 Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -899,8 +813,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '241329 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -908,8 +820,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2001 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -917,8 +827,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '0001 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -934,8 +842,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '20241329 03:00:00 +8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -951,8 +857,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '241329 03:00 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -977,8 +881,6 @@ datetimeoffset
 -- -- invalid syntax
 SELECT CONVERT(DATETIMEOFFSET, '0')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -986,8 +888,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '1')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -995,8 +895,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '11')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1004,8 +902,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '111')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1013,8 +909,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '11111')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1022,8 +916,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '1111111')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1048,8 +940,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '4:12:12:1234 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1114,8 +1004,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -1132,8 +1020,6 @@ datetimeoffset
 -- -- hijri leap year
 SELECT CONVERT(DATETIMEOFFSET, '20241230', 130)
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1296,8 +1182,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1329,8 +1213,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1339,8 +1221,6 @@ datetimeoffset
 -- -- out of bound values
 SELECT CONVERT(DATETIMEOFFSET,'2022-10-00 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1348,8 +1228,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'0000-10-01 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1357,8 +1235,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'2023-00-01 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1366,8 +1242,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'0000-00-00 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1375,8 +1249,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'2022-10-21 23:59:59.990 +14:01')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1384,8 +1256,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'2022-10-21 23:59:59.990 -15:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1747,8 +1617,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1756,8 +1624,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1768,8 +1634,6 @@ SELECT CONVERT(DATETIMEOFFSET, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIMEOFFSET, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1777,8 +1641,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1794,8 +1656,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2011-08-15 14:30.00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1835,8 +1695,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1844,8 +1702,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1862,8 +1718,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '02001-04-22 16:23:51 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1879,8 +1733,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2000-04-22 16:23:51.7668c0 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2027,8 +1879,6 @@ GO
 
 EXEC test_conv_string_to_datetimeoffset_p7
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetimeoffset is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_datetimeoffset-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_datetimeoffset-vu-verify.out
@@ -147,8 +147,6 @@ datetimeoffset
 -- invalid syntax
 SELECT CONVERT(DATETIMEOFFSET, '3 12 2024 +8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -156,8 +154,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '3#12#2024 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -165,8 +161,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '3/12.2024 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -383,8 +377,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr,24 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -448,8 +440,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, Apr, 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -465,8 +455,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, Apr 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -474,8 +462,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, Apr, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -483,8 +469,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024 Apr, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -492,8 +476,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, Apr 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -501,8 +483,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 12, 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -518,8 +498,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 12 2024 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -527,8 +505,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 2024, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -536,8 +512,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr 2024, 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -545,8 +519,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, 'Apr, 2024 12 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -554,8 +526,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, 2024, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -563,8 +533,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12 2024, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -572,8 +540,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '12, 2024 Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -581,8 +547,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, 12, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -590,8 +554,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024 12, Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -599,8 +561,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2024, 12 Apr 14:30 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -609,8 +569,6 @@ datetimeoffset
 -- W3C XML
 SELECT CONVERT(DATETIMEOFFSET, '2023-11-27-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -619,8 +577,6 @@ datetimeoffset
 -- ISO 8601	
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -628,8 +584,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.123-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -653,8 +607,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -662,8 +614,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10 -30T03: 00:00-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -671,8 +621,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.12345-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -680,8 +628,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:123-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -689,8 +635,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:12345-8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -698,8 +642,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2023-11-27+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -707,8 +649,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -716,8 +656,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.123+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -741,8 +679,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -750,8 +686,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10 -30T03: 00:00+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -759,8 +693,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00.12345+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -768,8 +700,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:123+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -777,8 +707,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:12345+8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -826,8 +754,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -835,8 +761,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10 -30T03: 00:00Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -852,8 +776,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:123Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -861,8 +783,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2022-10-30T03:00:00:12345Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -872,8 +792,6 @@ datetimeoffset
 -- Unseparated
 SELECT CONVERT(DATETIMEOFFSET, '20240129 +8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -881,8 +799,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '20241329 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -890,8 +806,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '240129 Z')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -899,8 +813,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '241329 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -908,8 +820,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2001 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -917,8 +827,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '0001 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -934,8 +842,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '20241329 03:00:00 +8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -951,8 +857,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '241329 03:00 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -977,8 +881,6 @@ datetimeoffset
 -- -- invalid syntax
 SELECT CONVERT(DATETIMEOFFSET, '0')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -986,8 +888,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '1')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -995,8 +895,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '11')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1004,8 +902,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '111')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1013,8 +909,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '11111')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1022,8 +916,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '1111111')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1048,8 +940,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '4:12:12:1234 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1114,8 +1004,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '22/12/1440 1:39:17.090PM', 130)
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The input character string does not follow style 130, either change the input character string or use a different style.)~~
@@ -1132,8 +1020,6 @@ datetimeoffset
 -- -- hijri leap year
 SELECT CONVERT(DATETIMEOFFSET, '20241230', 130)
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1296,8 +1182,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1329,8 +1213,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1339,8 +1221,6 @@ datetimeoffset
 -- -- out of bound values
 SELECT CONVERT(DATETIMEOFFSET,'2022-10-00 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1348,8 +1228,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'0000-10-01 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1357,8 +1235,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'2023-00-01 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1366,8 +1242,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'0000-00-00 23:59:59.990 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1375,8 +1249,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'2022-10-21 23:59:59.990 +14:01')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1384,8 +1256,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET,'2022-10-21 23:59:59.990 -15:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a datetimeoffset data type resulted in an out-of-range value.)~~
@@ -1747,8 +1617,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1756,8 +1624,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1768,8 +1634,6 @@ SELECT CONVERT(DATETIMEOFFSET, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(DATETIMEOFFSET, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1777,8 +1641,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '02001-04-22 16:23:51')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1794,8 +1656,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2011-08-15 14:30.00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1835,8 +1695,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1844,8 +1702,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1862,8 +1718,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '02001-04-22 16:23:51 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1879,8 +1733,6 @@ datetimeoffset
 
 SELECT CONVERT(DATETIMEOFFSET, '2000-04-22 16:23:51.7668c0 -8:00')
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2021,16 +1873,12 @@ datetimeoffset
 
 SELECT * FROM test_conv_string_to_datetimeoffset_v7
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetimeoffset is not allowed.)~~
 
 EXEC test_conv_string_to_datetimeoffset_p7
 GO
-~~START~~
-datetimeoffset
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to datetimeoffset is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_smalldatetime-before-14_6-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_smalldatetime-before-14_6-vu-verify.out
@@ -147,8 +147,6 @@ smalldatetime
 -- invalid syntax
 SELECT CONVERT(SMALLDATETIME, '3 12 2024')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -156,8 +154,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '3#12#2024')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -286,8 +282,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'April 16 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -375,8 +369,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr24 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -384,8 +376,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr,24 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -393,8 +383,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '24 Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -474,8 +462,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, Apr, 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -491,8 +477,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, Apr 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -524,8 +508,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr, 2024, 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -533,8 +515,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr 2024, 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -550,8 +530,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '12, 2024, Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -559,8 +537,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '12 2024, Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -576,8 +552,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, 12, Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -593,8 +567,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, 12 Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -604,8 +576,6 @@ smalldatetime
 -- this is only applicable for datetime and smalldatetime, for other datatypes error will be thrown
 SELECT CONVERT(SMALLDATETIME, N'محرم 12,2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -613,8 +583,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 12 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -622,8 +590,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -631,8 +597,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1,2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -640,8 +604,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -649,8 +611,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16, 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -658,8 +618,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1, 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -667,8 +625,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16, 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -676,8 +632,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16  2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -685,8 +639,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16, 24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -694,8 +646,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16,4 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -703,8 +653,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1,4 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -712,8 +660,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16    24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -721,8 +667,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16 4 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -730,8 +674,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -739,8 +681,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -748,8 +688,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 22 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -757,8 +695,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 2 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -766,8 +702,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'24 محرم, 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -775,8 +709,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3 محرم, 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -784,8 +716,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -793,8 +723,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -802,8 +730,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3 محرم 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -811,8 +737,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3محرم2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -820,8 +744,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3محرم24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -829,8 +751,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -838,8 +758,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم,24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -847,8 +765,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'24 محرم 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -856,8 +772,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 24 محرم 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -865,8 +779,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 2024 محرم 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -874,8 +786,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -883,8 +793,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 12 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -892,8 +800,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 9 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -901,8 +807,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 محرم 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -910,8 +814,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, محرم, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -919,8 +821,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 محرم, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -928,8 +828,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, محرم 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -937,8 +835,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, محرم, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -946,8 +842,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 محرم, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -955,8 +849,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, محرم 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -964,8 +856,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 12, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -973,8 +863,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 12, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -982,8 +870,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 12 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -991,8 +877,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 2024, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1000,8 +884,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1009,8 +891,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 2024 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1018,8 +898,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, 2024, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1027,8 +905,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 2024, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1036,8 +912,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, 2024 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1045,8 +919,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, 12, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1054,8 +926,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 12, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1063,8 +933,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, 12 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1097,8 +965,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00.123-12:12')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1106,8 +972,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00.123+12:12')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1115,8 +979,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1124,8 +986,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10 -30T03: 00:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1133,8 +993,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00.12345')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1142,8 +1000,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00:123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1151,8 +1007,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00:12345')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1169,8 +1023,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20241329')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1186,8 +1038,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '241329')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1203,8 +1053,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '0001')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1220,8 +1068,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20241329 03:00:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1237,8 +1083,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '241329 03:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1254,8 +1098,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '0001 03:00:00.421')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1264,8 +1106,6 @@ smalldatetime
 -- -- invalid syntax
 SELECT CONVERT(SMALLDATETIME, '0')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1273,8 +1113,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '1')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1282,8 +1120,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '11')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1291,8 +1127,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '111')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1300,8 +1134,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '11111')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1309,8 +1141,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '1111111')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1335,8 +1165,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '4:12:12:1234')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1344,8 +1172,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '4:12:12.1234')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1354,8 +1180,6 @@ smalldatetime
 -- hijri
 SELECT CONVERT(SMALLDATETIME, '20231229', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1363,8 +1187,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20231230', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1372,8 +1194,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20231129', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1381,8 +1201,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20231130', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1423,8 +1241,6 @@ smalldatetime
 -- -- hijri leap year
 SELECT CONVERT(SMALLDATETIME, '20241230', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1450,8 +1266,6 @@ smalldatetime
 -- SMALLDATETIME with typmod
 SELECT CONVERT(SMALLDATETIME(1), '01/01/98 23:59:59.123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'smalldatetime')~~
@@ -1459,8 +1273,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME(2), '01/01/98 23:59:59.123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'smalldatetime')~~
@@ -1468,8 +1280,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME(3), '01/01/98 23:59:59.123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'smalldatetime')~~
@@ -1478,8 +1288,6 @@ smalldatetime
 -- boundary tests
 SELECT CONVERT(SMALLDATETIME, '2079-06-06 23:59:29.999')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1496,8 +1304,6 @@ smalldatetime
 -- -- out of bound values
 SELECT CONVERT(SMALLDATETIME,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1505,8 +1311,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1514,8 +1318,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1523,8 +1325,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1532,8 +1332,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'1742-10-01 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1686,8 +1484,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '02/12/21 15:13:14 PM', 22)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1695,8 +1491,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2021-02-12', 23)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1704,8 +1498,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2021-02-12 15:13:14.123', 25)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1873,8 +1665,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '12/02/2021 15:13:14:123 PM', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1899,8 +1689,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1908,8 +1696,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1920,8 +1706,6 @@ SELECT CONVERT(SMALLDATETIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(SMALLDATETIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1929,8 +1713,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1938,8 +1720,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '1900-05-06 13:59:29.050 -8:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1987,8 +1767,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1996,8 +1774,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~

--- a/test/JDBC/expected/test_conv_string_to_smalldatetime-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_smalldatetime-vu-verify.out
@@ -147,8 +147,6 @@ smalldatetime
 -- invalid syntax
 SELECT CONVERT(SMALLDATETIME, '3 12 2024')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -156,8 +154,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '3#12#2024')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -286,8 +282,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'April 16 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -375,8 +369,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr24 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -384,8 +376,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr,24 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -393,8 +383,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '24 Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -474,8 +462,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, Apr, 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -491,8 +477,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, Apr 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -524,8 +508,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr, 2024, 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -533,8 +515,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, 'Apr 2024, 12 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -550,8 +530,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '12, 2024, Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -559,8 +537,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '12 2024, Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -576,8 +552,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, 12, Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -593,8 +567,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2024, 12 Apr 14:30')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -604,8 +576,6 @@ smalldatetime
 -- this is only applicable for datetime and smalldatetime, for other datatypes error will be thrown
 SELECT CONVERT(SMALLDATETIME, N'محرم 12,2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -613,8 +583,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 12 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -622,8 +590,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -631,8 +597,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1,2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -640,8 +604,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -649,8 +611,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16, 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -658,8 +618,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1, 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -667,8 +625,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16, 2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -676,8 +632,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16  2000 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -685,8 +639,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16, 24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -694,8 +646,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16,4 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -703,8 +653,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 1,4 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -712,8 +660,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16    24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -721,8 +667,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16 4 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -730,8 +674,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 16 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -739,8 +681,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -748,8 +688,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 22 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -757,8 +695,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 2 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -766,8 +702,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'24 محرم, 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -775,8 +709,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3 محرم, 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -784,8 +716,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -793,8 +723,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -802,8 +730,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3 محرم 2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -811,8 +737,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3محرم2024 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -820,8 +744,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'3محرم24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -829,8 +751,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -838,8 +758,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم,24 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -847,8 +765,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'24 محرم 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -856,8 +772,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 24 محرم 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -865,8 +779,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 2024 محرم 14:30', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -874,8 +786,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -883,8 +793,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 12 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -892,8 +800,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 9 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -901,8 +807,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 محرم 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -910,8 +814,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, محرم, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -919,8 +821,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 محرم, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -928,8 +828,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, محرم 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -937,8 +835,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, محرم, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -946,8 +842,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 محرم, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -955,8 +849,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, محرم 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -964,8 +856,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 12, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -973,8 +863,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 12, 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -982,8 +870,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 12 2024 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -991,8 +877,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 2024, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1000,8 +884,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم 2024, 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1009,8 +891,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'محرم, 2024 12 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1018,8 +898,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, 2024, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1027,8 +905,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12 2024, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1036,8 +912,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'12, 2024 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1045,8 +919,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, 12, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1054,8 +926,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024 12, محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1063,8 +933,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, N'2024, 12 محرم 14:30', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1097,8 +965,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00.123-12:12')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1106,8 +972,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00.123+12:12')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1115,8 +979,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1124,8 +986,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10 -30T03: 00:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1133,8 +993,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00.12345')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1142,8 +1000,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00:123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1151,8 +1007,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2022-10-30T03:00:00:12345')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1169,8 +1023,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20241329')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1186,8 +1038,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '241329')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1203,8 +1053,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '0001')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1220,8 +1068,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20241329 03:00:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1237,8 +1083,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '241329 03:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1254,8 +1098,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '0001 03:00:00.421')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1264,8 +1106,6 @@ smalldatetime
 -- -- invalid syntax
 SELECT CONVERT(SMALLDATETIME, '0')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1273,8 +1113,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '1')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1282,8 +1120,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '11')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1291,8 +1127,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '111')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1300,8 +1134,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '11111')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1309,8 +1141,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '1111111')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1335,8 +1165,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '4:12:12:1234')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1344,8 +1172,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '4:12:12.1234')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1354,8 +1180,6 @@ smalldatetime
 -- hijri
 SELECT CONVERT(SMALLDATETIME, '20231229', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1363,8 +1187,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20231230', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1372,8 +1194,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20231129', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1381,8 +1201,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '20231130', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1423,8 +1241,6 @@ smalldatetime
 -- -- hijri leap year
 SELECT CONVERT(SMALLDATETIME, '20241230', 130)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1450,8 +1266,6 @@ smalldatetime
 -- SMALLDATETIME with typmod
 SELECT CONVERT(SMALLDATETIME(1), '01/01/98 23:59:59.123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'smalldatetime')~~
@@ -1459,8 +1273,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME(2), '01/01/98 23:59:59.123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'smalldatetime')~~
@@ -1468,8 +1280,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME(3), '01/01/98 23:59:59.123')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: CAST or CONVERT: invalid attributes specified for type 'smalldatetime')~~
@@ -1478,8 +1288,6 @@ smalldatetime
 -- boundary tests
 SELECT CONVERT(SMALLDATETIME, '2079-06-06 23:59:29.999')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1496,8 +1304,6 @@ smalldatetime
 -- -- out of bound values
 SELECT CONVERT(SMALLDATETIME,'2022-10-00 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1505,8 +1311,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'0000-10-01 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1514,8 +1318,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'2023-00-01 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1523,8 +1325,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'0000-00-00 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1532,8 +1332,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME,'1742-10-01 23:59:59.990')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1686,8 +1484,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '02/12/21 15:13:14 PM', 22)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1695,8 +1491,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2021-02-12', 23)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1704,8 +1498,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2021-02-12 15:13:14.123', 25)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1873,8 +1665,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '12/02/2021 15:13:14:123 PM', 131)
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a smalldatetime data type resulted in an out-of-range value.)~~
@@ -1899,8 +1689,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1908,8 +1696,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1920,8 +1706,6 @@ SELECT CONVERT(SMALLDATETIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(SMALLDATETIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1929,8 +1713,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1938,8 +1720,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '1900-05-06 13:59:29.050 -8:00')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1987,8 +1767,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2011-08-15 10:30.00 AMZ')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~
@@ -1996,8 +1774,6 @@ smalldatetime
 
 SELECT CONVERT(SMALLDATETIME, '2011-08-15 10:30.00 PMZ')
 GO
-~~START~~
-smalldatetime
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting character string to smalldatetime data type.)~~

--- a/test/JDBC/expected/test_conv_string_to_time-before-13_6-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_time-before-13_6-vu-verify.out
@@ -25,8 +25,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -50,8 +48,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -59,8 +55,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -84,8 +78,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -109,8 +101,6 @@ time
 
 SELECT CONVERT(TIME, '24PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -118,8 +108,6 @@ time
 
 SELECT CONVERT(TIME, '11')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -151,8 +139,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -160,8 +146,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -169,8 +153,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -210,8 +192,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -259,8 +239,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -375,8 +353,6 @@ time
 
 SELECT CONVERT(TIME, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -408,8 +384,6 @@ time
 
 SELECT CONVERT(TIME, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -521,8 +495,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -546,8 +518,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -555,8 +525,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -580,8 +548,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -605,8 +571,6 @@ time
 
 SELECT CONVERT(TIME, '24PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -614,8 +578,6 @@ time
 
 SELECT CONVERT(TIME, '11 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -647,8 +609,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -656,8 +616,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -665,8 +623,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -706,8 +662,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -755,8 +709,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -788,8 +740,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -813,8 +763,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -822,8 +770,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -847,8 +793,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -872,8 +816,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -881,8 +823,6 @@ time
 
 SELECT CONVERT(TIME, '11 -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -914,8 +854,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -923,8 +861,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -932,8 +868,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -973,8 +907,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1022,8 +954,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1055,8 +985,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1080,8 +1008,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1089,8 +1015,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1114,8 +1038,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1139,8 +1061,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1148,8 +1068,6 @@ time
 
 SELECT CONVERT(TIME, '11 -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1181,8 +1099,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1190,8 +1106,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1199,8 +1113,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1240,8 +1152,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1289,8 +1199,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1314,8 +1222,6 @@ time
 
 SELECT CONVERT(TIME, '11 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1323,8 +1229,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1332,8 +1236,6 @@ time
 
 SELECT CONVERT(TIME, '11 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1341,8 +1243,6 @@ time
 
 SELECT CONVERT(TIME, '13 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1350,8 +1250,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1359,8 +1257,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1368,8 +1264,6 @@ time
 
 SELECT CONVERT(TIME, '0 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1377,8 +1271,6 @@ time
 
 SELECT CONVERT(TIME, '11AM       +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1386,8 +1278,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1395,8 +1285,6 @@ time
 
 SELECT CONVERT(TIME, '11PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1404,8 +1292,6 @@ time
 
 SELECT CONVERT(TIME, '13PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1413,8 +1299,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1422,8 +1306,6 @@ time
 
 SELECT CONVERT(TIME, '11 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1431,8 +1313,6 @@ time
 
 SELECT CONVERT(TIME, '    11:22     +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1440,8 +1320,6 @@ time
 
 SELECT CONVERT(TIME, '11:22 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1449,8 +1327,6 @@ time
 
 SELECT CONVERT(TIME, '11:22 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1458,8 +1334,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1467,8 +1341,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1476,8 +1348,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1485,8 +1355,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22   :12 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1494,8 +1362,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1503,8 +1369,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22:12 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1512,8 +1376,6 @@ time
 
 SELECT CONVERT(TIME, '11 :22:12:123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1521,8 +1383,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1530,8 +1390,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:123 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1539,8 +1397,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12  :123 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1548,8 +1404,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22:12.123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1557,8 +1411,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  1234 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1566,8 +1418,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  123456789 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1575,8 +1425,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1584,8 +1432,6 @@ time
 
 SELECT CONVERT(TIME, '11: 22:12.123 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1593,8 +1439,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  123234 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1610,8 +1454,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1635,8 +1477,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1644,8 +1484,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1669,8 +1507,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1694,8 +1530,6 @@ time
 
 SELECT CONVERT(TIME, '24PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1703,8 +1537,6 @@ time
 
 SELECT CONVERT(TIME, '11Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1736,8 +1568,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1745,8 +1575,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1754,8 +1582,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1795,8 +1621,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1844,8 +1668,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2232,8 +2054,6 @@ time
 
 SELECT CONVERT(TIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2241,8 +2061,6 @@ time
 
 SELECT CONVERT(TIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2250,8 +2068,6 @@ time
 
 SELECT CONVERT(TIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2262,8 +2078,6 @@ SELECT CONVERT(TIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(TIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2271,8 +2085,6 @@ time
 
 SELECT CONVERT(TIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2288,8 +2100,6 @@ time
 
 SELECT CONVERT(TIME, '2011-08-15 14:30.00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2297,8 +2107,6 @@ time
 
 SELECT CONVERT(TIME, '2011-08-15 14:30.00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2494,16 +2302,12 @@ time
 
 SELECT * FROM test_conv_string_to_time_v8
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: cannot cast type integer to time without time zone)~~
 
 EXEC test_conv_string_to_time_p8
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~
@@ -2541,8 +2345,6 @@ time
 
 SELECT * FROM test_conv_string_to_time_v10
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting time from character string.)~~
@@ -2550,8 +2352,6 @@ time
 
 SELECT * FROM test_conv_string_to_time_v11
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting time from character string.)~~
@@ -2559,8 +2359,6 @@ time
 
 SELECT * FROM test_conv_string_to_time_v12
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: cannot cast type integer to time without time zone)~~

--- a/test/JDBC/expected/test_conv_string_to_time-before-16_3-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_time-before-16_3-vu-verify.out
@@ -25,8 +25,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -50,8 +48,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -59,8 +55,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -84,8 +78,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -109,8 +101,6 @@ time
 
 SELECT CONVERT(TIME, '24PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -118,8 +108,6 @@ time
 
 SELECT CONVERT(TIME, '11')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -151,8 +139,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -160,8 +146,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -169,8 +153,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -210,8 +192,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -259,8 +239,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -375,8 +353,6 @@ time
 
 SELECT CONVERT(TIME, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -408,8 +384,6 @@ time
 
 SELECT CONVERT(TIME, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -521,8 +495,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -546,8 +518,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -555,8 +525,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -580,8 +548,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -605,8 +571,6 @@ time
 
 SELECT CONVERT(TIME, '24PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -614,8 +578,6 @@ time
 
 SELECT CONVERT(TIME, '11 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -647,8 +609,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -656,8 +616,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -665,8 +623,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -706,8 +662,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -755,8 +709,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -788,8 +740,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -813,8 +763,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -822,8 +770,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -847,8 +793,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -872,8 +816,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -881,8 +823,6 @@ time
 
 SELECT CONVERT(TIME, '11 -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -914,8 +854,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -923,8 +861,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -932,8 +868,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -973,8 +907,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1022,8 +954,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1055,8 +985,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1080,8 +1008,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1089,8 +1015,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1114,8 +1038,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1139,8 +1061,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1148,8 +1068,6 @@ time
 
 SELECT CONVERT(TIME, '11 -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1181,8 +1099,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1190,8 +1106,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1199,8 +1113,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1240,8 +1152,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1289,8 +1199,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1314,8 +1222,6 @@ time
 
 SELECT CONVERT(TIME, '11 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1323,8 +1229,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1332,8 +1236,6 @@ time
 
 SELECT CONVERT(TIME, '11 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1341,8 +1243,6 @@ time
 
 SELECT CONVERT(TIME, '13 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1350,8 +1250,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1359,8 +1257,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1368,8 +1264,6 @@ time
 
 SELECT CONVERT(TIME, '0 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1377,8 +1271,6 @@ time
 
 SELECT CONVERT(TIME, '11AM       +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1386,8 +1278,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1395,8 +1285,6 @@ time
 
 SELECT CONVERT(TIME, '11PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1404,8 +1292,6 @@ time
 
 SELECT CONVERT(TIME, '13PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1413,8 +1299,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1422,8 +1306,6 @@ time
 
 SELECT CONVERT(TIME, '11 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1431,8 +1313,6 @@ time
 
 SELECT CONVERT(TIME, '    11:22     +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1440,8 +1320,6 @@ time
 
 SELECT CONVERT(TIME, '11:22 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1449,8 +1327,6 @@ time
 
 SELECT CONVERT(TIME, '11:22 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1458,8 +1334,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1467,8 +1341,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1476,8 +1348,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1485,8 +1355,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22   :12 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1494,8 +1362,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1503,8 +1369,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22:12 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1512,8 +1376,6 @@ time
 
 SELECT CONVERT(TIME, '11 :22:12:123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1521,8 +1383,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1530,8 +1390,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:123 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1539,8 +1397,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12  :123 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1548,8 +1404,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22:12.123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1557,8 +1411,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  1234 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1566,8 +1418,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  123456789 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1575,8 +1425,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1584,8 +1432,6 @@ time
 
 SELECT CONVERT(TIME, '11: 22:12.123 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1593,8 +1439,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  123234 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1610,8 +1454,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1635,8 +1477,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1644,8 +1484,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1669,8 +1507,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1694,8 +1530,6 @@ time
 
 SELECT CONVERT(TIME, '24PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1703,8 +1537,6 @@ time
 
 SELECT CONVERT(TIME, '11Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1736,8 +1568,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1745,8 +1575,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1754,8 +1582,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1795,8 +1621,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1844,8 +1668,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2232,8 +2054,6 @@ time
 
 SELECT CONVERT(TIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2241,8 +2061,6 @@ time
 
 SELECT CONVERT(TIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2250,8 +2068,6 @@ time
 
 SELECT CONVERT(TIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2262,8 +2078,6 @@ SELECT CONVERT(TIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(TIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2271,8 +2085,6 @@ time
 
 SELECT CONVERT(TIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2288,8 +2100,6 @@ time
 
 SELECT CONVERT(TIME, '2011-08-15 14:30.00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2297,8 +2107,6 @@ time
 
 SELECT CONVERT(TIME, '2011-08-15 14:30.00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2502,8 +2310,6 @@ time
 
 EXEC test_conv_string_to_time_p8
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~

--- a/test/JDBC/expected/test_conv_string_to_time-vu-verify.out
+++ b/test/JDBC/expected/test_conv_string_to_time-vu-verify.out
@@ -25,8 +25,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -50,8 +48,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -59,8 +55,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -84,8 +78,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -109,8 +101,6 @@ time
 
 SELECT CONVERT(TIME, '24PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -118,8 +108,6 @@ time
 
 SELECT CONVERT(TIME, '11')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -151,8 +139,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -160,8 +146,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -169,8 +153,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -210,8 +192,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -259,8 +239,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -375,8 +353,6 @@ time
 
 SELECT CONVERT(TIME, '9999-12-30 23:59:59.9999999999')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -408,8 +384,6 @@ time
 
 SELECT CONVERT(TIME, '9999-12-31 23:59:59.9999999999')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -521,8 +495,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -546,8 +518,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -555,8 +525,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -580,8 +548,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -605,8 +571,6 @@ time
 
 SELECT CONVERT(TIME, '24PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -614,8 +578,6 @@ time
 
 SELECT CONVERT(TIME, '11 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -647,8 +609,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -656,8 +616,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -665,8 +623,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -706,8 +662,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -755,8 +709,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +00:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -788,8 +740,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -813,8 +763,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -822,8 +770,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -847,8 +793,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -872,8 +816,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -881,8 +823,6 @@ time
 
 SELECT CONVERT(TIME, '11 -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -914,8 +854,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -923,8 +861,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -932,8 +868,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -973,8 +907,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1022,8 +954,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +05:12')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1055,8 +985,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1080,8 +1008,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1089,8 +1015,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1114,8 +1038,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1139,8 +1061,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1148,8 +1068,6 @@ time
 
 SELECT CONVERT(TIME, '11 -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1181,8 +1099,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1190,8 +1106,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1199,8 +1113,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1240,8 +1152,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1289,8 +1199,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +14:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1314,8 +1222,6 @@ time
 
 SELECT CONVERT(TIME, '11 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1323,8 +1229,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1332,8 +1236,6 @@ time
 
 SELECT CONVERT(TIME, '11 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1341,8 +1243,6 @@ time
 
 SELECT CONVERT(TIME, '13 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1350,8 +1250,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1359,8 +1257,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1368,8 +1264,6 @@ time
 
 SELECT CONVERT(TIME, '0 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1377,8 +1271,6 @@ time
 
 SELECT CONVERT(TIME, '11AM       +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1386,8 +1278,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1395,8 +1285,6 @@ time
 
 SELECT CONVERT(TIME, '11PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1404,8 +1292,6 @@ time
 
 SELECT CONVERT(TIME, '13PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1413,8 +1299,6 @@ time
 
 SELECT CONVERT(TIME, '24PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1422,8 +1306,6 @@ time
 
 SELECT CONVERT(TIME, '11 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1431,8 +1313,6 @@ time
 
 SELECT CONVERT(TIME, '    11:22     +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1440,8 +1320,6 @@ time
 
 SELECT CONVERT(TIME, '11:22 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1449,8 +1327,6 @@ time
 
 SELECT CONVERT(TIME, '11:22 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1458,8 +1334,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1467,8 +1341,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1476,8 +1348,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1485,8 +1355,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22   :12 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1494,8 +1362,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1503,8 +1369,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22:12 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1512,8 +1376,6 @@ time
 
 SELECT CONVERT(TIME, '11 :22:12:123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1521,8 +1383,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1530,8 +1390,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:123 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1539,8 +1397,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12  :123 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1548,8 +1404,6 @@ time
 
 SELECT CONVERT(TIME, '11:  22:12.123 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1557,8 +1411,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  1234 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1566,8 +1418,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  123456789 -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1575,8 +1425,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891 +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1584,8 +1432,6 @@ time
 
 SELECT CONVERT(TIME, '11: 22:12.123 AM -14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1593,8 +1439,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12.  123234 PM +14:10')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1610,8 +1454,6 @@ time
 
 SELECT CONVERT(TIME, '13 AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1635,8 +1477,6 @@ time
 
 SELECT CONVERT(TIME, '24 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1644,8 +1484,6 @@ time
 
 SELECT CONVERT(TIME, '0 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1669,8 +1507,6 @@ time
 
 SELECT CONVERT(TIME, '     13AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1694,8 +1530,6 @@ time
 
 SELECT CONVERT(TIME, '24PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: The conversion of a varchar data type to a time data type resulted in an out-of-range value.)~~
@@ -1703,8 +1537,6 @@ time
 
 SELECT CONVERT(TIME, '11Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1736,8 +1568,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1745,8 +1575,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 AM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1754,8 +1582,6 @@ time
 
 SELECT CONVERT(TIME, '11:22.123 PM Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1795,8 +1621,6 @@ time
 
 SELECT CONVERT(TIME, '11:22:12:1234Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -1844,8 +1668,6 @@ time
 
 SELECT CONVERT(TIME, '11:22  :12.1234567891Z')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2232,8 +2054,6 @@ time
 
 SELECT CONVERT(TIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2241,8 +2061,6 @@ time
 
 SELECT CONVERT(TIME, '2000-04-22 16:23:51.7668c0')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2250,8 +2068,6 @@ time
 
 SELECT CONVERT(TIME, '2001-04-022 16:23:51.766890 +12:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2262,8 +2078,6 @@ SELECT CONVERT(TIME, '02001-04-22 16:23:51.766890 +12:00')
 GO 
 SELECT CONVERT(TIME, ' 2001- 04 - 22 16: 23: 51. 766890 +12:00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2271,8 +2085,6 @@ time
 
 SELECT CONVERT(TIME, '02001-04-22 16:23:51')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2288,8 +2100,6 @@ time
 
 SELECT CONVERT(TIME, '2011-08-15 14:30.00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2297,8 +2107,6 @@ time
 
 SELECT CONVERT(TIME, '2011-08-15 14:30.00')
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Conversion failed when converting date and/or time from character string.)~~
@@ -2494,16 +2302,12 @@ time
 
 SELECT * FROM test_conv_string_to_time_v8
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~
 
 EXEC test_conv_string_to_time_p8
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~
@@ -2557,8 +2361,6 @@ time
 
 SELECT * FROM test_conv_string_to_time_v12
 GO
-~~START~~
-time
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Explicit conversion from data type integer to time is not allowed.)~~

--- a/test/JDBC/input/BABEL-5031-vu-verify.sql
+++ b/test/JDBC/input/BABEL-5031-vu-verify.sql
@@ -1,0 +1,72 @@
+-- Customer case
+CREATE TABLE [dbo].[babel_5031_MemberValues](
+    [Id] [uniqueidentifier] NOT NULL,
+    [PanelId] [uniqueidentifier] NOT NULL,
+    [EndEffectiveDate] [datetime2](7) NOT NULL
+);
+GO
+
+CREATE NONCLUSTERED INDEX [babel_5031_IDX_MBRVAL_SHARED_LATEST_FILT] ON [dbo].[babel_5031_MemberValues] ([PanelId] ASC)
+WHERE ([EndEffectiveDate]=CONVERT([datetime2](7),'9999-12-31 23:59:59.9999999'));
+GO
+
+DROP TABLE babel_5031_MemberValues
+GO
+
+-- Using convert function for converting from string to date/datetime/datetime2/datetimeoffset/smalldatetime/time 
+-- in computed column of table
+CREATE TABLE babel_5031_t1(col_string VARCHAR(100),
+                        col_date AS CONVERT(date, col_string),
+                        col_datetime AS CONVERT(datetime, col_string),
+                        col_datetime2 AS CONVERT(datetime2, col_string),
+                        col_dateoffset AS CONVERT(datetimeoffset, col_string),
+                        col_smalldatetime AS CONVERT(smalldatetime, col_string),
+                        col_time AS CONVERT(time, col_string));
+GO
+
+INSERT INTO babel_5031_t1 VALUES('2026-12-31 23:59:59.99');
+GO
+
+INSERT INTO babel_5031_t1 VALUES('11.12.2024');
+GO
+
+INSERT INTO babel_5031_t1 VALUES('2022-10-30T03:00:00.123');
+GO
+
+INSERT INTO babel_5031_t1 VALUES('20240129 03:00:00');
+GO
+
+SELECT * FROM babel_5031_t1
+GO
+
+DROP TABLE babel_5031_t1
+GO
+
+-- Using convert function for converting from string to date/datetime/datetime2/datetimeoffset/smalldatetime/time 
+-- in check constraint of table
+CREATE TABLE babel_5031_t2(col_string VARCHAR(100),
+                        CHECK (CONVERT(date, col_string) > CONVERT(date, '03-05-2023')),
+                        CHECK (CONVERT(datetime, col_string) > CONVERT(datetime, '03-05-2023')),
+                        CHECK (CONVERT(datetime2, col_string) > CONVERT(datetime2, '03-05-2023')),
+                        CHECK (CONVERT(datetimeoffset, col_string) > CONVERT(datetimeoffset, '03-05-2023')),
+                        CHECK (CONVERT(smalldatetime, col_string) > CONVERT(smalldatetime, '03-05-2023')),
+                        CHECK (CONVERT(time, col_string) > CONVERT(time, '03-05-2023')));
+GO
+
+INSERT INTO babel_5031_t2 VALUES('2026-12-31 23:59:59.99');
+GO
+
+INSERT INTO babel_5031_t2 VALUES('11.12.2024');
+GO
+
+INSERT INTO babel_5031_t2 VALUES('2022-10-30T03:00:00.123');
+GO
+
+INSERT INTO babel_5031_t2 VALUES('20240129 03:00:00');
+GO
+
+SELECT * FROM babel_5031_t2
+GO
+
+DROP TABLE babel_5031_t2
+GO

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -239,3 +239,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-13_6
+BABEL-5031

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -292,3 +292,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-13_6
+BABEL-5031

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -348,3 +348,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -341,3 +341,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -341,3 +341,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -346,3 +346,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -448,3 +448,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -446,3 +446,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -447,3 +447,4 @@ test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
 BABEL-3401
+BABEL-5031

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -369,3 +369,4 @@ test_conv_string_to_datetime2-before-14_5
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -381,3 +381,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime-before-14_6
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -418,3 +418,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -439,3 +439,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -441,3 +441,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -444,3 +444,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -417,3 +417,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -452,3 +452,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -471,3 +471,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -483,3 +483,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -514,3 +514,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -530,3 +530,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -528,3 +528,4 @@ test_conv_string_to_smalldatetime
 test_conv_string_to_time
 BABEL-3401
 babel_726
+BABEL-5031

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -522,3 +522,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -537,3 +537,4 @@ test_conv_string_to_datetime2-before-16_3
 test_conv_string_to_datetimeoffset-before-16_3
 test_conv_string_to_smalldatetime
 test_conv_string_to_time-before-16_3
+BABEL-5031

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -541,3 +541,4 @@ test_conv_string_to_datetimeoffset
 test_conv_string_to_smalldatetime
 test_conv_string_to_time
 BABEL-3401
+BABEL-5031


### PR DESCRIPTION
### Description
Currently, helper functions used by convert function for converting string to date and time related types, are marked `STABLE`, due to this creation of indexes and computed columns on this functions throws error as follows.
```
functions in index predicate must be marked IMMUTABLE 
```
This PR fixes this issue by updating volatility of all these helper functions used by convert function to convert from string to date and time related types, to `IMMUTABLE`. These functions are marked `IMMUTABLE` as they qualify the criteria to be a `IMMUTABLE` function.

Authored-by: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved
BABEL-5031

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).