### PR TITLE
Add test files for tsql_openjson_with_get_subjsonb engine crash fix

### DIFF
--- a/test/JDBC/expected/BABEL-3820-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3820-vu-cleanup.out
@@ -1,0 +1,33 @@
+drop procedure openjson_3820_p1
+go
+
+drop procedure openjson_3820_p2
+go
+
+drop procedure openjson_3820_p3
+go
+
+drop procedure openjson_3820_p4
+go
+
+drop procedure openjson_3820_p5
+go
+
+drop procedure openjson_3820_p6
+go
+
+drop procedure openjson_3820_p7
+go
+
+drop procedure openjson_3820_p8
+go
+
+drop procedure openjson_3820_p9
+go
+
+
+drop procedure openjson_3820_p10
+go
+
+drop procedure openjson_3820_p11
+go

--- a/test/JDBC/expected/BABEL-3820-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3820-vu-prepare.out
@@ -1,0 +1,106 @@
+-- Test strict mode where path does not exist
+-- Expect error
+CREATE PROCEDURE openjson_3820_p1
+AS
+BEGIN
+    SELECT * FROM OPENJSON('{}') WITH(field int 'strict$.field')
+END;
+GO
+
+-- Test lax mode where path does not exist
+-- Expect empty result and no error
+CREATE PROCEDURE openjson_3820_p2
+AS
+BEGIN
+    DECLARE @json_p2 NVarChar(max)=N'{"someKey" : "someValue"}';
+    SELECT * from OPENJSON(@json_p2,'$.somePathWhichDoesNotExists') WITH (id VARCHAR(100) '$')
+END;
+GO
+
+-- Test strict mode where path does not exist
+-- Expect an error for no path
+CREATE PROCEDURE openjson_3820_p3
+AS
+BEGIN
+    DECLARE @json_p3 NVarChar(max)=N'{"someKey" : "someValue"}';
+    SELECT * from OPENJSON(@json_p3,'strict $.somePathWhichDoesNotExists') WITH (id VARCHAR(100) '$')
+END;
+GO
+
+-- Test standard OPENJSON call
+-- Expect result
+CREATE PROCEDURE openjson_3820_p4
+AS
+BEGIN
+    DECLARE @json_p4 NVarChar(max)=N'{"obj":{"a":1}}';
+    SELECT * FROM OPENJSON(@json_p4, 'strict $.obj') WITH (a char(20))
+END;
+GO
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+CREATE PROCEDURE openjson_3820_p5
+AS
+BEGIN
+    SELECT * FROM OPENJSON(N'[{"Item": {"Price":2024.9940}}]') WITH(field int 'strict $.field')
+END;
+GO
+
+-- Test lax mode where path does not exist
+-- Expect empty result because path does not exist
+CREATE PROCEDURE openjson_3820_p6
+AS
+BEGIN
+    DECLARE @json_p6 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}';
+    SELECT [key], value FROM OPENJSON(@json_p6,'lax$.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON strict call where path exists
+-- Expect json result
+CREATE PROCEDURE openjson_3820_p7
+AS
+BEGIN
+    DECLARE @json_p7 NVARCHAR(4000) = N'{"path": {"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p7,'strict $.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON strict call where path exists, strict is mixed case, 
+-- and no space between "strict" and the path. Expect json result
+CREATE PROCEDURE openjson_3820_p8
+AS
+BEGIN
+    DECLARE @json_p8 NVARCHAR(4000) = N'{"path": {"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p8,'sTrIct$.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON strict with incorrect path
+-- Expect error
+CREATE PROCEDURE openjson_3820_p9
+AS
+BEGIN
+    DECLARE @json_p9 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p9,'strict $.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON with incorrect path
+-- Expect empty result
+CREATE PROCEDURE openjson_3820_p10
+AS
+BEGIN
+    DECLARE @json_p10 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p10,'$.path.to."sub-object"')
+END;
+GO
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+CREATE PROCEDURE openjson_3820_p11
+AS
+BEGIN
+    SELECT * FROM OPENJSON(N'{}') WITH(field int 'strict $.field')
+END;
+GO

--- a/test/JDBC/expected/BABEL-3820-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3820-vu-verify.out
@@ -1,0 +1,120 @@
+-- Test strict mode where path does not exist
+-- Expect error
+exec openjson_3820_p1
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "field")~~
+
+
+-- Test lax mode where path does not exist
+-- Expect empty result and no error
+exec openjson_3820_p2
+go
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- Test strict mode where path does not exist
+-- Expect an error for no path
+exec openjson_3820_p3
+go
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "somePathWhichDoesNotExists")~~
+
+
+-- Test standard OPENJSON call
+-- Expect result
+exec openjson_3820_p4
+go
+~~START~~
+char
+1                   
+~~END~~
+
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+exec openjson_3820_p5
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "field")~~
+
+
+-- Test lax mode where path does not exist
+-- Expect empty result because path does not exist
+exec openjson_3820_p6
+go
+~~START~~
+nvarchar#!#nvarchar
+~~END~~
+
+
+-- Test OPENJSON strict call where path exists
+-- Expect json result
+exec openjson_3820_p7
+go
+~~START~~
+nvarchar#!#nvarchar
+0#!#en-GB
+1#!#en-UK
+2#!#de-AT
+3#!#es-AR
+4#!#sr-Cyrl
+~~END~~
+
+
+-- Test OPENJSON strict call where path exists, strict is mixed case, 
+-- and no space between "strict" and the path. Expect json result
+exec openjson_3820_p8
+go
+~~START~~
+nvarchar#!#nvarchar
+0#!#en-GB
+1#!#en-UK
+2#!#de-AT
+3#!#es-AR
+4#!#sr-Cyrl
+~~END~~
+
+
+-- Test OPENJSON strict with incorrect path
+-- Expect error
+exec openjson_3820_p9
+go
+~~START~~
+nvarchar#!#nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "path")~~
+
+
+-- Test OPENJSON with incorrect path
+-- Expect empty result
+exec openjson_3820_p10
+go
+~~START~~
+nvarchar#!#nvarchar
+~~END~~
+
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+exec openjson_3820_p11
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: JSON object does not contain key "field")~~
+

--- a/test/JDBC/input/openjson/BABEL-3820-vu-cleanup.sql
+++ b/test/JDBC/input/openjson/BABEL-3820-vu-cleanup.sql
@@ -1,0 +1,33 @@
+drop procedure openjson_3820_p1
+go
+
+drop procedure openjson_3820_p2
+go
+
+drop procedure openjson_3820_p3
+go
+
+drop procedure openjson_3820_p4
+go
+
+drop procedure openjson_3820_p5
+go
+
+drop procedure openjson_3820_p6
+go
+
+drop procedure openjson_3820_p7
+go
+
+drop procedure openjson_3820_p8
+go
+
+drop procedure openjson_3820_p9
+go
+
+
+drop procedure openjson_3820_p10
+go
+
+drop procedure openjson_3820_p11
+go

--- a/test/JDBC/input/openjson/BABEL-3820-vu-prepare.sql
+++ b/test/JDBC/input/openjson/BABEL-3820-vu-prepare.sql
@@ -1,0 +1,106 @@
+-- Test strict mode where path does not exist
+-- Expect error
+CREATE PROCEDURE openjson_3820_p1
+AS
+BEGIN
+    SELECT * FROM OPENJSON('{}') WITH(field int 'strict$.field')
+END;
+GO
+
+-- Test lax mode where path does not exist
+-- Expect empty result and no error
+CREATE PROCEDURE openjson_3820_p2
+AS
+BEGIN
+    DECLARE @json_p2 NVarChar(max)=N'{"someKey" : "someValue"}';
+    SELECT * from OPENJSON(@json_p2,'$.somePathWhichDoesNotExists') WITH (id VARCHAR(100) '$')
+END;
+GO
+
+-- Test strict mode where path does not exist
+-- Expect an error for no path
+CREATE PROCEDURE openjson_3820_p3
+AS
+BEGIN
+    DECLARE @json_p3 NVarChar(max)=N'{"someKey" : "someValue"}';
+    SELECT * from OPENJSON(@json_p3,'strict $.somePathWhichDoesNotExists') WITH (id VARCHAR(100) '$')
+END;
+GO
+
+-- Test standard OPENJSON call
+-- Expect result
+CREATE PROCEDURE openjson_3820_p4
+AS
+BEGIN
+    DECLARE @json_p4 NVarChar(max)=N'{"obj":{"a":1}}';
+    SELECT * FROM OPENJSON(@json_p4, 'strict $.obj') WITH (a char(20))
+END;
+GO
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+CREATE PROCEDURE openjson_3820_p5
+AS
+BEGIN
+    SELECT * FROM OPENJSON(N'[{"Item": {"Price":2024.9940}}]') WITH(field int 'strict $.field')
+END;
+GO
+
+-- Test lax mode where path does not exist
+-- Expect empty result because path does not exist
+CREATE PROCEDURE openjson_3820_p6
+AS
+BEGIN
+    DECLARE @json_p6 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}';
+    SELECT [key], value FROM OPENJSON(@json_p6,'lax$.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON strict call where path exists
+-- Expect json result
+CREATE PROCEDURE openjson_3820_p7
+AS
+BEGIN
+    DECLARE @json_p7 NVARCHAR(4000) = N'{"path": {"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p7,'strict $.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON strict call where path exists, strict is mixed case, 
+-- and no space between "strict" and the path. Expect json result
+CREATE PROCEDURE openjson_3820_p8
+AS
+BEGIN
+    DECLARE @json_p8 NVARCHAR(4000) = N'{"path": {"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p8,'sTrIct$.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON strict with incorrect path
+-- Expect error
+CREATE PROCEDURE openjson_3820_p9
+AS
+BEGIN
+    DECLARE @json_p9 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p9,'strict $.path.to."sub-object"')
+END;
+GO
+
+-- Test OPENJSON with incorrect path
+-- Expect empty result
+CREATE PROCEDURE openjson_3820_p10
+AS
+BEGIN
+    DECLARE @json_p10 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}'; 
+    SELECT [key], value FROM OPENJSON(@json_p10,'$.path.to."sub-object"')
+END;
+GO
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+CREATE PROCEDURE openjson_3820_p11
+AS
+BEGIN
+    SELECT * FROM OPENJSON(N'{}') WITH(field int 'strict $.field')
+END;
+GO

--- a/test/JDBC/input/openjson/BABEL-3820-vu-verify.sql
+++ b/test/JDBC/input/openjson/BABEL-3820-vu-verify.sql
@@ -1,0 +1,54 @@
+-- Test strict mode where path does not exist
+-- Expect error
+exec openjson_3820_p1
+go
+
+-- Test lax mode where path does not exist
+-- Expect empty result and no error
+exec openjson_3820_p2
+go
+
+-- Test strict mode where path does not exist
+-- Expect an error for no path
+exec openjson_3820_p3
+go
+
+-- Test standard OPENJSON call
+-- Expect result
+exec openjson_3820_p4
+go
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+exec openjson_3820_p5
+go
+
+-- Test lax mode where path does not exist
+-- Expect empty result because path does not exist
+exec openjson_3820_p6
+go
+
+-- Test OPENJSON strict call where path exists
+-- Expect json result
+exec openjson_3820_p7
+go
+
+-- Test OPENJSON strict call where path exists, strict is mixed case, 
+-- and no space between "strict" and the path. Expect json result
+exec openjson_3820_p8
+go
+
+-- Test OPENJSON strict with incorrect path
+-- Expect error
+exec openjson_3820_p9
+go
+
+-- Test OPENJSON with incorrect path
+-- Expect empty result
+exec openjson_3820_p10
+go
+
+-- Test strict mode where path does not exist
+-- Expect error in strict mode
+exec openjson_3820_p11
+go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -533,3 +533,4 @@ BABEL-3401
 babel_4328_datetime
 babel_4328_datetime2
 babel_4328_datetimeoffset
+BABEL-3820


### PR DESCRIPTION
### Description
This commit adds test files for the engine fix of the crash in `tsql_openjson_with_get_subjsonb`.

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/406


### Issues Resolved
BABEL-3820

### Test Scenarios Covered ###
* **Use case based -**
```
1> SELECT * FROM OPENJSON('{}') WITH(field int 'strict$.field')
2> go
Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
JSON object does not contain key "field"
```

```
1> DECLARE @json NVarChar(max)=N'{"someKey" : "someValue"}';
2> SELECT * from OPENJSON(@json,'$.somePathWhichDoesNotExists') WITH (id VARCHAR(100) '$')
3> go
id                                                                                                  
----------------------------------------------------------------------------------------------------
NULL         
```

```
1> DECLARE @json_p9 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}'; 
2> SELECT [key], value FROM OPENJSON(@json_p9,'strict $.path.to."sub-object"')
3> go
Msg 33557097, Level 16, State 1, Server BABELFISH, Line 2
JSON object does not contain key "path"
```

```
1> DECLARE @json_p10 NVARCHAR(4000) = N'{"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}'; 
2> SELECT [key], value FROM OPENJSON(@json_p10,'$.path.to."sub-object"')
3> go
key                         value                                                                                                                                                                                                                                                           
---------------------------------------------------------------------------------------------------------------------------
```

```
1> DECLARE @json_p8 NVARCHAR(4000) = N'{"path": {"to":{"sub-object":["en-GB", "en-UK","de-AT","es-AR","sr-Cyrl"]}}}'; 
2> SELECT [key], value FROM OPENJSON(@json_p8,'strict$.path.to."sub-object"')
3> go
nvarchar#!#nvarchar
0#!#en-GB
1#!#en-UK
2#!#de-AT
3#!#es-AR
4#!#sr-Cyrl
```


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).