### PR TITLE
Remove error context handling from string literal hook

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -989,7 +989,7 @@ is_tsql_char_type_with_len(Oid type)
 }
 
 static Node *
-tsql_coerce_string_literal_hook(ParseCallbackState *pcbstate, Oid targetTypeId,
+tsql_coerce_string_literal_hook(Oid targetTypeId,
 								int32 targetTypeMod, int32 baseTypeMod,
 								Const *newcon, char *value,
 								CoercionContext ccontext, CoercionForm cformat,
@@ -1104,8 +1104,6 @@ tsql_coerce_string_literal_hook(ParseCallbackState *pcbstate, Oid targetTypeId,
 														false,
 														false));
 							errFunc = makeFuncExpr(errFuncOid, targetTypeId, args, 0, 0, COERCE_EXPLICIT_CALL);
-
-							cancel_parser_errposition_callback(pcbstate);
 
 							result = (Node *) errFunc;
 

--- a/test/JDBC/expected/babel_726.out
+++ b/test/JDBC/expected/babel_726.out
@@ -638,6 +638,20 @@ x
 ~~END~~
 
 
+-- check that duplicate view with varbinary cast does not cause crash (#2693)
+create view babel_726_v1 as select cast('a' as varbinary)
+go
+
+create view babel_726_v1 as select cast('a' as varbinary)
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "babel_726_v1" already exists)~~
+
+
+drop view babel_726_v1
+go
+
 drop table babel_726_t1
 go
 

--- a/test/JDBC/input/datatypes/babel_726.sql
+++ b/test/JDBC/input/datatypes/babel_726.sql
@@ -290,6 +290,16 @@ go
 select coalesce(CAST('x'AS VARBINARY), CAST('x' AS NVARCHAR(4000)), 'x')
 go
 
+-- check that duplicate view with varbinary cast does not cause crash (#2693)
+create view babel_726_v1 as select cast('a' as varbinary)
+go
+
+create view babel_726_v1 as select cast('a' as varbinary)
+go
+
+drop view babel_726_v1
+go
+
 drop table babel_726_t1
 go
 


### PR DESCRIPTION
### Description

This change removes error context handling call from string literal hook. It seems to be better to have this call in engine so it happens on all code paths. Hook signature is simplified because passing parser state is no longer needed.

### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/407

### Cherry Picked From: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2695

### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/2693

### Sign Off

Author: Alex Kasko [alex@staticlibs.net](mailto:alex@staticlibs.net)
Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).