### PR TITLE
Fix tsql_stat_get_activity() and tsql_read_current_status() to consider only valid tds backends

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -583,6 +583,21 @@ tdsstat_fetch_stat_local_tdsentry(int beid)
 }
 
 /* ----------
+ * tdsstat_fetch_stat_numbackends() -
+ *
+ *	Support function for the SQL-callable pgstat* functions. Returns
+ *	the number of sessions known in the localTdsStatusTable, i.e.
+ *	the maximum 1-based index to pass to tdsstat_fetch_stat_local_tdsentry().
+ * ----------
+ */
+int
+tdsstat_fetch_stat_numbackends(void)
+{
+	tdsstat_read_current_status();
+	return localNumBackends;
+}
+
+/* ----------
  * tdsstat_read_current_status() -
  *
  *	Copy the current contents of the TdsStatus array to local memory,
@@ -723,10 +738,12 @@ tdsstat_read_current_status(void)
 
 		/* Only valid entries get included into the local array */
 		if (localentry->tdsStatus.st_procpid > 0)
+		{
 			BackendIdGetTransactionIds(i, &localentry->backend_xid, &localentry->backend_xmin);
 
-		localentry++;
-		localNumBackends++;
+			localentry++;
+			localNumBackends++;
+		}
 	}
 
 	localTdsStatusTable = localtable;

--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -195,6 +195,7 @@ pe_tds_init(void)
 	pltsql_plugin_handler_ptr->set_db_stat_var = &TdsSetDatabaseStatVariable;
 	pltsql_plugin_handler_ptr->get_stat_values = &tds_stat_get_activity;
 	pltsql_plugin_handler_ptr->invalidate_stat_view = &invalidate_stat_table;
+	pltsql_plugin_handler_ptr->get_tds_numbackends = &tdsstat_fetch_stat_numbackends;
 	pltsql_plugin_handler_ptr->get_host_name = &get_tds_host_name;
 	pltsql_plugin_handler_ptr->get_client_pid = &get_tds_client_pid;
 	pltsql_plugin_handler_ptr->get_context_info = &get_tds_context_info;

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -335,6 +335,7 @@ extern void TdsSetGucStatVariable(const char *guc, bool boolVal, const char *str
 extern void TdsSetAtAtStatVariable(TdsAtAtVarType at_at_var, int intVal, uint64 bigintVal);
 extern void TdsSetDatabaseStatVariable(int16 db_id);
 extern bool tds_stat_get_activity(Datum *values, bool *nulls, int len, int pid, int curr_backend);
+extern int tdsstat_fetch_stat_numbackends(void);
 extern void invalidate_stat_table(void);
 extern char *get_tds_host_name(void);
 extern uint32_t get_tds_client_pid(void);

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1741,7 +1741,7 @@ Datum
 tsql_stat_get_activity(PG_FUNCTION_ARGS)
 {
 	Oid			sysadmin_oid = get_role_oid("sysadmin", false);
-	int			num_backends = pgstat_fetch_stat_numbackends();
+	int			num_backends = 0;
 	int			curr_backend;
 	char	   *view_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	int			pid = -1;
@@ -1826,6 +1826,9 @@ tsql_stat_get_activity(PG_FUNCTION_ARGS)
 	rsinfo->setDesc = tupdesc;
 
 	MemoryContextSwitchTo(oldcontext);
+
+	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->get_tds_numbackends)
+		num_backends = (*pltsql_protocol_plugin_ptr)->get_tds_numbackends();
 
 	/* 1-based index */
 	for (curr_backend = 1; curr_backend <= num_backends; curr_backend++)

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1651,6 +1651,7 @@ typedef struct PLtsql_protocol_plugin
 	void		(*set_db_stat_var) (int16 db_id);
 	bool		(*get_stat_values) (Datum *values, bool *nulls, int len, int pid, int curr_backend);
 	void		(*invalidate_stat_view) (void);
+	int		(*get_tds_numbackends) (void);
 	char	       *(*get_host_name) (void);
 	uint32_t        (*get_client_pid) (void);
 	Datum		(*get_datum_from_byte_ptr) (StringInfo buf, int datatype, int scale);

--- a/test/JDBC/expected/kill-vu-cleanup.out
+++ b/test/JDBC/expected/kill-vu-cleanup.out
@@ -17,3 +17,29 @@ go
 DROP TABLE tab_kill_test
 go
 
+DROP Database test_kill_db1
+GO
+DROP Database test_kill_db2
+GO
+DROP Database test_kill_db3
+GO
+DROP Database test_kill_db4
+GO
+DROP Database test_kill_db5
+GO
+DROP Database test_kill_db6
+GO
+DROP Database test_kill_db7
+GO
+DROP Database test_kill_db8
+GO
+DROP Database test_kill_db9
+GO
+DROP Database test_kill_db10
+GO
+DROP Database test_kill_db11
+GO
+
+DROP LOGIN test_kill;
+GO
+

--- a/test/JDBC/expected/single_db/kill-vu-cleanup.out
+++ b/test/JDBC/expected/single_db/kill-vu-cleanup.out
@@ -1,0 +1,85 @@
+-- tsql
+DROP LOGIN victim_user_tds
+go
+
+DROP TABLE tab_kill_spid
+go
+
+DROP PROCEDURE kill_proc_1
+go
+
+DROP PROCEDURE kill_proc_2
+go
+
+DROP PROCEDURE kill_proc_3
+go
+
+DROP TABLE tab_kill_test
+go
+
+DROP Database test_kill_db1
+GO
+DROP Database test_kill_db2
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db2" does not exist)~~
+
+DROP Database test_kill_db3
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db3" does not exist)~~
+
+DROP Database test_kill_db4
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db4" does not exist)~~
+
+DROP Database test_kill_db5
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db5" does not exist)~~
+
+DROP Database test_kill_db6
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db6" does not exist)~~
+
+DROP Database test_kill_db7
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db7" does not exist)~~
+
+DROP Database test_kill_db8
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db8" does not exist)~~
+
+DROP Database test_kill_db9
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db9" does not exist)~~
+
+DROP Database test_kill_db10
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db10" does not exist)~~
+
+DROP Database test_kill_db11
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db11" does not exist)~~
+
+
+DROP LOGIN test_kill;
+GO
+

--- a/test/JDBC/expected/single_db/kill-vu-verify.out
+++ b/test/JDBC/expected/single_db/kill-vu-verify.out
@@ -454,74 +454,194 @@ go
 
 create database test_kill_db2
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db2
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db2" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db3
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db3
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db3" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db4
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db4
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db4" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db5
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db5
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db5" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db6
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db6
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db6" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db7
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db7
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db7" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db8
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db8
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db8" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db9
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db9
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db9" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 
 create database test_kill_db10
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db10
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db10" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 create database test_kill_db11
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "test_kill_db1" already exists)~~
+
 use test_kill_db11
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db11" does not exist)~~
+
 CREATE USER user_kill FOR LOGIN test_kill;
 go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "test_kill_db1_user_kill" already exists)~~
+
 
 -- tsql user=test_kill password=12345678 database=test_kill_db1
 -- CREATE 11 sessions
@@ -534,6 +654,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db2
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db2" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -543,6 +667,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db3
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db3" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -552,6 +680,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db4
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db4" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -561,6 +693,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db5
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db5" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -570,6 +706,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db6
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db6" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -579,6 +719,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db7
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db7" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -588,6 +732,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db8
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db8" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -597,6 +745,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db9
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db9" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -606,6 +758,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db10
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db10" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -615,6 +771,10 @@ int
 
 
 -- tsql user=test_kill password=12345678 database=test_kill_db11
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "test_kill_db11" does not exist )~~
+
 SELECT 1
 GO
 ~~START~~
@@ -628,7 +788,7 @@ SELECT count(*) from sys.dm_exec_sessions where login_name = 'test_kill'
 GO
 ~~START~~
 int
-11
+1
 ~~END~~
 
 
@@ -636,7 +796,7 @@ SELECT COUNT(*) from pg_stat_activity where usename = 'test_kill'
 GO
 ~~START~~
 int
-11
+1
 ~~END~~
 
 
@@ -671,66 +831,6 @@ END
 -- Temporary Table Cleaning
 DROP TABLE #UserSessions
 GO
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 11~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
-~~WARNING (Code: 0)~~
-
-~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~
-
-~~ROW COUNT: 1~~
-
 ~~WARNING (Code: 0)~~
 
 ~~WARNING (Message: Changed database context to 'master'.  Server SQLState: S0001)~~

--- a/test/JDBC/input/kill-vu-cleanup.mix
+++ b/test/JDBC/input/kill-vu-cleanup.mix
@@ -1,3 +1,4 @@
+-- single_db_mode_expected
 -- tsql
 DROP LOGIN victim_user_tds
 go
@@ -16,4 +17,30 @@ go
 
 DROP TABLE tab_kill_test
 go
+
+DROP Database test_kill_db1
+GO
+DROP Database test_kill_db2
+GO
+DROP Database test_kill_db3
+GO
+DROP Database test_kill_db4
+GO
+DROP Database test_kill_db5
+GO
+DROP Database test_kill_db6
+GO
+DROP Database test_kill_db7
+GO
+DROP Database test_kill_db8
+GO
+DROP Database test_kill_db9
+GO
+DROP Database test_kill_db10
+GO
+DROP Database test_kill_db11
+GO
+
+DROP LOGIN test_kill;
+GO
 

--- a/test/JDBC/input/kill-vu-verify.mix
+++ b/test/JDBC/input/kill-vu-verify.mix
@@ -1,3 +1,4 @@
+-- single_db_mode_expected
 -- tsql
 create table tab_kill_spid(spid int)
 go
@@ -225,3 +226,181 @@ SELECT @@TRANCOUNT
 go
 SELECT * FROM tab_kill_test
 go
+
+-- BABEL-5219 Multiple Session Kill
+-- tsql
+CREATE LOGIN test_kill WITH PASSWORD = '12345678'
+GO
+
+-- CREATE 11 Databases
+create database test_kill_db1
+GO
+use test_kill_db1
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db2
+GO
+use test_kill_db2
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db3
+GO
+use test_kill_db3
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db4
+GO
+use test_kill_db4
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db5
+GO
+use test_kill_db5
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db6
+GO
+use test_kill_db6
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db7
+GO
+use test_kill_db7
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db8
+GO
+use test_kill_db8
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db9
+GO
+use test_kill_db9
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+
+create database test_kill_db10
+GO
+use test_kill_db10
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+create database test_kill_db11
+GO
+use test_kill_db11
+GO
+CREATE USER user_kill FOR LOGIN test_kill;
+go
+
+-- CREATE 11 sessions
+-- tsql user=test_kill password=12345678 database=test_kill_db1
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db2
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db3
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db4
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db5
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db6
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db7
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db8
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db9
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db10
+SELECT 1
+GO
+
+-- tsql user=test_kill password=12345678 database=test_kill_db11
+SELECT 1
+GO
+
+-- tsql
+SELECT count(*) from sys.dm_exec_sessions where login_name = 'test_kill' 
+GO
+
+SELECT COUNT(*) from pg_stat_activity where usename = 'test_kill'
+GO
+
+-- Kill Sessions
+USE [MASTER]
+DECLARE @UserName NVARCHAR(255) = 'test_kill'
+DECLARE @SPID INT
+-- Creates temp table to store SPIDs
+IF OBJECT_ID('tempdb..#UserSessions') IS NOT NULL
+BEGIN
+-- dropa tabela se existir
+DROP TABLE #UserSessions
+END
+CREATE TABLE #UserSessions (SPID INT)
+-- Inserting SPIDs from User Sessions into the Temporary Table
+INSERT INTO #UserSessions (SPID)
+SELECT session_id
+FROM sys.dm_exec_sessions
+WHERE login_name = @UserName
+-- Loop to kill user sessions
+DECLARE @RowCount INT = (SELECT COUNT(*) FROM #UserSessions)
+DECLARE @Counter INT = 1
+DECLARE @CmdKill NVARCHAR(100)
+WHILE @Counter <= @RowCount
+BEGIN
+SELECT TOP 1 @SPID = SPID FROM #UserSessions
+SET @CmdKill = 'KILL ' + CAST(@SPID AS NVARCHAR(10))
+execute(@CmdKill)
+DELETE FROM #UserSessions WHERE SPID = @SPID
+SET @Counter = @Counter + 1
+END
+-- Temporary Table Cleaning
+DROP TABLE #UserSessions
+GO
+
+-- allow the kill to complete; this might take a while under heavy workload
+exec pg_sleep 5
+go
+
+SELECT count(*) from sys.dm_exec_sessions where login_name = 'test_kill' 
+GO
+
+SELECT COUNT(*) from pg_stat_activity where usename = 'test_kill'
+GO


### PR DESCRIPTION
### Description
Fixed the `tsql_read_current_status` to increment LocalNumBackends only when it has a valid pid, also fixed `tsql_stat_get_activity` to use numbackends as calculated by TDS extension insteand of pg_stat_activity.

#### Issue 
When idle Babelfish sessions are killed one-by-one, after killing a certain number of sessions (usually 8-9), other yet-unkilled sessions suddenly disappear from sys.dm_exec_sessions. They still do appear in pg_stat_activity.

#### RCA

There seems to be 2 issues 

1. We are incorrectly setting numLocalBackends(Static variable) for TDS in function `tdsstat_read_current_status` Check [link](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/60c02e02b2b45683f0f11ea68ca338503093dc0a/contrib/babelfishpg_tds/src/backend/tds/tds.c#L736-L745) vs [how pg does it](https://github.com/postgres/postgres/blob/master/src/backend/utils/activity/backend_status.c#L829-L855) (Basic if logic bug)

2. We are using `pg_stat_fetch_numbackends` Function in tsql_stat_get_activity , which seems wrong because the status Array for pg vs tds BackendStatus are different so are the `numLocalBackends` variable.  [Check Link](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_4_X_DEV/contrib/babelfishpg_tsql/runtime/functions.c#L1750) 

These bugs seem to exist from [this commit onwards](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/a16fd4b09470122e36458afe6b5d1d4313a6fb08)


CHERRY-PICK from 4X https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2905 
### Issues Resolved
BABEL-5219

### Test Scenarios Covered ###
* **Use case based -**
YES

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).