### PR TITLE
Fix valgrind warning in bbf_create_partition_tables function

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_partition.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_partition.c
@@ -199,8 +199,6 @@ bbf_create_partition_tables(CreateStmt *stmt)
 	 */
 	if (partition_column_typoid != input_type_oid)
 	{
-		systable_endscan(scan);
-		table_close(rel, AccessShareLock);
 		ereport(ERROR, 
 			(errcode(ERRCODE_UNDEFINED_OBJECT), 
 				errmsg("Partition column '%s' has data type '%s' which is different from the partition function '%s' parameter data type '%s'.",
@@ -222,6 +220,7 @@ bbf_create_partition_tables(CreateStmt *stmt)
 								CSTRINGOID, -1);
 	}
 
+	/* Close the catalog. */
 	systable_endscan(scan);
 	table_close(rel, AccessShareLock);
 

--- a/contrib/babelfishpg_tsql/src/pltsql_partition.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_partition.c
@@ -173,9 +173,6 @@ bbf_create_partition_tables(CreateStmt *stmt)
 	values = DatumGetArrayTypeP(heap_getattr(tuple, Anum_bbf_partition_function_range_values, RelationGetDescr(rel), &isnull));
 	deconstruct_array(values, sql_variant_type_oid, -1, false, 'i', &datum_values, &nulls, &nelems);
 
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
 	/*
 	 * If the partition columns type is UDT type, then we need
 	 * to use the base type of that type while comparing with
@@ -202,6 +199,8 @@ bbf_create_partition_tables(CreateStmt *stmt)
 	 */
 	if (partition_column_typoid != input_type_oid)
 	{
+		systable_endscan(scan);
+		table_close(rel, AccessShareLock);
 		ereport(ERROR, 
 			(errcode(ERRCODE_UNDEFINED_OBJECT), 
 				errmsg("Partition column '%s' has data type '%s' which is different from the partition function '%s' parameter data type '%s'.",
@@ -222,6 +221,9 @@ bbf_create_partition_tables(CreateStmt *stmt)
 								sql_variant_type_oid, -1,
 								CSTRINGOID, -1);
 	}
+
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
 
 	/*
 	 * Find default schema for current user when schema


### PR DESCRIPTION
### Description
During the creation of a partitioned table using a partition scheme, the range values array was extracted from the catalog, and the array values were deconstructed into datums using the `deconstruct_array` function. However, the catalog was closed before processing the datums returned by `deconstruct_array`. If the datatype of the array elements is pass-by-ref, the returned datums are pointers to the array object, which can lead to an invalid read after closing the catalog. 

This commit fixes the issue by keeping the catalog open until all the processing of the datums returned by `deconstruct_array` is complete in `bbf_create_partition_tables` and `search_partition` functions.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Issues Resolved

Task: BABEL-5213

### Test Scenarios Covered ###
I have tested valgrind issues locally. Automated tests are already present. 


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).