### PR TITLE
Support increment of identity sequence in TSQL Bulk Copy when in 'keep identity values' mode

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -678,6 +678,15 @@ ExecuteBulkCopy(BulkCopyState cstate, int rowCount, int colCount,
 					 */
 					if (cstate->seq_index == i)
 					{
+						/* 
+						 * For an identity column if there is identity_insert ON for the table and
+					 	 * we do not receive any data for this column, then we throw an error.
+						 */
+						if (tsql_identity_insert.valid)
+							ereport(ERROR,
+								(errcode(ERRCODE_UNDEFINED_COLUMN),
+								errmsg("Explicit value must be specified for identity column in table '%s' when IDENTITY_INSERT is set to ON", cstate->cur_relname)));
+
 						myslot->tts_values[i] = Int64GetDatum(nextval_internal(cstate->seqid, true));
 					}
 					else
@@ -700,6 +709,15 @@ ExecuteBulkCopy(BulkCopyState cstate, int rowCount, int colCount,
 					else
 					{
 						myslot->tts_values[col_index_to_insert] = Values[col_index_to_fetch];
+
+						/* In case of identity column, store the updated identity sequence value. */
+						if (cstate->seq_index == i)
+						{
+							if (cstate->identity_col_incr_value > 0)
+								cstate->cur_identity_value = Max(cstate->cur_identity_value, DatumGetInt64(Values[col_index_to_fetch]));
+							else
+								cstate->cur_identity_value = Min(cstate->cur_identity_value, DatumGetInt64(Values[col_index_to_fetch]));
+						}
 					}
 					j++;
 
@@ -917,6 +935,31 @@ BeginBulkCopy(Relation rel,
 		}
 	}
 
+	/* Store the increment value of Identity column. */
+	cstate->identity_col_incr_value = 1;
+	if (cstate->seqid != InvalidOid)
+	{
+		ListCell   *seq_lc;
+		List	*seq_options = sequence_options(cstate->seqid);
+
+		foreach(seq_lc, seq_options)
+		{
+			DefElem    *defel = (DefElem *) lfirst(seq_lc);
+
+			if (strcmp(defel->defname, "increment") == 0)
+			{
+				cstate->identity_col_incr_value = defGetInt64(defel);
+				break;
+			}
+		}
+		pfree(seq_options);
+	}
+	/* Initialize the current identity value variable based on the increment value. */
+	if (cstate->identity_col_incr_value > 0)
+		cstate->cur_identity_value = INT64_MIN;
+	else
+		cstate->cur_identity_value = INT64_MAX;
+
 	/* We keep those variables in cstate. */
 	cstate->defmap = defmap;
 	cstate->defexprs = defexprs;
@@ -975,6 +1018,57 @@ EndBulkCopy(BulkCopyState cstate, bool aborted)
 {
 	if (cstate)
 	{
+		/* 
+		 * for identity column reseed the identity sequence value, 
+		 * if cur_identity_value is more suitable as compared to previous seed value.
+		 */
+		if (cstate->seqid != InvalidOid && !aborted)
+		{
+			/* calculate the previous seed value */
+			int64	init_identity_value = 1;
+			bool	found_last_identity_value = false;
+
+			/* 
+			 * Fetch the last identity sequence value stored in the pg_sequences catalog. 
+			 * If not set, use the seed value instead.
+			 */
+			PG_TRY();
+			{
+				init_identity_value = DirectFunctionCall1(pg_sequence_last_value,
+															ObjectIdGetDatum(cstate->seqid));
+				found_last_identity_value = true;
+			}
+			PG_CATCH();
+			{
+				FlushErrorState();
+			}
+			PG_END_TRY();
+
+			if (!found_last_identity_value)
+			{
+				ListCell	*seq_lc;
+				List	*seq_options = sequence_options(cstate->seqid);
+
+				foreach(seq_lc, seq_options)
+				{
+					DefElem    *defel = (DefElem *) lfirst(seq_lc);
+
+					if (strcmp(defel->defname, "start") == 0)
+					{
+						init_identity_value = defGetInt64(defel);
+						break;
+					}
+				}
+				pfree(seq_options);
+			}
+
+			if ((cstate->identity_col_incr_value > 0 && cstate->cur_identity_value > init_identity_value) || 
+				(cstate->identity_col_incr_value < 0 && cstate->cur_identity_value < init_identity_value))
+				DirectFunctionCall2(setval_oid,
+								ObjectIdGetDatum(cstate->seqid),
+								Int64GetDatum(cstate->cur_identity_value));
+		}
+
 		/* Flush any remaining bufferes out to the table. */
 		if (!CopyMultiInsertInfoIsEmpty(&cstate->multiInsertInfo) && !aborted)
 			CopyMultiInsertInfoFlush(&cstate->multiInsertInfo, NULL);

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.h
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.h
@@ -49,6 +49,8 @@ typedef struct BulkCopyStateData
 	List	   *range_table;
 	int			seq_index;		/* index for an identity column */
 	Oid			seqid;			/* oid of the sequence for an identity column */
+	int64		cur_identity_value;	/* current Identity sequence value */
+	int64		identity_col_incr_value;	/* increment value of identity column */
 	int			rv_index;		/* index for a rowversion datatype column */
 } BulkCopyStateData;
 

--- a/test/dotnet/ExpectedOutput/bcp.out
+++ b/test/dotnet/ExpectedOutput/bcp.out
@@ -449,6 +449,190 @@ bcp#!#in#!#bcp_source#!#destinationTable
 2#!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, -4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+4
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity)
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, 2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity)
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, 2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, -4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# SET IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+4
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
 #Q#create table t_rcv (a int)
 #Q#create table t_rcv2 (b int)
 #Q#create trigger tri on t_rcv for insert as begin insert t_rcv2 select a*-1 from inserted end

--- a/test/dotnet/ExpectedOutput/bcpOptions.out
+++ b/test/dotnet/ExpectedOutput/bcpOptions.out
@@ -305,6 +305,311 @@ bcp -E#!#in#!#bcp_source#!#destinationTable
 #!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q#insert into sourceTable values (1), (2), (3)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#insert into destinationTable values (4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+2#!#2
+3#!#3
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+3
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+4
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, -4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+1
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+4
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+4
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, 2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+4
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+4
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, 2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-1
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, -4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-4
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+4
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-1
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT destinationTable ON
+#Q#INSERT INTO destinationTable (c1, c2) VALUES(1001, 'Foo')
+#Q# set IDENTITY_INSERT destinationTable OFF
+bcp -E#!#sourceTable#!#destinationTable
+#Q#create table sourceTable1(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable1 ON
+#Q#INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable1 OFF
+bcp -E#!#sourceTable1#!#destinationTable
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#select count(c1) from destinationTable
+#D#int
+1
+#Q#select Ident_CURRENT('sourceTable')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('sourceTable1')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('destinationTable')
+#D#decimal
+1001
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity, c2 CHAR(1024), check (c1 < 500))
+bcp#!#sourceTable1#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+#Q#create table sourceTable1(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable1 ON
+#Q#INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable1 OFF
+bcp -E#!#sourceTable1#!#destinationTable
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#select count(c1) from destinationTable
+#D#int
+0
+#Q#select Ident_CURRENT('sourceTable')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('sourceTable1')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('destinationTable')
+#D#decimal
+1
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) VALUES (1, 'Foo'), (2, 'Foo')
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT destinationTable ON
+#Q#INSERT INTO destinationTable (c1, c2) VALUES(2, 'Foo')
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+#Q#Select * from sourceTable
+#D#int#!#char
+1#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+2#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+#Q#Select * from destinationTable
+#D#int#!#char
+2#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+#Q#drop table sourceTable
+#Q#drop table destinationTable
 #Q#Create table sourceTable(a bigint, b bigint not null)
 #Q#Create table destinationTable(a bigint, b bigint not null)
 #Q#Insert into sourceTable values (1, 1);

--- a/test/dotnet/ExpectedOutput/insertBulk.out
+++ b/test/dotnet/ExpectedOutput/insertBulk.out
@@ -379,6 +379,244 @@ hello#!#jello
 2#!#2
 #Q#drop table sourceTable
 #Q#drop table destinationTable
+#Q#create table sourceTable(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity, c2 CHAR(1024), check (c1 < 500))
+#Q#create table sourceTable1(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable1 ON
+#Q#INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable1 OFF
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#select count(c1) from destinationTable
+#D#int
+2002
+#Q#select Ident_CURRENT('sourceTable')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('sourceTable1')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('destinationTable')
+#D#decimal
+1001
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int identity, b int)
+#Q#Create table destinationTable(a int identity(1, 2), b int)
+#Q#insert into sourceTable values (1)
+#Q#insert into sourceTable values (2)
+#Q# set IDENTITY_INSERT destinationTable ON
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select * from destinationTable
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+1
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int identity, b int)
+#Q#Create table destinationTable(a int identity(1, 2), b int)
+#Q#insert into sourceTable values (1)
+#Q#insert into sourceTable values (2)
+#Q# set IDENTITY_INSERT destinationTable ON
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, -4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+4
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, 2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity)
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#1
+2#!#2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, 2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity(-1, -1))
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -2)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-2
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+-2
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, -4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#-4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+1
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
+#Q#Create table sourceTable(a int, b int identity)
+#Q#Create table destinationTable(a int, b int identity(-1, -1))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#insert into sourceTable (a, b) values (1, -1)
+#Q#insert into sourceTable (a ,b) values (2, 4)
+#Q#Select * from sourceTable
+#D#int#!#int
+1#!#-1
+2#!#4
+#Q#Select * from destinationTable
+#D#int#!#int
+1#!#-1
+2#!#-2
+#Q#Select Ident_CURRENT('sourceTable')
+#D#decimal
+4
+#Q#Select Ident_CURRENT('destinationTable')
+#D#decimal
+-2
+#Q#drop table sourceTable
+#Q#drop table destinationTable
 #Q#create table t_rcv (a int)
 #Q#create table t_rcv2 (b int)
 #Q#create trigger tri on t_rcv for insert as begin insert t_rcv2 select a*-1 from inserted end

--- a/test/dotnet/ExpectedOutput/insertBulkErrors.out
+++ b/test/dotnet/ExpectedOutput/insertBulkErrors.out
@@ -655,3 +655,84 @@ on
 #Q#drop table sourceTable1
 #Q#drop table destinationTable
 #Q# SET implicit_transactions OFF
+#Q#create table sourceTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT destinationTable ON
+#Q#INSERT INTO destinationTable (c1, c2) VALUES(1001, 'Foo')
+#Q# set IDENTITY_INSERT destinationTable OFF
+#Q#create table sourceTable1(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable1 ON
+#Q#INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable1 OFF
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#select count(c1) from destinationTable
+#D#int
+1
+#Q#select Ident_CURRENT('sourceTable')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('sourceTable1')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('destinationTable')
+#D#decimal
+1001
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity, c2 CHAR(1024), check (c1 < 500))
+#Q#create table sourceTable1(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable1 ON
+#Q#INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+#Q#INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+#Q# set IDENTITY_INSERT sourceTable1 OFF
+#Q#Select count(c1) from sourceTable
+#D#int
+1001
+#Q#select count(c1) from sourceTable1
+#D#int
+1001
+#Q#select count(c1) from destinationTable
+#D#int
+0
+#Q#select Ident_CURRENT('sourceTable')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('sourceTable1')
+#D#decimal
+1001
+#Q#select Ident_CURRENT('destinationTable')
+#D#decimal
+1
+#Q#drop table sourceTable
+#Q#drop table sourceTable1
+#Q#drop table destinationTable
+#Q#create table sourceTable(c1 int identity, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT sourceTable ON
+#Q#INSERT INTO sourceTable (c1, c2) VALUES (1, 'Foo'), (2, 'Foo')
+#Q# set IDENTITY_INSERT sourceTable OFF
+#Q#create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+#Q# set IDENTITY_INSERT destinationTable ON
+#Q#INSERT INTO destinationTable (c1, c2) VALUES(2, 'Foo')
+#Q#Select * from sourceTable
+#D#int#!#char
+1#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+2#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+#Q#Select * from destinationTable
+#D#int#!#char
+2#!#Foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+#Q#drop table sourceTable
+#Q#drop table destinationTable

--- a/test/dotnet/input/InsertBulk/insertBulk.txt
+++ b/test/dotnet/input/InsertBulk/insertBulk.txt
@@ -296,6 +296,169 @@ Select * from destinationTable
 drop table sourceTable
 drop table destinationTable
 
+# identity test in case of check constraints off and KeepIdentity is on
+create table sourceTable(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity, c2 CHAR(1024), check (c1 < 500))
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+create table sourceTable1(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable1 ON
+INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable1 OFF
+traninsertbulk#!#sourceTable1#!#destinationTable#!#keepIdentity
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+select count(c1) from destinationTable
+select Ident_CURRENT('sourceTable')
+select Ident_CURRENT('sourceTable1')
+select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+# identity test when IDENTITY_INSERT destinationTable is ON inside the same connection which does the insert bulk without keepIdentity
+Create table sourceTable(a int identity, b int)
+Create table destinationTable(a int identity(1, 2), b int)
+insert into sourceTable values (1)
+insert into sourceTable values (2)
+ set IDENTITY_INSERT destinationTable ON
+traninsertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when IDENTITY_INSERT destinationTable is ON inside the same connection which does the insert bulk with keepIdentity
+Create table sourceTable(a int identity, b int)
+Create table destinationTable(a int identity(1, 2), b int)
+insert into sourceTable values (1)
+insert into sourceTable values (2)
+ set IDENTITY_INSERT destinationTable ON
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have positive increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, -4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have positive increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, 4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when source table has negative increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, 2)
+insert into sourceTable (a ,b) values (2, 4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when source table has negative increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -2)
+insert into sourceTable (a ,b) values (2, 4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have negative increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, 2)
+insert into sourceTable (a ,b) values (2, 4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have negative increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -2)
+insert into sourceTable (a ,b) values (2, 4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when destination table has negative increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, -4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when destination table has negative increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, 4)
+insertbulk#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
 # trigger
 create table t_rcv (a int)
 create table t_rcv2 (b int)

--- a/test/dotnet/input/InsertBulk/insertBulkErrors.txt
+++ b/test/dotnet/input/InsertBulk/insertBulkErrors.txt
@@ -14,6 +14,10 @@
 ### 6. Reset-connection testing with Primary Key error
 ### 7. Savepoint rollback and commit in error and non-error case.
 ### 8. implicit_transactions have no role to play here but we have still added tests.
+### 9. Check identity with error case
+###    a. transaction testing with identity and primary key column
+###    b. transaction testing with identity and check constraint
+###    c. Test Reset-connection with error (retry the insert bulk in a loop)
 ### The above tests test the seq and index.
 ##########################################################
 
@@ -556,3 +560,77 @@ drop table sourceTable1
 drop table destinationTable
 
  SET implicit_transactions OFF
+
+# identity
+# test identity with primary key, will raise error on duplicate entries
+create table sourceTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT destinationTable ON
+INSERT INTO destinationTable (c1, c2) VALUES(1001, 'Foo')
+ set IDENTITY_INSERT destinationTable OFF
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+create table sourceTable1(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable1 ON
+INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable1 OFF
+traninsertbulk#!#sourceTable1#!#destinationTable#!#keepIdentity
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+select count(c1) from destinationTable
+select Ident_CURRENT('sourceTable')
+select Ident_CURRENT('sourceTable1')
+select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+# test identity with check constraint, will raise error on entries violating the constraint
+create table sourceTable(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity, c2 CHAR(1024), check (c1 < 500))
+traninsertbulk#!#sourceTable#!#destinationTable
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+create table sourceTable1(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable1 ON
+INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable1 OFF
+traninsertbulk#!#sourceTable1#!#destinationTable#!#keepIdentity
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+select count(c1) from destinationTable
+select Ident_CURRENT('sourceTable')
+select Ident_CURRENT('sourceTable1')
+select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+# Reset-connection with error (retry the insert bulk in a loop)
+create table sourceTable(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) VALUES (1, 'Foo'), (2, 'Foo')
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT destinationTable ON
+INSERT INTO destinationTable (c1, c2) VALUES(2, 'Foo')
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+traninsertbulk#!#sourceTable#!#destinationTable#!#keepIdentity
+Select * from sourceTable
+Select * from destinationTable
+drop table sourceTable
+drop table destinationTable

--- a/test/dotnet/input/bcp.txt
+++ b/test/dotnet/input/bcp.txt
@@ -334,6 +334,126 @@ Select * from destinationTable
 drop table sourceTable
 drop table destinationTable
 
+# identity test when both tables have positive increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, -4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have positive increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when source table has negative increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity)
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, 2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when source table has negative increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity)
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have negative increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity(-1, -1))
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, 2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when both tables have negative increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity(-1, -1))
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when destination table has negative increment value and we insert less than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity(-1, -1))
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, -4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# identity test when destination table has negative increment value and we insert more than seed value
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity(-1, -1))
+ SET IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, 4)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
 # trigger
 create table t_rcv (a int)
 create table t_rcv2 (b int)

--- a/test/dotnet/input/bcpOptions.txt
+++ b/test/dotnet/input/bcpOptions.txt
@@ -230,6 +230,206 @@ Select * from destinationTable
 drop table sourceTable
 drop table destinationTable
 
+# check if the identity value for newly inserted column is correctly assigned
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+insert into sourceTable values (1), (2), (3)
+bcp#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+insert into destinationTable values (4)
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# tests are same as in bcp.txt but with keep identity flag ON
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, -4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, 2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity)
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, 2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity(-1, -1))
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -2)
+insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, -4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+Create table sourceTable(a int, b int identity)
+Create table destinationTable(a int, b int identity(-1, -1))
+ set IDENTITY_INSERT sourceTable ON
+insert into sourceTable (a, b) values (1, -1)
+insert into sourceTable (a ,b) values (2, 4)
+bcp -E#!#out#!#bcp_source#!#sourceTable
+bcp -E#!#in#!#bcp_source#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+Select Ident_CURRENT('sourceTable')
+Select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table destinationTable
+
+# test identity with primary key, will raise error on duplicate entries
+create table sourceTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT destinationTable ON
+INSERT INTO destinationTable (c1, c2) VALUES(1001, 'Foo')
+ set IDENTITY_INSERT destinationTable OFF
+bcp -E#!#sourceTable#!#destinationTable
+create table sourceTable1(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable1 ON
+INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable1 OFF
+bcp -E#!#sourceTable1#!#destinationTable
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+select count(c1) from destinationTable
+select Ident_CURRENT('sourceTable')
+select Ident_CURRENT('sourceTable1')
+select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+# test identity with check constraint, will raise error on entries violating the constraint
+create table sourceTable(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) SELECT generate_series(1, 1001, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity, c2 CHAR(1024), check (c1 < 500))
+bcp#!#sourceTable1#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+create table sourceTable1(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable1 ON
+INSERT INTO sourceTable1 (c1, c2) VALUES(1001, 'Foo')
+INSERT INTO sourceTable1 (c1, c2) SELECT generate_series(1, 1000, 1), 'Foo';
+ set IDENTITY_INSERT sourceTable1 OFF
+bcp -E#!#sourceTable1#!#destinationTable
+Select count(c1) from sourceTable
+select count(c1) from sourceTable1
+select count(c1) from destinationTable
+select Ident_CURRENT('sourceTable')
+select Ident_CURRENT('sourceTable1')
+select Ident_CURRENT('destinationTable')
+drop table sourceTable
+drop table sourceTable1
+drop table destinationTable
+
+# retry the bcp command in a loop
+create table sourceTable(c1 int identity, c2 CHAR(1024))
+ set IDENTITY_INSERT sourceTable ON
+INSERT INTO sourceTable (c1, c2) VALUES (1, 'Foo'), (2, 'Foo')
+ set IDENTITY_INSERT sourceTable OFF
+create table destinationTable(c1 int identity PRIMARY KEY, c2 CHAR(1024))
+ set IDENTITY_INSERT destinationTable ON
+INSERT INTO destinationTable (c1, c2) VALUES(2, 'Foo')
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+bcp -E#!#sourceTable#!#destinationTable
+Select * from sourceTable
+Select * from destinationTable
+drop table sourceTable
+drop table destinationTable
+
 # -R 
 Create table sourceTable(a bigint, b bigint not null)
 Create table destinationTable(a bigint, b bigint not null)

--- a/test/dotnet/src/BatchRun.cs
+++ b/test/dotnet/src/BatchRun.cs
@@ -224,7 +224,13 @@ namespace BabelfishDotnetFramework
 								$"########################## INSERT BULK:- {strLine} ##########################", logger, "information");
 							string sourceTable = result[1];
 							string destinationTable = result[2];
-							testFlag &= testUtils.insertBulkCopyWithTransaction(bblCnn, bblCmd, sourceTable, destinationTable, bblTransaction, logger, ref stCount);
+							string bulkCopyOption = "";
+							/* Check if bulk copy option is specified explicitly. */
+							if (result.Length > 3)
+							{
+								bulkCopyOption = result[3];
+							}
+							testFlag &= testUtils.insertBulkCopyWithTransaction(bblCnn, bblCmd, sourceTable, destinationTable, bulkCopyOption, bblTransaction, logger, ref stCount);
 						}
 						/* Case for sp_customtype RPC. */
 						else if (strLine.ToLowerInvariant().StartsWith("storedp"))

--- a/test/dotnet/utils/TestUtils.cs
+++ b/test/dotnet/utils/TestUtils.cs
@@ -67,7 +67,7 @@ namespace BabelfishDotnetFramework
 			return true;
 		}
 
-		public bool insertBulkCopyWithTransaction(DbConnection bblCnn, DbCommand bblCmd, String sourceTable, String destinationTable, DbTransaction transaction, Logger logger, ref int stCount)
+		public bool insertBulkCopyWithTransaction(DbConnection bblCnn, DbCommand bblCmd, String sourceTable, String destinationTable, String bulkCopyOption, DbTransaction transaction, Logger logger, ref int stCount)
 		{
 			bblCmd.CommandText = "Select * from " + sourceTable;
 			bblCmd.Transaction = transaction;
@@ -79,8 +79,15 @@ namespace BabelfishDotnetFramework
 				dataTable.Load(reader);
 				reader.Close();
 
-				/* Set CheckConstraints default for this API since this is the only mechanism to use BCP Options. */
-				SqlBulkCopy bulkCopy = new SqlBulkCopy((SqlConnection)bblCnn, SqlBulkCopyOptions.CheckConstraints, (SqlTransaction) transaction);
+				SqlBulkCopy bulkCopy = null;
+
+				if (bulkCopyOption.Equals("keepIdentity"))
+					/* Set KeepIdentity option */
+					bulkCopy = new SqlBulkCopy((SqlConnection)bblCnn, SqlBulkCopyOptions.KeepIdentity, (SqlTransaction) transaction);
+				else
+					/* Set CheckConstraints default for this API since this is the only mechanism to use BCP Options. */
+					bulkCopy = new SqlBulkCopy((SqlConnection)bblCnn, SqlBulkCopyOptions.CheckConstraints, (SqlTransaction) transaction);
+
 				bulkCopy.DestinationTableName = destinationTable;
 				bulkCopy.WriteToServer(dataTable);
 			}


### PR DESCRIPTION
## Description

### 1. Issues
- Bcp / SqlBulkCopy / insert bulk should increment the identity sequence value when in "keep identity values" mode

### 2. Changes made to fix the issues
- Supported increment of identity sequence in TSQL Bulk Copy when in 'keep identity values' mode by seeding the identity sequence correctly during BulkCopy.
- Added Test Cases for the issue.

cherry-picked: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2885

Task: BABEL- 4865, BABEL- 4997
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)


### Test Scenarios Covered ###
* **Use case based -**  YES


* **Boundary conditions -** YES


* **Arbitrary inputs -** YES


* **Negative test cases -** YES


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**

* **Memory tests -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).