### PR TITLE
Use BIO_{get,set}_app_data instead of BIO_{get,set}_data (#2394)

### DIFF
--- a/.github/composite-actions/install-and-run-odbc/action.yml
+++ b/.github/composite-actions/install-and-run-odbc/action.yml
@@ -30,7 +30,7 @@ runs:
       if: always() && steps.install-unix-odbc-driver.outcome=='success'
       run: |
         cd ~
-        wget https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-16.00.0000.tar.gz
+        wget https://ftp.postgresql.org/pub/odbc/versions.old/src/psqlodbc-16.00.0000.tar.gz
         tar -zxvf psqlodbc-16.00.0000.tar.gz
         cd psqlodbc-16.00.0000
         ./configure

--- a/.github/template/version-branch-template.yml
+++ b/.github/template/version-branch-template.yml
@@ -38,7 +38,7 @@
   engine_branch: BABEL_2_7_STABLE__PG_14_10
   extension_branch: BABEL_2_7_STABLE
 '14.11':
-  engine_branch: BABEL_2_8_DEV__PG_14_11
+  engine_branch: BABEL_2_8_STABLE__PG_14_11
   extension_branch: BABEL_2_8_STABLE
 '15.2':
   engine_branch: BABEL_3_1_STABLE__PG_15_2
@@ -53,7 +53,7 @@
   engine_branch: BABEL_3_4_STABLE__PG_15_5
   extension_branch: BABEL_3_4_STABLE
 '15.6':
-  engine_branch: BABEL_3_5_DEV__PG_15_6
+  engine_branch: BABEL_3_5_STABLE__PG_15_6
   extension_branch: BABEL_3_5_STABLE
 '16.1':
   engine_branch: BABEL_4_0_STABLE__PG_16_1

--- a/.github/template/version-branch-template.yml
+++ b/.github/template/version-branch-template.yml
@@ -38,8 +38,8 @@
   engine_branch: BABEL_2_7_STABLE__PG_14_10
   extension_branch: BABEL_2_7_STABLE
 '14.11':
-  engine_branch: BABEL_2_X_DEV__PG_14_X
-  extension_branch: BABEL_2_X_DEV
+  engine_branch: BABEL_2_8_DEV__PG_14_11
+  extension_branch: BABEL_2_8_STABLE
 '15.2':
   engine_branch: BABEL_3_1_STABLE__PG_15_2
   extension_branch: BABEL_3_1_STABLE
@@ -53,8 +53,8 @@
   engine_branch: BABEL_3_4_STABLE__PG_15_5
   extension_branch: BABEL_3_4_STABLE
 '15.6':
-  engine_branch: BABEL_3_X_DEV__PG_15_X
-  extension_branch: BABEL_3_X_DEV
+  engine_branch: BABEL_3_5_DEV__PG_15_6
+  extension_branch: BABEL_3_5_STABLE
 '16.1':
   engine_branch: BABEL_4_0_STABLE__PG_16_1
   extension_branch: BABEL_4_0_STABLE

--- a/contrib/babelfishpg_tds/src/backend/tds/tds-secure-openssl.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds-secure-openssl.c
@@ -855,11 +855,6 @@ Tds_be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
  * to retry; do we need to adopt their logic for that?
  */
 
-#ifndef HAVE_BIO_GET_DATA
-#define BIO_get_data(bio) (bio->ptr)
-#define BIO_set_data(bio, data) (bio->ptr = data)
-#endif
-
 static int
 my_sock_read(BIO * h, char *buf, int size)
 {
@@ -867,7 +862,7 @@ my_sock_read(BIO * h, char *buf, int size)
 
 	if (buf != NULL)
 	{
-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
+		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
 		BIO_clear_retry_flags(h);
 		if (res <= 0)
 		{
@@ -887,7 +882,7 @@ my_sock_write(BIO * h, const char *buf, int size)
 {
 	int			res = 0;
 
-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
+	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
 	BIO_clear_retry_flags(h);
 	if (res <= 0)
 	{
@@ -967,7 +962,7 @@ my_SSL_set_fd(Port *port, int fd)
 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
 		goto err;
 	}
-	BIO_set_data(bio, port);
+	BIO_set_app_data(bio, port);
 
 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
 	SSL_set_bio(port->ssl, bio, bio);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -71,7 +71,7 @@ SslRead(BIO * h, char *buf, int size)
 
 	if (buf != NULL)
 	{
-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
+		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
 		BIO_clear_retry_flags(h);
 		if (res <= 0)
 		{
@@ -171,7 +171,7 @@ SslWrite(BIO * h, const char *buf, int size)
 {
 	int			res = 0;
 
-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
+	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
 	BIO_clear_retry_flags(h);
 	if (res <= 0)
 	{

--- a/contrib/babelfishpg_tds/src/include/tds_secure.h
+++ b/contrib/babelfishpg_tds/src/include/tds_secure.h
@@ -31,13 +31,6 @@
 #include "libpq/libpq.h"
 #include "port/pg_bswap.h"
 
-#ifdef USE_SSL
-#ifndef HAVE_BIO_GET_DATA
-#define BIO_get_data(bio) (bio->ptr)
-#define BIO_set_data(bio, data) (bio->ptr = data)
-#endif
-#endif
-
 BIO_METHOD *TdsBioSecureSocket(BIO_METHOD * my_bio_methods);
 
 extern int	tds_ssl_min_protocol_version;


### PR DESCRIPTION
### Description

Compilation of BABEL_4_X_DEV with postgresql_modified_for_babelfish/BABEL_4_X_DEV__PG_16_X, is broken due to changes in community PostgreSQL https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/21b3a29565dff7baa2548fd779a0afe737b42f33 

BIO_[get/set]data() is replaced with BIO[get/set]_app_data()

This commit also updates the 14.11 and 15.6 branches in the version-branch-template.yml file and also updates the ODBC driver URL for ODBC tests. 

Issue resolved : BABEL-4833

Co-authored-by: japinli@hotmail.com
Co-authored-by: Sharu Goel <goelshar@amazon.com>
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).