### PR TITLE
Fix definition of sys.identity_columns to return one row per identity column

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -814,7 +814,7 @@ SELECT
   , CAST(sys.babelfish_get_sequence_value(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname)) AS SQL_VARIANT) AS last_value
   , CAST(0 as sys.BIT) as is_not_for_replication
 FROM sys.columns_internal() sc
-INNER JOIN pg_attribute a ON sc.out_name = cast(a.attname as sys.sysname) AND sc.out_column_id = a.attnum
+INNER JOIN pg_attribute a ON a.attrelid = sc.out_object_id AND sc.out_column_id = a.attnum
 INNER JOIN pg_class c ON c.oid = a.attrelid
 INNER JOIN sys.pg_namespace_ext ext ON ext.oid = c.relnamespace
 WHERE NOT a.attisdropped

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
@@ -33,6 +33,56 @@ CREATE OR REPLACE AGGREGATE sys.string_agg(sys.NVARCHAR, sys.VARCHAR) (
     PARALLEL = SAFE
 );
 
+CREATE OR replace view sys.identity_columns AS
+SELECT 
+  CAST(out_object_id AS INT) AS object_id
+  , CAST(out_name AS SYSNAME) AS name
+  , CAST(out_column_id AS INT) AS column_id
+  , CAST(out_system_type_id AS TINYINT) AS system_type_id
+  , CAST(out_user_type_id AS INT) AS user_type_id
+  , CAST(out_max_length AS SMALLINT) AS max_length
+  , CAST(out_precision AS TINYINT) AS precision
+  , CAST(out_scale AS TINYINT) AS scale
+  , CAST(out_collation_name AS SYSNAME) AS collation_name
+  , CAST(out_is_nullable AS sys.BIT) AS is_nullable
+  , CAST(out_is_ansi_padded AS sys.BIT) AS is_ansi_padded
+  , CAST(out_is_rowguidcol AS sys.BIT) AS is_rowguidcol
+  , CAST(out_is_identity AS sys.BIT) AS is_identity
+  , CAST(out_is_computed AS sys.BIT) AS is_computed
+  , CAST(out_is_filestream AS sys.BIT) AS is_filestream
+  , CAST(out_is_replicated AS sys.BIT) AS is_replicated
+  , CAST(out_is_non_sql_subscribed AS sys.BIT) AS is_non_sql_subscribed
+  , CAST(out_is_merge_published AS sys.BIT) AS is_merge_published
+  , CAST(out_is_dts_replicated AS sys.BIT) AS is_dts_replicated
+  , CAST(out_is_xml_document AS sys.BIT) AS is_xml_document
+  , CAST(out_xml_collection_id AS INT) AS xml_collection_id
+  , CAST(out_default_object_id AS INT) AS default_object_id
+  , CAST(out_rule_object_id AS INT) AS rule_object_id
+  , CAST(out_is_sparse AS sys.BIT) AS is_sparse
+  , CAST(out_is_column_set AS sys.BIT) AS is_column_set
+  , CAST(out_generated_always_type AS TINYINT) AS generated_always_type
+  , CAST(out_generated_always_type_desc AS NVARCHAR(60)) AS generated_always_type_desc
+  , CAST(out_encryption_type AS INT) AS encryption_type
+  , CAST(out_encryption_type_desc AS NVARCHAR(60)) AS encryption_type_desc
+  , CAST(out_encryption_algorithm_name AS SYSNAME) AS encryption_algorithm_name
+  , CAST(out_column_encryption_key_id AS INT) column_encryption_key_id
+  , CAST(out_column_encryption_key_database_name AS SYSNAME) AS column_encryption_key_database_name
+  , CAST(out_is_hidden AS sys.BIT) AS is_hidden
+  , CAST(out_is_masked AS sys.BIT) AS is_masked
+  , CAST(sys.ident_seed(OBJECT_NAME(sc.out_object_id)) AS SQL_VARIANT) AS seed_value
+  , CAST(sys.ident_incr(OBJECT_NAME(sc.out_object_id)) AS SQL_VARIANT) AS increment_value
+  , CAST(sys.babelfish_get_sequence_value(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname)) AS SQL_VARIANT) AS last_value
+  , CAST(0 as sys.BIT) as is_not_for_replication
+FROM sys.columns_internal() sc
+INNER JOIN pg_attribute a ON a.attrelid = sc.out_object_id AND sc.out_column_id = a.attnum
+INNER JOIN pg_class c ON c.oid = a.attrelid
+INNER JOIN sys.pg_namespace_ext ext ON ext.oid = c.relnamespace
+WHERE NOT a.attisdropped
+AND sc.out_is_identity::INTEGER = 1
+AND pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname) IS NOT NULL
+AND has_sequence_privilege(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname), 'USAGE,SELECT,UPDATE');
+GRANT SELECT ON sys.identity_columns TO PUBLIC;
+
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();
 

--- a/test/JDBC/expected/sys-identity_columns-dep-vu-cleanup.out
+++ b/test/JDBC/expected/sys-identity_columns-dep-vu-cleanup.out
@@ -3,6 +3,9 @@ go
 
 DROP DATABASE sys_identity_columns_dep_vu_prepare_db1
 DROP PROCEDURE sys_identity_columns_dep_vu_prepare_p1
+DROP PROCEDURE sys_identity_columns_dep_vu_prepare_p2
 DROP FUNCTION sys_identity_columns_dep_vu_prepare_f1
+DROP FUNCTION sys_identity_columns_dep_vu_prepare_f2
 DROP TABLE sys_identity_columns_dep_vu_prepare
+DROP TABLE sys_identity_columns_dep_vu_prepare2
 go

--- a/test/JDBC/expected/sys-identity_columns-dep-vu-prepare.out
+++ b/test/JDBC/expected/sys-identity_columns-dep-vu-prepare.out
@@ -4,11 +4,19 @@ go
 CREATE TABLE sys_identity_columns_dep_vu_prepare (c1 int, c3 int IDENTITY(1,1))
 go
 
+-- table with different name having same columns name and position
+CREATE TABLE sys_identity_columns_dep_vu_prepare2 (c1 int, c3 int IDENTITY(1,1))
+go
+
 CREATE DATABASE sys_identity_columns_dep_vu_prepare_db1
 go
 
 CREATE PROCEDURE sys_identity_columns_dep_vu_prepare_p1 AS
     SELECT seed_value, increment_value, last_value FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare')
+go
+
+CREATE PROCEDURE sys_identity_columns_dep_vu_prepare_p2 AS
+    SELECT seed_value, increment_value, last_value FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare2')
 go
 
 CREATE FUNCTION sys_identity_columns_dep_vu_prepare_f1()
@@ -19,9 +27,21 @@ BEGIN
 END
 go
 
+CREATE FUNCTION sys_identity_columns_dep_vu_prepare_f2()
+RETURNS INT 
+AS
+BEGIN 
+    RETURN (SELECT COUNT(*) FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare2'))
+END
+go
+
 USE sys_identity_columns_dep_vu_prepare_db1
 go
 
 CREATE VIEW sys_identity_columns_dep_vu_prepare_v1 AS
     SELECT COUNT(*) FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare')
+go
+
+CREATE VIEW sys_identity_columns_dep_vu_prepare_v2 AS
+    SELECT COUNT(*) FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare2')
 go

--- a/test/JDBC/expected/sys-identity_columns-dep-vu-verify.out
+++ b/test/JDBC/expected/sys-identity_columns-dep-vu-verify.out
@@ -1,7 +1,16 @@
 USE master
 go
 
+-- should give single row as output
 EXEC sys_identity_columns_dep_vu_prepare_p1
+go
+~~START~~
+sql_variant#!#sql_variant#!#sql_variant
+1#!#1#!#1
+~~END~~
+
+
+EXEC sys_identity_columns_dep_vu_prepare_p2
 go
 ~~START~~
 sql_variant#!#sql_variant#!#sql_variant
@@ -17,11 +26,27 @@ int
 ~~END~~
 
 
+SELECT * FROM sys_identity_columns_dep_vu_prepare_f2()
+go
+~~START~~
+int
+1
+~~END~~
+
+
 USE sys_identity_columns_dep_vu_prepare_db1
 go
 
 -- should not be visible here
 SELECT * FROM sys_identity_columns_dep_vu_prepare_v1
+go
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT * FROM sys_identity_columns_dep_vu_prepare_v2
 go
 ~~START~~
 int

--- a/test/JDBC/input/views/sys-identity_columns-dep-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys-identity_columns-dep-vu-cleanup.sql
@@ -3,6 +3,9 @@ go
 
 DROP DATABASE sys_identity_columns_dep_vu_prepare_db1
 DROP PROCEDURE sys_identity_columns_dep_vu_prepare_p1
+DROP PROCEDURE sys_identity_columns_dep_vu_prepare_p2
 DROP FUNCTION sys_identity_columns_dep_vu_prepare_f1
+DROP FUNCTION sys_identity_columns_dep_vu_prepare_f2
 DROP TABLE sys_identity_columns_dep_vu_prepare
+DROP TABLE sys_identity_columns_dep_vu_prepare2
 go

--- a/test/JDBC/input/views/sys-identity_columns-dep-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-identity_columns-dep-vu-prepare.sql
@@ -4,11 +4,19 @@ go
 CREATE TABLE sys_identity_columns_dep_vu_prepare (c1 int, c3 int IDENTITY(1,1))
 go
 
+-- table with different name having same columns name and position
+CREATE TABLE sys_identity_columns_dep_vu_prepare2 (c1 int, c3 int IDENTITY(1,1))
+go
+
 CREATE DATABASE sys_identity_columns_dep_vu_prepare_db1
 go
 
 CREATE PROCEDURE sys_identity_columns_dep_vu_prepare_p1 AS
     SELECT seed_value, increment_value, last_value FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare')
+go
+
+CREATE PROCEDURE sys_identity_columns_dep_vu_prepare_p2 AS
+    SELECT seed_value, increment_value, last_value FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare2')
 go
 
 CREATE FUNCTION sys_identity_columns_dep_vu_prepare_f1()
@@ -19,9 +27,21 @@ BEGIN
 END
 go
 
+CREATE FUNCTION sys_identity_columns_dep_vu_prepare_f2()
+RETURNS INT 
+AS
+BEGIN 
+    RETURN (SELECT COUNT(*) FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare2'))
+END
+go
+
 USE sys_identity_columns_dep_vu_prepare_db1
 go
 
 CREATE VIEW sys_identity_columns_dep_vu_prepare_v1 AS
     SELECT COUNT(*) FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare')
+go
+
+CREATE VIEW sys_identity_columns_dep_vu_prepare_v2 AS
+    SELECT COUNT(*) FROM sys.identity_columns WHERE object_id = object_id('sys_identity_columns_dep_vu_prepare2')
 go

--- a/test/JDBC/input/views/sys-identity_columns-dep-vu-verify.sql
+++ b/test/JDBC/input/views/sys-identity_columns-dep-vu-verify.sql
@@ -1,10 +1,17 @@
 USE master
 go
 
+-- should give single row as output
 EXEC sys_identity_columns_dep_vu_prepare_p1
 go
 
+EXEC sys_identity_columns_dep_vu_prepare_p2
+go
+
 SELECT * FROM sys_identity_columns_dep_vu_prepare_f1()
+go
+
+SELECT * FROM sys_identity_columns_dep_vu_prepare_f2()
 go
 
 USE sys_identity_columns_dep_vu_prepare_db1
@@ -12,4 +19,7 @@ go
 
 -- should not be visible here
 SELECT * FROM sys_identity_columns_dep_vu_prepare_v1
+go
+
+SELECT * FROM sys_identity_columns_dep_vu_prepare_v2
 go

--- a/test/python/expected/pyodbc/ddl_triggers.out
+++ b/test/python/expected/pyodbc/ddl_triggers.out
@@ -2,7 +2,6 @@ SET ANSI_NULLS ON
 SET QUOTED_IDENTIFIER ON
 CREATE TABLE [dbo].[babel_1654_vu_prepare_employeedata](
 	[id] [int] IDENTITY(1,1) NOT NULL,
-	[id] [int] IDENTITY(1,1) NOT NULL,
 	[emp_first_name] [varchar](50) NULL,
 	[emp_last_name] [varchar](50) NULL,
 	[emp_salary] [int] NULL,
@@ -23,7 +22,6 @@ GO
 SET ANSI_NULLS ON
 SET QUOTED_IDENTIFIER ON
 CREATE TABLE [dbo].[babel_1654_vu_prepare_t](
-	[id] [int] IDENTITY(1,1) NOT NULL,
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[a] [varchar](50) NULL,
 	[b] [varchar](50) NULL,


### PR DESCRIPTION
### Description
The sys.identity_columns view was previously returning multiple rows for a identify column of table if there were other tables with identity columns having the same column name and column ordinal position. It was due missing table's object ID filter when joining sys.columns_internal() and pg_attribute within the view definition.

This commit addresses the issue by introducing a restriction on the table's object ID in the join condition, ensuring that the view returns only one row for each identity column within a table.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/40d057c02687ad6afd7670a23e12c85c8dc05789

### Issues Resolved

Task: BABEL-5254

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** Yes


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).