### PR TITLE
Use database level collation for collatable datatypes for prepared statements

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -45,6 +45,7 @@
 #include "codegen.h"
 #include "iterative_exec.h"
 #include "multidb.h"
+#include "collation.h"
 
 /* ----------
  * Our own local and global variables
@@ -2592,6 +2593,10 @@ pltsql_build_datatype(Oid typeOid, int32 typmod,
 		elog(ERROR, "cache lookup failed for type %u", typeOid);
 
 	typ = build_datatype(typeTup, typmod, collation, origtypname);
+
+	/* Check whether datatype is collatable, if yes then assign database level collation to it */
+	if (OidIsValid(typ->collation))
+		typ->collation = tsql_get_database_or_server_collation_oid_internal(false);
 
 	ReleaseSysCache(typeTup);
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -64,6 +64,7 @@
 #include "session.h"
 #include "guc.h"
 #include "catalog.h"
+#include "collation.h"
 
 uint64		rowcount_var = 0;
 List	   *columns_updated_list = NIL;
@@ -7100,7 +7101,12 @@ pltsql_exec_get_datum_type_info(PLtsql_execstate *estate,
 
 				*typeId = var->datatype->typoid;
 				*typMod = var->datatype->atttypmod;
-				*collation = var->datatype->collation;
+
+				/* Check whether datatype is collatable, if yes then assign database level collation to it */
+				if (OidIsValid(var->datatype->collation))
+					*collation = tsql_get_database_or_server_collation_oid_internal(false);
+				else 
+					*collation = var->datatype->collation;
 				break;
 			}
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -64,7 +64,6 @@
 #include "session.h"
 #include "guc.h"
 #include "catalog.h"
-#include "collation.h"
 
 uint64		rowcount_var = 0;
 List	   *columns_updated_list = NIL;
@@ -7101,12 +7100,7 @@ pltsql_exec_get_datum_type_info(PLtsql_execstate *estate,
 
 				*typeId = var->datatype->typoid;
 				*typMod = var->datatype->atttypmod;
-
-				/* Check whether datatype is collatable, if yes then assign database level collation to it */
-				if (OidIsValid(var->datatype->collation))
-					*collation = tsql_get_database_or_server_collation_oid_internal(false);
-				else 
-					*collation = var->datatype->collation;
+				*collation = var->datatype->collation;
 				break;
 			}
 

--- a/test/JDBC/README.md
+++ b/test/JDBC/README.md
@@ -519,9 +519,9 @@ After building the modified PostgreSQL engine and Babelfish extensions using the
     ```
 4. How to add expected output for some test
     1. By default expected output of a test should be added into `expected` folder.
-    2. If JDBC is running in normal mode with database collation=<database_collation_name> and expected output of some test is different then add this new expected output in `expected/db_collation` folder.
+    2. If JDBC is running in normal mode with isdbCollationMode=true and expected output of some test is different then add this new expected output in `expected/db_collation` folder.
     3. If JDBC is running in parallel query mode with default database collation and expected output of some test is different then the expected output should be added in `expected/parallel_query` folder.(As mentioned in [Running Tests with Parallel Query Enabled](#running-tests-with-parallel-query-enabled))
-    4. If JDBC is running in parallel query mode with database collation=<database_collation_name> and expected output of some test is different then add this new expected output in `expected/parallel_query/db_collation` folder.
+    4. If JDBC is running in parallel query mode with isdbCollationMode=true and expected output of some test is different then add this new expected output in `expected/parallel_query/db_collation` folder.
 
 5. Cleanup all the objects, users, roles and databases created while running the tests:
     ```bash

--- a/test/JDBC/expected/db_collation/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_db_collation-vu-verify.out
@@ -1652,7 +1652,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.202 ms
+Babelfish T-SQL Batch Parsing Time: 0.275 ms
 ~~END~~
 
 
@@ -1667,7 +1667,7 @@ Index Only Scan using clustered_idxtest_db_collation_37f23e48f4ded8db470285703bb
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.145 ms
+Babelfish T-SQL Batch Parsing Time: 0.206 ms
 ~~END~~
 
 
@@ -1682,7 +1682,7 @@ Index Only Scan using nonclustered_idxtest_db_collaticabf982079a2aad31147844db2b
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.145 ms
 ~~END~~
 
 
@@ -1697,7 +1697,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.160 ms
+Babelfish T-SQL Batch Parsing Time: 0.181 ms
 ~~END~~
 
 
@@ -1712,7 +1712,7 @@ Index Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc6e1c3
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.453 ms
+Babelfish T-SQL Batch Parsing Time: 43.266 ms
 ~~END~~
 
 
@@ -1728,7 +1728,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.569 ms
+Babelfish T-SQL Batch Parsing Time: 8.765 ms
 ~~END~~
 
 
@@ -1743,7 +1743,7 @@ Index Only Scan using computed_column_idxtest_db_coll8143f54fa9d8b0c6f3d683b2a9f
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.147 ms
 ~~END~~
 
 
@@ -1758,7 +1758,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.177 ms
+Babelfish T-SQL Batch Parsing Time: 0.178 ms
 ~~END~~
 
 
@@ -1775,7 +1775,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -1992,6 +1992,27 @@ café
 ~~END~~
 
 
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = ? OR nv = ? OR nv = ? OR nv = ?#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
+
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv IN (?, ?, ?, ?)#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
 
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;

--- a/test/JDBC/expected/db_collation/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_db_collation-vu-verify.out
@@ -1652,7 +1652,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.242 ms
+Babelfish T-SQL Batch Parsing Time: 0.202 ms
 ~~END~~
 
 
@@ -1667,7 +1667,7 @@ Index Only Scan using clustered_idxtest_db_collation_37f23e48f4ded8db470285703bb
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.148 ms
+Babelfish T-SQL Batch Parsing Time: 0.145 ms
 ~~END~~
 
 
@@ -1682,7 +1682,7 @@ Index Only Scan using nonclustered_idxtest_db_collaticabf982079a2aad31147844db2b
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -1697,7 +1697,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.165 ms
+Babelfish T-SQL Batch Parsing Time: 0.160 ms
 ~~END~~
 
 
@@ -1712,7 +1712,7 @@ Index Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc6e1c3
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.999 ms
+Babelfish T-SQL Batch Parsing Time: 41.453 ms
 ~~END~~
 
 
@@ -1728,7 +1728,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.585 ms
+Babelfish T-SQL Batch Parsing Time: 8.569 ms
 ~~END~~
 
 
@@ -1758,7 +1758,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.179 ms
+Babelfish T-SQL Batch Parsing Time: 0.177 ms
 ~~END~~
 
 
@@ -1952,47 +1952,47 @@ TEññiȘ
 
 
 
-
-
-
-
-
--- COMMENTING IT FOR NOW AS PREP EXEC IS NOT GIVING CORRECT OUTOUT
 -- Case 6.2: Validate whether correct collation is being picked up or not by PREPARED STATEMENTS
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- EXEC sp_executesql N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1;', N'@prefix1 NVARCHAR(50)', @prefix1;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'
--- DECLARE @nv NVARCHAR(50);
--- DECLARE CurResult CURSOR FOR
---     SELECT nv FROM test_db_collation_vu_prepare_db121_t1
---     WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4;
--- OPEN CurResult;
--- FETCH NEXT FROM CurResult INTO @nv;
--- WHILE @@FETCH_STATUS = 0
--- BEGIN
---     PRINT @nv;
---     FETCH NEXT FROM CurResult INTO @nv;
--- END
--- CLOSE CurResult;
--- DEALLOCATE CurResult;';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
+-- Simple prep-exec
+DECLARE @prefix1 NVARCHAR(50) = 'cafe';
+DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
+DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
+DECLARE @prefix4 NVARCHAR(50) = 'pínata';
+DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
+EXEC sp_executesql @query,
+                   N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
+                   @prefix1, @prefix2, @prefix3, @prefix4;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+
+
+--- prep-exec using CURSOR
+DECLARE @query NVARCHAR(MAX) = N'
+DECLARE @nv NVARCHAR(50);
+DECLARE CurResult CURSOR FOR
+SELECT nv FROM test_db_collation_vu_prepare_db121_t1
+WHERE nv = @prefix;
+OPEN CurResult;
+FETCH NEXT FROM CurResult;
+CLOSE CurResult;
+DEALLOCATE CurResult;';
+DECLARE @prefix NVARCHAR(50) = 'cafe';
+EXEC sp_executesql @query, N'@prefix NVARCHAR(50)', @prefix;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+
+
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;
 GO

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_db_collation-vu-verify.out
@@ -1613,7 +1613,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.243 ms
+Babelfish T-SQL Batch Parsing Time: 0.370 ms
 ~~END~~
 
 
@@ -1628,7 +1628,7 @@ Index Only Scan using clustered_idxtest_db_collation_37f23e48f4ded8db470285703bb
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.149 ms
+Babelfish T-SQL Batch Parsing Time: 0.224 ms
 ~~END~~
 
 
@@ -1643,7 +1643,7 @@ Index Only Scan using nonclustered_idxtest_db_collaticabf982079a2aad31147844db2b
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.222 ms
 ~~END~~
 
 
@@ -1658,7 +1658,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.233 ms
+Babelfish T-SQL Batch Parsing Time: 0.267 ms
 ~~END~~
 
 
@@ -1673,7 +1673,7 @@ Index Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc6e1c3
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.672 ms
+Babelfish T-SQL Batch Parsing Time: 42.063 ms
 ~~END~~
 
 
@@ -1689,7 +1689,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.583 ms
+Babelfish T-SQL Batch Parsing Time: 8.665 ms
 ~~END~~
 
 
@@ -1704,7 +1704,7 @@ Index Only Scan using computed_column_idxtest_db_coll8143f54fa9d8b0c6f3d683b2a9f
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.170 ms
+Babelfish T-SQL Batch Parsing Time: 0.152 ms
 ~~END~~
 
 
@@ -1719,7 +1719,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.222 ms
+Babelfish T-SQL Batch Parsing Time: 0.185 ms
 ~~END~~
 
 
@@ -1736,7 +1736,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.179 ms
+Babelfish T-SQL Batch Parsing Time: 0.146 ms
 ~~END~~
 
 
@@ -1953,6 +1953,27 @@ café
 ~~END~~
 
 
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = ? OR nv = ? OR nv = ? OR nv = ?#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
+
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv IN (?, ?, ?, ?)#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
 
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_db_collation-vu-verify.out
@@ -1613,7 +1613,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.215 ms
+Babelfish T-SQL Batch Parsing Time: 0.243 ms
 ~~END~~
 
 
@@ -1628,7 +1628,7 @@ Index Only Scan using clustered_idxtest_db_collation_37f23e48f4ded8db470285703bb
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.149 ms
 ~~END~~
 
 
@@ -1643,7 +1643,7 @@ Index Only Scan using nonclustered_idxtest_db_collaticabf982079a2aad31147844db2b
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -1658,7 +1658,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.233 ms
 ~~END~~
 
 
@@ -1673,7 +1673,7 @@ Index Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc6e1c3
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.235 ms
+Babelfish T-SQL Batch Parsing Time: 41.672 ms
 ~~END~~
 
 
@@ -1689,7 +1689,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.625 ms
+Babelfish T-SQL Batch Parsing Time: 8.583 ms
 ~~END~~
 
 
@@ -1704,7 +1704,7 @@ Index Only Scan using computed_column_idxtest_db_coll8143f54fa9d8b0c6f3d683b2a9f
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.170 ms
 ~~END~~
 
 
@@ -1719,7 +1719,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.176 ms
+Babelfish T-SQL Batch Parsing Time: 0.222 ms
 ~~END~~
 
 
@@ -1736,7 +1736,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.179 ms
 ~~END~~
 
 
@@ -1913,47 +1913,47 @@ TEññiȘ
 
 
 
-
-
-
-
-
--- COMMENTING IT FOR NOW AS PREP EXEC IS NOT GIVING CORRECT OUTOUT
 -- Case 6.2: Validate whether correct collation is being picked up or not by PREPARED STATEMENTS
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- EXEC sp_executesql N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1;', N'@prefix1 NVARCHAR(50)', @prefix1;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'
--- DECLARE @nv NVARCHAR(50);
--- DECLARE CurResult CURSOR FOR
---     SELECT nv FROM test_db_collation_vu_prepare_db121_t1
---     WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4;
--- OPEN CurResult;
--- FETCH NEXT FROM CurResult INTO @nv;
--- WHILE @@FETCH_STATUS = 0
--- BEGIN
---     PRINT @nv;
---     FETCH NEXT FROM CurResult INTO @nv;
--- END
--- CLOSE CurResult;
--- DEALLOCATE CurResult;';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
+-- Simple prep-exec
+DECLARE @prefix1 NVARCHAR(50) = 'cafe';
+DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
+DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
+DECLARE @prefix4 NVARCHAR(50) = 'pínata';
+DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
+EXEC sp_executesql @query,
+                   N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
+                   @prefix1, @prefix2, @prefix3, @prefix4;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+
+
+--- prep-exec using CURSOR
+DECLARE @query NVARCHAR(MAX) = N'
+DECLARE @nv NVARCHAR(50);
+DECLARE CurResult CURSOR FOR
+SELECT nv FROM test_db_collation_vu_prepare_db121_t1
+WHERE nv = @prefix;
+OPEN CurResult;
+FETCH NEXT FROM CurResult;
+CLOSE CurResult;
+DEALLOCATE CurResult;';
+DECLARE @prefix NVARCHAR(50) = 'cafe';
+EXEC sp_executesql @query, N'@prefix NVARCHAR(50)', @prefix;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+
+
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;
 GO

--- a/test/JDBC/expected/parallel_query/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_db_collation-vu-verify.out
@@ -1655,7 +1655,7 @@ Gather  (cost=0.14..12.27 rows=9 width=8)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.215 ms
+Babelfish T-SQL Batch Parsing Time: 0.271 ms
 ~~END~~
 
 
@@ -1673,7 +1673,7 @@ Gather  (cost=0.14..12.27 rows=9 width=2)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.146 ms
+Babelfish T-SQL Batch Parsing Time: 0.147 ms
 ~~END~~
 
 
@@ -1691,7 +1691,7 @@ Gather  (cost=0.14..12.27 rows=9 width=8)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -1709,7 +1709,7 @@ Gather  (cost=0.14..12.27 rows=9 width=10)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.160 ms
+Babelfish T-SQL Batch Parsing Time: 0.162 ms
 ~~END~~
 
 
@@ -1727,7 +1727,7 @@ Gather  (cost=0.14..12.27 rows=9 width=22)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.189 ms
+Babelfish T-SQL Batch Parsing Time: 41.141 ms
 ~~END~~
 
 
@@ -1746,7 +1746,7 @@ Gather  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.595 ms
+Babelfish T-SQL Batch Parsing Time: 9.059 ms
 ~~END~~
 
 
@@ -1764,7 +1764,7 @@ Gather  (cost=0.13..12.19 rows=4 width=9)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -1782,7 +1782,7 @@ Gather  (cost=0.14..12.27 rows=9 width=18)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.176 ms
+Babelfish T-SQL Batch Parsing Time: 0.286 ms
 ~~END~~
 
 
@@ -1802,7 +1802,7 @@ Gather  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.149 ms
 ~~END~~
 
 
@@ -1979,47 +1979,47 @@ TEññiȘ
 
 
 
-
-
-
-
-
--- COMMENTING IT FOR NOW AS PREP EXEC IS NOT GIVING CORRECT OUTOUT
 -- Case 6.2: Validate whether correct collation is being picked up or not by PREPARED STATEMENTS
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- EXEC sp_executesql N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1;', N'@prefix1 NVARCHAR(50)', @prefix1;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'
--- DECLARE @nv NVARCHAR(50);
--- DECLARE CurResult CURSOR FOR
---     SELECT nv FROM test_db_collation_vu_prepare_db121_t1
---     WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4;
--- OPEN CurResult;
--- FETCH NEXT FROM CurResult INTO @nv;
--- WHILE @@FETCH_STATUS = 0
--- BEGIN
---     PRINT @nv;
---     FETCH NEXT FROM CurResult INTO @nv;
--- END
--- CLOSE CurResult;
--- DEALLOCATE CurResult;';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
+-- Simple prep-exec
+DECLARE @prefix1 NVARCHAR(50) = 'cafe';
+DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
+DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
+DECLARE @prefix4 NVARCHAR(50) = 'pínata';
+DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
+EXEC sp_executesql @query,
+                   N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
+                   @prefix1, @prefix2, @prefix3, @prefix4;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+
+
+--- prep-exec using CURSOR
+DECLARE @query NVARCHAR(MAX) = N'
+DECLARE @nv NVARCHAR(50);
+DECLARE CurResult CURSOR FOR
+SELECT nv FROM test_db_collation_vu_prepare_db121_t1
+WHERE nv = @prefix;
+OPEN CurResult;
+FETCH NEXT FROM CurResult;
+CLOSE CurResult;
+DEALLOCATE CurResult;';
+DECLARE @prefix NVARCHAR(50) = 'cafe';
+EXEC sp_executesql @query, N'@prefix NVARCHAR(50)', @prefix;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+
+
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;
 GO

--- a/test/JDBC/expected/parallel_query/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_db_collation-vu-verify.out
@@ -1655,7 +1655,7 @@ Gather  (cost=0.14..12.27 rows=9 width=8)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.271 ms
+Babelfish T-SQL Batch Parsing Time: 0.205 ms
 ~~END~~
 
 
@@ -1691,7 +1691,7 @@ Gather  (cost=0.14..12.27 rows=9 width=8)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -1709,7 +1709,7 @@ Gather  (cost=0.14..12.27 rows=9 width=10)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.161 ms
 ~~END~~
 
 
@@ -1727,7 +1727,7 @@ Gather  (cost=0.14..12.27 rows=9 width=22)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.141 ms
+Babelfish T-SQL Batch Parsing Time: 40.928 ms
 ~~END~~
 
 
@@ -1746,7 +1746,7 @@ Gather  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 9.059 ms
+Babelfish T-SQL Batch Parsing Time: 8.990 ms
 ~~END~~
 
 
@@ -1764,7 +1764,7 @@ Gather  (cost=0.13..12.19 rows=4 width=9)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -1782,7 +1782,7 @@ Gather  (cost=0.14..12.27 rows=9 width=18)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.286 ms
+Babelfish T-SQL Batch Parsing Time: 0.177 ms
 ~~END~~
 
 
@@ -1802,7 +1802,7 @@ Gather  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.149 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 
@@ -2019,6 +2019,27 @@ café
 ~~END~~
 
 
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = ? OR nv = ? OR nv = ? OR nv = ?#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
+
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv IN (?, ?, ?, ?)#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
 
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;

--- a/test/JDBC/expected/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/test_db_collation-vu-verify.out
@@ -1652,7 +1652,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.237 ms
+Babelfish T-SQL Batch Parsing Time: 0.182 ms
 ~~END~~
 
 
@@ -1667,7 +1667,7 @@ Index Only Scan using clustered_idxtest_db_collation_37f23e48f4ded8db470285703bb
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.193 ms
+Babelfish T-SQL Batch Parsing Time: 0.145 ms
 ~~END~~
 
 
@@ -1682,7 +1682,7 @@ Index Only Scan using nonclustered_idxtest_db_collaticabf982079a2aad31147844db2b
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.182 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 
@@ -1697,7 +1697,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.202 ms
+Babelfish T-SQL Batch Parsing Time: 0.160 ms
 ~~END~~
 
 
@@ -1712,7 +1712,7 @@ Index Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc6e1c3
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 41.049 ms
+Babelfish T-SQL Batch Parsing Time: 40.793 ms
 ~~END~~
 
 
@@ -1728,7 +1728,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.601 ms
+Babelfish T-SQL Batch Parsing Time: 8.562 ms
 ~~END~~
 
 
@@ -1743,7 +1743,7 @@ Index Only Scan using computed_column_idxtest_db_coll8143f54fa9d8b0c6f3d683b2a9f
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.189 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -1758,7 +1758,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.223 ms
+Babelfish T-SQL Batch Parsing Time: 0.179 ms
 ~~END~~
 
 
@@ -1775,7 +1775,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.183 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -1952,47 +1952,47 @@ TEññiȘ
 
 
 
-
-
-
-
-
--- COMMENTING IT FOR NOW AS PREP EXEC IS NOT GIVING CORRECT OUTOUT
 -- Case 6.2: Validate whether correct collation is being picked up or not by PREPARED STATEMENTS
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- EXEC sp_executesql N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1;', N'@prefix1 NVARCHAR(50)', @prefix1;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
--- DECLARE @query NVARCHAR(MAX) = N'
--- DECLARE @nv NVARCHAR(50);
--- DECLARE CurResult CURSOR FOR
---     SELECT nv FROM test_db_collation_vu_prepare_db121_t1
---     WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4;
--- OPEN CurResult;
--- FETCH NEXT FROM CurResult INTO @nv;
--- WHILE @@FETCH_STATUS = 0
--- BEGIN
---     PRINT @nv;
---     FETCH NEXT FROM CurResult INTO @nv;
--- END
--- CLOSE CurResult;
--- DEALLOCATE CurResult;';
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
+-- Simple prep-exec
+DECLARE @prefix1 NVARCHAR(50) = 'cafe';
+DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
+DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
+DECLARE @prefix4 NVARCHAR(50) = 'pínata';
+DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
+EXEC sp_executesql @query,
+                   N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
+                   @prefix1, @prefix2, @prefix3, @prefix4;
+GO
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+
+
+--- prep-exec using CURSOR
+DECLARE @query NVARCHAR(MAX) = N'
+DECLARE @nv NVARCHAR(50);
+DECLARE CurResult CURSOR FOR
+SELECT nv FROM test_db_collation_vu_prepare_db121_t1
+WHERE nv = @prefix;
+OPEN CurResult;
+FETCH NEXT FROM CurResult;
+CLOSE CurResult;
+DEALLOCATE CurResult;';
+DECLARE @prefix NVARCHAR(50) = 'cafe';
+EXEC sp_executesql @query, N'@prefix NVARCHAR(50)', @prefix;
+GO
+~~START~~
+nvarchar
+café
+~~END~~
+
+
+
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;
 GO

--- a/test/JDBC/expected/test_db_collation-vu-verify.out
+++ b/test/JDBC/expected/test_db_collation-vu-verify.out
@@ -1652,7 +1652,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.182 ms
+Babelfish T-SQL Batch Parsing Time: 0.271 ms
 ~~END~~
 
 
@@ -1667,7 +1667,7 @@ Index Only Scan using clustered_idxtest_db_collation_37f23e48f4ded8db470285703bb
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.145 ms
+Babelfish T-SQL Batch Parsing Time: 0.146 ms
 ~~END~~
 
 
@@ -1697,7 +1697,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.160 ms
+Babelfish T-SQL Batch Parsing Time: 0.162 ms
 ~~END~~
 
 
@@ -1712,7 +1712,7 @@ Index Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc6e1c3
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 40.793 ms
+Babelfish T-SQL Batch Parsing Time: 41.544 ms
 ~~END~~
 
 
@@ -1728,7 +1728,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.562 ms
+Babelfish T-SQL Batch Parsing Time: 8.595 ms
 ~~END~~
 
 
@@ -1743,7 +1743,7 @@ Index Only Scan using computed_column_idxtest_db_coll8143f54fa9d8b0c6f3d683b2a9f
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -1758,7 +1758,7 @@ Index Only Scan using composite_idxtest_db_collation_cd26051c2ba0b21abcc428177cc
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.179 ms
+Babelfish T-SQL Batch Parsing Time: 0.178 ms
 ~~END~~
 
 
@@ -1775,7 +1775,7 @@ Sort  (cost=12.41..12.44 rows=9 width=14)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 
@@ -1992,6 +1992,27 @@ café
 ~~END~~
 
 
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = ? OR nv = ? OR nv = ? OR nv = ?#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
+
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv IN (?, ?, ?, ?)#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+~~START~~
+nvarchar
+café
+jalapeño
+naïve
+Piñata
+~~END~~
+
+GO
 
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;

--- a/test/JDBC/input/test_db_collation-vu-verify.mix
+++ b/test/JDBC/input/test_db_collation-vu-verify.mix
@@ -609,6 +609,11 @@ DECLARE @prefix NVARCHAR(50) = 'cafe';
 EXEC sp_executesql @query, N'@prefix NVARCHAR(50)', @prefix;
 GO
 
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+GO
+
+prepst#!#SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv IN (@prefix1, @prefix2, @prefix3, @prefix4)#!#NVARCHAR|-|prefix1|-|cafe#!#NVARCHAR|-|prefix2|-|JALAPeno#!#NVARCHAR|-|prefix3|-|ñáIVE#!#NVARCHAR|-|prefix4|-|pínata
+GO
 
 -- case 9: Cross-database queries (will behave like JOIN)
 USE test_db_collation_vu_prepare_db121;

--- a/test/JDBC/input/test_db_collation-vu-verify.mix
+++ b/test/JDBC/input/test_db_collation-vu-verify.mix
@@ -579,48 +579,35 @@ GO
 SELECT t1.nv FROM test_db_collation_vu_prepare_db121_t1 t1 INNER JOIN test_db_collation_vu_prepare_db121_t2 t2 on t1.nv = t2.nv ORDER BY t1.nv;
 GO
 
--- COMMENTING IT FOR NOW AS PREP EXEC IS NOT GIVING CORRECT OUTOUT
 -- Case 6.2: Validate whether correct collation is being picked up or not by PREPARED STATEMENTS
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
 
--- DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
+-- Simple prep-exec
+DECLARE @prefix1 NVARCHAR(50) = 'cafe';
+DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
+DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
+DECLARE @prefix4 NVARCHAR(50) = 'pínata';
 
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- EXEC sp_executesql N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1;', N'@prefix1 NVARCHAR(50)', @prefix1;
--- GO
+DECLARE @query NVARCHAR(MAX) = N'SELECT nv FROM test_db_collation_vu_prepare_db121_t1 WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4';
 
--- DECLARE @prefix1 NVARCHAR(50) = 'cafe';
--- DECLARE @prefix2 NVARCHAR(50) = 'JALAPeno';
--- DECLARE @prefix3 NVARCHAR(50) = 'ñáIVE';
--- DECLARE @prefix4 NVARCHAR(50) = 'pínata';
+EXEC sp_executesql @query,
+                   N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
+                   @prefix1, @prefix2, @prefix3, @prefix4;
+GO
 
--- DECLARE @query NVARCHAR(MAX) = N'
--- DECLARE @nv NVARCHAR(50);
--- DECLARE CurResult CURSOR FOR
---     SELECT nv FROM test_db_collation_vu_prepare_db121_t1
---     WHERE nv = @prefix1 OR nv = @prefix2 OR nv = @prefix3 OR nv = @prefix4;
+--- prep-exec using CURSOR
+DECLARE @query NVARCHAR(MAX) = N'
+DECLARE @nv NVARCHAR(50);
+DECLARE CurResult CURSOR FOR
+SELECT nv FROM test_db_collation_vu_prepare_db121_t1
+WHERE nv = @prefix;
+OPEN CurResult;
+FETCH NEXT FROM CurResult;
+CLOSE CurResult;
+DEALLOCATE CurResult;';
 
--- OPEN CurResult;
--- FETCH NEXT FROM CurResult INTO @nv;
--- WHILE @@FETCH_STATUS = 0
--- BEGIN
---     PRINT @nv;
---     FETCH NEXT FROM CurResult INTO @nv;
--- END
--- CLOSE CurResult;
--- DEALLOCATE CurResult;';
-
--- EXEC sp_executesql @query,
---                    N'@prefix1 NVARCHAR(50), @prefix2 NVARCHAR(50), @prefix3 NVARCHAR(50), @prefix4 NVARCHAR(50)',
---                    @prefix1, @prefix2, @prefix3, @prefix4;
--- GO
+DECLARE @prefix NVARCHAR(50) = 'cafe';
+EXEC sp_executesql @query, N'@prefix NVARCHAR(50)', @prefix;
+GO
 
 
 -- case 9: Cross-database queries (will behave like JOIN)


### PR DESCRIPTION
### Description
Update collation for collatable datatypes to pick up database level collation for prepared statements. Till now, server level collation was being picked up. This commit updates that to pick correct database level collation.


### Issues Resolved
BABEL-5203
Authored by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)
### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).