### PR TITLE
Add quote identifier in search path for multi-db (#2776)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -10301,8 +10301,9 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 					*old_search_path = flatten_search_path(path_oids);
 					list_free(path_oids);
 				}
-				new_search_path = psprintf("%s, %s, %s", physical_schema, dbo_schema, *old_search_path);
+				new_search_path = psprintf("%s, %s, %s", quote_identifier(physical_schema), quote_identifier(dbo_schema), *old_search_path);
 
+				pfree(physical_schema);
 				/*
 				 * Add the schema where the object is referenced and dbo
 				 * schema to the new search path
@@ -10310,6 +10311,7 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 				(void) set_config_option("search_path", new_search_path,
 										 PGC_USERSET, PGC_S_SESSION,
 										 GUC_ACTION_SAVE, true, 0, false);
+				pfree(new_search_path);
 				return true;
 			}
 			else if (top_es_entry->estate->db_name != NULL && stmt->is_ddl)
@@ -10350,8 +10352,9 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 						*old_search_path = flatten_search_path(path_oids);
 						list_free(path_oids);
 					}
-					new_search_path = psprintf("%s, %s, %s", physical_schema, dbo_schema, *old_search_path);
+					new_search_path = psprintf("%s, %s, %s", quote_identifier(physical_schema), quote_identifier(dbo_schema), *old_search_path);
 
+					pfree(physical_schema);
 					/*
 					 * Add the schema where the object is referenced and dbo
 					 * schema to the new search path
@@ -10359,6 +10362,7 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 					(void) set_config_option("search_path", new_search_path,
 											 PGC_USERSET, PGC_S_SESSION,
 											 GUC_ACTION_SAVE, true, 0, false);
+					pfree(new_search_path);
 					return true;
 				}
 			}
@@ -10379,8 +10383,9 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 			*old_search_path = flatten_search_path(path_oids);
 			list_free(path_oids);
 		}
-		new_search_path = psprintf("%s, %s, %s", physical_schema, dbo_schema, *old_search_path);
+		new_search_path = psprintf("%s, %s, %s", quote_identifier(physical_schema), quote_identifier(dbo_schema), *old_search_path);
 
+		pfree(physical_schema);
 		/*
 		 * Add the schema where the object is referenced and dbo schema to the
 		 * new search path
@@ -10388,8 +10393,11 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 		(void) set_config_option("search_path", new_search_path,
 								 PGC_USERSET, PGC_S_SESSION,
 								 GUC_ACTION_SAVE, true, 0, false);
+		pfree(new_search_path);
 		return true;
 	}
+	
+	pfree(cur_dbname);
 	return false;
 }
 

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -186,7 +186,7 @@ set_search_path_for_user_schema(const char *db_name, const char *user)
 		physical_schema = get_physical_schema_name(pstrdup(db_name), schema);
 	}
 
-	path = psprintf(buffer, physical_schema);
+	path = psprintf(buffer, quote_identifier(physical_schema));
 	SetConfigOption("search_path",
 					path,
 					PGC_SUSET,

--- a/test/JDBC/expected/BABEL-4279.out
+++ b/test/JDBC/expected/BABEL-4279.out
@@ -1,4 +1,28 @@
 -- tsql
+CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+~~ROW COUNT: 1~~
+
+
+-- test multi-db mode
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
+GO
+~~START~~
+text
+multi-db
+~~END~~
+
+
+-- tsql
 CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
 GO
 
@@ -80,7 +104,7 @@ SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_
 GO
 ~~START~~
 text
- SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
+ SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM """test_babel_4279_d.1""_test_babel_4279_s1".test_babel_4279_st1;
 ~~END~~
 
 
@@ -88,7 +112,7 @@ SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_
 GO
 ~~START~~
 text
- SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
+ SELECT test_babel_4279_st1."abc.nfds" AS "ABC.nfds"<newline>   FROM """test_babel_4279_d.1""_test_babel_4279_s1".test_babel_4279_st1;
 ~~END~~
 
 
@@ -235,3 +259,24 @@ GO
 DROP TABLE t3
 GO
 
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+
+-- Reset migration mode to default
+DECLARE @mig_mode VARCHAR(10)
+SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
+SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Drop Table IF EXISTS babelfish_migration_mode_table
+GO

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_search_path.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_search_path.out
@@ -1,0 +1,212 @@
+CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+~~ROW COUNT: 1~~
+
+
+-- test multi-db mode
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
+GO
+~~START~~
+text
+multi-db
+~~END~~
+
+
+-- check if correct schema is present in search path
+CREATE DATABASE ["BABEL_5111.db"]
+GO
+
+CREATE DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+use ["BABEL_5111.db"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+~~START~~
+text
+"""babel_5111.db""_dbo", "$user", sys, pg_catalog
+~~END~~
+
+
+CREATE SCHEMA ["BABEL_5111.scm"]
+GO
+
+CREATE TABLE ["BABEL_5111.scm"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.scm"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.scm"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1 on ["BABEL_5111.scm"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.scm"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+~~START~~
+text
+"""龙漫远; 龍漫遠.??€?""_dbo", "$user", sys, pg_catalog
+~~END~~
+
+
+CREATE SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+CREATE TABLE ["BABEL_5111.😃😄😉😊"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.😃😄😉😊"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.😃😄😉😊"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1 on ["BABEL_5111.😃😄😉😊"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.😃😄😉😊"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE master
+GO
+
+EXEC ["BABEL_5111.db"].["BABEL_5111.scm"].p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].v1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].v1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+use ["BABEL_5111.db"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.scm"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.scm"].v1
+GO
+
+DROP TABLE ["BABEL_5111.scm"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.scm"]
+GO
+
+DROP TABLE t1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.😃😄😉😊"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.😃😄😉😊"].v1
+GO
+
+DROP TABLE ["BABEL_5111.😃😄😉😊"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+USE master
+GO
+
+DROP DATABASE ["BABEL_5111.db"]
+GO
+
+DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+
+-- Reset migration mode to default
+DECLARE @mig_mode VARCHAR(10)
+SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
+SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Drop Table IF EXISTS babelfish_migration_mode_table
+GO

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_search_path.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_search_path.out
@@ -1,0 +1,212 @@
+CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+~~ROW COUNT: 1~~
+
+
+-- test multi-db mode
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
+GO
+~~START~~
+text
+multi-db
+~~END~~
+
+
+-- check if correct schema is present in search path
+CREATE DATABASE ["BABEL_5111.db"]
+GO
+
+CREATE DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+use ["BABEL_5111.db"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+~~START~~
+text
+"""babel_5111.db""_dbo", "$user", sys, pg_catalog
+~~END~~
+
+
+CREATE SCHEMA ["BABEL_5111.scm"]
+GO
+
+CREATE TABLE ["BABEL_5111.scm"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.scm"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.scm"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1 on ["BABEL_5111.scm"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.scm"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+~~START~~
+text
+"""龙漫远; 龍漫遠.??€?""_dbo", "$user", sys, pg_catalog
+~~END~~
+
+
+CREATE SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+CREATE TABLE ["BABEL_5111.😃😄😉😊"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.😃😄😉😊"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.😃😄😉😊"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1 on ["BABEL_5111.😃😄😉😊"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.😃😄😉😊"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE master
+GO
+
+EXEC ["BABEL_5111.db"].["BABEL_5111.scm"].p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].v1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].v1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+use ["BABEL_5111.db"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.scm"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.scm"].v1
+GO
+
+DROP TABLE ["BABEL_5111.scm"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.scm"]
+GO
+
+DROP TABLE t1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.😃😄😉😊"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.😃😄😉😊"].v1
+GO
+
+DROP TABLE ["BABEL_5111.😃😄😉😊"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+USE master
+GO
+
+DROP DATABASE ["BABEL_5111.db"]
+GO
+
+DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+
+-- Reset migration mode to default
+DECLARE @mig_mode VARCHAR(10)
+SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
+SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Drop Table IF EXISTS babelfish_migration_mode_table
+GO

--- a/test/JDBC/expected/test_search_path.out
+++ b/test/JDBC/expected/test_search_path.out
@@ -1,0 +1,212 @@
+CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+~~ROW COUNT: 1~~
+
+
+-- test multi-db mode
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
+GO
+~~START~~
+text
+multi-db
+~~END~~
+
+
+-- check if correct schema is present in search path
+CREATE DATABASE ["BABEL_5111.db"]
+GO
+
+CREATE DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+use ["BABEL_5111.db"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+~~START~~
+text
+"""babel_5111.db""_dbo", "$user", sys, pg_catalog
+~~END~~
+
+
+CREATE SCHEMA ["BABEL_5111.scm"]
+GO
+
+CREATE TABLE ["BABEL_5111.scm"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.scm"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.scm"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1 on ["BABEL_5111.scm"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.scm"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+~~START~~
+text
+"""???; ???.¢£€¥""_dbo", "$user", sys, pg_catalog
+~~END~~
+
+
+CREATE SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+CREATE TABLE ["BABEL_5111.😃😄😉😊"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.😃😄😉😊"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.😃😄😉😊"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1 on ["BABEL_5111.😃😄😉😊"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.😃😄😉😊"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE master
+GO
+
+EXEC ["BABEL_5111.db"].["BABEL_5111.scm"].p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].v1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].p1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].t1
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].v1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+use ["BABEL_5111.db"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.scm"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.scm"].v1
+GO
+
+DROP TABLE ["BABEL_5111.scm"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.scm"]
+GO
+
+DROP TABLE t1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.😃😄😉😊"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.😃😄😉😊"].v1
+GO
+
+DROP TABLE ["BABEL_5111.😃😄😉😊"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+USE master
+GO
+
+DROP DATABASE ["BABEL_5111.db"]
+GO
+
+DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+jdbc_user
+~~END~~
+
+
+-- Reset migration mode to default
+DECLARE @mig_mode VARCHAR(10)
+SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
+SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+Drop Table IF EXISTS babelfish_migration_mode_table
+GO

--- a/test/JDBC/input/BABEL-4279.mix
+++ b/test/JDBC/input/BABEL-4279.mix
@@ -1,4 +1,16 @@
 -- tsql
+CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+
+-- test multi-db mode
+SELECT set_config('role', 'jdbc_user', false);
+GO
+SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
+GO
+
+-- tsql
 CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
 GO
 
@@ -190,3 +202,14 @@ GO
 DROP TABLE t3
 GO
 
+SELECT set_config('role', 'jdbc_user', false);
+GO
+
+-- Reset migration mode to default
+DECLARE @mig_mode VARCHAR(10)
+SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
+SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
+GO
+
+Drop Table IF EXISTS babelfish_migration_mode_table
+GO

--- a/test/JDBC/input/test_search_path.sql
+++ b/test/JDBC/input/test_search_path.sql
@@ -1,0 +1,152 @@
+CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+
+-- test multi-db mode
+SELECT set_config('role', 'jdbc_user', false);
+GO
+SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
+GO
+
+-- check if correct schema is present in search path
+CREATE DATABASE ["BABEL_5111.db"]
+GO
+
+CREATE DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+use ["BABEL_5111.db"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+
+CREATE SCHEMA ["BABEL_5111.scm"]
+GO
+
+CREATE TABLE ["BABEL_5111.scm"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.scm"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.scm"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1 on ["BABEL_5111.scm"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.scm"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+CREATE TABLE t1(a int)
+GO
+
+SELECT current_setting('search_path')
+GO
+
+CREATE SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+CREATE TABLE ["BABEL_5111.😃😄😉😊"].t1(a int)
+GO
+
+CREATE VIEW ["BABEL_5111.😃😄😉😊"].v1 AS SELECT 1
+GO
+
+CREATE PROCEDURE ["BABEL_5111.😃😄😉😊"].p1 AS SELECT 1
+GO
+
+CREATE TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1 on ["BABEL_5111.😃😄😉😊"].t1 AFTER INSERT AS BEGIN END
+GO
+
+ALTER TABLE ["BABEL_5111.😃😄😉😊"].t1 ENABLE TRIGGER BABEL_5111_trgger1
+GO
+
+USE master
+GO
+
+EXEC ["BABEL_5111.db"].["BABEL_5111.scm"].p1
+GO
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].t1
+GO
+
+SELECT * from ["BABEL_5111.db"].["BABEL_5111.scm"].v1
+GO
+
+EXEC ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].p1
+GO
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].t1
+GO
+
+SELECT * from ["龙漫远; 龍漫遠.¢£€¥"].["BABEL_5111.😃😄😉😊"].v1
+GO
+
+use ["BABEL_5111.db"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.scm"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.scm"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.scm"].v1
+GO
+
+DROP TABLE ["BABEL_5111.scm"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.scm"]
+GO
+
+DROP TABLE t1
+GO
+
+USE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+DROP PROCEDURE ["BABEL_5111.😃😄😉😊"].p1
+GO
+
+DROP TRIGGER ["BABEL_5111.😃😄😉😊"].BABEL_5111_trgger1
+GO
+
+DROP VIEW ["BABEL_5111.😃😄😉😊"].v1
+GO
+
+DROP TABLE ["BABEL_5111.😃😄😉😊"].t1
+GO
+
+DROP SCHEMA ["BABEL_5111.😃😄😉😊"]
+GO
+
+USE master
+GO
+
+DROP DATABASE ["BABEL_5111.db"]
+GO
+
+DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
+GO
+
+SELECT set_config('role', 'jdbc_user', false);
+GO
+
+-- Reset migration mode to default
+DECLARE @mig_mode VARCHAR(10)
+SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
+SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
+GO
+
+Drop Table IF EXISTS babelfish_migration_mode_table
+GO


### PR DESCRIPTION
Earlier the database and schema name in format with quotes was not handled in the reset search path as when database and schema was created in format ["abc.df"], it was unable to find the correct search with this database and the creation of some objects like view inside a schema in this database was also not able to reset the search path correctly as it was giving invalid value for parameter.

In this commit, we have added quote identifier in search path to support database name and schema name in quotes for multi-db

Issues Resolved: BABEL-5111
