### PR TITLE
Add tests for crash due to uninitialized rte->relid in temp table with trigger

### DIFF
--- a/test/JDBC/expected/BABEL-5071-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-5071-vu-cleanup.out
@@ -1,0 +1,15 @@
+drop trigger trig5071_1
+go
+
+drop table tab5071_1
+go
+
+DROP TRIGGER tab4992_1deleteOperation
+GO
+
+DROP TABLE tab4992_1
+GO
+
+DROP TABLE tab4992_2
+GO
+

--- a/test/JDBC/expected/BABEL-5071-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-5071-vu-prepare.out
@@ -1,0 +1,35 @@
+create table tab5071_1 (a int)
+go
+
+create trigger trig5071_1 on tab5071_1 for insert as begin
+create table #temp_tst (a int)
+insert #temp_tst select a*-1 from inserted;
+select * from #temp_tst;
+drop table #temp_tst
+end
+go
+
+CREATE TABLE tab4992_1 (c1 int, c2 int)
+GO
+
+CREATE TABLE tab4992_2 (c1 int, c2 int)
+GO
+
+INSERT INTO tab4992_1 VALUES(1, 2)
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TRIGGER tab4992_1deleteOperation on [dbo].[tab4992_1]
+after delete AS
+BEGIN
+            CREATE TABLE #tmp
+            (
+                c1 INT PRIMARY KEY,
+                c2 INT,
+                c3 VARCHAR(64) NOT NULL DEFAULT ''
+            )
+            INSERT INTO #tmp VALUES (1, 2, '')
+            INSERT INTO tab4992_2 SELECT c1,c2 FROM #tmp --> Crash
+END
+GO

--- a/test/JDBC/expected/BABEL-5071-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5071-vu-verify.out
@@ -1,0 +1,31 @@
+
+-- Test case found in 5071
+insert tab5071_1 values (123)
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+-123
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- Test case found in 4992
+DELETE FROM tab4992_1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM tab4992_1
+GO
+~~START~~
+int#!#int
+~~END~~
+

--- a/test/JDBC/input/BABEL-5071-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-5071-vu-cleanup.sql
@@ -1,0 +1,15 @@
+drop trigger trig5071_1
+go
+
+drop table tab5071_1
+go
+
+DROP TRIGGER tab4992_1deleteOperation
+GO
+
+DROP TABLE tab4992_1
+GO
+
+DROP TABLE tab4992_2
+GO
+

--- a/test/JDBC/input/BABEL-5071-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-5071-vu-prepare.sql
@@ -1,0 +1,33 @@
+create table tab5071_1 (a int)
+go
+
+create trigger trig5071_1 on tab5071_1 for insert as begin
+create table #temp_tst (a int)
+insert #temp_tst select a*-1 from inserted;
+select * from #temp_tst;
+drop table #temp_tst
+end
+go
+
+CREATE TABLE tab4992_1 (c1 int, c2 int)
+GO
+
+CREATE TABLE tab4992_2 (c1 int, c2 int)
+GO
+
+INSERT INTO tab4992_1 VALUES(1, 2)
+GO
+
+CREATE TRIGGER tab4992_1deleteOperation on [dbo].[tab4992_1]
+after delete AS
+BEGIN
+            CREATE TABLE #tmp
+            (
+                c1 INT PRIMARY KEY,
+                c2 INT,
+                c3 VARCHAR(64) NOT NULL DEFAULT ''
+            )
+            INSERT INTO #tmp VALUES (1, 2, '')
+            INSERT INTO tab4992_2 SELECT c1,c2 FROM #tmp --> Crash
+END
+GO

--- a/test/JDBC/input/BABEL-5071-vu-verify.sql
+++ b/test/JDBC/input/BABEL-5071-vu-verify.sql
@@ -1,0 +1,12 @@
+-- Test case found in 5071
+
+insert tab5071_1 values (123)
+go
+
+-- Test case found in 4992
+
+DELETE FROM tab4992_1
+GO
+
+SELECT * FROM tab4992_1
+GO

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -516,3 +516,4 @@ babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
 babel_726-before-14_12-or-15_7-or-16_3
+BABEL-5071

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -531,3 +531,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+BABEL-5071

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -515,3 +515,4 @@ Test_alter_db_rename
 Test_sp_renamedb
 Test_sp_rename_database
 BABEL-4869
+BABEL-5071

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -538,3 +538,4 @@ babel_4328_datetimeoffset
 babel_726
 BABEL-3401
 PARTITION
+BABEL-5071


### PR DESCRIPTION
### Description

Fixing a crash in temp tables with trigger. `rte->relid` was uninitialized in `addRangeTableEntryForENR` when dealing with TSQL temp tables, causing an assert to fail. Adding tests for this change.

### Issues Resolved

BABEL-5071
BABEL-4992

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).