### PR TITLE
[BABEL-2177] fix the bug allowing create trigger on tmp tables (#2775)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -982,6 +982,29 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 
 		switch (nodeTag(parsetree))
 		{
+			case T_CreateFunctionStmt:
+			{
+				ListCell 		*option;
+				CreateTrigStmt *trigStmt;
+				Relation rel;
+				foreach (option, ((CreateFunctionStmt *) parsetree)->options){
+					DefElem *defel = (DefElem *) lfirst(option);
+					if (strcmp(defel->defname, "trigStmt") == 0)
+					{
+						trigStmt = (CreateTrigStmt *) defel->arg;
+						rel = table_openrv(trigStmt->relation, ShareRowExclusiveLock);
+						if (rel->rd_islocaltemp){
+							ereport(ERROR,
+							(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+							errmsg("Cannot create trigger on a temporary object."),
+							"Cannot create trigger on a temporary object."
+							));
+						}
+						table_close(rel, NoLock);
+					}
+				}
+			}
+			break;
 			case T_CreateStmt:
 				{
 					CreateStmt *stmt = (CreateStmt *) parsetree;

--- a/test/JDBC/expected/babel_trigger.out
+++ b/test/JDBC/expected/babel_trigger.out
@@ -435,6 +435,23 @@ babel_trigger_trig2#!#babel_trigger_sch1
 ~~END~~
 
 
+CREATE TABLE #babel_2177(id int)
+go
+
+-- will fail and print error when trying to create trigger on temp table 
+CREATE TRIGGER trigger_babel_2177 ON #babel_2177
+AFTER INSERT
+AS
+	INSERT into #babel_2177 VALUES (7)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create trigger on a temporary object.)~~
+
+
+drop table #babel_2177;
+GO
+
 -- clean up
 drop trigger babel_trigger_sch1.babel_trigger_trig1
 GO

--- a/test/JDBC/expected/temp_table_jdbc.out
+++ b/test/JDBC/expected/temp_table_jdbc.out
@@ -1,0 +1,1 @@
+Cannot create trigger on a temporary object.

--- a/test/JDBC/input/babel_trigger.sql
+++ b/test/JDBC/input/babel_trigger.sql
@@ -343,6 +343,19 @@ GO
 select name,schema_name(schema_id) from sys.objects where name in ('babel_trigger_trig1','babel_trigger_trig2','babel_trigger_trig3','babel_trigger_trig4') order by name;
 GO
 
+CREATE TABLE #babel_2177(id int)
+go
+
+-- will fail and print error when trying to create trigger on temp table 
+CREATE TRIGGER trigger_babel_2177 ON #babel_2177
+AFTER INSERT
+AS
+	INSERT into #babel_2177 VALUES (7)
+go
+
+drop table #babel_2177;
+GO
+
 -- clean up
 drop trigger babel_trigger_sch1.babel_trigger_trig1
 GO


### PR DESCRIPTION
previously babel allow create trigger on tmp tables this commit fix the bug, and will print an error when customer try to create trigger on tmp table

Task: BABEL-2177

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).