### PR TITLE
Updated expected output of reverse-vu-verify in japanese_ci_as server collation

### DIFF
--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/reverse-vu-verify.out
@@ -31,7 +31,7 @@ SELECT reverse(@inputString)
 GO
 ~~START~~
 varchar
-                   ???·??
+               斯莫拉??比
 ~~END~~
 
 
@@ -40,7 +40,7 @@ SELECT reverse(@inputString) COLLATE CHINESE_PRC_CI_AS
 GO
 ~~START~~
 varchar
-                   ???·??
+               斯莫拉??比
 ~~END~~
 
 
@@ -59,7 +59,7 @@ SELECT reverse(@inputString)
 GO
 ~~START~~
 varchar
-???·??
+斯莫拉??比
 ~~END~~
 
 
@@ -189,7 +189,7 @@ SELECT reverse(@inputString)
 GO
 ~~START~~
 nvarchar
-                   ???·??
+               斯莫拉??比
 ~~END~~
 
 


### PR DESCRIPTION
### Description
Expected output of reverse-vu-verify test file in `japanese_ci_as` server collation was incorrect. Updated the expected output with correct expected output.

PR in which this expected output file got introduced: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2719

### Issues Resolved
NA

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).