### PR TITLE
Uninitialized variable fix for ISNUMERIC function with varchar and nvarchar arguments

### DIFF
--- a/contrib/babelfishpg_common/src/varchar.c
+++ b/contrib/babelfishpg_common/src/varchar.c
@@ -922,7 +922,11 @@ varchar2numeric(PG_FUNCTION_ARGS)
 	char	   *str;
 
 	str = varchar2cstring(source);
-	result = DatumGetNumeric(DirectFunctionCall1(numeric_in, CStringGetDatum(str)));
+	/* Updating numeric_in call with additional expected arguments `Elem type Oid` and `typmod` - BABEL-5129 */
+	result = DatumGetNumeric(DirectFunctionCall3(numeric_in, 
+        CStringGetDatum(str), 
+        ObjectIdGetDatum(InvalidOid),
+        Int32GetDatum(-1)));
 	pfree(str);
 	PG_RETURN_NUMERIC(result);
 }

--- a/contrib/babelfishpg_common/src/varchar.c
+++ b/contrib/babelfishpg_common/src/varchar.c
@@ -922,11 +922,10 @@ varchar2numeric(PG_FUNCTION_ARGS)
 	char	   *str;
 
 	str = varchar2cstring(source);
-	/* Updating numeric_in call with additional expected arguments `Elem type Oid` and `typmod` - BABEL-5129 */
 	result = DatumGetNumeric(DirectFunctionCall3(numeric_in, 
-        CStringGetDatum(str), 
-        ObjectIdGetDatum(InvalidOid),
-        Int32GetDatum(-1)));
+												 CStringGetDatum(str), 
+												 ObjectIdGetDatum(InvalidOid),
+												 Int32GetDatum(-1)));
 	pfree(str);
 	PG_RETURN_NUMERIC(result);
 }

--- a/test/JDBC/expected/BABEL-5129-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-5129-vu-cleanup.out
@@ -1,0 +1,2 @@
+DROP TABLE babel_5129
+GO

--- a/test/JDBC/expected/BABEL-5129-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-5129-vu-prepare.out
@@ -1,0 +1,28 @@
+
+-- Tests for ISNUMERIC function with varchar and nvarchar variables
+CREATE TABLE babel_5129 (
+    int_type int,
+    numeric_type numeric(10,5),
+    money_type money,
+    varchar_type varchar(20),
+    nvarchar_type nvarchar(20)
+)
+GO
+
+INSERT INTO babel_5129 (
+    int_type,
+    numeric_type,
+    money_type,
+    varchar_type,
+    nvarchar_type
+)
+VALUES (
+    45000,
+    12345.12,
+    237891.22,
+    '12.3420000000',
+    '12.3420000000'
+)
+GO
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/BABEL-5129-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5129-vu-verify.out
@@ -1,0 +1,131 @@
+
+-- Tests for ISNUMERIC function with varchar and nvarchar variables
+SELECT * FROM babel_5129
+GO
+~~START~~
+int#!#numeric#!#money#!#varchar#!#nvarchar
+45000#!#12345.12000#!#237891.2200#!#12.3420000000#!#12.3420000000
+~~END~~
+
+-- Test int
+SELECT ISNUMERIC(int_type)
+FROM babel_5129
+GO
+~~START~~
+int
+1
+~~END~~
+
+-- Test numeric
+SELECT ISNUMERIC(numeric_type)
+FROM babel_5129
+GO
+~~START~~
+int
+1
+~~END~~
+
+-- Test money
+SELECT ISNUMERIC(money_type)
+FROM babel_5129
+GO
+~~START~~
+int
+1
+~~END~~
+
+-- Test varchar
+SELECT ISNUMERIC(varchar_type)
+FROM babel_5129
+GO
+~~START~~
+int
+1
+~~END~~
+
+-- Test nvarchar
+SELECT ISNUMERIC(nvarchar_type)
+FROM babel_5129
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test numeric variable
+DECLARE @a numeric(24,6);
+SELECT @a = 12.3420000000;
+SELECT ISNUMERIC(@a), LEN(@a), DATALENGTH(@a)
+GO
+~~START~~
+int#!#int#!#int
+1#!#9#!#6
+~~END~~
+
+
+-- Test varchar variable
+DECLARE @v varchar(20);
+SELECT @v = '12.3420000000';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+1#!#13#!#13
+~~END~~
+
+
+-- Test nvarchar variable
+DECLARE @nv nvarchar(10);
+SELECT @nv = '12.3420000000';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#10
+~~END~~
+
+
+-- Test empty varchar variable
+DECLARE @v varchar(20);
+SELECT @v = '';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+0#!#0#!#0
+~~END~~
+
+
+-- Test empty nvarchar variable
+DECLARE @nv nvarchar(10);
+SELECT @nv = '';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+0#!#0#!#0
+~~END~~
+
+
+-- Test varchar variable with invalid numeric
+DECLARE @v varchar(20);
+SELECT @v = '12.34.20000000';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+0#!#14#!#14
+~~END~~
+
+
+-- Test nvarchar variable with invalid numeric
+DECLARE @nv nvarchar(10);
+SELECT @nv = '12.34.20000000';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+0#!#10#!#10
+~~END~~
+

--- a/test/JDBC/expected/BABEL-5129-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5129-vu-verify.out
@@ -86,6 +86,28 @@ int#!#int#!#int
 ~~END~~
 
 
+-- Test NULL varchar variable
+DECLARE @v varchar(20);
+SELECT @v = NULL;
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+0#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- Test NULL nvarchar variable
+DECLARE @nv nvarchar(10);
+SELECT @nv = null;
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+0#!#<NULL>#!#<NULL>
+~~END~~
+
+
 -- Test empty varchar variable
 DECLARE @v varchar(20);
 SELECT @v = '';

--- a/test/JDBC/expected/BABEL-5129-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5129-vu-verify.out
@@ -130,6 +130,70 @@ int#!#int#!#int
 ~~END~~
 
 
+-- Test varchar with number argument that exceeds range of bigint.
+DECLARE @v varchar(20);
+SELECT @v = '9223372036854775807';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+1#!#19#!#19
+~~END~~
+
+
+DECLARE @v varchar(20);
+SELECT @v = '-9223372036854775808';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+1#!#20#!#20
+~~END~~
+
+
+-- Test nvarchar with number argument that exceeds range of bigint.
+DECLARE @nv nvarchar(20);
+SELECT @nv = '9223372036854775807';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+1#!#19#!#19
+~~END~~
+
+
+DECLARE @nv nvarchar(20);
+SELECT @nv = '-9223372036854775808';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+1#!#20#!#20
+~~END~~
+
+
+-- Test varchar with lengthy numeric value
+DECLARE @v varchar;
+SELECT @v = '12345678901234567890123456789012345';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+1#!#1#!#1
+~~END~~
+
+
+-- Test nvarchar with lengthy numeric value
+DECLARE @nv nvarchar;
+SELECT @nv = '12345678901234567890123456789012345';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+~~START~~
+int#!#int#!#int
+1#!#1#!#1
+~~END~~
+
+
 -- Test varchar variable with invalid numeric
 DECLARE @v varchar(20);
 SELECT @v = '12.34.20000000';

--- a/test/JDBC/input/BABEL-5129-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-5129-vu-cleanup.sql
@@ -1,0 +1,2 @@
+DROP TABLE babel_5129
+GO

--- a/test/JDBC/input/BABEL-5129-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-5129-vu-prepare.sql
@@ -1,0 +1,26 @@
+-- Tests for ISNUMERIC function with varchar and nvarchar variables
+
+CREATE TABLE babel_5129 (
+    int_type int,
+    numeric_type numeric(10,5),
+    money_type money,
+    varchar_type varchar(20),
+    nvarchar_type nvarchar(20)
+)
+GO
+
+INSERT INTO babel_5129 (
+    int_type,
+    numeric_type,
+    money_type,
+    varchar_type,
+    nvarchar_type
+)
+VALUES (
+    45000,
+    12345.12,
+    237891.22,
+    '12.3420000000',
+    '12.3420000000'
+)
+GO

--- a/test/JDBC/input/BABEL-5129-vu-verify.sql
+++ b/test/JDBC/input/BABEL-5129-vu-verify.sql
@@ -1,0 +1,66 @@
+-- Tests for ISNUMERIC function with varchar and nvarchar variables
+
+SELECT * FROM babel_5129
+GO
+-- Test int
+SELECT ISNUMERIC(int_type)
+FROM babel_5129
+GO
+-- Test numeric
+SELECT ISNUMERIC(numeric_type)
+FROM babel_5129
+GO
+-- Test money
+SELECT ISNUMERIC(money_type)
+FROM babel_5129
+GO
+-- Test varchar
+SELECT ISNUMERIC(varchar_type)
+FROM babel_5129
+GO
+-- Test nvarchar
+SELECT ISNUMERIC(nvarchar_type)
+FROM babel_5129
+GO
+
+-- Test numeric variable
+DECLARE @a numeric(24,6);
+SELECT @a = 12.3420000000;
+SELECT ISNUMERIC(@a), LEN(@a), DATALENGTH(@a)
+GO
+
+-- Test varchar variable
+DECLARE @v varchar(20);
+SELECT @v = '12.3420000000';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+-- Test nvarchar variable
+DECLARE @nv nvarchar(10);
+SELECT @nv = '12.3420000000';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+
+-- Test empty varchar variable
+DECLARE @v varchar(20);
+SELECT @v = '';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+-- Test empty nvarchar variable
+DECLARE @nv nvarchar(10);
+SELECT @nv = '';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+
+-- Test varchar variable with invalid numeric
+DECLARE @v varchar(20);
+SELECT @v = '12.34.20000000';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+-- Test nvarchar variable with invalid numeric
+DECLARE @nv nvarchar(10);
+SELECT @nv = '12.34.20000000';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO

--- a/test/JDBC/input/BABEL-5129-vu-verify.sql
+++ b/test/JDBC/input/BABEL-5129-vu-verify.sql
@@ -41,6 +41,18 @@ SELECT @nv = '12.3420000000';
 SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
 GO
 
+-- Test NULL varchar variable
+DECLARE @v varchar(20);
+SELECT @v = NULL;
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+-- Test NULL nvarchar variable
+DECLARE @nv nvarchar(10);
+SELECT @nv = null;
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+
 -- Test empty varchar variable
 DECLARE @v varchar(20);
 SELECT @v = '';

--- a/test/JDBC/input/BABEL-5129-vu-verify.sql
+++ b/test/JDBC/input/BABEL-5129-vu-verify.sql
@@ -65,6 +65,40 @@ SELECT @nv = '';
 SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
 GO
 
+-- Test varchar with number argument that exceeds range of bigint.
+DECLARE @v varchar(20);
+SELECT @v = '9223372036854775807';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+DECLARE @v varchar(20);
+SELECT @v = '-9223372036854775808';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+-- Test nvarchar with number argument that exceeds range of bigint.
+DECLARE @nv nvarchar(20);
+SELECT @nv = '9223372036854775807';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+
+DECLARE @nv nvarchar(20);
+SELECT @nv = '-9223372036854775808';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+
+-- Test varchar with lengthy numeric value
+DECLARE @v varchar;
+SELECT @v = '12345678901234567890123456789012345';
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+-- Test nvarchar with lengthy numeric value
+DECLARE @nv nvarchar;
+SELECT @nv = '12345678901234567890123456789012345';
+SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
+GO
+
 -- Test varchar variable with invalid numeric
 DECLARE @v varchar(20);
 SELECT @v = '12.34.20000000';

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -568,4 +568,5 @@ SELECT_INTO_TEST
 binary-datatype-operators
 cast-varchar-to-time
 BABEL-5119
+BABEL-5129
 


### PR DESCRIPTION
### Description

This change addresses a bug about the incorrect behavior of the ISNUMERIC function in Babelfish when handling string variables (NVARCHAR and VARCHAR). 

Currently, production Babelfish instances (specifically `PostgreSQL 16.2 on aarch64-unknown-linux-gnu (Babelfish 4.1.1)`) incorrectly handle the ISNUMERIC function for string variables (NVARCHAR and VARCHAR), returning 0 (false) for valid numeric string representations. With this change, ISNUMERIC will correctly return 1 (true) for valid numeric strings, aligning its behavior with SQL Server.

The issue stemmed from an uninitialized variable `typmod` containing garbage values, which impacted the behavior of the `numeric_in` function, invoked by the `varchar2numeric` function.
In the production instances, the typmod variable, happens to point to an incorrect positive garbage values, bypassing the `is_valid_numeric_typmod` check, trickling down into an error. The change adds two arguments to the numeric_in call made in varchar2numeric, namely `OID (Elem Type)` and `TYPMOD`, which are then used to initialize the variables in numeric_in to default values, ensuring that no garbage values are used. It was also observed that numeric_in is invoked similarly with three arguments in other functions such as `cstring_to_numeric`, `fixeddecimal_numeric` etc, except this particular function.

Test cases test `ISNUMERIC` with varchar/nvarchar variables, invoking `varchar2numeric`. Existing test cases `babel_isnumeric`, `babel_isnumeric-vu-verify` already cover various other data types and scenarios: numeric data types and string literals.

### Issues Resolved

BABEL-5129


### Test Scenarios Covered ###
* **Use case based -**

```
-- Test varchar
SELECT ISNUMERIC(varchar_type)
FROM babel_5129
GO
~~START~~
int
1
~~END~~


-- Test varchar variable
DECLARE @v varchar(20);
SELECT @v = '12.3420000000';
SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
GO
~~START~~
int#!#int#!#int
1#!#13#!#13
~~END~~
```
```
-- Test nvarchar
SELECT ISNUMERIC(nvarchar_type)
FROM babel_5129
GO
~~START~~
int
1
~~END~~


-- Test nvarchar variable
DECLARE @nv nvarchar(10);
SELECT @nv = '12.3420000000';
SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
GO
~~START~~
int#!#int#!#int
1#!#10#!#10
~~END~~

```
* **Existing Test cases -**

- test/JDBC/input/babel_isnumeric.sql
- test/JDBC/input/babel_isnumeric-vu-verify.sql

```
CREATE TABLE test_isnumeric (
    bigint_type bigint,
    int_type int,
    smallint_type smallint,
    tinyint_type tinyint,
    bit_type bit,
    decimal_type decimal(5,2),
    numeric_type numeric(10,5),
    float_type float,
    real_type real,
    money_type money,
    smallmoney_type money
)
GO
...
-- Test bigint
SELECT ISNUMERIC(bigint_type)
FROM test_isnumeric
GO
...
-- Test valid and invalid operators and literals
select isnumeric(' + $ 1.1234')
GO

select isnumeric('abcdefghijklmnop')
GO
...
```

* **Boundary conditions -**

```
-- Test empty varchar variable
DECLARE @v varchar(20);
SELECT @v = '';
SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
GO
~~START~~
int#!#int#!#int
0#!#0#!#0
~~END~~


-- Test empty nvarchar variable
DECLARE @nv nvarchar(10);
SELECT @nv = '';
SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
GO
~~START~~
int#!#int#!#int
0#!#0#!#0
~~END~~
```

```
-- Test varchar with number argument that exceeds range of bigint.
DECLARE @v varchar(20);
SELECT @v = '9223372036854775807';
SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
GO
~~START~~
int#!#int#!#int
1#!#19#!#19
~~END~~


DECLARE @v varchar(20);
SELECT @v = '-9223372036854775808';
SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
GO
~~START~~
int#!#int#!#int
1#!#20#!#20
~~END~~
```

```
-- Test nvarchar with lengthy numeric value
DECLARE @nv nvarchar;
SELECT @nv = '12345678901234567890123456789012345';
SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
GO
~~START~~
int#!#int#!#int
1#!#1#!#1 --LEN=1 matches SQL server behavior (BABEL-1513)
~~END~~
```

* **Negative test cases -**
```
-- Test varchar variable with invalid numeric
DECLARE @v varchar(20);
SELECT @v = '12.34.20000000';
SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
GO
~~START~~
int#!#int#!#int
0#!#14#!#14
~~END~~


-- Test nvarchar variable with invalid numeric
DECLARE @nv nvarchar(10);
SELECT @nv = '12.34.20000000';
SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
GO
~~START~~
int#!#int#!#int
0#!#10#!#10
~~END~~

```

* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).