### PR TITLE
Fix crash in sp_describe_undeclared_parameters

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1270,7 +1270,9 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 							if (is_supported_case_sp_describe_undeclared_parameters)
 								fields = columnref->fields;
 
-							if (is_supported_case_sp_describe_undeclared_parameters && !(nodeTag(columnref) != T_ColumnRef && nodeTag(parsetree->stmt) != T_DeleteStmt))
+							if (is_supported_case_sp_describe_undeclared_parameters &&
+								!(nodeTag(columnref) != T_ColumnRef &&
+								nodeTag(parsetree->stmt) != T_DeleteStmt))
 							{
 								foreach(fieldcell, fields)
 								{

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -592,7 +592,7 @@ handle_bool_expr_rec(BoolExpr *expr, List *list, bool is_sp_describe_undeclared_
 	A_Expr	   *xpr;
 	ColumnRef  *ref;
 
-	if (!is_sp_describe_undeclared_parameters)
+	if (is_sp_describe_undeclared_parameters && !is_supported_case_sp_describe_undeclared_parameters)
 		return list;
 
 	foreach(lc, args)
@@ -640,7 +640,7 @@ handle_where_clause_attnums(ParseState *pstate, Node *w_clause, List *target_att
 	char	   *name;
 	int			attrno;
 
-	if (!is_sp_describe_undeclared_parameters)
+	if (is_sp_describe_undeclared_parameters && !is_supported_case_sp_describe_undeclared_parameters)
 		return target_attnums;
 
 	if (w_clause && nodeTag(w_clause) == T_A_Expr)
@@ -741,7 +741,7 @@ handle_where_clause_restargets_left(ParseState *pstate, Node *w_clause, List *ex
 	char	   *name;
 	int			attrno;
 
-	if (!is_sp_describe_undeclared_parameters)
+	if (is_sp_describe_undeclared_parameters && !is_supported_case_sp_describe_undeclared_parameters)
 		return extra_restargets;
 
 	if (w_clause && nodeTag(w_clause) == T_A_Expr)
@@ -857,7 +857,7 @@ handle_where_clause_restargets_right(ParseState *pstate, Node *w_clause, List *e
 	String	   *field;
 	ResTarget  *res;
 
-	if (!is_sp_describe_undeclared_parameters)
+	if (is_sp_describe_undeclared_parameters && !is_supported_case_sp_describe_undeclared_parameters)
 		return extra_restargets;
 
 	if (w_clause && nodeTag(w_clause) == T_A_Expr)

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -592,6 +592,9 @@ handle_bool_expr_rec(BoolExpr *expr, List *list, bool is_sp_describe_undeclared_
 	A_Expr	   *xpr;
 	ColumnRef  *ref;
 
+	if (!is_sp_describe_undeclared_parameters)
+		return list;
+
 	foreach(lc, args)
 	{
 		Expr	   *arg = (Expr *) lfirst(lc);
@@ -636,6 +639,9 @@ handle_where_clause_attnums(ParseState *pstate, Node *w_clause, List *target_att
 	String	   *field;
 	char	   *name;
 	int			attrno;
+
+	if (!is_sp_describe_undeclared_parameters)
+		return target_attnums;
 
 	if (w_clause && nodeTag(w_clause) == T_A_Expr)
 	{
@@ -734,6 +740,9 @@ handle_where_clause_restargets_left(ParseState *pstate, Node *w_clause, List *ex
 	String	   *field;
 	char	   *name;
 	int			attrno;
+
+	if (!is_sp_describe_undeclared_parameters)
+		return extra_restargets;
 
 	if (w_clause && nodeTag(w_clause) == T_A_Expr)
 	{
@@ -847,6 +856,9 @@ handle_where_clause_restargets_right(ParseState *pstate, Node *w_clause, List *e
 	ColumnRef  *ref;
 	String	   *field;
 	ResTarget  *res;
+
+	if (!is_sp_describe_undeclared_parameters)
+		return extra_restargets;
 
 	if (w_clause && nodeTag(w_clause) == T_A_Expr)
 	{
@@ -1202,7 +1214,7 @@ sp_describe_undeclared_parameters_internal(PG_FUNCTION_ARGS)
 						break;
 				}
 
-				if (!(list_length(values_list) > 1) && is_supported_case_sp_describe_undeclared_parameters)
+				if (is_supported_case_sp_describe_undeclared_parameters && !(list_length(values_list) > 1))
 				{
 					foreach(lc, values_list)
 					{


### PR DESCRIPTION
### Description
In our previous attempt of fixing sp_describe_undeclared_parameters related crash, we missed some corner cases where few variables will be left NULL if is_sp_describe_undeclared_parameters is marked as false. Then when we try to access those variables, we get seg fault. 
In this commit, we fix it by adding extra check on is_sp_describe_undeclared_parameters.



### Issues Resolved

BABEL-5068
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).