### PR TITLE
Add instructions for running JDBC tests with single-db migration mode and add single-db schedule file

### DIFF
--- a/test/JDBC/README.md
+++ b/test/JDBC/README.md
@@ -20,6 +20,7 @@ The JDBC test framework for Babelfish uses the JDBC Driver for SQL Server for da
 - [Adding the test cases](#adding-the-test-cases)
 - [Reading the console output and diff](#reading-the-console-output-and-diff)
 - [Running Tests with Parallel Query Enabled](#running-tests-with-parallel-query-enabled)
+- [Running Tests with Single-DB Migration Mode](#running-tests-with-single-db-migration-mode)
 - [Running Tests with Non Default Server Collation](#running-tests-with-non-default-server-collation)
 
 ## Running the test framework
@@ -484,6 +485,7 @@ After building the modified PostgreSQL engine and Babelfish extensions using the
 4. How to add expected output for some test
     1. By default expected output of a test should be added into `expected` folder.
     2. If the expected output is different for single-db migration mode compared to multi-db migration mode, one can add a different expected output specially for single-db migration mode in `expected/single_db/` folder. Additionally, one needs to add `-- single_db_mode_expected` flag in the corresponding input file.
+    
 5. To exclude some tests from running via the JDBC in single-db migration mode, you can add test-case name with prefix `ignore#!#` in `singledb_jdbc_schedule` file.
 
 6. Cleanup all the objects, users, roles and databases created while running the tests:

--- a/test/JDBC/README.md
+++ b/test/JDBC/README.md
@@ -462,6 +462,40 @@ After building the modified PostgreSQL engine and Babelfish extensions using the
    ```
 If you encounter failing or crashing tests in the "JDBC tests with parallel query" GitHub workflow, consider adding the names of these problematic test cases to the `parallel_query_jdbc_schedule` file. Prefix these test case names with `ignore#!#`. As we work towards resolving these issues in the future, we will gradually remove these excluded tests from the `parallel_query_jdbc_schedule` scheduling file.
 
+## Running Tests with Single-DB Migration Mode
+
+After building the modified PostgreSQL engine and Babelfish extensions using the [online instructions](../../contrib/README.md), you must:
+1. Create a PostgreSQL database and initialize Babelfish extensions with single-db migration mode by adding following line in `postgres/data/postgresql.conf` and restart engine, then initialize Babelfish extensions using the [online instructions](../../contrib/README.md)
+
+   ```bash
+   babelfishpg_tsql.migration_mode = 'single-db'
+    ```
+2. Before running JDBC tests, set the `isSingleDbMode` environment variable to `true`:
+
+   ```bash
+    export isSingleDbMode=true
+    # Verify if isSingleDbMode is set to true
+    echo $isSingleDbMode
+   ```
+3. Now Run the tests:
+    ```bash
+    mvn test
+    ```
+4. How to add expected output for some test
+    1. By default expected output of a test should be added into `expected` folder.
+    2. If the expected output is different for single-db migration mode compared to multi-db migration mode, one can add a different expected output specially for single-db migration mode in `expected/single_db/` folder. Additionally, one needs to add `-- single_db_mode_expected` flag in the corresponding input file.
+5. To exclude some tests from running via the JDBC in single-db migration mode, you can add test-case name with prefix `ignore#!#` in `singledb_jdbc_schedule` file.
+
+6. Cleanup all the objects, users, roles and databases created while running the tests:
+    ```bash
+    ./cleanup.sh
+    ```
+7. Please note that whenever you had changed the migration mode and reinitialised Babelfish extensions. Update the `isSingleDbMode` environment variable with appropriate value and unset when migration mode is set to 'multi-db'.
+    ```bash
+    unset isSingleDbMode
+    ```
+    This ensures that correct expected output is picked for current migration mode.
+
 ## Running Tests with Non Default Server Collation
 
 After building the modified PostgreSQL engine and Babelfish extensions using the [online instructions](../../contrib/README.md), you must:

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -1,0 +1,5 @@
+# Schedule File for JDBC Test Framework for local run for single-db run to ignore specific tests
+# 1. Lines starting with '#' will be treated as comments
+# 2. To ignore any test file, add an entry like ignore#!#<test_file_name>
+
+

--- a/test/JDBC/src/main/java/com/sqlsamples/Config.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/Config.java
@@ -29,6 +29,7 @@ public class Config {
     static boolean isSingleDbMode = Boolean.parseBoolean(properties.getProperty("isSingleDbMode"));
     static String serverCollationName = properties.getProperty("serverCollationName");
     static String parallelQueryTestIgnoreFileName = "./parallel_query_jdbc_schedule";
+    static String singleDBIgnoreFileName = "./singledb_jdbc_schedule";
     static boolean checkParallelQueryExpected = false;
     static boolean checkSingleDbModeExpected = false;
     static String testFileRoot = properties.getProperty("testFileRoot");

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -164,6 +164,7 @@ public class TestQueryFile {
         File dir = new File(inputFilesDirectoryPath);
         File scheduleFile = new File(scheduleFileName);
         File parallelQueryTestIgnoreFile = new File(parallelQueryTestIgnoreFileName);
+        File singleDBIgnoreFile = new File(singleDBIgnoreFileName);
         
         try (BufferedReader br = new BufferedReader(new FileReader(scheduleFile))) {
             String line;
@@ -178,6 +179,19 @@ public class TestQueryFile {
         /* Ignore tests in case of parallel query mode on */
         if (isParallelQueryMode) {
             try (BufferedReader br = new BufferedReader(new FileReader(parallelQueryTestIgnoreFile))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    if (!line.startsWith("#") && line.trim().length() > 0 && line.startsWith("ignore#!#"))
+                        testsToIgnore.add(line.split("#!#", -1)[1]);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        /* Ignore tests in case of single-db mode test */
+        if (isSingleDbMode) {
+            try (BufferedReader br = new BufferedReader(new FileReader(singleDBIgnoreFile))) {
                 String line;
                 while ((line = br.readLine()) != null) {
                     if (!line.startsWith("#") && line.trim().length() > 0 && line.startsWith("ignore#!#"))


### PR DESCRIPTION
### Description

This commit adds instructions for running JDBC tests with single-db migration mode. And it also adds `singledb_jdbc_schedule` which can be used to exclude some tests from running via the JDBC in single-db migration mode.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).