### PR TITLE
Fix crash issue in pre transforming column name

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1741,7 +1741,17 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 				colname_start = pstate->p_sourcetext + res->location;
 				last_dot = colname_start;
 				while(*colname_start != '\0')
-				{	
+				{
+					/*
+					 * comment follow up with column like : 
+					 *
+					 * 'SELECT table1.c2--table1.REPGETTEXT('
+					 * 
+					 * will cause crash if we don't break the searching
+					 * for the last_dot position
+					 */
+					if (*colname_start == '-' && *(colname_start+1) == '-')
+						break;
 					if(open_square_bracket == 0 && *colname_start == '"')
 					{
 						double_quotes++;

--- a/test/JDBC/expected/BABEL-4484-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4484-vu-verify.out
@@ -26,3 +26,43 @@ GO
 varchar
 ~~END~~
 
+
+SELECT test_babel_4484_t1.ced--table1.REPGETTEXT(
+FROM test_babel_4484_t1
+GO
+~~START~~
+varchar
+~~END~~
+
+
+select test_babel_4484_t1.您您--table1.a.b.c
+from test_babel_4484_t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column test_babel_4484_t1.您您 does not exist)~~
+
+
+select test_babel_4484_t2.您您--table1.a.b.c
+from test_babel_4484_t2
+GO
+~~START~~
+varchar
+~~END~~
+
+
+select test_babel_4484_t1.您您 as kk--table1.a.b.c
+from test_babel_4484_t1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column test_babel_4484_t1.您您 does not exist)~~
+
+
+select test_babel_4484_t2.您您 as kk--table1.a.b.c
+from test_babel_4484_t2
+GO
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/input/BABEL-4484-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4484-vu-verify.sql
@@ -9,3 +9,23 @@ GO
 
 SELECT test_babel_4484_t1.ced FROM test_babel_4484_t1 INNER JOIN test_babel_4484_t2 ON test_babel_4484_t1.ABC = test_babel_4484_t2.ABC WHERE test_babel_4484_t1.ABC = 1;
 GO
+
+SELECT test_babel_4484_t1.ced--table1.REPGETTEXT(
+FROM test_babel_4484_t1
+GO
+
+select test_babel_4484_t1.您您--table1.a.b.c
+from test_babel_4484_t1
+GO
+
+select test_babel_4484_t2.您您--table1.a.b.c
+from test_babel_4484_t2
+GO
+
+select test_babel_4484_t1.您您 as kk--table1.a.b.c
+from test_babel_4484_t1
+GO
+
+select test_babel_4484_t2.您您 as kk--table1.a.b.c
+from test_babel_4484_t2
+GO


### PR DESCRIPTION
Fix the crash happen when column ref is followed by a comment without space like : 'SELECT table1.c2--table1.REPGETTEXT('.

Previously, the column transform didn't consider '--' will directly followed with column ref and will wrongly regard the comment part as the column ref, thus will cause crash later in finding the column name.

This fix add the check for '--' at the end of column def in the sql string to avoid this crash.

Task: BABEL-5070


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).