### PR TITLE
Restrict dropping user created for another database

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3290,9 +3290,11 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									int			role_oid;
 									int			rolename_len;
 									bool		is_tsql_db_principal = false;
+									Oid			dbowner;
 
 									user_name = get_physical_user_name(db_name, rolspec->rolename, false);
 									db_owner_name = get_db_owner_name(db_name);
+									dbowner = get_role_oid(db_owner_name, false);
 									role_oid = get_role_oid(user_name, true);
 									rolename_len = strlen(rolspec->rolename);
 									is_tsql_db_principal = OidIsValid(role_oid) &&
@@ -3311,8 +3313,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 * must be database owner to drop user/role
 									 */
 									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
-										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)) ||
-										(is_tsql_db_principal && !is_member_of_role(get_role_oid(db_owner_name, false), role_oid)))
+										!is_member_of_role(GetUserId(), dbowner) ||
+										(is_tsql_db_principal && !is_member_of_role(dbowner, role_oid)))
 										ereport(ERROR,
 												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3311,7 +3311,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 * must be database owner to drop user/role
 									 */
 									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
-										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)))
+										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)) ||
+										(is_tsql_db_principal && !is_member_of_role(get_role_oid(db_owner_name, false), role_oid)))
 										ereport(ERROR,
 												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3290,6 +3290,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									int			role_oid;
 									int			rolename_len;
 									bool		is_tsql_db_principal = false;
+									bool		is_psql_db_principal = false;
 									Oid			dbowner;
 
 									user_name = get_physical_user_name(db_name, rolspec->rolename, false);
@@ -3300,6 +3301,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									is_tsql_db_principal = OidIsValid(role_oid) &&
 														   ((drop_user && is_user(role_oid)) ||
 															(drop_role && is_role(role_oid)));
+									is_psql_db_principal = OidIsValid(role_oid) && !is_tsql_db_principal;
 
 									/* If user is dbo or role is db_owner, restrict dropping */
 									if ((drop_user && rolename_len == 3 && strncmp(rolspec->rolename, "dbo", 3) == 0) ||
@@ -3314,7 +3316,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 */
 									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
 										!is_member_of_role(GetUserId(), dbowner) ||
-										(is_tsql_db_principal && !is_member_of_role(dbowner, role_oid)))
+										(is_tsql_db_principal && !is_member_of_role(dbowner, role_oid)) || is_psql_db_principal)
 										ereport(ERROR,
 												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -211,10 +211,24 @@ drop user if exists fake_user;
 go
 
 -- both of the following statements should be executed successfully since user/role exists
+drop role if exists no_priv_user3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'no_priv_user3', because it does not exist or you do not have permission.)~~
+
+
 drop user if exists no_priv_user3;
 go
 
 drop user if exists no_priv_role3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'no_priv_role3', because it does not exist or you do not have permission.)~~
+
+
+drop role if exists no_priv_role3;
 go
 
 select count(*) from sys.database_principals where name like '%no_priv_%3';
@@ -251,14 +265,14 @@ drop user if exists pguser1;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied to drop role)~~
+~~ERROR (Message: Cannot drop the user 'pguser1', because it does not exist or you do not have permission.)~~
 
 
 drop role if exists pguser1;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied to drop role)~~
+~~ERROR (Message: Cannot drop the role 'pguser1', because it does not exist or you do not have permission.)~~
 
 
 -- psql
@@ -301,18 +315,43 @@ go
 drop database restrict_user_db1
 go
 
--- tsql
+-- psql
 -- 3.5 - Try dropping user created for another database
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+GO
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
 create database restrict_user_db1;
+go
+
+create database restrict_user_db1_restrict_user_db1;
 go
 
 create login restrict_user_l1 with password = '12345678'
 go
 
+use restrict_user_db1
+go
+
 create user restrict_user_db1_user1 for login restrict_user_l1;
 go
 
-use restrict_user_db1
+use restrict_user_db1_restrict_user_db1
 go
 
 drop user user1;
@@ -324,6 +363,10 @@ go
 
 drop user if exists user1;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'user1', because it does not exist or you do not have permission.)~~
+
 
 use master
 go
@@ -339,7 +382,13 @@ bool
 
 
 -- tsql
+use restrict_user_db1
+go
+
 drop user restrict_user_db1_user1;
+go
+
+use master
 go
 
 drop login restrict_user_l1;
@@ -347,3 +396,18 @@ go
 
 drop database restrict_user_db1;
 go
+
+drop database restrict_user_db1_restrict_user_db1;
+go
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -322,6 +322,9 @@ go
 ~~ERROR (Message: Cannot drop the user 'user1', because it does not exist or you do not have permission.)~~
 
 
+drop user if exists user1;
+go
+
 use master
 go
 

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -300,3 +300,47 @@ go
 
 drop database restrict_user_db1
 go
+
+-- tsql
+-- 3.5 - Try dropping user created for another database
+create database restrict_user_db1;
+go
+
+create login restrict_user_l1 with password = '12345678'
+go
+
+create user restrict_user_db1_user1 for login restrict_user_l1;
+go
+
+use restrict_user_db1
+go
+
+drop user user1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'user1', because it does not exist or you do not have permission.)~~
+
+
+use master
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+~~END~~
+
+
+-- tsql
+drop user restrict_user_db1_user1;
+go
+
+drop login restrict_user_l1;
+go
+
+drop database restrict_user_db1;
+go

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -219,6 +219,9 @@ go
 drop user user1;
 go
 
+drop user if exists user1;
+go
+
 use master
 go
 

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -143,10 +143,16 @@ drop user if exists fake_user;
 go
 
 -- both of the following statements should be executed successfully since user/role exists
+drop role if exists no_priv_user3;
+go
+
 drop user if exists no_priv_user3;
 go
 
 drop user if exists no_priv_role3;
+go
+
+drop role if exists no_priv_role3;
 go
 
 select count(*) from sys.database_principals where name like '%no_priv_%3';
@@ -203,17 +209,32 @@ drop database restrict_user_db1
 go
 
 -- 3.5 - Try dropping user created for another database
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+GO
+SELECT pg_reload_conf();
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
 -- tsql
 create database restrict_user_db1;
+go
+
+create database restrict_user_db1_restrict_user_db1;
 go
 
 create login restrict_user_l1 with password = '12345678'
 go
 
+use restrict_user_db1
+go
+
 create user restrict_user_db1_user1 for login restrict_user_l1;
 go
 
-use restrict_user_db1
+use restrict_user_db1_restrict_user_db1
 go
 
 drop user user1;
@@ -232,7 +253,13 @@ WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client b
 go
 
 -- tsql
+use restrict_user_db1
+go
+
 drop user restrict_user_db1_user1;
+go
+
+use master
 go
 
 drop login restrict_user_l1;
@@ -240,3 +267,13 @@ go
 
 drop database restrict_user_db1;
 go
+
+drop database restrict_user_db1_restrict_user_db1;
+go
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -201,3 +201,39 @@ go
 
 drop database restrict_user_db1
 go
+
+-- 3.5 - Try dropping user created for another database
+-- tsql
+create database restrict_user_db1;
+go
+
+create login restrict_user_l1 with password = '12345678'
+go
+
+create user restrict_user_db1_user1 for login restrict_user_l1;
+go
+
+use restrict_user_db1
+go
+
+drop user user1;
+go
+
+use master
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- tsql
+drop user restrict_user_db1_user1;
+go
+
+drop login restrict_user_l1;
+go
+
+drop database restrict_user_db1;
+go


### PR DESCRIPTION
### Description

Earlier, a user was able to drop user/role that belonged to another database.

With this commit, a user can only drop the role/user that belongs to the same database with sufficient privileges. 


### Issues Resolved
Task: BABEL-5173
Signed-off-by: Shalini Lohia <lshalini@amazon.com>



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).