### PR TITLE
fix infinite loop in replace with AI collations

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -52,7 +52,7 @@
 #define UCHAR_IS_SURROGATE(c) ((c & 0xF800) == 0xD800)
 
 /* Find length of given Uchar */
-#define UCHAR_LENGTH(c) ( UCHAR_IS_SURROGATE(c) ? 2 : 1)
+#define UCHAR_LENGTH(c) (UCHAR_IS_SURROGATE(c) ? 2 : 1)
 
 Oid			server_collation_oid = InvalidOid;
 collation_callbacks *collation_callbacks_ptr = NULL;

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1475,12 +1475,13 @@ pltsql_strpos_non_determinstic(text *src_text, text *substr_text, Oid collid, in
 		int32_t src_len_utf8 = VARSIZE_ANY_EXHDR(src_text);
 		int32_t substr_len_utf8 = VARSIZE_ANY_EXHDR(substr_text);
 		int32_t src_ulen, substr_ulen;
-		int32_t u8_pos = -1;
+		int32_t u8_pos = -1, pos_prev_loop = -1;
 		UErrorCode	status = U_ZERO_ERROR;
 		UStringSearch *usearch;
 		UChar *src_uchar, *substr_uchar;
 		coll_info_t coll_info_of_inputcollid = tsql_lookup_collation_table_internal(collid);
 		bool is_CS_AI = false;
+		bool is_substr_starts_with_surrogate;
 
 		if (OidIsValid(coll_info_of_inputcollid.oid) &&
 		    coll_info_of_inputcollid.collateflags == 0x000e /* CS_AI  */ )
@@ -1490,6 +1491,8 @@ pltsql_strpos_non_determinstic(text *src_text, text *substr_text, Oid collid, in
 
 		src_ulen = icu_to_uchar(&src_uchar, VARDATA_ANY(src_text), src_len_utf8);
 		substr_ulen = icu_to_uchar(&substr_uchar, VARDATA_ANY(substr_text), substr_len_utf8);
+
+		is_substr_starts_with_surrogate = U16_IS_SURROGATE(substr_uchar[0]);
 
 		usearch = usearch_openFromCollator(substr_uchar,
 										substr_ulen,
@@ -1507,7 +1510,7 @@ pltsql_strpos_non_determinstic(text *src_text, text *substr_text, Oid collid, in
 					 errmsg("failed to perform ICU search: %s",
 							u_errorName(status))));
 
-		for (int u16_pos = usearch_first(usearch, &status);
+		for (int32_t u16_pos = usearch_first(usearch, &status);
 		     u16_pos != USEARCH_DONE;
 		     u16_pos = usearch_next(usearch, &status))
 		{
@@ -1516,6 +1519,28 @@ pltsql_strpos_non_determinstic(text *src_text, text *substr_text, Oid collid, in
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("failed to perform ICU search: %s",
 							u_errorName(status))));
+
+			/* ICU bug, When pattern start with a surrogate pair ICU usearch_next stops moving forward entering an infinite loop */
+			if (u16_pos == pos_prev_loop)
+			{
+				/* IF UTF16 code point is in the range D800 - DBFF, then it is a surrogate pair */
+				int32_t next_char_idx = u16_pos + ((src_uchar[u16_pos] & 0xF800) == 0xD800 ? 2 : 1);
+
+				if (is_substr_starts_with_surrogate && next_char_idx < src_ulen)
+				{
+					usearch_setOffset(usearch, next_char_idx, &status);
+
+					if (U_FAILURE(status))
+						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						        errmsg("failed to set offset in ICU search: %s", u_errorName(status))));
+
+					continue;
+				}
+				else
+					break;
+			}
+
+			pos_prev_loop = u16_pos;
 
 			/* for CS_AI collations usearch can give false positives so we double check the results here */
 			if (!(is_CS_AI && icu_compare_utf8_coll(mylocale->info.icu.ucol, &src_uchar[usearch_getMatchedStart(usearch)], usearch_getMatchedLength(usearch), substr_uchar, substr_ulen, false) != 0))
@@ -1564,7 +1589,7 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 		int32_t src_len = VARSIZE_ANY_EXHDR(src_text);
 		int32_t from_str_len = VARSIZE_ANY_EXHDR(from_text);
 		int32_t to_str_len = VARSIZE_ANY_EXHDR(to_text);
-		int32_t previous_pos;
+		int32_t previous_pos, pos_prev_loop = -1;
 		int32_t src_ulen, from_ulen;		/* in utf-16 units */
 		UErrorCode	status = U_ZERO_ERROR;
 		UStringSearch *usearch;
@@ -1573,6 +1598,7 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 		StringInfoData resbuf;
 		coll_info_t coll_info_of_inputcollid = tsql_lookup_collation_table_internal(collid);
 		bool is_CS_AI = false;
+		bool is_substr_starts_with_surrogate;
 
 		if (OidIsValid(coll_info_of_inputcollid.oid) &&
 		    coll_info_of_inputcollid.collateflags == 0x000e /* CS_AI  */ )
@@ -1582,6 +1608,8 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 
 		src_ulen = icu_to_uchar(&src_uchar, VARDATA_ANY(src_text), src_len);
 		from_ulen = icu_to_uchar(&from_uchar, VARDATA_ANY(from_text), from_str_len);
+
+		is_substr_starts_with_surrogate = U16_IS_SURROGATE(from_uchar[0]);
 
 		usearch = usearch_openFromCollator(from_uchar, /* needle */
 										from_ulen,
@@ -1596,7 +1624,7 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 		initStringInfo(&resbuf);
 		previous_pos = 0;
 
-		for (int pos = usearch_first(usearch, &status);
+		for (int32_t pos = usearch_first(usearch, &status);
 		     pos != USEARCH_DONE;
 		     pos = usearch_next(usearch, &status))
 		{
@@ -1608,6 +1636,28 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("failed to perform ICU search: %s",
 							u_errorName(status))));
+
+			/* ICU bug, When pattern start with a surrogate pair ICU usearch_next stops moving forward entering an infinite loop */
+			if (pos == pos_prev_loop)
+			{
+				/* IF UTF16 code point is in the range D800 - DBFF, then it is a surrogate pair */
+				int32_t next_char_idx = pos + ((src_uchar[pos] & 0xF800) == 0xD800 ? 2 : 1);
+
+				if (is_substr_starts_with_surrogate && next_char_idx < src_ulen)
+				{
+					usearch_setOffset(usearch, next_char_idx, &status);
+
+					if (U_FAILURE(status))
+						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						        errmsg("failed to set offset in ICU search: %s", u_errorName(status))));
+
+					continue;
+				}
+				else
+					break;
+			}
+
+			pos_prev_loop = pos;
 
 			/* for CS_AI collations usearch can give false positives so we double check the results here */
 			if (is_CS_AI && icu_compare_utf8_coll(mylocale->info.icu.ucol, &src_uchar[usearch_getMatchedStart(usearch)], usearch_getMatchedLength(usearch), from_uchar, from_ulen, false) != 0)

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1492,7 +1492,7 @@ pltsql_strpos_non_determinstic(text *src_text, text *substr_text, Oid collid, in
 		src_ulen = icu_to_uchar(&src_uchar, VARDATA_ANY(src_text), src_len_utf8);
 		substr_ulen = icu_to_uchar(&substr_uchar, VARDATA_ANY(substr_text), substr_len_utf8);
 
-		is_substr_starts_with_surrogate = U16_IS_SURROGATE(substr_uchar[0]);
+		is_substr_starts_with_surrogate = ((substr_uchar[0] & 0xF800) == 0xD800);
 
 		usearch = usearch_openFromCollator(substr_uchar,
 										substr_ulen,
@@ -1609,7 +1609,7 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 		src_ulen = icu_to_uchar(&src_uchar, VARDATA_ANY(src_text), src_len);
 		from_ulen = icu_to_uchar(&from_uchar, VARDATA_ANY(from_text), from_str_len);
 
-		is_substr_starts_with_surrogate = U16_IS_SURROGATE(from_uchar[0]);
+		is_substr_starts_with_surrogate = ((from_uchar[0] & 0xF800) == 0xD800);
 
 		usearch = usearch_openFromCollator(from_uchar, /* needle */
 										from_ulen,

--- a/test/JDBC/expected/charindex_and_replace_CIAI_collations.out
+++ b/test/JDBC/expected/charindex_and_replace_CIAI_collations.out
@@ -642,6 +642,66 @@ AAAAAABBBBBBBEEEEEEAAAAA
 DROP TABLE BABEL_4850_T
 GO
 
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂def🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂D', N'abc🙂d🙂d🙂D' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+GO
+~~START~~
+int
+14
+~~END~~
+
+~~START~~
+int
+8
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT REPLACE(N'abc🙂defghi🙂🙂', N'🙂def', N'jhi🙂' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂🙂defghi🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'🙂abc🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+GO
+~~START~~
+nvarchar
+abcjhi🙂ghi🙂🙂
+~~END~~
+
+~~START~~
+nvarchar
+abc<----><----><----><----><---->defghi<----><---->
+~~END~~
+
+~~START~~
+nvarchar
+abc<----><----><----><---->
+~~END~~
+
+~~START~~
+nvarchar
+<---->abc<---->
+~~END~~
+
+
 -- psql
 CREATE COLLATION case_insensitive (provider = icu, locale = 'und-u-ks-level2', deterministic = false);
 CREATE COLLATION ignore_accents (provider = icu, locale = 'nd-u-kc-true-ks-level1', deterministic = false);

--- a/test/JDBC/input/charindex_and_replace_CIAI_collations.mix
+++ b/test/JDBC/input/charindex_and_replace_CIAI_collations.mix
@@ -204,6 +204,21 @@ GO
 DROP TABLE BABEL_4850_T
 GO
 
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂def🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂D', N'abc🙂d🙂d🙂D' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+GO
+
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT REPLACE(N'abc🙂defghi🙂🙂', N'🙂def', N'jhi🙂' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂🙂defghi🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'🙂abc🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+GO
+
 -- psql
 CREATE COLLATION case_insensitive (provider = icu, locale = 'und-u-ks-level2', deterministic = false);
 CREATE COLLATION ignore_accents (provider = icu, locale = 'nd-u-kc-true-ks-level1', deterministic = false);


### PR DESCRIPTION
### Description

ICU usearch_next() goes into infinite loop when pattern to search starts with a surrogate pair.
To get around this we check if output of usearch_next() is stuck and not proceeding forwards 
and set the offset for next search ourselves.
The next offset is simply the next character after the current char in source string.

```
SRC STRING - 'abc🙂defghi🙂🙂'    PATTERN TO FIND = '🙂def'

usearch_next() gets stuck on "🙂" idx = 3 and repeatedly returns this index.
We will intervene and set the offset to "d" idx = 4. 
So that usearch_next only starts looking from this character.
```
### Issues Resolved

[BABEL-5169]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).