### PR TITLE
Restrict DROP USER/ROLE from non-dbo user (#2859)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3241,7 +3241,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 * must be database owner to drop user/role
 									 */
 									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
-										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)))
+										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)) ||
+										(is_tsql_db_principal && !is_member_of_role(get_role_oid(db_owner_name, false), role_oid)))
 										ereport(ERROR,
 												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3219,6 +3219,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									int			role_oid;
 									int			rolename_len;
 									bool		is_tsql_db_principal = false;
+									bool		is_psql_db_principal = false;
 									Oid			dbowner;
 
 									user_name = get_physical_user_name(db_name, rolspec->rolename);
@@ -3230,6 +3231,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									is_tsql_db_principal = OidIsValid(role_oid) &&
 														   ((drop_user && is_user(role_oid)) ||
 															(drop_role && is_role(role_oid)));
+									is_psql_db_principal = OidIsValid(role_oid) && !is_tsql_db_principal;
 
 									/* If user is dbo or role is db_owner, restrict dropping */
 									if ((drop_user && rolename_len == 3 && strncmp(rolspec->rolename, "dbo", 3) == 0) ||
@@ -3244,7 +3246,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 */
 									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
 										!is_member_of_role(GetUserId(), dbowner) ||
-										(is_tsql_db_principal && !is_member_of_role(dbowner, role_oid)))
+										(is_tsql_db_principal && !is_member_of_role(dbowner, role_oid)) || is_psql_db_principal)
 										ereport(ERROR,
 												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3219,10 +3219,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									int			role_oid;
 									int			rolename_len;
 									bool		is_tsql_db_principal = false;
+									Oid			dbowner;
 
 									user_name = get_physical_user_name(db_name, rolspec->rolename);
 									
 									db_owner_name = get_db_owner_name(db_name);
+									dbowner = get_role_oid(db_owner_name, false);
 									role_oid = get_role_oid(user_name, true);
 									rolename_len = strlen(rolspec->rolename);
 									is_tsql_db_principal = OidIsValid(role_oid) &&
@@ -3241,8 +3243,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									 * must be database owner to drop user/role
 									 */
 									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
-										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)) ||
-										(is_tsql_db_principal && !is_member_of_role(get_role_oid(db_owner_name, false), role_oid)))
+										!is_member_of_role(GetUserId(), dbowner) ||
+										(is_tsql_db_principal && !is_member_of_role(dbowner, role_oid)))
 										ereport(ERROR,
 												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3214,15 +3214,44 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								{
 									RoleSpec   *rolspec = lfirst(item);
 									char	   *user_name;
+									const char *db_principal_type = drop_user ? "user" : "role";
+									const char *db_owner_name;
+									int			role_oid;
+									int			rolename_len;
+									bool		is_tsql_db_principal = false;
 
 									user_name = get_physical_user_name(db_name, rolspec->rolename);
+									
+									db_owner_name = get_db_owner_name(db_name);
+									role_oid = get_role_oid(user_name, true);
+									rolename_len = strlen(rolspec->rolename);
+									is_tsql_db_principal = OidIsValid(role_oid) &&
+														   ((drop_user && is_user(role_oid)) ||
+															(drop_role && is_role(role_oid)));
 
+									/* If user is dbo or role is db_owner, restrict dropping */
+									if ((drop_user && rolename_len == 3 && strncmp(rolspec->rolename, "dbo", 3) == 0) ||
+										(drop_role && rolename_len == 8 && strncmp(rolspec->rolename, "db_owner", 8) == 0))
+										ereport(ERROR,
+												(errcode(ERRCODE_CHECK_VIOLATION),
+												 errmsg("Cannot drop the %s '%s'.", db_principal_type, rolspec->rolename)));
+
+									/* 
+									 * Check for current_user's privileges 
+									 * must be database owner to drop user/role
+									 */
+									if ((!stmt->missing_ok && !is_tsql_db_principal) ||
+										!is_member_of_role(GetUserId(), get_role_oid(db_owner_name, false)))
+										ereport(ERROR,
+												(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+												 errmsg("Cannot drop the %s '%s', because it does not exist or you do not have permission.", db_principal_type, rolspec->rolename)));
+									
 									/*
 									 * If a role has members, do not drop it.
 									 * Note that here we don't handle invalid
 									 * roles.
 									 */
-									if (drop_role && !is_empty_role(get_role_oid(user_name, true)))
+									if (drop_role && !is_empty_role(role_oid))
 										ereport(ERROR,
 												(errcode(ERRCODE_CHECK_VIOLATION),
 												 errmsg("The role has members. It must be empty before it can be dropped.")));

--- a/test/JDBC/expected/BABEL-3844-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-3844-vu-cleanup.out
@@ -6,7 +6,7 @@ drop user test_user;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: role "master_test_user" does not exist)~~
+~~ERROR (Message: Cannot drop the user 'test_user', because it does not exist or you do not have permission.)~~
 
 
 drop login [babel\aduser1];

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -211,10 +211,24 @@ drop user if exists fake_user;
 go
 
 -- both of the following statements should be executed successfully since user/role exists
+drop role if exists no_priv_user3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'no_priv_user3', because it does not exist or you do not have permission.)~~
+
+
 drop user if exists no_priv_user3;
 go
 
 drop user if exists no_priv_role3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'no_priv_role3', because it does not exist or you do not have permission.)~~
+
+
+drop role if exists no_priv_role3;
 go
 
 select count(*) from sys.database_principals where name like '%no_priv_%3';
@@ -251,14 +265,14 @@ drop user if exists pguser1;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied to drop role)~~
+~~ERROR (Message: Cannot drop the user 'pguser1', because it does not exist or you do not have permission.)~~
 
 
 drop role if exists pguser1;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied to drop role)~~
+~~ERROR (Message: Cannot drop the role 'pguser1', because it does not exist or you do not have permission.)~~
 
 
 -- psql
@@ -301,18 +315,43 @@ go
 drop database restrict_user_db1
 go
 
--- tsql
+-- psql
 -- 3.5 - Try dropping user created for another database
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+GO
+SELECT pg_reload_conf();
+GO
+~~START~~
+bool
+t
+~~END~~
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
 create database restrict_user_db1;
+go
+
+create database restrict_user_db1_restrict_user_db1;
 go
 
 create login restrict_user_l1 with password = '12345678'
 go
 
+use restrict_user_db1
+go
+
 create user restrict_user_db1_user1 for login restrict_user_l1;
 go
 
-use restrict_user_db1
+use restrict_user_db1_restrict_user_db1
 go
 
 drop user user1;
@@ -324,6 +363,10 @@ go
 
 drop user if exists user1;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'user1', because it does not exist or you do not have permission.)~~
+
 
 use master
 go
@@ -339,7 +382,13 @@ bool
 
 
 -- tsql
+use restrict_user_db1
+go
+
 drop user restrict_user_db1_user1;
+go
+
+use master
 go
 
 drop login restrict_user_l1;
@@ -347,3 +396,18 @@ go
 
 drop database restrict_user_db1;
 go
+
+drop database restrict_user_db1_restrict_user_db1;
+go
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -322,6 +322,9 @@ go
 ~~ERROR (Message: Cannot drop the user 'user1', because it does not exist or you do not have permission.)~~
 
 
+drop user if exists user1;
+go
+
 use master
 go
 

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -300,3 +300,47 @@ go
 
 drop database restrict_user_db1
 go
+
+-- tsql
+-- 3.5 - Try dropping user created for another database
+create database restrict_user_db1;
+go
+
+create login restrict_user_l1 with password = '12345678'
+go
+
+create user restrict_user_db1_user1 for login restrict_user_l1;
+go
+
+use restrict_user_db1
+go
+
+drop user user1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'user1', because it does not exist or you do not have permission.)~~
+
+
+use master
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+~~END~~
+
+
+-- tsql
+drop user restrict_user_db1_user1;
+go
+
+drop login restrict_user_l1;
+go
+
+drop database restrict_user_db1;
+go

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -1,0 +1,302 @@
+-- tsql
+create login no_priv_login1 with password = '12345678'
+go
+
+create role dont_drop_role
+go
+
+create login no_priv_login2 with password = '12345678'
+go
+
+create user no_priv_user2 for login no_priv_login2
+go
+
+create login no_priv_login3 with password = '12345678'
+go
+
+create user no_priv_user3 for login no_priv_login3
+go
+
+create role no_priv_role3;
+go
+
+create database restrict_user_db1
+go
+
+use restrict_user_db1
+go
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+use master
+go
+
+-- tsql user=no_priv_login1 password=12345678
+-- case-1 - when current user is guest
+-- permission denied
+select current_user,db_name()
+go
+~~START~~
+varchar#!#nvarchar
+guest#!#master
+~~END~~
+
+
+drop role dont_drop_role
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'dont_drop_role', because it does not exist or you do not have permission.)~~
+
+
+drop user no_priv_user2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'no_priv_user2', because it does not exist or you do not have permission.)~~
+
+
+-- tsql
+select current_user,db_name()
+go
+~~START~~
+varchar#!#nvarchar
+dbo#!#master
+~~END~~
+
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- tsql user=no_priv_login1 password=12345678
+-- case-2 - when current user has no privilege
+-- permission denied
+use master
+go
+
+select current_user
+go
+~~START~~
+varchar
+no_priv_user1
+~~END~~
+
+
+drop role dont_drop_role
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'dont_drop_role', because it does not exist or you do not have permission.)~~
+
+
+drop user no_priv_user2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'no_priv_user2', because it does not exist or you do not have permission.)~~
+
+
+-- tsql
+
+-- case-3 - when current login has privilege
+-- 3.1 - when login is database owner
+Alter authorization on database::restrict_user_db1 to no_priv_login2
+go
+
+-- tsql user=no_priv_login2 password=12345678 database=restrict_user_db1
+-- allowed
+select current_user
+go
+~~START~~
+varchar
+dbo
+~~END~~
+
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user1
+go
+
+-- error
+-- try to drop non existing role/user
+drop role fake_role
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'fake_role', because it does not exist or you do not have permission.)~~
+
+
+drop user fake_user;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'fake_user', because it does not exist or you do not have permission.)~~
+
+
+drop user db
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'db', because it does not exist or you do not have permission.)~~
+
+
+drop role db_own
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'db_own', because it does not exist or you do not have permission.)~~
+
+
+drop user dbo_u1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'dbo_u1', because it does not exist or you do not have permission.)~~
+
+
+drop role db_owner_r1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'db_owner_r1', because it does not exist or you do not have permission.)~~
+
+
+-- should deny
+-- try to drop dbo user, db_owner role
+drop role db_owner
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'db_owner'.)~~
+
+
+drop user dbo
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'dbo'.)~~
+
+
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- tsql
+-- 3.2 - when login is sysadmin
+-- allowed
+drop user no_priv_user1
+go
+
+drop user no_priv_user2
+go
+
+drop role dont_drop_role
+go
+
+-- 3.3 - when drop user/role has IF EXISTS clause
+-- Should not throw error for the case where IF EXISTS clause is included
+drop role if exists fake_role;
+go
+
+drop user if exists fake_user;
+go
+
+-- both of the following statements should be executed successfully since user/role exists
+drop user if exists no_priv_user3;
+go
+
+drop user if exists no_priv_role3;
+go
+
+select count(*) from sys.database_principals where name like '%no_priv_%3';
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- psql
+-- 3.4 - Try dropping role created from PG role
+create role master_pguser1;
+go
+
+-- tsql
+drop user pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'pguser1', because it does not exist or you do not have permission.)~~
+
+
+drop role pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the role 'pguser1', because it does not exist or you do not have permission.)~~
+
+
+-- it will still try to drop it, but permission denied will be generated since
+-- bbf_role_admin won't have privilege to drop non-babelfish roles
+drop user if exists pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied to drop role)~~
+
+
+drop role if exists pguser1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied to drop role)~~
+
+
+-- psql
+drop role master_pguser1;
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+
+-- tsql
+drop login no_priv_login1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+drop login no_priv_login2
+go
+
+drop login no_priv_login3
+go
+
+drop database restrict_user_db1
+go

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -1,0 +1,203 @@
+-- tsql
+create login no_priv_login1 with password = '12345678'
+go
+
+create role dont_drop_role
+go
+
+create login no_priv_login2 with password = '12345678'
+go
+
+create user no_priv_user2 for login no_priv_login2
+go
+
+create login no_priv_login3 with password = '12345678'
+go
+
+create user no_priv_user3 for login no_priv_login3
+go
+
+create role no_priv_role3;
+go
+
+create database restrict_user_db1
+go
+
+use restrict_user_db1
+go
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+use master
+go
+
+-- case-1 - when current user is guest
+-- permission denied
+-- tsql user=no_priv_login1 password=12345678
+select current_user,db_name()
+go
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user2
+go
+
+-- tsql
+select current_user,db_name()
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- case-2 - when current user has no privilege
+-- permission denied
+-- tsql user=no_priv_login1 password=12345678
+use master
+go
+
+select current_user
+go
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user2
+go
+
+-- case-3 - when current login has privilege
+-- tsql
+
+-- 3.1 - when login is database owner
+Alter authorization on database::restrict_user_db1 to no_priv_login2
+go
+
+-- allowed
+-- tsql user=no_priv_login2 password=12345678 database=restrict_user_db1
+select current_user
+go
+
+drop role dont_drop_role
+go
+
+drop user no_priv_user1
+go
+
+-- error
+-- try to drop non existing role/user
+drop role fake_role
+go
+
+drop user fake_user;
+go
+
+drop user db
+go
+
+drop role db_own
+go
+
+drop user dbo_u1
+go
+
+drop role db_owner_r1
+go
+
+-- should deny
+-- try to drop dbo user, db_owner role
+drop role db_owner
+go
+
+drop user dbo
+go
+
+
+create role dont_drop_role
+go
+
+create user no_priv_user1 for login no_priv_login1
+go
+
+-- 3.2 - when login is sysadmin
+-- allowed
+-- tsql
+drop user no_priv_user1
+go
+
+drop user no_priv_user2
+go
+
+drop role dont_drop_role
+go
+
+-- 3.3 - when drop user/role has IF EXISTS clause
+-- Should not throw error for the case where IF EXISTS clause is included
+drop role if exists fake_role;
+go
+
+drop user if exists fake_user;
+go
+
+-- both of the following statements should be executed successfully since user/role exists
+drop user if exists no_priv_user3;
+go
+
+drop user if exists no_priv_role3;
+go
+
+select count(*) from sys.database_principals where name like '%no_priv_%3';
+go
+
+-- 3.4 - Try dropping role created from PG role
+-- psql
+create role master_pguser1;
+go
+
+-- tsql
+drop user pguser1;
+go
+
+drop role pguser1;
+go
+
+-- it will still try to drop it, but permission denied will be generated since
+-- bbf_role_admin won't have privilege to drop non-babelfish roles
+drop user if exists pguser1;
+go
+
+drop role if exists pguser1;
+go
+
+-- psql
+drop role master_pguser1;
+go
+
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+
+-- tsql
+drop login no_priv_login1
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'no_priv_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- tsql
+drop login no_priv_login2
+go
+
+drop login no_priv_login3
+go
+
+drop database restrict_user_db1
+go

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -219,6 +219,9 @@ go
 drop user user1;
 go
 
+drop user if exists user1;
+go
+
 use master
 go
 

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -143,10 +143,16 @@ drop user if exists fake_user;
 go
 
 -- both of the following statements should be executed successfully since user/role exists
+drop role if exists no_priv_user3;
+go
+
 drop user if exists no_priv_user3;
 go
 
 drop user if exists no_priv_role3;
+go
+
+drop role if exists no_priv_role3;
 go
 
 select count(*) from sys.database_principals where name like '%no_priv_%3';
@@ -203,17 +209,32 @@ drop database restrict_user_db1
 go
 
 -- 3.5 - Try dropping user created for another database
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
+GO
+SELECT pg_reload_conf();
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
 -- tsql
 create database restrict_user_db1;
+go
+
+create database restrict_user_db1_restrict_user_db1;
 go
 
 create login restrict_user_l1 with password = '12345678'
 go
 
+use restrict_user_db1
+go
+
 create user restrict_user_db1_user1 for login restrict_user_l1;
 go
 
-use restrict_user_db1
+use restrict_user_db1_restrict_user_db1
 go
 
 drop user user1;
@@ -232,7 +253,13 @@ WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client b
 go
 
 -- tsql
+use restrict_user_db1
+go
+
 drop user restrict_user_db1_user1;
+go
+
+use master
 go
 
 drop login restrict_user_l1;
@@ -240,3 +267,13 @@ go
 
 drop database restrict_user_db1;
 go
+
+drop database restrict_user_db1_restrict_user_db1;
+go
+
+-- psql
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';
+GO
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -201,3 +201,39 @@ go
 
 drop database restrict_user_db1
 go
+
+-- 3.5 - Try dropping user created for another database
+-- tsql
+create database restrict_user_db1;
+go
+
+create login restrict_user_l1 with password = '12345678'
+go
+
+create user restrict_user_db1_user1 for login restrict_user_l1;
+go
+
+use restrict_user_db1
+go
+
+drop user user1;
+go
+
+use master
+go
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- tsql
+drop user restrict_user_db1_user1;
+go
+
+drop login restrict_user_l1;
+go
+
+drop database restrict_user_db1;
+go


### PR DESCRIPTION
Earlier, any user was able to drop user/role, irrespective of whether that user has required privileges or not.

With this commit, Only dbo and members of db_owner will have the permission to drop user/role.  Additionally, this restricts dropping internal database principal such as dbo and db_owner, it restricts dropping non-Babelfish roles from TDS endpoint.

Task: BABEL-5173

Authored-by: ANJU BHARTI <abanju@amazon.com>

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).