### PR TITLE
Fix JDBC upgrade file for 15_7

### DIFF
--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -66,6 +66,7 @@ BABEL-3117
 BABEL-3118
 BABEL-3121
 BABEL-3144
+BABEL-3147
 BABEL-3166
 BABEL-3192
 BABEL-3204
@@ -114,6 +115,7 @@ BABEL-3914
 BABEL-3938
 BABEL-3952
 BABEL-3953-datetrunc
+BABEL-404
 BABEL-405
 BABEL-4078
 BABEL-4098
@@ -123,6 +125,7 @@ babel_417
 BABEL-493
 BABEL-4888
 BABEL_539
+BABEL-621
 BABEL-728
 BABEL-733
 BABEL-741
@@ -147,6 +150,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+check_for_inconsistent_metadata
 babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
@@ -244,6 +248,7 @@ msdb-dbo-syspolicy_configuration
 msdb-dbo-syspolicy_system_health_state
 nested_trigger_inside_proc
 nested_trigger_with_dml
+newid
 objectpropertyex
 openjson
 openquery_upgrd_before_15_4
@@ -266,6 +271,7 @@ sys_all_objects-dep
 sys-all_parameters
 sys-all_parameters-dep
 sys-all_sql_modules
+sys-all_sql_modules-dep
 sys-all_views
 sys-assemblies
 sys-assembly_modules
@@ -362,6 +368,7 @@ sys-sp_statistics-dep
 sys-sp_tables_view
 sys-sp_tables_view-dep
 sys-sql_modules
+sys-sql_modules-dep
 sys-stats
 sys-suser_sid
 sys-suser_sname
@@ -445,6 +452,7 @@ TestTableType
 TestText
 TestTime
 TestTinyInt
+TestUDD
 TestUniqueIdentifier
 Test_user_from_win_login
 TestVarChar
@@ -495,6 +503,7 @@ pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
 TestDatatypeAggSort
+babel_index_nulls_order
 BABEL-2999
 BABEL-4606
 BABEL-4672
@@ -506,6 +515,23 @@ BABEL-730
 babel-4475
 babel-3254
 babel-4517
+alter-procedure
+babel_table_type
+1_GRANT_SCHEMA
+BABEL-4707
 BABEL_4817
+BABEL-4641
+BABEL-4863
+babel_test_int4_numeric_oper
+babel_test_int8_numeric_oper
+babel_test_int2_numeric_oper
+login_token-dep
+test_like_for_AI
+babel_726
 BABEL-4869
 BABEL-4815
+BABEL-3401
+babel_4328_datetime
+babel_4328_datetime2
+babel_4328_datetimeoffset
+BABEL-3820

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -248,7 +248,7 @@ msdb-dbo-syspolicy_configuration
 msdb-dbo-syspolicy_system_health_state
 nested_trigger_inside_proc
 nested_trigger_with_dml
-newid
+newid_before_15_8_or_16_4
 objectpropertyex
 openjson
 openquery_upgrd_before_15_4


### PR DESCRIPTION
### Description

When BABEL_3_X_DEV was originally cut for 15.8 development, the upgrade schedule file for 15.7 was mistakenly copied from 15.6 instead of using the (at the time) latest schedule file. This commit updates the 15.7 schedule file to match the previous latest schedule file.

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).