### PR TITLE
Fix valgrind warning in patindex

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1865,7 +1865,7 @@ icu_find_matched_length(char *src_text, int src_len, char *substr_text, int subs
 		/* substr should start matching from the first position in src string */
 		u16_pos = usearch_first(usearch, &status);
 		if (!U_FAILURE(status) && u16_pos != USEARCH_DONE && u16_pos == 0 && (!is_cs_ai ||
-		    icu_compare_utf8_coll(mylocale->info.icu.ucol, src_uchar, usearch_getMatchedLength(usearch), substr_uchar, substr_len_utf8, false) == 0))
+		    icu_compare_utf8_coll(mylocale->info.icu.ucol, src_uchar, usearch_getMatchedLength(usearch), substr_uchar, substr_ulen, false) == 0))
 		{
 			/* u16 position will only be zero */
 			matched_length_u16 = usearch_getMatchedLength(usearch);

--- a/test/JDBC/expected/patindex-AI-collations.out
+++ b/test/JDBC/expected/patindex-AI-collations.out
@@ -1189,3 +1189,30 @@ bigint
 4
 ~~END~~
 
+
+-- Surrogate pair charcters CS AI
+SELECT PATINDEX(N'%😀%', N'😀' COLLATE Latin1_General_CS_AI)
+SELECT PATINDEX(N'%Z%', N'ABC😀ZABC' COLLATE Latin1_General_CS_AI)
+SELECT PATINDEX(N'😀%', N'😀A' COLLATE Latin1_General_CS_AI)
+SELECT PATINDEX(N'%D😀%', N'ABCD😀ABCD' COLLATE Latin1_General_CS_AI)
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+~~START~~
+bigint
+5
+~~END~~
+
+~~START~~
+bigint
+1
+~~END~~
+
+~~START~~
+bigint
+4
+~~END~~
+

--- a/test/JDBC/input/patindex-AI-collations.sql
+++ b/test/JDBC/input/patindex-AI-collations.sql
@@ -513,3 +513,10 @@ SELECT PATINDEX(N'%Z%', N'ABC😀ZABC' COLLATE Latin1_General_CI_AI)
 SELECT PATINDEX(N'😀%', N'😀A' COLLATE Latin1_General_CI_AI)
 SELECT PATINDEX(N'%D😀%', N'ABCD😀ABCD' COLLATE Latin1_General_CI_AI)
 GO
+
+-- Surrogate pair charcters CS AI
+SELECT PATINDEX(N'%😀%', N'😀' COLLATE Latin1_General_CS_AI)
+SELECT PATINDEX(N'%Z%', N'ABC😀ZABC' COLLATE Latin1_General_CS_AI)
+SELECT PATINDEX(N'😀%', N'😀A' COLLATE Latin1_General_CS_AI)
+SELECT PATINDEX(N'%D😀%', N'ABCD😀ABCD' COLLATE Latin1_General_CS_AI)
+GO


### PR DESCRIPTION
### Description

When using ICU functions, lengths should be in UTF 16
In icu_find_matched_length() we were mistakenly using
UTF-8 length of substr in icu_compare_utf8_coll().
Replaced it to use UTF 16 length instead

### Issues Resolved

[BABEL-5253]

### Test Scenarios Covered ###

patindex-AI-collations runs without any warnings in valgrind
also added some tests which depend on this change

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).