### PR TITLE
Add escape hatch for metadata inconsistency check

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
@@ -45,6 +45,32 @@ ALTER TABLE sys.babelfish_function_ext DROP CONSTRAINT babelfish_function_ext_pk
 ALTER TABLE sys.babelfish_function_ext ADD CONSTRAINT babelfish_function_ext_pkey PRIMARY KEY (funcname, nspname, funcsignature);
 RESET allow_system_table_mods;
 
+CREATE OR REPLACE FUNCTION sys.check_for_inconsistent_metadata()
+RETURNS BOOLEAN AS $$
+DECLARE
+    has_inconsistent_metadata BOOLEAN;
+    num_rows INT;
+    eh_setting TEXT;
+BEGIN
+    eh_setting = (SELECT s.setting FROM pg_catalog.pg_settings s WHERE NAME = 'babelfishpg_tsql.escape_hatch_metadata_inconsistency_check');
+    
+    IF eh_setting = 'strict' THEN
+      -- Count the number of inconsistent metadata rows from Babelfish catalogs
+      SELECT COUNT(*) INTO num_rows
+      FROM sys.babelfish_inconsistent_metadata();
+
+      has_inconsistent_metadata := num_rows > 0;
+
+      -- Additional checks can be added here to update has_inconsistent_metadata accordingly
+    ELSE
+      has_inconsistent_metadata := FALSE;
+    END IF;
+    
+    RETURN has_inconsistent_metadata;
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
 -- BBF_PARTITION_FUNCTION
 -- This catalog stores the metadata of partition funtions.
 CREATE TABLE sys.babelfish_partition_function

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1268,6 +1268,7 @@ int			pltsql_isolation_level_repeatable_read = ISOLATION_OFF;
 int 		pltsql_isolation_level_serializable = ISOLATION_OFF;
 int 		escape_hatch_identity_function = EH_STRICT;
 int 		escape_hatch_insert_bulk_options = EH_IGNORE;
+int 		escape_hatch_metadata_inconsistency_check = EH_STRICT;
 
 void
 define_escape_hatch_variables(void)
@@ -1386,6 +1387,16 @@ define_escape_hatch_variables(void)
 	 * PGC_USERSET, GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE |
 	 * GUC_DISALLOW_IN_AUTO_FILE, NULL, NULL, NULL);
 	 */
+
+	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_metadata_inconsistency_check",
+							 gettext_noop("escape hatch for babelfish metadata inconsistency check"),
+							 NULL,
+							 &escape_hatch_metadata_inconsistency_check,
+							 EH_STRICT,
+							 escape_hatch_options,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
 
 	/* fulltext */
 	DefineCustomEnumVariable("babelfishpg_tsql.escape_hatch_fulltext",

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2016,6 +2016,7 @@ babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for log
 babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
 babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
 babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_metadata_inconsistency_check#!#strict#!#escape hatch for babelfish metadata inconsistency check
 babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
 babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
 babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints
@@ -2085,6 +2086,7 @@ babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for log
 babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
 babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
 babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_metadata_inconsistency_check#!#strict#!#escape hatch for babelfish metadata inconsistency check
 babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
 babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
 babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints
@@ -2135,6 +2137,7 @@ babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for log
 babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
 babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
 babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_metadata_inconsistency_check#!#strict#!#escape hatch for babelfish metadata inconsistency check
 babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
 babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
 babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints

--- a/test/JDBC/expected/check_for_inconsistent_metadata-vu-verify.out
+++ b/test/JDBC/expected/check_for_inconsistent_metadata-vu-verify.out
@@ -4,16 +4,23 @@
 
 
 
+
 -- Updating one entry from pg_proc pg catalog so that metadata inconsistency fails during check against babelfish_function_ext babelfish catalog
+CALL sys.sp_babelfish_configure('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check', 'ignore');
+SELECT CURRENT_SETTING('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check');
 UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
 SELECT proname, prosrc FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
 SELECT nspname, funcname FROM sys.babelfish_function_ext WHERE funcname = 'check_for_inconsistent_metadata_vu_prepare_func';
--- should return true because of inconsistency
-SELECT sys.check_for_inconsistent_metadata();
 -- should return the inconsistent row data
 SELECT sys.babelfish_inconsistent_metadata();
-UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
+-- should return false as escape hatch is set to ignore for inconsistency check
+SELECT sys.check_for_inconsistent_metadata();
 GO
+~~START~~
+text
+ignore
+~~END~~
+
 ~~ROW COUNT: 1~~
 
 ~~START~~
@@ -27,13 +34,35 @@ master_dbo#!#check_for_inconsistent_metadata_vu_prepare_func
 ~~END~~
 
 ~~START~~
-bool
-t
+record
+(name,pg_catalog,proname,"{""Rule"": ""<funcname> in babelfish_function_ext must also exist in pg_proc""}")
 ~~END~~
 
 ~~START~~
-record
-(name,pg_catalog,proname,"{""Rule"": ""<funcname> in babelfish_function_ext must also exist in pg_proc""}")
+bool
+f
+~~END~~
+
+
+-- psql
+
+
+
+-- enabling inconsistency check
+CALL sys.sp_babelfish_configure('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check', 'strict');
+SELECT CURRENT_SETTING('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check');
+-- should return true because of inconsistency
+SELECT sys.check_for_inconsistent_metadata();
+UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
+GO
+~~START~~
+text
+strict
+~~END~~
+
+~~START~~
+bool
+t
 ~~END~~
 
 ~~ROW COUNT: 1~~

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -2024,6 +2024,7 @@ babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for log
 babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
 babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
 babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_metadata_inconsistency_check#!#strict#!#escape hatch for babelfish metadata inconsistency check
 babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
 babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
 babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints
@@ -2093,6 +2094,7 @@ babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for log
 babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
 babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
 babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_metadata_inconsistency_check#!#strict#!#escape hatch for babelfish metadata inconsistency check
 babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
 babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
 babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints
@@ -2143,6 +2145,7 @@ babelfishpg_tsql.escape_hatch_login_misc_options#!#strict#!#escape hatch for log
 babelfishpg_tsql.escape_hatch_login_old_password#!#strict#!#escape hatch for login old passwords
 babelfishpg_tsql.escape_hatch_login_password_must_change#!#strict#!#escape hatch for login passwords must_change option
 babelfishpg_tsql.escape_hatch_login_password_unlock#!#strict#!#escape hatch for login passwords unlock option
+babelfishpg_tsql.escape_hatch_metadata_inconsistency_check#!#strict#!#escape hatch for babelfish metadata inconsistency check
 babelfishpg_tsql.escape_hatch_nocheck_add_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table add
 babelfishpg_tsql.escape_hatch_nocheck_existing_constraint#!#strict#!#escape hatch for WITH [NO]CHECK option in alter table on exsiting constraint
 babelfishpg_tsql.escape_hatch_query_hints#!#ignore#!#escape hatch for query hints

--- a/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
+++ b/test/JDBC/expected/sys_babelfish_configurations_view-vu-verify.out
@@ -2,7 +2,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_view
 GO
 ~~START~~
 int
-43
+44
 ~~END~~
 
 
@@ -10,7 +10,7 @@ EXEC sys_babelfish_configurations_view_vu_prepare_proc
 GO
 ~~START~~
 int
-43
+44
 ~~END~~
 
 
@@ -18,7 +18,7 @@ SELECT * FROM sys_babelfish_configurations_view_vu_prepare_func()
 GO
 ~~START~~
 int
-43
+44
 ~~END~~
 
 

--- a/test/JDBC/input/check_for_inconsistent_metadata-vu-verify.mix
+++ b/test/JDBC/input/check_for_inconsistent_metadata-vu-verify.mix
@@ -1,16 +1,30 @@
 -- Updating one entry from pg_proc pg catalog so that metadata inconsistency fails during check against babelfish_function_ext babelfish catalog
 -- psql
+CALL sys.sp_babelfish_configure('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check', 'ignore');
+
+SELECT CURRENT_SETTING('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check');
+
 UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func';
 
 SELECT proname, prosrc FROM pg_catalog.pg_proc WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
 
 SELECT nspname, funcname FROM sys.babelfish_function_ext WHERE funcname = 'check_for_inconsistent_metadata_vu_prepare_func';
 
--- should return true because of inconsistency
-SELECT sys.check_for_inconsistent_metadata();
-
 -- should return the inconsistent row data
 SELECT sys.babelfish_inconsistent_metadata();
+
+-- should return false as escape hatch is set to ignore for inconsistency check
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- psql
+-- enabling inconsistency check
+CALL sys.sp_babelfish_configure('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check', 'strict');
+
+SELECT CURRENT_SETTING('babelfishpg_tsql.escape_hatch_metadata_inconsistency_check');
+
+-- should return true because of inconsistency
+SELECT sys.check_for_inconsistent_metadata();
 
 UPDATE pg_catalog.pg_proc SET proname = 'check_for_inconsistent_metadata_vu_prepare_func' WHERE proname = 'check_for_inconsistent_metadata_vu_prepare_func_wrong';
 GO


### PR DESCRIPTION
### Description
This commit adds an escape hatch for Babelfish metadata inconsistency check. By default, this escape hatch is set to strict meaning the inconsistency check will be enabled. It can be set to ignore in case the user doesn't want to run these checks.

### Issues Resolved

Task: BABEL-4139

### Test Scenarios Covered ###
* **Use case based -** yes


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).