### PR TITLE
Fix dangling file storage when aborting a transaction with a temp table.

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -44,5 +44,5 @@ void		pltsql_revert_guc(int nest_level);
 
 extern int	pltsql_new_scope_identity_nest_level(void);
 extern void pltsql_revert_last_scope_identity(int nest_level);
-extern void pltsql_remove_current_query_env(void);
+extern void pltsql_remove_current_query_env(bool is_abort);
 #endif

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1686,14 +1686,14 @@ execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockArgs *args, 
 	PG_CATCH();
 	{
 		/* Delete temporary tables as ENR */
-		pltsql_remove_current_query_env();
+		pltsql_remove_current_query_env(true);
 
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
 	/* Delete temporary tables as ENR */
-	pltsql_remove_current_query_env();
+	pltsql_remove_current_query_env(false);
 
 	after_lxid = MyProc->lxid;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -30,6 +30,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_default_acl.h"
 #include "catalog/pg_shdepend.h"
+#include "catalog/storage.h"
 #include "commands/createas.h"
 #include "commands/dbcommands.h"
 #include "commands/defrem.h"
@@ -5224,7 +5225,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 
 		func->cur_estate = save_cur_estate;
 
-		pltsql_remove_current_query_env();
+		pltsql_remove_current_query_env(send_error);
 		pltsql_revert_guc(save_nestlevel);
 		pltsql_revert_last_scope_identity(scope_level);
 	}
@@ -6498,7 +6499,7 @@ set_current_query_is_create_tbl_check_constraint(Node *expr)
 }
 
 void
-pltsql_remove_current_query_env(void)
+pltsql_remove_current_query_env(bool is_abort)
 {
 	bool old_abort_curr_txn = AbortCurTransaction;
 
@@ -6508,6 +6509,8 @@ pltsql_remove_current_query_env(void)
 		AbortCurTransaction = false;
 
 		ENRDropTempTables(currentQueryEnv);
+		if (is_abort)
+			smgrDoPendingDeletes(!old_abort_curr_txn);
 	}
 	PG_FINALLY();
 	{

--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -12,3 +12,6 @@ GO
 
 DROP PROCEDURE tv_base_rollback
 GO
+
+DROP PROCEDURE tv_tt_no_error
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -64,3 +64,13 @@ BEGIN
     INSERT INTO @tv VALUES (1)
 END
 GO
+
+CREATE PROCEDURE tv_tt_no_error AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    CREATE TABLE #t1 (a int)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO #t1 VALUES (1)
+END
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -859,6 +859,75 @@ int
 ~~END~~
 
 
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+CREATE TABLE #outer_table (a int)
+INSERT INTO #outer_table VALUES (1)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * FROM #outer_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#outer_table" does not exist)~~
+
+
 DROP TABLE temp_tab_rollback_mytab
 GO
 

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -67,6 +67,16 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE tv_tt_no_error AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    CREATE TABLE #t1 (a int)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO #t1 VALUES (1)
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -927,6 +937,75 @@ int
 ~~END~~
 
 
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+CREATE TABLE #outer_table (a int)
+INSERT INTO #outer_table VALUES (1)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * FROM #outer_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#outer_table" does not exist)~~
+
+
 DROP TABLE temp_tab_rollback_mytab
 GO
 
@@ -1397,4 +1476,7 @@ DROP PROCEDURE implicit_rollback_in_proc
 GO
 
 DROP PROCEDURE tv_base_rollback
+GO
+
+DROP PROCEDURE tv_tt_no_error
 GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -67,6 +67,16 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE tv_tt_no_error AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    CREATE TABLE #t1 (a int)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO #t1 VALUES (1)
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -927,6 +937,75 @@ int
 ~~END~~
 
 
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+CREATE TABLE #outer_table (a int)
+INSERT INTO #outer_table VALUES (1)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * FROM #outer_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#outer_table" does not exist)~~
+
+
 DROP TABLE temp_tab_rollback_mytab
 GO
 
@@ -1397,4 +1476,7 @@ DROP PROCEDURE implicit_rollback_in_proc
 GO
 
 DROP PROCEDURE tv_base_rollback
+GO
+
+DROP PROCEDURE tv_tt_no_error
 GO

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -67,6 +67,16 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE tv_tt_no_error AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    CREATE TABLE #t1 (a int)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO #t1 VALUES (1)
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -928,6 +938,75 @@ int
 ~~END~~
 
 
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+CREATE TABLE #outer_table (a int)
+INSERT INTO #outer_table VALUES (1)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+1
+~~END~~
+
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+~~START~~
+int
+~~END~~
+
+
+SELECT * FROM #outer_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#outer_table" does not exist)~~
+
+
 DROP TABLE temp_tab_rollback_mytab
 GO
 
@@ -1398,4 +1477,7 @@ DROP PROCEDURE implicit_rollback_in_proc
 GO
 
 DROP PROCEDURE tv_base_rollback
+GO
+
+DROP PROCEDURE tv_tt_no_error
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -12,3 +12,6 @@ GO
 
 DROP PROCEDURE tv_base_rollback
 GO
+
+DROP PROCEDURE tv_tt_no_error
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -64,3 +64,13 @@ BEGIN
     INSERT INTO @tv VALUES (1)
 END
 GO
+
+CREATE PROCEDURE tv_tt_no_error AS
+BEGIN
+    DECLARE @tv TABLE (a int)
+    CREATE TABLE #t1 (a int)
+    INSERT INTO temp_tab_rollback_mytab VALUES (1)
+    INSERT INTO @tv VALUES (1)
+    INSERT INTO #t1 VALUES (1)
+END
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -464,6 +464,33 @@ ROLLBACK
 SELECT * FROM temp_tab_rollback_mytab
 GO
 
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+
+BEGIN TRAN
+INSERT INTO temp_tab_rollback_mytab VALUES (2)
+CREATE TABLE #outer_table (a int)
+INSERT INTO #outer_table VALUES (1)
+EXEC tv_tt_no_error
+SELECT * FROM temp_tab_rollback_mytab
+DROP TABLE temp_tab_rollback_mytab
+ROLLBACK
+GO
+
+SELECT * FROM temp_tab_rollback_mytab
+GO
+
+SELECT * FROM #outer_table
+GO
+
 DROP TABLE temp_tab_rollback_mytab
 GO
 


### PR DESCRIPTION
### Description

There were some cases when a transaction or procedure was aborted, and 
the transaction/procedure created a temp table, where the physical on-disk file 
associated with the temp table was not properly being deleted. This commit fixes the
behavior by triggering a manual call to smgrDoPendingDeletes() (with the
appropriate isCommit flag) when necessary during transaction aborts.

### Issues Resolved

BABEL-4751

### Test Scenarios Covered ###
* **Use case based -**
The issue is due to orphaned files, so it cannot be tested through SQL tests. Instead, these changes were manually verified by running tests which previously would leave orphaned files on disk, and verified that after these changes there are no longer orphaned files left on disk. There are also some additional tests where temp and permanent tables are both used within an aborted transaction to confirm that this change does not cause regressions for those use cases.

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).