### PR TITLE
Restrict DROP USER/ROLE from non-dbo user

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3443,24 +3443,24 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 errmsg("Could not drop login '%s' as the user is currently logged in.", role_name)));
 					}
 					/* If user/role, check for current_user's privileges */
-						else if (drop_user || drop_role)
-						{
-							const char *db_owner_name;
-							char       *db_principal;
-							int			role_oid = get_role_oid(role_name, true);
+					else if (drop_user || drop_role)
+					{
+						const char *db_owner_name;
+						char       *db_principal;
+						int			role_oid = get_role_oid(role_name, true);
 
-							if (drop_user)
-								db_principal = "user";
-							else
-								db_principal = "role";
-							
-							/* must be database owner to drop user/role */
-							db_owner_name = get_db_owner_name(get_cur_db_name());
-							if ((!stmt->missing_ok && !OidIsValid(role_oid)) || !is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)))
-								ereport(ERROR,
-										(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-										errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal, role_name)));
-						}
+						if (drop_user)
+							db_principal = "user";
+						else
+							db_principal = "role";
+						
+						/* must be database owner to drop user/role */
+						db_owner_name = get_db_owner_name(get_cur_db_name());
+						if ((!stmt->missing_ok && !OidIsValid(role_oid)) || !is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)))
+							ereport(ERROR,
+									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+									errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal, role_name)));
+					}
 
 					/*
 					 * We have performed all the permissions checks.

--- a/test/JDBC/expected/BABEL-3844-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3844-vu-cleanup.out
@@ -6,7 +6,7 @@ drop user test_user;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: role "master_test_user" does not exist)~~
+~~ERROR (Message: Cannot drop the user 'master_test_user', because it does not exist or you do not have permission.)~~
 
 
 drop login [babel\aduser1];

--- a/test/JDBC/expected/BABEL-3844-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3844-vu-cleanup.out
@@ -6,7 +6,7 @@ drop user test_user;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the user 'master_test_user', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the user 'test_user', because it does not exist or you do not have permission.)~~
 
 
 drop login [babel\aduser1];

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -41,14 +41,14 @@ drop role dont_drop_role
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the role 'master_dont_drop_role', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the role 'dont_drop_role', because it does not exist or you do not have permission.)~~
 
 
 drop user no_priv_user2
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the user 'master_no_priv_user2', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the user 'no_priv_user2', because it does not exist or you do not have permission.)~~
 
 
 -- tsql
@@ -81,14 +81,14 @@ drop role dont_drop_role
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the role 'master_dont_drop_role', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the role 'dont_drop_role', because it does not exist or you do not have permission.)~~
 
 
 drop user no_priv_user2
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the user 'master_no_priv_user2', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the user 'no_priv_user2', because it does not exist or you do not have permission.)~~
 
 
 -- tsql
@@ -120,14 +120,14 @@ drop role fake_role
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the role 'restrict_user_db1_fake_role', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the role 'fake_role', because it does not exist or you do not have permission.)~~
 
 
 drop user fake_user
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot drop the user 'restrict_user_db1_fake_user', because it does not exist or you do not have permission.)~~
+~~ERROR (Message: Cannot drop the user 'fake_user', because it does not exist or you do not have permission.)~~
 
 
 -- should deny

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -225,8 +225,46 @@ int
 ~~END~~
 
 
+-- psql
+-- 3.4 - Try dropping role created from PG role
+create role master_pguser1;
+go
+
+-- tsql
+drop user pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'pguser1', because it does not exist or you do not have permission.)~~
+
+
+drop role pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'pguser1', because it does not exist or you do not have permission.)~~
+
+
+-- it will still try to drop it, but permission denied will be generated since
+-- bbf_role_admin won't have privilege to drop non-babelfish roles
+drop user if exists pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied to drop role)~~
+
+
+drop role if exists pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied to drop role)~~
+
 
 -- psql
+drop role master_pguser1;
+go
+
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -1,0 +1,167 @@
+-- tsql
+create login no_priv_login1 with password = '12345678'
+go
+
+create role dont_drop_role
+go
+
+create login no_priv_login2 with password = '12345678'
+go
+
+create user no_priv_user2 for login no_priv_login2
+go
+
+create database restrict_user_db1
+go
+
+use restrict_user_db1
+go
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+use master
+go
+
+-- tsql user=no_priv_login1 password=12345678
+-- case-1 - when current user is guest
+-- permission denied
+select current_user,db_name()
+go
+~~START~~
+varchar#!#nvarchar
+guest#!#master
+~~END~~
+
+
+drop role dont_drop_role
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+drop user no_priv_user2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+-- tsql
+select current_user,db_name()
+go
+~~START~~
+varchar#!#nvarchar
+dbo#!#master
+~~END~~
+
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- tsql user=no_priv_login1 password=12345678
+-- case-2 - when current user has no privilege
+-- permission denied
+use master
+go
+
+select current_user
+go
+~~START~~
+varchar
+no_priv_user1
+~~END~~
+
+
+drop role dont_drop_role
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+drop user no_priv_user2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+-- tsql
+
+-- case-3 - when current login has privilege
+-- 3.1 - when login is database owner
+Alter authorization on database::restrict_user_db1 to no_priv_login2
+go
+
+-- tsql user=no_priv_login2 password=12345678 database=restrict_user_db1
+-- allowed
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user1
+go
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- tsql
+-- 3.2 - when login is sysadmin
+-- allowed
+drop user no_priv_user1
+go
+
+drop user no_priv_user2
+go
+
+drop role dont_drop_role
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+
+-- tsql
+drop login no_priv_login1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+drop login no_priv_login2
+go
+
+drop database restrict_user_db1
+go

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -130,6 +130,34 @@ go
 ~~ERROR (Message: Cannot drop the user 'fake_user', because it does not exist or you do not have permission.)~~
 
 
+drop user db
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'db', because it does not exist or you do not have permission.)~~
+
+
+drop role db_own
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'db_own', because it does not exist or you do not have permission.)~~
+
+
+drop user dbo_u1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'dbo_u1', because it does not exist or you do not have permission.)~~
+
+
+drop role db_owner_r1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'db_owner_r1', because it does not exist or you do not have permission.)~~
+
+
 -- should deny
 -- try to drop dbo user, db_owner role
 drop role db_owner

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -41,14 +41,14 @@ drop role dont_drop_role
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User does not have permission to perform this action.)~~
+~~ERROR (Message: Cannot drop the role 'master_dont_drop_role', because it does not exist or you do not have permission.)~~
 
 
 drop user no_priv_user2
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User does not have permission to perform this action.)~~
+~~ERROR (Message: Cannot drop the user 'master_no_priv_user2', because it does not exist or you do not have permission.)~~
 
 
 -- tsql
@@ -81,14 +81,14 @@ drop role dont_drop_role
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User does not have permission to perform this action.)~~
+~~ERROR (Message: Cannot drop the role 'master_dont_drop_role', because it does not exist or you do not have permission.)~~
 
 
 drop user no_priv_user2
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: User does not have permission to perform this action.)~~
+~~ERROR (Message: Cannot drop the user 'master_no_priv_user2', because it does not exist or you do not have permission.)~~
 
 
 -- tsql
@@ -113,6 +113,39 @@ go
 
 drop user no_priv_user1
 go
+
+-- error
+-- try to drop non existing role/user
+drop role fake_role
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'restrict_user_db1_fake_role', because it does not exist or you do not have permission.)~~
+
+
+drop user fake_user
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'restrict_user_db1_fake_user', because it does not exist or you do not have permission.)~~
+
+
+-- should deny
+-- try to drop dbo user, db_owner role
+drop role db_owner
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'db_owner'.)~~
+
+
+drop user dbo
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'dbo'.)~~
+
+
 
 create role dont_drop_role
 go

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -11,6 +11,15 @@ go
 create user no_priv_user2 for login no_priv_login2
 go
 
+create login no_priv_login3 with password = '12345678'
+go
+
+create user no_priv_user3 for login no_priv_login3
+go
+
+create role no_priv_role3;
+go
+
 create database restrict_user_db1
 go
 
@@ -123,7 +132,7 @@ go
 ~~ERROR (Message: Cannot drop the role 'fake_role', because it does not exist or you do not have permission.)~~
 
 
-drop user fake_user
+drop user fake_user;
 go
 ~~ERROR (Code: 33557097)~~
 
@@ -193,6 +202,30 @@ go
 drop role dont_drop_role
 go
 
+-- 3.3 - when drop user/role has IF EXISTS clause
+-- Should not throw error for the case where IF EXISTS clause is included
+drop role if exists fake_role;
+go
+
+drop user if exists fake_user;
+go
+
+-- both of the following statements should be executed successfully since user/role exists
+drop user if exists no_priv_user3;
+go
+
+drop user if exists no_priv_role3;
+go
+
+select count(*) from sys.database_principals where name like '%no_priv_%3';
+go
+~~START~~
+int
+0
+~~END~~
+
+
+
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
@@ -222,6 +255,9 @@ t
 
 -- tsql
 drop login no_priv_login2
+go
+
+drop login no_priv_login3
 go
 
 drop database restrict_user_db1

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -152,8 +152,30 @@ go
 select count(*) from sys.database_principals where name like '%no_priv_%3';
 go
 
+-- 3.4 - Try dropping role created from PG role
+-- psql
+create role master_pguser1;
+go
+
+-- tsql
+drop user pguser1;
+go
+
+drop role pguser1;
+go
+
+-- it will still try to drop it, but permission denied will be generated since
+-- bbf_role_admin won't have privilege to drop non-babelfish roles
+drop user if exists pguser1;
+go
+
+drop role if exists pguser1;
+go
 
 -- psql
+drop role master_pguser1;
+go
+
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -11,6 +11,15 @@ go
 create user no_priv_user2 for login no_priv_login2
 go
 
+create login no_priv_login3 with password = '12345678'
+go
+
+create user no_priv_user3 for login no_priv_login3
+go
+
+create role no_priv_role3;
+go
+
 create database restrict_user_db1
 go
 
@@ -83,7 +92,7 @@ go
 drop role fake_role
 go
 
-drop user fake_user
+drop user fake_user;
 go
 
 drop user db
@@ -125,6 +134,25 @@ go
 drop role dont_drop_role
 go
 
+-- 3.3 - when drop user/role has IF EXISTS clause
+-- Should not throw error for the case where IF EXISTS clause is included
+drop role if exists fake_role;
+go
+
+drop user if exists fake_user;
+go
+
+-- both of the following statements should be executed successfully since user/role exists
+drop user if exists no_priv_user3;
+go
+
+drop user if exists no_priv_role3;
+go
+
+select count(*) from sys.database_principals where name like '%no_priv_%3';
+go
+
+
 -- psql
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
@@ -144,6 +172,9 @@ go
 
 -- tsql
 drop login no_priv_login2
+go
+
+drop login no_priv_login3
 go
 
 drop database restrict_user_db1

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -1,0 +1,121 @@
+-- tsql
+create login no_priv_login1 with password = '12345678'
+go
+
+create role dont_drop_role
+go
+
+create login no_priv_login2 with password = '12345678'
+go
+
+create user no_priv_user2 for login no_priv_login2
+go
+
+create database restrict_user_db1
+go
+
+use restrict_user_db1
+go
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+use master
+go
+
+-- case-1 - when current user is guest
+-- permission denied
+-- tsql user=no_priv_login1 password=12345678
+select current_user,db_name()
+go
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user2
+go
+
+-- tsql
+select current_user,db_name()
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- case-2 - when current user has no privilege
+-- permission denied
+-- tsql user=no_priv_login1 password=12345678
+use master
+go
+
+select current_user
+go
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user2
+go
+
+-- case-3 - when current login has privilege
+-- tsql
+
+-- 3.1 - when login is database owner
+Alter authorization on database::restrict_user_db1 to no_priv_login2
+go
+
+-- allowed
+-- tsql user=no_priv_login2 password=12345678 database=restrict_user_db1
+select current_user
+go
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user1
+go
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- 3.2 - when login is sysadmin
+-- allowed
+-- tsql
+drop user no_priv_user1
+go
+
+drop user no_priv_user2
+go
+
+drop role dont_drop_role
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+
+-- tsql
+drop login no_priv_login1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- tsql
+drop login no_priv_login2
+go
+
+drop database restrict_user_db1
+go

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -86,6 +86,18 @@ go
 drop user fake_user
 go
 
+drop user db
+go
+
+drop role db_own
+go
+
+drop user dbo_u1
+go
+
+drop role db_owner_r1
+go
+
 -- should deny
 -- try to drop dbo user, db_owner role
 drop role db_owner

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -78,6 +78,23 @@ go
 drop user no_priv_user1
 go
 
+-- error
+-- try to drop non existing role/user
+drop role fake_role
+go
+
+drop user fake_user
+go
+
+-- should deny
+-- try to drop dbo user, db_owner role
+drop role db_owner
+go
+
+drop user dbo
+go
+
+
 create role dont_drop_role
 go
 


### PR DESCRIPTION
### Description
Earlier, any user was able to drop user/role, irrespective of whether that user has required privileges or not.

With this commit, only dbo should have the permission to drop user/role.

### Issues Resolved

BABEL-5173

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).