### PR TITLE
Fix crash in datumCopy during copyParamList() when pgaudit is installed

### DIFF
--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -295,6 +295,7 @@ SetTvpRowData(ParameterToken temp, const StringInfo message, uint64_t *offset)
 			rowData = temp;
 		}
 
+		temp->tvpInfo->rowCount += 1;
 		rowData->columnValues = palloc0(temp->tvpInfo->colCount * sizeof(StringInfoData));
 		rowData->isNull = palloc0(temp->tvpInfo->colCount);
 		(*offset)++;
@@ -303,7 +304,6 @@ SetTvpRowData(ParameterToken temp, const StringInfo message, uint64_t *offset)
 		{
 			initStringInfo(&rowData->columnValues[i]);
 			rowData->isNull[i] = 'f';
-			temp->tvpInfo->rowCount += 1;
 			switch (colmetadata[i].columnTdsType)
 			{
 				case TDS_TYPE_INTEGER:


### PR DESCRIPTION
### Description

Cherry picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2871

Fix crash in datum copy when pgaudit copies the parameters of
the internal prep/exec query used to insert rows into TVP. 
Root cause was incorrect computation of rowCount in TVP, and
incorrect count of bind variables (nargs) of internal prep/exec
query for TVP since it depends upon rowCount as well.

pgaudit then copies all the bind variables using the total count
we provided and ends up accessing an out of bound index
of the values array.

### Issues Resolved

[BABEL-4983]

### Test Scenarios Covered ###

Locally ran the java script which produces the crash and verified that crash does not happen post fix.

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).