### PR TITLE
Update Vector version and related test file changes (#2674)

### DIFF
--- a/.github/composite-actions/build-vector-extension/action.yml
+++ b/.github/composite-actions/build-vector-extension/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Build vector Extension
       run: |
         cd ..
-        export VECTOR_VERSION="0.5.1"
+        export VECTOR_VERSION="0.7.2"
         sudo apt-get install wget
         wget https://github.com/pgvector/pgvector/archive/refs/tags/v${VECTOR_VERSION}.tar.gz
         tar -xvzf v${VECTOR_VERSION}.tar.gz

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Build vector Extension
       run: |
         cd ..
-        export VECTOR_VERSION="0.5.1"
+        export VECTOR_VERSION="0.7.2"
         sudo apt-get install wget
         wget https://github.com/pgvector/pgvector/archive/refs/tags/v${VECTOR_VERSION}.tar.gz 
         tar -xvzf v${VECTOR_VERSION}.tar.gz

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build vector Extension
         run: |
           cd ..
-          export VECTOR_VERSION="0.5.1"
+          export VECTOR_VERSION="0.7.2"
           sudo apt-get install wget
           wget https://github.com/pgvector/pgvector/archive/refs/tags/v${VECTOR_VERSION}.tar.gz
           tar -xvzf v${VECTOR_VERSION}.tar.gz

--- a/test/JDBC/expected/TestVectorDatatype.out
+++ b/test/JDBC/expected/TestVectorDatatype.out
@@ -101,7 +101,7 @@ go
 ~~ERROR (Message: value out of range: underflow)~~
 
 
-SELECT vector_dims('[1,2,3]');
+SELECT vector_dims(CAST('[1,2,3]' as vector));
 go
 ~~START~~
 int
@@ -140,7 +140,7 @@ go
 ~~ERROR (Message: syntax error near 'Cast' at line 1 and character position 19)~~
 
 
-SELECT l2_distance('[0,0]', '[3,4]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -148,7 +148,7 @@ float
 ~~END~~
 
 
-SELECT l2_distance('[0,0]', '[0,1]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 ~~START~~
 float
@@ -156,14 +156,14 @@ float
 ~~END~~
 
 
-SELECT l2_distance('[1,2]', '[3]');
+SELECT l2_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT l2_distance('[3e38]', '[-3e38]');
+SELECT l2_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 ~~START~~
 float
@@ -171,7 +171,7 @@ Infinity
 ~~END~~
 
 
-SELECT inner_product('[1,2]', '[3,4]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -179,14 +179,14 @@ float
 ~~END~~
 
 
-SELECT inner_product('[1,2]', '[3]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT inner_product('[3e38]', '[3e38]');
+SELECT inner_product(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 ~~START~~
 float
@@ -194,7 +194,7 @@ Infinity
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[2,4]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[2,4]' as vector));
 go
 ~~START~~
 float
@@ -202,7 +202,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[0,0]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[0,0]' as vector));
 go
 ~~START~~
 float
@@ -210,7 +210,7 @@ NaN
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[1,1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1,1]' as vector));
 go
 ~~START~~
 float
@@ -218,7 +218,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,0]', '[0,2]');
+SELECT cosine_distance(CAST('[1,0]' as vector), CAST('[0,2]' as vector));
 go
 ~~START~~
 float
@@ -226,7 +226,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[-1,-1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1,-1]' as vector));
 go
 ~~START~~
 float
@@ -234,14 +234,14 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[3]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT cosine_distance('[1,1]', '[1.1,1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1.1,1.1]' as vector));
 go
 ~~START~~
 float
@@ -249,7 +249,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[-1.1,-1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1.1,-1.1]' as vector));
 go
 ~~START~~
 float
@@ -257,7 +257,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[3e38]', '[3e38]');
+SELECT cosine_distance(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 ~~START~~
 float
@@ -265,7 +265,7 @@ NaN
 ~~END~~
 
 
-SELECT l1_distance('[0,0]', '[3,4]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -273,7 +273,7 @@ float
 ~~END~~
 
 
-SELECT l1_distance('[0,0]', '[0,1]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 ~~START~~
 float
@@ -281,14 +281,14 @@ float
 ~~END~~
 
 
-SELECT l1_distance('[1,2]', '[3]');
+SELECT l1_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT l1_distance('[3e38]', '[-3e38]');
+SELECT l1_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 ~~START~~
 float
@@ -1160,49 +1160,49 @@ SELECT CAST('[4e38,1]' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: infinite value not allowed in vector)~~
+~~ERROR (Message: "4e38" is out of range for type vector)~~
 
 
 SELECT CAST('[1,2,3' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,2,3")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,2,3")~~
 
 
 SELECT CAST('[1,2,3]9' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,2,3]9")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,2,3]9")~~
 
 
 SELECT CAST('1,2,3' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "1,2,3")~~
+~~ERROR (Message: invalid input syntax for type vector: "1,2,3")~~
 
 
 SELECT CAST('' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "")~~
+~~ERROR (Message: invalid input syntax for type vector: "")~~
 
 
 SELECT CAST('[' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[")~~
+~~ERROR (Message: invalid input syntax for type vector: "[")~~
 
 
 SELECT CAST('[,' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[,")~~
+~~ERROR (Message: invalid input syntax for type vector: "[,")~~
 
 
 SELECT CAST('[]' as vector);
@@ -1230,7 +1230,7 @@ SELECT CAST('[1,,3]' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,,3]")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,,3]")~~
 
 
 SELECT CAST('[1, ,3]' as vector);

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
@@ -101,7 +101,7 @@ go
 ~~ERROR (Message: value out of range: underflow)~~
 
 
-SELECT vector_dims('[1,2,3]');
+SELECT vector_dims(CAST('[1,2,3]' as vector));
 go
 ~~START~~
 int
@@ -140,7 +140,7 @@ go
 ~~ERROR (Message: syntax error near 'Cast' at line 1 and character position 19)~~
 
 
-SELECT l2_distance('[0,0]', '[3,4]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -148,7 +148,7 @@ float
 ~~END~~
 
 
-SELECT l2_distance('[0,0]', '[0,1]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 ~~START~~
 float
@@ -156,14 +156,14 @@ float
 ~~END~~
 
 
-SELECT l2_distance('[1,2]', '[3]');
+SELECT l2_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT l2_distance('[3e38]', '[-3e38]');
+SELECT l2_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 ~~START~~
 float
@@ -171,7 +171,7 @@ Infinity
 ~~END~~
 
 
-SELECT inner_product('[1,2]', '[3,4]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -179,14 +179,14 @@ float
 ~~END~~
 
 
-SELECT inner_product('[1,2]', '[3]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT inner_product('[3e38]', '[3e38]');
+SELECT inner_product(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 ~~START~~
 float
@@ -194,7 +194,7 @@ Infinity
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[2,4]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[2,4]' as vector));
 go
 ~~START~~
 float
@@ -202,7 +202,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[0,0]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[0,0]' as vector));
 go
 ~~START~~
 float
@@ -210,7 +210,7 @@ NaN
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[1,1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1,1]' as vector));
 go
 ~~START~~
 float
@@ -218,7 +218,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,0]', '[0,2]');
+SELECT cosine_distance(CAST('[1,0]' as vector), CAST('[0,2]' as vector));
 go
 ~~START~~
 float
@@ -226,7 +226,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[-1,-1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1,-1]' as vector));
 go
 ~~START~~
 float
@@ -234,14 +234,14 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[3]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT cosine_distance('[1,1]', '[1.1,1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1.1,1.1]' as vector));
 go
 ~~START~~
 float
@@ -249,7 +249,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[-1.1,-1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1.1,-1.1]' as vector));
 go
 ~~START~~
 float
@@ -257,7 +257,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[3e38]', '[3e38]');
+SELECT cosine_distance(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 ~~START~~
 float
@@ -265,7 +265,7 @@ NaN
 ~~END~~
 
 
-SELECT l1_distance('[0,0]', '[3,4]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -273,7 +273,7 @@ float
 ~~END~~
 
 
-SELECT l1_distance('[0,0]', '[0,1]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 ~~START~~
 float
@@ -281,14 +281,14 @@ float
 ~~END~~
 
 
-SELECT l1_distance('[1,2]', '[3]');
+SELECT l1_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT l1_distance('[3e38]', '[-3e38]');
+SELECT l1_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 ~~START~~
 float
@@ -1160,49 +1160,49 @@ SELECT CAST('[4e38,1]' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: infinite value not allowed in vector)~~
+~~ERROR (Message: "4e38" is out of range for type vector)~~
 
 
 SELECT CAST('[1,2,3' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,2,3")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,2,3")~~
 
 
 SELECT CAST('[1,2,3]9' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,2,3]9")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,2,3]9")~~
 
 
 SELECT CAST('1,2,3' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "1,2,3")~~
+~~ERROR (Message: invalid input syntax for type vector: "1,2,3")~~
 
 
 SELECT CAST('' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "")~~
+~~ERROR (Message: invalid input syntax for type vector: "")~~
 
 
 SELECT CAST('[' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[")~~
+~~ERROR (Message: invalid input syntax for type vector: "[")~~
 
 
 SELECT CAST('[,' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[,")~~
+~~ERROR (Message: invalid input syntax for type vector: "[,")~~
 
 
 SELECT CAST('[]' as vector);
@@ -1230,7 +1230,7 @@ SELECT CAST('[1,,3]' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,,3]")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,,3]")~~
 
 
 SELECT CAST('[1, ,3]' as vector);

--- a/test/JDBC/expected/parallel_query/TestVectorDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestVectorDatatype.out
@@ -101,7 +101,7 @@ go
 ~~ERROR (Message: value out of range: underflow)~~
 
 
-SELECT vector_dims('[1,2,3]');
+SELECT vector_dims(CAST('[1,2,3]' as vector));
 go
 ~~START~~
 int
@@ -140,7 +140,7 @@ go
 ~~ERROR (Message: syntax error near 'Cast' at line 1 and character position 19)~~
 
 
-SELECT l2_distance('[0,0]', '[3,4]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -148,7 +148,7 @@ float
 ~~END~~
 
 
-SELECT l2_distance('[0,0]', '[0,1]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 ~~START~~
 float
@@ -156,14 +156,14 @@ float
 ~~END~~
 
 
-SELECT l2_distance('[1,2]', '[3]');
+SELECT l2_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT l2_distance('[3e38]', '[-3e38]');
+SELECT l2_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 ~~START~~
 float
@@ -171,7 +171,7 @@ Infinity
 ~~END~~
 
 
-SELECT inner_product('[1,2]', '[3,4]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -179,14 +179,14 @@ float
 ~~END~~
 
 
-SELECT inner_product('[1,2]', '[3]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT inner_product('[3e38]', '[3e38]');
+SELECT inner_product(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 ~~START~~
 float
@@ -194,7 +194,7 @@ Infinity
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[2,4]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[2,4]' as vector));
 go
 ~~START~~
 float
@@ -202,7 +202,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[0,0]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[0,0]' as vector));
 go
 ~~START~~
 float
@@ -210,7 +210,7 @@ NaN
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[1,1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1,1]' as vector));
 go
 ~~START~~
 float
@@ -218,7 +218,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,0]', '[0,2]');
+SELECT cosine_distance(CAST('[1,0]' as vector), CAST('[0,2]' as vector));
 go
 ~~START~~
 float
@@ -226,7 +226,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[-1,-1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1,-1]' as vector));
 go
 ~~START~~
 float
@@ -234,14 +234,14 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,2]', '[3]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT cosine_distance('[1,1]', '[1.1,1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1.1,1.1]' as vector));
 go
 ~~START~~
 float
@@ -249,7 +249,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[1,1]', '[-1.1,-1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1.1,-1.1]' as vector));
 go
 ~~START~~
 float
@@ -257,7 +257,7 @@ float
 ~~END~~
 
 
-SELECT cosine_distance('[3e38]', '[3e38]');
+SELECT cosine_distance(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 ~~START~~
 float
@@ -265,7 +265,7 @@ NaN
 ~~END~~
 
 
-SELECT l1_distance('[0,0]', '[3,4]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 ~~START~~
 float
@@ -273,7 +273,7 @@ float
 ~~END~~
 
 
-SELECT l1_distance('[0,0]', '[0,1]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 ~~START~~
 float
@@ -281,14 +281,14 @@ float
 ~~END~~
 
 
-SELECT l1_distance('[1,2]', '[3]');
+SELECT l1_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: different vector dimensions 2 and 1)~~
 
 
-SELECT l1_distance('[3e38]', '[-3e38]');
+SELECT l1_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 ~~START~~
 float
@@ -1216,49 +1216,49 @@ SELECT CAST('[4e38,1]' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: infinite value not allowed in vector)~~
+~~ERROR (Message: "4e38" is out of range for type vector)~~
 
 
 SELECT CAST('[1,2,3' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,2,3")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,2,3")~~
 
 
 SELECT CAST('[1,2,3]9' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,2,3]9")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,2,3]9")~~
 
 
 SELECT CAST('1,2,3' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "1,2,3")~~
+~~ERROR (Message: invalid input syntax for type vector: "1,2,3")~~
 
 
 SELECT CAST('' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "")~~
+~~ERROR (Message: invalid input syntax for type vector: "")~~
 
 
 SELECT CAST('[' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[")~~
+~~ERROR (Message: invalid input syntax for type vector: "[")~~
 
 
 SELECT CAST('[,' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[,")~~
+~~ERROR (Message: invalid input syntax for type vector: "[,")~~
 
 
 SELECT CAST('[]' as vector);
@@ -1286,7 +1286,7 @@ SELECT CAST('[1,,3]' as vector);
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: malformed vector literal: "[1,,3]")~~
+~~ERROR (Message: invalid input syntax for type vector: "[1,,3]")~~
 
 
 SELECT CAST('[1, ,3]' as vector);

--- a/test/JDBC/input/datatypes/TestVectorDatatype.mix
+++ b/test/JDBC/input/datatypes/TestVectorDatatype.mix
@@ -52,7 +52,7 @@ go
 SELECT CAST('[1e-37]' as vector) * '[1e-37]';
 go
 
-SELECT vector_dims('[1,2,3]');
+SELECT vector_dims(CAST('[1,2,3]' as vector));
 go
 
 SELECT round(cast(vector_norm('[1,1]') as numeric), 5);
@@ -67,64 +67,64 @@ go
 SELECT vector_norm(Cast('[3e37,4e37]') as real);
 go
 
-SELECT l2_distance('[0,0]', '[3,4]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 
-SELECT l2_distance('[0,0]', '[0,1]');
+SELECT l2_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 
-SELECT l2_distance('[1,2]', '[3]');
+SELECT l2_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 
-SELECT l2_distance('[3e38]', '[-3e38]');
+SELECT l2_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 
-SELECT inner_product('[1,2]', '[3,4]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3,4]' as vector));
 go
 
-SELECT inner_product('[1,2]', '[3]');
+SELECT inner_product(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 
-SELECT inner_product('[3e38]', '[3e38]');
+SELECT inner_product(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 
-SELECT cosine_distance('[1,2]', '[2,4]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[2,4]' as vector));
 go
 
-SELECT cosine_distance('[1,2]', '[0,0]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[0,0]' as vector));
 go
 
-SELECT cosine_distance('[1,1]', '[1,1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1,1]' as vector));
 go
 
-SELECT cosine_distance('[1,0]', '[0,2]');
+SELECT cosine_distance(CAST('[1,0]' as vector), CAST('[0,2]' as vector));
 go
 
-SELECT cosine_distance('[1,1]', '[-1,-1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1,-1]' as vector));
 go
 
-SELECT cosine_distance('[1,2]', '[3]');
+SELECT cosine_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 
-SELECT cosine_distance('[1,1]', '[1.1,1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[1.1,1.1]' as vector));
 go
 
-SELECT cosine_distance('[1,1]', '[-1.1,-1.1]');
+SELECT cosine_distance(CAST('[1,1]' as vector), CAST('[-1.1,-1.1]' as vector));
 go
 
-SELECT cosine_distance('[3e38]', '[3e38]');
+SELECT cosine_distance(CAST('[3e38]' as vector), CAST('[3e38]' as vector));
 go
 
-SELECT l1_distance('[0,0]', '[3,4]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[3,4]' as vector));
 go
 
-SELECT l1_distance('[0,0]', '[0,1]');
+SELECT l1_distance(CAST('[0,0]' as vector), CAST('[0,1]' as vector));
 go
 
-SELECT l1_distance('[1,2]', '[3]');
+SELECT l1_distance(CAST('[1,2]' as vector), CAST('[3]' as vector));
 go
 
-SELECT l1_distance('[3e38]', '[-3e38]');
+SELECT l1_distance(CAST('[3e38]' as vector), CAST('[-3e38]' as vector));
 go
 
 SELECT vector_avg(array_agg(n)) FROM generate_series(1, 16002) n;


### PR DESCRIPTION
### Description
In 0.7 version of pgvector, there are now new types added. Although we do not support it entirely with this commit, we fix the changes required to the test files. These changes, change in error messages and adding explicit casts while calling a the SQL utility function, are expected and have been updated in the pgvector extension as well.


### Issues Resolved
BABEL-5058

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).