### PR TITLE
Reset proconfig for functions even when babelfish is installed 

### DIFF
--- a/test/JDBC/expected/BABEL_4982.out
+++ b/test/JDBC/expected/BABEL_4982.out
@@ -1,0 +1,95 @@
+-- psql
+CREATE SCHEMA s1
+GO
+
+CREATE TABLE s1.babel_4982_t (id VARCHAR(100))
+GO
+
+
+
+CREATE FUNCTION babel_4982_ddl_trigger()
+RETURNS event_trigger AS
+$$
+BEGIN
+INSERT INTO babel_4982_t VALUES (current_setting('search_path'));
+END;
+$$
+SECURITY DEFINER
+SET search_path = s1, pg_catalog, pg_temp
+LANGUAGE plpgsql;
+CREATE EVENT TRIGGER babel_4982_ddl_trigger
+	ON ddl_command_end
+	EXECUTE PROCEDURE babel_4982_ddl_trigger();
+SELECT set_config('search_path', 'master_dbo, sys, '||current_setting('search_path'), false);
+GO
+~~START~~
+text
+master_dbo, sys, "$user", public
+~~END~~
+
+
+SHOW search_path
+GO
+~~START~~
+text
+master_dbo, sys, "$user", public
+~~END~~
+
+
+CREATE TABLE babel_4982_t2 (id INT)
+GO
+
+SHOW search_path
+GO
+~~START~~
+text
+master_dbo, sys, "$user", public
+~~END~~
+
+
+BEGIN
+GO
+
+SHOW search_path
+GO
+~~START~~
+text
+master_dbo, sys, "$user", public
+~~END~~
+
+
+DROP TABLE babel_4982_t2
+GO
+
+SHOW search_path
+GO
+~~START~~
+text
+master_dbo, sys, "$user", public
+~~END~~
+
+
+COMMIT
+GO
+
+-- two entries since two DDLs after trigger was created
+SELECT * FROM s1.babel_4982_t
+GO
+~~START~~
+varchar
+s1, pg_catalog, pg_temp
+s1, pg_catalog, pg_temp
+~~END~~
+
+
+DROP EVENT TRIGGER babel_4982_ddl_trigger
+GO
+
+DROP FUNCTION babel_4982_ddl_trigger
+GO
+
+DROP TABLE s1.babel_4982_t
+GO
+
+DROP SCHEMA s1
+GO

--- a/test/JDBC/input/BABEL_4982.mix
+++ b/test/JDBC/input/BABEL_4982.mix
@@ -1,0 +1,64 @@
+-- psql
+CREATE SCHEMA s1
+GO
+
+CREATE TABLE s1.babel_4982_t (id VARCHAR(100))
+GO
+
+CREATE FUNCTION babel_4982_ddl_trigger()
+RETURNS event_trigger AS
+$$
+BEGIN
+INSERT INTO babel_4982_t VALUES (current_setting('search_path'));
+END;
+$$
+SECURITY DEFINER
+SET search_path = s1, pg_catalog, pg_temp
+LANGUAGE plpgsql;
+
+CREATE EVENT TRIGGER babel_4982_ddl_trigger
+	ON ddl_command_end
+	EXECUTE PROCEDURE babel_4982_ddl_trigger();
+
+SELECT set_config('search_path', 'master_dbo, sys, '||current_setting('search_path'), false);
+GO
+
+SHOW search_path
+GO
+
+CREATE TABLE babel_4982_t2 (id INT)
+GO
+
+SHOW search_path
+GO
+
+BEGIN
+GO
+
+SHOW search_path
+GO
+
+DROP TABLE babel_4982_t2
+GO
+
+SHOW search_path
+GO
+
+COMMIT
+GO
+
+-- two entries since two DDLs after trigger was created
+SELECT * FROM s1.babel_4982_t
+GO
+
+DROP EVENT TRIGGER babel_4982_ddl_trigger
+GO
+
+DROP FUNCTION babel_4982_ddl_trigger
+GO
+
+DROP TABLE s1.babel_4982_t
+GO
+
+DROP SCHEMA s1
+GO


### PR DESCRIPTION
### Description

Cherry picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2641

If babelfish is installed the set_sql_dialect is installed. That means we were never resetting the proconfig values for triggers/functions. One major symptom of this is mVU failure when there are some other extensions installed which change search path in proconfig.

### Issues Resolved

[BABEL-4982]

### Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).