### PR TITLE
fix infinite loop in replace with AI collations

### DIFF
--- a/test/JDBC/expected/charindex_and_replace_CIAI_collations.out
+++ b/test/JDBC/expected/charindex_and_replace_CIAI_collations.out
@@ -642,6 +642,66 @@ AAAAAABBBBBBBEEEEEEAAAAA
 DROP TABLE BABEL_4850_T
 GO
 
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂def🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂D', N'abc🙂d🙂d🙂D' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+GO
+~~START~~
+int
+14
+~~END~~
+
+~~START~~
+int
+8
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT REPLACE(N'abc🙂defghi🙂🙂', N'🙂def', N'jhi🙂' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂🙂defghi🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'🙂abc🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+GO
+~~START~~
+nvarchar
+abcjhi🙂ghi🙂🙂
+~~END~~
+
+~~START~~
+nvarchar
+abc<----><----><----><----><---->defghi<----><---->
+~~END~~
+
+~~START~~
+nvarchar
+abc<----><----><----><---->
+~~END~~
+
+~~START~~
+nvarchar
+<---->abc<---->
+~~END~~
+
+
 -- psql
 CREATE COLLATION case_insensitive (provider = icu, locale = 'und-u-ks-level2', deterministic = false);
 CREATE COLLATION ignore_accents (provider = icu, locale = 'nd-u-kc-true-ks-level1', deterministic = false);

--- a/test/JDBC/input/charindex_and_replace_CIAI_collations.mix
+++ b/test/JDBC/input/charindex_and_replace_CIAI_collations.mix
@@ -204,6 +204,21 @@ GO
 DROP TABLE BABEL_4850_T
 GO
 
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂def🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂D', N'abc🙂d🙂d🙂D' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂dEf', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CS_AI)
+SELECT CHARINDEX(N'🙂', N'abc🙂defgh🙂dEfi🙂🙂' COLLATE Latin1_General_CI_AI)
+GO
+
+/* Substring to find starts with surrogate pair BABEL-5169 */
+SELECT REPLACE(N'abc🙂defghi🙂🙂', N'🙂def', N'jhi🙂' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂🙂defghi🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'abc🙂🙂🙂🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+SELECT REPLACE(N'🙂abc🙂', N'🙂', N'<---->' COLLATE Latin1_General_CI_AI)
+GO
+
 -- psql
 CREATE COLLATION case_insensitive (provider = icu, locale = 'und-u-ks-level2', deterministic = false);
 CREATE COLLATION ignore_accents (provider = icu, locale = 'nd-u-kc-true-ks-level1', deterministic = false);


### PR DESCRIPTION
### Description

Cherry Picked From : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2849

ICU usearch_next() goes into infinite loop when pattern to search starts with a surrogate pair.
To get around this we check if output of usearch_next() is stuck and not proceeding forwards 
and set the offset for next search ourselves.
The next offset is simply the next character after the current char in source string.

```
SRC STRING - 'abc🙂defghi🙂🙂'    PATTERN TO FIND = '🙂def'

usearch_next() gets stuck on "🙂" idx = 3 and repeatedly returns this index.
We will intervene and set the offset to "d" idx = 4. 
So that usearch_next only starts looking from this character.
```
### Issues Resolved

[BABEL-5169]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).