### PR TITLE
Update 15_8/schedule file to fix test failures

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_explain.c
+++ b/contrib/babelfishpg_tsql/src/pl_explain.c
@@ -21,6 +21,8 @@ int			pltsql_explain_format = EXPLAIN_FORMAT_TEXT;
 
 static ExplainInfo *get_last_explain_info();
 
+instr_time	antlr_parse_time;
+
 bool
 is_explain_analyze_mode()
 {
@@ -157,6 +159,7 @@ append_explain_info(QueryDesc *queryDesc, const char *queryString)
 		{
 			PLtsql_execstate *time_state = get_current_tsql_estate();
 
+			ExplainPropertyFloat("ANTLR Parsing Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(antlr_parse_time), 3, es);
 			ExplainPropertyFloat("Planning Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(time_state->planning_end), 3, es);
 			INSTR_TIME_SET_CURRENT(time_state->execution_end);
 			INSTR_TIME_SUBTRACT(time_state->execution_end, time_state->execution_start);

--- a/contrib/babelfishpg_tsql/src/pl_explain.c
+++ b/contrib/babelfishpg_tsql/src/pl_explain.c
@@ -21,8 +21,6 @@ int			pltsql_explain_format = EXPLAIN_FORMAT_TEXT;
 
 static ExplainInfo *get_last_explain_info();
 
-instr_time	antlr_parse_time;
-
 bool
 is_explain_analyze_mode()
 {
@@ -159,7 +157,6 @@ append_explain_info(QueryDesc *queryDesc, const char *queryString)
 		{
 			PLtsql_execstate *time_state = get_current_tsql_estate();
 
-			ExplainPropertyFloat("ANTLR Parsing Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(antlr_parse_time), 3, es);
 			ExplainPropertyFloat("Planning Time", "ms", 1000.0 * INSTR_TIME_GET_DOUBLE(time_state->planning_end), 3, es);
 			INSTR_TIME_SET_CURRENT(time_state->execution_end);
 			INSTR_TIME_SUBTRACT(time_state->execution_end, time_state->execution_start);

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -90,7 +90,7 @@ BABEL-3402
 BABEL-3474
 BABEL-3478
 BABEL-3486
-BABEL-3513_before_15_8_or_16_4
+BABEL-3513
 BABEL-3556
 BABEL-3588
 BABEL-3614
@@ -245,7 +245,7 @@ msdb-dbo-syspolicy_configuration
 msdb-dbo-syspolicy_system_health_state
 nested_trigger_inside_proc
 nested_trigger_with_dml
-newid_before_15_8_or_16_4
+newid
 objectpropertyex
 openjson
 openquery_upgrd_before_15_4


### PR DESCRIPTION
This commit updates 15_8/schedule to reflect correct test files to run in order to fix test failures.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).