### PR TITLE
Fixed crash happening due to schema does not exist during GRANT operation

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3764,7 +3764,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					ListCell   *lc;
 					ListCell	*lc1;
 					if (rv->schemaname != NULL)
-						logical_schema = get_logical_schema_name(rv->schemaname, true);
+						logical_schema = get_logical_schema_name(rv->schemaname, false);
 					else
 						logical_schema = get_authid_user_ext_schema_name(dbname, current_user);
 

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -4639,3 +4639,19 @@ go
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"
 ~~END~~
 
+
+-- tsql
+-- should properly throw an error when schema does not exist
+GRANT SELECT on doesnt_exist.tbl TO public;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_doesnt_exist" does not exist)~~
+
+
+grant execute on xyz.babel_4344_p to public;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "master_xyz" does not exist)~~
+

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -2333,3 +2333,11 @@ go
 -- should have no entries since the table is dropped
 select schema_name, object_name, permission, grantee from sys.babelfish_schema_permissions where object_name = 'babel_4344_t1';
 go
+
+-- tsql
+-- should properly throw an error when schema does not exist
+GRANT SELECT on doesnt_exist.tbl TO public;
+GO
+
+grant execute on xyz.babel_4344_p to public;
+GO


### PR DESCRIPTION
Previously, If end user tries to grant select on table using schema qualified name and if schema does not exist then server will crash due to segmentation fault issue. This commit aims to fix that issue by appropriately checking existence of the jira.

Task: BABEL-5078

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).