### PR TITLE
Show public role entry in sys.server_principals (#2765)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -357,7 +357,7 @@ FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ex
 WHERE pg_has_role(suser_id(), 'sysadmin'::TEXT, 'MEMBER')
   OR Ext.orig_loginname = suser_name()
   OR Ext.orig_loginname = (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = CURRENT_DATABASE()) COLLATE sys.database_default
-  OR Ext.type = 'R';
+  OR Ext.type = 'R'
 UNION ALL
 SELECT
 CAST('public' AS SYS.SYSNAME) AS name,

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -355,9 +355,24 @@ CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.owning_principal_id END AS INT) AS
 CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.is_fixed_role END AS sys.BIT) AS is_fixed_role
 FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname
 WHERE pg_has_role(suser_id(), 'sysadmin'::TEXT, 'MEMBER')
-OR Ext.orig_loginname = suser_name()
-OR Ext.orig_loginname = (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = CURRENT_DATABASE()) COLLATE sys.database_default
-OR Ext.type = 'R';
+  OR Ext.orig_loginname = suser_name()
+  OR Ext.orig_loginname = (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = CURRENT_DATABASE()) COLLATE sys.database_default
+  OR Ext.type = 'R';
+UNION ALL
+SELECT
+CAST('public' AS SYS.SYSNAME) AS name,
+CAST(-1 AS INT) AS principal_id,
+CAST(CAST(0 as INT) as sys.varbinary(85)) AS sid,
+CAST('R' AS CHAR(1)) as type,
+CAST('SERVER_ROLE' AS NVARCHAR(60)) AS type_desc,
+CAST(0 AS INT) AS is_disabled,
+CAST(NULL AS SYS.DATETIME) AS create_date,
+CAST(NULL AS SYS.DATETIME) AS modify_date,
+CAST(NULL AS SYS.SYSNAME) AS default_database_name,
+CAST(NULL AS SYS.SYSNAME) AS default_language_name,
+CAST(NULL AS INT) AS credential_id,
+CAST(1 AS INT) AS owning_principal_id,
+CAST(0 AS sys.BIT) AS is_fixed_role;
 
 GRANT SELECT ON sys.server_principals TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
@@ -5389,7 +5389,7 @@ FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ex
 WHERE pg_has_role(suser_id(), 'sysadmin'::TEXT, 'MEMBER')
   OR Ext.orig_loginname = suser_name()
   OR Ext.orig_loginname = (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = CURRENT_DATABASE()) COLLATE sys.database_default
-  OR Ext.type = 'R';
+  OR Ext.type = 'R'
 UNION ALL
 SELECT
 CAST('public' AS SYS.SYSNAME) AS name,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.6.0--3.7.0.sql
@@ -5362,6 +5362,52 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
+-- SERVER_PRINCIPALS
+CREATE OR REPLACE VIEW sys.server_principals
+AS SELECT
+CAST(Ext.orig_loginname AS sys.SYSNAME) AS name,
+CAST(Base.oid As INT) AS principal_id,
+CAST(CAST(Base.oid as INT) as sys.varbinary(85)) AS sid,
+CAST(Ext.type AS CHAR(1)) as type,
+CAST(
+  CASE
+    WHEN Ext.type = 'S' THEN 'SQL_LOGIN'
+    WHEN Ext.type = 'R' THEN 'SERVER_ROLE'
+    WHEN Ext.type = 'U' THEN 'WINDOWS_LOGIN'
+    ELSE NULL
+  END
+  AS NVARCHAR(60)) AS type_desc,
+CAST(Ext.is_disabled AS INT) AS is_disabled,
+CAST(Ext.create_date AS SYS.DATETIME) AS create_date,
+CAST(Ext.modify_date AS SYS.DATETIME) AS modify_date,
+CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.default_database_name END AS SYS.SYSNAME) AS default_database_name,
+CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
+CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.credential_id END AS INT) AS credential_id,
+CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.owning_principal_id END AS INT) AS owning_principal_id,
+CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.is_fixed_role END AS sys.BIT) AS is_fixed_role
+FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname
+WHERE pg_has_role(suser_id(), 'sysadmin'::TEXT, 'MEMBER')
+  OR Ext.orig_loginname = suser_name()
+  OR Ext.orig_loginname = (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = CURRENT_DATABASE()) COLLATE sys.database_default
+  OR Ext.type = 'R';
+UNION ALL
+SELECT
+CAST('public' AS SYS.SYSNAME) AS name,
+CAST(-1 AS INT) AS principal_id,
+CAST(CAST(0 as INT) as sys.varbinary(85)) AS sid,
+CAST('R' AS CHAR(1)) as type,
+CAST('SERVER_ROLE' AS NVARCHAR(60)) AS type_desc,
+CAST(0 AS INT) AS is_disabled,
+CAST(NULL AS SYS.DATETIME) AS create_date,
+CAST(NULL AS SYS.DATETIME) AS modify_date,
+CAST(NULL AS SYS.SYSNAME) AS default_database_name,
+CAST(NULL AS SYS.SYSNAME) AS default_language_name,
+CAST(NULL AS INT) AS credential_id,
+CAST(1 AS INT) AS owning_principal_id,
+CAST(0 AS sys.BIT) AS is_fixed_role;
+
+GRANT SELECT ON sys.server_principals TO PUBLIC;
+
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,

--- a/test/JDBC/expected/sys-server_principals-vu-prepare.out
+++ b/test/JDBC/expected/sys-server_principals-vu-prepare.out
@@ -4,3 +4,10 @@ GO
 
 CREATE LOGIN sys_server_principals_vu_login_with_sa with password = '123'
 GO
+
+CREATE LOGIN [public] WITH PASSWORD = 'test';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role name "public" is reserved)~~
+

--- a/test/JDBC/expected/sys-server_principals-vu-verify.out
+++ b/test/JDBC/expected/sys-server_principals-vu-verify.out
@@ -30,6 +30,16 @@ sysadmin#!#R#!#SERVER_ROLE#!#<NULL>#!#English#!#<NULL>#!#1#!#1
 ~~END~~
 
 
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id, is_fixed_role
+FROM sys.server_principals 
+WHERE name =  'public';
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int#!#int#!#bit
+public#!#R#!#SERVER_ROLE#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0
+~~END~~
+
+
 -- reset the login password
 ALTER LOGIN sys_server_principals_vu_login_without_sa WITH PASSWORD = '123';
 GO
@@ -42,6 +52,7 @@ GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int#!#int#!#bit
 jdbc_user#!#S#!#SQL_LOGIN#!#master#!#English#!#-1#!#-1#!#0
+public#!#R#!#SERVER_ROLE#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0
 sys_server_principals_vu_login_without_sa#!#S#!#SQL_LOGIN#!#master#!#English#!#-1#!#-1#!#0
 sysadmin#!#R#!#SERVER_ROLE#!#<NULL>#!#English#!#<NULL>#!#1#!#1
 ~~END~~

--- a/test/JDBC/input/sys-server_principals-vu-prepare.mix
+++ b/test/JDBC/input/sys-server_principals-vu-prepare.mix
@@ -4,3 +4,6 @@ GO
 
 CREATE LOGIN sys_server_principals_vu_login_with_sa with password = '123'
 GO
+
+CREATE LOGIN [public] WITH PASSWORD = 'test';
+GO

--- a/test/JDBC/input/sys-server_principals-vu-verify.mix
+++ b/test/JDBC/input/sys-server_principals-vu-verify.mix
@@ -15,6 +15,11 @@ FROM sys.server_principals
 WHERE name =  'sysadmin';
 GO
 
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id, is_fixed_role
+FROM sys.server_principals 
+WHERE name =  'public';
+GO
+
 -- reset the login password
 ALTER LOGIN sys_server_principals_vu_login_without_sa WITH PASSWORD = '123';
 GO

--- a/test/JDBC/input/views/sys-server_principals.sql
+++ b/test/JDBC/input/views/sys-server_principals.sql
@@ -11,7 +11,15 @@ FROM sys.server_principals
 WHERE name =  'sysadmin';
 GO
 
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id, is_fixed_role
+FROM sys.server_principals 
+WHERE name =  'public';
+GO
+
 CREATE LOGIN serv_principal_test WITH PASSWORD = 'test';
+GO
+
+CREATE LOGIN [public] WITH PASSWORD = 'test';
 GO
 
 SELECT name, type, type_desc, default_database_name, default_language_name

--- a/test/JDBC/sql_expected/sys-server_principals.out
+++ b/test/JDBC/sql_expected/sys-server_principals.out
@@ -26,8 +26,25 @@ sysadmin#!#R#!#SERVER_ROLE#!#<NULL>#!#English#!#<NULL>#!#1#!#1
 ~~END~~
 
 
+SELECT name, type, type_desc, default_database_name, default_language_name, credential_id, owning_principal_id, is_fixed_role
+FROM sys.server_principals 
+WHERE name =  'public';
+GO
+~~START~~
+varchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int#!#int#!#bit
+public#!#R#!#SERVER_ROLE#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0
+~~END~~
+
+
 CREATE LOGIN serv_principal_test WITH PASSWORD = 'test';
 GO
+
+CREATE LOGIN [public] WITH PASSWORD = 'test';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role name "public" is reserved)~~
+
 
 SELECT name, type, type_desc, default_database_name, default_language_name
 FROM sys.server_principals 


### PR DESCRIPTION
### Description
Currently in Babelfish we don't show any `public` entry. We should show the public role as well. To achieve this I have added a `public` entry in the sys.server_principals by making changes in the ownership.sql and added relevant testcases.

A sysadmin login and a non-sysadmin login both see the public role in the sys.server_principals entries.

Example shown below:
```
--BBF Server
1> select name from sys.server_principals
2> go 
name 
------------ 
sysadmin 
rcv
```
## Changes Made:
- Updated `sys.server_principals` view to show `public` role entry
- Added test for the `public` role

### Issues Resolved
Task: BABEL-4518

### Test Scenarios Covered ###
* **Use case based -** yes


* **Boundary conditions -** yes


* **Arbitrary inputs -** yes


* **Negative test cases -** yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

Signed-off-by: P Aswini Kumar [aswinii@amazon.com](mailto:aswinii@amazon.com)

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).