### PR TITLE
Add support for Attribute-Centric Columns in FOR XML PATH

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -229,6 +229,45 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 }
 
 /*
+ * validate_attribute_centric_col_names_xml
+ *	Check if the tupdesc has attribute-centric columns and if present 
+ *	check the following - 
+ *	1. all of them are present in the starting of attribute list before any non-attribute-centric column , 
+ *	2. the element_name to be not NULL for tupdesc having attribute-centric columns.
+ */
+static bool
+validate_attribute_centric_col_names_xml(const char *element_name, TupleDesc tupdesc)
+{
+	bool seen_non_att_centric = false;
+	bool seen_att_centric = false;
+	for (int i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		if (NameStr(att->attname)[0] == '@')
+		{
+			seen_att_centric = true;
+			if(seen_non_att_centric)
+				ereport(ERROR,
+					(errcode(ERRCODE_INVALID_XML_PROCESSING_INSTRUCTION),
+					 errmsg("Attribute-centric column '%s' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.",
+					  NameStr(att->attname))));
+		}
+		else
+			seen_non_att_centric = true;
+	}
+
+	if(seen_att_centric && element_name[0] == '\0')
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_XML_PROCESSING_INSTRUCTION),
+				 errmsg("Row tag omission (empty row tag name) cannot be used " \
+				 		"with attribute-centric FOR XML serialization.")));
+	}
+
+	return seen_att_centric;
+}
+
+/*
  * Map an SQL row to an XML element in PATH mode.
  */
 static void
@@ -241,6 +280,8 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 	HeapTupleData tmptup;
 	HeapTuple	tuple;
 	bool		allnull = true;
+	bool		has_att_centric = false;
+	bool		first = true;
 
 	td = DatumGetHeapTupleHeader(record);
 
@@ -254,13 +295,21 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 	tmptup.t_data = td;
 	tuple = &tmptup;
 
+	has_att_centric = validate_attribute_centric_col_names_xml(element_name, tupdesc);
+
 	/*
 	 * each tuple is either contained in a "row" tag, or standalone if the
 	 * element_name is an empty string
 	 */
 	if (element_name[0] != '\0')
-		/* if "''" is the input path, ignore it per SQL Server behavior */
-		appendStringInfo(state, "<%s>", element_name);
+	{
+		/* if "''" is the input path, ignore it per TSQL behavior */
+		if (has_att_centric)
+			appendStringInfo(state, "<%s ", element_name);
+		else
+			appendStringInfo(state, "<%s>", element_name);
+
+	}
 
 	/* process the tuple into tags */
 	for (int i = 0; i < tupdesc->natts; i++)
@@ -283,10 +332,33 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 		if (!isnull)
 		{
 			allnull = false;
-			appendStringInfo(state, "<%s>%s</%s>",
-							 colname,
-							 map_sql_value_to_xml_value(colval, datatype_oid, true),
-							 colname);
+			if(NameStr(att->attname)[0] == '@')
+			{
+				appendStringInfo(state, "%s=\"%s\" ",
+								 NameStr(att->attname)+1,
+								 map_sql_value_to_xml_value(colval, datatype_oid, true));
+			}
+			else
+			{
+				if (has_att_centric && first)
+				{
+					appendStringInfoChar(state, '>');
+					first = false;
+				}
+				if(strncmp(NameStr(att->attname), "?column?", 8) == 0)
+				{
+					/* Dont include Default Colname that is assigned by PG */
+					appendStringInfo(state, "%s",
+									map_sql_value_to_xml_value(colval, datatype_oid, true));
+				}
+				else
+				{
+					appendStringInfo(state, "<%s>%s</%s>",
+									 colname,
+									 map_sql_value_to_xml_value(colval, datatype_oid, true),
+									 colname);
+				}
+			}
 		}
 	}
 
@@ -301,7 +373,12 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 		appendStringInfoString(state, ">");
 	}
 	else if (element_name[0] != '\0')
-		appendStringInfo(state, "</%s>", element_name);
+	{
+		if (has_att_centric && first)
+			appendStringInfoString(state, "/>");
+		else
+			appendStringInfo(state, "</%s>", element_name);
+	}
 	ReleaseTupleDesc(tupdesc);
 }
 

--- a/test/JDBC/expected/forxml-path-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-path-vu-cleanup.out
@@ -1,0 +1,14 @@
+DROP PROCEDURE for_xml_path_p1
+DROP PROCEDURE for_xml_path_p2
+DROP PROCEDURE for_xml_path_p3
+DROP PROCEDURE for_xml_path_p4
+GO
+
+DROP VIEW for_xml_path_v1
+DROP VIEW for_xml_path_v2
+DROP VIEW for_xml_path_v3
+DROP VIEW for_xml_path_v4
+GO
+
+DROP TABLE for_xml_path
+GO

--- a/test/JDBC/expected/forxml-path-vu-prepare.out
+++ b/test/JDBC/expected/forxml-path-vu-prepare.out
@@ -1,0 +1,31 @@
+CREATE TABLE for_xml_path (SequenceNumber  INTEGER PRIMARY KEY, String VARCHAR(100) NOT NULL);
+GO
+
+INSERT INTO for_xml_path VALUES (1,'SELECT'),(2,'Product,'),(3,'UnitPrice,'),(4,'EffectiveDate'),(5,'FROM'), (6,'Products'),(7,'WHERE'),(8,'UnitPrice'),(9,'> 100');
+GO
+~~ROW COUNT: 9~~
+
+
+CREATE VIEW for_xml_path_v1 AS SELECT String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
+GO
+
+CREATE VIEW for_xml_path_v2 AS SELECT hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+CREATE VIEW for_xml_path_v3 AS SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+
+CREATE VIEW for_xml_path_v4 AS SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+CREATE PROCEDURE for_xml_path_p1 AS SELECT  String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
+GO
+
+CREATE PROCEDURE for_xml_path_p2 AS SELECT hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+CREATE PROCEDURE for_xml_path_p3 AS SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+
+CREATE PROCEDURE for_xml_path_p4 AS SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO

--- a/test/JDBC/expected/forxml-path-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-vu-verify.out
@@ -1,0 +1,125 @@
+-- Should throw Error , att-centric after normal columns
+SELECT  String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@param2' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+-- Should throw error, PATH supplied is NULL
+SELECT hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Row tag omission (empty row tag name) cannot be used with attribute-centric FOR XML serialization.)~~
+
+
+
+-- NORMAL Usecase both types of columns
+SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+~~START~~
+ntext
+<row param2="SELECT" ><string>SELECT</string></row><row param2="Product," ><string>Product,</string></row><row param2="UnitPrice," ><string>UnitPrice,</string></row><row param2="EffectiveDate" ><string>EffectiveDate</string></row><row param2="FROM" ><string>FROM</string></row><row param2="Products" ><string>Products</string></row><row param2="WHERE" ><string>WHERE</string></row><row param2="UnitPrice" ><string>UnitPrice</string></row><row param2="&gt; 100" ><string>&gt; 100</string></row>
+~~END~~
+
+
+-- Only att-centric columns
+SELECT String as [@param2]  FROM for_xml_path ORDER BY SequenceNumber FOR XML PATH
+GO
+~~START~~
+ntext
+<row param2="SELECT" /><row param2="Product," /><row param2="UnitPrice," /><row param2="EffectiveDate" /><row param2="FROM" /><row param2="Products" /><row param2="WHERE" /><row param2="UnitPrice" /><row param2="&gt; 100" />
+~~END~~
+
+
+-- Complex expression without column name , should not add a <?column?> tag
+SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+~~START~~
+ntext
+ SELECT Product, UnitPrice, EffectiveDate FROM Products WHERE UnitPrice &gt; 100
+~~END~~
+
+
+-- Complex expression without column name , should not add a <?column?> tag
+SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+~~START~~
+ntext
+<row> SELECT</row><row> Product,</row><row> UnitPrice,</row><row> EffectiveDate</row><row> FROM</row><row> Products</row><row> WHERE</row><row> UnitPrice</row><row> &gt; 100</row>
+~~END~~
+
+
+-- Dep Objects
+SELECT * FROM for_xml_path_v1
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@param2' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+SELECT * FROM for_xml_path_v2
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Row tag omission (empty row tag name) cannot be used with attribute-centric FOR XML serialization.)~~
+
+
+SELECT * FROM for_xml_path_v3
+GO
+~~START~~
+ntext
+<row param2="SELECT" ><string>SELECT</string></row><row param2="Product," ><string>Product,</string></row><row param2="UnitPrice," ><string>UnitPrice,</string></row><row param2="EffectiveDate" ><string>EffectiveDate</string></row><row param2="FROM" ><string>FROM</string></row><row param2="Products" ><string>Products</string></row><row param2="WHERE" ><string>WHERE</string></row><row param2="UnitPrice" ><string>UnitPrice</string></row><row param2="&gt; 100" ><string>&gt; 100</string></row>
+~~END~~
+
+
+SELECT * FROM for_xml_path_v4
+GO
+~~START~~
+ntext
+ SELECT Product, UnitPrice, EffectiveDate FROM Products WHERE UnitPrice &gt; 100
+~~END~~
+
+
+EXEC for_xml_path_p1
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@param2' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+EXEC for_xml_path_p2
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Row tag omission (empty row tag name) cannot be used with attribute-centric FOR XML serialization.)~~
+
+
+EXEC for_xml_path_p3
+GO
+~~START~~
+ntext
+<row param2="SELECT" ><string>SELECT</string></row><row param2="Product," ><string>Product,</string></row><row param2="UnitPrice," ><string>UnitPrice,</string></row><row param2="EffectiveDate" ><string>EffectiveDate</string></row><row param2="FROM" ><string>FROM</string></row><row param2="Products" ><string>Products</string></row><row param2="WHERE" ><string>WHERE</string></row><row param2="UnitPrice" ><string>UnitPrice</string></row><row param2="&gt; 100" ><string>&gt; 100</string></row>
+~~END~~
+
+
+EXEC for_xml_path_p4
+GO
+~~START~~
+ntext
+ SELECT Product, UnitPrice, EffectiveDate FROM Products WHERE UnitPrice &gt; 100
+~~END~~
+

--- a/test/JDBC/input/forxml/forxml-path-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-cleanup.sql
@@ -1,0 +1,14 @@
+DROP PROCEDURE for_xml_path_p1
+DROP PROCEDURE for_xml_path_p2
+DROP PROCEDURE for_xml_path_p3
+DROP PROCEDURE for_xml_path_p4
+GO
+
+DROP VIEW for_xml_path_v1
+DROP VIEW for_xml_path_v2
+DROP VIEW for_xml_path_v3
+DROP VIEW for_xml_path_v4
+GO
+
+DROP TABLE for_xml_path
+GO

--- a/test/JDBC/input/forxml/forxml-path-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-prepare.sql
@@ -1,0 +1,29 @@
+CREATE TABLE for_xml_path (SequenceNumber  INTEGER PRIMARY KEY, String VARCHAR(100) NOT NULL);
+GO
+
+INSERT INTO for_xml_path VALUES (1,'SELECT'),(2,'Product,'),(3,'UnitPrice,'),(4,'EffectiveDate'),(5,'FROM'), (6,'Products'),(7,'WHERE'),(8,'UnitPrice'),(9,'> 100');
+GO
+
+CREATE VIEW for_xml_path_v1 AS SELECT String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
+GO
+
+CREATE VIEW for_xml_path_v2 AS SELECT hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+CREATE VIEW for_xml_path_v3 AS SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+
+CREATE VIEW for_xml_path_v4 AS SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+CREATE PROCEDURE for_xml_path_p1 AS SELECT  String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
+GO
+
+CREATE PROCEDURE for_xml_path_p2 AS SELECT hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+CREATE PROCEDURE for_xml_path_p3 AS SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+
+CREATE PROCEDURE for_xml_path_p4 AS SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO

--- a/test/JDBC/input/forxml/forxml-path-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-verify.sql
@@ -1,0 +1,49 @@
+-- Should throw Error , att-centric after normal columns
+SELECT  String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
+GO
+
+-- Should throw error, PATH supplied is NULL
+SELECT hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+
+-- NORMAL Usecase both types of columns
+SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+
+-- Only att-centric columns
+SELECT String as [@param2]  FROM for_xml_path ORDER BY SequenceNumber FOR XML PATH
+GO
+
+-- Complex expression without column name , should not add a <?column?> tag
+SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('')
+GO
+
+-- Complex expression without column name , should not add a <?column?> tag
+SELECT ' '+string  FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH
+GO
+
+-- Dep Objects
+SELECT * FROM for_xml_path_v1
+GO
+
+SELECT * FROM for_xml_path_v2
+GO
+
+SELECT * FROM for_xml_path_v3
+GO
+
+SELECT * FROM for_xml_path_v4
+GO
+
+EXEC for_xml_path_p1
+GO
+
+EXEC for_xml_path_p2
+GO
+
+EXEC for_xml_path_p3
+GO
+
+EXEC for_xml_path_p4
+GO

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -148,6 +148,7 @@ forjson
 forjson-subquery
 forjson-datatypes
 forxml
+forxml-path
 forxml-subquery
 BABEL-PROCID
 babel_trigger

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -149,6 +149,7 @@ forjson
 forjson-subquery
 forjson-datatypes
 forxml
+forxml-path
 forxml-subquery
 BABEL-PROCID
 babel_trigger

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -148,6 +148,7 @@ forjson
 forjson-subquery
 forjson-datatypes
 forxml
+forxml-path
 forxml-subquery
 BABEL-PROCID
 babel_trigger

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -148,6 +148,7 @@ forjson
 forjson-subquery
 forjson-datatypes
 forxml
+forxml-path
 forxml-subquery
 BABEL-PROCID
 babel_trigger

--- a/test/JDBC/upgrade/14_14/schedule
+++ b/test/JDBC/upgrade/14_14/schedule
@@ -148,6 +148,7 @@ forjson
 forjson-subquery
 forjson-datatypes
 forxml
+forxml-path
 forxml-subquery
 BABEL-PROCID
 babel_trigger

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -200,6 +200,7 @@ forjson-subquery
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 get_tds_id

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -198,6 +198,7 @@ forjson-subquery
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 get_tds_id

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -148,6 +148,7 @@ forjson
 forjson-subquery
 forjson-datatypes
 forxml
+forxml-path
 forxml-subquery
 BABEL-PROCID
 babel_trigger

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -183,6 +183,7 @@ forjson-datatypes
 format
 format-dep
 forxml
+forxml-path
 fulltextserviceproperty
 get_tds_id
 HAS_DBACCESS

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -199,6 +199,7 @@ forjson-subquery
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 get_tds_id

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -209,6 +209,7 @@ forjson-subquery
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 get_tds_id

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -212,6 +212,7 @@ forjson-subquery
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 get_tds_id

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -216,6 +216,7 @@ forjson-nesting
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 FULLTEXT_INDEX

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -223,6 +223,7 @@ forjsonauto
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 FULLTEXT_INDEX

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -224,6 +224,7 @@ forjsonauto
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 FULLTEXT_INDEX

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -223,6 +223,7 @@ forjsonauto
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 FULLTEXT_INDEX

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -223,6 +223,7 @@ forjsonauto
 format
 format-dep
 forxml
+forxml-path
 forxml-subquery
 fulltextserviceproperty
 FULLTEXT_INDEX


### PR DESCRIPTION
### Description
Added support for attribute-centric columns for `FOR XML PATH` feature ([reference](https://github.com/MicrosoftDocs/sql-docs/blob/787fc53553c9fb6fc0932c597237ad1fb979c8bf/docs/relational-databases/xml/use-nested-for-xml-queries.md?plain=1#L105)) , these columns start with `@` and should be specified before all the non-attribute-centric columns. The columns are specified as members of parent XML element.

This commit also fixes an issue when we have a column which does not have a name specified and is an expression whose name cannot be determined by DB engine and uses `?column?` as default column name in that case we dont need to create a separate element for such columns.

Cherry Pick https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/153fda2dbccb846d5d566c4e874a72affd5b12ba
### Issues Resolved
BABEL-4871, BABEL-5235

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -**


* **Negative test cases -** Yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**

Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).