### PR TITLE
Block cross-db 'SELECT ... INTO table FROM ...' statement

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1787,6 +1787,22 @@ public:
 		if (is_schema_specified)
 			stmt->is_schema_specified = true;
 
+		if (is_cross_db)
+		{
+			if (ctx->select_statement_standalone() &&
+				ctx->select_statement_standalone()->select_statement() &&
+				ctx->select_statement_standalone()->select_statement()->query_expression() &&
+				ctx->select_statement_standalone()->select_statement()->query_expression()->query_specification() &&
+				ctx->select_statement_standalone()->select_statement()->query_expression()->query_specification()->INTO() &&
+				ctx->select_statement_standalone()->select_statement()->query_expression()->query_specification()->table_name())
+			{
+				throw PGErrorWrapperException(ERROR,
+						ERRCODE_FEATURE_NOT_SUPPORTED,
+						"cross-db 'SELECT INTO' statement is not supported in Babelfish",
+						getLineAndPos(ctx->select_statement_standalone()));
+			}
+		}
+
 		if (is_compiling_create_function())
 		{
 			/* select without destination should be blocked. We can use already information about desitnation, which is already processed. */

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1798,7 +1798,7 @@ public:
 			{
 				throw PGErrorWrapperException(ERROR,
 						ERRCODE_FEATURE_NOT_SUPPORTED,
-						"cross-db 'SELECT INTO' statement is not supported in Babelfish",
+						"cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.",
 						getLineAndPos(ctx->select_statement_standalone()));
 			}
 		}

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -652,6 +652,27 @@ GO
 ~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
 
 
+SELECT * INTO master..t222 FROM db_4934_2..t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO db_4934_1..t222 FROM db_4934_2..t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO master..t222 FROM master..t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
 -- #4934.2 Following statements will succeed across same database
 SELECT * INTO t3 FROM db_4934_1.dbo.t1;
 GO

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -583,35 +583,35 @@ SELECT * INTO t222 FROM master.dbo.t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM master..t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM db_4934_2..t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM db_4934_2.dbo.t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM db_4934_2..t1, t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM t1, db_4934_1..t2;
@@ -621,56 +621,56 @@ SELECT * INTO t222 FROM master..t1, db_4934_2..t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM (SELECT * FROM master..t1);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM (SELECT * FROM t1, master..t1);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM master..t1) FROM t1);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM t1) FROM master..t3);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO master..t222 FROM db_4934_2..t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO db_4934_1..t222 FROM db_4934_2..t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 SELECT * INTO master..t222 FROM master..t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 -- #4934.2 Following statements will succeed across same database
@@ -728,7 +728,7 @@ SELECT * INTO tempdb..#t3 FROM db_4934_1.dbo.t1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish. As a workaround, consider running CREATE TABLE and INSERT-SELECT statements.)~~
 
 
 

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -541,6 +541,188 @@ GO
 DROP DATABASE db2;
 GO
 
+-- BABEL-4934 Test blocking cross-db SELECT-INTO statement
+CREATE DATABASE db_4934_1;
+GO
+
+CREATE DATABASE db_4934_2;
+GO
+
+USE master;
+GO
+
+CREATE TABLE t1(a int);
+GO
+
+CREATE TABLE t2(b int);
+GO
+
+USE db_4934_1;
+GO
+
+CREATE TABLE t1(a int);
+GO
+
+CREATE TABLE t2(b int);
+GO
+
+USE db_4934_2;
+GO
+
+CREATE TABLE t1(a int);
+GO
+
+CREATE TABLE t2(b int);
+GO
+
+USE db_4934_1;
+GO
+
+-- #4934.1 It should be blocked
+SELECT * INTO t222 FROM master.dbo.t1; 
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM master..t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM db_4934_2..t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM db_4934_2.dbo.t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM db_4934_2..t1, t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM t1, db_4934_1..t2;
+GO
+
+SELECT * INTO t222 FROM master..t1, db_4934_2..t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM (SELECT * FROM master..t1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM (SELECT * FROM t1, master..t1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM master..t1) FROM t1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM t1) FROM master..t3);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+-- #4934.2 Following statements will succeed across same database
+SELECT * INTO t3 FROM db_4934_1.dbo.t1;
+GO
+
+SELECT * INTO t4 FROM dbo.t1;
+GO
+
+SELECT * INTO t5 FROM db_4934_1..t1;
+GO
+
+SELECT * INTO t6 FROM db_4934_1..t1, db_4934_1..t2;
+GO
+
+SELECT * INTO t7 FROM (SELECT * FROM db_4934_1..t1);
+GO
+
+SELECT * INTO t8 FROM (SELECT *, (SELECT * FROM db_4934_1..t2) FROM db_4934_1..t1);
+GO
+
+-- validate the access
+SELECT * FROM t3, t4, t5, t6, t7, t8;
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+DROP TABLE t3, t4, t5, t6, t7, t8;
+GO
+
+-- #4934.3 Temporary table should not be blocked
+SELECT * INTO #t1 FROM db_4934_1.dbo.t1;
+GO
+
+SELECT * INTO #t2 FROM (SELECT * FROM db_4934_1.dbo.t1);
+GO
+
+-- validate the access
+SELECT * FROM #t1, #t2;
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+DROP TABLE #t1, #t2;
+GO
+
+-- Even though this is same as above statement, this will still fail since
+-- internally it considers as cross-db statement (This behaviour is general to
+-- all of the applicable DMLs)
+SELECT * INTO tempdb..#t3 FROM db_4934_1.dbo.t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cross-db 'SELECT INTO' statement is not supported in Babelfish)~~
+
+
+
+USE master;
+GO
+
+DROP TABLE t1, t2;
+GO
+
+DROP DATABASE db_4934_1;
+GO
+
+DROP DATABASE db_4934_2;
+GO
+
 -- psql
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
 SELECT pg_reload_conf();

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -359,6 +359,136 @@ GO
 DROP DATABASE db2;
 GO
 
+-- BABEL-4934 Test blocking cross-db SELECT-INTO statement
+CREATE DATABASE db_4934_1;
+GO
+
+CREATE DATABASE db_4934_2;
+GO
+
+USE master;
+GO
+
+CREATE TABLE t1(a int);
+GO
+
+CREATE TABLE t2(b int);
+GO
+
+USE db_4934_1;
+GO
+
+CREATE TABLE t1(a int);
+GO
+
+CREATE TABLE t2(b int);
+GO
+
+USE db_4934_2;
+GO
+
+CREATE TABLE t1(a int);
+GO
+
+CREATE TABLE t2(b int);
+GO
+
+USE db_4934_1;
+GO
+
+-- #4934.1 It should be blocked
+SELECT * INTO t222 FROM master.dbo.t1; 
+GO
+
+SELECT * INTO t222 FROM master..t1;
+GO
+
+SELECT * INTO t222 FROM db_4934_2..t1;
+GO
+
+SELECT * INTO t222 FROM db_4934_2.dbo.t1;
+GO
+
+SELECT * INTO t222 FROM db_4934_2..t1, t1;
+GO
+
+SELECT * INTO t222 FROM t1, db_4934_1..t2;
+GO
+
+SELECT * INTO t222 FROM master..t1, db_4934_2..t1;
+GO
+
+SELECT * INTO t222 FROM (SELECT * FROM master..t1);
+GO
+
+SELECT * INTO t222 FROM (SELECT * FROM t1, master..t1);
+GO
+
+SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM master..t1) FROM t1);
+GO
+
+SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM t1) FROM master..t3);
+GO
+
+-- #4934.2 Following statements will succeed across same database
+SELECT * INTO t3 FROM db_4934_1.dbo.t1;
+GO
+
+SELECT * INTO t4 FROM dbo.t1;
+GO
+
+SELECT * INTO t5 FROM db_4934_1..t1;
+GO
+
+SELECT * INTO t6 FROM db_4934_1..t1, db_4934_1..t2;
+GO
+
+SELECT * INTO t7 FROM (SELECT * FROM db_4934_1..t1);
+GO
+
+SELECT * INTO t8 FROM (SELECT *, (SELECT * FROM db_4934_1..t2) FROM db_4934_1..t1);
+GO
+
+-- validate the access
+SELECT * FROM t3, t4, t5, t6, t7, t8;
+GO
+
+DROP TABLE t3, t4, t5, t6, t7, t8;
+GO
+
+-- #4934.3 Temporary table should not be blocked
+SELECT * INTO #t1 FROM db_4934_1.dbo.t1;
+GO
+
+SELECT * INTO #t2 FROM (SELECT * FROM db_4934_1.dbo.t1);
+GO
+
+-- validate the access
+SELECT * FROM #t1, #t2;
+GO
+
+DROP TABLE #t1, #t2;
+GO
+
+-- Even though this is same as above statement, this will still fail since
+-- internally it considers as cross-db statement (This behaviour is general to
+-- all of the applicable DMLs)
+SELECT * INTO tempdb..#t3 FROM db_4934_1.dbo.t1;
+GO
+
+
+USE master;
+GO
+
+DROP TABLE t1, t2;
+GO
+
+DROP DATABASE db_4934_1;
+GO
+
+DROP DATABASE db_4934_2;
+GO
+
 -- psql
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
 SELECT pg_reload_conf();

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -430,6 +430,15 @@ GO
 SELECT * INTO t222 FROM (SELECT *, (SELECT * FROM t1) FROM master..t3);
 GO
 
+SELECT * INTO master..t222 FROM db_4934_2..t1;
+GO
+
+SELECT * INTO db_4934_1..t222 FROM db_4934_2..t1;
+GO
+
+SELECT * INTO master..t222 FROM master..t1;
+GO
+
 -- #4934.2 Following statements will succeed across same database
 SELECT * INTO t3 FROM db_4934_1.dbo.t1;
 GO


### PR DESCRIPTION
### Description

Before this commit, Cross-db 'SELECT ... INTO table FROM ...' was allowed to be executed unintentionally since it was missed to be blocked when cross-db DMLs got supported. Due to this unblocked behaviour, It creates a table whose owner is current session's login since internally cross-db statement execution sets current role to current session's login.

This commit blocks cross-db 'SELECT ... INTO table FROM ...' statement by adding relevant check on ANTLR parser.

Task: BABEL-4934
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Issues Resolved
BABEL-4934

### Test Scenarios Covered ###
* **Use case based -**
SELECT INTO query with table within same-db/cross-db
SELECT INTO temp table query

* **Boundary conditions -**
NA

* **Arbitrary inputs -**
NA

* **Negative test cases -**
SELECT INTO query with table within same-db

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).