### PR TITLE
Fix the issue the column name is not right

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1783,7 +1783,11 @@ pre_transform_target_entry(ResTarget *res, ParseState *pstate,
 					 * for the last_dot position
 					 */
 					if (*colname_start == '-' && *(colname_start+1) == '-')
+					{
+						last_dot++;
+						colname_start = last_dot;
 						break;
+					}
 					if(open_square_bracket == 0 && *colname_start == '"')
 					{
 						double_quotes++;


### PR DESCRIPTION
Column name is wrong when the column is followed with a direct '--' comment, this commit fix the issue by correctly set the column_start pointer during the identifier search.

Task: BABEL-5139

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).