### PR TITLE
[OSS-ONLY] Add support for windows roles in T-SQL IS_MEMBER() (#2583)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -499,6 +499,7 @@ CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
 CAST(Ext.orig_username AS SYS.NVARCHAR(128)) AS NAME,
 CAST(CASE
 WHEN Ext.type = 'U' THEN 'WINDOWS LOGIN'
+WHEN Ext.type = 'R' THEN 'ROLE'
 ELSE 'SQL USER' END
 AS SYS.NVARCHAR(128)) AS TYPE,
 CAST('GRANT OR DENY' as SYS.NVARCHAR(128)) as USAGE
@@ -507,8 +508,8 @@ ON Base.rolname = Ext.rolname
 LEFT OUTER JOIN pg_catalog.pg_roles Base2
 ON Ext.login_name = Base2.rolname
 WHERE Ext.database_name = sys.DB_NAME()
-AND Ext.rolname = CURRENT_USER
-AND Ext.type in ('S','U')
+AND ((Ext.rolname = CURRENT_USER AND Ext.type in ('S','U')) OR
+((SELECT orig_username FROM sys.babelfish_authid_user_ext WHERE rolname = CURRENT_USER) != 'dbo' AND Ext.type = 'R' AND pg_has_role(current_user, Ext.rolname, 'MEMBER')))
 UNION ALL
 SELECT
 CAST(-1 AS INT) AS principal_id,

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -3423,9 +3423,35 @@ LANGUAGE C STABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION sys.is_member(IN role sys.SYSNAME)
 RETURNS INT AS
 $$
-	SELECT sys.is_rolemember_internal(role, NULL);
+DECLARE
+    is_windows_grp boolean := (CHARINDEX('\', role) != 0);
+BEGIN
+    -- Always return 1 for 'public'
+    IF (role = 'public')
+    THEN RETURN 1;
+    END IF;
+
+    IF EXISTS (SELECT orig_loginname FROM sys.babelfish_authid_login_ext WHERE orig_loginname = role AND type != 'S') -- do not consider sql logins
+    THEN
+        IF ((EXISTS (SELECT name FROM sys.login_token WHERE name = role AND type IN ('SERVER ROLE', 'SQL LOGIN'))) OR is_windows_grp) -- do not consider sql logins, server roles
+        THEN RETURN NULL; -- Also return NULL if session is not a windows auth session but argument is a windows group
+        ELSIF EXISTS (SELECT name FROM sys.login_token WHERE name = role AND type NOT IN ('SERVER ROLE', 'SQL LOGIN'))
+        THEN RETURN 1; -- Return 1 if current session user is a member of role or windows group
+        ELSE RETURN 0; -- Return 0 if current session user is not a member of role or windows group
+        END IF;
+    ELSIF EXISTS (SELECT orig_username FROM sys.babelfish_authid_user_ext WHERE orig_username = role)
+    THEN
+        IF EXISTS (SELECT name FROM sys.user_token WHERE name = role)
+        THEN RETURN 1; -- Return 1 if current session user is a member of role or windows group
+        ELSIF (is_windows_grp)
+        THEN RETURN NULL; -- Return NULL if session is not a windows auth session but argument is a windows group
+        ELSE RETURN 0; -- Return 0 if current session user is not a member of role or windows group
+        END IF;
+    ELSE RETURN NULL; -- Return NULL if role/group does not exist
+    END IF;
+END;
 $$
-LANGUAGE SQL STRICT STABLE PARALLEL SAFE;
+LANGUAGE plpgsql STRICT STABLE;
 
 CREATE OR REPLACE FUNCTION sys.is_rolemember(IN role sys.SYSNAME)
 RETURNS INT AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
@@ -288,6 +288,67 @@ CAST(-1 AS INT) AS default_language_lcid,
 CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
 FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
 
+CREATE OR REPLACE VIEW sys.user_token AS
+SELECT
+CAST(Base.oid AS INT) AS principal_id,
+CAST(CAST(Base2.oid AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST(Ext.orig_username AS SYS.NVARCHAR(128)) AS NAME,
+CAST(CASE
+WHEN Ext.type = 'U' THEN 'WINDOWS LOGIN'
+WHEN Ext.type = 'R' THEN 'ROLE'
+ELSE 'SQL USER' END
+AS SYS.NVARCHAR(128)) AS TYPE,
+CAST('GRANT OR DENY' as SYS.NVARCHAR(128)) as USAGE
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_user_ext AS Ext
+ON Base.rolname = Ext.rolname
+LEFT OUTER JOIN pg_catalog.pg_roles Base2
+ON Ext.login_name = Base2.rolname
+WHERE Ext.database_name = sys.DB_NAME()
+AND ((Ext.rolname = CURRENT_USER AND Ext.type in ('S','U')) OR
+((SELECT orig_username FROM sys.babelfish_authid_user_ext WHERE rolname = CURRENT_USER) != 'dbo' AND Ext.type = 'R' AND pg_has_role(current_user, Ext.rolname, 'MEMBER')))
+UNION ALL
+SELECT
+CAST(-1 AS INT) AS principal_id,
+CAST(CAST(-1 AS INT) AS SYS.VARBINARY(85)) AS SID,
+CAST('public' AS SYS.NVARCHAR(128)) AS NAME,
+CAST('ROLE' AS SYS.NVARCHAR(128)) AS TYPE,
+CAST('GRANT OR DENY' as SYS.NVARCHAR(128)) as USAGE
+WHERE (SELECT orig_username FROM sys.babelfish_authid_user_ext WHERE rolname = CURRENT_USER) != 'dbo';
+
+GRANT SELECT ON sys.user_token TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.is_member(IN role sys.SYSNAME)
+RETURNS INT AS
+$$
+DECLARE
+    is_windows_grp boolean := (CHARINDEX('\', role) != 0);
+BEGIN
+    -- Always return 1 for 'public'
+    IF (role = 'public')
+    THEN RETURN 1;
+    END IF;
+    IF EXISTS (SELECT orig_loginname FROM sys.babelfish_authid_login_ext WHERE orig_loginname = role AND type != 'S') -- do not consider sql logins
+    THEN
+        IF ((EXISTS (SELECT name FROM sys.login_token WHERE name = role AND type IN ('SERVER ROLE', 'SQL LOGIN'))) OR is_windows_grp) -- do not consider sql logins, server roles
+        THEN RETURN NULL; -- Also return NULL if session is not a windows auth session but argument is a windows group
+        ELSIF EXISTS (SELECT name FROM sys.login_token WHERE name = role AND type NOT IN ('SERVER ROLE', 'SQL LOGIN'))
+        THEN RETURN 1; -- Return 1 if current session user is a member of role or windows group
+        ELSE RETURN 0; -- Return 0 if current session user is not a member of role or windows group
+        END IF;
+    ELSIF EXISTS (SELECT orig_username FROM sys.babelfish_authid_user_ext WHERE orig_username = role)
+    THEN
+        IF EXISTS (SELECT name FROM sys.user_token WHERE name = role)
+        THEN RETURN 1; -- Return 1 if current session user is a member of role or windows group
+        ELSIF (is_windows_grp)
+        THEN RETURN NULL; -- Return NULL if session is not a windows auth session but argument is a windows group
+        ELSE RETURN 0; -- Return 0 if current session user is not a member of role or windows group
+        END IF;
+    ELSE RETURN NULL; -- Return NULL if role/group does not exist
+    END IF;
+END;
+$$
+LANGUAGE plpgsql STRICT STABLE;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER-vu-verify.out
@@ -262,12 +262,12 @@ int
 ~~END~~
 
 
--- Given role name is not a real role, should return NULL
+-- Given name is a real user but not associated with login, should return 0
 SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_user1')
 GO
 ~~START~~
 int
-<NULL>
+0
 ~~END~~
 
 SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_user1')

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER.out
@@ -49,6 +49,13 @@ GO
 CREATE USER test_user3 FOR LOGIN test_login3
 GO
 
+-- check for roles with name > 64 characters
+CREATE ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111
+GO
+
+CREATE ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111_dup
+GO
+
 -- role1 -> role2 -> role3 -> role4
 ALTER ROLE test_role1 ADD MEMBER test_role2
 GO
@@ -66,6 +73,9 @@ GO
 ALTER ROLE test_role3 ADD MEMBER test_user3
 GO
 
+ALTER ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111 ADD MEMBER test_user3
+GO
+
 -- Print the current membership status
 EXEC babel_role_members
 GO
@@ -78,6 +88,7 @@ test_role2#!#R#!#test_role3#!#R
 test_role2#!#R#!#test_user2#!#S
 test_role3#!#R#!#test_role4#!#R
 test_role3#!#R#!#test_user3#!#S
+thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111#!#R#!#test_user3#!#S
 ~~END~~
 
 
@@ -204,6 +215,32 @@ int
 ~~END~~
 
 
+-- Return NULL for server roles other than public
+SELECT IS_MEMBER('sysadmin')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+-- Return NULL for SQL logins and users
+SELECT IS_MEMBER('test_login1')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT IS_MEMBER('test_user1')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
 -- Should return 0
 SELECT IS_ROLEMEMBER('db_owner', 'test_role1')
 GO
@@ -269,7 +306,7 @@ SELECT IS_MEMBER('test_user1')
 GO
 ~~START~~
 int
-<NULL>
+0
 ~~END~~
 
 SELECT IS_ROLEMEMBER('test_user1')
@@ -550,9 +587,23 @@ int
 1
 ~~END~~
 
+SELECT IS_MEMBER('thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111')
+GO
+~~START~~
+int
+1
+~~END~~
+
 
 -- Should return 0
 SELECT IS_MEMBER('test_role4')
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT IS_MEMBER('thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111_dup')
 GO
 ~~START~~
 int
@@ -614,6 +665,10 @@ GO
 DROP ROLE test_role2
 GO
 DROP ROLE test_role1
+GO
+DROP ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111
+GO
+DROP ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111_dup
 GO
 
 -- psql

--- a/test/JDBC/expected/login_token.out
+++ b/test/JDBC/expected/login_token.out
@@ -66,8 +66,8 @@ select name, type, usage from sys.user_token order by name;
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar
-login_token2#!#SQL USER#!#GRANT OR DENY
 login_token_role#!#ROLE#!#GRANT OR DENY
+login_token2#!#SQL USER#!#GRANT OR DENY
 public#!#ROLE#!#GRANT OR DENY
 ~~END~~
 

--- a/test/JDBC/expected/login_token.out
+++ b/test/JDBC/expected/login_token.out
@@ -8,6 +8,12 @@ go
 create user login_token2;
 go
 
+create role login_token_role
+go
+
+alter role login_token_role add member login_token2
+go
+
 create login login_token3 with password = '12345678'
 go
 
@@ -61,6 +67,7 @@ go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar
 login_token2#!#SQL USER#!#GRANT OR DENY
+login_token_role#!#ROLE#!#GRANT OR DENY
 public#!#ROLE#!#GRANT OR DENY
 ~~END~~
 
@@ -83,6 +90,12 @@ dbo#!#SQL USER#!#GRANT OR DENY
 
 
 -- tsql
+alter role login_token_role drop member login_token2
+go
+
+drop role login_token_role
+go
+
 drop user login_token2;
 go
 

--- a/test/JDBC/input/BABEL-ROLE-MEMBER-vu-verify.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER-vu-verify.mix
@@ -86,7 +86,7 @@ GO
 SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_role1', NULL)
 GO
 
--- Given role name is not a real role, should return NULL
+-- Given name is a real user but not associated with login, should return 0
 SELECT IS_MEMBER('BABEL_ROLE_MEMBER_vu_prepare_user1')
 GO
 SELECT IS_ROLEMEMBER('BABEL_ROLE_MEMBER_vu_prepare_user1')

--- a/test/JDBC/input/BABEL-ROLE-MEMBER.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER.mix
@@ -44,6 +44,13 @@ GO
 CREATE USER test_user3 FOR LOGIN test_login3
 GO
 
+-- check for roles with name > 64 characters
+CREATE ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111
+GO
+
+CREATE ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111_dup
+GO
+
 -- role1 -> role2 -> role3 -> role4
 ALTER ROLE test_role1 ADD MEMBER test_role2
 GO
@@ -59,6 +66,9 @@ ALTER ROLE test_role2 ADD MEMBER test_user2
 GO
 -- role3 -> user3
 ALTER ROLE test_role3 ADD MEMBER test_user3
+GO
+
+ALTER ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111 ADD MEMBER test_user3
 GO
 
 -- Print the current membership status
@@ -106,6 +116,17 @@ GO
 SELECT IS_ROLEMEMBER('public', 'test_role1')
 GO
 SELECT IS_ROLEMEMBER('public', 'test_user1')
+GO
+
+-- Return NULL for server roles other than public
+SELECT IS_MEMBER('sysadmin')
+GO
+
+-- Return NULL for SQL logins and users
+SELECT IS_MEMBER('test_login1')
+GO
+
+SELECT IS_MEMBER('test_user1')
 GO
 
 -- Should return 0
@@ -239,9 +260,13 @@ SELECT IS_ROLEMEMBER('test_role1', 'test_role3')
 GO
 SELECT IS_MEMBER('test_user3')
 GO
+SELECT IS_MEMBER('thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111')
+GO
 
 -- Should return 0
 SELECT IS_MEMBER('test_role4')
+GO
+SELECT IS_MEMBER('thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111_dup')
 GO
 
 -- Doesn't have permission, should return NULL
@@ -280,6 +305,10 @@ GO
 DROP ROLE test_role2
 GO
 DROP ROLE test_role1
+GO
+DROP ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111
+GO
+DROP ROLE thisroleisaveryuniquerolewhereitsnamelengthisveryveryverylongandspansonehundredandelevencharacterswhichis__111_dup
 GO
 
 -- psql

--- a/test/JDBC/input/login_token.mix
+++ b/test/JDBC/input/login_token.mix
@@ -8,6 +8,12 @@ go
 create user login_token2;
 go
 
+create role login_token_role
+go
+
+alter role login_token_role add member login_token2
+go
+
 create login login_token3 with password = '12345678'
 go
 
@@ -39,6 +45,12 @@ select name, type, usage from sys.user_token order by name;
 go
 
 -- tsql
+alter role login_token_role drop member login_token2
+go
+
+drop role login_token_role
+go
+
 drop user login_token2;
 go
 


### PR DESCRIPTION
### Description

This commits adds support in T-SQL IS_MEMBER() function to show
membership information for windows roles. The re-implemented
IS_MEMBER() function relies on views sys.login_token and sys.user_token
to see if current session user is member of a given role. The
sys.user_token view has also been modified as part of this commit to
show all the roles current_user is member of.

Task: BABEL-4822
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).