### PR TITLE
Add automated tests which validates oid returned from sys.triggers, sys.events, sys.objects, sys.all_objects same as object_id

### DIFF
--- a/test/JDBC/expected/sys-events-vu-verify.out
+++ b/test/JDBC/expected/sys-events-vu-verify.out
@@ -22,6 +22,15 @@ sys_events_vu_prepare_trig3
 ~~END~~
 
 
+select o.name, case when o.object_id = e.object_id and o.object_id = object_id(o.name) then 'equal' else 'not equal' end
+from sys.objects o join sys.events e on o.object_id = e.object_id where o.name = 'sys_events_vu_prepare_trig3';
+go
+~~START~~
+varchar#!#text
+sys_events_vu_prepare_trig3#!#equal
+~~END~~
+
+
 USE master
 GO
 

--- a/test/JDBC/expected/sys-objects-vu-verify.out
+++ b/test/JDBC/expected/sys-objects-vu-verify.out
@@ -57,6 +57,15 @@ varchar#!#char#!#nvarchar
 USE master
 GO
 
+select case when object_id([name]) = object_id then 'equal' else 'not equal' end
+from sys_objects_vu_prepare_db1.sys.objects where [name] = 'sys_objects_vu_prepare_trig1'
+go
+~~START~~
+text
+equal
+~~END~~
+
+
 -- Verify cross db reference, it should show the same rows as displayed by the cross db query above.
 select name from sys_objects_vu_prepare_db1.sys.objects order by name;
 GO

--- a/test/JDBC/expected/sys-triggers.out
+++ b/test/JDBC/expected/sys-triggers.out
@@ -35,6 +35,15 @@ SELECT 1
 END
 GO
 
+select case when object_id([name]) = object_id then 'equal' else 'not equal' end 
+from sys.triggers where [name] = 'trig2'
+go
+~~START~~
+text
+equal
+~~END~~
+
+
 -- test instead of insert trigger
 SELECT 
     name,

--- a/test/JDBC/expected/sys_all_objects-vu-verify.out
+++ b/test/JDBC/expected/sys_all_objects-vu-verify.out
@@ -11,3 +11,12 @@ sys_all_objects_vu_prepare_1_6_if_1#!#IF#!#SQL_INLINE_TABLE_VALUED_FUNCTION
 sys_all_objects_vu_prepare_1_7_if_2#!#IF#!#SQL_INLINE_TABLE_VALUED_FUNCTION
 ~~END~~
 
+
+select case when object_id([name]) = object_id then 'equal' else 'not equal' end
+from sys.all_objects where [name] = 'sys_all_objects_vu_prepare_1_3'
+go
+~~START~~
+text
+equal
+~~END~~
+

--- a/test/JDBC/input/views/sys-events-vu-verify.sql
+++ b/test/JDBC/input/views/sys-events-vu-verify.sql
@@ -12,6 +12,10 @@ JOIN sys.events e ON e.object_id = ao.object_id
 WHERE name = 'sys_events_vu_prepare_trig3'
 GO
 
+select o.name, case when o.object_id = e.object_id and o.object_id = object_id(o.name) then 'equal' else 'not equal' end
+from sys.objects o join sys.events e on o.object_id = e.object_id where o.name = 'sys_events_vu_prepare_trig3';
+go
+
 USE master
 GO
 

--- a/test/JDBC/input/views/sys-objects-vu-verify.sql
+++ b/test/JDBC/input/views/sys-objects-vu-verify.sql
@@ -27,6 +27,10 @@ GO
 USE master
 GO
 
+select case when object_id([name]) = object_id then 'equal' else 'not equal' end
+from sys_objects_vu_prepare_db1.sys.objects where [name] = 'sys_objects_vu_prepare_trig1'
+go
+
 -- Verify cross db reference, it should show the same rows as displayed by the cross db query above.
 select name from sys_objects_vu_prepare_db1.sys.objects order by name;
 GO

--- a/test/JDBC/input/views/sys-triggers.sql
+++ b/test/JDBC/input/views/sys-triggers.sql
@@ -35,6 +35,10 @@ SELECT 1
 END
 GO
 
+select case when object_id([name]) = object_id then 'equal' else 'not equal' end 
+from sys.triggers where [name] = 'trig2'
+go
+
 -- test instead of insert trigger
 SELECT 
     name,

--- a/test/JDBC/input/views/sys_all_objects-vu-verify.sql
+++ b/test/JDBC/input/views/sys_all_objects-vu-verify.sql
@@ -1,2 +1,6 @@
 SELECT name, type, type_desc from sys.all_objects  where name like 'sys_all_objects_vu_prepare_1%' order by name;
 GO
+
+select case when object_id([name]) = object_id then 'equal' else 'not equal' end
+from sys.all_objects where [name] = 'sys_all_objects_vu_prepare_1_3'
+go


### PR DESCRIPTION


### Description

Add automated tests which validates oid returned from sys.triggers, sys.events, sys.objects, sys.all_objects same as object_id

### Issues Resolved

Issues Resolved: Task: BABEL-5108, BABEL-3927

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).