### PR TITLE
Fix permission leak in sys.database_principals (#2672)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -435,6 +435,8 @@ ON Base.rolname = Ext.rolname
 LEFT OUTER JOIN pg_catalog.pg_roles Base2
 ON Ext.login_name = Base2.rolname
 WHERE Ext.database_name = DB_NAME()
+  AND (Ext.orig_username IN ('dbo', 'db_owner', 'guest') -- system users should always be visible
+  OR pg_has_role(Ext.rolname, 'MEMBER')) -- Current user should be able to see users it has permission of
 UNION ALL
 SELECT
 CAST(name AS SYS.SYSNAME) AS name,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
@@ -231,6 +231,62 @@ WHERE
   ps.dbid = sys.db_id();
 GRANT SELECT ON sys.partition_schemes TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.database_principals AS
+SELECT
+CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
+CAST(Base.oid AS INT) AS principal_id,
+CAST(Ext.type AS CHAR(1)) as type,
+CAST(
+  CASE
+    WHEN Ext.type = 'S' THEN 'SQL_USER'
+    WHEN Ext.type = 'R' THEN 'DATABASE_ROLE'
+    WHEN Ext.type = 'U' THEN 'WINDOWS_USER'
+    ELSE NULL
+  END
+  AS SYS.NVARCHAR(60)) AS type_desc,
+CAST(Ext.default_schema_name AS SYS.SYSNAME) AS default_schema_name,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(Ext.owning_principal_id AS INT) AS owning_principal_id,
+CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(Ext.is_fixed_role AS SYS.BIT) AS is_fixed_role,
+CAST(Ext.authentication_type AS INT) AS authentication_type,
+CAST(Ext.authentication_type_desc AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(Ext.default_language_lcid AS INT) AS default_language_lcid,
+CAST(Ext.allow_encrypted_value_modifications AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
+ON Base.rolname = Ext.rolname
+LEFT OUTER JOIN pg_catalog.pg_roles Base2
+ON Ext.login_name = Base2.rolname
+WHERE Ext.database_name = DB_NAME()
+  AND (Ext.orig_username IN ('dbo', 'db_owner', 'guest') -- system users should always be visible
+  OR pg_has_role(Ext.rolname, 'MEMBER')) -- Current user should be able to see users it has permission of
+UNION ALL
+SELECT
+CAST(name AS SYS.SYSNAME) AS name,
+CAST(-1 AS INT) AS principal_id,
+CAST(type AS CHAR(1)) as type,
+CAST(
+  CASE
+    WHEN type = 'S' THEN 'SQL_USER'
+    WHEN type = 'R' THEN 'DATABASE_ROLE'
+    WHEN type = 'U' THEN 'WINDOWS_USER'
+    ELSE NULL
+  END
+  AS SYS.NVARCHAR(60)) AS type_desc,
+CAST(NULL AS SYS.SYSNAME) AS default_schema_name,
+CAST(NULL AS SYS.DATETIME) AS create_date,
+CAST(NULL AS SYS.DATETIME) AS modify_date,
+CAST(-1 AS INT) AS owning_principal_id,
+CAST(CAST(0 AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(0 AS SYS.BIT) AS is_fixed_role,
+CAST(-1 AS INT) AS authentication_type,
+CAST(NULL AS SYS.NVARCHAR(60)) AS authentication_type_desc,
+CAST(NULL AS SYS.SYSNAME) AS default_language_name,
+CAST(-1 AS INT) AS default_language_lcid,
+CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
+FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
 
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.

--- a/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
+++ b/test/JDBC/expected/BABEL-LOGIN-USER-EXT.out
@@ -1399,3 +1399,148 @@ void
 
 ~~END~~
 
+
+-- tsql
+CREATE DATABASE babel_4935_db
+GO
+
+USE babel_4935_db
+GO
+
+-- Login that is member sysadmin
+CREATE LOGIN babel_4935_sysadmin WITH PASSWORD = '123'
+GO
+
+ALTER ROLE sysadmin ADD MEMBER babel_4935_sysadmin
+GO
+
+-- Logins that are not a member of sysadmin but have users associated
+CREATE LOGIN babel_4935_no_sysadmin1 WITH PASSWORD = '123'
+CREATE LOGIN babel_4935_no_sysadmin2 WITH PASSWORD = '123'
+GO
+
+CREATE USER babel_4935_no_sysadmin1
+CREATE USER babel_4935_no_sysadmin2
+GO
+
+-- Login that is not a member of sysadmin and has no user associated
+CREATE LOGIN babel_4935_guest WITH PASSWORD = '123'
+GO
+
+GRANT CONNECT TO guest
+GO
+
+-- jdbc_user is superuser so should see all the users
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+~~START~~
+varchar
+babel_4935_no_sysadmin1
+babel_4935_no_sysadmin2
+db_owner
+dbo
+guest
+INFORMATION_SCHEMA
+public
+sys
+~~END~~
+
+
+-- tsql user=babel_4935_sysadmin password=123 database=babel_4935_db
+-- login is member of sysadmin so should see all the users
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+~~START~~
+varchar
+babel_4935_no_sysadmin1
+babel_4935_no_sysadmin2
+db_owner
+dbo
+guest
+INFORMATION_SCHEMA
+public
+sys
+~~END~~
+
+
+-- tsql user=babel_4935_no_sysadmin1 password=123 database=babel_4935_db
+-- login is not member of sysadmin so should see all the system users and only it's own user
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+~~START~~
+varchar
+babel_4935_no_sysadmin1
+db_owner
+dbo
+guest
+INFORMATION_SCHEMA
+public
+sys
+~~END~~
+
+
+-- tsql user=babel_4935_guest password=123 database=babel_4935_db
+-- login is not member of sysadmin and no user associated so should only see system users
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+~~START~~
+varchar
+db_owner
+dbo
+guest
+INFORMATION_SCHEMA
+public
+sys
+~~END~~
+
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4935_sysadmin' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4935_no_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4935_guest' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE master
+GO
+
+DROP DATABASE babel_4935_db
+GO
+
+DROP LOGIN babel_4935_sysadmin
+DROP LOGIN babel_4935_no_sysadmin1
+DROP LOGIN babel_4935_no_sysadmin2
+DROP LOGIN babel_4935_guest
+GO

--- a/test/JDBC/input/BABEL-LOGIN-USER-EXT.mix
+++ b/test/JDBC/input/BABEL-LOGIN-USER-EXT.mix
@@ -715,3 +715,83 @@ GO
 
 SELECT pg_sleep(1);
 GO
+
+-- tsql
+CREATE DATABASE babel_4935_db
+GO
+
+USE babel_4935_db
+GO
+
+-- Login that is member sysadmin
+CREATE LOGIN babel_4935_sysadmin WITH PASSWORD = '123'
+GO
+
+ALTER ROLE sysadmin ADD MEMBER babel_4935_sysadmin
+GO
+
+-- Logins that are not a member of sysadmin but have users associated
+CREATE LOGIN babel_4935_no_sysadmin1 WITH PASSWORD = '123'
+CREATE LOGIN babel_4935_no_sysadmin2 WITH PASSWORD = '123'
+GO
+
+CREATE USER babel_4935_no_sysadmin1
+CREATE USER babel_4935_no_sysadmin2
+GO
+
+-- Login that is not a member of sysadmin and has no user associated
+CREATE LOGIN babel_4935_guest WITH PASSWORD = '123'
+GO
+
+GRANT CONNECT TO guest
+GO
+
+-- jdbc_user is superuser so should see all the users
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+
+-- tsql user=babel_4935_sysadmin password=123 database=babel_4935_db
+-- login is member of sysadmin so should see all the users
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+
+-- tsql user=babel_4935_no_sysadmin1 password=123 database=babel_4935_db
+-- login is not member of sysadmin so should see all the system users and only it's own user
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+
+-- tsql user=babel_4935_guest password=123 database=babel_4935_db
+-- login is not member of sysadmin and no user associated so should only see system users
+SELECT name FROM sys.database_principals ORDER BY name
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4935_sysadmin' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4935_no_sysadmin1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_4935_guest' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+USE master
+GO
+
+DROP DATABASE babel_4935_db
+GO
+
+DROP LOGIN babel_4935_sysadmin
+DROP LOGIN babel_4935_no_sysadmin1
+DROP LOGIN babel_4935_no_sysadmin2
+DROP LOGIN babel_4935_guest
+GO


### PR DESCRIPTION
### Description

Currently, sys.database_principals T-SQL view shows all the T-SQL users irrespective of the current user. The expectation is that current user should only be able to see the system users and users it has permission of.

This commit fixes the sys.database_principals view to align with the expected T-SQL behaviour.

Task: BABEL-4935
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** Already present


* **Major version upgrade tests -** Already present

* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).