### PR TITLE
Fix protocol violation error happening due to Const node under append node

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -25,8 +25,10 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
 #include "nodes/pathnodes.h"
 #include "parser/parse_coerce.h"
+#include "parser/parse_type.h"
 #include "parser/parsetree.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
@@ -127,6 +129,7 @@ static TdsColumnMetaData *colMetaData = NULL;
 static List *relMetaDataInfoList = NULL;
 
 static Oid sys_vector_oid = InvalidOid;
+static Oid decimal_oid = InvalidOid;
 
 static void FillTabNameWithNumParts(StringInfo buf, uint8 numParts, TdsRelationMetaDataInfo relMetaDataInfo);
 static void FillTabNameWithoutNumParts(StringInfo buf, uint8 numParts, TdsRelationMetaDataInfo relMetaDataInfo);
@@ -512,6 +515,24 @@ resolve_numeric_typmod_outer_var(Plan *plan, AttrNumber attno)
 	return resolve_numeric_typmod_from_exp(outerplan, (Node *)tle->expr);
 }
 
+/*
+ * is_numeric_datatype - returns bool if given datatype is numeric or decimal.
+ */
+static bool
+is_numeric_datatype(Oid typid)
+{
+	if (typid == NUMERICOID)
+	{
+		return true;
+	}
+	if (!OidIsValid(decimal_oid))
+	{
+		TypeName *typename = makeTypeNameFromNameList(list_make2(makeString("sys"), makeString("decimal")));
+		decimal_oid = LookupTypeNameOid(NULL, typename, false);
+	}
+	return decimal_oid == typid;
+}
+
 /* look for a typmod to return from a numeric expression */
 static int32
 resolve_numeric_typmod_from_exp(Plan *plan, Node *expr)
@@ -525,15 +546,10 @@ resolve_numeric_typmod_from_exp(Plan *plan, Node *expr)
 				Const	   *con = (Const *) expr;
 				Numeric		num;
 
-				/*
-				 * TODO: We used a workaround here, that we will assume typmod
-				 * is 0 if the value we have is not numeric. See walkaround in
-				 * T_FuncExpr part of this function. JIRA: BABEL-1007
-				 */
-				if (con->consttype != NUMERICOID || con->constisnull)
+				if (!is_numeric_datatype(con->consttype) || con->constisnull)
 				{
-					return 0;
-					/* Typmod doesn 't really matter since it' s a const NULL. */
+					/* typmod is undefined */
+					return -1;
 				}
 				else
 				{

--- a/test/JDBC/expected/babel_numeric.out
+++ b/test/JDBC/expected/babel_numeric.out
@@ -121,3 +121,344 @@ numeric
 
 drop table t1;
 go
+
+select cast(1.23 as decimal(18,2))
+union all
+select cast(1.23 as decimal(7,2))
+go
+~~START~~
+numeric
+1.23
+1.23
+~~END~~
+
+
+select cast(NULL as decimal(18,2))
+union all
+select cast(1.23 as decimal(7,2))
+go
+~~START~~
+numeric
+<NULL>
+1.23
+~~END~~
+
+
+select cast(9999999999999999.99 as decimal(18,2))
+union all
+select cast(99999.99 as decimal(7,2))
+go
+~~START~~
+numeric
+9999999999999999.99
+99999.99
+~~END~~
+
+
+create type decimal_18_2 from decimal(18,2);
+go
+
+create type decimal_7_2 from decimal(7,2);
+go
+
+select cast(1.23 as decimal_18_2)
+union all
+select cast(1.23 as decimal_7_2)
+go
+~~START~~
+numeric
+1.23
+1.23
+~~END~~
+
+
+select cast(1.23 as decimal_18_2)
+union all
+select cast(NULL as decimal_7_2)
+go
+~~START~~
+numeric
+1.23
+<NULL>
+~~END~~
+
+
+select cast(9999999999999999.99 as decimal_18_2)
+union all
+select cast(99999.99 as decimal_7_2)
+go
+~~START~~
+numeric
+9999999999999999.99
+99999.99
+~~END~~
+
+
+create table babel_5086_t1 (a decimal(18,2), b decimal(7,2), c decimal_18_2, d decimal_7_2);
+go
+
+insert into babel_5086_t1 values (1.23, 1.23, 1.23, 1.23);
+insert into babel_5086_t1 values (9999999999999999.99, NULL, 9999999999999999.99, NULL);
+insert into babel_5086_t1 values (NULL, 99999.99, NULL, 99999.99);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from 
+(
+    select a as col from babel_5086_t1
+    union all
+    select b as col from babel_5086_t1
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23
+1.23
+99999.99
+9999999999999999.99
+~~END~~
+
+
+select * from 
+(
+    select c as col from babel_5086_t1
+    union all
+    select d as col from babel_5086_t1
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23000000
+1.23000000
+99999.99000000
+9999999999999999.99000000
+~~END~~
+
+
+select * from 
+(
+    select a as col from babel_5086_t1
+    union all
+    select b as col from babel_5086_t1
+    union all
+    select c as col from babel_5086_t1
+    union all
+    select d as col from babel_5086_t1
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+1.23
+1.23
+1.23
+1.23
+99999.99
+99999.99
+9999999999999999.99
+9999999999999999.99
+~~END~~
+
+
+select * from 
+(
+    select a as col from babel_5086_t1
+    union all
+    select c as col from babel_5086_t1
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23
+1.23
+9999999999999999.99
+9999999999999999.99
+~~END~~
+
+
+select * from 
+(
+    select b as col from babel_5086_t1
+    union all
+    select d as col from babel_5086_t1
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23
+1.23
+99999.99
+99999.99
+~~END~~
+
+
+create type numeric_18_2 from numeric(18,2);
+go
+
+create type numeric_7_2 from numeric(7,2);
+go
+
+select cast(1.23 as numeric_18_2)
+union all
+select cast(1.23 as numeric_7_2)
+go
+~~START~~
+numeric
+1.23
+1.23
+~~END~~
+
+
+ select cast(12344.234 as numeric_18_2)
+union all
+select cast(1.23 as numeric_7_2)
+go
+~~START~~
+numeric
+12344.23
+1.23
+~~END~~
+
+
+create table babel_5086_t2 (a numeric(18,2), b numeric(7,2), c numeric_18_2, d numeric_7_2);
+go
+
+insert into babel_5086_t2 values (1.23, 1.23, 1.23, 1.23);
+insert into babel_5086_t2 values (9999999999999999.99, NULL, 9999999999999999.99, NULL);
+insert into babel_5086_t2 values (NULL, 99999.99, NULL, 99999.99);
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+select * from 
+(
+    select a as col from babel_5086_t2 
+    union all
+    select b as col from babel_5086_t2
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23
+1.23
+99999.99
+9999999999999999.99
+~~END~~
+
+
+select * from 
+(
+    select c as col from babel_5086_t2
+    union all
+    select d as col from babel_5086_t2
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23000000
+1.23000000
+99999.99000000
+9999999999999999.99000000
+~~END~~
+
+
+select * from 
+(
+    select a as col from babel_5086_t2
+    union all
+    select b as col from babel_5086_t2
+    union all
+    select c as col from babel_5086_t2
+    union all
+    select d as col from babel_5086_t2
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+<NULL>
+<NULL>
+1.23
+1.23
+1.23
+1.23
+99999.99
+99999.99
+9999999999999999.99
+9999999999999999.99
+~~END~~
+
+
+select * from 
+(
+    select a as col from babel_5086_t2
+    union all
+    select c as col from babel_5086_t2
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23
+1.23
+9999999999999999.99
+9999999999999999.99
+~~END~~
+
+
+
+select * from 
+(
+    select b as col from babel_5086_t2
+    union all
+    select d as col from babel_5086_t2
+) dummy order by col;
+go
+~~START~~
+numeric
+<NULL>
+<NULL>
+1.23
+1.23
+99999.99
+99999.99
+~~END~~
+
+
+drop  table babel_5086_t1;
+go
+
+drop  table babel_5086_t2;
+go
+
+drop type decimal_18_2;
+drop type decimal_7_2;
+drop type numeric_18_2;
+drop type numeric_7_2;
+go

--- a/test/JDBC/expected/babel_numeric.out
+++ b/test/JDBC/expected/babel_numeric.out
@@ -122,9 +122,12 @@ numeric
 drop table t1;
 go
 
-select cast(1.23 as decimal(18,2))
-union all
-select cast(1.23 as decimal(7,2))
+select * from 
+(
+    select cast(1.23 as decimal(18,2)) as col
+    union all
+    select cast(1.23 as decimal(7,2)) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
@@ -133,9 +136,12 @@ numeric
 ~~END~~
 
 
-select cast(NULL as decimal(18,2))
-union all
-select cast(1.23 as decimal(7,2))
+select * from 
+(
+    select cast(NULL as decimal(18,2)) as col
+    union all
+    select cast(1.23 as decimal(7,2)) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
@@ -144,14 +150,17 @@ numeric
 ~~END~~
 
 
-select cast(9999999999999999.99 as decimal(18,2))
-union all
-select cast(99999.99 as decimal(7,2))
+select * from 
+(
+    select cast(9999999999999999.99 as decimal(18,2)) as col
+    union all
+    select cast(99999.99 as decimal(7,2)) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
-9999999999999999.99
 99999.99
+9999999999999999.99
 ~~END~~
 
 
@@ -161,9 +170,12 @@ go
 create type decimal_7_2 from decimal(7,2);
 go
 
-select cast(1.23 as decimal_18_2)
-union all
-select cast(1.23 as decimal_7_2)
+select * from 
+(
+    select cast(1.23 as decimal_18_2) as col
+    union all
+    select cast(1.23 as decimal_7_2) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
@@ -172,25 +184,31 @@ numeric
 ~~END~~
 
 
-select cast(1.23 as decimal_18_2)
-union all
-select cast(NULL as decimal_7_2)
+select * from 
+(
+    select cast(1.23 as decimal_18_2) as col
+    union all
+    select cast(NULL as decimal_7_2) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
-1.23
 <NULL>
+1.23
 ~~END~~
 
 
-select cast(9999999999999999.99 as decimal_18_2)
-union all
-select cast(99999.99 as decimal_7_2)
+select * from 
+(
+    select cast(9999999999999999.99 as decimal_18_2) as col
+    union all
+    select cast(99999.99 as decimal_7_2) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
-9999999999999999.99
 99999.99
+9999999999999999.99
 ~~END~~
 
 
@@ -314,9 +332,12 @@ go
 create type numeric_7_2 from numeric(7,2);
 go
 
-select cast(1.23 as numeric_18_2)
-union all
-select cast(1.23 as numeric_7_2)
+select * from 
+(
+    select cast(1.23 as numeric_18_2) as col
+    union all
+    select cast(1.23 as numeric_7_2) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
@@ -325,14 +346,17 @@ numeric
 ~~END~~
 
 
- select cast(12344.234 as numeric_18_2)
-union all
-select cast(1.23 as numeric_7_2)
+select * from 
+(
+    select cast(12344.234 as numeric_18_2) as col
+    union all
+    select cast(1.23 as numeric_7_2) as col
+) dummy order by col;
 go
 ~~START~~
 numeric
-12344.23
 1.23
+12344.23
 ~~END~~
 
 

--- a/test/JDBC/input/babel_numeric.sql
+++ b/test/JDBC/input/babel_numeric.sql
@@ -62,19 +62,28 @@ go
 drop table t1;
 go
 
-select cast(1.23 as decimal(18,2))
-union all
-select cast(1.23 as decimal(7,2))
+select * from 
+(
+    select cast(1.23 as decimal(18,2)) as col
+    union all
+    select cast(1.23 as decimal(7,2)) as col
+) dummy order by col;
 go
 
-select cast(NULL as decimal(18,2))
-union all
-select cast(1.23 as decimal(7,2))
+select * from 
+(
+    select cast(NULL as decimal(18,2)) as col
+    union all
+    select cast(1.23 as decimal(7,2)) as col
+) dummy order by col;
 go
 
-select cast(9999999999999999.99 as decimal(18,2))
-union all
-select cast(99999.99 as decimal(7,2))
+select * from 
+(
+    select cast(9999999999999999.99 as decimal(18,2)) as col
+    union all
+    select cast(99999.99 as decimal(7,2)) as col
+) dummy order by col;
 go
 
 create type decimal_18_2 from decimal(18,2);
@@ -83,19 +92,28 @@ go
 create type decimal_7_2 from decimal(7,2);
 go
 
-select cast(1.23 as decimal_18_2)
-union all
-select cast(1.23 as decimal_7_2)
+select * from 
+(
+    select cast(1.23 as decimal_18_2) as col
+    union all
+    select cast(1.23 as decimal_7_2) as col
+) dummy order by col;
 go
 
-select cast(1.23 as decimal_18_2)
-union all
-select cast(NULL as decimal_7_2)
+select * from 
+(
+    select cast(1.23 as decimal_18_2) as col
+    union all
+    select cast(NULL as decimal_7_2) as col
+) dummy order by col;
 go
 
-select cast(9999999999999999.99 as decimal_18_2)
-union all
-select cast(99999.99 as decimal_7_2)
+select * from 
+(
+    select cast(9999999999999999.99 as decimal_18_2) as col
+    union all
+    select cast(99999.99 as decimal_7_2) as col
+) dummy order by col;
 go
 
 create table babel_5086_t1 (a decimal(18,2), b decimal(7,2), c decimal_18_2, d decimal_7_2);
@@ -156,14 +174,20 @@ go
 create type numeric_7_2 from numeric(7,2);
 go
 
-select cast(1.23 as numeric_18_2)
-union all
-select cast(1.23 as numeric_7_2)
+select * from 
+(
+    select cast(1.23 as numeric_18_2) as col
+    union all
+    select cast(1.23 as numeric_7_2) as col
+) dummy order by col;
 go
 
- select cast(12344.234 as numeric_18_2)
-union all
-select cast(1.23 as numeric_7_2)
+select * from 
+(
+    select cast(12344.234 as numeric_18_2) as col
+    union all
+    select cast(1.23 as numeric_7_2) as col
+) dummy order by col;
 go
 
 create table babel_5086_t2 (a numeric(18,2), b numeric(7,2), c numeric_18_2, d numeric_7_2);

--- a/test/JDBC/input/babel_numeric.sql
+++ b/test/JDBC/input/babel_numeric.sql
@@ -61,3 +61,172 @@ go
 
 drop table t1;
 go
+
+select cast(1.23 as decimal(18,2))
+union all
+select cast(1.23 as decimal(7,2))
+go
+
+select cast(NULL as decimal(18,2))
+union all
+select cast(1.23 as decimal(7,2))
+go
+
+select cast(9999999999999999.99 as decimal(18,2))
+union all
+select cast(99999.99 as decimal(7,2))
+go
+
+create type decimal_18_2 from decimal(18,2);
+go
+
+create type decimal_7_2 from decimal(7,2);
+go
+
+select cast(1.23 as decimal_18_2)
+union all
+select cast(1.23 as decimal_7_2)
+go
+
+select cast(1.23 as decimal_18_2)
+union all
+select cast(NULL as decimal_7_2)
+go
+
+select cast(9999999999999999.99 as decimal_18_2)
+union all
+select cast(99999.99 as decimal_7_2)
+go
+
+create table babel_5086_t1 (a decimal(18,2), b decimal(7,2), c decimal_18_2, d decimal_7_2);
+go
+
+insert into babel_5086_t1 values (1.23, 1.23, 1.23, 1.23);
+insert into babel_5086_t1 values (9999999999999999.99, NULL, 9999999999999999.99, NULL);
+insert into babel_5086_t1 values (NULL, 99999.99, NULL, 99999.99);
+go
+
+select * from 
+(
+    select a as col from babel_5086_t1
+    union all
+    select b as col from babel_5086_t1
+) dummy order by col;
+go
+
+select * from 
+(
+    select c as col from babel_5086_t1
+    union all
+    select d as col from babel_5086_t1
+) dummy order by col;
+go
+
+select * from 
+(
+    select a as col from babel_5086_t1
+    union all
+    select b as col from babel_5086_t1
+    union all
+    select c as col from babel_5086_t1
+    union all
+    select d as col from babel_5086_t1
+) dummy order by col;
+go
+
+select * from 
+(
+    select a as col from babel_5086_t1
+    union all
+    select c as col from babel_5086_t1
+) dummy order by col;
+go
+
+select * from 
+(
+    select b as col from babel_5086_t1
+    union all
+    select d as col from babel_5086_t1
+) dummy order by col;
+go
+
+create type numeric_18_2 from numeric(18,2);
+go
+
+create type numeric_7_2 from numeric(7,2);
+go
+
+select cast(1.23 as numeric_18_2)
+union all
+select cast(1.23 as numeric_7_2)
+go
+
+ select cast(12344.234 as numeric_18_2)
+union all
+select cast(1.23 as numeric_7_2)
+go
+
+create table babel_5086_t2 (a numeric(18,2), b numeric(7,2), c numeric_18_2, d numeric_7_2);
+go
+
+insert into babel_5086_t2 values (1.23, 1.23, 1.23, 1.23);
+insert into babel_5086_t2 values (9999999999999999.99, NULL, 9999999999999999.99, NULL);
+insert into babel_5086_t2 values (NULL, 99999.99, NULL, 99999.99);
+go
+
+select * from 
+(
+    select a as col from babel_5086_t2 
+    union all
+    select b as col from babel_5086_t2
+) dummy order by col;
+go
+
+select * from 
+(
+    select c as col from babel_5086_t2
+    union all
+    select d as col from babel_5086_t2
+) dummy order by col;
+go
+
+select * from 
+(
+    select a as col from babel_5086_t2
+    union all
+    select b as col from babel_5086_t2
+    union all
+    select c as col from babel_5086_t2
+    union all
+    select d as col from babel_5086_t2
+) dummy order by col;
+go
+
+select * from 
+(
+    select a as col from babel_5086_t2
+    union all
+    select c as col from babel_5086_t2
+) dummy order by col;
+go
+
+
+select * from 
+(
+    select b as col from babel_5086_t2
+    union all
+    select d as col from babel_5086_t2
+) dummy order by col;
+go
+
+drop  table babel_5086_t1;
+go
+
+drop  table babel_5086_t2;
+go
+
+drop type decimal_18_2;
+drop type decimal_7_2;
+drop type numeric_18_2;
+drop type numeric_7_2;
+go


### PR DESCRIPTION
### Description

Previously, certain driver was running into an protocol violation error when Const node in target list appears under Append node. This was happening because resolve_numeric_typmod_from_exp was not implemented to handle Const node properly for decimal data types. This commit fixes that issue by properly handling decimal data type for Const node under Append node.

Task: BABEL-5086
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).