### PR TITLE
Fixed issue in SP_TABLES() when @table_name parameter has square brackets around underscore

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -952,8 +952,8 @@ BEGIN
 		AND (@table_qualifier IS NULL OR table_qualifier LIKE @table_qualifier collate database_default)
 		AND (
 			@table_type IS NULL OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
+			(CAST(@table_type AS varchar(100)) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
 		)
 		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
 	ELSE
@@ -969,8 +969,8 @@ BEGIN
 		AND (@table_qualifier IS NULL OR table_qualifier = @table_qualifier collate database_default)
 		AND (
 			@table_type IS NULL OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
+			(CAST(@table_type AS varchar(100)) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
 		)
 		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
 END;

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -945,7 +945,7 @@ BEGIN
 			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
 			CAST(table_name AS sys.sysname) AS TABLE_NAME,
 			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
-			CAST(remarks AS sys.varchar(254)) AS REMARKS
+			remarks AS REMARKS
 		FROM sys.sp_tables_view 
 		WHERE (@table_name IS NULL OR table_name LIKE @table_name collate database_default)
 		AND (@table_owner IS NULL OR table_owner LIKE @table_owner collate database_default)
@@ -962,7 +962,7 @@ BEGIN
 			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
 			CAST(table_name AS sys.sysname) AS TABLE_NAME,
 			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
-			CAST(remarks AS sys.varchar(254)) AS REMARKS
+			remarks AS REMARKS
 		FROM sys.sp_tables_view
 		WHERE (@table_name IS NULL OR table_name = @table_name collate database_default)
 		AND (@table_owner IS NULL OR table_owner = @table_owner collate database_default)

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -911,63 +911,6 @@ AND has_schema_privilege(t1.relnamespace, 'USAGE')
 AND has_table_privilege(t1.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
 GRANT SELECT ON sys.sp_tables_view TO PUBLIC;
 
-CREATE OR REPLACE FUNCTION sys.sp_tables_internal(
-	in_table_name sys.nvarchar(384) = NULL,
-	in_table_owner sys.nvarchar(384) = NULL, 
-	in_table_qualifier sys.sysname = NULL,
-	in_table_type sys.varchar(100) = NULL,
-	in_fusepattern sys.bit = '1')
-	RETURNS TABLE (
-		out_table_qualifier sys.sysname,
-		out_table_owner sys.sysname,
-		out_table_name sys.sysname,
-		out_table_type sys.varchar(32),
-		out_remarks sys.varchar(254)
-	)
-	AS $$
-		DECLARE opt_table sys.varchar(16) = '';
-		DECLARE opt_view sys.varchar(16) = '';
-		DECLARE cs_as_in_table_type varchar COLLATE "C" = in_table_type;
-	BEGIN
-		IF upper(cs_as_in_table_type) LIKE '%''TABLE''%' THEN
-			opt_table = 'TABLE';
-		END IF;
-		IF upper(cs_as_in_table_type) LIKE '%''VIEW''%' THEN
-			opt_view = 'VIEW';
-		END IF;
-		IF in_fusepattern = 1 THEN
-			RETURN query
-			SELECT 
-			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
-			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
-			CAST(table_name AS sys.sysname) AS TABLE_NAME,
-			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
-			CAST(remarks AS sys.varchar(254)) AS REMARKS
-			FROM sys.sp_tables_view
-			WHERE (in_table_name IS NULL OR table_name LIKE in_table_name collate sys.database_default)
-			AND (in_table_owner IS NULL OR table_owner LIKE in_table_owner collate sys.database_default)
-			AND (in_table_qualifier IS NULL OR table_qualifier LIKE in_table_qualifier collate sys.database_default)
-			AND (cs_as_in_table_type IS NULL OR table_type = opt_table OR table_type = opt_view)
-			ORDER BY table_qualifier, table_owner, table_name;
-		ELSE 
-			RETURN query
-			SELECT 
-			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
-			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
-			CAST(table_name AS sys.sysname) AS TABLE_NAME,
-			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
-			CAST(remarks AS sys.varchar(254)) AS REMARKS
-			FROM sys.sp_tables_view
-			WHERE (in_table_name IS NULL OR table_name = in_table_name collate sys.database_default)
-			AND (in_table_owner IS NULL OR table_owner = in_table_owner collate sys.database_default)
-			AND (in_table_qualifier IS NULL OR table_qualifier = in_table_qualifier collate sys.database_default)
-			AND (cs_as_in_table_type IS NULL OR table_type = opt_table OR table_type = opt_view)
-			ORDER BY table_qualifier, table_owner, table_name;
-		END IF;
-	END;
-$$
-LANGUAGE plpgsql STABLE;
-
 CREATE OR REPLACE PROCEDURE sys.sp_tables (
     "@table_name" sys.nvarchar(384) = NULL,
     "@table_owner" sys.nvarchar(384) = NULL, 
@@ -996,13 +939,40 @@ BEGIN
 		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
 	END
 	
-	SELECT
-	CAST(out_table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
-	CAST(out_table_owner AS sys.sysname) AS TABLE_OWNER,
-	CAST(out_table_name AS sys.sysname) AS TABLE_NAME,
-	CAST(out_table_type AS sys.varchar(32)) AS TABLE_TYPE,
-	CAST(out_remarks AS sys.varchar(254)) AS REMARKS
-	FROM sys.sp_tables_internal(@table_name, @table_owner, @table_qualifier, CAST(@table_type AS varchar(100)), @fusepattern);
+	IF (@fusepattern = 1)
+		SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(remarks AS sys.varchar(254)) AS REMARKS
+		FROM sys.sp_tables_view 
+		WHERE (@table_name IS NULL OR table_name LIKE @table_name collate database_default)
+		AND (@table_owner IS NULL OR table_owner LIKE @table_owner collate database_default)
+		AND (@table_qualifier IS NULL OR table_qualifier LIKE @table_qualifier collate database_default)
+		AND (
+			@table_type IS NULL OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
+		)
+		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
+	ELSE
+		SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(remarks AS sys.varchar(254)) AS REMARKS
+		FROM sys.sp_tables_view
+		WHERE (@table_name IS NULL OR table_name = @table_name collate database_default)
+		AND (@table_owner IS NULL OR table_owner = @table_owner collate database_default)
+		AND (@table_qualifier IS NULL OR table_qualifier = @table_qualifier collate database_default)
+		AND (
+			@table_type IS NULL OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
+		)
+		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
 END;
 $$
 LANGUAGE 'pltsql';

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -4,6 +4,33 @@
 -- add 'sys' to search path for the convenience
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
 
+-- Drops an object if it does not have any dependent objects.
+-- Is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
+-- Please have this be one of the first statements executed in this upgrade script. 
+CREATE OR REPLACE PROCEDURE babelfish_drop_deprecated_object(object_type varchar, schema_name varchar, object_name varchar) AS
+$$
+DECLARE
+    error_msg text;
+    query1 text;
+    query2 text;
+BEGIN
+
+    query1 := pg_catalog.format('alter extension babelfishpg_tsql drop %s %s.%s', object_type, schema_name, object_name);
+    query2 := pg_catalog.format('drop %s %s.%s', object_type, schema_name, object_name);
+
+    execute query1;
+    execute query2;
+EXCEPTION
+    when object_not_in_prerequisite_state then --if 'alter extension' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+    when dependent_objects_still_exist then --if 'drop view' statement fails
+        GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;
+        raise warning '%', error_msg;
+end
+$$
+LANGUAGE plpgsql;
+
 -- Please add your SQLs here
 /*
  * Note: These SQL statements may get executed multiple times specially when some features get backpatched.
@@ -1723,6 +1750,81 @@ AND sc.out_is_identity::INTEGER = 1
 AND pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname) IS NOT NULL
 AND has_sequence_privilege(pg_get_serial_sequence(quote_ident(ext.nspname)||'.'||quote_ident(c.relname), a.attname), 'USAGE,SELECT,UPDATE');
 GRANT SELECT ON sys.identity_columns TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_tables (
+    "@table_name" sys.nvarchar(384) = NULL,
+    "@table_owner" sys.nvarchar(384) = NULL, 
+    "@table_qualifier" sys.sysname = NULL,
+    "@table_type" sys.nvarchar(100) = NULL,
+    "@fusepattern" sys.bit = '1')
+AS $$
+BEGIN
+
+	-- Handle special case: Enumerate all databases when name and owner are blank but qualifier is '%'
+	IF (@table_qualifier = '%' AND @table_owner = '' AND @table_name = '')
+	BEGIN
+		SELECT
+			d.name AS TABLE_QUALIFIER,
+			CAST(NULL AS sys.sysname) AS TABLE_OWNER,
+			CAST(NULL AS sys.sysname) AS TABLE_NAME,
+			CAST(NULL AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(NULL AS sys.varchar(254)) AS REMARKS
+		FROM sys.databases d ORDER BY TABLE_QUALIFIER;
+		
+		RETURN;
+	END;
+
+	IF (@table_qualifier != '' AND LOWER(@table_qualifier) != LOWER(sys.db_name()))
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+	END
+	
+	IF (@fusepattern = 1)
+		SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(remarks AS sys.varchar(254)) AS REMARKS
+		FROM sys.sp_tables_view 
+		WHERE (@table_name IS NULL OR table_name LIKE @table_name collate database_default)
+		AND (@table_owner IS NULL OR table_owner LIKE @table_owner collate database_default)
+		AND (@table_qualifier IS NULL OR table_qualifier LIKE @table_qualifier collate database_default)
+		AND (
+			@table_type IS NULL OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE') OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW')
+		)
+		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
+	ELSE
+		SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(remarks AS sys.varchar(254)) AS REMARKS
+		FROM sys.sp_tables_view
+		WHERE (@table_name IS NULL OR table_name = @table_name collate database_default)
+		AND (@table_owner IS NULL OR table_owner = @table_owner collate database_default)
+		AND (@table_qualifier IS NULL OR table_qualifier = @table_qualifier collate database_default)
+		AND (
+			@table_type IS NULL OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE') OR 
+			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW')
+		)
+		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_tables TO PUBLIC;
+
+ALTER FUNCTION sys.sp_tables_internal RENAME TO sp_tables_internal_deprecated_in_4_3_0;
+
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'sp_tables_internal_deprecated_in_4_3_0');
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
 
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -1792,8 +1792,8 @@ BEGIN
 		AND (@table_qualifier IS NULL OR table_qualifier LIKE @table_qualifier collate database_default)
 		AND (
 			@table_type IS NULL OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE') OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW')
+			(CAST(@table_type AS varchar(100)) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
 		)
 		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
 	ELSE
@@ -1809,8 +1809,8 @@ BEGIN
 		AND (@table_qualifier IS NULL OR table_qualifier = @table_qualifier collate database_default)
 		AND (
 			@table_type IS NULL OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE') OR 
-			(upper(CAST(@table_type AS varchar(100))) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW')
+			(CAST(@table_type AS varchar(100)) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
 		)
 		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
 END;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -1818,9 +1818,9 @@ $$
 LANGUAGE 'pltsql';
 GRANT EXECUTE ON PROCEDURE sys.sp_tables TO PUBLIC;
 
-ALTER FUNCTION sys.sp_tables_internal RENAME TO sp_tables_internal_deprecated_in_4_3_0;
+ALTER FUNCTION sys.sp_tables_internal RENAME TO sp_tables_internal_deprecated_in_4_4_0;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'sp_tables_internal_deprecated_in_4_3_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'sp_tables_internal_deprecated_in_4_4_0');
 
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -1785,7 +1785,7 @@ BEGIN
 			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
 			CAST(table_name AS sys.sysname) AS TABLE_NAME,
 			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
-			CAST(remarks AS sys.varchar(254)) AS REMARKS
+			remarks AS REMARKS
 		FROM sys.sp_tables_view 
 		WHERE (@table_name IS NULL OR table_name LIKE @table_name collate database_default)
 		AND (@table_owner IS NULL OR table_owner LIKE @table_owner collate database_default)
@@ -1802,7 +1802,7 @@ BEGIN
 			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
 			CAST(table_name AS sys.sysname) AS TABLE_NAME,
 			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
-			CAST(remarks AS sys.varchar(254)) AS REMARKS
+			remarks AS REMARKS
 		FROM sys.sp_tables_view
 		WHERE (@table_name IS NULL OR table_name = @table_name collate database_default)
 		AND (@table_owner IS NULL OR table_owner = @table_owner collate database_default)

--- a/test/JDBC/expected/BABEL-SP_TABLES-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES-vu-cleanup.out
@@ -5,6 +5,12 @@ drop view babel_sp_tables_vu_prepare_t_sptables5
 go
 drop table babel_sp_tables_vu_prepare_t_sptables
 go
+drop table babel_sp_tables_vu_prepare_t_s_tables2
+go
+drop table babel_sp_tables_vu_prepare_t__tables2
+go
+drop table babel_sp_tables_vu_prepare_test_escape_chars_sp_tables
+go
 drop table babel_sp_tables_vu_prepare_MyTable1
 go
 drop table [babel_sp_tables_vu_prepare_MyTable2]

--- a/test/JDBC/expected/BABEL-SP_TABLES-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES-vu-prepare.out
@@ -10,6 +10,12 @@ create table babel_sp_tables_vu_prepare_t_sptables2(b int)
 go
 create table babel_sp_tables_vu_prepare_t_sotables2(c int)
 go
+create table babel_sp_tables_vu_prepare_t_s_tables2(c int)
+go
+create table babel_sp_tables_vu_prepare_t__tables2(c int)
+go
+create table babel_sp_tables_vu_prepare_test_escape_chars_sp_tables(c int)
+go
 create table babel_sp_tables_vu_prepare_MyTable1 (a int, b int, c int)
 go
 create table [babel_sp_tables_vu_prepare_MyTable2] ([a] int, [b] int, [c] int)

--- a/test/JDBC/expected/BABEL-SP_TABLES-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES-vu-verify.out
@@ -190,11 +190,13 @@ babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#
 ~~END~~
 
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
+-- NOTE: Incorrect output with [] wildcards, see BABEL-2452 -- Fixed in BABEL-4128
 exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[op]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sotables2#!#TABLE#!#<NULL>
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -202,6 +204,7 @@ exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[^o]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -209,6 +212,40 @@ exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[o-p]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sotables2#!#TABLE#!#<NULL>
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sotables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sotables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables5', @table_type = "'VIEW'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables5#!#VIEW#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_TABLES-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES-vu-verify.out
@@ -185,6 +185,7 @@ exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s_tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
 babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sotables2#!#TABLE#!#<NULL>
 babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
@@ -204,6 +205,7 @@ exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[^o]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
 babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
@@ -246,6 +248,66 @@ go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]s[_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_][_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t__tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[__]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[[_]]sptables', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test\_escape_chars\_sp_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test\_escape\_chars\_sp\_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test_escape_chars_sp_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_test_escape_chars_sp_tables#!#TABLE#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_TABLES-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES-vu-verify.out
@@ -311,6 +311,31 @@ babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_test_escape_ch
 ~~END~~
 
 
+-- table type with mixed case
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'Table'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'tAbLe'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'table'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+babel_sp_tables_vu_prepare_db1#!#dbo#!#babel_sp_tables_vu_prepare_t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
 -- unnamed invocation
 exec sp_tables 'babel_sp_tables_vu_prepare_t_sptables', 'dbo', 'babel_sp_tables_vu_prepare_db1'
 go

--- a/test/JDBC/expected/BABEL-SP_TABLES.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES.out
@@ -10,6 +10,12 @@ create table t_sptables2(b int)
 go
 create table t_sotables2(c int)
 go
+create table t_s_tables2(c int)
+go
+create table t__tables2(c int)
+go
+create table test_escape_chars_sp_tables(c int)
+go
 create table MyTable1 (a int, b int, c int)
 go
 create table [MyTable2] ([a] int, [b] int, [c] int)
@@ -203,6 +209,7 @@ exec sp_tables @table_name = 't_s_tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
 db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
 db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
@@ -222,6 +229,7 @@ exec sp_tables @table_name = 't_s[^o]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
 db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
@@ -264,6 +272,66 @@ go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]s[_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_][_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t__tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[__]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 't[[_]]sptables', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'test\_escape_chars\_sp_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'test\_escape\_chars\_sp\_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'test_escape_chars_sp_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#test_escape_chars_sp_tables#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -414,6 +482,12 @@ go
 drop table t_sptables2
 go
 drop table t_sotables2
+go
+drop table t_s_tables2
+go
+drop table t__tables2
+go
+drop table test_escape_chars_sp_tables
 go
 use master
 go
@@ -435,6 +509,12 @@ create table t_sptables2(b int)
 go
 create table t_sotables2(c int)
 go
+create table t_s_tables2(c int)
+go
+create table t__tables2(c int)
+go
+create table test_escape_chars_sp_tables(c int)
+go
 create table MyTable1 (a int, b int, c int)
 go
 create table [MyTable2] ([a] int, [b] int, [c] int)
@@ -628,6 +708,7 @@ exec sp_tables @table_name = 't_s_tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
 db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
 db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
@@ -647,6 +728,7 @@ exec sp_tables @table_name = 't_s[^o]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
 db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
@@ -689,6 +771,66 @@ go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]s[_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_][_]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t__tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[__]tables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 't[[_]]sptables', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'test\_escape_chars\_sp_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'test\_escape\_chars\_sp\_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+~~END~~
+
+
+exec sp_tables @table_name = 'test_escape_chars_sp_tables', @table_type = "'TABLE'"
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#test_escape_chars_sp_tables#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -839,6 +981,12 @@ go
 drop table t_sptables2
 go
 drop table t_sotables2
+go
+drop table t_s_tables2
+go
+drop table t__tables2
+go
+drop table test_escape_chars_sp_tables
 go
 use master
 go

--- a/test/JDBC/expected/BABEL-SP_TABLES.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES.out
@@ -208,11 +208,13 @@ db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
+-- NOTE: Incorrect output with [] wildcards, see BABEL-2452 -- Fixed in BABEL-4128
 exec sp_tables @table_name = 't_s[op]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -220,6 +222,7 @@ exec sp_tables @table_name = 't_s[^o]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -227,6 +230,40 @@ exec sp_tables @table_name = 't_s[o-p]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sptables', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sptables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sotables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sptables5', @table_type = "'VIEW'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
 ~~END~~
 
 
@@ -596,11 +633,13 @@ db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
+-- NOTE: Incorrect output with [] wildcards, see BABEL-2452 -- Fixed in BABEL-4128
 exec sp_tables @table_name = 't_s[op]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -608,6 +647,7 @@ exec sp_tables @table_name = 't_s[^o]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
 ~~END~~
 
 
@@ -615,6 +655,40 @@ exec sp_tables @table_name = 't_s[o-p]tables2'
 go
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sptables', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sptables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sotables2', @table_type = "'TABLE'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sotables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't[_]sptables5', @table_type = "'VIEW'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_sptables5#!#VIEW#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SP_TABLES.out
+++ b/test/JDBC/expected/BABEL-SP_TABLES.out
@@ -335,6 +335,31 @@ db1#!#dbo#!#test_escape_chars_sp_tables#!#TABLE#!#<NULL>
 ~~END~~
 
 
+-- table type with mixed case
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'Table'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'tAbLe'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'table'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
 -- unnamed invocation
 exec sp_tables 't_sptables', 'dbo', 'db1'
 go
@@ -831,6 +856,31 @@ GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar
 db1#!#dbo#!#test_escape_chars_sp_tables#!#TABLE#!#<NULL>
+~~END~~
+
+
+-- table type with mixed case
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'Table'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'tAbLe'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
+~~END~~
+
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'table'"
+go
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar
+db1#!#dbo#!#t_s_tables2#!#TABLE#!#<NULL>
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-SP_TABLES-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES-vu-cleanup.sql
@@ -5,6 +5,12 @@ drop view babel_sp_tables_vu_prepare_t_sptables5
 go
 drop table babel_sp_tables_vu_prepare_t_sptables
 go
+drop table babel_sp_tables_vu_prepare_t_s_tables2
+go
+drop table babel_sp_tables_vu_prepare_t__tables2
+go
+drop table babel_sp_tables_vu_prepare_test_escape_chars_sp_tables
+go
 drop table babel_sp_tables_vu_prepare_MyTable1
 go
 drop table [babel_sp_tables_vu_prepare_MyTable2]

--- a/test/JDBC/input/BABEL-SP_TABLES-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES-vu-prepare.sql
@@ -10,6 +10,12 @@ create table babel_sp_tables_vu_prepare_t_sptables2(b int)
 go
 create table babel_sp_tables_vu_prepare_t_sotables2(c int)
 go
+create table babel_sp_tables_vu_prepare_t_s_tables2(c int)
+go
+create table babel_sp_tables_vu_prepare_t__tables2(c int)
+go
+create table babel_sp_tables_vu_prepare_test_escape_chars_sp_tables(c int)
+go
 create table babel_sp_tables_vu_prepare_MyTable1 (a int, b int, c int)
 go
 create table [babel_sp_tables_vu_prepare_MyTable2] ([a] int, [b] int, [c] int)

--- a/test/JDBC/input/BABEL-SP_TABLES-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES-vu-verify.sql
@@ -97,6 +97,30 @@ go
 exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables5', @table_type = "'VIEW'"
 go
 
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]s[_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_][_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[__]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[[_]]sptables', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test\_escape_chars\_sp_tables', @table_type = "'TABLE'"
+GO
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test\_escape\_chars\_sp\_tables', @table_type = "'TABLE'"
+GO
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test_escape_chars_sp_tables', @table_type = "'TABLE'"
+GO
+
 -- unnamed invocation
 exec sp_tables 'babel_sp_tables_vu_prepare_t_sptables', 'dbo', 'babel_sp_tables_vu_prepare_db1'
 go

--- a/test/JDBC/input/BABEL-SP_TABLES-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES-vu-verify.sql
@@ -75,7 +75,7 @@ go
 exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s_tables2'
 go
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
+-- NOTE: Incorrect output with [] wildcards, see BABEL-2452 -- Fixed in BABEL-4128
 exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[op]tables2'
 go
 
@@ -83,6 +83,18 @@ exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[^o]tables2'
 go
 
 exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[o-p]tables2'
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sotables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t[_]sptables5', @table_type = "'VIEW'"
 go
 
 -- unnamed invocation

--- a/test/JDBC/input/BABEL-SP_TABLES-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES-vu-verify.sql
@@ -121,6 +121,16 @@ GO
 exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_test_escape_chars_sp_tables', @table_type = "'TABLE'"
 GO
 
+-- table type with mixed case
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'Table'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'tAbLe'"
+go
+
+exec sp_tables @table_name = 'babel_sp_tables_vu_prepare_t_s[_]tables2', @table_type = "'table'"
+go
+
 -- unnamed invocation
 exec sp_tables 'babel_sp_tables_vu_prepare_t_sptables', 'dbo', 'babel_sp_tables_vu_prepare_db1'
 go

--- a/test/JDBC/input/BABEL-SP_TABLES.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES.sql
@@ -10,6 +10,12 @@ create table t_sptables2(b int)
 go
 create table t_sotables2(c int)
 go
+create table t_s_tables2(c int)
+go
+create table t__tables2(c int)
+go
+create table test_escape_chars_sp_tables(c int)
+go
 create table MyTable1 (a int, b int, c int)
 go
 create table [MyTable2] ([a] int, [b] int, [c] int)
@@ -115,6 +121,30 @@ go
 exec sp_tables @table_name = 't[_]sptables5', @table_type = "'VIEW'"
 go
 
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]s[_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_][_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[__]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[[_]]sptables', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'test\_escape_chars\_sp_tables', @table_type = "'TABLE'"
+GO
+
+exec sp_tables @table_name = 'test\_escape\_chars\_sp\_tables', @table_type = "'TABLE'"
+GO
+
+exec sp_tables @table_name = 'test_escape_chars_sp_tables', @table_type = "'TABLE'"
+GO
+
 -- unnamed invocation
 exec sp_tables 't_sptables', 'dbo', 'db1'
 go
@@ -177,6 +207,12 @@ go
 drop table t_sptables2
 go
 drop table t_sotables2
+go
+drop table t_s_tables2
+go
+drop table t__tables2
+go
+drop table test_escape_chars_sp_tables
 go
 use master
 go
@@ -198,6 +234,12 @@ create table t_sptables2(b int)
 go
 create table t_sotables2(c int)
 go
+create table t_s_tables2(c int)
+go
+create table t__tables2(c int)
+go
+create table test_escape_chars_sp_tables(c int)
+go
 create table MyTable1 (a int, b int, c int)
 go
 create table [MyTable2] ([a] int, [b] int, [c] int)
@@ -303,6 +345,30 @@ go
 exec sp_tables @table_name = 't[_]sptables5', @table_type = "'VIEW'"
 go
 
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]s[_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_][_]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[__]tables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[[_]]sptables', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 'test\_escape_chars\_sp_tables', @table_type = "'TABLE'"
+GO
+
+exec sp_tables @table_name = 'test\_escape\_chars\_sp\_tables', @table_type = "'TABLE'"
+GO
+
+exec sp_tables @table_name = 'test_escape_chars_sp_tables', @table_type = "'TABLE'"
+GO
+
 -- unnamed invocation
 exec sp_tables 't_sptables', 'dbo', 'db1'
 go
@@ -365,6 +431,12 @@ go
 drop table t_sptables2
 go
 drop table t_sotables2
+go
+drop table t_s_tables2
+go
+drop table t__tables2
+go
+drop table test_escape_chars_sp_tables
 go
 use master
 go

--- a/test/JDBC/input/BABEL-SP_TABLES.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES.sql
@@ -145,6 +145,16 @@ GO
 exec sp_tables @table_name = 'test_escape_chars_sp_tables', @table_type = "'TABLE'"
 GO
 
+-- table type with mixed case
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'Table'"
+go
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'tAbLe'"
+go
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'table'"
+go
+
 -- unnamed invocation
 exec sp_tables 't_sptables', 'dbo', 'db1'
 go
@@ -368,6 +378,16 @@ GO
 
 exec sp_tables @table_name = 'test_escape_chars_sp_tables', @table_type = "'TABLE'"
 GO
+
+-- table type with mixed case
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'Table'"
+go
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'tAbLe'"
+go
+
+exec sp_tables @table_name = 't_s[_]tables2', @table_type = "'table'"
+go
 
 -- unnamed invocation
 exec sp_tables 't_sptables', 'dbo', 'db1'

--- a/test/JDBC/input/BABEL-SP_TABLES.sql
+++ b/test/JDBC/input/BABEL-SP_TABLES.sql
@@ -93,7 +93,7 @@ go
 exec sp_tables @table_name = 't_s_tables2'
 go
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
+-- NOTE: Incorrect output with [] wildcards, see BABEL-2452 -- Fixed in BABEL-4128
 exec sp_tables @table_name = 't_s[op]tables2'
 go
 
@@ -101,6 +101,18 @@ exec sp_tables @table_name = 't_s[^o]tables2'
 go
 
 exec sp_tables @table_name = 't_s[o-p]tables2'
+go
+
+exec sp_tables @table_name = 't[_]sptables', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]sptables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]sotables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]sptables5', @table_type = "'VIEW'"
 go
 
 -- unnamed invocation
@@ -269,7 +281,7 @@ go
 exec sp_tables @table_name = 't_s_tables2'
 go
 
--- NOTE: Incorrect output with [] wildcards, see BABEL-2452
+-- NOTE: Incorrect output with [] wildcards, see BABEL-2452 -- Fixed in BABEL-4128
 exec sp_tables @table_name = 't_s[op]tables2'
 go
 
@@ -277,6 +289,18 @@ exec sp_tables @table_name = 't_s[^o]tables2'
 go
 
 exec sp_tables @table_name = 't_s[o-p]tables2'
+go
+
+exec sp_tables @table_name = 't[_]sptables', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]sptables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]sotables2', @table_type = "'TABLE'"
+go
+
+exec sp_tables @table_name = 't[_]sptables5', @table_type = "'VIEW'"
 go
 
 -- unnamed invocation

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -42,7 +42,6 @@ Could not find tests for function sys.sp_releaseapplock_function
 Could not find tests for function sys.sp_special_columns_length_helper
 Could not find tests for function sys.sp_special_columns_precision_helper
 Could not find tests for function sys.sp_special_columns_scale_helper
-Could not find tests for function sys.sp_tables_internal
 Could not find tests for function sys.suser_id_internal
 Could not find tests for function sys.suser_name_internal
 Could not find tests for function sys.systypes_precision_helper
@@ -157,7 +156,6 @@ Could not find upgrade tests for function sys.sp_releaseapplock_function
 Could not find upgrade tests for function sys.sp_special_columns_length_helper
 Could not find upgrade tests for function sys.sp_special_columns_precision_helper
 Could not find upgrade tests for function sys.sp_special_columns_scale_helper
-Could not find upgrade tests for function sys.sp_tables_internal
 Could not find upgrade tests for function sys.suser_id_internal
 Could not find upgrade tests for function sys.suser_name_internal
 Could not find upgrade tests for function sys.systypes_precision_helper

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -65,6 +65,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--4.0.0--4.1.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--4.1.0--4.2.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--4.2.0--4.3.0.sql
+Unexpected drop found for procedure sys.babelfish_drop_deprecated_object in file babelfishpg_tsql--4.3.0--4.4.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_table in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--1.0.0--1.1.0.sql
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -637,7 +637,6 @@ Function sys.sp_releaseapplock_function(character varying,character varying,char
 Function sys.sp_special_columns_length_helper(text,integer,smallint,bigint)
 Function sys.sp_special_columns_precision_helper(text,integer,smallint,bigint)
 Function sys.sp_special_columns_scale_helper(text,integer)
-Function sys.sp_tables_internal(sys.nvarchar,sys.nvarchar,sys.sysname,sys."varchar",sys."bit")
 Function sys.sql_variant_property(sys.sql_variant,sys."varchar")
 Function sys.sqlvariant_bbfbinary(sys.sql_variant)
 Function sys.sqlvariant_bigint(sys.sql_variant)


### PR DESCRIPTION
### Description
Currently, `SP_TABLES` procedure does not support wild card `[]`, which matches to any character that is specified in square bracket. Due to this `SP_TABLES` procedure returns different output when @table_name parameter value is `table_1` and `table[_]1`. This issue exists because previously we were using helper function `sp_tables_internal` whose body language was `plpgsql` hence we were using PostgresSQL Like operator for comparison, which does not support square bracket wild card expression. Fixed the issue by removing this helper function and migrating this function logic inside the SP_TABLES procedure whose language is `pltsql` and `Like` operator in `pltsql` supports square bracket wild card.

Authored-by: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved
BABEL-4128

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** YES


* **Major version upgrade tests -** YES


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).