### PR TITLE
Fix Error Handling and Cleanup during Insert Bulk Process

### DIFF
--- a/.github/composite-actions/install-and-run-dotnet/action.yml
+++ b/.github/composite-actions/install-and-run-dotnet/action.yml
@@ -34,6 +34,7 @@ runs:
     run: |
       cd test/dotnet
       dotnet build
+      VSTEST_DISABLE_STANDARD_OUTPUT_CAPTURING=1 \
       babel_URL=localhost \
         babel_port=1433 \
         babel_databaseName=master \

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -127,7 +127,7 @@ ResetTDSConnection(void)
 	TdsErrorContext->err_text = "Resetting the TDS connection";
 
 	/* Make sure we've killed any active transaction */
-	AbortOutOfAnyTransaction();
+	pltsql_plugin_handler_ptr->pltsql_abort_any_transaction_callback();
 
 	/*
 	 * Save the transaction isolation level that should be restored after
@@ -153,6 +153,7 @@ ResetTDSConnection(void)
 	TdsProtocolInit();
 	TdsResetCache();
 	TdsResponseReset();
+	TdsResetBcpOffset();
 	SetConfigOption("default_transaction_isolation", isolationOld,
 					PGC_BACKEND, PGC_S_CLIENT);
 

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -377,4 +377,7 @@ extern coll_info_t TdsLookupCollationTableCallback(Oid oid);
 extern Datum TdsBytePtrToDatum(StringInfo buf, int datatype, int scale);
 extern Datum TdsDateTimeTypeToDatum(uint64 time, int32 date, int datatype, int scale);
 
+/* Functions in tdsbulkload.c */
+extern void TdsResetBcpOffset(void);
+
 #endif							/* TDS_INT_H */

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4568,6 +4568,8 @@ _PG_init(void)
 		(*pltsql_protocol_plugin_ptr)->sp_unprepare_callback = &sp_unprepare;
 		(*pltsql_protocol_plugin_ptr)->reset_session_properties = &reset_session_properties;
 		(*pltsql_protocol_plugin_ptr)->bulk_load_callback = &execute_bulk_load_insert;
+		(*pltsql_protocol_plugin_ptr)->pltsql_rollback_txn_callback = &pltsql_rollback_txn;
+		(*pltsql_protocol_plugin_ptr)->pltsql_abort_any_transaction_callback = &pltsql_abort_any_transaction;
 		(*pltsql_protocol_plugin_ptr)->pltsql_declare_var_callback = &pltsql_declare_variable;
 		(*pltsql_protocol_plugin_ptr)->pltsql_read_out_param_callback = &pltsql_read_composite_out_param;
 		(*pltsql_protocol_plugin_ptr)->sqlvariant_set_metadata = common_utility_plugin_ptr->TdsSetMetaData;

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1726,6 +1726,10 @@ typedef struct PLtsql_protocol_plugin
 	uint64		(*bulk_load_callback) (int ncol, int nrow,
 									   Datum *Values, bool *Nulls);
 
+	void 		(*pltsql_rollback_txn_callback) (void);
+
+	void		(*pltsql_abort_any_transaction_callback) (void);
+
 	int			(*pltsql_get_generic_typmod) (Oid funcid, int nargs, Oid declared_oid);
 
 	const char *(*pltsql_get_logical_schema_name) (const char *physical_schema_name, bool missingOk);
@@ -2085,6 +2089,7 @@ extern void PLTsqlRollbackTransaction(char *txnName, QueryCompletion *qc, bool c
 extern void pltsql_start_txn(void);
 extern void pltsql_commit_txn(void);
 extern void pltsql_rollback_txn(void);
+extern void pltsql_abort_any_transaction(void);
 extern bool pltsql_get_errdata(int *tsql_error_code, int *tsql_error_severity, int *tsql_error_state);
 extern void pltsql_eval_txn_data(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt, CachedPlanSource *cachedPlanSource);
 extern bool is_sysname_column(ColumnDef *coldef);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -851,6 +851,13 @@ pltsql_rollback_txn(void)
 	StartTransactionCommand();
 }
 
+void
+pltsql_abort_any_transaction(void)
+{
+	NestedTranCount = 0;
+	AbortOutOfAnyTransaction();
+}
+
 bool
 pltsql_get_errdata(int *tsql_error_code, int *tsql_error_severity, int *tsql_error_state)
 {

--- a/test/dotnet/ExpectedOutput/insertBulkErrors.out
+++ b/test/dotnet/ExpectedOutput/insertBulkErrors.out
@@ -1,0 +1,657 @@
+#Q#Create table sourceTable(a int, b int not null)
+#Q#Create table destinationTable(a int, b int not null)
+#Q#Insert into sourceTable values (1, 1);
+#Q#Insert into sourceTable values (NULL, 2);
+#Q#select @@trancount;
+#D#int
+1
+#Q#select @@trancount
+#D#int
+1
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int not null)
+#Q#Create table destinationTable(a int, b int not null)
+#Q#Insert into sourceTable values (1, 1);
+#Q#Insert into sourceTable values (NULL, 2);
+#Q#select @@trancount;
+#D#int
+1
+#Q#select @@trancount
+#D#int
+1
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#Select * from destinationTable
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int not null)
+#Q#Create table destinationTable(a int, b int not null)
+#Q#create index idx on destinationTable(a);
+#Q#Insert into sourceTable values (1, 1);
+#Q#Insert into sourceTable values (NULL, 2);
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int not null)
+#Q#Create table destinationTable(a int, b int not null)
+#Q#create index idx on destinationTable(a);
+#Q#Insert into sourceTable values (1, 1);
+#Q#Insert into sourceTable values (NULL, 2);
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select * from destinationTable
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select * from destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+#!#2
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+#Q#INSERT INTO destinationTable VALUES(1001, 'Foo')
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int unique, c2 CHAR(1024))
+#Q#INSERT INTO destinationTable VALUES(1001, 'Foo')
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#INSERT INTO sourceTable VALUES (NULL, NULL)
+#Q#create table destinationTable(c1 int NOT NULL, c2 CHAR(1024))
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(NULL, NULL)
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 999, 1), 'Foo'
+#Q#Select count(*) from sourceTable
+#D#int
+1001
+#Q#select count(*) from sourceTable1
+#D#int
+1000
+#Q#Select count(*) from destinationTable
+#D#int
+0
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+0
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+0
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable VALUES (1, 'Foo'), (2, 'Foo')
+#Q#create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+#Q#INSERT INTO destinationTable VALUES(2, 'Foo')
+#Q#Select * from sourceTable
+#D#int#!#char
+1#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+2#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select c1 from destinationTable
+#D#int
+2
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select c1 from destinationTable
+#D#int
+2
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+#Q#create index idx on destinationTable(c1);
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#INSERT INTO destinationTable VALUES (-1, 'Foo');
+#Q#INSERT INTO destinationTable VALUES (-2, 'Foo');
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+#Q#create index idx on destinationTable(c1);
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#INSERT INTO destinationTable VALUES (-1, 'Foo');
+#Q#INSERT INTO destinationTable VALUES (-2, 'Foo');
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#SELECT @@trancount
+#D#int
+1
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+4
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+4
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q# SET implicit_transactions ON
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+#Q#create index idx on destinationTable(c1);
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#INSERT INTO destinationTable VALUES (-1, 'Foo');
+#Q#INSERT INTO destinationTable VALUES (-2, 'Foo');
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+1
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#E#table "sourcetable" does not exist
+#Q#drop table sourceTable1
+#E#table "sourcetable1" does not exist
+#Q#drop table destinationTable
+#E#table "destinationtable" does not exist
+#Q#create table sourceTable(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+#Q#create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+#Q#create index idx on destinationTable(c1);
+#Q#create table sourceTable1(c1 int, c2 CHAR(1024))
+#Q#INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+#Q#INSERT INTO destinationTable VALUES (-1, 'Foo');
+#Q#INSERT INTO destinationTable VALUES (-2, 'Foo');
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#SELECT @@trancount
+#D#int
+2
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'off', false);
+#D#text
+off
+#Q#Select count(c1) from destinationTable
+#D#int
+4
+#Q#SELECT set_config('enable_bitmapscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_seqscan', 'off', false);
+#D#text
+off
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#Select count(c1) from destinationTable
+#D#int
+4
+#Q#SELECT set_config('enable_bitmapscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_seqscan', 'on', false);
+#D#text
+on
+#Q#SELECT set_config('enable_indexscan', 'on', false);
+#D#text
+on
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q# SET implicit_transactions OFF

--- a/test/dotnet/input/InsertBulk/insertBulkErrors.txt
+++ b/test/dotnet/input/InsertBulk/insertBulkErrors.txt
@@ -1,0 +1,558 @@
+##########################################################
+#################### TEST DETAILS ########################
+### 1. Testing explicit transaction (error case handled in 5.)
+###    a. Commit without error
+###    b. Rollback without error
+### 2. Index with without transaction
+### 3. Primary Key error case
+### 4. Unique constraint with error case
+### 5. Check constraint with error case
+###    a. transaction testing during error scenarios
+###    b. @@trancount test - error should not terminate transaction
+###    c. Test CheckConstraint BCP Option Enabled
+###    d. Test Reusing the same connection for BCP even after error scenarios
+### 6. Reset-connection testing with Primary Key error
+### 7. Savepoint rollback and commit in error and non-error case.
+### 8. implicit_transactions have no role to play here but we have still added tests.
+### The above tests test the seq and index.
+##########################################################
+
+####### Testing explicit transaction #######
+# commit and then check for inserts
+Create table sourceTable(a int, b int not null)
+Create table destinationTable(a int, b int not null)
+Insert into sourceTable values (1, 1);
+Insert into sourceTable values (NULL, 2);
+txn#!#begin
+select @@trancount;
+traninsertbulk#!#sourceTable#!#destinationTable
+
+select @@trancount
+txn#!#commit
+
+Select * from sourceTable
+Select * from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+# rollback and then check for inserts
+Create table sourceTable(a int, b int not null)
+Create table destinationTable(a int, b int not null)
+Insert into sourceTable values (1, 1);
+Insert into sourceTable values (NULL, 2);
+txn#!#begin
+select @@trancount;
+# int
+traninsertbulk#!#sourceTable#!#destinationTable
+
+select @@trancount
+txn#!#rollback
+
+Select * from sourceTable
+Select * from destinationTable
+drop table sourceTable
+drop table destinationTable
+
+# Index without transaction
+Create table sourceTable(a int, b int not null)
+Create table destinationTable(a int, b int not null)
+create index idx on destinationTable(a);
+Insert into sourceTable values (1, 1);
+Insert into sourceTable values (NULL, 2);
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select * from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select * from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+drop table sourceTable
+drop table destinationTable
+
+####### Index with transaction #######
+Create table sourceTable(a int, b int not null)
+Create table destinationTable(a int, b int not null)
+create index idx on destinationTable(a);
+Insert into sourceTable values (1, 1);
+Insert into sourceTable values (NULL, 2);
+
+# transaction rollback test with index
+txn#!#begin
+traninsertbulk#!#sourceTable#!#destinationTable
+txn#!#rollback
+Select * from sourceTable
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select * from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select * from destinationTable
+
+# transaction commit test with index
+txn#!#begin
+traninsertbulk#!#sourceTable#!#destinationTable
+txn#!#commit
+Select * from sourceTable
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select * from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select * from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+drop table sourceTable
+drop table destinationTable
+
+
+####### Primary Key error #######
+
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+INSERT INTO destinationTable VALUES(1001, 'Foo')
+
+insertbulk#!#sourceTable#!#destinationTable
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+insertbulk#!#sourceTable1#!#destinationTable
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+
+####### Unique #######
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int unique, c2 CHAR(1024))
+INSERT INTO destinationTable VALUES(1001, 'Foo')
+
+insertbulk#!#sourceTable#!#destinationTable
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+insertbulk#!#sourceTable1#!#destinationTable
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+####### Not Null #######
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1000, 1), 'Foo'
+INSERT INTO sourceTable VALUES (NULL, NULL)
+create table destinationTable(c1 int NOT NULL, c2 CHAR(1024))
+
+insertbulk#!#sourceTable#!#destinationTable
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(NULL, NULL)
+INSERT INTO sourceTable1 SELECT generate_series(1, 999, 1), 'Foo'
+
+insertbulk#!#sourceTable1#!#destinationTable
+
+Select count(*) from sourceTable
+select count(*) from sourceTable1
+
+Select count(*) from destinationTable
+
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+####### Check #######
+##### THESE TESTS ALSO TEST REUSING THE SAME CONNECTION
+##### ON WHICH WE ERROR OUT AND NEED TO RESET TDS STATE
+##### WE ALSO SEE THAT TRANSACTION IS NOT ROLLED BACK FOR
+##### ANY ERROR DURING BULK OPERATION
+
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+txn#!#begin
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+txn#!#commit
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+####### Reset-connection with error (retry the insert bulk in a loop) #######
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable VALUES (1, 'Foo'), (2, 'Foo')
+create table destinationTable(c1 int PRIMARY KEY, c2 CHAR(1024))
+INSERT INTO destinationTable VALUES(2, 'Foo')
+
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+insertbulk#!#sourceTable#!#destinationTable
+
+Select * from sourceTable
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select c1 from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select c1 from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+drop table sourceTable
+drop table destinationTable
+
+####### Savepoint rollback with and without error #######
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+create index idx on destinationTable(c1);
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+txn#!#begin
+INSERT INTO destinationTable VALUES (-1, 'Foo');
+txn#!#savepoint#!#sp1
+INSERT INTO destinationTable VALUES (-2, 'Foo');
+
+###### WITHOUT ERROR ######
+SELECT @@trancount
+traninsertbulk#!#destinationTable#!#destinationTable
+
+###### WITH ERROR ######
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+
+txn#!#rollback#!#sp1
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+
+txn#!#rollback
+
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+
+####### Savepoint commit with and without error #######
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+create index idx on destinationTable(c1);
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+txn#!#begin
+INSERT INTO destinationTable VALUES (-1, 'Foo');
+txn#!#savepoint#!#sp1
+INSERT INTO destinationTable VALUES (-2, 'Foo');
+
+###### WITHOUT ERROR ######
+SELECT @@trancount
+traninsertbulk#!#destinationTable#!#destinationTable
+###### WITH ERROR ######
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+
+txn#!#commit#!#sp1
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+ SET implicit_transactions ON
+####### implicit_transactions rollback with and without error #######
+
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+create index idx on destinationTable(c1);
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+txn#!#begin
+INSERT INTO destinationTable VALUES (-1, 'Foo');
+txn#!#savepoint#!#sp1
+INSERT INTO destinationTable VALUES (-2, 'Foo');
+
+###### WITHOUT ERROR ######
+SELECT @@trancount
+traninsertbulk#!#destinationTable#!#destinationTable
+
+###### WITH ERROR ######
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+
+txn#!#rollback#!#sp1
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+
+txn#!#rollback
+
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+####### implicit_transactions commit with and without error #######
+# last row is error (last packet will be flushed)
+create table sourceTable(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable SELECT generate_series(1, 1001, 1), 'Foo'
+create table destinationTable(c1 int, c2 CHAR(1024), check(c1 < 1000))
+create index idx on destinationTable(c1);
+
+# 1st row is error (remaining packets to be discarded)
+create table sourceTable1(c1 int, c2 CHAR(1024))
+INSERT INTO sourceTable1 VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 SELECT generate_series(1, 1000, 1), 'Foo'
+
+txn#!#begin
+INSERT INTO destinationTable VALUES (-1, 'Foo');
+txn#!#savepoint#!#sp1
+INSERT INTO destinationTable VALUES (-2, 'Foo');
+
+###### WITHOUT ERROR ######
+SELECT @@trancount
+traninsertbulk#!#destinationTable#!#destinationTable
+###### WITH ERROR ######
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable#!#destinationTable
+SELECT @@trancount
+traninsertbulk#!#sourceTable1#!#destinationTable
+SELECT @@trancount
+
+txn#!#commit#!#sp1
+
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+
+# Seq scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'off', false);
+Select count(c1) from destinationTable
+
+# Index scan
+SELECT set_config('enable_bitmapscan', 'off', false);
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_indexscan', 'on', false);
+Select count(c1) from destinationTable
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+SELECT set_config('enable_seqscan', 'on', false);
+SELECT set_config('enable_indexscan', 'on', false);
+
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+ SET implicit_transactions OFF

--- a/test/dotnet/src/BatchRun.cs
+++ b/test/dotnet/src/BatchRun.cs
@@ -217,6 +217,15 @@ namespace BabelfishDotnetFramework
 							string destinationTable = result[2];
 							testFlag &= testUtils.insertBulkCopy(bblCnn, bblCmd, sourceTable, destinationTable, logger, ref stCount);
 						}
+						else if (strLine.ToLowerInvariant().StartsWith("traninsertbulk"))
+						{
+							var result = strLine.Split("#!#", StringSplitOptions.RemoveEmptyEntries);
+							testUtils.PrintToLogsOrConsole(
+								$"########################## INSERT BULK:- {strLine} ##########################", logger, "information");
+							string sourceTable = result[1];
+							string destinationTable = result[2];
+							testFlag &= testUtils.insertBulkCopyWithTransaction(bblCnn, bblCmd, sourceTable, destinationTable, bblTransaction, logger, ref stCount);
+						}
 						/* Case for sp_customtype RPC. */
 						else if (strLine.ToLowerInvariant().StartsWith("storedp"))
 						{
@@ -290,7 +299,7 @@ namespace BabelfishDotnetFramework
 							}
 							else if (query.ToLowerInvariant().StartsWith("insert") || query.ToLowerInvariant().StartsWith("update") || query.ToLowerInvariant().StartsWith("alter")
 									 || query.ToLowerInvariant().StartsWith("delete") || query.ToLowerInvariant().StartsWith("begin") || query.ToLowerInvariant().StartsWith("commit")
-									 || query.ToLowerInvariant().StartsWith("rollback") || query.ToLowerInvariant().StartsWith("save") || query.ToLowerInvariant().StartsWith("use")
+									 || query.ToLowerInvariant().StartsWith("rollback") || query.ToLowerInvariant().StartsWith("save") || query.ToLowerInvariant().StartsWith("use") || query.ToLowerInvariant().StartsWith(" set")
 									 || query.ToLowerInvariant().StartsWith("create") || query.ToLowerInvariant().StartsWith("drop") || query.ToLowerInvariant().StartsWith("exec") || query.ToLowerInvariant().StartsWith("declare"))
 							{
 								bblCmd?.Dispose();

--- a/test/dotnet/utils/ConfigSetup.cs
+++ b/test/dotnet/utils/ConfigSetup.cs
@@ -9,6 +9,8 @@ namespace BabelfishDotnetFramework
 		/* Declaring variables required for a Test Run. */
 		static readonly Dictionary<string, string> Dictionary = LoadConfig();
 		public static readonly string BblConnectionString = Dictionary["bblConnectionString"];
+
+		public static readonly string BCPConnectionString = Dictionary["BCPConnectionString"];
 		public static readonly string QueryFolder = Dictionary["queryFolder"];
 		public static readonly string TestName = Dictionary["testName"];
 		public static readonly bool RunInParallel = bool.Parse(Dictionary["runInParallel"]);
@@ -46,6 +48,9 @@ namespace BabelfishDotnetFramework
 			/* Creating Server Connection String and Query. */
 			dictionary["bblConnectionString"] = BuildConnectionString(dictionary["babel_URL"], dictionary["babel_port"],
 				dictionary["babel_databaseName"],
+				dictionary["babel_user"], dictionary["babel_password"]) + "pooling=false;";
+			dictionary["BCPConnectionString"] = BuildConnectionString(dictionary["babel_URL"], dictionary["babel_port"],
+				dictionary["babel_databaseName"],
 				dictionary["babel_user"], dictionary["babel_password"]);
 			return dictionary;
 		}
@@ -56,10 +61,10 @@ namespace BabelfishDotnetFramework
 			{
 				case "oledb":
 					return @"Provider = " + ConfigSetup.Provider + ";Data Source = " + url + "," + port + "; Initial Catalog = " + db
-						   + "; User ID = " + uid + "; Password = " + pwd + ";Pooling=false;";
+						   + "; User ID = " + uid + "; Password = " + pwd + ";";
 				case "sql":
 					return @"Data Source = " + url + "," + port + "; Initial Catalog = " + db
-						   + "; User ID = " + uid + "; Password = " + pwd + ";Pooling=false;";
+						   + "; User ID = " + uid + "; Password = " + pwd + ";";
 				default:
 					throw new Exception("Driver Not Supported");
 			}

--- a/test/dotnet/utils/TestUtils.cs
+++ b/test/dotnet/utils/TestUtils.cs
@@ -39,10 +39,50 @@ namespace BabelfishDotnetFramework
 			DbDataReader reader = null;
 			try
 			{
+				/* To Enforce Reset Connection. */
 				reader = bblCmd.ExecuteReader();
-				SqlBulkCopy bulkCopy = new SqlBulkCopy(ConfigSetup.BblConnectionString);
+				using (SqlConnection destinationConnection =
+                       new SqlConnection(ConfigSetup.BCPConnectionString))
+				{
+					destinationConnection.Open();
+
+					SqlBulkCopy bulkCopy = new SqlBulkCopy(destinationConnection);
+					bulkCopy.DestinationTableName = destinationTable;
+					bulkCopy.WriteToServer(reader);
+				}
+			}
+			catch (Exception e)
+			{
+				PrintToLogsOrConsole("#################################################################", logger, "information");
+				PrintToLogsOrConsole(
+					$"############# ERROR IN EXECUTING WITH BABEL  ####################\n{e}\n",
+					logger, "information");
+				stCount--;
+				return false;
+			}
+			finally
+			{
+				reader.Close();
+			}
+			return true;
+		}
+
+		public bool insertBulkCopyWithTransaction(DbConnection bblCnn, DbCommand bblCmd, String sourceTable, String destinationTable, DbTransaction transaction, Logger logger, ref int stCount)
+		{
+			bblCmd.CommandText = "Select * from " + sourceTable;
+			bblCmd.Transaction = transaction;
+			DbDataReader reader = null;
+			DataTable dataTable = new DataTable();
+			try
+			{
+				reader = bblCmd.ExecuteReader();
+				dataTable.Load(reader);
+				reader.Close();
+
+				/* Set CheckConstraints default for this API since this is the only mechanism to use BCP Options. */
+				SqlBulkCopy bulkCopy = new SqlBulkCopy((SqlConnection)bblCnn, SqlBulkCopyOptions.CheckConstraints, (SqlTransaction) transaction);
 				bulkCopy.DestinationTableName = destinationTable;
-				bulkCopy.WriteToServer(reader);
+				bulkCopy.WriteToServer(dataTable);
 			}
 			catch (Exception e)
 			{
@@ -403,7 +443,7 @@ namespace BabelfishDotnetFramework
 					dictionary["others"] = result[i].Split("|-|")[1];
 			}
 			return @"Data Source = " + dictionary["url"] + "; Initial Catalog = " + dictionary["db"] +
-												"; User ID = " + dictionary["user"] + "; Password = " + dictionary["pwd"] + ";Pooling=false;" + dictionary["others"];
+												"; User ID = " + dictionary["user"] + "; Password = " + dictionary["pwd"] + ";" + dictionary["others"];
 		}
 
 		/* Depending on the OS we use the appropriate diff command. */


### PR DESCRIPTION
### Description
This commit fixes an issue with the error handling and cleanup phase of the Insert Bulk Process.
1. For Error Handling there was a scenario where bulk_load_callback(0, 0, NULL, NULL) call for cleanup would flush the remaining rows during EndBulkCopy and could result in an error. To fix this, we move the transaction rollback logic from TSQL extension to TDS. We also improved it by using Savepoints in case of active transaction which is aligned with TSQL Behaviour
2. In this case, if we have a reset-connection after the Bulk Load TDS packet we werent cleaning up the Bulk Load state. To do so we reset the offset.
3. During Reset Connection TDS is not resetting any TSQL transaction semantic. To resolve this we introduce a wrapper of AbortOutOfAnyTransaction to reset NestedTranCount.

Issues Resolved
BABEL-5200, BABEL-5199, BABEL-5220

Authored-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)
Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)

### Test Scenarios Covered ###

1. Testing explicit transaction (error case handled in 5.)
a. Commit without error
b. Rollback without error
2. Index with without transaction
4. Primary Key error case
5. Unique constraint with error case
6. Check constraint with error case
a. transaction testing during error scenarios
b. @@trancount test - error should not terminate transaction
c. Test CheckConstraint BCP Option Enabled
d. Test Reusing the same connection for BCP even after error scenarios
7. Reset-connection testing with Primary Key error
The above tests test the seq and index.

For Reset-connection, Although the tests in 6. do reset but for validation through logs I added a temp log to debug TdsResetConnection and with this log its evident that pid 21384 is being reset and reused for Bulk Load
```
2024-08-27 10:52:28.688 UTC [21384] CONTEXT:  TDS Protocol: Message Type: SQL BATCH, Phase: TDS_REQUEST_PHASE_FETCH. Resetting the TDS connection
2024-08-27 10:52:28.696 UTC [21384] ERROR:  duplicate key value violates unique constraint "destinationtable_pkey"
2024-08-27 10:52:28.696 UTC [21384] DETAIL:  Key (c1)=(2) already exists.
2024-08-27 10:52:28.696 UTC [21384] CONTEXT:  TDS Protocol: Message Type: Bulk Load, Phase: TDS_REQUEST_PHASE_PROCESS. Processing Bulk Load Request
2024-08-27 10:52:28.697 UTC [21384] LOG:  BULK LOAD RESET NOW
2024-08-27 10:52:28.697 UTC [21384] CONTEXT:  TDS Protocol: Message Type: SQL BATCH, Phase: TDS_REQUEST_PHASE_FETCH. Resetting the TDS connection
2024-08-27 10:52:28.706 UTC [21384] ERROR:  duplicate key value violates unique constraint "destinationtable_pkey"
2024-08-27 10:52:28.706 UTC [21384] DETAIL:  Key (c1)=(2) already exists.
2024-08-27 10:52:28.706 UTC [21384] CONTEXT:  TDS Protocol: Message Type: Bulk Load, Phase: TDS_REQUEST_PHASE_PROCESS. Processing Bulk Load Request
2024-08-27 10:52:28.707 UTC [21384] LOG:  BULK LOAD RESET NOW
2024-08-27 10:52:28.707 UTC [21384] CONTEXT:  TDS Protocol: Message Type: SQL BATCH, Phase: TDS_REQUEST_PHASE_FETCH. Resetting the TDS connection
2024-08-27 10:52:28.712 UTC [21384] ERROR:  duplicate key value violates unique constraint "destinationtable_pkey"
2024-08-27 10:52:28.712 UTC [21384] DETAIL:  Key (c1)=(2) already exists.
2024-08-27 10:52:28.712 UTC [21384] CONTEXT:  TDS Protocol: Message Type: Bulk Load, Phase: TDS_REQUEST_PHASE_PROCESS. Processing Bulk Load Request
2024-08-27 10:52:28.714 UTC [21384] LOG:  BULK LOAD RESET NOW
2024-08-27 10:52:28.714 UTC [21384] CONTEXT:  TDS Protocol: Message Type: SQL BATCH, Phase: TDS_REQUEST_PHASE_FETCH. Resetting the TDS connection
2024-08-27 10:52:28.719 UTC [21384] ERROR:  duplicate key value violates unique constraint "destinationtable_pkey"
2024-08-27 10:52:28.719 UTC [21384] DETAIL:  Key (c1)=(2) already exists.
2024-08-27 10:52:28.719 UTC [21384] CONTEXT:  TDS Protocol: Message Type: Bulk Load, Phase: TDS_REQUEST_PHASE_PROCESS. Processing Bulk Load Request
2024-08-27 10:52:28.720 UTC [21384] LOG:  BULK LOAD RESET NOW
2024-08-27 10:52:28.720 UTC [21384] CONTEXT:  TDS Protocol: Message Type: SQL BATCH, Phase: TDS_REQUEST_PHASE_FETCH. Resetting the TDS connection
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).