### PR TITLE
[OSS-ONLY] Fix build failure due to deprecated artifact version

### DIFF
--- a/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
+++ b/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
@@ -83,7 +83,7 @@ jobs:
       
       - name: Upload Output Diff
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: output-diff.diff
           path: test/JDBC/Info/output-diff.diff

--- a/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
+++ b/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: postgres-log
           path: ~/postgres/data/logfile
@@ -76,7 +76,7 @@ jobs:
       
       - name: Upload Run Summary 
         if: always() && steps.test-file-rename == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: run-summary.log
           path: test/JDBC/Info/run-summary.log

--- a/.github/workflows/jdbc-tests-with-parallel-query.yml
+++ b/.github/workflows/jdbc-tests-with-parallel-query.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: postgres-log
           path: ~/psql/data/logfile
@@ -73,14 +73,14 @@ jobs:
       
       - name: Upload Run Summary 
         if: always() && steps.test-file-rename == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: run-summary.log
           path: test/JDBC/Info/run-summary.log
       
       - name: Upload Output Diff
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: output-diff.diff
           path: test/JDBC/Info/output-diff.diff

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: postgres-log
           path: ~/postgres/data/logfile
@@ -67,14 +67,14 @@ jobs:
       
       - name: Upload Run Summary 
         if: always() && steps.test-file-rename == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: run-summary.log
           path: test/JDBC/Info/run-summary.log
       
       - name: Upload Output Diff
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: output-diff.diff
           path: test/JDBC/Info/output-diff.diff

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -136,14 +136,14 @@ jobs:
      
       - name: Upload Postgres log
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: postgres-log
          path: ~/${{env.NEW_INSTALL_DIR}}/data/logfile
 
       - name: Upload upgrade Log
         if: always() && steps.run-pg_upgrade.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-logs
           path: ~/upgrade/*.log
@@ -161,14 +161,14 @@ jobs:
 
       - name: Upload Run Summary
         if: always() && steps.test-file-rename.outcome == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: run-summary.log
           path: test/JDBC/Info/run-summary.log
 
       - name: Upload Output Diff
         if: always() && steps.test-file-rename.outcome == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: output-diff.diff
           path: test/JDBC/Info/output-diff.diff

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: postgres-log
           path: ~/postgres/data/logfile
@@ -92,14 +92,14 @@ jobs:
 
       - name: Upload Run Summary 
         if: always() && steps.test-file-rename == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-run-summary.log
           path: test/JDBC/Info/upgrade-run-summary.log
 
       - name: Upload Output Diff
         if: always() && steps.jdbc.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-output-diff.diff
           path: test/JDBC/Info/upgrade-output-diff.diff

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -46,14 +46,14 @@ jobs:
       
       - name: Upload New Postgres log
         if: always() && steps.upgrade-and-verify.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: postgres-log-new
          path: ~/${{env.NEW_INSTALL_DIR}}/data/logfile
 
       - name: Upload upgrade Log
         if: always() && steps.upgrade-and-verify.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-logs
           path: ~/upgrade/*.log
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload Run Summary
         if: always() && steps.test-file-rename.outcome == 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Test Run Artificats
           path: |

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -20,7 +20,7 @@ jobs:
           python3 sql_validation.py
       - name: Upload artifacts
         if: always() && steps.run-test.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: expected-output-files
           path: test/python/output/sql_validation_framework/*

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload Logs
         if: always() && steps.tap.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tap_tests_logs
           path: contrib/babelfishpg_tds/test/tmp_check/log

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload Log
         if: always() && steps.unit.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: postgres-log
           path: ~/psql/data/logfile

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -124,7 +124,7 @@ jobs:
  
       - name: Upload Logs
         if: always() && steps.upgrade-and-test.outcome != 'success'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-logs-${{ matrix.upgrade-path.title }}
           path: |


### PR DESCRIPTION
### Description

Build is failing due to deprecated artifact version for actions/upload-artifact in the workflows.

((https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/))


Authored-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).