### PR TITLE
Fix incorrect ordinal position issue in partition function when implicit conversion of range values fails

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -4257,7 +4257,7 @@ exec_stmt_partition_function(PLtsql_execstate *estate, PLtsql_stmt_partition_fun
 
 	input_values = palloc(nargs * sizeof(Datum));
 
-	for (int i = 0; i < nargs; i++)
+	for (volatile int i = 0; i < nargs; i++)
 	{
 		Datum val;
 


### PR DESCRIPTION
### Description

This commit fix the issue of incorrect ordinal position in error message occuring on aarch machine when implicit conversion of range values to the expected parameter type of the partition function fails.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

Root cause:

We were getting incorrect ordinal position in error message which is being raised inside catch block. The issue was only arising on ARM architecture which seems due to compilers improperly optimizing the local variable and later extraction of value from register after longjmp was giving incorrect value.

PG suggests to use volatile for local variable if is being modified in try block and want to access it in catch block to restrict compiler optimization (ref [link](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/c2282d61fcce0fa321f56f1d5f4d5c4018d10253/src/include/utils/elog.h#L368)) but here even though it is not being modified in try block but it was leading to similar issue.

### Test Scenarios Covered ###
Already present

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).