### PR TITLE
Add string empty checks to stripQuoteFromId

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -361,12 +361,12 @@ stripQuoteFromId(TSqlParser::IdContext *ctx)
 std::string
 stripQuoteFromId(std::string s)
 {
-	if (s.front() == '[')
+	if (!s.empty() && s.front() == '[')
 	{
 		Assert(s.back() == ']');
 		return s.substr(1,s.length()-2);
 	}
-	else if (s.front() == '"')
+	else if (!s.empty() && s.front() == '"')
 	{
 		Assert(s.back() == '"');
 		return s.substr(1,s.length()-2);


### PR DESCRIPTION
### Description

Add checks that string is not empty before calling `.front()` on it (that is [UB on empty string](https://en.cppreference.com/w/cpp/string/basic_string/front)).

### Issues Resolved

#2760

### Test Scenarios Covered ###

Numerous test failures on `-O0` builds.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>