### PR TITLE
fix valgrind crashes in alter function

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2356,11 +2356,13 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					bool				isSameProc;
 					ObjectAddress 		address;
 					CreateFunctionStmt	*cfs;
-					ListCell 			*option, *location_cell = NULL, *return_cell = NULL;
+					ListCell 			*option;
 					int 				origname_location = -1;
 					ListCell            *parameter;
 
 					cfs = makeNode(CreateFunctionStmt);
+					cfs->returnType = NULL;
+					cfs->is_procedure = true;
 
 					if (!IS_TDS_CLIENT())
 					{
@@ -2394,32 +2396,17 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								* name from queryString.
 								*/
 								origname_location = intVal((Node *) defel->arg);
-								location_cell = option;
+								stmt->actions = foreach_delete_current(stmt->actions, option);
 								pfree(defel);
 							}
 							else if (strcmp(defel->defname, "return") == 0)
 							{
 								cfs->returnType = (TypeName *) defel->arg;
-								return_cell = option;
+								cfs->is_procedure = false;
+								stmt->actions = foreach_delete_current(stmt->actions, option);
 								pfree(defel);
 								stmt->objtype = OBJECT_FUNCTION;
 							}
-						}
-
-						/* delete location cell if it exists as it is for internal use only */
-						if (location_cell)
-							stmt->actions = list_delete_cell(stmt->actions, location_cell);
-
-						if (return_cell) 
-						{
-							if(location_cell)
-								return_cell -= 1;
-							stmt->actions = list_delete_cell(stmt->actions, return_cell);
-							cfs->is_procedure = false;
-						} else 
-						{
-							cfs->returnType = NULL;
-							cfs->is_procedure = true;
 						}
 
 						/* make a CreateFunctionStmt to pass into CreateFunction() */

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2113,7 +2113,7 @@ sp_addrole(PG_FUNCTION_ARGS)
 
 		/* Remove trailing whitespaces */
 		len = strlen(lowercase_rolname);
-		while (isspace(lowercase_rolname[len - 1]))
+		while (len > 0 && isspace(lowercase_rolname[len - 1]))
 			lowercase_rolname[--len] = 0;
 
 		/* check if role name is empty after removing trailing spaces */
@@ -2146,7 +2146,7 @@ sp_addrole(PG_FUNCTION_ARGS)
 
 		/* Remove trailing whitespaces */
 		len = strlen(rolname);
-		while (isspace(rolname[len - 1]))
+		while (len > 0 && isspace(rolname[len - 1]))
 			rolname[--len] = 0;
 
 		/* Advance cmd counter to make the delete visible */
@@ -2269,7 +2269,7 @@ sp_droprole(PG_FUNCTION_ARGS)
 
 		/* Remove trailing whitespaces */
 		len = strlen(lowercase_rolname);
-		while (isspace(lowercase_rolname[len - 1]))
+		while (len > 0 && isspace(lowercase_rolname[len - 1]))
 			lowercase_rolname[--len] = 0;
 
 		/* check if role name is empty after removing trailing spaces */


### PR DESCRIPTION
### Description

Root cause - References to list cell become invalid after calls to list_delete_cell().
In alter function statement we were referencing the `return_cell` across call to list_delete_cell(). list_delete_cell() completely copies a list to new location when VALGRIND is enabled which meant that `return_cell` was no longer valid.
As a fix we use `foreach_delete_current` to delete the defelem inside the foreach loop and skip maintaining a list cell pointer altogether.

### Issues Resolved

[BABEL-5249]

### Test Scenarios Covered

These tests runs clean with valgrind now

alter-function-schema
alter-procedure-vu-prepare
alter-procedure-vu-verify
alter-procedure-vu-cleanup

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).