### PR TITLE
Make maven invocation in GitHub actions less verbose

### DIFF
--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -79,11 +79,11 @@ runs:
           tar_dir="latest"
         fi
         export inputFilesPath=upgrade/$tar_dir/verification_cleanup/$base_dir
-        mvn test
+        mvn -B -ntp test
         export inputFilesPath=input
         for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" upgrade/$base_dir/schedule); do
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-verify\\n$filename-vu-cleanup/g" upgrade/$base_dir/schedule
         done
         export scheduleFile=upgrade/$base_dir/schedule
-        mvn test
+        mvn -B -ntp test
       shell: bash      

--- a/.github/composite-actions/run-jdbc-tests/action.yml
+++ b/.github/composite-actions/run-jdbc-tests/action.yml
@@ -22,7 +22,7 @@ runs:
           cd test/JDBC/
           if [[ '${{ inputs.migration_mode }}' == 'single-db' ]];then
             export isSingleDbMode=true
-            mvn test
+            mvn -B -ntp test
             unset isSingleDbMode
           else
             mvn -B -ntp test

--- a/.github/composite-actions/run-jdbc-tests/action.yml
+++ b/.github/composite-actions/run-jdbc-tests/action.yml
@@ -25,6 +25,6 @@ runs:
             mvn test
             unset isSingleDbMode
           else
-            mvn test
+            mvn -B -ntp test
           fi
       shell: bash

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -61,7 +61,7 @@ runs:
           export inputFilesPath=upgrade/singledb/verification_cleanup
         fi
 
-        mvn test
+        mvn -B -ntp test
         export inputFilesPath=input
 
         # Skip test BABEL-404 for previous versions while testing dump/restore since it specifies
@@ -74,7 +74,7 @@ runs:
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-verify\\n$filename-vu-cleanup/g" upgrade/$base_dir/schedule
         done
         export scheduleFile=upgrade/$base_dir/schedule
-        mvn test
+        mvn -B -ntp test
       shell: bash
 
     - name: Cleanup babelfish database

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -191,7 +191,7 @@ runs:
         fi
 
         export inputFilesPath=upgrade/$base_dir/preparation
-        mvn test
+        mvn -B -ntp test
 
         # Skip test BABEL-404 for previous versions while testing dump/restore since it specifies
         # contraint column ordering which is expected to fail after fix for BABEL-4888
@@ -211,7 +211,7 @@ runs:
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-prepare/g" upgrade/$base_dir/schedule
         done
         export scheduleFile=upgrade/$base_dir/schedule
-        mvn test
+        mvn -B -ntp test
       shell: bash
 
     - uses: actions/checkout@v2

--- a/.github/workflows/jdbc-tests-db-collation.yml
+++ b/.github/workflows/jdbc-tests-db-collation.yml
@@ -65,7 +65,7 @@ jobs:
           sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "select default_collation from sys.babelfish_sysdatabases where name = 'master';"
           cd test/JDBC/
           export isdbCollationMode=true
-          mvn test
+          mvn -B -ntp test
           unset isdbCollationMode
 
       - name: Start secondary server
@@ -96,7 +96,7 @@ jobs:
           cd test/JDBC/
           export isdbCollationMode=true
           export inputFilesPath=replication
-          mvn test
+          mvn -B -ntp test
           unset isdbCollationMode
 
       - name: Cleanup babelfish database

--- a/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
+++ b/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
@@ -65,7 +65,7 @@ jobs:
           cd test/JDBC/
           # set env variable serverCollationName to current server collation name
           export serverCollationName=${{ env.SERVER_COLLATION_NAME }}
-          mvn test
+          mvn -B -ntp test
           # reset env variable
           unset serverCollationName
 

--- a/.github/workflows/jdbc-tests-with-parallel-query.yml
+++ b/.github/workflows/jdbc-tests-with-parallel-query.yml
@@ -62,7 +62,7 @@ jobs:
           cd test/JDBC/
           # set env variable isParallelQueryMode to true to let jdbc know not to run tests of file parallel_query_jdbc_schedule
           export isParallelQueryMode=true
-          mvn test
+          mvn -B -ntp test
           # reset env variable
           unset isParallelQueryMode
 

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -223,7 +223,7 @@ jobs:
           cd test/JDBC/
           # temporarily ignore test BABEL-2086
           echo 'ignore#!#BABEL-2086' >> jdbc_schedule
-          mvn test
+          mvn -B -ntp test
      
       - name: Upload Postgres log
         if: always() && steps.jdbc.outcome == 'failure'

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -146,7 +146,7 @@ jobs:
           export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           cd test/JDBC/
-          mvn test
+          mvn -B -ntp test
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'


### PR DESCRIPTION
### Description

This change adds the following flags to Maven invocation in GitHub actions JDBC test runs:

 - `-B, --batch-mode`: suppresses `Progress` messages
 - `-ntp,--no-transfer-progress`: suppresses `Downloading` messages

### Issues Resolved

N/A

### Test Scenarios Covered ###

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>