### PR TITLE
Remove deprecated configuration parameter from README.md

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -224,7 +224,6 @@ Build babelfishpg_unit extension if you want to run/add unit tests (Optional):
     CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE;
     GRANT ALL ON SCHEMA sys to babelfish_user;
     ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';
-    ALTER SYSTEM SET babelfishpg_tds.set_db_session_property = true;
     ALTER DATABASE babelfish_db SET babelfishpg_tsql.migration_mode = 'single-db'|'multi-db';
     SELECT pg_reload_conf();
     CALL SYS.INITIALIZE_BABELFISH('babelfish_user');


### PR DESCRIPTION
### Description

This commit removes depricated configuration parameter babelfishpg_tds.set_db_session_property from build instructions in README

Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).