### PR TITLE
More specific error message on creation of windows login for NT Service domain (#2828)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2615,6 +2615,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 							if (from_windows && orig_loginname)
 							{
+								char* domain_name = NULL;
+
 								/*
 								 * The login name must contain '\' if it is
 								 * windows login or else throw error.
@@ -2653,6 +2655,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								if (windows_login_contains_invalid_chars(orig_loginname))
 									ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 													errmsg("'%s' is not a valid name because it contains invalid characters.", orig_loginname)));
+
+								/* 
+								 * Check whether the domain name is supported 
+								 * or not
+								 */
+								domain_name = get_windows_domain_name(orig_loginname);
+								if(windows_domain_is_not_supported(domain_name))
+									ereport(ERROR,
+											(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+												errmsg("'%s' domain is not yet supported in Babelfish.", domain_name)));
 
 								/*
 								 * Check whether the domain name contains invalid characters or not.

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2328,6 +2328,31 @@ windows_login_contains_invalid_chars(char *input)
 	return false;
 }
 
+/*
+ * Extract the domain name from the orig_loginname
+ */
+char*
+get_windows_domain_name(char* input){
+	char *pos_slash = strchr(input, '\\');
+	int domain_len = pos_slash - input;
+	char *domain_name = palloc(domain_len+1);
+	strncpy(domain_name, input, domain_len);
+	domain_name[domain_len] = '\0';
+	return domain_name;
+}
+
+/*
+ * Check whether the domain name is supported or not
+ */
+bool
+windows_domain_is_not_supported(char* domain_name)
+{
+	if(strcasecmp(domain_name, "nt service") == 0) {
+		return true;
+	}
+	return false;
+}
+
 /**
  * Domain name checks, doesnot allow characters like "<>&*|quotes spaces"
  * */

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -80,6 +80,8 @@ extern char *convertToUPN(char *input);
 extern bool windows_login_contains_invalid_chars(char *input);
 extern bool windows_domain_contains_invalid_chars(char *input);
 extern bool check_windows_logon_length(char *input);
+extern char* get_windows_domain_name(char* input);
+extern bool windows_domain_is_not_supported(char* domain_name);
 
 
 #endif

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -2966,3 +2966,117 @@ GO
 ~~ERROR (Message: 'EXTERNAL NAME' is not currently supported in Babelfish)~~
 
 
+-- create login from windows
+-- Add 'dummydomain' domain entry
+exec sys.babelfish_add_domain_mapping_entry 'dummydomain', 'dummydomain.babel';
+GO
+
+CREATE LOGIN [NT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Service' domain is not yet supported in Babelfish.)~~
+
+
+CREATE LOGIN [\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The login name '\MSSQLSERVER' is invalid. The domain can not be empty.)~~
+
+
+CREATE LOGIN [NT Servicesomething\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Servicesomething\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [NT ServiceNT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT ServiceNT Service\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [NT ServiceNT SerViCe\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT ServiceNT SerViCe\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [somethingNT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'somethingNT Service\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [NT Service\NT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The login name 'NT Service\NT Service\MSSQLSERVER' has invalid length. Login name length should be between 1 and 20 for windows login.)~~
+
+
+CREATE LOGIN [NT S\ervice\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT S\ervice\MSSQLSERVER' is not a valid name because it contains invalid characters.)~~
+
+
+CREATE LOGIN [NT Service\\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Service\\MSSQLSERVER' is not a valid name because it contains invalid characters.)~~
+
+
+CREATE LOGIN ["NT Service"\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: '"NT Service"\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [[NT Service]\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '\' at line 1 and character position 26)~~
+
+
+CREATE LOGIN [["NT Service"]\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '\' at line 1 and character position 28)~~
+
+
+CREATE LOGIN [NT Service\MSSQLSERVER] FROM WINDOWS WITH DEFAULT_DATABASE=[test]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Service' domain is not yet supported in Babelfish.)~~
+
+
+CREATE LOGIN [NT SerViCe\MSSQLSERVER] FROM WINDOWS WITH DEFAULT_DATABASE=[test]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT SerViCe' domain is not yet supported in Babelfish.)~~
+
+
+CREATE LOGIN [dummydomain\NT Service] FROM WINDOWS
+GO
+
+-- Dropping 'nt service@DUMMYDOMAIN.BABEL'
+DROP LOGIN [dummydomain\NT Service]
+GO
+
+-- Remove entry for 'dummydomain'
+exec babelfish_remove_domain_mapping_entry 'dummydomain'
+GO
+

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -2974,3 +2974,117 @@ GO
 ~~ERROR (Message: 'EXTERNAL NAME' is not currently supported in Babelfish)~~
 
 
+-- create login from windows
+-- Add 'dummydomain' domain entry
+exec sys.babelfish_add_domain_mapping_entry 'dummydomain', 'dummydomain.babel';
+GO
+
+CREATE LOGIN [NT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Service' domain is not yet supported in Babelfish.)~~
+
+
+CREATE LOGIN [\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The login name '\MSSQLSERVER' is invalid. The domain can not be empty.)~~
+
+
+CREATE LOGIN [NT Servicesomething\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Servicesomething\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [NT ServiceNT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT ServiceNT Service\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [NT ServiceNT SerViCe\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT ServiceNT SerViCe\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [somethingNT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'somethingNT Service\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [NT Service\NT Service\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The login name 'NT Service\NT Service\MSSQLSERVER' has invalid length. Login name length should be between 1 and 20 for windows login.)~~
+
+
+CREATE LOGIN [NT S\ervice\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT S\ervice\MSSQLSERVER' is not a valid name because it contains invalid characters.)~~
+
+
+CREATE LOGIN [NT Service\\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Service\\MSSQLSERVER' is not a valid name because it contains invalid characters.)~~
+
+
+CREATE LOGIN ["NT Service"\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: '"NT Service"\MSSQLSERVER' is not valid because the domain name contains invalid characters.)~~
+
+
+CREATE LOGIN [[NT Service]\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '\' at line 1 and character position 26)~~
+
+
+CREATE LOGIN [["NT Service"]\MSSQLSERVER] FROM WINDOWS
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '\' at line 1 and character position 28)~~
+
+
+CREATE LOGIN [NT Service\MSSQLSERVER] FROM WINDOWS WITH DEFAULT_DATABASE=[test]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT Service' domain is not yet supported in Babelfish.)~~
+
+
+CREATE LOGIN [NT SerViCe\MSSQLSERVER] FROM WINDOWS WITH DEFAULT_DATABASE=[test]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'NT SerViCe' domain is not yet supported in Babelfish.)~~
+
+
+CREATE LOGIN [dummydomain\NT Service] FROM WINDOWS
+GO
+
+-- Dropping 'nt service@DUMMYDOMAIN.BABEL'
+DROP LOGIN [dummydomain\NT Service]
+GO
+
+-- Remove entry for 'dummydomain'
+exec babelfish_remove_domain_mapping_entry 'dummydomain'
+GO
+

--- a/test/JDBC/input/BABEL-UNSUPPORTED.sql
+++ b/test/JDBC/input/BABEL-UNSUPPORTED.sql
@@ -1642,6 +1642,64 @@ AS
 EXTERNAL NAME babel_3571
 GO
 
+-- create login from windows
+-- Add 'dummydomain' domain entry
+exec sys.babelfish_add_domain_mapping_entry 'dummydomain', 'dummydomain.babel';
+GO
+
+CREATE LOGIN [NT Service\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT Servicesomething\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT ServiceNT Service\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT ServiceNT SerViCe\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [somethingNT Service\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT Service\NT Service\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT S\ervice\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT Service\\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN ["NT Service"\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [[NT Service]\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [["NT Service"]\MSSQLSERVER] FROM WINDOWS
+GO
+
+CREATE LOGIN [NT Service\MSSQLSERVER] FROM WINDOWS WITH DEFAULT_DATABASE=[test]
+GO
+
+CREATE LOGIN [NT SerViCe\MSSQLSERVER] FROM WINDOWS WITH DEFAULT_DATABASE=[test]
+GO
+
+CREATE LOGIN [dummydomain\NT Service] FROM WINDOWS
+GO
+
+-- Dropping 'nt service@DUMMYDOMAIN.BABEL'
+DROP LOGIN [dummydomain\NT Service]
+GO
+
+-- Remove entry for 'dummydomain'
+exec babelfish_remove_domain_mapping_entry 'dummydomain'
+GO
+
 -- INSERT BULK is No op. No point in failing this 
 INSERT BULK babel_3571 (
     ID INT PRIMARY KEY NOT NULL IDENTITY(1,1),


### PR DESCRIPTION
### Description
Currently in babelfish, when a new windows login is created for `NT Service` domain - it raises an error on space character. With this change babelfish will check for the `NT Service` domain and print an error specifically indicating this is not supported in Babelfish and added relevant test cases.

`NT Service` may be spelled in mixed case.

### Changes Made
In the `pl_handler.c`, I added a check which would check for the 'NT Service' domain and report a not supported error if that domain is found.


### Issues Resolved

BABEL-4212

### Test Scenarios Covered ###
* **Use case based -** yes


* **Boundary conditions -** yes


* **Arbitrary inputs -** yes


* **Negative test cases -** yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

Signed-off-by: P Aswini Kumar [aswinii@amazon.com](mailto:aswinii@amazon.com)

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).