### PR TITLE
[Test PR]Update column object_id for triggers

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2319,15 +2319,10 @@ object_id(PG_FUNCTION_ARGS)
 			else if (!strcmp(object_type, "af") || !strcmp(object_type, "fn") || !strcmp(object_type, "fs") ||
 					 !strcmp(object_type, "ft") || !strcmp(object_type, "if") || !strcmp(object_type, "p") ||
 					 !strcmp(object_type, "pc") || !strcmp(object_type, "tf") || !strcmp(object_type, "rf") ||
-					 !strcmp(object_type, "x"))
+					 !strcmp(object_type, "x") || !strcmp(object_type, "tr") || !strcmp(object_type, "ta"))
 			{
 				/* search in pg_proc by name and schema oid */
 				result = tsql_get_proc_oid(object_name, schema_oid, user_id);
-			}
-			else if (!strcmp(object_type, "tr") || !strcmp(object_type, "ta"))
-			{
-				/* search in pg_trigger by name and schema oid */
-				result = tsql_get_trigger_oid(object_name, schema_oid, user_id);
 			}
 			else if (!strcmp(object_type, "r") || !strcmp(object_type, "ec") || !strcmp(object_type, "pg") ||
 					 !strcmp(object_type, "sn") || !strcmp(object_type, "sq") || !strcmp(object_type, "tt"))
@@ -2367,12 +2362,6 @@ object_id(PG_FUNCTION_ARGS)
 			if (OidIsValid(relid) && pg_class_aclcheck(relid, user_id, ACL_SELECT) == ACLCHECK_OK)
 			{
 				result = relid;
-			}
-
-			if (!OidIsValid(result))	/* search only if not found earlier */
-			{
-				/* search in pg_trigger by name and schema oid */
-				result = tsql_get_trigger_oid(object_name, schema_oid, user_id);
 			}
 
 			if (!OidIsValid(result))

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2321,6 +2321,9 @@ object_id(PG_FUNCTION_ARGS)
 					 !strcmp(object_type, "pc") || !strcmp(object_type, "tf") || !strcmp(object_type, "rf") ||
 					 !strcmp(object_type, "x") || !strcmp(object_type, "tr") || !strcmp(object_type, "ta"))
 			{
+				/* If the object type is specified as 'p' and it's actually a trigger, then return NULL. */
+				if (!strcmp(object_type, "p") && tsql_get_trigger_oid(object_name, schema_oid, user_id))
+					PG_RETURN_NULL();
 				/* search in pg_proc by name and schema oid */
 				result = tsql_get_proc_oid(object_name, schema_oid, user_id);
 			}

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1457,9 +1457,7 @@ union all
 -- details of system defined procedures
 select
     p.proname::sys.sysname as name 
-  , case
-      when t.typname = 'trigger' then tr.oid else p.oid
-    end as object_id
+  , p.oid as object_id
   , null::integer as principal_id
   , s.oid as schema_id
   , cast (case when tr.tgrelid is not null 
@@ -1753,7 +1751,7 @@ CREATE OR REPLACE VIEW sys.triggers
 AS
 SELECT
   CAST(p.proname as sys.sysname) as name,
-  CAST(tr.oid as int) as object_id,
+  CAST(p.oid as int) as object_id,
   CAST(1 as sys.tinyint) as parent_class,
   CAST('OBJECT_OR_COLUMN' as sys.nvarchar(60)) AS parent_class_desc,
   CAST(tr.tgrelid as int) AS parent_id,
@@ -1863,7 +1861,7 @@ select
       CAST(tr.name as sys.sysname) as name
     , CAST(tr.object_id as int) as object_id
     , CAST(NULL as int) as principal_id
-    , CAST(p.relnamespace as int) as schema_id
+    , CAST(p.pronamespace as int) as schema_id
     , CAST(tr.parent_id as int) as parent_object_id
     , CAST(tr.type as char(2)) as type
     , CAST(tr.type_desc as sys.nvarchar(60)) as type_desc
@@ -1873,7 +1871,7 @@ select
     , CAST(0 as sys.bit) as is_published
     , CAST(0 as sys.bit) as is_schema_published
   from sys.triggers tr
-  inner join pg_class p on p.oid = tr.parent_id
+  inner join pg_proc p on p.oid = tr.object_id
 union all 
 select
     CAST(def.name as sys.sysname) as name

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1457,7 +1457,9 @@ union all
 -- details of system defined procedures
 select
     p.proname::sys.sysname as name 
-  , p.oid as object_id
+  , case
+      when t.typname = 'trigger' then tr.oid else p.oid
+    end as object_id
   , null::integer as principal_id
   , s.oid as schema_id
   , cast (case when tr.tgrelid is not null 
@@ -1751,7 +1753,7 @@ CREATE OR REPLACE VIEW sys.triggers
 AS
 SELECT
   CAST(p.proname as sys.sysname) as name,
-  CAST(p.oid as int) as object_id,
+  CAST(tr.oid as int) as object_id,
   CAST(1 as sys.tinyint) as parent_class,
   CAST('OBJECT_OR_COLUMN' as sys.nvarchar(60)) AS parent_class_desc,
   CAST(tr.tgrelid as int) AS parent_id,
@@ -1861,7 +1863,7 @@ select
       CAST(tr.name as sys.sysname) as name
     , CAST(tr.object_id as int) as object_id
     , CAST(NULL as int) as principal_id
-    , CAST(p.pronamespace as int) as schema_id
+    , CAST(p.relnamespace as int) as schema_id
     , CAST(tr.parent_id as int) as parent_object_id
     , CAST(tr.type as char(2)) as type
     , CAST(tr.type_desc as sys.nvarchar(60)) as type_desc
@@ -1871,7 +1873,7 @@ select
     , CAST(0 as sys.bit) as is_published
     , CAST(0 as sys.bit) as is_schema_published
   from sys.triggers tr
-  inner join pg_proc p on p.oid = tr.object_id
+  inner join pg_class p on p.oid = tr.parent_id
 union all 
 select
     CAST(def.name as sys.sysname) as name


### PR DESCRIPTION
### Description

1. Show oid of pg_proc for OBJECT_ID() in case of triggers. It removes inconsistency of object_id  between OBJECT_ID() and SYS views.
2. If the object type is specified as 'p' and it's actually a trigger, then return NULL.

### Issues Resolved

Task: BABEL-5108
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###

* **Use case based -** Tested locally
```

select OBJECT_ID([name]), object_id from sys.objects where [name] = 't_trigger'
go
object_id   object_id  
----------- -----------
      19747       19747

(1 rows affected)
select OBJECT_ID([name]), object_id from sys.triggers where [name] = 't_trigger'
go
object_id   object_id  
----------- -----------
      19747       19747

(1 rows affected)
select OBJECT_ID([name]), object_id from sys.all_objects where [name] = 't_trigger'
go
object_id   object_id  
----------- -----------
      19747       19747

(1 rows affected)

select OBJECT_ID('t_trigger', 'p');
go
object_id  
-----------
      NULL

(1 rows affected)
select OBJECT_ID('t_trigger', 'tr');
go
object_id  
-----------
      19747

(1 rows affected)
select OBJECT_ID('t_trigger');
go
object_id  
-----------
      19747

(1 rows affected)
```

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).