### PR TITLE
Fixed crash happening due to schema does not exist during GRANT operation

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -632,7 +632,7 @@ get_logical_schema_name(const char *physical_schema_name, bool missingOk)
 		if (!missingOk)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("Could find logical schema name for: \"%s\"", physical_schema_name)));
+					 errmsg("Could find logical schema name for: \"%s\" because it does not exist.", physical_schema_name)));
 		return NULL;
 	}
 	datum = heap_getattr(tuple, Anum_namespace_ext_orig_name, dsc, &isnull);
@@ -1081,6 +1081,13 @@ get_authid_user_ext_schema_name(const char *db_name, const char *user)
 
 	table_endscan(scan);
 	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+
+	if (schema_name == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("Could find default schema name for the user: \"%s\"", user)));
+	}
 
 	return schema_name;
 }

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -632,7 +632,7 @@ get_logical_schema_name(const char *physical_schema_name, bool missingOk)
 		if (!missingOk)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("Could find logical schema name for: \"%s\" because it does not exist.", physical_schema_name)));
+					 errmsg("Could find logical schema name for: \"%s\"", physical_schema_name)));
 		return NULL;
 	}
 	datum = heap_getattr(tuple, Anum_namespace_ext_orig_name, dsc, &isnull);
@@ -1081,13 +1081,6 @@ get_authid_user_ext_schema_name(const char *db_name, const char *user)
 
 	table_endscan(scan);
 	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
-
-	if (schema_name == NULL)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("Could find default schema name for the user: \"%s\"", user)));
-	}
 
 	return schema_name;
 }

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3808,7 +3808,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					ListCell   *lc;
 					ListCell	*lc1;
 					if (rv->schemaname != NULL)
-						logical_schema = get_logical_schema_name(rv->schemaname, true);
+						logical_schema = get_logical_schema_name(rv->schemaname, false);
 					else
 						logical_schema = get_authid_user_ext_schema_name(dbname, current_user);
 

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -397,11 +397,11 @@ go
 
 ~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
 
-grant select on schema::non_existing_schema to guest; -- should fail 
+grant select on schema::babel_4344_d1_non_existing_schema to guest; -- should fail 
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "non_existing_schema" does not exist)~~
+~~ERROR (Message: schema "babel_4344_d1_babel_4344_d1_non_existing_schema" does not exist)~~
 
 -- grant statement via a procedure
 create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
@@ -939,7 +939,7 @@ go
 
 -- psql
 -- grant object permission
-grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
+grant select on babel_4344_d1_babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql
@@ -970,7 +970,7 @@ go
 
 -- psql
 -- revoke schema permission
-revoke select on all tables in schema babel_4344_s1 from babel_4344_d1_babel_4344_u1;
+revoke select on all tables in schema babel_4344_d1_babel_4344_s1 from babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql user=babel_4344_l1 password=12345678
@@ -4638,4 +4638,20 @@ go
 ~~START~~
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
 ~~END~~
+
+
+-- tsql
+-- should properly throw an error when schema does not exist
+GRANT SELECT on doesnt_exist.tbl TO public;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_doesnt_exist" does not exist)~~
+
+
+grant execute on xyz.babel_4344_p to public;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_xyz" does not exist)~~
 

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -397,11 +397,11 @@ go
 
 ~~ERROR (Message: An object or column name is missing or empty. For SELECT INTO statements, verify each column has a name. For other statements, look for empty alias names. Aliases defined as "" or [] are not allowed. Change the alias to a valid name.)~~
 
-grant select on schema::babel_4344_d1_non_existing_schema to guest; -- should fail 
+grant select on schema::non_existing_schema to guest; -- should fail 
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "babel_4344_d1_babel_4344_d1_non_existing_schema" does not exist)~~
+~~ERROR (Message: schema "non_existing_schema" does not exist)~~
 
 -- grant statement via a procedure
 create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
@@ -939,7 +939,7 @@ go
 
 -- psql
 -- grant object permission
-grant select on babel_4344_d1_babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
+grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql
@@ -970,7 +970,7 @@ go
 
 -- psql
 -- revoke schema permission
-revoke select on all tables in schema babel_4344_d1_babel_4344_s1 from babel_4344_d1_babel_4344_u1;
+revoke select on all tables in schema babel_4344_s1 from babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql user=babel_4344_l1 password=12345678

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -283,7 +283,7 @@ grant SELECT on schema::"babel_4344_s2" to guest; -- should pass
 go
 grant select on schema::"" to guest; -- should fail 
 go
-grant select on schema::babel_4344_d1_non_existing_schema to guest; -- should fail 
+grant select on schema::non_existing_schema to guest; -- should fail 
 go
 -- grant statement via a procedure
 create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
@@ -566,7 +566,7 @@ go
 
 -- psql
 -- grant object permission
-grant select on babel_4344_d1_babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
+grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql
@@ -588,7 +588,7 @@ go
 
 -- psql
 -- revoke schema permission
-revoke select on all tables in schema babel_4344_d1_babel_4344_s1 from babel_4344_d1_babel_4344_u1;
+revoke select on all tables in schema babel_4344_s1 from babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql user=babel_4344_l1 password=12345678

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -283,7 +283,7 @@ grant SELECT on schema::"babel_4344_s2" to guest; -- should pass
 go
 grant select on schema::"" to guest; -- should fail 
 go
-grant select on schema::non_existing_schema to guest; -- should fail 
+grant select on schema::babel_4344_d1_non_existing_schema to guest; -- should fail 
 go
 -- grant statement via a procedure
 create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
@@ -566,7 +566,7 @@ go
 
 -- psql
 -- grant object permission
-grant select on babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
+grant select on babel_4344_d1_babel_4344_s1.babel_4344_t1_new to babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql
@@ -588,7 +588,7 @@ go
 
 -- psql
 -- revoke schema permission
-revoke select on all tables in schema babel_4344_s1 from babel_4344_d1_babel_4344_u1;
+revoke select on all tables in schema babel_4344_d1_babel_4344_s1 from babel_4344_d1_babel_4344_u1;
 go
 
 -- tsql user=babel_4344_l1 password=12345678
@@ -2333,3 +2333,11 @@ go
 -- should have no entries since the table is dropped
 select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
 go
+
+-- tsql
+-- should properly throw an error when schema does not exist
+GRANT SELECT on doesnt_exist.tbl TO public;
+GO
+
+grant execute on xyz.babel_4344_p to public;
+GO


### PR DESCRIPTION
### Description

Previously, If end user tries to grant select on table using schema qualified name and if schema does not exist then server will crash due to segmentation fault issue. This commit aims to fix that issue by appropriately checking existence of the jira.

Task: BABEL-5078

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).