### PR TITLE
Restrict rename operation on babelfish partition tables

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -5677,7 +5677,7 @@ remove_entry_from_bbf_partition_depend(int16 dbid, char *schema_name, char *tabl
  * 	RENAME TABLE command to have consistency with the new names.
  */
 void
-rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt)
+rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt, char *logical_schema_name, int16 dbid)
 {
 	Relation	rel;
 	HeapTuple	tuple, new_tuple;
@@ -5687,18 +5687,7 @@ rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt)
 	Datum		new_record[BBF_PARTITION_DEPEND_NUM_COLS];
 	bool		new_record_nulls[BBF_PARTITION_DEPEND_NUM_COLS];
 	bool		new_record_replace[BBF_PARTITION_DEPEND_NUM_COLS];
-	char		*logical_schema_name;
 	char		*table_name = stmt->relation->relname;
-	int16		dbid;
-
-	/* Find the logical schema name from physical schema name. */
-	logical_schema_name = (char *) get_logical_schema_name(stmt->relation->schemaname, true);
-
-	if (!logical_schema_name) /* not a TSQL schema */
-		return;
-
-	/* Find the dbid from physical schema name. */
-	dbid = get_dbid_from_physical_schema_name(stmt->relation->schemaname, false);
 
 	/* Open the catalog table. */
 	rel = table_open(get_bbf_partition_depend_oid(), RowExclusiveLock);
@@ -5751,9 +5740,6 @@ rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt)
 	systable_endscan(scan);
 	/* Close the catalog table. */
 	table_close(rel, RowExclusiveLock);
-
-	/* Free the allocated memory. */
-	pfree(logical_schema_name);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -473,7 +473,7 @@ extern void	add_entry_to_bbf_partition_depend(int16 dbid, char* partition_scheme
 extern void	remove_entry_from_bbf_partition_depend(int16 dbid, char *schema_name, char *table_name);
 extern bool	is_bbf_partitioned_table(int16 dbid, char *schema_name, char *table_name);
 extern char	*get_partition_scheme_for_partitioned_table(int16 dbid, char *schema_name, char *table_name);
-extern void	rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt);
+extern void	rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt, char *logical_schema_name, int16 dbid);
 
 
 typedef struct FormData_bbf_extended_properties

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3684,10 +3684,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 											params, queryEnv, dest, qc);
 				
 				if (stmt->renameType == OBJECT_TABLE)
-				{
-					rename_table_update_bbf_partitions_name(stmt);
-					rename_table_update_bbf_partition_depend_catalog(stmt);
-				}
+					bbf_rename_handle_partitioned_table(stmt);
 				if (sql_dialect == SQL_DIALECT_TSQL)
 				{
 					rename_update_bbf_catalog(stmt);

--- a/contrib/babelfishpg_tsql/src/pltsql_partition.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_partition.c
@@ -48,6 +48,7 @@ static void set_partition_range_bounds(PartitionBoundSpec *partbound, Datum *ran
 					int total_partitions, bool is_binary_datatype);
 static void set_node_value_from_datum(A_Const *node, Datum val, bool is_binary_datatype);
 static CreateStmt *create_partition_stmt(char *physical_schema_name, char *relname);
+static void rename_table_update_bbf_partitions_name(RenameStmt *stmt, Oid parentrelid);
 
 
 /*
@@ -618,19 +619,93 @@ bbf_validate_partitioned_index_alignment(IndexStmt *stmt)
 }
 
 /*
+ * bbf_rename_handle_partitioned_table
+ * 	1. For a rename operation on a babelfish partitioned table, rename all of its partition and
+ * 	   and update the table_name in sys.babelfish_partition_depend catalog.
+ * 	2. For a rename operation on a babelfish partition table, raise error.
+ */
+void
+bbf_rename_handle_partitioned_table(RenameStmt *stmt)
+{
+	char		*physical_schema_name = stmt->relation->schemaname;
+	char		*table_name = stmt->relation->relname;
+	char		*logical_schema_name;
+	bool		is_partition_table, is_partitioned_table;
+	Form_pg_class	form;
+	HeapTuple	tuple;
+	Oid		relid;
+	int16		dbid;
+
+	/* Find logical schema name from the physical schema name. */
+	logical_schema_name = (char *) get_logical_schema_name(physical_schema_name, true);
+
+	if (!logical_schema_name) /* not a TSQL schema */
+		return;
+	
+	/* Find relation's pg_class tuple using the name and schema name. */
+	tuple =	SearchSysCache2(RELNAMENSP,
+					CStringGetDatum(stmt->newname),
+					ObjectIdGetDatum(get_namespace_oid(physical_schema_name, false)));
+
+	if (!HeapTupleIsValid(tuple)) /* Sanity check. */
+	{
+		pfree(logical_schema_name);
+		return;
+	}
+	
+	form = (Form_pg_class) GETSTRUCT(tuple);
+	relid = form->oid;
+	is_partition_table = form->relispartition;
+	is_partitioned_table = (form->relkind == RELKIND_PARTITIONED_TABLE);
+	ReleaseSysCache(tuple);
+
+	/* Proceed further only if table is a partition or partitioned table. */
+	if (!is_partition_table && !is_partitioned_table)
+	{
+		pfree(logical_schema_name);
+		return;
+	}
+
+	/* Find dbid from the physical schema name. */
+	dbid = get_dbid_from_physical_schema_name(physical_schema_name, false);
+
+	/*
+	 * For babelfish partition table, user should not
+	 * be allowed to rename it.
+	 */
+	if (is_partition_table)
+	{
+		char	*parent_table_name = get_rel_name(get_partition_parent(relid, false));
+		if (is_bbf_partitioned_table(dbid, logical_schema_name, parent_table_name))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("Cannot rename babelfish partition table '%s'.", stmt->relation->relname)));
+		pfree(parent_table_name);
+	}
+	/*
+	 * For babelfish partitioned table, rename all of its partition and
+	 * update the table_name in sys.babelfish_partition_depend catalog.
+	 */
+	else if (is_bbf_partitioned_table(dbid, logical_schema_name, table_name))
+	{
+		rename_table_update_bbf_partitions_name(stmt, relid);
+		rename_table_update_bbf_partition_depend_catalog(stmt, logical_schema_name, dbid);
+	}
+	pfree(logical_schema_name);
+}
+
+/*
  * rename_table_update_bbf_partitions_name
  *	For a rename operation on a babelfish partitioned table, it renames all partition
  *	of the table to the new name using hash based on the new name, so that
  *	name of partitions of any partitioned table doesn't conflict.
  */
-void
-rename_table_update_bbf_partitions_name(RenameStmt *stmt)
+static void
+rename_table_update_bbf_partitions_name(RenameStmt *stmt, Oid parentrelid)
 {
 	char		*physical_schema_name = stmt->relation->schemaname;
-	char		*logical_schema_name;
 	char		*table_name = stmt->relation->relname;
 	List		*partition_names = NIL;
-	int16		dbid;
 	char		*new_hash;
 	PlannedStmt	*wrapper;
 	RenameStmt	*rename_partition_stmt = NULL;
@@ -638,28 +713,12 @@ rename_table_update_bbf_partitions_name(RenameStmt *stmt)
 	Relation	relation;
 	SysScanDesc	scan;
 	ScanKeyData	key;
-	Oid		parentrelid;
 	Oid		inhrelid;
 	HeapTuple	tuple;
 	const char	*old_dialect;
 	StringInfoData	query;
 	char		*partition_name;
 	char		*new_partition_name;
-
-	logical_schema_name = (char *) get_logical_schema_name(physical_schema_name, true);
-
-	if (!logical_schema_name) /* not a TSQL schema */
-		return;
-	
-	dbid = get_dbid_from_physical_schema_name(physical_schema_name, false);
-	
-	if (!is_bbf_partitioned_table(dbid, logical_schema_name, table_name))
-	{
-		pfree(logical_schema_name);
-		return;
-	}
-
-	parentrelid = get_relname_relid(stmt->newname, get_namespace_oid(physical_schema_name, false));
 
 	relation = table_open(InheritsRelationId, AccessShareLock);
 
@@ -757,7 +816,6 @@ rename_table_update_bbf_partitions_name(RenameStmt *stmt)
 	/* Free the allocated memory. */
 	if (partition_names)
 		list_free(partition_names);
-	pfree(logical_schema_name);
 	pfree(new_hash);
 	pfree(query.data);
 }

--- a/contrib/babelfishpg_tsql/src/pltsql_partition.h
+++ b/contrib/babelfishpg_tsql/src/pltsql_partition.h
@@ -25,6 +25,6 @@ extern void bbf_create_partition_tables(CreateStmt *stmt);
 extern void bbf_drop_handle_partitioned_table(DropStmt *stmt);
 extern void bbf_alter_handle_partitioned_table(AlterTableStmt *stmt);
 extern bool bbf_validate_partitioned_index_alignment(IndexStmt *stmt);
-extern void rename_table_update_bbf_partitions_name(RenameStmt *stmt);
+extern void bbf_rename_handle_partitioned_table(RenameStmt *stmt);
 
 #endif							/* PLTSQL_PARTITION_H */

--- a/test/JDBC/expected/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/PARTITION-vu-verify.out
@@ -2647,6 +2647,39 @@ GO
 ~~ERROR (Message: Cannot drop the babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_0'.)~~
 
 
+-- psql
+--------------------------------------------------------------------
+-- user should not be allowed to rename partition of
+-- babelfish partitioned table neither from psql nor tsql endpoint
+--------------------------------------------------------------------
+-- Attempt to rename partition of babelfish partitioned table from psql endpoint
+-- explicit schema name specified
+ALTER TABLE master_dbo."363863941f079adaa9aa733200e57c9f_partition_0" 
+RENAME TO xyz
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Cannot rename babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_0'.
+    Server SQLState: 0A000)~~
+
+
+-- using search_path
+SET search_path = public, master_dbo;
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
+RENAME TO xyz
+GO
+
+-- tsql
+-- Attempt to rename partition of babelfish partitioned table from tsql endpoint
+-- NOTE: object not found error because sp_rename lookup in sys.objects which 
+-- will not list child objects
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: There is no object with the given @objname.)~~
+
+
 --------------------------------------------------------------------
 --- Unsupported Option with CREATE TABLE with PARTITION SCHEME
 --------------------------------------------------------------------

--- a/test/JDBC/expected/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/PARTITION-vu-verify.out
@@ -2665,15 +2665,20 @@ GO
 
 -- using search_path
 SET search_path = public, master_dbo;
-ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
-RENAME TO xyz
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_1"
+RENAME TO xyz1
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Cannot rename babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_1'.
+    Server SQLState: 0A000)~~
+
 
 -- tsql
 -- Attempt to rename partition of babelfish partitioned table from tsql endpoint
 -- NOTE: object not found error because sp_rename lookup in sys.objects which 
 -- will not list child objects
-EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_2', 'xyz2', 'OBJECT'
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
@@ -2647,6 +2647,39 @@ GO
 ~~ERROR (Message: Cannot drop the babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_0'.)~~
 
 
+-- psql
+--------------------------------------------------------------------
+-- user should not be allowed to rename partition of
+-- babelfish partitioned table neither from psql nor tsql endpoint
+--------------------------------------------------------------------
+-- Attempt to rename partition of babelfish partitioned table from psql endpoint
+-- explicit schema name specified
+ALTER TABLE master_dbo."363863941f079adaa9aa733200e57c9f_partition_0" 
+RENAME TO xyz
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Cannot rename babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_0'.
+    Server SQLState: 0A000)~~
+
+
+-- using search_path
+SET search_path = public, master_dbo;
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
+RENAME TO xyz
+GO
+
+-- tsql
+-- Attempt to rename partition of babelfish partitioned table from tsql endpoint
+-- NOTE: object not found error because sp_rename lookup in sys.objects which 
+-- will not list child objects
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: There is no object with the given @objname.)~~
+
+
 --------------------------------------------------------------------
 --- Unsupported Option with CREATE TABLE with PARTITION SCHEME
 --------------------------------------------------------------------

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
@@ -2665,15 +2665,20 @@ GO
 
 -- using search_path
 SET search_path = public, master_dbo;
-ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
-RENAME TO xyz
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_1"
+RENAME TO xyz1
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Cannot rename babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_1'.
+    Server SQLState: 0A000)~~
+
 
 -- tsql
 -- Attempt to rename partition of babelfish partitioned table from tsql endpoint
 -- NOTE: object not found error because sp_rename lookup in sys.objects which 
 -- will not list child objects
-EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_2', 'xyz2', 'OBJECT'
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
@@ -2756,6 +2756,39 @@ GO
 ~~ERROR (Message: Cannot drop the babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_0'.)~~
 
 
+-- psql
+--------------------------------------------------------------------
+-- user should not be allowed to rename partition of
+-- babelfish partitioned table neither from psql nor tsql endpoint
+--------------------------------------------------------------------
+-- Attempt to rename partition of babelfish partitioned table from psql endpoint
+-- explicit schema name specified
+ALTER TABLE master_dbo."363863941f079adaa9aa733200e57c9f_partition_0" 
+RENAME TO xyz
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Cannot rename babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_0'.
+    Server SQLState: 0A000)~~
+
+
+-- using search_path
+SET search_path = public, master_dbo;
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
+RENAME TO xyz
+GO
+
+-- tsql
+-- Attempt to rename partition of babelfish partitioned table from tsql endpoint
+-- NOTE: object not found error because sp_rename lookup in sys.objects which 
+-- will not list child objects
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: There is no object with the given @objname.)~~
+
+
 --------------------------------------------------------------------
 --- Unsupported Option with CREATE TABLE with PARTITION SCHEME
 --------------------------------------------------------------------

--- a/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
@@ -2774,15 +2774,20 @@ GO
 
 -- using search_path
 SET search_path = public, master_dbo;
-ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
-RENAME TO xyz
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_1"
+RENAME TO xyz1
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Cannot rename babelfish partition table '363863941f079adaa9aa733200e57c9f_partition_1'.
+    Server SQLState: 0A000)~~
+
 
 -- tsql
 -- Attempt to rename partition of babelfish partitioned table from tsql endpoint
 -- NOTE: object not found error because sp_rename lookup in sys.objects which 
 -- will not list child objects
-EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_2', 'xyz2', 'OBJECT'
 GO
 ~~ERROR (Code: 33557097)~~
 

--- a/test/JDBC/input/PARTITION-vu-verify.mix
+++ b/test/JDBC/input/PARTITION-vu-verify.mix
@@ -1084,6 +1084,30 @@ DROP TABLE [363863941f079adaa9aa733200e57c9f_partition_0]
 GO
 
 --------------------------------------------------------------------
+-- user should not be allowed to rename partition of
+-- babelfish partitioned table neither from psql nor tsql endpoint
+--------------------------------------------------------------------
+-- Attempt to rename partition of babelfish partitioned table from psql endpoint
+-- psql
+-- explicit schema name specified
+ALTER TABLE master_dbo."363863941f079adaa9aa733200e57c9f_partition_0" 
+RENAME TO xyz
+GO
+
+-- using search_path
+SET search_path = public, master_dbo;
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
+RENAME TO xyz
+GO
+
+-- Attempt to rename partition of babelfish partitioned table from tsql endpoint
+-- NOTE: object not found error because sp_rename lookup in sys.objects which 
+-- will not list child objects
+-- tsql
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+GO
+--------------------------------------------------------------------
+
 --- Unsupported Option with CREATE TABLE with PARTITION SCHEME
 --------------------------------------------------------------------
 -- Computed column as partitioning column is not yet supported in babelfish

--- a/test/JDBC/input/PARTITION-vu-verify.mix
+++ b/test/JDBC/input/PARTITION-vu-verify.mix
@@ -1096,15 +1096,15 @@ GO
 
 -- using search_path
 SET search_path = public, master_dbo;
-ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_0"
-RENAME TO xyz
+ALTER TABLE "363863941f079adaa9aa733200e57c9f_partition_1"
+RENAME TO xyz1
 GO
 
 -- Attempt to rename partition of babelfish partitioned table from tsql endpoint
 -- NOTE: object not found error because sp_rename lookup in sys.objects which 
 -- will not list child objects
 -- tsql
-EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_0', 'xyz', 'OBJECT'
+EXEC sp_rename '363863941f079adaa9aa733200e57c9f_partition_2', 'xyz2', 'OBJECT'
 GO
 --------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

This commit restricts the rename operation on partition of babelfish partitioned tables. Allowing rename operation on partitions of a Babelfish partitioned table will break the naming convention we are following to generate partition names.


### Issues Resolved

Task: BABEL-5143

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).