### PR TITLE
Add dump/restore tests for older versions

### DIFF
--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -46,9 +46,16 @@ runs:
         extension_branch: ${{ inputs.extension_branch }}
         pg_new_dir: ${{ inputs.pg_new_dir }}
 
+    - name: Build latest dump/restore utilities
+      id: build-dump-utils
+      if: always() && steps.setup-new-version.outcome == 'success' && '${{ inputs.pg_new_dir }}' != 'psqltarget'
+      uses: ./.github/composite-actions/build-modified-postgres
+      with:
+        install_dir: psqltarget
+
     - name: Dump and restore database
       id: run-pg_dump-restore
-      if: always() && steps.setup-new-version.outcome == 'success'
+      if: always() && steps.build-dump-utils.outcome != 'failed'
       run: |
         ulimit -c unlimited
         echo 'Starting dump...'
@@ -58,6 +65,7 @@ runs:
         cd upgrade/dump
         export PGPASSWORD=12345678
         export PATH=/opt/mssql-tools/bin:$PATH
+        export DUMP_RESTORE_UTILS_PATH=$HOME/psqltarget/bin
 
         if [[ '${{ inputs.dump_data_as }}' == 'inserts' ]];then
           export DUMP_OPTS='--column-inserts --rows-per-insert=50'
@@ -65,19 +73,21 @@ runs:
           export DUMP_OPTS=''
         fi
         export DUMP_OPTS="$DUMP_OPTS --format=${{ inputs.dump_format }}"
+        echo "pg_dump version = "
+        $DUMP_RESTORE_UTILS_PATH/pg_dump -V
 
         if [[ ${{ inputs.database_level }} == false ]];then
           echo "Starting to dump whole Babelfish physical database"
           if [[ '${{ inputs.type }}' == 'full' ]];then
             # Perform the complete dump
-            ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords -f pg_dump_globals.sql > ~/upgrade/error.log
-            ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --file="pg_dump.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords -f pg_dump_globals.sql > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --file="pg_dump.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
           else
             # First perform the schema-only dump and then perform the data-only dump to produce a complete dump
-            ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords -f pg_dump_globals_so.sql > ~/upgrade/error.log
-            ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --file="pg_dump_so.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords -f pg_dump_globals_so.sql > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --file="pg_dump_so.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
 
-            ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --file="pg_dump_do.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --file="pg_dump_do.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
           fi
         else
           echo "Starting to dump all the Babelfish logical databases"
@@ -107,7 +117,7 @@ runs:
           ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/servers_file.txt
 
           # Get the list of all the Babelfish logical datababses in a file
-          query="SELECT name FROM sys.babelfish_sysdatabases;"
+          query="SELECT name FROM sys.babelfish_sysdatabases ORDER BY name DESC;"
           ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/databases_file.txt
 
           # Loop through the list of all the Babelfish logical database and dump them one by one.
@@ -116,14 +126,14 @@ runs:
             db_trimmed="$(echo "${db}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             if [[ '${{ inputs.type }}' == 'full' ]];then
               # Perform the complete dump
-              ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
-              ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed".archive --dbname=jdbc_testdb > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed".archive --dbname=jdbc_testdb > ~/upgrade/error.log
             else
               # First perform the schema-only dump and then perform the data-only dump to produce a complete dump
-              ~/${{ inputs.pg_new_dir }}/bin/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
-              ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_so.archive --dbname=jdbc_testdb > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
+             $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_so.archive --dbname=jdbc_testdb > ~/upgrade/error.log
 
-              ~/${{ inputs.pg_new_dir }}/bin/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_do.archive --dbname=jdbc_testdb > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_do.archive --dbname=jdbc_testdb > ~/upgrade/error.log
             fi
           done < <(tail -n +3 ~/upgrade/databases_file.txt | head -n -2)
         fi
@@ -141,23 +151,23 @@ runs:
           echo "Starting to restore whole Babelfish physical database"
           if [[ '${{ inputs.type }}' == 'full' ]];then
             echo 'Restoring from pg_dumpall'
-            sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals.sql > ~/upgrade/error.log
+            sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals.sql > ~/upgrade/error.log
             echo 'Restoring from pg_dump'
             if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-              sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
             else
-              ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
             fi
           else
             echo 'Restoring from pg_dumpall'
-            sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_so.sql > ~/upgrade/error.log
+            sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_so.sql > ~/upgrade/error.log
             echo 'Restoring from pg_dump'
             if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-              sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
-              sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
             else
-              ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
-              ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
             fi
           fi
         else
@@ -168,20 +178,20 @@ runs:
             db_trimmed="$(echo -e "${db}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             echo "Restoring $db_trimmed"
             if [[ '${{ inputs.type }}' == 'full' ]];then
-              sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
               if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-                sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
+                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
               else
-                ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
+                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
               fi
             else
               sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
               if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-                sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
-                sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
+                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
+                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
               else
-                ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
-                ~/${{ inputs.pg_new_dir }}/bin/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
+                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
+                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
               fi
             fi
           done < <(tail -n +3 ~/upgrade/databases_file.txt | head -n -2)
@@ -313,3 +323,5 @@ runs:
         is_final_ver: ${{ inputs.is_final_ver }}
         pg_new_dir: ${{ inputs.pg_new_dir }}
         migration_mode: ${{ inputs.migration_mode }}
+        extension_branch: ${{ inputs.extension_branch }}
+        dump_restore: 'true'

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -136,6 +136,9 @@ runs:
               $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_do.archive --dbname=jdbc_testdb > ~/upgrade/error.log
             fi
           done < <(tail -n +3 ~/upgrade/databases_file.txt | head -n -2)
+
+          # Also dump the objects in PUBLIC schema.
+          $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user --quote-all-identifiers --schema=public --schema-only --file=pg_dump_public.sql --dbname=jdbc_testdb > ~/upgrade/error_public_schema.log
         fi
 
         # Stop old server and start the new.
@@ -309,6 +312,9 @@ runs:
             # Execute the query to create the user mapping
             sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "$query;"
           done < <(tail -n +3 ~/upgrade/servers_file.txt | head -n -2)
+
+          # Restore the objects in PUBLIC schema.
+          sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -h localhost -d jdbc_testdb -U jdbc_user -f ~/upgrade/dump/pg_dump_public.sql &> ~/upgrade/error_public_schema.log
         fi
         echo 'Database restore complete.'
         rm -rf ~/upgrade/dump

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -13,10 +13,24 @@ inputs:
     description: "Server collation name"
     required: false
     default: "default"
+  extension_branch:
+    description: "Extension Branch"
+    required: false
+    default: 'latest'
+  dump_restore:
+    description: "Whether it is version upgrade or dump/restore"
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
   steps:
+    - if: ${{ inputs.extension_branch != 'latest' && inputs.dump_restore == 'true' }}
+      uses: actions/checkout@v2
+      with:
+        repository: babelfish-for-postgresql/babelfish_extensions
+        ref: ${{ inputs.extension_branch }}
+
     - name: Run JDBC Verify Tests
       if: always()
       id: jdbc-verify-tests
@@ -35,10 +49,10 @@ runs:
         if [[ "$migr_mode" == "multi-db" ]];then
           base_dir=${{ matrix.upgrade-path.path[0] }}
           tar_dir=${{ matrix.upgrade-path.last_version }}
-          if [[ "$base_dir" == *"latest"* ]]; then
+          if [[ "$base_dir" == *"latest"* || ${{ inputs.dump_restore }} == 'true' ]]; then
             base_dir="latest"
           fi
-          if [[ "$tar_dir" == *"latest"* ]]; then
+          if [[ "$tar_dir" == *"latest"* || ${{ inputs.dump_restore }} == 'true' ]]; then
             tar_dir="latest"
           fi
           export inputFilesPath=upgrade/$tar_dir/verification_cleanup/$base_dir

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Server collation name which need to be set in postgresql.conf"
     required: false
     default: "default"
+  dump_restore:
+    description: "Whether it is version upgrade or dump/restore"
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -147,8 +151,6 @@ runs:
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash
 
-    - uses: actions/checkout@v2
-
     - name: Change migration mode to multi-db
       id: change-migration-mode
       if: ${{ inputs.migration_mode == 'multi-db' }} && always()
@@ -156,6 +158,15 @@ runs:
         sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
         sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
       shell: bash
+
+    - if: ${{ inputs.extension_branch != 'latest' && inputs.dump_restore == 'true' }}
+      uses: actions/checkout@v2
+      with:
+        repository: babelfish-for-postgresql/babelfish_extensions
+        ref: ${{ inputs.extension_branch }}
+
+    - if: ${{ inputs.extension_branch == 'latest' || inputs.dump_restore != 'true' }}
+      uses: actions/checkout@v2
 
     - name: Run JDBC Upgrade Tests
       id: jdbc-upgrade-tests
@@ -172,7 +183,7 @@ runs:
         if [[ "$migr_mode" == "multi-db" ]];then
           export isUpgradeTestMode=true
           base_dir=${{ matrix.upgrade-path.path[0] }}
-          if [[ "$base_dir" == *"latest"* ]]; then
+          if [[ "$base_dir" == *"latest"* || ${{ inputs.dump_restore }} == 'true' ]]; then
             base_dir="latest"
           fi
         else
@@ -195,6 +206,8 @@ runs:
         export scheduleFile=upgrade/$base_dir/schedule
         mvn test
       shell: bash
+
+    - uses: actions/checkout@v2
 
     - name: Install Python
       id: install-python

--- a/.github/composite-actions/setup-dump-restore-ca/action.yml
+++ b/.github/composite-actions/setup-dump-restore-ca/action.yml
@@ -40,6 +40,10 @@ runs:
           is_final_ver=false; [[ i -eq $LEN-1 ]] && is_final_ver=true
           pg_old_dir=$(echo psql$(awk -F. '{print $1}' <<< $previous_installed_version))
           pg_new_dir=$(echo psql$(awk -F. '{print $1}' <<< $dump_restore_version))
+
+          if [[ "$previous_installed_version" == "$dump_restore_version" ]]; then
+            pg_new_dir=$(echo $pg_new_dir.$i)
+          fi
           uses_file=./.github/composite-actions/dump-restore-util
           temp="&& steps.dump-restore-version-$(($i-1)).outcome == 'success'"; [[ i -eq 1 ]] && temp=""
 

--- a/.github/configuration/dump-restore-test-configuration.yml
+++ b/.github/configuration/dump-restore-test-configuration.yml
@@ -109,4 +109,20 @@ dump-restore-version: [[
     database-level: true,
     type: full
   }
+],
+[
+  {
+    version: 16.1,
+    dump-data-as: inserts,
+    dump-format: custom,
+    database-level: true,
+    type: full
+  },
+  {
+    version: 16.1,
+    dump-data-as: inserts,
+    dump-format: custom,
+    database-level: true,
+    type: full
+  }
 ]]

--- a/.github/configuration/dump-restore-test-configuration.yml
+++ b/.github/configuration/dump-restore-test-configuration.yml
@@ -93,4 +93,20 @@ dump-restore-version: [[
     database-level: true,
     type: schema-cum-data-only
   }
+],
+[
+  {
+    version: 15.5,
+    dump-data-as: copy,
+    dump-format: tar,
+    database-level: true,
+    type: full
+  },
+  {
+    version: 15.5,
+    dump-data-as: copy,
+    dump-format: tar,
+    database-level: true,
+    type: full
+  }
 ]]

--- a/.github/workflows/pg_dump-restore-test.yml
+++ b/.github/workflows/pg_dump-restore-test.yml
@@ -73,6 +73,7 @@ jobs:
           extension_branch: ${{ steps.find-branch.outputs.base-extension-branch }}
           install_dir: ${{ steps.find-branch.outputs.base-dir }}
           migration_mode: 'multi-db'
+          dump_restore: 'true'
 
       - name: Setup Dump Restore Composite Action
         id: setup-dump-restore-ca
@@ -85,6 +86,8 @@ jobs:
         id: dump-restore-and-test
         if: always() && steps.setup-dump-restore-ca.outcome == 'success' 
         uses: ./.github/composite-actions/dump-restore
+
+      - uses: actions/checkout@v2
 
       # Due to some action/checkout's in previous step the dynamically generated dump-restore composite action isn't available,
       # hence to avoid error in post action step recreated the dump-restore composite action


### PR DESCRIPTION
### Description
Add workflows to test dump/restore of version 15.5, the first
version which supports dump/restore, and 16.1 so that the dump
utilities always remain backward compatible.

Task: BABEL-5029
 Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/385

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).