### PR TITLE
Refactoring create & drop db code and add some helper functions for making RoleSpec and AccessPriv nodes #2951

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2610,13 +2610,8 @@ create_guest_role_for_db(const char *dbname)
 
 	if (list_length(logins) > 0)
 	{
-		AccessPriv *tmp = makeNode(AccessPriv);
-
-		tmp->priv_name = pstrdup(guest);
-		tmp->cols = NIL;
-
 		stmt = parsetree_nth_stmt(res, i++);
-		update_GrantRoleStmt(stmt, list_make1(tmp), logins);
+		update_GrantRoleStmt(stmt, list_make1(make_accesspriv_node(guest)), logins);
 	}
 
 	/* Set current user to session user for create permissions */

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -7,6 +7,7 @@
 #include "nodes/nodeFuncs.h"
 #include "parser/scansup.h"
 #include "parser/parser.h"
+#include "pltsql.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
@@ -354,12 +355,7 @@ rewrite_object_refs(Node *stmt)
 
 							if (strcmp(defel->defname, "rolemembers") == 0)
 							{
-								RoleSpec   *spec;
-
-								spec = makeNode(RoleSpec);
-								spec->roletype = ROLESPEC_CSTRING;
-								spec->location = -1;
-								spec->rolename = pstrdup(get_db_owner_name(db_name));
+								RoleSpec   *spec = make_rolespec_node(get_db_owner_name(db_name));
 
 								if (defel->arg == NULL)
 									defel->arg = (Node *) list_make1(spec);

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2107,6 +2107,8 @@ extern void update_GrantRoleStmt(Node *n, List *privs, List *roles);
 extern void update_GrantStmt(Node *n, const char *object, const char *obj_schema, const char *grantee, const char *priv);
 extern void update_RenameStmt(Node *n, const char *old_name, const char *new_name);
 extern void update_ViewStmt(Node *n, const char *view_schema);
+extern AccessPriv *make_accesspriv_node(const char *priv_name);
+extern RoleSpec   *make_rolespec_node(const char *rolename);
 extern void pltsql_check_or_set_default_typmod(TypeName *typeName, int32 *typmod, bool is_cast);
 extern bool TryLockLogicalDatabaseForSession(int16 dbid, LOCKMODE lockmode);
 extern void UnlockLogicalDatabaseForSession(int16 dbid, LOCKMODE lockmode, bool force);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1017,12 +1017,7 @@ update_DropOwnedStmt(Node *n, List *role_list)
 	foreach(elem, role_list)
 	{
 		char	   *name = (char *) lfirst(elem);
-		RoleSpec   *tmp = makeNode(RoleSpec);
-
-		tmp->roletype = ROLESPEC_CSTRING;
-		tmp->location = -1;
-		tmp->rolename = pstrdup(name);
-		rolespec_list = lappend(rolespec_list, tmp);
+		rolespec_list = lappend(rolespec_list, make_rolespec_node(name));
 	}
 	stmt->roles = rolespec_list;
 }
@@ -2283,4 +2278,31 @@ privilege_to_string(AclMode privilege)
 			elog(ERROR, "unrecognized privilege: %d", (int) privilege);
 	}
 	return NULL;
+}
+
+AccessPriv *
+make_accesspriv_node(const char *priv_name)
+{
+	AccessPriv *n = makeNode(AccessPriv);
+
+	Assert(priv_name != NULL || strlen(priv_name) != 0);
+
+	n->priv_name = pstrdup(priv_name);
+	n->cols = NIL;
+
+	return n;
+}
+
+RoleSpec *
+make_rolespec_node(const char *rolename)
+{
+	RoleSpec *n = makeNode(RoleSpec);
+
+	Assert(rolename != NULL || strlen(rolename) != 0);
+
+	n->roletype = ROLESPEC_CSTRING;
+	n->location = -1;
+	n->rolename = pstrdup(rolename);
+
+	return n;
 }

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -499,7 +499,6 @@ grant_guests_to_login(const char *login)
 	List	   *parsetree_list;
 	List	   *guests = NIL;
 	Node	   *stmt;
-	RoleSpec   *tmp;
 	PlannedStmt *wrapper;
 
 	initStringInfo(&query);
@@ -516,17 +515,12 @@ grant_guests_to_login(const char *login)
 
 		const char *db_name = TextDatumGetCString(db_name_datum);
 		const char *guest_name = NULL;
-		AccessPriv *tmp = makeNode(AccessPriv);
 
 		if (guest_role_exists_for_db(db_name))
 			guest_name = get_guest_role_name(db_name);
 
 		if (guest_name)
-		{
-			tmp->priv_name = pstrdup(guest_name);
-			tmp->cols = NIL;
-			guests = lappend(guests, tmp);
-		}
+			guests = lappend(guests, make_accesspriv_node(guest_name));
 
 		tuple = heap_getnext(scan, ForwardScanDirection);
 	}
@@ -549,12 +543,7 @@ grant_guests_to_login(const char *login)
 
 	/* Update the dummy statement with real values */
 	stmt = parsetree_nth_stmt(parsetree_list, 0);
-	tmp = makeNode(RoleSpec);
-	tmp->roletype = ROLESPEC_CSTRING;
-	tmp->location = -1;
-	tmp->rolename = pstrdup(login);
-
-	update_GrantRoleStmt(stmt, guests, list_make1(tmp));
+	update_GrantRoleStmt(stmt, guests, list_make1(make_rolespec_node(login)));
 
 	/* Run the built query */
 	/* need to make a wrapper PlannedStmt */
@@ -592,18 +581,13 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 	List	   *parsetree_list;
 	List	   *dbo = NIL;
 	Node	   *stmt;
-	RoleSpec   *tmp;
 	PlannedStmt *wrapper;
-	AccessPriv *acc;
 
 	const char *dbo_role_name = get_dbo_role_name(db_name);
 
 	initStringInfo(&query);
 
-	acc = makeNode(AccessPriv);
-	acc->priv_name = pstrdup(dbo_role_name);
-	acc->cols = NIL;
-	dbo = lappend(dbo, acc);
+	dbo = lappend(dbo, make_accesspriv_node(dbo_role_name));
 
 	if (is_grant)
 	{
@@ -626,12 +610,7 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 
 	/* Update the dummy statement with real values */
 	stmt = parsetree_nth_stmt(parsetree_list, 0);
-	tmp = makeNode(RoleSpec);
-	tmp->roletype = ROLESPEC_CSTRING;
-	tmp->location = -1;
-	tmp->rolename = pstrdup(login);
-
-	update_GrantRoleStmt(stmt, dbo, list_make1(tmp));
+	update_GrantRoleStmt(stmt, dbo, list_make1(make_rolespec_node(login)));
 
 	/* Run the built query */
 	/* need to make a wrapper PlannedStmt */
@@ -1324,7 +1303,6 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 		const char *dbo_role;
 		const char *db_owner_role;
 		const char *guest;
-		RoleSpec   *rolspec;
 
 		db_name_datum = heap_getattr(tuple,
 									 Anum_sysdatabases_name,
@@ -1339,11 +1317,7 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 		/* Add users to catalog ext */
 		if (dbo_role)
 		{
-			rolspec = makeNode(RoleSpec);
-			rolspec->type = ROLESPEC_CSTRING;
-			rolspec->location = -1;
-			rolspec->rolename = pstrdup(dbo_role);
-			dbo_list = lappend(dbo_list, rolspec);
+			dbo_list = lappend(dbo_list, make_rolespec_node(dbo_role));
 			add_to_bbf_authid_user_ext(dbo_role, "dbo", db_name, "dbo", NULL, false, true, false);
 		}
 		if (db_owner_role)
@@ -2503,16 +2477,11 @@ remove_createrole_from_logins(PG_FUNCTION_ARGS)
 		if ((strcmp(rolname, "sysadmin") != 0) && !has_privs_of_role(get_role_oid(rolname, false), get_sysadmin_oid()))
 		{
 			StringInfoData query;
-			RoleSpec *role;
 
-			role = makeNode(RoleSpec);
-			role->roletype = ROLESPEC_CSTRING;
-			role->location = -1;
-			role->rolename = rolname;
 			initStringInfo(&query);
 
 			appendStringInfo(&query, "ALTER ROLE dummy WITH nocreaterole nocreatedb; ");
-			exec_alter_role_cmd(query.data, role);
+			exec_alter_role_cmd(query.data, make_rolespec_node(rolname));
 			pfree(query.data);
 		}
 		pfree(rolname);


### PR DESCRIPTION
### Description

Reduce the number of arguments passed to `gen_createdb_subcmds` & `gen_dropdb_subcmds`.
Create a helper functions to generate RoleSpec & AccessPriv nodes from cstring.
Create a new function for inserting fixed roles/users to bbf_authid_user_ext catalog during create database.
Remove unused declaration `update_RevokeRoleStmt`

### Issues Resolved

[BABEL-5274]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).