### PR TITLE
jTDS: support logins without PRELOGIN message

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1991,41 +1991,54 @@ TdsProcessLogin(Port *port, bool loadedSsl)
 	TdsErrorContext->phase = 0;
 	TdsErrorContext->reqType = TDS_LOGIN7;
 
-	PG_TRY();
+	/*
+	 * Check whether the first client message is indeed PRELOGIN.
+	 * 7.1 clients may send LOGIN7 instead, for example
+	 * jTDS sends PRELOGIN only when SSL is enabled.
+	 */
+	if (TdsReadNextBuffer() != EOF && TdsCheckMessageType(TDS_PRELOGIN))
 	{
-		TdsErrorContext->err_text = "Parsing PreLogin Request";
-		/* Pre-Login */
-		rc = ParsePreLoginRequest();
+		PG_TRY();
+		{
+			TdsErrorContext->err_text = "Parsing PreLogin Request";
+			/* Pre-Login */
+			rc = ParsePreLoginRequest();
+			if (rc < 0)
+				return rc;
+
+			TdsErrorContext->err_text = "Make PreLogin Response";
+
+			loadEncryption = MakePreLoginResponse(port, loadedSsl);
+			TdsFlush();
+
+			TdsErrorContext->err_text = "Setup SSL Handshake";
+			/* Setup the SSL handshake */
+			if (loadEncryption == TDS_ENCRYPT_ON ||
+				loadEncryption == TDS_ENCRYPT_OFF ||
+				loadEncryption == TDS_ENCRYPT_REQ)
+				rc = SecureOpenServer(port);
+		}
+		PG_CATCH();
+		{
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
+
+		/*
+		 * If SSL handshake failure has occurred then no need to go ahead with
+		 * login, Just return from here.
+		 */
 		if (rc < 0)
 			return rc;
 
-		TdsErrorContext->err_text = "Make PreLogin Response";
-
-		loadEncryption = MakePreLoginResponse(port, loadedSsl);
-		TdsFlush();
-
-		TdsErrorContext->err_text = "Setup SSL Handshake";
-		/* Setup the SSL handshake */
-		if (loadEncryption == TDS_ENCRYPT_ON ||
-			loadEncryption == TDS_ENCRYPT_OFF ||
-			loadEncryption == TDS_ENCRYPT_REQ)
-			rc = SecureOpenServer(port);
+		if (loadEncryption == TDS_ENCRYPT_ON)
+			TDSInstrumentation(INSTR_TDS_LOGIN_END_TO_END_ENCRYPT);
 	}
-	PG_CATCH();
+	else
 	{
-		PG_RE_THROW();
+		TDS_DEBUG(TDS_DEBUG3, "TDS7 PreLogin Message Skipped");
+		loadEncryption = TDS_ENCRYPT_OFF;
 	}
-	PG_END_TRY();
-
-	/*
-	 * If SSL handshake failure has occurred then no need to go ahead with
-	 * login, Just return from here.
-	 */
-	if (rc < 0)
-		return rc;
-
-	if (loadEncryption == TDS_ENCRYPT_ON)
-		TDSInstrumentation(INSTR_TDS_LOGIN_END_TO_END_ENCRYPT);
 
 	PG_TRY();
 	{


### PR DESCRIPTION
### Description

This PR is a part of a change originally implemented in #2320.

This change modifies the TDS login allowing to receive `LOGIN7` as the first client message instead of `PRELOGIN`. It allows to successfully open a connection to Babelfish using jTDS driver without SSL. When the first message is `PRELOGIN` - then login logic is unchanged.

Copying review comments from #2320:

> 1. Let's add a comment why we may not expecting TDS_PRELOGIN as the first request.

Added clarifying comment.

>     2. The check should be
> 
> 
> ```
> if (TdsReadNextBuffer() != EOF && TdsCheckMessageType(TDS_PRELOGIN))
> ```

Modified the check.

>     3. If the prelogin message is not sent, what's the SSL behavior - TDS_ENCRYPT_NOT_SUP or TDS_ENCRYPT_OFF? OFF means the login will still happen in an encrypted manner.

If the first message is `LOGIN7` then SSL behaviour is `TDS_ENCRYPT_OFF (0x00)`. Login does not happen in encrypted manner in this case - password is sent by client in plain text in `LOGIN7` message.

>     4. According the code, the loadEncryption defaults to 0 which is TDS_ENCRYPT_OFF. So, we're freeing the ssl structure towards the end of the function without setting up the socket. Also, according to the code, the login is probably not happening in an encrypted manner.

This is correct, `loadEncryption` was `0` by default, added a branch to explicitly set it to `TDS_ENCRYPT_OFF (0x00)`.
 
> Actually, let's not modify the SSL code at all. Something like as following (after confirming the SSL behavior):

SSL behaviour with jTDS is the following (assuming `babelfishpg_tds.tds_ssl_encrypt = 'false'`):

1. `ssl=off` (in jTDS URL, also default): `PRELOGIN` is not sent, `loadEncryption = TDS_ENCRYPT_OFF (0x00)`

2. `ssl=request`: `PRELOGIN` is sent with `TDS_ENCRYPT_OFF (0x00)`, `loadEncryption = TDS_ENCRYPT_OFF (0x00)`

3. `ssl=require` or `ssl=authenticate`: `PRELOGIN` is sent with `TDS_ENCRYPT_ON (0x01)`, `loadEncryption = TDS_ENCRYPT_ON (0x01)`

> we can have more safer check by checking whether client has ssl=off. If that's the case then only we should skip pre-login msg. Throw an FATAL error otherwise and should terminate connection

M, it seems that we don't have such information at the point of the check. First message (either `PRELOGIN` or `LOGIN7`) is always sent without SSL. Client SSL-request value is included in the `PRELOGIN` message itself.

### Issues Resolved

#2137

### Test Scenarios Covered ###

JDBC test suite changes to support jTDS will follow in a separate PR.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>