### PR TITLE
Added wrapper functions for REVERSE() function to fix issue with input containing multi-byte characters.

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -4868,3 +4868,79 @@ CREATE OR REPLACE FUNCTION sys.bbf_pivot()
 RETURNS setof record
 AS 'babelfishpg_tsql', 'bbf_pivot'
 LANGUAGE C STABLE;
+
+-- wrapper functions for reverse
+CREATE OR REPLACE FUNCTION sys.reverse(string ANYELEMENT)
+RETURNS sys.VARCHAR
+AS
+$BODY$
+DECLARE
+    string_arg_datatype text;
+    string_arg_typeid oid;
+    string_basetype oid;
+BEGIN
+    string_arg_typeid := pg_typeof(string)::oid;
+    string_arg_datatype := sys.translate_pg_type_to_tsql(string_arg_typeid);
+    IF string_arg_datatype IS NULL THEN
+        -- for User Defined Datatype, use immediate base type to check for argument datatype validation
+        string_basetype := sys.bbf_get_immediate_base_type_of_UDT(string_arg_typeid);
+        string_arg_datatype := sys.translate_pg_type_to_tsql(string_basetype);
+    END IF;
+
+    -- restricting arguments with invalid datatypes for reverse function
+    IF string_arg_datatype IN ('image', 'sql_variant', 'xml', 'geometry', 'geography') THEN
+        RAISE EXCEPTION 'Argument data type % is invalid for argument 1 of reverse function.', string_arg_datatype;
+    END IF;
+
+    IF string IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    RETURN PG_CATALOG.reverse(string::sys.varchar);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.reverse(string sys.NCHAR)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.reverse(string sys.NVARCHAR)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Adding following definition will make sure that reverse with text input
+-- will use following definition instead of PG reverse
+CREATE OR REPLACE FUNCTION sys.reverse(string TEXT)
+RETURNS sys.VARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+-- Adding following definition will make sure that reverse with ntext input
+-- will use following definition instead of PG reverse
+CREATE OR REPLACE FUNCTION sys.reverse(string NTEXT)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
@@ -5475,6 +5475,81 @@ RETURNS OID
 AS 'babelfishpg_tsql', 'get_immediate_base_type_of_UDT'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- wrapper functions for reverse
+CREATE OR REPLACE FUNCTION sys.reverse(string ANYELEMENT)
+RETURNS sys.VARCHAR
+AS
+$BODY$
+DECLARE
+    string_arg_datatype text;
+    string_arg_typeid oid;
+    string_basetype oid;
+BEGIN
+    string_arg_typeid := pg_typeof(string)::oid;
+    string_arg_datatype := sys.translate_pg_type_to_tsql(string_arg_typeid);
+    IF string_arg_datatype IS NULL THEN
+        -- for User Defined Datatype, use immediate base type to check for argument datatype validation
+        string_basetype := sys.bbf_get_immediate_base_type_of_UDT(string_arg_typeid);
+        string_arg_datatype := sys.translate_pg_type_to_tsql(string_basetype);
+    END IF;
+
+    -- restricting arguments with invalid datatypes for reverse function
+    IF string_arg_datatype IN ('image', 'sql_variant', 'xml', 'geometry', 'geography') THEN
+        RAISE EXCEPTION 'Argument data type % is invalid for argument 1 of reverse function.', string_arg_datatype;
+    END IF;
+
+    IF string IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    RETURN PG_CATALOG.reverse(string::sys.varchar);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.reverse(string sys.NCHAR)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.reverse(string sys.NVARCHAR)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Adding following definition will make sure that reverse with text input
+-- will use following definition instead of PG reverse
+CREATE OR REPLACE FUNCTION sys.reverse(string TEXT)
+RETURNS sys.VARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+-- Adding following definition will make sure that reverse with ntext input
+-- will use following definition instead of PG reverse
+CREATE OR REPLACE FUNCTION sys.reverse(string NTEXT)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+BEGIN
+    RETURN PG_CATALOG.reverse(string);
+END;
+$BODY$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
 
 create or replace view sys.tables as
 with tt_internal as MATERIALIZED

--- a/test/JDBC/expected/BABEL-1994-CHAR-vu-verify.out
+++ b/test/JDBC/expected/BABEL-1994-CHAR-vu-verify.out
@@ -160,7 +160,7 @@ select
 ;
 go
 ~~START~~
-int#!#text#!#nvarchar#!#bigint#!#varchar
+int#!#varchar#!#nvarchar#!#bigint#!#varchar
 97#!#    a#!#[a[]] b ]#!#1#!#a
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-1994-CHAR.out
+++ b/test/JDBC/expected/BABEL-1994-CHAR.out
@@ -191,7 +191,7 @@ select
 ;
 go
 ~~START~~
-int#!#text#!#nvarchar#!#bigint#!#varchar
+int#!#varchar#!#nvarchar#!#bigint#!#varchar
 97#!#    a#!#[a[]] b ]#!#1#!#a
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-1994-VARCHAR-vu-verify.out
+++ b/test/JDBC/expected/BABEL-1994-VARCHAR-vu-verify.out
@@ -165,7 +165,7 @@ select
 ;
 go
 ~~START~~
-int#!#text#!#nvarchar#!#bigint#!#varchar
+int#!#varchar#!#nvarchar#!#bigint#!#varchar
 97#!# a#!#[a[]] b ]#!#1#!#a
 ~~END~~
 

--- a/test/JDBC/expected/BABEL-1994-VARCHAR.out
+++ b/test/JDBC/expected/BABEL-1994-VARCHAR.out
@@ -189,7 +189,7 @@ select
 ;
 go
 ~~START~~
-int#!#text#!#nvarchar#!#bigint#!#varchar
+int#!#varchar#!#nvarchar#!#bigint#!#varchar
 97#!# a#!#[a[]] b ]#!#1#!#a
 ~~END~~
 

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -68,7 +68,7 @@ PRIMARY#!#1#!#FG#!#ROWS_FILEGROUP#!#1#!#0
 SELECT a*2, REVERSE(b) FROM bbf_fpn_server...fpn_table
 GO
 ~~START~~
-int#!#text
+int#!#varchar
 2#!#eno
 4#!#owt
 6#!#eerht

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/reverse-before-15_8-or-16_4-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/reverse-before-15_8-or-16_4-vu-verify.out
@@ -1,0 +1,602 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- empty string
+SELECT reverse('')
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             斯莫拉·尔比
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+             斯莫拉·尔比
+~~END~~
+
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+斯莫拉·尔比
+~~END~~
+
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+EXEC babel_4839_reverse_dep_proc
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+~~START~~
+text
+                                      ??ihgfed?cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+~~START~~
+text
+                                         ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+~~START~~
+text
+ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+~~START~~
+text
+0202463626160202x0
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+fedcba
+~~END~~
+
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+12-21-6102
+~~END~~
+
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:00:00 12-21-6102
+~~END~~
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:34:21 31-21-5591
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.50:01:21
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:01+ 4321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+654321
+~~END~~
+
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+54321
+~~END~~
+
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+65321
+~~END~~
+
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+532
+~~END~~
+
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type sql_variant is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type xml is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geometry is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geography is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+>ydob/<>/tiurf<>ydob<
+~~END~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+)2 1(TNIOP
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/reverse-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/reverse-vu-verify.out
@@ -1,0 +1,602 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- empty string
+SELECT reverse('')
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             斯莫拉·尔比
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+             斯莫拉·尔比
+~~END~~
+
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+斯莫拉·尔比
+~~END~~
+
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+EXEC babel_4839_reverse_dep_proc
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+~~START~~
+varchar
+                                         ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+~~START~~
+varchar
+ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+~~START~~
+varchar
+  dcba  
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+fedcba
+~~END~~
+
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+12-21-6102
+~~END~~
+
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:00:00 12-21-6102
+~~END~~
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:34:21 31-21-5591
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.50:01:21
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:01+ 4321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+654321
+~~END~~
+
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+54321
+~~END~~
+
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+65321
+~~END~~
+
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+532
+~~END~~
+
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type sql_variant is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type xml is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geometry is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geography is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+>ydob/<>/tiurf<>ydob<
+~~END~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+)2 1(TNIOP
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-before-15_8-or-16_4-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-before-15_8-or-16_4-vu-verify.out
@@ -1,0 +1,602 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- empty string
+SELECT reverse('')
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+               斯莫拉??比
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+               斯莫拉??比
+~~END~~
+
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+斯莫拉??比
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+               斯莫拉??比
+~~END~~
+
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+斯莫拉·尔比
+~~END~~
+
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+EXEC babel_4839_reverse_dep_proc
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+~~START~~
+text
+                                      ??ihgfed?cba
+                                            斯莫拉??比
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+~~START~~
+text
+                                         ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+~~START~~
+text
+ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+~~START~~
+text
+0202463626160202x0
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+fedcba
+~~END~~
+
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+12-21-6102
+~~END~~
+
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:00:00 12-21-6102
+~~END~~
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:34:21 31-21-5591
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.50:01:21
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:01+ 4321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+654321
+~~END~~
+
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+54321
+~~END~~
+
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+65321
+~~END~~
+
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+532
+~~END~~
+
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type sql_variant is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type xml is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geometry is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geography is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+>ydob/<>/tiurf<>ydob<
+~~END~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+)2 1(TNIOP
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-vu-verify.out
@@ -1,0 +1,602 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- empty string
+SELECT reverse('')
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+                   ???·??
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+                   ???·??
+~~END~~
+
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+???·??
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+                   ???·??
+~~END~~
+
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+斯莫拉·尔比
+~~END~~
+
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+EXEC babel_4839_reverse_dep_proc
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+~~START~~
+varchar
+                                         ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+~~START~~
+varchar
+ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+~~START~~
+varchar
+  dcba  
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+fedcba
+~~END~~
+
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+12-21-6102
+~~END~~
+
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:00:00 12-21-6102
+~~END~~
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:34:21 31-21-5591
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.50:01:21
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:01+ 4321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+654321
+~~END~~
+
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+54321
+~~END~~
+
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+65321
+~~END~~
+
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+532
+~~END~~
+
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type sql_variant is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type xml is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geometry is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geography is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+>ydob/<>/tiurf<>ydob<
+~~END~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+)2 1(TNIOP
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-vu-verify.out
@@ -31,7 +31,7 @@ SELECT reverse(@inputString)
 GO
 ~~START~~
 varchar
-                   ???·??
+               斯莫拉??比
 ~~END~~
 
 
@@ -40,7 +40,7 @@ SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
 GO
 ~~START~~
 varchar
-                   ???·??
+               斯莫拉??比
 ~~END~~
 
 
@@ -59,7 +59,7 @@ SELECT reverse(@inputString)
 GO
 ~~START~~
 varchar
-???·??
+斯莫拉??比
 ~~END~~
 
 
@@ -189,7 +189,7 @@ SELECT reverse(@inputString)
 GO
 ~~START~~
 nvarchar
-                   ???·??
+               斯莫拉??比
 ~~END~~
 
 

--- a/test/JDBC/expected/pg_stat_statements_tsql.out
+++ b/test/JDBC/expected/pg_stat_statements_tsql.out
@@ -539,7 +539,7 @@ int
 SELECT REVERSE(name) FROM pgss_cust
 go
 ~~START~~
-text
+varchar
 CBA
 ZYX
 NML

--- a/test/JDBC/expected/reverse-before-15_8-or-16_4-vu-cleanup.out
+++ b/test/JDBC/expected/reverse-before-15_8-or-16_4-vu-cleanup.out
@@ -1,0 +1,80 @@
+DROP FUNCTION babel_4839_reverse_itvf_func
+GO
+
+DROP FUNCTION babel_4839_reverse_dep_func
+GO
+
+DROP PROCEDURE babel_4839_reverse_dep_proc
+GO
+
+DROP VIEW babel_4839_reverse_dep_view
+GO
+
+DROP TABLE babel_4839_reverse_UDT
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_1
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_2
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_3
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_4
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_5
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_6
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_7
+GO
+
+DROP TYPE dbo.babel_4839_reverse_varUDT
+GO
+
+DROP TYPE dbo.babel_4839_reverse_imageUDT
+GO
+
+DROP TABLE babel_4839_reverse_text
+GO
+
+DROP TABLE babel_4839_reverse_image
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_arabic_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_t5
+GO
+
+DROP TABLE babel_4839_reverse_t4
+GO
+
+DROP TABLE babel_4839_reverse_t3
+GO
+
+DROP TABLE babel_4839_reverse_t2
+GO
+
+DROP TABLE babel_4839_reverse_t1
+GO

--- a/test/JDBC/expected/reverse-before-15_8-or-16_4-vu-prepare.out
+++ b/test/JDBC/expected/reverse-before-15_8-or-16_4-vu-prepare.out
@@ -1,0 +1,156 @@
+CREATE TABLE babel_4839_reverse_t1(a NCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t1 VALUES(N'abc🙂defghi🙂🙂')
+INSERT INTO babel_4839_reverse_t1 VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t2(a NVARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t2 VALUES(N'abc🙂defghi🙂🙂')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t3(a CHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t3 VALUES('abcdefghi')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t4(a VARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t4 VALUES('abcdefghi')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t5(a VARBINARY(50))
+GO
+INSERT INTO babel_4839_reverse_t5 VALUES(0x2020616263642020)
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_as(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_as VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_chinese_prc_cs_as(a VARCHAR(50) COLLATE CHINESE_PRC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_cs_as VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_ai(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_ai VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_arabic_ci_as(a VARCHAR(50) COLLATE ARABIC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_as VALUES(N'الله مع المتقين')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_arabic_cs_as(a VARCHAR(50) COLLATE ARABIC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_cs_as VALUES(N'الله مع المتقين')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_arabic_ci_ai(a VARCHAR(50) COLLATE ARABIC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_ai VALUES(N'الله مع المتقين')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_image(a IMAGE)
+GO
+INSERT INTO babel_4839_reverse_image values(CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS image))
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_text(a TEXT, b NTEXT)
+GO
+INSERT INTO babel_4839_reverse_text VALUES (N'abc🙂defghi🙂🙂', N'abc🙂defghi🙂🙂')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TYPE dbo.babel_4839_reverse_imageUDT FROM image;
+GO
+
+CREATE TYPE dbo.babel_4839_reverse_varUDT FROM varchar(50);
+GO
+
+CREATE TABLE babel_4839_reverse_UDT(a dbo.babel_4839_reverse_imageUDT, b dbo.babel_4839_reverse_varUDT)
+GO
+INSERT INTO babel_4839_reverse_UDT VALUES(CAST('abcdef' as dbo.babel_4839_reverse_imageUDT), CAST('abcdef' as dbo.babel_4839_reverse_varUDT))
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE VIEW babel_4839_reverse_dep_view AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE PROCEDURE babel_4839_reverse_dep_proc AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE FUNCTION babel_4839_reverse_dep_func()
+RETURNS NVARCHAR(50)
+AS
+BEGIN
+RETURN (SELECT TOP 1 reverse(a) from babel_4839_reverse_t2)
+END
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_1 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t1
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_2 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t2
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_3 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t3
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_4 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t4
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_5 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t5
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_6 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_text
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_7 AS
+    SELECT reverse(b) as result FROM babel_4839_reverse_text
+GO
+
+CREATE FUNCTION babel_4839_reverse_itvf_func()
+RETURNS TABLE
+AS
+RETURN (SELECT reverse(a) as result from babel_4839_reverse_t2)
+GO

--- a/test/JDBC/expected/reverse-before-15_8-or-16_4-vu-verify.out
+++ b/test/JDBC/expected/reverse-before-15_8-or-16_4-vu-verify.out
@@ -1,0 +1,602 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- empty string
+SELECT reverse('')
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+                   ???·??
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+                   ???·??
+~~END~~
+
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+???·??
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+                   ???·??
+~~END~~
+
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+斯莫拉·尔比
+~~END~~
+
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+EXEC babel_4839_reverse_dep_proc
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+~~START~~
+text
+                                      ??ihgfed?cba
+                                            ???·??
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+~~START~~
+text
+                                         ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+~~START~~
+text
+ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+~~START~~
+text
+0202463626160202x0
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+~~START~~
+text
+??ihgfed?cba
+~~END~~
+
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+fedcba
+~~END~~
+
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+12-21-6102
+~~END~~
+
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:00:00 12-21-6102
+~~END~~
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:34:21 31-21-5591
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.50:01:21
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:01+ 4321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+654321
+~~END~~
+
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+54321
+~~END~~
+
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+65321
+~~END~~
+
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+532
+~~END~~
+
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type sql_variant is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type xml is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geometry is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geography is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+>ydob/<>/tiurf<>ydob<
+~~END~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+)2 1(TNIOP
+~~END~~
+

--- a/test/JDBC/expected/reverse-vu-cleanup.out
+++ b/test/JDBC/expected/reverse-vu-cleanup.out
@@ -1,0 +1,80 @@
+DROP FUNCTION babel_4839_reverse_itvf_func
+GO
+
+DROP FUNCTION babel_4839_reverse_dep_func
+GO
+
+DROP PROCEDURE babel_4839_reverse_dep_proc
+GO
+
+DROP VIEW babel_4839_reverse_dep_view
+GO
+
+DROP TABLE babel_4839_reverse_UDT
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_1
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_2
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_3
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_4
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_5
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_6
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_7
+GO
+
+DROP TYPE dbo.babel_4839_reverse_varUDT
+GO
+
+DROP TYPE dbo.babel_4839_reverse_imageUDT
+GO
+
+DROP TABLE babel_4839_reverse_text
+GO
+
+DROP TABLE babel_4839_reverse_image
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_arabic_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_t5
+GO
+
+DROP TABLE babel_4839_reverse_t4
+GO
+
+DROP TABLE babel_4839_reverse_t3
+GO
+
+DROP TABLE babel_4839_reverse_t2
+GO
+
+DROP TABLE babel_4839_reverse_t1
+GO

--- a/test/JDBC/expected/reverse-vu-prepare.out
+++ b/test/JDBC/expected/reverse-vu-prepare.out
@@ -1,0 +1,156 @@
+CREATE TABLE babel_4839_reverse_t1(a NCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t1 VALUES(N'abc🙂defghi🙂🙂')
+INSERT INTO babel_4839_reverse_t1 VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t2(a NVARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t2 VALUES(N'abc🙂defghi🙂🙂')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t3(a CHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t3 VALUES('abcdefghi')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t4(a VARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t4 VALUES('abcdefghi')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_t5(a VARBINARY(50))
+GO
+INSERT INTO babel_4839_reverse_t5 VALUES(0x2020616263642020)
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_as(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_as VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_chinese_prc_cs_as(a VARCHAR(50) COLLATE CHINESE_PRC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_cs_as VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_ai(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_ai VALUES(N'比尔·拉莫斯')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_arabic_ci_as(a VARCHAR(50) COLLATE ARABIC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_as VALUES(N'الله مع المتقين')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_arabic_cs_as(a VARCHAR(50) COLLATE ARABIC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_cs_as VALUES(N'الله مع المتقين')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_arabic_ci_ai(a VARCHAR(50) COLLATE ARABIC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_ai VALUES(N'الله مع المتقين')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_image(a IMAGE)
+GO
+INSERT INTO babel_4839_reverse_image values(CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS image))
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_4839_reverse_text(a TEXT, b NTEXT)
+GO
+INSERT INTO babel_4839_reverse_text VALUES (N'abc🙂defghi🙂🙂', N'abc🙂defghi🙂🙂')
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TYPE dbo.babel_4839_reverse_imageUDT FROM image;
+GO
+
+CREATE TYPE dbo.babel_4839_reverse_varUDT FROM varchar(50);
+GO
+
+CREATE TABLE babel_4839_reverse_UDT(a dbo.babel_4839_reverse_imageUDT, b dbo.babel_4839_reverse_varUDT)
+GO
+INSERT INTO babel_4839_reverse_UDT VALUES(CAST('abcdef' as dbo.babel_4839_reverse_imageUDT), CAST('abcdef' as dbo.babel_4839_reverse_varUDT))
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE VIEW babel_4839_reverse_dep_view AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE PROCEDURE babel_4839_reverse_dep_proc AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE FUNCTION babel_4839_reverse_dep_func()
+RETURNS NVARCHAR(50)
+AS
+BEGIN
+RETURN (SELECT TOP 1 reverse(a) from babel_4839_reverse_t2)
+END
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_1 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t1
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_2 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t2
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_3 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t3
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_4 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t4
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_5 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t5
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_6 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_text
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_7 AS
+    SELECT reverse(b) as result FROM babel_4839_reverse_text
+GO
+
+CREATE FUNCTION babel_4839_reverse_itvf_func()
+RETURNS TABLE
+AS
+RETURN (SELECT reverse(a) as result from babel_4839_reverse_t2)
+GO

--- a/test/JDBC/expected/reverse-vu-verify.out
+++ b/test/JDBC/expected/reverse-vu-verify.out
@@ -1,0 +1,602 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+~~START~~
+varchar
+<NULL>
+~~END~~
+
+
+-- empty string
+SELECT reverse('')
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+                   ???·??
+~~END~~
+
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+                   ???·??
+~~END~~
+
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+???·??
+~~END~~
+
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+~~START~~
+varchar
+斯莫拉·尔比
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+~~START~~
+varchar
+نيقتملا عم هللا
+~~END~~
+
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+             ??ihgfed?cba
+~~END~~
+
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+                   ???·??
+~~END~~
+
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+~~START~~
+nvarchar
+斯莫拉·尔比
+~~END~~
+
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+hgfedcba
+~~END~~
+
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+EXEC babel_4839_reverse_dep_proc
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+~~START~~
+nvarchar
+                                      🙂🙂ihgfed🙂cba
+                                            斯莫拉·尔比
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+~~START~~
+varchar
+                                         ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+~~START~~
+varchar
+ihgfedcba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+~~START~~
+varchar
+  dcba  
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+~~START~~
+varchar
+fedcba
+~~END~~
+
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+12-21-6102
+~~END~~
+
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:00:00 12-21-6102
+~~END~~
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:34:21 31-21-5591
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.50:01:21
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+00:01+ 4321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+7321.73:54:21 32-01-8691
+~~END~~
+
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+654321
+~~END~~
+
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+54321
+~~END~~
+
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1.54321
+~~END~~
+
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+87654321
+~~END~~
+
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+65321
+~~END~~
+
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+532
+~~END~~
+
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+0000.65321
+~~END~~
+
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type image is invalid for argument 1 of reverse function.)~~
+
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+~~START~~
+varchar
+??ihgfed?cba
+~~END~~
+
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+~~START~~
+nvarchar
+🙂🙂ihgfed🙂cba
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type sql_variant is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type xml is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geometry is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Argument data type geography is invalid for argument 1 of reverse function.)~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+FF469CF40C00-D24B-110D-68B8-FF9169F6
+~~END~~
+
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+>ydob/<>/tiurf<>ydob<
+~~END~~
+
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+~~START~~
+varchar
+)2 1(TNIOP
+~~END~~
+

--- a/test/JDBC/input/functions/string_functions/reverse-before-15_8-or-16_4-vu-cleanup.sql
+++ b/test/JDBC/input/functions/string_functions/reverse-before-15_8-or-16_4-vu-cleanup.sql
@@ -1,0 +1,80 @@
+DROP FUNCTION babel_4839_reverse_itvf_func
+GO
+
+DROP FUNCTION babel_4839_reverse_dep_func
+GO
+
+DROP PROCEDURE babel_4839_reverse_dep_proc
+GO
+
+DROP VIEW babel_4839_reverse_dep_view
+GO
+
+DROP TABLE babel_4839_reverse_UDT
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_1
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_2
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_3
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_4
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_5
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_6
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_7
+GO
+
+DROP TYPE dbo.babel_4839_reverse_varUDT
+GO
+
+DROP TYPE dbo.babel_4839_reverse_imageUDT
+GO
+
+DROP TABLE babel_4839_reverse_text
+GO
+
+DROP TABLE babel_4839_reverse_image
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_arabic_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_t5
+GO
+
+DROP TABLE babel_4839_reverse_t4
+GO
+
+DROP TABLE babel_4839_reverse_t3
+GO
+
+DROP TABLE babel_4839_reverse_t2
+GO
+
+DROP TABLE babel_4839_reverse_t1
+GO

--- a/test/JDBC/input/functions/string_functions/reverse-before-15_8-or-16_4-vu-prepare.sql
+++ b/test/JDBC/input/functions/string_functions/reverse-before-15_8-or-16_4-vu-prepare.sql
@@ -1,0 +1,126 @@
+CREATE TABLE babel_4839_reverse_t1(a NCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t1 VALUES(N'abc🙂defghi🙂🙂')
+INSERT INTO babel_4839_reverse_t1 VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_t2(a NVARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t2 VALUES(N'abc🙂defghi🙂🙂')
+GO
+
+CREATE TABLE babel_4839_reverse_t3(a CHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t3 VALUES('abcdefghi')
+GO
+
+CREATE TABLE babel_4839_reverse_t4(a VARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t4 VALUES('abcdefghi')
+GO
+
+CREATE TABLE babel_4839_reverse_t5(a VARBINARY(50))
+GO
+INSERT INTO babel_4839_reverse_t5 VALUES(0x2020616263642020)
+GO
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_as(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_as VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_chinese_prc_cs_as(a VARCHAR(50) COLLATE CHINESE_PRC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_cs_as VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_ai(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_ai VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_arabic_ci_as(a VARCHAR(50) COLLATE ARABIC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_as VALUES(N'الله مع المتقين')
+GO
+
+CREATE TABLE babel_4839_reverse_arabic_cs_as(a VARCHAR(50) COLLATE ARABIC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_cs_as VALUES(N'الله مع المتقين')
+GO
+
+CREATE TABLE babel_4839_reverse_arabic_ci_ai(a VARCHAR(50) COLLATE ARABIC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_ai VALUES(N'الله مع المتقين')
+GO
+
+CREATE TABLE babel_4839_reverse_image(a IMAGE)
+GO
+INSERT INTO babel_4839_reverse_image values(CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS image))
+GO
+
+CREATE TABLE babel_4839_reverse_text(a TEXT, b NTEXT)
+GO
+INSERT INTO babel_4839_reverse_text VALUES (N'abc🙂defghi🙂🙂', N'abc🙂defghi🙂🙂')
+GO
+
+CREATE TYPE dbo.babel_4839_reverse_imageUDT FROM image;
+GO
+
+CREATE TYPE dbo.babel_4839_reverse_varUDT FROM varchar(50);
+GO
+
+CREATE TABLE babel_4839_reverse_UDT(a dbo.babel_4839_reverse_imageUDT, b dbo.babel_4839_reverse_varUDT)
+GO
+INSERT INTO babel_4839_reverse_UDT VALUES(CAST('abcdef' as dbo.babel_4839_reverse_imageUDT), CAST('abcdef' as dbo.babel_4839_reverse_varUDT))
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE PROCEDURE babel_4839_reverse_dep_proc AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE FUNCTION babel_4839_reverse_dep_func()
+RETURNS NVARCHAR(50)
+AS
+BEGIN
+RETURN (SELECT TOP 1 reverse(a) from babel_4839_reverse_t2)
+END
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_1 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t1
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_2 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t2
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_3 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t3
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_4 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t4
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_5 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t5
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_6 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_text
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_7 AS
+    SELECT reverse(b) as result FROM babel_4839_reverse_text
+GO
+
+CREATE FUNCTION babel_4839_reverse_itvf_func()
+RETURNS TABLE
+AS
+RETURN (SELECT reverse(a) as result from babel_4839_reverse_t2)
+GO

--- a/test/JDBC/input/functions/string_functions/reverse-before-15_8-or-16_4-vu-verify.sql
+++ b/test/JDBC/input/functions/string_functions/reverse-before-15_8-or-16_4-vu-verify.sql
@@ -1,0 +1,262 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+
+-- empty string
+SELECT reverse('')
+GO
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+
+EXEC babel_4839_reverse_dep_proc
+GO
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO

--- a/test/JDBC/input/functions/string_functions/reverse-vu-cleanup.sql
+++ b/test/JDBC/input/functions/string_functions/reverse-vu-cleanup.sql
@@ -1,0 +1,80 @@
+DROP FUNCTION babel_4839_reverse_itvf_func
+GO
+
+DROP FUNCTION babel_4839_reverse_dep_func
+GO
+
+DROP PROCEDURE babel_4839_reverse_dep_proc
+GO
+
+DROP VIEW babel_4839_reverse_dep_view
+GO
+
+DROP TABLE babel_4839_reverse_UDT
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_1
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_2
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_3
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_4
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_5
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_6
+GO
+
+DROP VIEW babel_4839_reverse_dep_view_7
+GO
+
+DROP TYPE dbo.babel_4839_reverse_varUDT
+GO
+
+DROP TYPE dbo.babel_4839_reverse_imageUDT
+GO
+
+DROP TABLE babel_4839_reverse_text
+GO
+
+DROP TABLE babel_4839_reverse_image
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_arabic_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_arabic_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_cs_as
+GO
+
+DROP TABLE babel_4839_reverse_chinese_prc_ci_as
+GO
+
+DROP TABLE babel_4839_reverse_t5
+GO
+
+DROP TABLE babel_4839_reverse_t4
+GO
+
+DROP TABLE babel_4839_reverse_t3
+GO
+
+DROP TABLE babel_4839_reverse_t2
+GO
+
+DROP TABLE babel_4839_reverse_t1
+GO

--- a/test/JDBC/input/functions/string_functions/reverse-vu-prepare.sql
+++ b/test/JDBC/input/functions/string_functions/reverse-vu-prepare.sql
@@ -1,0 +1,126 @@
+CREATE TABLE babel_4839_reverse_t1(a NCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t1 VALUES(N'abc🙂defghi🙂🙂')
+INSERT INTO babel_4839_reverse_t1 VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_t2(a NVARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t2 VALUES(N'abc🙂defghi🙂🙂')
+GO
+
+CREATE TABLE babel_4839_reverse_t3(a CHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t3 VALUES('abcdefghi')
+GO
+
+CREATE TABLE babel_4839_reverse_t4(a VARCHAR(50))
+GO
+INSERT INTO babel_4839_reverse_t4 VALUES('abcdefghi')
+GO
+
+CREATE TABLE babel_4839_reverse_t5(a VARBINARY(50))
+GO
+INSERT INTO babel_4839_reverse_t5 VALUES(0x2020616263642020)
+GO
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_as(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_as VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_chinese_prc_cs_as(a VARCHAR(50) COLLATE CHINESE_PRC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_cs_as VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_chinese_prc_ci_ai(a VARCHAR(50) COLLATE CHINESE_PRC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_chinese_prc_ci_ai VALUES(N'比尔·拉莫斯')
+GO
+
+CREATE TABLE babel_4839_reverse_arabic_ci_as(a VARCHAR(50) COLLATE ARABIC_CI_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_as VALUES(N'الله مع المتقين')
+GO
+
+CREATE TABLE babel_4839_reverse_arabic_cs_as(a VARCHAR(50) COLLATE ARABIC_CS_AS)
+GO
+INSERT INTO babel_4839_reverse_arabic_cs_as VALUES(N'الله مع المتقين')
+GO
+
+CREATE TABLE babel_4839_reverse_arabic_ci_ai(a VARCHAR(50) COLLATE ARABIC_CI_AI)
+GO
+INSERT INTO babel_4839_reverse_arabic_ci_ai VALUES(N'الله مع المتقين')
+GO
+
+CREATE TABLE babel_4839_reverse_image(a IMAGE)
+GO
+INSERT INTO babel_4839_reverse_image values(CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS image))
+GO
+
+CREATE TABLE babel_4839_reverse_text(a TEXT, b NTEXT)
+GO
+INSERT INTO babel_4839_reverse_text VALUES (N'abc🙂defghi🙂🙂', N'abc🙂defghi🙂🙂')
+GO
+
+CREATE TYPE dbo.babel_4839_reverse_imageUDT FROM image;
+GO
+
+CREATE TYPE dbo.babel_4839_reverse_varUDT FROM varchar(50);
+GO
+
+CREATE TABLE babel_4839_reverse_UDT(a dbo.babel_4839_reverse_imageUDT, b dbo.babel_4839_reverse_varUDT)
+GO
+INSERT INTO babel_4839_reverse_UDT VALUES(CAST('abcdef' as dbo.babel_4839_reverse_imageUDT), CAST('abcdef' as dbo.babel_4839_reverse_varUDT))
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE PROCEDURE babel_4839_reverse_dep_proc AS
+    SELECT reverse(a) as result from babel_4839_reverse_t2
+GO
+
+CREATE FUNCTION babel_4839_reverse_dep_func()
+RETURNS NVARCHAR(50)
+AS
+BEGIN
+RETURN (SELECT TOP 1 reverse(a) from babel_4839_reverse_t2)
+END
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_1 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t1
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_2 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t2
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_3 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t3
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_4 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t4
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_5 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_t5
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_6 AS
+    SELECT reverse(a) as result FROM babel_4839_reverse_text
+GO
+
+CREATE VIEW babel_4839_reverse_dep_view_7 AS
+    SELECT reverse(b) as result FROM babel_4839_reverse_text
+GO
+
+CREATE FUNCTION babel_4839_reverse_itvf_func()
+RETURNS TABLE
+AS
+RETURN (SELECT reverse(a) as result from babel_4839_reverse_t2)
+GO

--- a/test/JDBC/input/functions/string_functions/reverse-vu-verify.sql
+++ b/test/JDBC/input/functions/string_functions/reverse-vu-verify.sql
@@ -1,0 +1,262 @@
+-- NULL
+SELECT reverse(NULL)
+GO
+
+-- empty string
+SELECT reverse('')
+GO
+
+-- input type char
+DECLARE @inputString CHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString CHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+
+-- input type varchar
+DECLARE @inputString VARCHAR(25) = 'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString VARCHAR(25) = '比尔·拉莫斯'
+SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
+GO
+
+-- with table column of type varchar with collation chinese_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AS FROM babel_4839_reverse_chinese_prc_ci_as
+GO
+
+-- with table column of type varchar with collation chinese_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CS_AS FROM babel_4839_reverse_chinese_prc_cs_as
+GO
+
+-- with table column of type varchar with collation chinese_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+SELECT reverse(a) COLLATE CHINESE_PRC_CI_AI FROM babel_4839_reverse_chinese_prc_ci_ai
+GO
+
+-- with table column of type varchar with collation arabic_prc_ci_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_as
+GO
+
+SELECT reverse(a) COLLATE ARABIC_CI_AS FROM babel_4839_reverse_arabic_ci_as
+GO
+
+-- with table column of type varchar with collation arabic_prc_cs_as
+SELECT reverse(a) FROM babel_4839_reverse_arabic_cs_as
+GO
+
+SELECT reverse(a) COLLATE ARABIC_CS_AS FROM babel_4839_reverse_arabic_cs_as
+GO
+
+-- with table column of type varchar with collation arabic_prc_ci_ai
+SELECT reverse(a) FROM babel_4839_reverse_arabic_ci_ai
+GO
+
+SELECT reverse(a) COLLATE ARABIC_CI_AI FROM babel_4839_reverse_arabic_ci_ai
+GO
+
+-- input type nchar
+DECLARE @inputString NCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString NCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+-- with table column of type nchar
+SELECT reverse(a) FROM babel_4839_reverse_t1 
+GO
+
+-- input type nvarchar
+DECLARE @inputString NVARCHAR(25) = N'abc🙂defghi🙂🙂'
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString NVARCHAR(25) = N'比尔·拉莫斯'
+SELECT reverse(@inputString)
+GO
+
+-- input type binary
+DECLARE @inputString BINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+
+-- input type varbinary
+DECLARE @inputString VARBINARY(10) = 0x6162636465666768
+SELECT reverse(@inputString)
+GO
+
+-- dependent objects
+SELECT * FROM babel_4839_reverse_dep_view
+GO
+
+EXEC babel_4839_reverse_dep_proc
+GO
+
+SELECT * FROM babel_4839_reverse_dep_func()
+GO
+
+SELECT * FROM babel_4839_reverse_itvf_func()
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_1
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_2
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_3
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_4
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_5
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_6
+GO
+
+SELECT * FROM babel_4839_reverse_dep_view_7
+GO
+
+-- input type UDT
+-- -- in table babel_4839_reverse_UDT, col 'a' has basetype image and col 'b' has basetype varchar
+SELECT reverse(a) FROM babel_4839_reverse_UDT
+GO
+
+SELECT reverse(b) FROM babel_4839_reverse_UDT
+GO
+
+-- other different datatypes, datatypes that are not implicitly coercible to varchar/nvarchar should throw error
+DECLARE @inputString date = '2016-12-21';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @date date = '12-21-16';  
+DECLARE @inputString datetime = @date;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString decimal = 123456;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString numeric = 12345.12;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString float = 12345.1;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString real = 12345.1;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString bigint = 12345678;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString int = 12345678;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString smallint = 12356;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString tinyint = 235;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString money = 12356;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString smallmoney = 12356;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString bit = 1;
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString uniqueidentifier = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS uniqueidentifier)
+SELECT reverse(@inputString)
+GO
+
+SELECT reverse(a) from babel_4839_reverse_image;
+GO
+
+-- input datatype text
+SELECT reverse(a) FROM babel_4839_reverse_text
+GO
+
+-- input datatype ntext
+SELECT reverse(b) FROM babel_4839_reverse_text
+GO
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.65100)', 4326);
+SELECT reverse(@inputString)
+GO
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+
+DECLARE @inputString xml = CAST ('<body><fruit/></body>' AS xml)
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO
+
+DECLARE @inputString geometry = geometry::STGeomFromText('POINT (1 2)', 0);
+SELECT reverse(CAST(@inputString AS VARCHAR(50)))
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -331,6 +331,10 @@ ignore#!#catalogs_dbo_sys_schema-upgrade-vu-prepare
 ignore#!#catalogs_dbo_sys_schema-upgrade-vu-verify
 ignore#!#catalogs_dbo_sys_schema-upgrade-vu-cleanup
 
+# These tests are meant for upgrade scenario prior to 15_8 or 16_4 release
+ignore#!#reverse-before-15_8-or-16_4-vu-prepare
+ignore#!#reverse-before-15_8-or-16_4-vu-verify
+ignore#!#reverse-before-15_8-or-16_4-vu-cleanup
 ignore#!#ISC-Tables-before_16_4_or_15_8_or_14_13-vu-prepare
 ignore#!#ISC-Tables-before_16_4_or_15_8_or_14_13-vu-verify
 ignore#!#ISC-Tables-before_16_4_or_15_8_or_14_13-vu-cleanup

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -240,3 +240,4 @@ left-before-15_8-or-16_4
 right-before-15_8-or-16_4
 BABEL-4863-before-16_3-or-15_7-or-14_12
 BABEL-4869
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -293,3 +293,4 @@ left-before-15_8-or-16_4
 right-before-15_8-or-16_4
 BABEL-4863-before-16_3-or-15_7-or-14_12
 BABEL-4869
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -349,3 +349,4 @@ right-before-15_8-or-16_4
 BABEL-4863-before-16_3-or-15_7-or-14_12
 babel_726-before-14_12-or-15_7-or-16_3
 BABEL-4869
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -342,3 +342,4 @@ left-before-15_8-or-16_4
 right-before-15_8-or-16_4
 BABEL-4863-before-16_3-or-15_7-or-14_12
 BABEL-4869
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -342,3 +342,4 @@ left-before-15_8-or-16_4
 right-before-15_8-or-16_4
 BABEL-4863-before-16_3-or-15_7-or-14_12
 BABEL-4869
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -347,3 +347,4 @@ right-before-15_8-or-16_4
 BABEL-4863-before-16_3-or-15_7-or-14_12
 babel_726-before-14_12-or-15_7-or-16_3
 BABEL-4869
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -449,3 +449,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -447,3 +447,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -448,3 +448,4 @@ babel_4328_datetime2
 babel_4328_datetimeoffset
 babel_726
 BABEL-3401
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -448,3 +448,4 @@ babel_4328_datetime2
 babel_4328_datetimeoffset
 babel_726
 BABEL-3401
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -370,3 +370,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -382,3 +382,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -419,3 +419,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -440,3 +440,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -442,3 +442,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -445,3 +445,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -418,3 +418,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -453,3 +453,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -472,3 +472,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -484,3 +484,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -515,3 +515,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -531,3 +531,4 @@ BABEL-4869
 babel_4328_datetime-before-16_3
 babel_4328_datetime2-before-16_3
 babel_4328_datetimeoffset-before-16_3
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -533,6 +533,7 @@ test_like_for_AI
 babel_726
 BABEL-4869
 BABEL-4815
+reverse-before-15_8-or-16_4
 BABEL-3401
 babel_4328_datetime
 babel_4328_datetime2

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -528,3 +528,4 @@ ltrim
 rtrim
 left
 right
+reverse

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -524,3 +524,4 @@ ltrim-before-15_8-or-16_4
 rtrim-before-15_8-or-16_4
 left-before-15_8-or-16_4
 right-before-15_8-or-16_4
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -539,3 +539,4 @@ ltrim-before-15_8-or-16_4
 rtrim-before-15_8-or-16_4
 left-before-15_8-or-16_4
 right-before-15_8-or-16_4
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -541,3 +541,4 @@ ltrim-before-15_8-or-16_4
 rtrim-before-15_8-or-16_4
 left-before-15_8-or-16_4
 right-before-15_8-or-16_4
+reverse-before-15_8-or-16_4

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -550,3 +550,4 @@ BABEL-3820
 PARTITION
 BABEL-5071
 string_agg
+reverse


### PR DESCRIPTION
### Description
Currently for string function `REVERSE()` we are directly using corresponding PG function whose input and output datatype is `TEXT`. This leads to incorrect output for input containing multi-byte characters with `nchar` and `nvarchar` datatype. This PR will fix this issue by adding wrapper functions with correct input and return datatype for `REVERSE()` function.

cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2719

Authored-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved

BABEL-4839

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** YES


* **Arbitrary inputs -** YES


* **Negative test cases -** YES


* **Minor version upgrade tests -** YES


* **Major version upgrade tests -** YES


* **Performance tests -** NO


* **Tooling impact -** NO


* **Client tests -** NO



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).