### PR TITLE
jTDS: support running JDBC tests with jTDS driver

### DIFF
--- a/.github/workflows/jdbc-tests-with-jtds.yml
+++ b/.github/workflows/jdbc-tests-with-jtds.yml
@@ -1,0 +1,107 @@
+name: JDBC Tests With jTDS
+on: [push, pull_request]
+
+jobs:
+  run-babelfish-jdbc-tests-with-jtds:
+    env:
+      INSTALL_DIR: psql
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        uses: ./.github/composite-actions/install-dependencies
+
+      - name: Build Modified Postgres
+        id: build-modified-postgres
+        if: always() && steps.install-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+      
+      - name: Compile ANTLR
+        id: compile-antlr
+        if: always() && steps.build-modified-postgres.outcome == 'success'
+        uses: ./.github/composite-actions/compile-antlr
+      
+      - name: Build Extensions
+        id: build-extensions
+        if: always() && steps.compile-antlr.outcome == 'success'
+        uses: ./.github/composite-actions/build-extensions
+
+      - name: Build tds_fdw Extension
+        id: build-tds_fdw-extension
+        if: always() && steps.build-extensions.outcome == 'success'
+        uses: ./.github/composite-actions/build-tds_fdw-extension
+
+      - name: Build vector Extension
+        id: build-vector-extension
+        if: always() &&  steps.build-tds_fdw-extension.outcome == 'success'
+        uses: ./.github/composite-actions/build-vector-extension
+
+      - name: Build PostGIS Extension
+        id: build-postgis-extension
+        if: always() &&  steps.build-vector-extension.outcome == 'success'
+        uses: ./.github/composite-actions/build-postgis-extension
+
+      - name: Install Extensions
+        id: install-extensions
+        if: always() && steps.build-postgis-extension.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
+
+      - name: Run JDBC Tests
+        id: jdbc
+        if: always() && steps.install-extensions.outcome == 'success'
+        timeout-minutes: 120
+        run: |
+          export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
+          export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
+          cd test/JDBC/
+          # set env variable useJTDSInsteadOfMSSQLJDBC to true to run tests from file jtds_jdbc_schedule
+          export useJTDSInsteadOfMSSQLJDBC=true
+          mvn -B -ntp test
+          # reset env variable
+          unset useJTDSInsteadOfMSSQLJDBC
+
+      - name: Cleanup babelfish database
+        id: cleanup
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+
+      - name: Upload Log
+        if: always() && steps.jdbc.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: postgres-log
+          path: ~/psql/data/logfile
+      
+      # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
+      - name: Rename Test Summary Files
+        id: test-file-rename
+        if: always() && steps.jdbc.outcome == 'failure'
+        run: |
+          cd test/JDBC/Info
+          timestamp=`ls -Art | tail -n 1`
+          cd $timestamp
+          mv $timestamp.diff ../output-diff.diff
+          mv "$timestamp"_runSummary.log ../run-summary.log
+      
+      - name: Upload Run Summary 
+        if: always() && steps.test-file-rename == 'success'
+        uses: actions/upload-artifact@v2
+        with:
+          name: run-summary.log
+          path: test/JDBC/Info/run-summary.log
+      
+      - name: Upload Output Diff
+        if: always() && steps.jdbc.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: output-diff.diff
+          path: test/JDBC/Info/output-diff.diff
+      
+      - name: Check and upload coredumps
+        if: always() && steps.jdbc.outcome == 'failure'
+        uses: ./.github/composite-actions/upload-coredump

--- a/test/JDBC/expected/jtds-TestErrorsWithTryCatch.out
+++ b/test/JDBC/expected/jtds-TestErrorsWithTryCatch.out
@@ -1,0 +1,1650 @@
+CREATE TABLE ErrorWithTryCatchTable (a varchar(15) UNIQUE NOT NULL, b nvarchar(25), c int PRIMARY KEY, d char(15) DEFAULT 'Whoops!', e nchar(25), f datetime, g numeric(4,1) CHECK (g >= 103.5))
+GO
+
+-- setup for "invalid characters found: cannot cast value "%s" to money" error
+CREATE TABLE t293_1(a money, b int);
+GO
+
+INSERT INTO t293_1(a, b) values ($100, 1), ($101, 2);
+GO
+~~ROW COUNT: 2~~
+
+
+-- setup for error "column \"%s\" of relation \"%s\" is a generated column" error
+CREATE TABLE t1752_2(c1 INT, c2 INT, c3 as c1*c2)
+GO
+
+-- setup for "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations" error
+CREATE TABLE t141_2(c1 int, c2 int); 
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY 
+BEGIN CATCH 
+    SELECT xact_state(); 
+END CATCH 
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Simple batch with transaction inside try-catch
+BEGIN TRY 
+    BEGIN TRAN 
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY 
+BEGIN CATCH 
+    SELECT xact_state(); 
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+GO
+BEGIN TRY 
+    SELECT xact_state(); 
+    EXEC errorWithTryCatchProc1; 
+END TRY 
+BEGIN CATCH
+    SELECT xact_state(); 
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state(); 
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS 
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+-- Error: check constraint violation
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+
+
+
+-- Error: not null constraint violation
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+
+
+
+-- Error: creating an existing table
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE ErrorWithTryCatchTable (a int);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE ErrorWithTryCatchTable (a int);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE ErrorWithTryCatchTable (a int);
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE ErrorWithTryCatchTable (a int);
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE ErrorWithTryCatchTable (a int);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE ErrorWithTryCatchTable (a int);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+
+
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+~~START~~
+smallint
+0
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_2" is a generated column)~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_2" is a generated column)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations"
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_2;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations"
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a int; SELECT @a = c1, c2 FROM t141_2;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "value for domain tinyint violates check constraint "tinyint_check""
+-- Simple error inside try-catch
+BEGIN TRY
+    SELECT xact_state();
+    DECLARE @a tinyint = 1000;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+0
+~~END~~
+
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+-1
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Uncommittable transaction is detected at the end of the batch. The transaction is rolled back.)~~
+
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- valid INSERT inside catch after an error
+-- Simple batch with try catch
+BEGIN TRY
+    BEGIN TRAN
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Orange', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select a from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar
+Apple
+Orange
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+-- invalid INSERT inside catch after an error
+-- Simple batch with try catch
+BEGIN TRY
+    BEGIN TRAN
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END CATCH;
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+smallint
+1
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "errorwithtrycatchtable_a_key")~~
+
+select a from ErrorWithTryCatchTable ORDER BY c
+GO
+~~START~~
+varchar
+Apple
+~~END~~
+
+truncate table ErrorWithTryCatchTable
+GO
+
+
+DROP TABLE ErrorWithTryCatchTable
+GO
+
+-- cleanup for "invalid characters found: cannot cast value "%s" to money" error
+DROP TABLE t293_1;
+GO
+
+-- cleanup for error "column \"%s\" of relation \"%s\" is a generated column" error
+DROP TABLE t1752_2
+GO
+
+-- cleanup for "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations" error
+DROP TABLE t141_2;
+GO
+
+while (@@trancount > 0) commit tran;
+GO
+

--- a/test/JDBC/expected/jtds-TestSQLQueries.out
+++ b/test/JDBC/expected/jtds-TestSQLQueries.out
@@ -1,0 +1,839 @@
+#1 CREATE TABLE with primary and unique keyword
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+CREATE TABLE tmp(a int PRIMARY KEY, b int UNIQUE);
+INSERT INTO tmp(a,b) values(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) values(2,2);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+~~END~~
+
+DROP TABLE tmp;
+
+#2 2 table with foreign key relation
+#CREATE TABLE tmp1(b int PRIMARY KEY);
+#CREATE TABLE tmp2(a int PRIMARY KEY, b int FOREIGN KEY REFERENCES tmp1(b));
+#INSERT INTO tmp1(b) VALUES (1);
+#INSERT INTO tmp2(a,b) values(1,1);
+#SELECT * FROM tmp1;
+#SELECT * FROM tmp2;
+#DROP TABLE tmp2;
+#DROP TABLE tmp1;
+
+#3 Repeated #2 with CONSTRAINT keyword
+#CREATE TABLE tmp1(b int PRIMARY KEY);
+#CREATE TABLE tmp2(a int, b int, PRIMARY KEY(a), CONSTRAINT FK_tmp FOREIGN KEY (b) REFERENCES tmp1(b));
+#INSERT INTO tmp1(b) VALUES (1);
+#INSERT INTO tmp2(a,b) values(1,1);
+#SELECT * FROM tmp1;
+#SELECT * FROM tmp2;
+#DROP TABLE tmp2;
+#DROP TABLE tmp1;
+
+#4 CREATE TABLE with NOT NULL column
+CREATE TABLE tmp(a int PRIMARY KEY,b int NOT NULL);
+INSERT INTO tmp(a,b) values(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) values(2,1);
+~~ROW COUNT: 1~~
+
+#INSERT INTO tmp(a,b) values(2,NULL);
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+~~END~~
+
+DROP TABLE tmp;
+
+#5 INSERTION and DELETION
+CREATE TABLE tmp(a int PRIMARY KEY);
+INSERT INTO tmp(a) VALUES(1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a) VALUES(2);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a) VALUES(3);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a) VALUES(4);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a) VALUES(5);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int
+1
+2
+3
+4
+5
+~~END~~
+
+DELETE FROM tmp WHERE a>2;
+~~ROW COUNT: 3~~
+
+SELECT * FROM tmp;
+~~START~~
+int
+1
+2
+~~END~~
+
+DROP TABLE tmp;
+
+#6 IS NOT NULL condition in WHERE clause
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) values(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) values(2,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) values(3,NULL);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) values(4,NULL);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp WHERE b IS NOT NULL;
+~~START~~
+int#!#int
+1#!#1
+2#!#1
+~~END~~
+
+DROP TABLE tmp;
+
+#7 Add new column using ALTER TABLE
+CREATE TABLE tmp(a int PRIMARY KEY);
+INSERT INTO tmp(a) VALUES(1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a) VALUES(2);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int
+1
+2
+~~END~~
+
+ALTER TABLE tmp ADD b VARCHAR(20) NULL;
+SELECT * FROM tmp;
+~~START~~
+int#!#varchar
+1#!#<NULL>
+2#!#<NULL>
+~~END~~
+
+INSERT INTO tmp(a,b) VALUES(4,'Dipesh');
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(5,' Dipesh');
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#varchar
+1#!#<NULL>
+2#!#<NULL>
+4#!#Dipesh
+5#!# Dipesh
+~~END~~
+
+DROP TABLE tmp;
+
+#8 Repeated #8 with default value for newly added col
+CREATE TABLE tmp(a int PRIMARY KEY);
+INSERT INTO tmp(a) VALUES(1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a) VALUES(2);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int
+1
+2
+~~END~~
+
+ALTER TABLE tmp ADD b VARCHAR(20) DEFAULT 'Dipesj';
+SELECT * FROM tmp;
+~~START~~
+int#!#varchar
+1#!#Dipesj
+2#!#Dipesj
+~~END~~
+
+INSERT INTO tmp(a,b) VALUES(4,'Dipesh');
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(5,' Dipesh');
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#varchar
+1#!#Dipesj
+2#!#Dipesj
+4#!#Dipesh
+5#!# Dipesh
+~~END~~
+
+DROP TABLE tmp;
+
+#9 Change datatype of existing column using ALTER TABLE
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(2,2);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+~~END~~
+
+ALTER TABLE tmp ALTER COLUMN b VARCHAR(10);
+SELECT * FROM tmp;
+~~START~~
+int#!#varchar
+1#!#1
+2#!#2
+~~END~~
+
+INSERT INTO tmp(a,b) VALUES(4,'Dipesh');
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(5,' Dipesh');
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#varchar
+1#!#1
+2#!#2
+4#!#Dipesh
+5#!# Dipesh
+~~END~~
+
+DROP TABLE tmp;
+
+#10 UPDATE TABLE with fancy condition
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(2,2);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(3,3);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(4,4);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(5,5);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+UPDATE tmp SET b=b+1 WHERE b>2;
+~~ROW COUNT: 3~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#4
+4#!#5
+5#!#6
+~~END~~
+
+DROP TABLE tmp;
+
+#11 DROP some column using ALTER TABLE
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(2,2);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(3,3);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(4,4);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(5,5);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+#ALTER TABLE tmp DROP COLUMN b;
+#INSERT INTO tmp(a) values (6);
+#SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#12 CREATE TABLE with fancy constraint
+CREATE TABLE tmp(a int PRIMARY KEY CHECK (a>10),b int);
+INSERT INTO tmp(a,b) VALUES(11,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(12,2);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(13,3);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(14,4);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(15,5);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+11#!#1
+12#!#2
+13#!#3
+14#!#4
+15#!#5
+~~END~~
+
+DROP TABLE tmp;
+
+#CREATE PROCEDURE tmp AS
+#BEGIN
+#    CREATE TABLE dip(a int PRIMARY KEY CHECK (a>10),b int);
+#    INSERT INTO dip(a,b) VALUES(11,1);
+#    INSERT INTO dip(a,b) VALUES(12,2);
+#    INSERT INTO dip(a,b) VALUES(13,3);
+#    INSERT INTO dip(a,b) VALUES(14,4);
+#    INSERT INTO dip(a,b) VALUES(15,5);
+#    SELECT * FROM dip;
+#    DROP TABLE dip;
+#END;
+
+#13 invoke simple stored procedure using EXECUTE
+EXECUTE tmp;
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: procedure tmp() does not exist)~~
+
+
+#14 invoke simple stored procedure using EXEC
+EXEC tmp;
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: procedure tmp() does not exist)~~
+
+
+#DROP PROCEDURE tmp;
+
+#15 UPDATE rows in existing table
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
+~~ROW COUNT: 5~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+UPDATE tmp SET b=b*2+1 WHERE (a>2);
+~~ROW COUNT: 3~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#7
+4#!#9
+5#!#11
+~~END~~
+
+DROP TABLE tmp;
+
+#16 TRUNCATE table
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
+~~ROW COUNT: 5~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+TRUNCATE TABLE tmp;
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+~~END~~
+
+DROP TABLE tmp;
+
+CREATE TABLE temp1 (i INT,j INT,t TEXT);
+
+CREATE TABLE temp2 ( i INT,k INT);
+
+INSERT INTO temp1 VALUES (1, 4, 'one');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (2, 3, 'two');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (3, 2, 'three');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (4, 1, 'four');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (5, 0, 'five');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (6, 6, 'six');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (7, 7, 'seven');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (8, 8, 'eight');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (0, NULL, 'zero');
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (NULL, NULL, NULL);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp1 VALUES (NULL, 0, 'zero');
+~~ROW COUNT: 1~~
+
+
+INSERT INTO temp2 VALUES (1, -1);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (2, 2);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (3, -3);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (2, 4);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (5, -5);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (5, -5);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (0, NULL);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (NULL, NULL);
+~~ROW COUNT: 1~~
+
+INSERT INTO temp2 VALUES (NULL, 0);
+~~ROW COUNT: 1~~
+
+
+#17 CROSS JOIN
+SELECT * FROM temp1 CROSS JOIN temp2;
+~~START~~
+int#!#int#!#text#!#int#!#int
+1#!#4#!#one#!#1#!#-1
+2#!#3#!#two#!#1#!#-1
+3#!#2#!#three#!#1#!#-1
+4#!#1#!#four#!#1#!#-1
+5#!#0#!#five#!#1#!#-1
+6#!#6#!#six#!#1#!#-1
+7#!#7#!#seven#!#1#!#-1
+8#!#8#!#eight#!#1#!#-1
+0#!#<NULL>#!#zero#!#1#!#-1
+<NULL>#!#<NULL>#!#<NULL>#!#1#!#-1
+<NULL>#!#0#!#zero#!#1#!#-1
+1#!#4#!#one#!#2#!#2
+2#!#3#!#two#!#2#!#2
+3#!#2#!#three#!#2#!#2
+4#!#1#!#four#!#2#!#2
+5#!#0#!#five#!#2#!#2
+6#!#6#!#six#!#2#!#2
+7#!#7#!#seven#!#2#!#2
+8#!#8#!#eight#!#2#!#2
+0#!#<NULL>#!#zero#!#2#!#2
+<NULL>#!#<NULL>#!#<NULL>#!#2#!#2
+<NULL>#!#0#!#zero#!#2#!#2
+1#!#4#!#one#!#3#!#-3
+2#!#3#!#two#!#3#!#-3
+3#!#2#!#three#!#3#!#-3
+4#!#1#!#four#!#3#!#-3
+5#!#0#!#five#!#3#!#-3
+6#!#6#!#six#!#3#!#-3
+7#!#7#!#seven#!#3#!#-3
+8#!#8#!#eight#!#3#!#-3
+0#!#<NULL>#!#zero#!#3#!#-3
+<NULL>#!#<NULL>#!#<NULL>#!#3#!#-3
+<NULL>#!#0#!#zero#!#3#!#-3
+1#!#4#!#one#!#2#!#4
+2#!#3#!#two#!#2#!#4
+3#!#2#!#three#!#2#!#4
+4#!#1#!#four#!#2#!#4
+5#!#0#!#five#!#2#!#4
+6#!#6#!#six#!#2#!#4
+7#!#7#!#seven#!#2#!#4
+8#!#8#!#eight#!#2#!#4
+0#!#<NULL>#!#zero#!#2#!#4
+<NULL>#!#<NULL>#!#<NULL>#!#2#!#4
+<NULL>#!#0#!#zero#!#2#!#4
+1#!#4#!#one#!#5#!#-5
+2#!#3#!#two#!#5#!#-5
+3#!#2#!#three#!#5#!#-5
+4#!#1#!#four#!#5#!#-5
+5#!#0#!#five#!#5#!#-5
+6#!#6#!#six#!#5#!#-5
+7#!#7#!#seven#!#5#!#-5
+8#!#8#!#eight#!#5#!#-5
+0#!#<NULL>#!#zero#!#5#!#-5
+<NULL>#!#<NULL>#!#<NULL>#!#5#!#-5
+<NULL>#!#0#!#zero#!#5#!#-5
+1#!#4#!#one#!#5#!#-5
+2#!#3#!#two#!#5#!#-5
+3#!#2#!#three#!#5#!#-5
+4#!#1#!#four#!#5#!#-5
+5#!#0#!#five#!#5#!#-5
+6#!#6#!#six#!#5#!#-5
+7#!#7#!#seven#!#5#!#-5
+8#!#8#!#eight#!#5#!#-5
+0#!#<NULL>#!#zero#!#5#!#-5
+<NULL>#!#<NULL>#!#<NULL>#!#5#!#-5
+<NULL>#!#0#!#zero#!#5#!#-5
+1#!#4#!#one#!#0#!#<NULL>
+2#!#3#!#two#!#0#!#<NULL>
+3#!#2#!#three#!#0#!#<NULL>
+4#!#1#!#four#!#0#!#<NULL>
+5#!#0#!#five#!#0#!#<NULL>
+6#!#6#!#six#!#0#!#<NULL>
+7#!#7#!#seven#!#0#!#<NULL>
+8#!#8#!#eight#!#0#!#<NULL>
+0#!#<NULL>#!#zero#!#0#!#<NULL>
+<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>
+<NULL>#!#0#!#zero#!#0#!#<NULL>
+1#!#4#!#one#!#<NULL>#!#<NULL>
+2#!#3#!#two#!#<NULL>#!#<NULL>
+3#!#2#!#three#!#<NULL>#!#<NULL>
+4#!#1#!#four#!#<NULL>#!#<NULL>
+5#!#0#!#five#!#<NULL>#!#<NULL>
+6#!#6#!#six#!#<NULL>#!#<NULL>
+7#!#7#!#seven#!#<NULL>#!#<NULL>
+8#!#8#!#eight#!#<NULL>#!#<NULL>
+0#!#<NULL>#!#zero#!#<NULL>#!#<NULL>
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+<NULL>#!#0#!#zero#!#<NULL>#!#<NULL>
+1#!#4#!#one#!#<NULL>#!#0
+2#!#3#!#two#!#<NULL>#!#0
+3#!#2#!#three#!#<NULL>#!#0
+4#!#1#!#four#!#<NULL>#!#0
+5#!#0#!#five#!#<NULL>#!#0
+6#!#6#!#six#!#<NULL>#!#0
+7#!#7#!#seven#!#<NULL>#!#0
+8#!#8#!#eight#!#<NULL>#!#0
+0#!#<NULL>#!#zero#!#<NULL>#!#0
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+<NULL>#!#0#!#zero#!#<NULL>#!#0
+~~END~~
+
+
+#18 INNER JOIN
+SELECT temp1.i, temp1.j, temp1.t, temp2.k FROM temp1 INNER JOIN temp2 ON temp1.i=temp2.i ORDER BY temp1.i;
+~~START~~
+int#!#int#!#text#!#int
+0#!#<NULL>#!#zero#!#<NULL>
+1#!#4#!#one#!#-1
+2#!#3#!#two#!#4
+2#!#3#!#two#!#2
+3#!#2#!#three#!#-3
+5#!#0#!#five#!#-5
+5#!#0#!#five#!#-5
+~~END~~
+
+SELECT temp1.i, temp1.j, temp1.t, temp2.k FROM temp1 JOIN temp2 ON temp1.i=temp2.i ORDER BY temp1.i;
+~~START~~
+int#!#int#!#text#!#int
+0#!#<NULL>#!#zero#!#<NULL>
+1#!#4#!#one#!#-1
+2#!#3#!#two#!#4
+2#!#3#!#two#!#2
+3#!#2#!#three#!#-3
+5#!#0#!#five#!#-5
+5#!#0#!#five#!#-5
+~~END~~
+
+
+#19 LEFT JOIN
+SELECT * FROM temp1 LEFT OUTER JOIN temp2 ON temp1.i=temp2.k ORDER BY temp1.i;
+~~START~~
+int#!#int#!#text#!#int#!#int
+<NULL>#!#0#!#zero#!#<NULL>#!#<NULL>
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+0#!#<NULL>#!#zero#!#<NULL>#!#0
+1#!#4#!#one#!#<NULL>#!#<NULL>
+2#!#3#!#two#!#2#!#2
+3#!#2#!#three#!#<NULL>#!#<NULL>
+4#!#1#!#four#!#2#!#4
+5#!#0#!#five#!#<NULL>#!#<NULL>
+6#!#6#!#six#!#<NULL>#!#<NULL>
+7#!#7#!#seven#!#<NULL>#!#<NULL>
+8#!#8#!#eight#!#<NULL>#!#<NULL>
+~~END~~
+
+
+#20 RIGHT JOIN
+SELECT * FROM temp1 RIGHT OUTER JOIN temp2 ON temp1.i=temp2.i ORDER BY temp1.i, temp2.k;
+~~START~~
+int#!#int#!#text#!#int#!#int
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+0#!#<NULL>#!#zero#!#0#!#<NULL>
+1#!#4#!#one#!#1#!#-1
+2#!#3#!#two#!#2#!#2
+2#!#3#!#two#!#2#!#4
+3#!#2#!#three#!#3#!#-3
+5#!#0#!#five#!#5#!#-5
+5#!#0#!#five#!#5#!#-5
+~~END~~
+
+
+#21 FULL OUTER JOIN
+SELECT * FROM temp1,temp2;
+~~START~~
+int#!#int#!#text#!#int#!#int
+1#!#4#!#one#!#1#!#-1
+2#!#3#!#two#!#1#!#-1
+3#!#2#!#three#!#1#!#-1
+4#!#1#!#four#!#1#!#-1
+5#!#0#!#five#!#1#!#-1
+6#!#6#!#six#!#1#!#-1
+7#!#7#!#seven#!#1#!#-1
+8#!#8#!#eight#!#1#!#-1
+0#!#<NULL>#!#zero#!#1#!#-1
+<NULL>#!#<NULL>#!#<NULL>#!#1#!#-1
+<NULL>#!#0#!#zero#!#1#!#-1
+1#!#4#!#one#!#2#!#2
+2#!#3#!#two#!#2#!#2
+3#!#2#!#three#!#2#!#2
+4#!#1#!#four#!#2#!#2
+5#!#0#!#five#!#2#!#2
+6#!#6#!#six#!#2#!#2
+7#!#7#!#seven#!#2#!#2
+8#!#8#!#eight#!#2#!#2
+0#!#<NULL>#!#zero#!#2#!#2
+<NULL>#!#<NULL>#!#<NULL>#!#2#!#2
+<NULL>#!#0#!#zero#!#2#!#2
+1#!#4#!#one#!#3#!#-3
+2#!#3#!#two#!#3#!#-3
+3#!#2#!#three#!#3#!#-3
+4#!#1#!#four#!#3#!#-3
+5#!#0#!#five#!#3#!#-3
+6#!#6#!#six#!#3#!#-3
+7#!#7#!#seven#!#3#!#-3
+8#!#8#!#eight#!#3#!#-3
+0#!#<NULL>#!#zero#!#3#!#-3
+<NULL>#!#<NULL>#!#<NULL>#!#3#!#-3
+<NULL>#!#0#!#zero#!#3#!#-3
+1#!#4#!#one#!#2#!#4
+2#!#3#!#two#!#2#!#4
+3#!#2#!#three#!#2#!#4
+4#!#1#!#four#!#2#!#4
+5#!#0#!#five#!#2#!#4
+6#!#6#!#six#!#2#!#4
+7#!#7#!#seven#!#2#!#4
+8#!#8#!#eight#!#2#!#4
+0#!#<NULL>#!#zero#!#2#!#4
+<NULL>#!#<NULL>#!#<NULL>#!#2#!#4
+<NULL>#!#0#!#zero#!#2#!#4
+1#!#4#!#one#!#5#!#-5
+2#!#3#!#two#!#5#!#-5
+3#!#2#!#three#!#5#!#-5
+4#!#1#!#four#!#5#!#-5
+5#!#0#!#five#!#5#!#-5
+6#!#6#!#six#!#5#!#-5
+7#!#7#!#seven#!#5#!#-5
+8#!#8#!#eight#!#5#!#-5
+0#!#<NULL>#!#zero#!#5#!#-5
+<NULL>#!#<NULL>#!#<NULL>#!#5#!#-5
+<NULL>#!#0#!#zero#!#5#!#-5
+1#!#4#!#one#!#5#!#-5
+2#!#3#!#two#!#5#!#-5
+3#!#2#!#three#!#5#!#-5
+4#!#1#!#four#!#5#!#-5
+5#!#0#!#five#!#5#!#-5
+6#!#6#!#six#!#5#!#-5
+7#!#7#!#seven#!#5#!#-5
+8#!#8#!#eight#!#5#!#-5
+0#!#<NULL>#!#zero#!#5#!#-5
+<NULL>#!#<NULL>#!#<NULL>#!#5#!#-5
+<NULL>#!#0#!#zero#!#5#!#-5
+1#!#4#!#one#!#0#!#<NULL>
+2#!#3#!#two#!#0#!#<NULL>
+3#!#2#!#three#!#0#!#<NULL>
+4#!#1#!#four#!#0#!#<NULL>
+5#!#0#!#five#!#0#!#<NULL>
+6#!#6#!#six#!#0#!#<NULL>
+7#!#7#!#seven#!#0#!#<NULL>
+8#!#8#!#eight#!#0#!#<NULL>
+0#!#<NULL>#!#zero#!#0#!#<NULL>
+<NULL>#!#<NULL>#!#<NULL>#!#0#!#<NULL>
+<NULL>#!#0#!#zero#!#0#!#<NULL>
+1#!#4#!#one#!#<NULL>#!#<NULL>
+2#!#3#!#two#!#<NULL>#!#<NULL>
+3#!#2#!#three#!#<NULL>#!#<NULL>
+4#!#1#!#four#!#<NULL>#!#<NULL>
+5#!#0#!#five#!#<NULL>#!#<NULL>
+6#!#6#!#six#!#<NULL>#!#<NULL>
+7#!#7#!#seven#!#<NULL>#!#<NULL>
+8#!#8#!#eight#!#<NULL>#!#<NULL>
+0#!#<NULL>#!#zero#!#<NULL>#!#<NULL>
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+<NULL>#!#0#!#zero#!#<NULL>#!#<NULL>
+1#!#4#!#one#!#<NULL>#!#0
+2#!#3#!#two#!#<NULL>#!#0
+3#!#2#!#three#!#<NULL>#!#0
+4#!#1#!#four#!#<NULL>#!#0
+5#!#0#!#five#!#<NULL>#!#0
+6#!#6#!#six#!#<NULL>#!#0
+7#!#7#!#seven#!#<NULL>#!#0
+8#!#8#!#eight#!#<NULL>#!#0
+0#!#<NULL>#!#zero#!#<NULL>#!#0
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+<NULL>#!#0#!#zero#!#<NULL>#!#0
+~~END~~
+
+
+DROP TABLE temp1;
+DROP TABLE temp2;
+
+#22 dropping all columns
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(2,2);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(3,3);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(4,4);
+~~ROW COUNT: 1~~
+
+INSERT INTO tmp(a,b) VALUES(5,5);
+~~ROW COUNT: 1~~
+
+SELECT * FROM tmp;
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+~~END~~
+
+#ALTER TABLE tmp DROP COLUMN b;
+#ALTER TABLE tmp DROP COLUMN a;
+#SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#23
+CREATE TABLE DATE_dt (a DATE);
+INSERT INTO DATE_dt(a) values('2000-12-13');
+~~ROW COUNT: 1~~
+
+INSERT INTO DATE_dt(a) values('1900-02-28');
+~~ROW COUNT: 1~~
+
+INSERT INTO DATE_dt(a) values('0001-01-01');
+~~ROW COUNT: 1~~
+
+INSERT INTO DATE_dt(a) values('9999-12-31');
+~~ROW COUNT: 1~~
+
+INSERT INTO DATE_dt(a) values(NULL);
+~~ROW COUNT: 1~~
+
+SELECT * FROM DATE_dt;
+~~START~~
+nvarchar
+2000-12-13
+1900-02-28
+0001-01-01
+9999-12-31
+<NULL>
+~~END~~
+
+ALTER TABLE DATE_dt ALTER COLUMN a DATETIME;
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: data out of range for datetime)~~
+
+SELECT * FROM DATE_dt;
+~~START~~
+nvarchar
+2000-12-13
+1900-02-28
+0001-01-01
+9999-12-31
+<NULL>
+~~END~~
+
+DROP TABLE DATE_dt;
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';

--- a/test/JDBC/expected/jtds-TestSimpleErrors.out
+++ b/test/JDBC/expected/jtds-TestSimpleErrors.out
@@ -1,0 +1,4752 @@
+CREATE TABLE simpleErrorTable (a varchar(15) UNIQUE NOT NULL, b nvarchar(25), c int PRIMARY KEY, d char(15) DEFAULT 'Whoops!', e nchar(25), f datetime, g numeric(4,1) CHECK (g >= 103.5))
+GO
+
+-- setup for "data out of range for datetime" error
+CREATE TABLE t517_1(a datetime);
+GO
+
+-- setup for "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations" error
+CREATE TABLE t141_1(c1 int, c2 int); 
+GO
+
+-- setup for "column \"%s\" of relation \"%s\" is a generated column"
+CREATE TABLE t1752_1(c1 INT, c2 INT, c3 as c1*c2)
+GO
+
+if @@trancount > 0 commit tran;
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    save tran sp1; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran sp1
+rollback tran;
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4); 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4); 
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4); 
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "simpleerrortable_a_key")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    rollback tran sp1;
+rollback tran;
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+            declare @err int = @@error; if @err = 0 select 0 else select 1;
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 517)~~
+
+~~ERROR (Message: Adding a value to a 'datetime' column caused an overflow.)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+commit tran;
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+rollback tran;
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    rollback tran sp1;
+rollback tran;
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+commit tran;
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~END~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "c" of relation "simpleerrortable" violates not-null constraint)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+
+-- Error: creating an existing table
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+CREATE TABLE simpleErrorTable (a int);
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+commit tran;
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+rollback tran;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+rollback tran sp1;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK TO SAVEPOINT can only be used in transaction blocks)~~
+
+rollback tran;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        CREATE TABLE simpleErrorTable (a int);
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran;
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ROW COUNT: 1~~
+
+commit tran;
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                CREATE TABLE simpleErrorTable (a int);
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE simpleErrorTable (a int);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE simpleErrorTable (a int);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE simpleErrorTable (a int);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "simpleerrortable" already exists)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    save tran sp1; 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran sp1; 
+rollback tran;
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+2
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+2
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 1752)~~
+
+~~ERROR (Message: column "c3" of relation "t1752_1" is a generated column)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+commit tran
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+	DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+	DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran sp1;
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK TO SAVEPOINT can only be used in transaction blocks)~~
+
+rollback tran;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+begin tran
+GO
+DECLARE @a tinyint = 1000;
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "simpleerrorproc1")~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+begin tran
+GO
+DECLARE @a tinyint = 1000;
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "simpleerrorproc1")~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a tinyint = 1000;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a tinyint = 1000;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+~~START~~
+int
+1
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a tinyint = 1000;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+Cherry#!#indigo#!#8#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a tinyint = 1000;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+select @@trancount;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+if @@trancount > 0 commit tran;
+GO
+
+-- Error: value for domain tinyint violates check constraint "tinyint_check"
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+DECLARE @a tinyint = 1000;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: could not find a procedure named "simpleerrorproc1")~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+rollback tran sp1;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK TO SAVEPOINT can only be used in transaction blocks)~~
+
+~~ROW COUNT: 1~~
+
+rollback tran;
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+commit tran; 
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+~~ROW COUNT: 1~~
+
+commit tran;
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Orange#!#<NULL>#!#3#!#Whoops!        #!#Happy😀                  #!#1900-02-28 23:59:59.99#!#342.5
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+commit tran
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+Apple#!#red#!#1#!#Delhi          #!#Sad😞                    #!#2000-12-13 12:58:23.123#!#123.1
+Pineapple#!#pink#!#7#!#Surat          #!#Frown😠                  #!#2000-12-13 12:58:23.123#!#123.1
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from simpleErrorTable ORDER BY c
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#char#!#nchar#!#datetime#!#numeric
+~~END~~
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- cleanup for "data out of range for datetime" error
+DROP TABLE t517_1;
+GO
+
+-- clean up for "A SELECT statement that assigns a value to a variable must not
+-- be combined with data-retrieval operations" error
+DROP TABLE t141_1;
+GO
+
+-- setup for "column \"%s\" of relation \"%s\" is a generated column"
+DROP TABLE t1752_1;
+GO
+
+drop table simpleErrorTable
+GO
+
+while (@@trancount > 0) commit tran;
+GO
+

--- a/test/JDBC/expected/jtds-TestStoredProcedures.out
+++ b/test/JDBC/expected/jtds-TestStoredProcedures.out
@@ -1,0 +1,558 @@
+# PROCEDURE WITH NO BODY
+#create procedure sp_test AS BEGIN END;
+# PROCEDURE WITH NO PARAMS
+create table temp_sp2(a int);
+CREATE PROCEDURE sp_test AS BEGIN insert into temp_sp2 values(1); END;
+storedproc#!#prep#!#sp_test#!#
+~~ROW COUNT: 1~~
+
+SELECT * FROM temp_sp2;
+~~START~~
+int
+1
+~~END~~
+
+drop table temp_sp2;
+drop Procedure sp_test;
+# PROCEDURE WITH INPUT PARAMETER
+#drop table temp_sp;
+create table temp_sp(a int);
+Create Procedure stored_proc1 (@a int) As Begin insert into temp_sp values(@a) End;
+# NOT WORKING FOR BABEL,RAISED JIRA 444
+storedproc#!#prep#!#stored_proc1#!#int|-|a|-|-100|-|input
+~~ROW COUNT: 1~~
+
+# MISMATCH IN RETURN VALUES
+exec stored_proc1 -200
+~~ROW COUNT: 1~~
+
+exec stored_proc1 0
+~~ROW COUNT: 1~~
+
+exec stored_proc1 -1
+~~ROW COUNT: 1~~
+
+exec stored_proc1 2
+~~ROW COUNT: 1~~
+
+# filed Jira on this, doesnt work for babel
+#exec stored_proc1 2.2
+SELECT * FROM temp_sp;
+~~START~~
+int
+-100
+-200
+0
+-1
+2
+~~END~~
+
+DROP table temp_sp;
+DROP Procedure stored_proc1
+# input parameter
+CREATE PROCEDURE sp_test1 (@a  INT) AS BEGIN SET @a=100; Select @a as a; END;
+exec sp_test1 2
+~~START~~
+int
+100
+~~END~~
+
+Declare @a int;Set @a=1; exec sp_test1 @a;select @a as a;
+~~START~~
+int
+100
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|1|-|input
+~~START~~
+int
+100
+~~END~~
+
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|10|-|input
+~~START~~
+int
+100
+~~END~~
+
+DROP PROCEDURE sp_test1
+# TESTING OUT PARAMETERS FOR ALL THE DATATYPES
+# int
+CREATE PROCEDURE sp_test1 (@a  INT OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+#Declare @a int;Set @a=1; exec sp_test1 @a;select @a as a;
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|1|-|output
+~~START~~
+int
+100
+~~END~~
+
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|1|-|inputoutput
+~~START~~
+int
+100
+~~END~~
+
+DROP PROCEDURE sp_test1
+# smallint
+CREATE PROCEDURE sp_test2 (@a SMALLINT OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+#Declare @a smallint;Set @a=1; exec sp_test2 @a;select @a as a;
+storedproc#!#prep#!#sp_test2#!#smallint|-|a|-|10|-|output
+~~START~~
+smallint
+100
+~~END~~
+
+storedproc#!#prep#!#sp_test2#!#smallint|-|a|-|10|-|inputoutput
+~~START~~
+smallint
+100
+~~END~~
+
+DROP PROCEDURE sp_test2
+# bigint
+CREATE PROCEDURE sp_test3 (@a BIGINT OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+storedproc#!#prep#!#sp_test3#!#bigint|-|a|-|10|-|output
+~~START~~
+bigint
+100
+~~END~~
+
+storedproc#!#prep#!#sp_test3#!#bigint|-|a|-|10|-|inputoutput
+~~START~~
+bigint
+100
+~~END~~
+
+DROP PROCEDURE sp_test3
+# tinyint
+#CREATE PROCEDURE sp_test4 (@a tinyint OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+#storedproc#!#prep#!#sp_test4#!#tinyint|-|a|-|10|-|output
+#storedproc#!#prep#!#sp_test4#!#tinyint|-|a|-|10|-|inputoutput
+#DROP PROCEDURE sp_test4
+# float
+CREATE PROCEDURE sp_test5 (@a float OUTPUT) AS BEGIN SET @a=100.12; Select @a as a; END;
+#Declare @a float;Set @a=1.1; exec sp_test5 @a;select @a as a;
+storedproc#!#prep#!#sp_test5#!#float|-|a|-|10.1|-|output
+~~START~~
+float
+100.12
+~~END~~
+
+storedproc#!#prep#!#sp_test5#!#float|-|a|-|10.1|-|inputoutput
+~~START~~
+float
+100.12
+~~END~~
+
+DROP PROCEDURE sp_test5
+# varchar
+#CREATE PROCEDURE sp_test6 (@a varchar OUTPUT) AS BEGIN SET @a='helloworld'; Select @a as a; END;
+#storedproc#!#prep#!#sp_test6#!#varchar|-|a|-|hello|-|output
+#storedproc#!#prep#!#sp_test6#!#varchar|-|a|-|hello|-|inputoutput
+#DROP PROCEDURE sp_test6
+# char BABEL-705
+#CREATE PROCEDURE sp_test7 (@a char OUTPUT) AS BEGIN SET @a='b'; Select @a as a; END;
+#Declare @a varchar;Set @a='h'; exec sp_test7 @a;select @a as a;
+#storedproc#!#prep#!#sp_test7#!#char|-|a|-|t|-|output
+#storedproc#!#prep#!#sp_test7#!#char|-|a|-|t|-|inputoutput
+#DROP PROCEDURE sp_test7
+# nvarchar
+#CREATE PROCEDURE sp_test9 (@a nvarchar OUTPUT) AS BEGIN SET @a='helloworld'; Select @a as a; END;
+#Declare @a nvarchar;Set @a='hello'; exec sp_test9 @a;select @a as a;
+#storedproc#!#prep#!#sp_test9#!#varchar|-|a|-|hello|-|output
+#storedproc#!#prep#!#sp_test9#!#varchar|-|a|-|hello|-|inputoutput
+#DROP PROCEDURE sp_test9
+# numeric 
+CREATE PROCEDURE sp_test10 (@a numeric(10,4) OUTPUT) AS BEGIN SET @a=100.41; Select @a as a; END;
+#Declare @a numeric(10,4);Set @a=10.04; exec sp_test10 @a;select @a as a;
+#storedproc#!#prep#!#sp_test10#!#numeric|-|a|-|123|-|10|-|3|-|output
+#storedproc#!#prep#!#sp_test10#!#numeric|-|a|-|123|-|10|-|2|-|inputoutput
+DROP PROCEDURE sp_test10
+# decimal 
+CREATE PROCEDURE sp_test11 (@a decimal(10,4) OUTPUT) AS BEGIN SET @a=100.41; Select @a as a; END;
+#Declare @a decimal(10,4);Set @a=10.04; exec sp_test11 @a;select @a as a;
+#storedproc#!#prep#!#sp_test11#!#decimal|-|a|-|123|-|10|-|3|-|output
+#storedproc#!#prep#!#sp_test11#!#decimal|-|a|-|123|-|10|-|2|-|inputoutput
+DROP PROCEDURE sp_test11
+# binary 
+#CREATE PROCEDURE sp_test12 (@a binary OUTPUT) AS BEGIN SET @a=0x121; Select @a as a; END;
+#exec sp_test12 0x122
+#Declare @a binary;Set @a=0x121; exec sp_test12 @a;select @a as a;
+#storedproc#!#prep#!#sp_test12#!#binary|-|a|-|0x122|-|output
+#storedproc#!#prep#!#sp_test12#!#binary|-|a|-|0x122|-|inputoutput
+#DROP PROCEDURE sp_test12
+# varbinary BABEL-701
+#CREATE PROCEDURE sp_test13 (@a varbinary OUTPUT) AS BEGIN SET @a=0x121; Select @a as a; END;
+#exec sp_test13 0x122
+#Declare @a varbinary;Set @a=0x122; exec sp_test13 @a;select @a as a;
+#storedproc#!#prep#!#sp_test13#!#varbinary|-|a|-|0x122|-|output
+#storedproc#!#prep#!#sp_test13#!#varbinary|-|a|-|0x122|-|inputoutput
+#DROP PROCEDURE sp_test13
+# date
+CREATE PROCEDURE sp_test14 (@a date output) AS BEGIN SET @a='1999-1-3'; Select @a as a; END;
+#Declare @a DATE;Set @a='9999-12-31'; exec sp_test14 @a;select @a as a;
+storedproc#!#prep#!#sp_test14#!#DATE|-|a|-|9999-12-31|-|output
+~~START~~
+nvarchar
+1999-01-03
+~~END~~
+
+storedproc#!#prep#!#sp_test14#!#DATE|-|a|-|9999-12-31|-|inputoutput
+~~START~~
+nvarchar
+1999-01-03
+~~END~~
+
+DROP PROCEDURE sp_test14
+# time
+#CREATE PROCEDURE sp_test15 (@a time(4) OUTPUT) AS BEGIN SET @a='11:25:07.123'; Select @a as a; END;
+#Declare @a Time;Set @a='12:45:37.123'; exec sp_test15 @a;select @a as a;
+#storedproc#!#prep#!#sp_test15#!#Time|-|a|-|12:45:37.123|-|3|-|output
+#storedproc#!#prep#!#sp_test15#!#Time|-|a|-|12:45:37.123|-|3|-|inputoutput
+#DROP PROCEDURE sp_test15
+# dateime BABEL-694
+#CREATE PROCEDURE sp_test16 (@a datetime output) AS BEGIN SET @a='2004-05-18 13:59:59.995'; Select @a as a; END;
+#Declare @a DATETIME;Set @a='2000-02-28 23:59:59.995'; exec sp_test16 @a;select @a as a;
+#storedproc#!#prep#!#sp_test16#!#DATETIME|-|a|-|2000-02-28 23:59:59.995|-|output
+#storedproc#!#prep#!#sp_test16#!#DATETIME|-|a|-|2000-02-28 23:59:59.995|-|inputoutput
+#DROP PROCEDURE sp_test16
+# datetime2
+#CREATE PROCEDURE sp_test17 (@a datetime2(5) OUTPUT) AS BEGIN SET @a='2014-10-2 1:45:37.123456'; Select @a as a; END;
+#Declare @a Datetime2;Set @a='2016-10-23 12:45:37.123456'; exec sp_test17 @a;select @a as a;
+#storedproc#!#prep#!#sp_test17#!#Datetime2|-|a|-|2016-10-23 12:45:37.123456|-|5|-|output
+#storedproc#!#prep#!#sp_test17#!#Datetime2|-|a|-|2016-10-23 12:45:37.123456|-|5|-|inputoutput
+#DROP PROCEDURE sp_test17
+# smalldatetime BABEL-694
+#CREATE PROCEDURE sp_test18 (@a smalldatetime output) AS BEGIN SET @a='2010-02-03 12:58:23'; Select @a as a; END;
+#Declare @a SMALLDATETIME;Set @a='2000-12-13 12:58:23'; exec sp_test18 @a;select @a as a;
+#storedproc#!#prep#!#sp_test18#!#SMALLDATETIME|-|a|-|2000-12-13 12:58:23|-|output
+#storedproc#!#prep#!#sp_test18#!#SMALLDATETIME|-|a|-|2000-12-13 12:58:23|-|inputoutput
+#DROP PROCEDURE sp_test18
+# UID
+#CREATE PROCEDURE sp_test19 (@a uniqueidentifier OUTPUT) AS BEGIN SET @a='ce8af10a-2709-43b0-9e4e-a02753929d17'; Select @a as a; END;
+#Declare @a uniqueidentifier;Set @a='5b7c2e8d-6d90-411d-8e19-9a81067e6f6c'; exec sp_test19 @a;select @a as a;
+#storedproc#!#prep#!#sp_test19#!#uniqueidentifier|-|a|-|5b7c2e8d-6d90-411d-8e19-9a81067e6f6c|-|output
+#storedproc#!#prep#!#sp_test19#!#uniqueidentifier|-|a|-|5b7c2e8d-6d90-411d-8e19-9a81067e6f6c|-|inputoutput
+#DROP PROCEDURE sp_test19
+
+CREATE PROCEDURE sp_test20 (@a INT, @b INT OUTPUT) AS BEGIN SET @b=100; SET @a=1000; Select @a as a, @b as b; END;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b OUT, @a=@a;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b, @a=@a OUT;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b OUT, @a=@a OUT;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b, @a=@a;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a, @b=@b;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a, @b=@b OUT;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a OUT, @b=@b;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a OUT, @b=@b OUT;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a OUT, @b OUT;select @a as a, @b as b;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|output#!#int|-|b|-|10|-|input
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|input
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|output#!#int|-|b|-|10|-|output
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|inputoutput#!#int|-|b|-|10|-|inputoutput
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|inputoutput#!#int|-|b|-|10|-|input
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+DROP PROCEDURE sp_test20
+
+CREATE PROCEDURE sp_test21 (@a INT, @b INT OUTPUT, @d INT, @c INT OUTPUT) AS BEGIN SET @a=100; SET @b=200; SET @c=300; SET @d=400; Select @a as a, @b as b, @c as c, @d as d; END;
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @b=@b OUT, @c=@c OUT, @a=@a, @d=@d; Select @a as a, @b as b, @c as c, @d as d;
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int
+20#!#200#!#300#!#30
+~~END~~
+
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @b=@b, @c=@c, @a=@a, @d=@d; Select @a as a, @b as b, @c as c, @d as d;
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int
+20#!#10#!#5#!#30
+~~END~~
+
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @c=@c OUT, @b=@b OUT, @a=@a, @d=@d; Select @a as a, @b as b, @c as c, @d as d;
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int
+20#!#200#!#300#!#30
+~~END~~
+
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @c=@c, @b=@b, @a=@a OUT, @d=@d OUT; Select @a as a, @b as b, @c as c, @d as d;
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int
+20#!#10#!#5#!#30
+~~END~~
+
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|inputoutput
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|output
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|inputoutput
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|output
+~~START~~
+int#!#int#!#int#!#int
+100#!#200#!#300#!#400
+~~END~~
+
+DROP PROCEDURE sp_test21
+
+CREATE PROCEDURE sp_test22 (@MixedCaseArg_1 INT, @MixedCaseArg_2 INT OUTPUT) AS BEGIN SET @MixedCaseArg_2=100; SET @MixedCaseArg_1=1000; Select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2; END;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1 OUT, @MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+~~START~~
+int#!#int
+1000#!#100
+~~END~~
+
+~~START~~
+int#!#int
+20#!#100
+~~END~~
+
+DROP PROCEDURE sp_test22

--- a/test/JDBC/expected/jtds-TestTransactionSupportForProcedure.out
+++ b/test/JDBC/expected/jtds-TestTransactionSupportForProcedure.out
@@ -1,0 +1,968 @@
+#setup
+create table txnproctable (c1 int not null, c2 varchar(100))
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+#  		ROLLBACK SAVEPOINT
+#		COMMIT
+create procedure txnproc1 as begin tran; insert into txnproctable values (1, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1;  rollback tran sp1; commit tran;
+select @@trancount;
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+select @@trancount;
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+#  		ROLLBACK SAVEPOINT
+#		ROLLBACK
+drop procedure txnproc1;
+create procedure txnproc1 as begin tran; insert into txnproctable values(2, 'xyz'); save tran sp1; delete from txnproctable; rollback tran sp1; rollback tran;
+select @@trancount;
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+select @@trancount;
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+#  		ROLLBACK SAVEPOINT
+# COMMIT
+drop procedure txnproc1
+create procedure txnproc1 as begin tran; insert into txnproctable values(3, 'dbd'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+exec txnproc1;
+~~ERROR (Code: 266)~~
+
+~~ERROR (Message: Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count 0 current count 1)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+~~END~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+~~END~~
+
+
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+# ROLLBACK SAVEPOINT
+# COMMIT
+drop procedure txnproc1
+create procedure txnproc1 as begin tran; insert into txnproctable values(4, 'sbd'); save tran sp1; update txnproctable set c1 = c1 + 1;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+~~END~~
+
+exec txnproc1;
+~~ERROR (Code: 266)~~
+
+~~ERROR (Message: Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count 0 current count 1)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 3~~
+
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+~~END~~
+
+rollback tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+~~END~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+~~END~~
+
+
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+# COMMIT
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(5, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 4~~
+
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+~~END~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+~~END~~
+
+
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+# ROLLBACK	
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(6, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 5~~
+
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+6#!#abc
+~~END~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+6#!#abc
+~~END~~
+
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+#		COMMIT
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+6#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(7, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1; update txnproctable set c1 = c1 + 1; commit tran; 
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+1#!#abc
+3#!#dbd
+4#!#sbd
+5#!#abc
+6#!#abc
+~~END~~
+
+exec txnproc1;
+~~ERROR (Code: 266)~~
+
+~~ERROR (Message: Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count 1 current count 0)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 6~~
+
+~~ROW COUNT: 6~~
+
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+#		ROLLBACK
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(8, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1; update txnproctable set c1 = c1 + 1; rollback tran; 
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+exec txnproc1;
+~~ERROR (Code: 266)~~
+
+~~ERROR (Message: Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count 1 current count 0)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 7~~
+
+~~ROW COUNT: 7~~
+
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+
+# BEGIN TRAN
+# START SAVEPOINT
+# PROC
+# ROLLBACK SAVEPOINT
+# ROLLBACK
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+save tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(9, 'abc'); update txnproctable set c1 = c1 + 1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 7~~
+
+rollback tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+rollback tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+
+# BEGIN TRAN
+# START SAVEPOINT
+# PROC
+# ROLLBACK SAVEPOINT
+# ROLLBACK
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+save tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(10, 'abc'); update txnproctable set c1 = c1 + 1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 7~~
+
+rollback tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+
+# BEGIN TRAN
+# START SAVEPOINT
+# PROC
+# 		ROLLBACK SAVEPOINT
+# ROLLBACK
+begin tran;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+save tran sp1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(11, 'abc'); rollback tran sp1; update txnproctable set c1 = c1 + 1;
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+2#!#abc
+4#!#dbd
+5#!#sbd
+6#!#abc
+7#!#abc
+8#!#abc
+~~END~~
+
+exec txnproc1;
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 6~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+3#!#abc
+5#!#dbd
+6#!#sbd
+7#!#abc
+8#!#abc
+9#!#abc
+~~END~~
+
+
+# PROC1
+#		BEGIN TRAN
+#		PROC2
+#			PROC3
+#				BEGIN TRAN
+#				START SAVEPOINT
+#				ROLLBACK SAVEPOINT
+#			COMMIT
+#	COMMIT
+create procedure txnProc3 as begin tran; insert into txnproctable values (16, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1;  rollback tran sp1;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+3#!#abc
+5#!#dbd
+6#!#sbd
+7#!#abc
+8#!#abc
+9#!#abc
+~~END~~
+
+create procedure txnProc2 as update txnproctable set c1 = c1 + 1; exec txnProc3; commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+3#!#abc
+5#!#dbd
+6#!#sbd
+7#!#abc
+8#!#abc
+9#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as delete from txnproctable; begin tran; exec txnProc2;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+3#!#abc
+5#!#dbd
+6#!#sbd
+7#!#abc
+8#!#abc
+9#!#abc
+~~END~~
+
+exec txnproc1;
+~~ERROR (Code: 266)~~
+
+~~ERROR (Message: Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count 1 current count 2)~~
+
+~~ROW COUNT: 6~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+select @@trancount
+~~START~~
+int
+1
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+16#!#abc
+~~END~~
+
+commit tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+16#!#abc
+~~END~~
+
+
+# PROC1
+#		BEGIN TRAN
+#		PROC2
+#			PROC3
+#				BEGIN TRAN
+#				START SAVEPOINT
+#				ROLLBACK SAVEPOINT
+#			ROLLBACK TRAN
+#	COMMIT
+drop procedure txnproc3
+create procedure txnProc3 as begin tran; insert into txnproctable values (20, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1;  rollback tran sp1;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+16#!#abc
+~~END~~
+
+drop procedure txnproc2
+create procedure txnProc2 as update txnproctable set c1 = c1 + 1; exec txnProc3; rollback tran;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+16#!#abc
+~~END~~
+
+drop procedure txnproc1
+create procedure txnproc1 as delete from txnproctable; begin tran; exec txnProc2;
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+16#!#abc
+~~END~~
+
+exec txnproc1;
+~~ERROR (Code: 266)~~
+
+~~ERROR (Message: Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count 1 current count 2)~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+select @@trancount
+~~START~~
+int
+0
+~~END~~
+
+select * from txnproctable order by c1;
+~~START~~
+int#!#varchar
+~~END~~
+
+
+#cleanup
+drop procedure txnproc3
+drop procedure txnproc2
+drop procedure txnproc1
+drop table txnproctable

--- a/test/JDBC/input/jtds/jtds-TestErrorsWithTryCatch.sql
+++ b/test/JDBC/input/jtds/jtds-TestErrorsWithTryCatch.sql
@@ -1,0 +1,979 @@
+CREATE TABLE ErrorWithTryCatchTable (a varchar(15) UNIQUE NOT NULL, b nvarchar(25), c int PRIMARY KEY, d char(15) DEFAULT 'Whoops!', e nchar(25), f datetime, g numeric(4,1) CHECK (g >= 103.5))
+GO
+
+-- setup for "invalid characters found: cannot cast value "%s" to money" error
+CREATE TABLE t293_1(a money, b int);
+GO
+
+INSERT INTO t293_1(a, b) values ($100, 1), ($101, 2);
+GO
+
+-- setup for error "column \"%s\" of relation \"%s\" is a generated column" error
+CREATE TABLE t1752_2(c1 INT, c2 INT, c3 as c1*c2)
+GO
+
+-- setup for "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations" error
+CREATE TABLE t141_2(c1 int, c2 int); 
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY 
+BEGIN CATCH 
+    SELECT xact_state(); 
+END CATCH 
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Simple batch with transaction inside try-catch
+BEGIN TRY 
+    BEGIN TRAN 
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY 
+BEGIN CATCH 
+    SELECT xact_state(); 
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+GO
+BEGIN TRY 
+    SELECT xact_state(); 
+    EXEC errorWithTryCatchProc1; 
+END TRY 
+BEGIN CATCH
+    SELECT xact_state(); 
+END CATCH;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state(); 
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS 
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+-- Error: check constraint violation
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: check constraint violation
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET g = 101.4 WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+
+
+
+-- Error: not null constraint violation
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: not null constraint violation
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE ErrorWithTryCatchTable SET c = NULL WHERE c = 1;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+
+
+
+-- Error: creating an existing table
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE ErrorWithTryCatchTable (a int);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE ErrorWithTryCatchTable (a int);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE ErrorWithTryCatchTable (a int);
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE ErrorWithTryCatchTable (a int);
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE ErrorWithTryCatchTable (a int);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: creating an existing table
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE ErrorWithTryCatchTable (a int);
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+
+
+
+
+
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_2 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations"
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_2;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations"
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a int; SELECT @a = c1, c2 FROM t141_2;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: "value for domain tinyint violates check constraint "tinyint_check""
+-- Simple error inside try-catch
+BEGIN TRY
+    SELECT xact_state();
+    DECLARE @a tinyint = 1000;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Simple batch with try catch
+BEGIN TRY
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Simple batch with transaction inside try-catch
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Simple procedure inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';;
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Transaction inside try-catch but not inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Transaction inside procedure but not inside try-catch
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    SELECT xact_state();
+    EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- Transaction inside try-catch and inside procedure
+CREATE PROCEDURE errorWithTryCatchProc1
+AS
+BEGIN
+    BEGIN TRAN
+        INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE t293_1 SET a = convert(money, ''string'') WHERE b > 1;';
+    COMMIT TRAN
+END
+GO
+BEGIN TRY
+    BEGIN TRAN
+        SELECT xact_state();
+        EXEC errorWithTryCatchProc1;
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+END CATCH;
+GO
+IF @@trancount > 0 ROLLBACK TRAN;
+GO
+DROP PROCEDURE errorWithTryCatchProc1
+GO
+select * from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- valid INSERT inside catch after an error
+-- Simple batch with try catch
+BEGIN TRY
+    BEGIN TRAN
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Orange', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END CATCH;
+GO
+select a from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+-- invalid INSERT inside catch after an error
+-- Simple batch with try catch
+BEGIN TRY
+    BEGIN TRAN
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END TRY
+BEGIN CATCH
+    SELECT xact_state();
+    INSERT INTO ErrorWithTryCatchTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+END CATCH;
+GO
+select a from ErrorWithTryCatchTable ORDER BY c
+GO
+truncate table ErrorWithTryCatchTable
+GO
+
+
+DROP TABLE ErrorWithTryCatchTable
+GO
+
+-- cleanup for "invalid characters found: cannot cast value "%s" to money" error
+DROP TABLE t293_1;
+GO
+
+-- cleanup for error "column \"%s\" of relation \"%s\" is a generated column" error
+DROP TABLE t1752_2
+GO
+
+-- cleanup for "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations" error
+DROP TABLE t141_2;
+GO
+
+while (@@trancount > 0) commit tran;
+GO
+

--- a/test/JDBC/input/jtds/jtds-TestSQLQueries.txt
+++ b/test/JDBC/input/jtds/jtds-TestSQLQueries.txt
@@ -1,0 +1,234 @@
+#1 CREATE TABLE with primary and unique keyword
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'ignore';
+CREATE TABLE tmp(a int PRIMARY KEY, b int UNIQUE);
+INSERT INTO tmp(a,b) values(1,1);
+INSERT INTO tmp(a,b) values(2,2);
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#2 2 table with foreign key relation
+#CREATE TABLE tmp1(b int PRIMARY KEY);
+#CREATE TABLE tmp2(a int PRIMARY KEY, b int FOREIGN KEY REFERENCES tmp1(b));
+#INSERT INTO tmp1(b) VALUES (1);
+#INSERT INTO tmp2(a,b) values(1,1);
+#SELECT * FROM tmp1;
+#SELECT * FROM tmp2;
+#DROP TABLE tmp2;
+#DROP TABLE tmp1;
+
+#3 Repeated #2 with CONSTRAINT keyword
+#CREATE TABLE tmp1(b int PRIMARY KEY);
+#CREATE TABLE tmp2(a int, b int, PRIMARY KEY(a), CONSTRAINT FK_tmp FOREIGN KEY (b) REFERENCES tmp1(b));
+#INSERT INTO tmp1(b) VALUES (1);
+#INSERT INTO tmp2(a,b) values(1,1);
+#SELECT * FROM tmp1;
+#SELECT * FROM tmp2;
+#DROP TABLE tmp2;
+#DROP TABLE tmp1;
+
+#4 CREATE TABLE with NOT NULL column
+CREATE TABLE tmp(a int PRIMARY KEY,b int NOT NULL);
+INSERT INTO tmp(a,b) values(1,1);
+INSERT INTO tmp(a,b) values(2,1);
+#INSERT INTO tmp(a,b) values(2,NULL);
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#5 INSERTION and DELETION
+CREATE TABLE tmp(a int PRIMARY KEY);
+INSERT INTO tmp(a) VALUES(1);
+INSERT INTO tmp(a) VALUES(2);
+INSERT INTO tmp(a) VALUES(3);
+INSERT INTO tmp(a) VALUES(4);
+INSERT INTO tmp(a) VALUES(5);
+SELECT * FROM tmp;
+DELETE FROM tmp WHERE a>2;
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#6 IS NOT NULL condition in WHERE clause
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) values(1,1);
+INSERT INTO tmp(a,b) values(2,1);
+INSERT INTO tmp(a,b) values(3,NULL);
+INSERT INTO tmp(a,b) values(4,NULL);
+SELECT * FROM tmp WHERE b IS NOT NULL;
+DROP TABLE tmp;
+
+#7 Add new column using ALTER TABLE
+CREATE TABLE tmp(a int PRIMARY KEY);
+INSERT INTO tmp(a) VALUES(1);
+INSERT INTO tmp(a) VALUES(2);
+SELECT * FROM tmp;
+ALTER TABLE tmp ADD b VARCHAR(20) NULL;
+SELECT * FROM tmp;
+INSERT INTO tmp(a,b) VALUES(4,'Dipesh');
+INSERT INTO tmp(a,b) VALUES(5,' Dipesh');
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#8 Repeated #8 with default value for newly added col
+CREATE TABLE tmp(a int PRIMARY KEY);
+INSERT INTO tmp(a) VALUES(1);
+INSERT INTO tmp(a) VALUES(2);
+SELECT * FROM tmp;
+ALTER TABLE tmp ADD b VARCHAR(20) DEFAULT 'Dipesj';
+SELECT * FROM tmp;
+INSERT INTO tmp(a,b) VALUES(4,'Dipesh');
+INSERT INTO tmp(a,b) VALUES(5,' Dipesh');
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#9 Change datatype of existing column using ALTER TABLE
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+INSERT INTO tmp(a,b) VALUES(2,2);
+SELECT * FROM tmp;
+ALTER TABLE tmp ALTER COLUMN b VARCHAR(10);
+SELECT * FROM tmp;
+INSERT INTO tmp(a,b) VALUES(4,'Dipesh');
+INSERT INTO tmp(a,b) VALUES(5,' Dipesh');
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#10 UPDATE TABLE with fancy condition
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+INSERT INTO tmp(a,b) VALUES(2,2);
+INSERT INTO tmp(a,b) VALUES(3,3);
+INSERT INTO tmp(a,b) VALUES(4,4);
+INSERT INTO tmp(a,b) VALUES(5,5);
+SELECT * FROM tmp;
+UPDATE tmp SET b=b+1 WHERE b>2;
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#11 DROP some column using ALTER TABLE
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+INSERT INTO tmp(a,b) VALUES(2,2);
+INSERT INTO tmp(a,b) VALUES(3,3);
+INSERT INTO tmp(a,b) VALUES(4,4);
+INSERT INTO tmp(a,b) VALUES(5,5);
+SELECT * FROM tmp;
+#ALTER TABLE tmp DROP COLUMN b;
+#INSERT INTO tmp(a) values (6);
+#SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#12 CREATE TABLE with fancy constraint
+CREATE TABLE tmp(a int PRIMARY KEY CHECK (a>10),b int);
+INSERT INTO tmp(a,b) VALUES(11,1);
+INSERT INTO tmp(a,b) VALUES(12,2);
+INSERT INTO tmp(a,b) VALUES(13,3);
+INSERT INTO tmp(a,b) VALUES(14,4);
+INSERT INTO tmp(a,b) VALUES(15,5);
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#CREATE PROCEDURE tmp AS
+#BEGIN
+#    CREATE TABLE dip(a int PRIMARY KEY CHECK (a>10),b int);
+#    INSERT INTO dip(a,b) VALUES(11,1);
+#    INSERT INTO dip(a,b) VALUES(12,2);
+#    INSERT INTO dip(a,b) VALUES(13,3);
+#    INSERT INTO dip(a,b) VALUES(14,4);
+#    INSERT INTO dip(a,b) VALUES(15,5);
+#    SELECT * FROM dip;
+#    DROP TABLE dip;
+#END;
+
+#13 invoke simple stored procedure using EXECUTE
+EXECUTE tmp;
+
+#14 invoke simple stored procedure using EXEC
+EXEC tmp;
+
+#DROP PROCEDURE tmp;
+
+#15 UPDATE rows in existing table
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
+SELECT * FROM tmp;
+UPDATE tmp SET b=b*2+1 WHERE (a>2);
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#16 TRUNCATE table
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
+SELECT * FROM tmp;
+TRUNCATE TABLE tmp;
+SELECT * FROM tmp;
+DROP TABLE tmp;
+
+CREATE TABLE temp1 (i INT,j INT,t TEXT);
+
+CREATE TABLE temp2 ( i INT,k INT);
+
+INSERT INTO temp1 VALUES (1, 4, 'one');
+INSERT INTO temp1 VALUES (2, 3, 'two');
+INSERT INTO temp1 VALUES (3, 2, 'three');
+INSERT INTO temp1 VALUES (4, 1, 'four');
+INSERT INTO temp1 VALUES (5, 0, 'five');
+INSERT INTO temp1 VALUES (6, 6, 'six');
+INSERT INTO temp1 VALUES (7, 7, 'seven');
+INSERT INTO temp1 VALUES (8, 8, 'eight');
+INSERT INTO temp1 VALUES (0, NULL, 'zero');
+INSERT INTO temp1 VALUES (NULL, NULL, NULL);
+INSERT INTO temp1 VALUES (NULL, 0, 'zero');
+
+INSERT INTO temp2 VALUES (1, -1);
+INSERT INTO temp2 VALUES (2, 2);
+INSERT INTO temp2 VALUES (3, -3);
+INSERT INTO temp2 VALUES (2, 4);
+INSERT INTO temp2 VALUES (5, -5);
+INSERT INTO temp2 VALUES (5, -5);
+INSERT INTO temp2 VALUES (0, NULL);
+INSERT INTO temp2 VALUES (NULL, NULL);
+INSERT INTO temp2 VALUES (NULL, 0);
+
+#17 CROSS JOIN
+SELECT * FROM temp1 CROSS JOIN temp2;
+
+#18 INNER JOIN
+SELECT temp1.i, temp1.j, temp1.t, temp2.k FROM temp1 INNER JOIN temp2 ON temp1.i=temp2.i ORDER BY temp1.i;
+SELECT temp1.i, temp1.j, temp1.t, temp2.k FROM temp1 JOIN temp2 ON temp1.i=temp2.i ORDER BY temp1.i;
+
+#19 LEFT JOIN
+SELECT * FROM temp1 LEFT OUTER JOIN temp2 ON temp1.i=temp2.k ORDER BY temp1.i;
+
+#20 RIGHT JOIN
+SELECT * FROM temp1 RIGHT OUTER JOIN temp2 ON temp1.i=temp2.i ORDER BY temp1.i, temp2.k;
+
+#21 FULL OUTER JOIN
+SELECT * FROM temp1,temp2;
+
+DROP TABLE temp1;
+DROP TABLE temp2;
+
+#22 dropping all columns
+CREATE TABLE tmp(a int PRIMARY KEY,b int);
+INSERT INTO tmp(a,b) VALUES(1,1);
+INSERT INTO tmp(a,b) VALUES(2,2);
+INSERT INTO tmp(a,b) VALUES(3,3);
+INSERT INTO tmp(a,b) VALUES(4,4);
+INSERT INTO tmp(a,b) VALUES(5,5);
+SELECT * FROM tmp;
+#ALTER TABLE tmp DROP COLUMN b;
+#ALTER TABLE tmp DROP COLUMN a;
+#SELECT * FROM tmp;
+DROP TABLE tmp;
+
+#23
+CREATE TABLE DATE_dt (a DATE);
+INSERT INTO DATE_dt(a) values('2000-12-13');
+INSERT INTO DATE_dt(a) values('1900-02-28');
+INSERT INTO DATE_dt(a) values('0001-01-01');
+INSERT INTO DATE_dt(a) values('9999-12-31');
+INSERT INTO DATE_dt(a) values(NULL);
+SELECT * FROM DATE_dt;
+ALTER TABLE DATE_dt ALTER COLUMN a DATETIME;
+SELECT * FROM DATE_dt;
+DROP TABLE DATE_dt;
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_unique_constraint', 'strict';

--- a/test/JDBC/input/jtds/jtds-TestSimpleErrors.sql
+++ b/test/JDBC/input/jtds/jtds-TestSimpleErrors.sql
@@ -1,0 +1,2533 @@
+-- sla_for_parallel_query_enforced 100000
+CREATE TABLE simpleErrorTable (a varchar(15) UNIQUE NOT NULL, b nvarchar(25), c int PRIMARY KEY, d char(15) DEFAULT 'Whoops!', e nchar(25), f datetime, g numeric(4,1) CHECK (g >= 103.5))
+GO
+
+-- setup for "data out of range for datetime" error
+CREATE TABLE t517_1(a datetime);
+GO
+
+-- setup for "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations" error
+CREATE TABLE t141_1(c1 int, c2 int); 
+GO
+
+-- setup for "column \"%s\" of relation \"%s\" is a generated column"
+CREATE TABLE t1752_1(c1 INT, c2 INT, c3 as c1*c2)
+GO
+
+if @@trancount > 0 commit tran;
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    save tran sp1; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran sp1
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4); 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4); 
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4); 
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: duplicate key value violates unique constraint
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'blue', 2, 'Chennai', N'Neutral😐',  '2006-11-11 22:47:23.128', 512.4);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    rollback tran sp1;
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+            declare @err int = @@error; if @err = 0 select 0 else select 1;
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: data out of range for datetime
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        INSERT INTO t517_1 VALUES (DATEADD(YY,-300,getdate()));
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+commit tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+    rollback tran sp1;
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+        declare @err int = @@error; if @err = 0 select 0 else select 1;
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: not null constraint violation
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        UPDATE simpleErrorTable SET c = NULL WHERE c = 1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+
+-- Error: creating an existing table
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+CREATE TABLE simpleErrorTable (a int);
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+rollback tran sp1;
+GO
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        CREATE TABLE simpleErrorTable (a int);
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran;
+GO
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+commit tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                CREATE TABLE simpleErrorTable (a int);
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE simpleErrorTable (a int);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    CREATE TABLE simpleErrorTable (a int);
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE simpleErrorTable (a int);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: creating an existing table
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        CREATE TABLE simpleErrorTable (a int);
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    save tran sp1; 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran sp1; 
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    commit tran; 
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "column \"%s\" of relation \"%s\" is a generated column"
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        ALTER TABLE t1752_1 ADD CONSTRAINT constraint1752 DEFAULT 'test' FOR c3;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+	DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+	DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran sp1;
+GO
+rollback tran;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+DECLARE @a tinyint = 1000;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+DECLARE @a tinyint = 1000;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+commit tran
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a tinyint = 1000;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    DECLARE @a tinyint = 1000;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc3
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a tinyint = 1000;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: "A SELECT statement that assigns a value to a variable must not be
+-- combined with data-retrieval operations"
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a int; SELECT @a = c1, c2 FROM t141_1;
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        DECLARE @a tinyint = 1000;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+select @@trancount;
+GO
+
+if @@trancount > 0 commit tran;
+GO
+
+-- Error: value for domain tinyint violates check constraint "tinyint_check"
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+DECLARE @a tinyint = 1000;
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch
+INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with commit transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with rollback transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with rollback transaction and rollback to savepoint
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    save tran sp1;
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+rollback tran sp1;
+GO
+rollback tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure
+create procedure simpleErrorProc1
+as 
+begin 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple batch with nested transaction
+begin tran; 
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+    begin tran; 
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+GO
+commit tran; 
+INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+GO
+commit tran;
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction
+create procedure simpleErrorProc1
+as 
+begin 
+    begin tran; 
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1); 
+            begin tran; 
+                EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+            commit tran; 
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5); 
+    commit tran; 
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction started inside procedure but ended outside procedure
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+commit tran
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction started outside procedure but ended inside procedure through commit
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- simple procedure with transaction started outside procedure but ended inside procedure through rollback
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+begin tran
+GO
+exec simpleErrorProc1
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure (level 2)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure (level 3)
+create procedure simpleErrorProc1
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+    INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+    exec simpleErrorProc1;
+    INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+end
+GO
+create procedure simpleErrorProc3
+as
+begin
+    SELECT 1;
+    exec simpleErrorProc2;
+    SELECT 2;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+drop procedure simpleErrorProc3
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure with commit transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    commit tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    commit tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- Error: conversion error and executing stored procedure using sp_executesql
+-- nested procedure with rollback transaction
+create procedure simpleErrorProc1
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Apple', N'red', 1, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+        EXECUTE sp_executesql N'UPDATE simpleErrorTable SET a = convert(int, ''abc'') WHERE c = 1;';
+        INSERT INTO simpleErrorTable(a, b, c, e, f, g) VALUES ('Orange', NULL, 3, N'Happy😀',  '1900-02-28 23:59:59.989', 342.5);
+    rollback tran;
+end
+GO
+create procedure simpleErrorProc2
+as
+begin
+    begin tran;
+        INSERT INTO simpleErrorTable VALUES ('Pineapple', N'pink', 7, 'Surat', N'Frown😠',  '2000-12-13 12:58:23.123', 123.1);
+        exec simpleErrorProc1;
+        INSERT INTO simpleErrorTable VALUES ('Cherry', N'indigo', 8, 'Delhi', N'Sad😞',  '2000-12-13 12:58:23.123', 123.1);
+    rollback tran;
+end
+GO
+exec simpleErrorProc2
+GO
+declare @err int = @@error; if @err = 0 select 0 else select 1;
+GO
+select * from simpleErrorTable ORDER BY c
+GO
+select @@trancount
+GO
+drop procedure simpleErrorProc1
+GO
+drop procedure simpleErrorProc2
+GO
+truncate table simpleErrorTable
+GO
+
+-- cleanup for "data out of range for datetime" error
+DROP TABLE t517_1;
+GO
+
+-- clean up for "A SELECT statement that assigns a value to a variable must not
+-- be combined with data-retrieval operations" error
+DROP TABLE t141_1;
+GO
+
+-- setup for "column \"%s\" of relation \"%s\" is a generated column"
+DROP TABLE t1752_1;
+GO
+
+drop table simpleErrorTable
+GO
+
+while (@@trancount > 0) commit tran;
+GO
+

--- a/test/JDBC/input/jtds/jtds-TestStoredProcedures.txt
+++ b/test/JDBC/input/jtds/jtds-TestStoredProcedures.txt
@@ -1,0 +1,182 @@
+# PROCEDURE WITH NO BODY
+#create procedure sp_test AS BEGIN END;
+# PROCEDURE WITH NO PARAMS
+create table temp_sp2(a int);
+CREATE PROCEDURE sp_test AS BEGIN insert into temp_sp2 values(1); END;
+storedproc#!#prep#!#sp_test#!#
+SELECT * FROM temp_sp2;
+drop table temp_sp2;
+drop Procedure sp_test;
+# PROCEDURE WITH INPUT PARAMETER
+#drop table temp_sp;
+create table temp_sp(a int);
+Create Procedure stored_proc1 (@a int) As Begin insert into temp_sp values(@a) End;
+# NOT WORKING FOR BABEL,RAISED JIRA 444
+storedproc#!#prep#!#stored_proc1#!#int|-|a|-|-100|-|input
+# MISMATCH IN RETURN VALUES
+exec stored_proc1 -200
+exec stored_proc1 0
+exec stored_proc1 -1
+exec stored_proc1 2
+# filed Jira on this, doesnt work for babel
+#exec stored_proc1 2.2
+SELECT * FROM temp_sp;
+DROP table temp_sp;
+DROP Procedure stored_proc1
+# input parameter
+CREATE PROCEDURE sp_test1 (@a  INT) AS BEGIN SET @a=100; Select @a as a; END;
+exec sp_test1 2
+Declare @a int;Set @a=1; exec sp_test1 @a;select @a as a;
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|1|-|input
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|10|-|input
+DROP PROCEDURE sp_test1
+# TESTING OUT PARAMETERS FOR ALL THE DATATYPES
+# int
+CREATE PROCEDURE sp_test1 (@a  INT OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+#Declare @a int;Set @a=1; exec sp_test1 @a;select @a as a;
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|1|-|output
+storedproc#!#prep#!#sp_test1#!#int|-|a|-|1|-|inputoutput
+DROP PROCEDURE sp_test1
+# smallint
+CREATE PROCEDURE sp_test2 (@a SMALLINT OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+#Declare @a smallint;Set @a=1; exec sp_test2 @a;select @a as a;
+storedproc#!#prep#!#sp_test2#!#smallint|-|a|-|10|-|output
+storedproc#!#prep#!#sp_test2#!#smallint|-|a|-|10|-|inputoutput
+DROP PROCEDURE sp_test2
+# bigint
+CREATE PROCEDURE sp_test3 (@a BIGINT OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+storedproc#!#prep#!#sp_test3#!#bigint|-|a|-|10|-|output
+storedproc#!#prep#!#sp_test3#!#bigint|-|a|-|10|-|inputoutput
+DROP PROCEDURE sp_test3
+# tinyint
+#CREATE PROCEDURE sp_test4 (@a tinyint OUTPUT) AS BEGIN SET @a=100; Select @a as a; END;
+#storedproc#!#prep#!#sp_test4#!#tinyint|-|a|-|10|-|output
+#storedproc#!#prep#!#sp_test4#!#tinyint|-|a|-|10|-|inputoutput
+#DROP PROCEDURE sp_test4
+# float
+CREATE PROCEDURE sp_test5 (@a float OUTPUT) AS BEGIN SET @a=100.12; Select @a as a; END;
+#Declare @a float;Set @a=1.1; exec sp_test5 @a;select @a as a;
+storedproc#!#prep#!#sp_test5#!#float|-|a|-|10.1|-|output
+storedproc#!#prep#!#sp_test5#!#float|-|a|-|10.1|-|inputoutput
+DROP PROCEDURE sp_test5
+# varchar
+#CREATE PROCEDURE sp_test6 (@a varchar OUTPUT) AS BEGIN SET @a='helloworld'; Select @a as a; END;
+#storedproc#!#prep#!#sp_test6#!#varchar|-|a|-|hello|-|output
+#storedproc#!#prep#!#sp_test6#!#varchar|-|a|-|hello|-|inputoutput
+#DROP PROCEDURE sp_test6
+# char BABEL-705
+#CREATE PROCEDURE sp_test7 (@a char OUTPUT) AS BEGIN SET @a='b'; Select @a as a; END;
+#Declare @a varchar;Set @a='h'; exec sp_test7 @a;select @a as a;
+#storedproc#!#prep#!#sp_test7#!#char|-|a|-|t|-|output
+#storedproc#!#prep#!#sp_test7#!#char|-|a|-|t|-|inputoutput
+#DROP PROCEDURE sp_test7
+# nvarchar
+#CREATE PROCEDURE sp_test9 (@a nvarchar OUTPUT) AS BEGIN SET @a='helloworld'; Select @a as a; END;
+#Declare @a nvarchar;Set @a='hello'; exec sp_test9 @a;select @a as a;
+#storedproc#!#prep#!#sp_test9#!#varchar|-|a|-|hello|-|output
+#storedproc#!#prep#!#sp_test9#!#varchar|-|a|-|hello|-|inputoutput
+#DROP PROCEDURE sp_test9
+# numeric 
+CREATE PROCEDURE sp_test10 (@a numeric(10,4) OUTPUT) AS BEGIN SET @a=100.41; Select @a as a; END;
+#Declare @a numeric(10,4);Set @a=10.04; exec sp_test10 @a;select @a as a;
+#storedproc#!#prep#!#sp_test10#!#numeric|-|a|-|123|-|10|-|3|-|output
+#storedproc#!#prep#!#sp_test10#!#numeric|-|a|-|123|-|10|-|2|-|inputoutput
+DROP PROCEDURE sp_test10
+# decimal 
+CREATE PROCEDURE sp_test11 (@a decimal(10,4) OUTPUT) AS BEGIN SET @a=100.41; Select @a as a; END;
+#Declare @a decimal(10,4);Set @a=10.04; exec sp_test11 @a;select @a as a;
+#storedproc#!#prep#!#sp_test11#!#decimal|-|a|-|123|-|10|-|3|-|output
+#storedproc#!#prep#!#sp_test11#!#decimal|-|a|-|123|-|10|-|2|-|inputoutput
+DROP PROCEDURE sp_test11
+# binary 
+#CREATE PROCEDURE sp_test12 (@a binary OUTPUT) AS BEGIN SET @a=0x121; Select @a as a; END;
+#exec sp_test12 0x122
+#Declare @a binary;Set @a=0x121; exec sp_test12 @a;select @a as a;
+#storedproc#!#prep#!#sp_test12#!#binary|-|a|-|0x122|-|output
+#storedproc#!#prep#!#sp_test12#!#binary|-|a|-|0x122|-|inputoutput
+#DROP PROCEDURE sp_test12
+# varbinary BABEL-701
+#CREATE PROCEDURE sp_test13 (@a varbinary OUTPUT) AS BEGIN SET @a=0x121; Select @a as a; END;
+#exec sp_test13 0x122
+#Declare @a varbinary;Set @a=0x122; exec sp_test13 @a;select @a as a;
+#storedproc#!#prep#!#sp_test13#!#varbinary|-|a|-|0x122|-|output
+#storedproc#!#prep#!#sp_test13#!#varbinary|-|a|-|0x122|-|inputoutput
+#DROP PROCEDURE sp_test13
+# date
+CREATE PROCEDURE sp_test14 (@a date output) AS BEGIN SET @a='1999-1-3'; Select @a as a; END;
+#Declare @a DATE;Set @a='9999-12-31'; exec sp_test14 @a;select @a as a;
+storedproc#!#prep#!#sp_test14#!#DATE|-|a|-|9999-12-31|-|output
+storedproc#!#prep#!#sp_test14#!#DATE|-|a|-|9999-12-31|-|inputoutput
+DROP PROCEDURE sp_test14
+# time
+#CREATE PROCEDURE sp_test15 (@a time(4) OUTPUT) AS BEGIN SET @a='11:25:07.123'; Select @a as a; END;
+#Declare @a Time;Set @a='12:45:37.123'; exec sp_test15 @a;select @a as a;
+#storedproc#!#prep#!#sp_test15#!#Time|-|a|-|12:45:37.123|-|3|-|output
+#storedproc#!#prep#!#sp_test15#!#Time|-|a|-|12:45:37.123|-|3|-|inputoutput
+#DROP PROCEDURE sp_test15
+# dateime BABEL-694
+#CREATE PROCEDURE sp_test16 (@a datetime output) AS BEGIN SET @a='2004-05-18 13:59:59.995'; Select @a as a; END;
+#Declare @a DATETIME;Set @a='2000-02-28 23:59:59.995'; exec sp_test16 @a;select @a as a;
+#storedproc#!#prep#!#sp_test16#!#DATETIME|-|a|-|2000-02-28 23:59:59.995|-|output
+#storedproc#!#prep#!#sp_test16#!#DATETIME|-|a|-|2000-02-28 23:59:59.995|-|inputoutput
+#DROP PROCEDURE sp_test16
+# datetime2
+#CREATE PROCEDURE sp_test17 (@a datetime2(5) OUTPUT) AS BEGIN SET @a='2014-10-2 1:45:37.123456'; Select @a as a; END;
+#Declare @a Datetime2;Set @a='2016-10-23 12:45:37.123456'; exec sp_test17 @a;select @a as a;
+#storedproc#!#prep#!#sp_test17#!#Datetime2|-|a|-|2016-10-23 12:45:37.123456|-|5|-|output
+#storedproc#!#prep#!#sp_test17#!#Datetime2|-|a|-|2016-10-23 12:45:37.123456|-|5|-|inputoutput
+#DROP PROCEDURE sp_test17
+# smalldatetime BABEL-694
+#CREATE PROCEDURE sp_test18 (@a smalldatetime output) AS BEGIN SET @a='2010-02-03 12:58:23'; Select @a as a; END;
+#Declare @a SMALLDATETIME;Set @a='2000-12-13 12:58:23'; exec sp_test18 @a;select @a as a;
+#storedproc#!#prep#!#sp_test18#!#SMALLDATETIME|-|a|-|2000-12-13 12:58:23|-|output
+#storedproc#!#prep#!#sp_test18#!#SMALLDATETIME|-|a|-|2000-12-13 12:58:23|-|inputoutput
+#DROP PROCEDURE sp_test18
+# UID
+#CREATE PROCEDURE sp_test19 (@a uniqueidentifier OUTPUT) AS BEGIN SET @a='ce8af10a-2709-43b0-9e4e-a02753929d17'; Select @a as a; END;
+#Declare @a uniqueidentifier;Set @a='5b7c2e8d-6d90-411d-8e19-9a81067e6f6c'; exec sp_test19 @a;select @a as a;
+#storedproc#!#prep#!#sp_test19#!#uniqueidentifier|-|a|-|5b7c2e8d-6d90-411d-8e19-9a81067e6f6c|-|output
+#storedproc#!#prep#!#sp_test19#!#uniqueidentifier|-|a|-|5b7c2e8d-6d90-411d-8e19-9a81067e6f6c|-|inputoutput
+#DROP PROCEDURE sp_test19
+
+CREATE PROCEDURE sp_test20 (@a INT, @b INT OUTPUT) AS BEGIN SET @b=100; SET @a=1000; Select @a as a, @b as b; END;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b OUT, @a=@a;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b, @a=@a OUT;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b OUT, @a=@a OUT;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @b=@b, @a=@a;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a, @b=@b;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a, @b=@b OUT;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a OUT, @b=@b;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a=@a OUT, @b=@b OUT;select @a as a, @b as b;
+Declare @a int;Declare @b int;Set @a=20;Set @b=10; exec sp_test20 @a OUT, @b OUT;select @a as a, @b as b;
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|output#!#int|-|b|-|10|-|input
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|input
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|output#!#int|-|b|-|10|-|output
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|inputoutput#!#int|-|b|-|10|-|inputoutput
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput
+storedproc#!#prep#!#sp_test20#!#int|-|a|-|20|-|inputoutput#!#int|-|b|-|10|-|input
+DROP PROCEDURE sp_test20
+
+CREATE PROCEDURE sp_test21 (@a INT, @b INT OUTPUT, @d INT, @c INT OUTPUT) AS BEGIN SET @a=100; SET @b=200; SET @c=300; SET @d=400; Select @a as a, @b as b, @c as c, @d as d; END;
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @b=@b OUT, @c=@c OUT, @a=@a, @d=@d; Select @a as a, @b as b, @c as c, @d as d;
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @b=@b, @c=@c, @a=@a, @d=@d; Select @a as a, @b as b, @c as c, @d as d;
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @c=@c OUT, @b=@b OUT, @a=@a, @d=@d; Select @a as a, @b as b, @c as c, @d as d;
+Declare @a int;Declare @b int;Declare @c int;Declare @d int;Set @a=20;Set @b=10;Set @c=5;Set @d=30; exec sp_test21 @c=@c, @b=@b, @a=@a OUT, @d=@d OUT; Select @a as a, @b as b, @c as c, @d as d;
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|inputoutput
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|output
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|output#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|inputoutput
+storedproc#!#prep#!#sp_test21#!#int|-|a|-|20|-|input#!#int|-|b|-|10|-|inputoutput#!#int|-|c|-|10|-|input#!#int|-|d|-|10|-|output
+DROP PROCEDURE sp_test21
+
+CREATE PROCEDURE sp_test22 (@MixedCaseArg_1 INT, @MixedCaseArg_2 INT OUTPUT) AS BEGIN SET @MixedCaseArg_2=100; SET @MixedCaseArg_1=1000; Select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2; END;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2 OUT, @MixedCaseArg_1=@MixedCaseArg_1 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_2=@MixedCaseArg_2, @MixedCaseArg_1=@MixedCaseArg_1;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1=@MixedCaseArg_1 OUT, @MixedCaseArg_2=@MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+Declare @MixedCaseArg_1 int;Declare @MixedCaseArg_2 int;Set @MixedCaseArg_1=20;Set @MixedCaseArg_2=10; exec sp_test22 @MixedCaseArg_1 OUT, @MixedCaseArg_2 OUT;select @MixedCaseArg_1 as MixedCaseArg_1, @MixedCaseArg_2 as MixedCaseArg_2;
+DROP PROCEDURE sp_test22

--- a/test/JDBC/input/jtds/jtds-TestTransactionSupportForProcedure.txt
+++ b/test/JDBC/input/jtds/jtds-TestTransactionSupportForProcedure.txt
@@ -1,0 +1,260 @@
+#setup
+create table txnproctable (c1 int not null, c2 varchar(100))
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+#  		ROLLBACK SAVEPOINT
+#		COMMIT
+create procedure txnproc1 as begin tran; insert into txnproctable values (1, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1;  rollback tran sp1; commit tran;
+select @@trancount;
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount;
+select * from txnproctable order by c1;
+
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+#  		ROLLBACK SAVEPOINT
+#		ROLLBACK
+drop procedure txnproc1;
+create procedure txnproc1 as begin tran; insert into txnproctable values(2, 'xyz'); save tran sp1; delete from txnproctable; rollback tran sp1; rollback tran;
+select @@trancount;
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount;
+select * from txnproctable order by c1;
+
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+#  		ROLLBACK SAVEPOINT
+# COMMIT
+drop procedure txnproc1
+create procedure txnproc1 as begin tran; insert into txnproctable values(3, 'dbd'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+
+# PROC
+# 		BEGIN TRAN
+#			SAVEPOINT
+# ROLLBACK SAVEPOINT
+# COMMIT
+drop procedure txnproc1
+create procedure txnproc1 as begin tran; insert into txnproctable values(4, 'sbd'); save tran sp1; update txnproctable set c1 = c1 + 1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+# COMMIT
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(5, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+# ROLLBACK	
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(6, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+#		COMMIT
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(7, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1; update txnproctable set c1 = c1 + 1; commit tran; 
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+
+# BEGIN TRAN 
+# PROC
+#		SAVEPOINT
+# 		ROLLBACK SAVEPOINT
+#		ROLLBACK
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(8, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1; rollback tran sp1; update txnproctable set c1 = c1 + 1; rollback tran; 
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+
+# BEGIN TRAN
+# START SAVEPOINT
+# PROC
+# ROLLBACK SAVEPOINT
+# ROLLBACK
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+save tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(9, 'abc'); update txnproctable set c1 = c1 + 1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+rollback tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+# BEGIN TRAN
+# START SAVEPOINT
+# PROC
+# ROLLBACK SAVEPOINT
+# ROLLBACK
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+save tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(10, 'abc'); update txnproctable set c1 = c1 + 1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+# BEGIN TRAN
+# START SAVEPOINT
+# PROC
+# 		ROLLBACK SAVEPOINT
+# ROLLBACK
+begin tran;
+select @@trancount
+select * from txnproctable order by c1;
+save tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as insert into txnproctable values(11, 'abc'); rollback tran sp1; update txnproctable set c1 = c1 + 1;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+# PROC1
+#		BEGIN TRAN
+#		PROC2
+#			PROC3
+#				BEGIN TRAN
+#				START SAVEPOINT
+#				ROLLBACK SAVEPOINT
+#			COMMIT
+#	COMMIT
+create procedure txnProc3 as begin tran; insert into txnproctable values (16, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1;  rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+create procedure txnProc2 as update txnproctable set c1 = c1 + 1; exec txnProc3; commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as delete from txnproctable; begin tran; exec txnProc2;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+commit tran;
+select @@trancount
+select * from txnproctable order by c1;
+
+# PROC1
+#		BEGIN TRAN
+#		PROC2
+#			PROC3
+#				BEGIN TRAN
+#				START SAVEPOINT
+#				ROLLBACK SAVEPOINT
+#			ROLLBACK TRAN
+#	COMMIT
+drop procedure txnproc3
+create procedure txnProc3 as begin tran; insert into txnproctable values (20, 'abc'); save tran sp1; update txnproctable set c1 = c1 + 1;  rollback tran sp1;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc2
+create procedure txnProc2 as update txnproctable set c1 = c1 + 1; exec txnProc3; rollback tran;
+select @@trancount
+select * from txnproctable order by c1;
+drop procedure txnproc1
+create procedure txnproc1 as delete from txnproctable; begin tran; exec txnProc2;
+select @@trancount
+select * from txnproctable order by c1;
+exec txnproc1;
+select @@trancount
+select * from txnproctable order by c1;
+
+#cleanup
+drop procedure txnproc3
+drop procedure txnproc2
+drop procedure txnproc1
+drop table txnproctable

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -369,3 +369,10 @@ ignore#!#BABEL_4330-before-15_8-or-16_4-vu-verify
 ignore#!#alter-procedure-before-15_8-or-16_4-vu-prepare
 ignore#!#alter-procedure-before-15_8-or-16_4-vu-verify
 ignore#!#alter-procedure-before-15_8-or-16_4-vu-cleanup
+
+# These tests are for jTDS driver
+ignore#!#jtds-TestSQLQueries
+ignore#!#jtds-TestSimpleErrors
+ignore#!#jtds-TestErrorsWithTryCatch
+ignore#!#jtds-TestStoredProcedures
+ignore#!#jtds-TestTransactionSupportForProcedure

--- a/test/JDBC/jtds_jdbc_schedule
+++ b/test/JDBC/jtds_jdbc_schedule
@@ -1,0 +1,36 @@
+# Schedule file for JDBC Test Framework running with jTDS driver instead of
+# mssql-jdbc driver. When 'useJTDSInsteadOfMSSQLJDBC' config option is set to
+# 'true' this file is used instead of 'jdbc_schedule' file.
+
+# About the test that were copied with "jtds-" prefix:
+#
+# jTDS has different behaviour from mssql-jdbc when error happens in a batch with multiple statements.
+# If a batch contains multiple DML statements and one of them is causing an error (like constraint violation),
+# then with mssql-jdbc stmt.execute() returns successfully, number of updated rows can be read from
+# stmt.getUpdateCount() and the Exception is thrown on stmt.getMoreResults() only after all successful
+# update counts are read.
+#
+# With jTDS, if none of the statements return a result set (no selects in batch, only DML), then the Exception
+# is thrown on stmt.execute(). If this exception is caught and handled, then update counts from successul
+# DML statements can be read with stmt.getUpdateCount().
+# And if the successful batch statements return one or more result sets, then stmt.execute() succeeds,
+# and update counts and result sets can be read successfully up to the errored one. And the Exception
+# is thrown on rs.next() after the last successful result set is exhausted.
+#
+# This jTDS behaviour is the same with both Babelfish and MSSQL.
+
+# sqlBatch
+# jTDS reports column type as nvarchar instead of date, behavior on MSSQL and Babelfish is the same
+jtds-TestSQLQueries
+
+# errorHandling
+jtds-TestSimpleErrors
+jtds-TestErrorsWithTryCatch
+
+# storedProcedures
+# jTDS reports column type as nvarchar instead of date, behavior on MSSQL and Babelfish is the same
+jtds-TestStoredProcedures
+
+# transactions
+TestTransactionsSQLBatch
+jtds-TestTransactionSupportForProcedure

--- a/test/JDBC/pom.xml
+++ b/test/JDBC/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>postgresql</artifactId>
             <version>42.4.4</version>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.jtds</groupId>
+            <artifactId>jtds</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/test/JDBC/src/main/java/com/sqlsamples/CompareResults.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/CompareResults.java
@@ -1,7 +1,5 @@
 package com.sqlsamples;
 
-import org.junit.jupiter.api.Assertions;
-import org.opentest4j.AssertionFailedError;
 import microsoft.sql.DateTimeOffset;
 import org.apache.logging.log4j.Logger;
 
@@ -138,10 +136,14 @@ public class CompareResults {
     static void processResults(Statement stmt, BufferedWriter bw, int resultsProcessed, boolean resultSetExist, boolean warningExist, Logger logger) {
         int updateCount = -9;  // initialize to impossible value
 
-        while (true) {
+        outer: while (true) {
             boolean exceptionOccurred = true;
             do {
                 try {
+                    if (stmt.getConnection().isClosed()) {
+                        // prevent infinite loop if connection was closed
+                        break outer;
+                    }
                     if (resultsProcessed > 0) {
                         resultSetExist = stmt.getMoreResults();
                     }
@@ -169,6 +171,12 @@ public class CompareResults {
                     writeResultSetToFile(bw, rs, logger);
                 } catch (SQLException e) {
                     handleSQLExceptionWithFile(e, bw, logger);
+                } catch (StringIndexOutOfBoundsException e) {
+                    // can be thrown by JtdsResultSet.next()
+                    logger.error("StringIndexOutOfBoundsException: " + e.getMessage(), e);
+                    handleSQLExceptionWithFile(new SQLException(e), bw, logger);
+                    // need to go out of the loop because result set cannot be read
+                    break;
                 }
             } else {
                 if (updateCount > 0) {

--- a/test/JDBC/src/main/java/com/sqlsamples/Config.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/Config.java
@@ -29,6 +29,8 @@ public class Config {
     static String serverCollationName = properties.getProperty("serverCollationName");
     static String parallelQueryTestIgnoreFileName = "./parallel_query_jdbc_schedule";
     static boolean checkParallelQueryExpected = false;
+    static boolean useJTDSInsteadOfMSSQLJDBC = Boolean.parseBoolean(properties.getProperty("useJTDSInsteadOfMSSQLJDBC"));
+    static String jTDSScheduleFileName = "./jtds_jdbc_schedule";
     static String testFileRoot = properties.getProperty("testFileRoot");
     static boolean isUpgradeTestMode =  Boolean.parseBoolean(properties.getProperty("isUpgradeTestMode"));
     static long defaultSLA = Long.parseLong(properties.getProperty("defaultSLA"));
@@ -119,13 +121,26 @@ public class Config {
     }
     
     static String createSQLServerConnectionString(String URL, String port, String databaseName, String user, String password) {
-        return "jdbc:sqlserver://" + URL + ":" + port + ";" + "databaseName="
-                + databaseName + ";" + "user=" + user + ";" + "password=" + password;
+        if (useJTDSInsteadOfMSSQLJDBC) {
+            return "jdbc:jtds:sqlserver://" + URL + ":" + port + "/"
+                    + databaseName + ";" + "user=" + user + ";" + "password=" + password;
+        } else {
+            return "jdbc:sqlserver://" + URL + ":" + port + ";" + "databaseName="
+                    + databaseName + ";" + "user=" + user + ";" + "password=" + password;
+        }
     }
 
     static String createPostgreSQLConnectionString(String URL, String port, String databaseName, String user, String password) {
         return "jdbc:postgresql://" + URL + ":" + port + "/"
                 + databaseName + "?" + "user=" + user + "&" + "password=" + password;
+    }
+
+    static String tdsConnectionDriverClassName() {
+        if (useJTDSInsteadOfMSSQLJDBC) {
+            return "net.sourceforge.jtds.jdbc.Driver";
+        } else {
+            return "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+        }
     }
     
     private static String constructConnectionString() {

--- a/test/JDBC/src/main/java/com/sqlsamples/HandleException.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/HandleException.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.*;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.sql.DataTruncation;
 import java.sql.SQLException;
 
 import org.postgresql.util.PSQLException;
@@ -19,6 +20,12 @@ public class HandleException {
     static void handleSQLExceptionWithFile(SQLException e, BufferedWriter bw, Logger logger) {
         try {
             if (outputErrorCode) {
+
+                // DataTruncation is used by jTDS for error code 220
+                if (e instanceof DataTruncation && e.getNextException() != null) {
+                    e = e.getNextException();
+                }
+
                 bw.write("~~ERROR (Code: " + e.getErrorCode() + ")~~");
                 bw.newLine();
                 bw.newLine();

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCAuthentication.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCAuthentication.java
@@ -44,7 +44,11 @@ public class JDBCAuthentication {
             port = properties.getProperty("psql_port");
         }
 
-        connectionPropertiesBabel.put("url", "jdbc:sqlserver://" + properties.getProperty("URL") + ":" + port);
+        if (useJTDSInsteadOfMSSQLJDBC) {
+            connectionPropertiesBabel.put("url", "jdbc:jtds:sqlserver://" + properties.getProperty("URL") + ":" + port);
+        } else {
+            connectionPropertiesBabel.put("url", "jdbc:sqlserver://" + properties.getProperty("URL") + ":" + port);
+        }
 
         String other_prop = "";
 
@@ -79,10 +83,18 @@ public class JDBCAuthentication {
             }
         }
 
-        return connectionPropertiesBabel.get("url")
-                + ";" + "databaseName=" + connectionPropertiesBabel.get("database")
-                + ";" + "user=" + connectionPropertiesBabel.get("user")
-                + ";" + "password=" + connectionPropertiesBabel.get("password")
-                + ";" + other_prop;
+        if (useJTDSInsteadOfMSSQLJDBC) {
+            return connectionPropertiesBabel.get("url")
+                    + "/" + connectionPropertiesBabel.get("database")
+                    + ";" + "user=" + connectionPropertiesBabel.get("user")
+                    + ";" + "password=" + connectionPropertiesBabel.get("password")
+                    + ";" + other_prop;
+        } else {
+            return connectionPropertiesBabel.get("url")
+                    + ";" + "databaseName=" + connectionPropertiesBabel.get("database")
+                    + ";" + "user=" + connectionPropertiesBabel.get("user")
+                    + ";" + "password=" + connectionPropertiesBabel.get("password")
+                    + ";" + other_prop;
+        }
     }
 }

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCCrossDialect.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCCrossDialect.java
@@ -94,8 +94,8 @@ public class JDBCCrossDialect {
         getConnectionAttributes(strLine);
 
         try {
-            // Use sqlserver JDBC driver
-            Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+            // Use mssql-jdbc or jTDS JDBC driver
+            Class.forName(tdsConnectionDriverClassName());
 
             if (newPort == null)
                 newPort = tsql_port;

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
@@ -15,7 +15,6 @@ import java.sql.*;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -223,6 +222,10 @@ public class JDBCPreparedStatement {
                 logger.error("Parse Exception: " + e.getMessage(), e);
             } catch (NumberFormatException e) {
                 logger.error("Number Format Exception: " + e.getMessage(), e);
+            } catch (AbstractMethodError e) {
+                logger.error("Abstract Method Error: " + e.getMessage(), e);
+            } catch (NullPointerException e) {
+                logger.error("Null Pointer Exception: " + e.getMessage(), e);
             }
         }
     }

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCStatement.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.SQLWarning;
@@ -37,6 +36,10 @@ public class JDBCStatement {
             bw.write(strLine);
             bw.newLine();
 
+            if (SQL.isEmpty()) {
+                return;
+            }
+
             SQLWarning sqlwarn = null;
             boolean resultSetExist = false;
             boolean warningExist = false;
@@ -49,9 +52,11 @@ public class JDBCStatement {
                 handleSQLExceptionWithFile(e, bw, logger);
                 resultsProcessed++;
             }
-            CompareResults.processResults(stmt_bbl, bw, resultsProcessed, resultSetExist, warningExist,logger);
+            CompareResults.processResults(stmt_bbl, bw, resultsProcessed, resultSetExist, warningExist, logger);
         } catch (IOException ioe) {
             logger.error("IO Exception: " + ioe.getMessage(), ioe);
+        } catch (IllegalStateException e) {
+            logger.error("Illegal State Exception: " + e.getMessage(), e);
         }
     }
 }

--- a/test/JDBC/src/main/resources/config.txt
+++ b/test/JDBC/src/main/resources/config.txt
@@ -42,6 +42,9 @@ isParallelQueryMode = false
 # WHETHER TEST MODE HAS NON-DEFAULT-SERVER-COLLATION-NAME
 serverCollationName = default
 
+# WHETHER TO USE JTDS DRIVER FOR TDS CONNECTIONS
+useJTDSInsteadOfMSSQLJDBC = false
+
 # Where to find the input, output, expected, etc.
 testFileRoot = ./
 

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -126,7 +126,7 @@ public class TestQueryFile {
         if (command[1].equalsIgnoreCase("sqlserver")) {
             /* if are trying to execute a t-sql command but we are using postgres driver */
             if(JDBCDriver.equalsIgnoreCase("postgresql")) {
-                Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");     //use sql server driver
+                Class.forName(tdsConnectionDriverClassName());     //use sql server driver
             }
             connectionString = createSQLServerConnectionString(URL, tsql_port, databaseName, user, password);
             summaryLogger.info("Execute T-SQL Command: " + command[2]);
@@ -156,14 +156,15 @@ public class TestQueryFile {
         if (JDBCDriver.equalsIgnoreCase("postgresql")) {
             Class.forName("org.postgresql.Driver");
         } else if (JDBCDriver.equalsIgnoreCase("sqlserver")) {
-            Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+            Class.forName(tdsConnectionDriverClassName());
         } else throw new ClassNotFoundException("Driver not found for: " + JDBCDriver +". Choose from either 'sqlserver' or 'postgresql'");
     }
 
     // test data is seeded from here
     static Stream<String> inputFileNames() {
         File dir = new File(inputFilesDirectoryPath);
-        File scheduleFile = new File(scheduleFileName);
+        String scheduleFileNameToUse = useJTDSInsteadOfMSSQLJDBC ? jTDSScheduleFileName : scheduleFileName;
+        File scheduleFile = new File(scheduleFileNameToUse);
         File parallelQueryTestIgnoreFile = new File(parallelQueryTestIgnoreFileName);
         
         try (BufferedReader br = new BufferedReader(new FileReader(scheduleFile))) {


### PR DESCRIPTION
### Description

This PR is a part of a change originally implemented in #2320.

This change to JDBC test harness introduces the `jtds_jdbc_schedule` list file. To run the test from this new file instead of `jdbc_schedule` file it is necessary to set `useJTDSInsteadOfMSSQLJDBC` environment variable to `true`:

```
useJTDSInsteadOfMSSQLJDBC=true mvn test
```

Changes from #2860 PR are required to run jTDS tests successfully.

For `jtds_jdbc_schedule` file the intention is to use original tests unmodified where possible. Test for which modifications were required (mostly due to data types and error handling differences) are copied with `jtds-` prefix.

Github workfow file `jdbc-tests-with-jtds.yml` is included, but tests there are failing until #2860 is integrated. It is based on `jdbc-tests-with-parallel-query.yml` workflow file.

### Issues Resolved

#2137

### Test Scenarios Covered ###

The following tests from the [original list](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2320#issuecomment-1997130178) are included:

 - `sqlBatch`
 -  `errorHandling`
 - `storedProcedures`
 - `transactions`

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>