### PR TITLE
Implement sys.sequences as an empty view to fix issue in DDL Export with SSMS

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -3314,3 +3314,25 @@ AS SELECT
     , CAST(0 as sys.BIT) AS is_contained
 WHERE FALSE;
 GRANT SELECT ON sys.availability_groups TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.sequences 
+AS SELECT 
+    so.*,
+    CAST(0 as sys.sql_variant) AS start_value
+    , CAST(0 as sys.sql_variant) AS increment
+    , CAST(0 as sys.sql_variant) AS minimum_value
+    , CAST(0 as sys.sql_variant) AS maximum_value
+    , CAST(0 as sys.BIT) AS is_cycling
+    , CAST(0 as sys.BIT) AS is_cached
+    , CAST(0 as INT) AS cache_size
+    , CAST(0 as INT) AS system_type_id
+    , CAST(0 as INT) AS user_type_id
+    , CAST(0 as sys.TINYINT) AS precision
+    , CAST(0 as sys.TINYINT) AS scale
+    , CAST(0 as sys.sql_variant) AS current_value
+    , CAST(0 as sys.BIT) AS is_exhausted
+    , CAST(0 as sys.sql_variant) AS last_used_value
+FROM sys.objects so
+WHERE FALSE;
+GRANT SELECT ON sys.sequences TO PUBLIC;
+

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
@@ -10511,6 +10511,27 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OR REPLACE VIEW sys.sequences 
+AS SELECT 
+    so.*,
+    CAST(0 as sys.sql_variant) AS start_value
+    , CAST(0 as sys.sql_variant) AS increment
+    , CAST(0 as sys.sql_variant) AS minimum_value
+    , CAST(0 as sys.sql_variant) AS maximum_value
+    , CAST(0 as sys.BIT) AS is_cycling
+    , CAST(0 as sys.BIT) AS is_cached
+    , CAST(0 as INT) AS cache_size
+    , CAST(0 as INT) AS system_type_id
+    , CAST(0 as INT) AS user_type_id
+    , CAST(0 as sys.TINYINT) AS precision
+    , CAST(0 as sys.TINYINT) AS scale
+    , CAST(0 as sys.sql_variant) AS current_value
+    , CAST(0 as sys.BIT) AS is_exhausted
+    , CAST(0 as sys.sql_variant) AS last_used_value
+FROM sys.objects so
+WHERE FALSE;
+GRANT SELECT ON sys.sequences TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/sys_sequences-vu-cleanup.out
+++ b/test/JDBC/expected/sys_sequences-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP VIEW sys_sequences_test_view
+GO
+
+DROP PROC sys_sequences_test_proc
+GO
+
+DROP FUNCTION sys_sequences_test_func
+GO

--- a/test/JDBC/expected/sys_sequences-vu-prepare.out
+++ b/test/JDBC/expected/sys_sequences-vu-prepare.out
@@ -1,0 +1,17 @@
+CREATE VIEW sys_sequences_test_view
+AS
+    SELECT * FROM sys.sequences;
+GO
+
+CREATE PROC sys_sequences_test_proc
+AS
+    SELECT * FROM sys.sequences
+GO
+
+CREATE FUNCTION sys_sequences_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.sequences)
+END
+GO

--- a/test/JDBC/expected/sys_sequences-vu-verify.out
+++ b/test/JDBC/expected/sys_sequences-vu-verify.out
@@ -1,0 +1,41 @@
+SELECT * FROM sys.sequences
+GO
+~~START~~
+varchar#!#int#!#int#!#int#!#int#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#bit#!#bit#!#int#!#int#!#int#!#tinyint#!#tinyint#!#sql_variant#!#bit#!#sql_variant
+~~END~~
+
+
+SELECT * FROM sys_sequences_test_view
+GO
+~~START~~
+varchar#!#int#!#int#!#int#!#int#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#bit#!#bit#!#int#!#int#!#int#!#tinyint#!#tinyint#!#sql_variant#!#bit#!#sql_variant
+~~END~~
+
+
+EXEC sys_sequences_test_proc
+GO
+~~START~~
+varchar#!#int#!#int#!#int#!#int#!#char#!#nvarchar#!#datetime#!#datetime#!#bit#!#bit#!#bit#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#bit#!#bit#!#int#!#int#!#int#!#tinyint#!#tinyint#!#sql_variant#!#bit#!#sql_variant
+~~END~~
+
+
+SELECT dbo.sys_sequences_test_func()
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT
+SCHEMA_NAME(seq.schema_id) AS [Schema],
+seq.name AS [Name]
+FROM
+sys.sequences AS seq
+ORDER BY
+[Schema] ASC,[Name] ASC
+GO
+~~START~~
+varchar#!#varchar
+~~END~~
+

--- a/test/JDBC/input/views/sys_sequences-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys_sequences-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP VIEW sys_sequences_test_view
+GO
+
+DROP PROC sys_sequences_test_proc
+GO
+
+DROP FUNCTION sys_sequences_test_func
+GO

--- a/test/JDBC/input/views/sys_sequences-vu-prepare.sql
+++ b/test/JDBC/input/views/sys_sequences-vu-prepare.sql
@@ -1,0 +1,17 @@
+CREATE VIEW sys_sequences_test_view
+AS
+    SELECT * FROM sys.sequences;
+GO
+
+CREATE PROC sys_sequences_test_proc
+AS
+    SELECT * FROM sys.sequences
+GO
+
+CREATE FUNCTION sys_sequences_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.sequences)
+END
+GO

--- a/test/JDBC/input/views/sys_sequences-vu-verify.sql
+++ b/test/JDBC/input/views/sys_sequences-vu-verify.sql
@@ -1,0 +1,20 @@
+SELECT * FROM sys.sequences
+GO
+
+SELECT * FROM sys_sequences_test_view
+GO
+
+EXEC sys_sequences_test_proc
+GO
+
+SELECT dbo.sys_sequences_test_func()
+GO
+
+SELECT
+SCHEMA_NAME(seq.schema_id) AS [Schema],
+seq.name AS [Name]
+FROM
+sys.sequences AS seq
+ORDER BY
+[Schema] ASC,[Name] ASC
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -543,3 +543,4 @@ babel_4328_datetime2
 babel_4328_datetimeoffset
 BABEL-3820
 reverse
+sys_sequences


### PR DESCRIPTION
### Description

Implement sys.sequences as an empty view to fix issue in DDL Export with SSMS

Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)

### Issues Resolved

BABEL-5099

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).