### PR TITLE
Add dummy sys.partition_functions and sys.partition_schemes views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -3351,3 +3351,15 @@ SELECT
   CAST(0 as sys.datetime) as modify_date
 WHERE FALSE;
 GRANT SELECT ON sys.partition_functions TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.partition_schemes AS
+SELECT
+  CAST(NULL as sys.NVARCHAR(128)) as name,
+  CAST(0 as int) as data_space_id,
+  CAST('PS' as sys.bpchar(2)) as type,
+  CAST('PARTITION_SCHEME' as sys.nvarchar(60)) as type_desc,
+  CAST(0 as sys.bit) as is_default,
+  CAST(0 as sys.bit) as is_system,
+  CAST(0 as int) function_id
+WHERE FALSE;
+GRANT SELECT ON sys.partition_schemes TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -3338,3 +3338,16 @@ FROM sys.objects so
 WHERE FALSE;
 GRANT SELECT ON sys.sequences TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.partition_functions AS
+SELECT
+  CAST(NULL as sys.NVARCHAR(128)) as name,
+  CAST(0 as int) function_id,
+  CAST('R' as sys.bpchar(2)) as type,
+  CAST('RANGE' as sys.nvarchar(60)) as type_desc,
+  CAST(0 as int) fanout,
+  CAST(0 as sys.bit) as boundary_value_on_right,
+  CAST(0 as sys.bit) as is_system,
+  CAST(0 as sys.datetime) as create_date,
+  CAST(0 as sys.datetime) as modify_date
+WHERE FALSE;
+GRANT SELECT ON sys.partition_functions TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
@@ -9939,6 +9939,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OR REPLACE VIEW sys.partition_functions AS
+SELECT
+  CAST(NULL as sys.NVARCHAR(128)) as name,
+  CAST(0 as int) function_id,
+  CAST('R' as sys.bpchar(2)) as type,
+  CAST('RANGE' as sys.nvarchar(60)) as type_desc,
+  CAST(0 as int) fanout,
+  CAST(0 as sys.bit) as boundary_value_on_right,
+  CAST(0 as sys.bit) as is_system,
+  CAST(0 as sys.datetime) as create_date,
+  CAST(0 as sys.datetime) as modify_date
+WHERE FALSE;
+GRANT SELECT ON sys.partition_functions TO PUBLIC;
+
 CREATE OR REPLACE VIEW sys.sequences 
 AS SELECT 
     so.*,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
@@ -9953,6 +9953,18 @@ SELECT
 WHERE FALSE;
 GRANT SELECT ON sys.partition_functions TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.partition_schemes AS
+SELECT
+  CAST(NULL as sys.NVARCHAR(128)) as name,
+  CAST(0 as int) as data_space_id,
+  CAST('PS' as sys.bpchar(2)) as type,
+  CAST('PARTITION_SCHEME' as sys.nvarchar(60)) as type_desc,
+  CAST(0 as sys.bit) as is_default,
+  CAST(0 as sys.bit) as is_system,
+  CAST(0 as int) function_id
+WHERE FALSE;
+GRANT SELECT ON sys.partition_schemes TO PUBLIC;
+
 CREATE OR REPLACE VIEW sys.sequences 
 AS SELECT 
     so.*,

--- a/test/JDBC/expected/sys_partition_functions-vu-cleanup.out
+++ b/test/JDBC/expected/sys_partition_functions-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP VIEW sys_partition_functions_test_view
+GO
+ 
+DROP PROC sys_partition_functions_test_proc
+GO
+ 
+DROP FUNCTION sys_partition_functions_test_func
+GO

--- a/test/JDBC/expected/sys_partition_functions-vu-prepare.out
+++ b/test/JDBC/expected/sys_partition_functions-vu-prepare.out
@@ -1,0 +1,17 @@
+CREATE VIEW sys_partition_functions_test_view
+AS
+    SELECT * FROM sys.partition_functions;
+GO
+
+CREATE PROC sys_partition_functions_test_proc
+AS
+    SELECT * FROM sys.partition_functions
+GO
+
+CREATE FUNCTION sys_partition_functions_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.partition_functions)
+END
+GO

--- a/test/JDBC/expected/sys_partition_functions-vu-verify.out
+++ b/test/JDBC/expected/sys_partition_functions-vu-verify.out
@@ -1,0 +1,21 @@
+SELECT * FROM sys_partition_functions_test_view
+GO
+~~START~~
+nvarchar#!#int#!#char#!#nvarchar#!#int#!#bit#!#bit#!#datetime#!#datetime
+~~END~~
+
+
+EXEC sys_partition_functions_test_proc
+GO
+~~START~~
+nvarchar#!#int#!#char#!#nvarchar#!#int#!#bit#!#bit#!#datetime#!#datetime
+~~END~~
+
+
+SELECT * FROM sys_partition_functions_test_func()
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/expected/sys_partition_schemes-vu-cleanup.out
+++ b/test/JDBC/expected/sys_partition_schemes-vu-cleanup.out
@@ -1,0 +1,8 @@
+DROP VIEW sys_partition_schemes_test_view
+GO
+
+DROP PROC sys_partition_schemes_test_proc
+GO
+
+DROP FUNCTION sys_partition_schemes_test_func
+GO

--- a/test/JDBC/expected/sys_partition_schemes-vu-prepare.out
+++ b/test/JDBC/expected/sys_partition_schemes-vu-prepare.out
@@ -1,0 +1,17 @@
+CREATE VIEW sys_partition_schemes_test_view
+AS
+    SELECT * FROM sys.partition_schemes;
+GO
+
+CREATE PROC sys_partition_schemes_test_proc
+AS
+    SELECT * FROM sys.partition_schemes
+GO
+
+CREATE FUNCTION sys_partition_schemes_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.partition_schemes)
+END
+GO

--- a/test/JDBC/expected/sys_partition_schemes-vu-verify.out
+++ b/test/JDBC/expected/sys_partition_schemes-vu-verify.out
@@ -1,0 +1,21 @@
+SELECT * FROM sys_partition_schemes_test_view
+GO
+~~START~~
+nvarchar#!#int#!#char#!#nvarchar#!#bit#!#bit#!#int
+~~END~~
+
+
+EXEC sys_partition_schemes_test_proc
+GO
+~~START~~
+nvarchar#!#int#!#char#!#nvarchar#!#bit#!#bit#!#int
+~~END~~
+
+
+SELECT * FROM sys_partition_schemes_test_func()
+GO
+~~START~~
+int
+0
+~~END~~
+

--- a/test/JDBC/input/views/sys_partition_functions-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys_partition_functions-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP VIEW sys_partition_functions_test_view
+GO
+ 
+DROP PROC sys_partition_functions_test_proc
+GO
+ 
+DROP FUNCTION sys_partition_functions_test_func
+GO

--- a/test/JDBC/input/views/sys_partition_functions-vu-prepare.sql
+++ b/test/JDBC/input/views/sys_partition_functions-vu-prepare.sql
@@ -1,0 +1,17 @@
+CREATE VIEW sys_partition_functions_test_view
+AS
+    SELECT * FROM sys.partition_functions;
+GO
+
+CREATE PROC sys_partition_functions_test_proc
+AS
+    SELECT * FROM sys.partition_functions
+GO
+
+CREATE FUNCTION sys_partition_functions_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.partition_functions)
+END
+GO

--- a/test/JDBC/input/views/sys_partition_functions-vu-verify.sql
+++ b/test/JDBC/input/views/sys_partition_functions-vu-verify.sql
@@ -1,0 +1,8 @@
+SELECT * FROM sys_partition_functions_test_view
+GO
+
+EXEC sys_partition_functions_test_proc
+GO
+
+SELECT * FROM sys_partition_functions_test_func()
+GO

--- a/test/JDBC/input/views/sys_partition_schemes-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys_partition_schemes-vu-cleanup.sql
@@ -1,0 +1,8 @@
+DROP VIEW sys_partition_schemes_test_view
+GO
+
+DROP PROC sys_partition_schemes_test_proc
+GO
+
+DROP FUNCTION sys_partition_schemes_test_func
+GO

--- a/test/JDBC/input/views/sys_partition_schemes-vu-prepare.sql
+++ b/test/JDBC/input/views/sys_partition_schemes-vu-prepare.sql
@@ -1,0 +1,17 @@
+CREATE VIEW sys_partition_schemes_test_view
+AS
+    SELECT * FROM sys.partition_schemes;
+GO
+
+CREATE PROC sys_partition_schemes_test_proc
+AS
+    SELECT * FROM sys.partition_schemes
+GO
+
+CREATE FUNCTION sys_partition_schemes_test_func()
+RETURNS INT
+AS
+BEGIN
+    RETURN (SELECT COUNT(*) FROM sys.partition_schemes)
+END
+GO

--- a/test/JDBC/input/views/sys_partition_schemes-vu-verify.sql
+++ b/test/JDBC/input/views/sys_partition_schemes-vu-verify.sql
@@ -1,0 +1,8 @@
+SELECT * FROM sys_partition_schemes_test_view
+GO
+
+EXEC sys_partition_schemes_test_proc
+GO
+
+SELECT * FROM sys_partition_schemes_test_func()
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -546,3 +546,5 @@ BABEL-3820
 replicate
 reverse
 sys_sequences
+sys_partition_functions
+sys_partition_schemes


### PR DESCRIPTION
### Description
SSMS attempts to script out partition functions and partition schemes during database export, and it uses the system views `sys.partition_functions` and `sys.partition_schemes` for this purpose. If these views are not present, database export fails.


This commit adds dummy versions of these views to prevent database export from failing.


Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Issues Resolved

Task: BABEL-5120

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** Yes


* **Client tests -** Yes



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).