### PR TITLE
Support Cross-database references in views (#2899)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -98,13 +98,6 @@ where ext.dbid = sys.db_id();
 GRANT SELECT ON sys.schemas TO PUBLIC;
 CREATE SEQUENCE sys.babelfish_db_seq MAXVALUE 32767 CYCLE;
 
--- CATALOG INITIALIZER
-CREATE OR REPLACE PROCEDURE babel_catalog_initializer()
-LANGUAGE C
-AS 'babelfishpg_tsql', 'init_catalog';
-
-CALL babel_catalog_initializer();
-
 CREATE OR REPLACE PROCEDURE babel_create_builtin_dbs(IN login TEXT)
 LANGUAGE C
 AS 'babelfishpg_tsql', 'create_builtin_dbs';
@@ -407,6 +400,13 @@ SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_namespace_ext', '');
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_login_ext', '');
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_authid_user_ext', '');
 SELECT pg_catalog.pg_extension_config_dump('sys.babelfish_schema_permissions', '');
+
+-- CATALOG INITIALIZER
+CREATE OR REPLACE PROCEDURE babel_catalog_initializer()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'init_catalog';
+
+CALL babel_catalog_initializer();
 
 -- DATABASE_PRINCIPALS
 CREATE OR REPLACE VIEW sys.database_principals AS

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -154,6 +154,28 @@ static struct cachedesc my_cacheinfo[] = {
 			0
 		},
 		16
+	},
+	{-1,						/* SYSNAMESPACENAME */
+		-1,
+		1,
+		{
+			Anum_namespace_ext_namespace,
+			0,
+			0,
+			0
+		},
+		16
+	},
+	{-1,						/* AUTHIDUSEREXTROLENAME */
+		-1,
+		1,
+		{
+			Anum_bbf_authid_user_ext_rolname,
+			0,
+			0,
+			0
+		},
+		16
 	}
 };
 
@@ -180,6 +202,12 @@ init_catalog(PG_FUNCTION_ARGS)
 	bbf_function_ext_oid = get_relname_relid(BBF_FUNCTION_EXT_TABLE_NAME, sys_schema_oid);
 	bbf_function_ext_idx_oid = get_relname_relid(BBF_FUNCTION_EXT_IDX_NAME, sys_schema_oid);
 
+	/* user ext */
+	bbf_authid_user_ext_oid = get_relname_relid(BBF_AUTHID_USER_EXT_TABLE_NAME,
+												sys_schema_oid);
+	bbf_authid_user_ext_idx_oid = get_relname_relid(BBF_AUTHID_USER_EXT_IDX_NAME,
+													sys_schema_oid);
+
 	/* syscache info */
 	my_cacheinfo[0].reloid = sysdatabases_oid;
 	my_cacheinfo[0].indoid = sysdatabaese_idx_oid_oid;
@@ -187,17 +215,16 @@ init_catalog(PG_FUNCTION_ARGS)
 	my_cacheinfo[1].indoid = sysdatabaese_idx_name_oid;
 	my_cacheinfo[2].reloid = bbf_function_ext_oid;
 	my_cacheinfo[2].indoid = bbf_function_ext_idx_oid;
+	my_cacheinfo[3].reloid = namespace_ext_oid;
+	my_cacheinfo[3].indoid = namespace_ext_idx_oid_oid;
+	my_cacheinfo[4].reloid = bbf_authid_user_ext_oid;
+	my_cacheinfo[4].indoid = bbf_authid_user_ext_idx_oid;
 
 	/* login ext */
 	bbf_authid_login_ext_oid = get_relname_relid(BBF_AUTHID_LOGIN_EXT_TABLE_NAME,
 												 sys_schema_oid);
 	bbf_authid_login_ext_idx_oid = get_relname_relid(BBF_AUTHID_LOGIN_EXT_IDX_NAME,
 													 sys_schema_oid);
-	/* user ext */
-	bbf_authid_user_ext_oid = get_relname_relid(BBF_AUTHID_USER_EXT_TABLE_NAME,
-												sys_schema_oid);
-	bbf_authid_user_ext_idx_oid = get_relname_relid(BBF_AUTHID_USER_EXT_IDX_NAME,
-													sys_schema_oid);
 
 	/* bbf_view_def */
 	bbf_view_def_oid = get_relname_relid(BBF_VIEW_DEF_TABLE_NAME, sys_schema_oid);
@@ -241,7 +268,7 @@ initTsqlSyscache()
 	/* Initialize info for catcache */
 	if (!tsql_syscache_inited)
 	{
-		InitExtensionCatalogCache(my_cacheinfo, SYSDATABASEOID, 3);
+		InitExtensionCatalogCache(my_cacheinfo, SYSDATABASEOID, 5);
 		tsql_syscache_inited = true;
 	}
 }
@@ -556,90 +583,54 @@ babelfish_helpdb(PG_FUNCTION_ARGS)
 const char *
 get_logical_schema_name(const char *physical_schema_name, bool missingOk)
 {
-	Relation	rel;
 	HeapTuple	tuple;
-	ScanKeyData scanKey;
-	SysScanDesc scan;
 	Datum		datum;
 	const char *logical_name;
-	TupleDesc	dsc;
 	bool		isnull;
 
 	if (get_namespace_oid(physical_schema_name, missingOk) == InvalidOid)
 		return NULL;
 
-	rel = table_open(namespace_ext_oid, AccessShareLock);
-	dsc = RelationGetDescr(rel);
-
-	ScanKeyInit(&scanKey,
-				Anum_namespace_ext_namespace,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(physical_schema_name));
-
-	scan = systable_beginscan(rel, namespace_ext_idx_oid_oid, true,
-							  NULL, 1, &scanKey);
-
-	tuple = systable_getnext(scan);
+	tuple = SearchSysCache1(SYSNAMESPACENAME, CStringGetDatum(physical_schema_name));
 	if (!HeapTupleIsValid(tuple))
 	{
-		systable_endscan(scan);
-		table_close(rel, AccessShareLock);
 		if (!missingOk)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("Could find logical schema name for: \"%s\"", physical_schema_name)));
 		return NULL;
 	}
-	datum = heap_getattr(tuple, Anum_namespace_ext_orig_name, dsc, &isnull);
+	datum = SysCacheGetAttr(SYSNAMESPACENAME, tuple, Anum_namespace_ext_orig_name, &isnull);
 	logical_name = pstrdup(TextDatumGetCString(datum));
+	ReleaseSysCache(tuple);
 
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
 	return logical_name;
 }
 
 int16
 get_dbid_from_physical_schema_name(const char *physical_schema_name, bool missingOk)
 {
-	Relation	rel;
 	HeapTuple	tuple;
-	ScanKeyData scanKey;
-	SysScanDesc scan;
 	Datum		datum;
 	int16		dbid;
-	TupleDesc	dsc;
 	bool		isnull;
 
 	if (get_namespace_oid(physical_schema_name, false) == InvalidOid)
 		return InvalidDbid;
 
-	rel = table_open(namespace_ext_oid, AccessShareLock);
-	dsc = RelationGetDescr(rel);
-
-	ScanKeyInit(&scanKey,
-				Anum_namespace_ext_namespace,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(physical_schema_name));
-
-	scan = systable_beginscan(rel, namespace_ext_idx_oid_oid, true,
-							  NULL, 1, &scanKey);
-
-	tuple = systable_getnext(scan);
+	tuple = SearchSysCache1(SYSNAMESPACENAME, CStringGetDatum(physical_schema_name));
 	if (!HeapTupleIsValid(tuple))
 	{
-		systable_endscan(scan);
-		table_close(rel, AccessShareLock);
 		if (!missingOk)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("Could not find db id for: \"%s\"", physical_schema_name)));
 		return InvalidDbid;
 	}
-	datum = heap_getattr(tuple, Anum_namespace_ext_dbid, dsc, &isnull);
+	datum = SysCacheGetAttr(SYSNAMESPACENAME, tuple, Anum_namespace_ext_dbid, &isnull);
 	dbid = DatumGetInt16(datum);
+	ReleaseSysCache(tuple);
 
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
 	return dbid;
 }
 
@@ -814,14 +805,10 @@ get_authid_login_ext_idx_oid(void)
 bool
 is_user(Oid role_oid)
 {
-	Relation	relation;
 	bool		is_user = true;
-	ScanKeyData scanKey;
-	SysScanDesc scan;
 	HeapTuple	tuple;
 	HeapTuple	authtuple;
 	NameData	rolname;
-	char	   *type_str = "";
 
 	authtuple = SearchSysCache1(AUTHOID, ObjectIdGetDatum(role_oid));
 	if (!HeapTupleIsValid(authtuple))
@@ -829,43 +816,23 @@ is_user(Oid role_oid)
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("role with OID %u does not exist", role_oid)));
 	rolname = ((Form_pg_authid) GETSTRUCT(authtuple))->rolname;
-
-	relation = table_open(get_authid_user_ext_oid(), AccessShareLock);
-
-	ScanKeyInit(&scanKey,
-				Anum_bbf_authid_user_ext_rolname,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				NameGetDatum(&rolname));
-
-	scan = systable_beginscan(relation,
-							  get_authid_user_ext_idx_oid(),
-							  true, NULL, 1, &scanKey);
-
-	tuple = systable_getnext(scan);
+	tuple = SearchSysCache1(AUTHIDUSEREXTROLENAME, NameGetDatum(&rolname));
 
 	if (!HeapTupleIsValid(tuple))
 		is_user = false;
 	else
 	{
-		Datum		datum;
-		bool		isnull;
-		TupleDesc	dsc;
+		BpChar type = ((Form_authid_user_ext) GETSTRUCT(tuple))->type;
+		char *type_str = bpchar_to_cstring(&type);
 
-		dsc = RelationGetDescr(relation);
-		datum = heap_getattr(tuple, USER_EXT_TYPE + 1, dsc, &isnull);
-		if (!isnull)
-			type_str = pstrdup(TextDatumGetCString(datum));
+		/*
+		 * Only sysadmin can not be dropped. For the rest of the cases i.e., type
+		 * is "S" or "U" etc, we should drop the user
+		 */
+		if (strcmp(type_str, "R") == 0)
+			is_user = false;
+		ReleaseSysCache(tuple);
 	}
-
-	/*
-	 * Only sysadmin can not be dropped. For the rest of the cases i.e., type
-	 * is "S" or "U" etc, we should drop the user
-	 */
-	if (strcmp(type_str, "R") == 0)
-		is_user = false;
-
-	systable_endscan(scan);
-	table_close(relation, AccessShareLock);
 
 	ReleaseSysCache(authtuple);
 
@@ -875,15 +842,10 @@ is_user(Oid role_oid)
 bool
 is_role(Oid role_oid)
 {
-	Relation	relation;
 	bool		is_role = true;
-	ScanKeyData scanKey;
-	SysScanDesc scan;
 	HeapTuple	tuple;
 	HeapTuple	authtuple;
 	NameData	rolname;
-	BpChar		type;
-	char	   *type_str = "";
 
 	authtuple = SearchSysCache1(AUTHOID, ObjectIdGetDatum(role_oid));
 	if (!HeapTupleIsValid(authtuple))
@@ -891,33 +853,19 @@ is_role(Oid role_oid)
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("role with OID %u does not exist", role_oid)));
 	rolname = ((Form_pg_authid) GETSTRUCT(authtuple))->rolname;
-
-	relation = table_open(get_authid_user_ext_oid(), AccessShareLock);
-
-	ScanKeyInit(&scanKey,
-				Anum_bbf_authid_user_ext_rolname,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				NameGetDatum(&rolname));
-
-	scan = systable_beginscan(relation,
-							  get_authid_user_ext_idx_oid(),
-							  true, NULL, 1, &scanKey);
-
-	tuple = systable_getnext(scan);
+	tuple = SearchSysCache1(AUTHIDUSEREXTROLENAME, NameGetDatum(&rolname));
 
 	if (!HeapTupleIsValid(tuple))
 		is_role = false;
 	else
 	{
-		type = ((Form_authid_user_ext) GETSTRUCT(tuple))->type;
-		type_str = bpchar_to_cstring(&type);
+		BpChar type = ((Form_authid_user_ext) GETSTRUCT(tuple))->type;
+		char *type_str = bpchar_to_cstring(&type);
 
 		if (strcmp(type_str, "R") != 0)
 			is_role = false;
+		ReleaseSysCache(tuple);
 	}
-
-	systable_endscan(scan);
-	table_close(relation, AccessShareLock);
 
 	ReleaseSysCache(authtuple);
 
@@ -2552,34 +2500,67 @@ guest_role_exists_for_db(const char *dbname)
 {
 	const char *guest_role = get_guest_role_name(dbname);
 	bool		role_exists = false;
-	Relation	bbf_authid_user_ext_rel;
 	HeapTuple	tuple;
-	ScanKeyData scanKey;
-	SysScanDesc scan;
 
-	/* Fetch the relation */
-	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
-
-	/* Search if the role exists */
-	ScanKeyInit(&scanKey,
-				Anum_bbf_authid_user_ext_rolname,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(guest_role));
-
-	scan = systable_beginscan(bbf_authid_user_ext_rel,
-							  get_authid_user_ext_idx_oid(),
-							  true, NULL, 1, &scanKey);
-
-	tuple = systable_getnext(scan);
+	tuple = SearchSysCache1(AUTHIDUSEREXTROLENAME, CStringGetDatum(guest_role));
 
 	if (HeapTupleIsValid(tuple))
+	{
 		role_exists = true;
-
-	systable_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+		ReleaseSysCache(tuple);
+	}
 
 	return role_exists;
+}
+
+/*
+ * get_login_for_user
+ * Get mapped login for given user_id.
+ * Usually login can be retrived from login_name column of bbf_authid_login_ext
+ * catalog although sometimes the column can be empty such as when user_id belongs
+ * to dbo or guest user. In case the user_id is of dbo role then we get owner of
+ * the respective database which can be deduced from physical_schema_name. For all
+ * other cases, return InvalidOid since mapped login does not exist for the rest.
+ */
+Oid
+get_login_for_user(Oid user_id, const char *physical_schema_name)
+{
+	HeapTuple	tuple;
+	Oid loginId = InvalidOid;
+	char *physical_user_name = GetUserNameFromId(user_id, true);
+
+	if (!physical_user_name || !physical_schema_name)
+		return InvalidOid;
+
+	/* Search if the role exists */
+	tuple = SearchSysCache1(AUTHIDUSEREXTROLENAME, CStringGetDatum(physical_user_name));
+
+	if (HeapTupleIsValid(tuple))
+	{
+		Datum datum;
+		bool isnull;
+
+		datum = SysCacheGetAttr(AUTHIDUSEREXTROLENAME, tuple, Anum_bbf_authid_user_ext_login_name, &isnull);
+		Assert(!isnull);
+		loginId = get_role_oid((DatumGetName(datum)->data), true);
+
+		if (!OidIsValid(loginId))
+		{
+			char *orig_username = TextDatumGetCString(SysCacheGetAttr(AUTHIDUSEREXTROLENAME,
+								tuple, Anum_bbf_authid_user_ext_orig_username, &isnull));
+
+			Assert(!isnull);
+			/* Get owner of the db if the user is dbo */
+			if (strlen(orig_username) == 3 && pg_strcasecmp(orig_username, "dbo") == 0)
+			{
+				int16 dbid = get_dbid_from_physical_schema_name(physical_schema_name, false);
+				loginId = get_role_oid(get_owner_of_db(get_db_name(dbid)), false);
+			}
+		}
+		ReleaseSysCache(tuple);
+	}
+
+	return loginId;
 }
 
 static void

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -157,6 +157,7 @@ extern char *get_user_for_database(const char *db_name);
 extern void alter_user_can_connect(bool is_grant, char *user_name, char *db_name);
 extern bool guest_role_exists_for_db(const char *dbname);
 extern void update_db_owner(const char *new_owner_name, const char *db_name);
+extern Oid get_login_for_user(Oid user_id, const char *physical_schema_name);
 
 /* MUST comply with babelfish_authid_user_ext table */
 typedef struct FormData_authid_user_ext

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -25,6 +25,7 @@
 #include "commands/trigger.h"
 #include "commands/view.h"
 #include "common/logging.h"
+#include "executor/execExpr.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
@@ -177,6 +178,7 @@ static void is_function_pg_stat_valid(FunctionCallInfo fcinfo,
 									  PgStat_FunctionCallUsage *fcu,
 									  char prokind, bool finalize);
 static void pass_pivot_data_to_fcinfo(FunctionCallInfo fcinfo, Expr *expr);
+static AclResult pltsql_ExecFuncProc_AclCheck(Oid funcid);
 
 /*****************************************
  * 			Replication Hooks
@@ -248,6 +250,7 @@ static called_for_tsql_itvf_func_hook_type prev_called_for_tsql_itvf_func_hook =
 static exec_tsql_cast_value_hook_type pre_exec_tsql_cast_value_hook = NULL;
 static pltsql_pgstat_end_function_usage_hook_type prev_pltsql_pgstat_end_function_usage_hook = NULL;
 static pltsql_unique_constraint_nulls_ordering_hook_type prev_pltsql_unique_constraint_nulls_ordering_hook = NULL;
+static ExecFuncProc_AclCheck_hook_type prev_ExecFuncProc_AclCheck_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -434,6 +437,9 @@ InstallExtendedHooks(void)
 
 	prev_pltsql_unique_constraint_nulls_ordering_hook = pltsql_unique_constraint_nulls_ordering_hook;
 	pltsql_unique_constraint_nulls_ordering_hook = unique_constraint_nulls_ordering;
+
+	prev_ExecFuncProc_AclCheck_hook  = ExecFuncProc_AclCheck_hook;
+	ExecFuncProc_AclCheck_hook = pltsql_ExecFuncProc_AclCheck;
 }
 
 void
@@ -501,6 +507,7 @@ UninstallExtendedHooks(void)
 	called_for_tsql_itvf_func_hook = prev_called_for_tsql_itvf_func_hook;
 	pltsql_pgstat_end_function_usage_hook = prev_pltsql_pgstat_end_function_usage_hook;
 	pltsql_unique_constraint_nulls_ordering_hook = prev_pltsql_unique_constraint_nulls_ordering_hook;
+	ExecFuncProc_AclCheck_hook = prev_ExecFuncProc_AclCheck_hook;
 
 	bbf_InitializeParallelDSM_hook = NULL;
 	bbf_ParallelWorkerMain_hook = NULL;
@@ -595,6 +602,38 @@ pltsql_GetNewObjectId(VariableCache variableCache)
 	ShmemVariableCache->oidCount = 0;
 }
 
+static AclResult
+pltsql_ExecFuncProc_AclCheck(Oid funcid)
+{
+	Oid userid = GetUserId();
+
+	/* In TDS client, the permissions might need to be checked against session user. */
+	if (IS_TDS_CLIENT())
+	{
+		Oid schema_id = get_func_namespace(funcid);
+
+		if (OidIsValid(schema_id))
+		{
+			char *nspname = get_namespace_name(schema_id);
+
+			/*
+			 * Check if function's schema is from a different logical database and
+			 * it is not a shared schema. If yes, then set userid to session user
+			 * to allow cross database access.
+			 */
+			if (nspname != NULL && !is_shared_schema(nspname) &&
+				!is_schema_from_db(schema_id, get_cur_db_id()))
+				userid = GetSessionUserId();
+			if (nspname)
+				pfree(nspname);
+		}
+	}
+	else if (prev_ExecFuncProc_AclCheck_hook)
+		return prev_ExecFuncProc_AclCheck_hook(funcid);
+
+	return pg_proc_aclcheck(funcid, userid, ACL_EXECUTE);
+}
+
 static void
 pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
@@ -618,6 +657,58 @@ pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			queryDesc->instrument_options |= INSTRUMENT_BUFFERS;
 		if (pltsql_explain_wal)
 			queryDesc->instrument_options |= INSTRUMENT_WAL;
+	}
+
+	/*
+	 * In TDS client, the RTE permissions might need to be checked against login mapped to given checkAsUser,
+	 * if it is valid, otherwise permissions are checked against session user (current login).
+	 */
+	if (IS_TDS_CLIENT() && queryDesc->plannedstmt != NULL)
+	{
+		ListCell	*lc;
+
+		foreach(lc, queryDesc->plannedstmt->rtable)
+		{
+			RangeTblEntry	*rte = lfirst_node(RangeTblEntry, lc);
+			Oid         	relOid = rte->relid;
+
+			if (OidIsValid(relOid))
+			{
+				Oid schema_id = get_rel_namespace(relOid);
+
+				if (OidIsValid(schema_id))
+				{
+					char *nspname = get_namespace_name(schema_id);
+
+					/*
+					 * Check if relation's schema is valid and is not a shared schema. If yes,
+					 * then replace checkAsUser to its mapped login if present otherwise replace
+					 * with session user (current login).
+					 * We do not blindly want to check the permissions against session user (current login)
+					 * since permissions of RTEs inside a view are checked against that view's owner
+					 * which can very well be a user of some different database. So if we blindly check
+					 * permission against session user instead of view's owner then it would break view's
+					 * ownership behavior. Instead, we will replace checkAsUser with it's corresponding mapped
+					 * login if present and only in cases where checkAsUser is not set, we will replace it
+					 * with session user (login). We are using login to allow cross database queries since login
+					 * can access all its objects across the databases.
+					 */
+					if (nspname != NULL && !is_shared_schema(nspname))
+					{
+						if (OidIsValid(rte->checkAsUser))
+						{
+							Oid loginId = get_login_for_user(rte->checkAsUser, nspname);
+							if (OidIsValid(loginId))
+								rte->checkAsUser = loginId;
+						}
+						else
+							rte->checkAsUser = GetSessionUserId();
+					}
+					if (nspname)
+						pfree(nspname);
+				}
+			}
+		}
 	}
 
 	if (prev_ExecutorStart)

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4622,7 +4622,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	CmdType		cmd = CMD_UNKNOWN;
 	bool		enable_txn_in_triggers = !pltsql_disable_txn_in_triggers;
 	StringInfoData query;
-	Oid			current_user_id = GetUserId();
 	bool		need_path_reset = false;
 	char	   *cur_dbname = get_cur_db_name();
 	bool		reset_session_properties = false;
@@ -4639,32 +4638,17 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 
 	if (stmt->is_cross_db)
 	{
-		char	   *login = GetUserNameFromId(GetSessionUserId(), false);
-		char	   *user = get_user_for_database(stmt->db_name);
-
 		if (stmt->insert_exec)
 		{
 			estate->db_name = stmt->db_name;
 		}
-
-		if (user)
-			SetCurrentRoleId(GetSessionUserId(), false);
-		else
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_DATABASE),
-					 errmsg("The server principal \"%s\" is not able to access "
-							"the database \"%s\" under the current security context",
-							login, stmt->db_name)));
 
 		/*
 		 * When there is cross db reference to sys or information_schema
 		 * schemas, Change the session property.
 		 */
 		if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
-		{
 			set_session_properties(stmt->db_name);
-			SetCurrentRoleId(GetSessionUserId(), false);
-		}
 	}
 	if (stmt->is_dml || stmt->is_ddl || stmt->is_create_view)
 	{
@@ -4688,13 +4672,10 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			{
 				if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
 					set_session_properties(cur_dbname);
-
-				SetCurrentRoleId(current_user_id, false);
 			}
 			if (reset_session_properties)
 			{
 				set_session_properties(cur_dbname);
-				SetCurrentRoleId(current_user_id, false);
 			}
 			return ret;
 		}
@@ -5098,13 +5079,11 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		if (reset_session_properties)
 		{
 			set_session_properties(cur_dbname);
-			SetCurrentRoleId(current_user_id, false);
 		}
 		if (stmt->is_cross_db)
 		{
 			if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
 				set_session_properties(cur_dbname);
-			SetCurrentRoleId(current_user_id, false);
 		}
 		PG_RE_THROW();
 	}
@@ -5117,13 +5096,11 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	if (reset_session_properties)
 	{
 		set_session_properties(cur_dbname);
-		SetCurrentRoleId(current_user_id, false);
 	}
 	if (stmt->is_cross_db)
 	{
 		if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
 			set_session_properties(cur_dbname);
-		SetCurrentRoleId(current_user_id, false);
 	}
 
 	return PLTSQL_RC_OK;

--- a/test/JDBC/expected/BABEL-5119-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5119-vu-verify.out
@@ -67,43 +67,43 @@ babel5119_p3
 ~~END~~
 
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
-master#!#guest#!#BABEL5119_t4#!#BASE TABLE
-master#!#guest#!#BABEL5119_t5#!#BASE TABLE
-master#!#guest#!#BABEL5119_t6#!#BASE TABLE
-master#!#guest#!#babel5119_v4#!#VIEW
-master#!#guest#!#babel5119_v5#!#VIEW
-master#!#guest#!#babel5119_v6#!#VIEW
+babel5119_db#!#dbo#!#BABEL5119_t1#!#BASE TABLE
+babel5119_db#!#dbo#!#BABEL5119_t2#!#BASE TABLE
+babel5119_db#!#dbo#!#BABEL5119_t3#!#BASE TABLE
+babel5119_db#!#dbo#!#babel5119_v1#!#VIEW
+babel5119_db#!#dbo#!#babel5119_v2#!#VIEW
+babel5119_db#!#dbo#!#babel5119_v3#!#VIEW
 ~~END~~
 
 
-SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-BABEL5119_t4#!#a
-BABEL5119_t5#!#a
-BABEL5119_t6#!#a
-babel5119_v4#!#?column?
-babel5119_v5#!#?column?
-babel5119_v6#!#?column?
+BABEL5119_t1#!#a
+BABEL5119_t2#!#a
+BABEL5119_t3#!#a
+babel5119_v1#!#?column?
+babel5119_v2#!#?column?
+babel5119_v3#!#?column?
 ~~END~~
 
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-babel5119_v4#!#CREATE VIEW BABEL5119_v4 AS SELECT 1
-babel5119_v5#!#CREATE VIEW BABEL5119_v5 AS SELECT 1
-babel5119_v6#!#CREATE VIEW BABEL5119_v6 AS SELECT 1
+babel5119_v1#!#CREATE VIEW BABEL5119_v1 AS SELECT 1
+babel5119_v2#!#CREATE VIEW BABEL5119_v2 AS SELECT 1
+babel5119_v3#!#CREATE VIEW BABEL5119_v3 AS SELECT 1
 ~~END~~
 
 
@@ -137,7 +137,7 @@ GO
 
 
 CREATE TABLE #babel5119_tmp_table_3(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_3 SELECT TABLE_NAME FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_3 SELECT TABLE_NAME FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 ~~ROW COUNT: 6~~
 
@@ -185,43 +185,43 @@ babel5119_p6
 ~~END~~
 
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
-babel5119_db#!#dbo#!#BABEL5119_t1#!#BASE TABLE
-babel5119_db#!#dbo#!#BABEL5119_t2#!#BASE TABLE
-babel5119_db#!#dbo#!#BABEL5119_t3#!#BASE TABLE
-babel5119_db#!#dbo#!#babel5119_v1#!#VIEW
-babel5119_db#!#dbo#!#babel5119_v2#!#VIEW
-babel5119_db#!#dbo#!#babel5119_v3#!#VIEW
+master#!#guest#!#BABEL5119_t4#!#BASE TABLE
+master#!#guest#!#BABEL5119_t5#!#BASE TABLE
+master#!#guest#!#BABEL5119_t6#!#BASE TABLE
+master#!#guest#!#babel5119_v4#!#VIEW
+master#!#guest#!#babel5119_v5#!#VIEW
+master#!#guest#!#babel5119_v6#!#VIEW
 ~~END~~
 
 
-SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-BABEL5119_t1#!#a
-BABEL5119_t2#!#a
-BABEL5119_t3#!#a
-babel5119_v1#!#?column?
-babel5119_v2#!#?column?
-babel5119_v3#!#?column?
+BABEL5119_t4#!#a
+BABEL5119_t5#!#a
+BABEL5119_t6#!#a
+babel5119_v4#!#?column?
+babel5119_v5#!#?column?
+babel5119_v6#!#?column?
 ~~END~~
 
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-babel5119_v1#!#CREATE VIEW BABEL5119_v1 AS SELECT 1
-babel5119_v2#!#CREATE VIEW BABEL5119_v2 AS SELECT 1
-babel5119_v3#!#CREATE VIEW BABEL5119_v3 AS SELECT 1
+babel5119_v4#!#CREATE VIEW BABEL5119_v4 AS SELECT 1
+babel5119_v5#!#CREATE VIEW BABEL5119_v5 AS SELECT 1
+babel5119_v6#!#CREATE VIEW BABEL5119_v6 AS SELECT 1
 ~~END~~
 
 
@@ -255,7 +255,7 @@ GO
 
 
 CREATE TABLE #babel5119_tmp_table_6(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_6 SELECT TABLE_NAME FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_6 SELECT TABLE_NAME FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 ~~ROW COUNT: 6~~
 
@@ -307,43 +307,43 @@ babel5119_p3
 ~~END~~
 
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
-master#!#guest#!#BABEL5119_t4#!#BASE TABLE
-master#!#guest#!#BABEL5119_t5#!#BASE TABLE
-master#!#guest#!#BABEL5119_t6#!#BASE TABLE
-master#!#guest#!#babel5119_v4#!#VIEW
-master#!#guest#!#babel5119_v5#!#VIEW
-master#!#guest#!#babel5119_v6#!#VIEW
+babel5119_db#!#dbo#!#BABEL5119_t1#!#BASE TABLE
+babel5119_db#!#dbo#!#BABEL5119_t2#!#BASE TABLE
+babel5119_db#!#dbo#!#BABEL5119_t3#!#BASE TABLE
+babel5119_db#!#dbo#!#babel5119_v1#!#VIEW
+babel5119_db#!#dbo#!#babel5119_v2#!#VIEW
+babel5119_db#!#dbo#!#babel5119_v3#!#VIEW
 ~~END~~
 
 
-SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-BABEL5119_t4#!#a
-BABEL5119_t5#!#a
-BABEL5119_t6#!#a
-babel5119_v4#!#?column?
-babel5119_v5#!#?column?
-babel5119_v6#!#?column?
+BABEL5119_t1#!#a
+BABEL5119_t2#!#a
+BABEL5119_t3#!#a
+babel5119_v1#!#?column?
+babel5119_v2#!#?column?
+babel5119_v3#!#?column?
 ~~END~~
 
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-babel5119_v4#!#CREATE VIEW BABEL5119_v4 AS SELECT 1
-babel5119_v5#!#CREATE VIEW BABEL5119_v5 AS SELECT 1
-babel5119_v6#!#CREATE VIEW BABEL5119_v6 AS SELECT 1
+babel5119_v1#!#CREATE VIEW BABEL5119_v1 AS SELECT 1
+babel5119_v2#!#CREATE VIEW BABEL5119_v2 AS SELECT 1
+babel5119_v3#!#CREATE VIEW BABEL5119_v3 AS SELECT 1
 ~~END~~
 
 
@@ -377,7 +377,7 @@ GO
 
 
 CREATE TABLE #babel5119_tmp_table_9(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_9 SELECT TABLE_NAME FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_9 SELECT TABLE_NAME FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 ~~ROW COUNT: 6~~
 
@@ -425,43 +425,43 @@ babel5119_p6
 ~~END~~
 
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar#!#varchar#!#varchar
-babel5119_db#!#dbo#!#BABEL5119_t1#!#BASE TABLE
-babel5119_db#!#dbo#!#BABEL5119_t2#!#BASE TABLE
-babel5119_db#!#dbo#!#BABEL5119_t3#!#BASE TABLE
-babel5119_db#!#dbo#!#babel5119_v1#!#VIEW
-babel5119_db#!#dbo#!#babel5119_v2#!#VIEW
-babel5119_db#!#dbo#!#babel5119_v3#!#VIEW
+master#!#guest#!#BABEL5119_t4#!#BASE TABLE
+master#!#guest#!#BABEL5119_t5#!#BASE TABLE
+master#!#guest#!#BABEL5119_t6#!#BASE TABLE
+master#!#guest#!#babel5119_v4#!#VIEW
+master#!#guest#!#babel5119_v5#!#VIEW
+master#!#guest#!#babel5119_v6#!#VIEW
 ~~END~~
 
 
-SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-BABEL5119_t1#!#a
-BABEL5119_t2#!#a
-BABEL5119_t3#!#a
-babel5119_v1#!#?column?
-babel5119_v2#!#?column?
-babel5119_v3#!#?column?
+BABEL5119_t4#!#a
+BABEL5119_t5#!#a
+BABEL5119_t6#!#a
+babel5119_v4#!#?column?
+babel5119_v5#!#?column?
+babel5119_v6#!#?column?
 ~~END~~
 
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
 nvarchar#!#nvarchar
-babel5119_v1#!#CREATE VIEW BABEL5119_v1 AS SELECT 1
-babel5119_v2#!#CREATE VIEW BABEL5119_v2 AS SELECT 1
-babel5119_v3#!#CREATE VIEW BABEL5119_v3 AS SELECT 1
+babel5119_v4#!#CREATE VIEW BABEL5119_v4 AS SELECT 1
+babel5119_v5#!#CREATE VIEW BABEL5119_v5 AS SELECT 1
+babel5119_v6#!#CREATE VIEW BABEL5119_v6 AS SELECT 1
 ~~END~~
 
 
@@ -495,7 +495,7 @@ GO
 
 
 CREATE TABLE #babel5119_tmp_table_12(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_12 SELECT TABLE_NAME FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_12 SELECT TABLE_NAME FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 ~~ROW COUNT: 6~~
 
@@ -540,8 +540,8 @@ GO
 ~~ERROR (Message: The server principal "login_babel5119_2" is not able to access the database "babel5119_db" under the current security context)~~
 
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~ERROR (Code: 33557097)~~
@@ -549,7 +549,7 @@ GO
 ~~ERROR (Message: The server principal "login_babel5119_2" is not able to access the database "babel5119_db" under the current security context)~~
 
 
-SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~ERROR (Code: 33557097)~~
@@ -557,7 +557,7 @@ GO
 ~~ERROR (Message: The server principal "login_babel5119_2" is not able to access the database "babel5119_db" under the current security context)~~
 
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~ERROR (Code: 33557097)~~
@@ -598,7 +598,7 @@ GO
 
 
 CREATE TABLE #babel5119_tmp_table_15(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_15 SELECT TABLE_NAME FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_15 SELECT TABLE_NAME FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 ~~ERROR (Code: 33557097)~~
 
@@ -643,8 +643,8 @@ babel5119_p6
 ~~END~~
 
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
@@ -658,7 +658,7 @@ master#!#guest#!#babel5119_v6#!#VIEW
 ~~END~~
 
 
-SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
@@ -672,7 +672,7 @@ babel5119_v6#!#?column?
 ~~END~~
 
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 ~~START~~
@@ -697,7 +697,7 @@ GO
 
 
 CREATE TABLE #babel5119_tmp_table_18(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_18 SELECT TABLE_NAME FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_18 SELECT TABLE_NAME FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 ~~ROW COUNT: 6~~
 

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
@@ -1,23 +1,111 @@
+-- psql
+DROP FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func;
+GO
+
 -- tsql
-USE babel_cross_db_vu_prepare_db1
+USE master
+GO
+
+DROP VIEW dbo.babel_cross_db_vu_prepare_v1;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4;
+GO
+
+DROP TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1;
+GO
+
+DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
+GO
+
+DROP PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
+GO
+
+DROP PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+
+DROP SCHEMA babel_cross_db_vu_prepare_s1;
+GO
+
+DROP USER babel_cross_db_vu_prepare_u1;
+GO
+
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 DROP TABLE dbo.babel_cross_db_vu_prepare_db1_t1
 GO
 
-DROP TABLE dbo.babel_cross_db_vu_prepare_db1_t2
+DROP TABLE dbo.my_babel_cross_db_vu_prepare_db1_t2
 GO
 
-DROP PROCEDURE babel_cross_db_vu_prepare_db1_p1
+DROP PROCEDURE my_babel_cross_db_vu_prepare_db1_p1
 GO
 
-DROP TABLE dbo.babel_cross_db_vu_prepare_db1_t3
+DROP TABLE dbo.my_babel_cross_db_vu_prepare_db1_t3
+GO
+
+DROP TABLE dbo.babel_cross_db_vu_prepare_t2;
+GO
+
+DROP TABLE dbo.babel_cross_db_vu_prepare_t3;
+GO
+
+DROP FUNCTION dbo.babel_cross_db_vu_prepare_f2;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
+GO
+
+DROP FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2;
+GO
+
+DROP TABLE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2;
+GO
+
+DROP PROCEDURE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_p2;
+GO
+
+DROP SCHEMA babel_cross_db_vu_prepare_s2;
+GO
+
+DROP USER babel_cross_db_vu_prepare_u2;
 GO
 
 USE master
 GO
 
-DROP DATABASE babel_cross_db_vu_prepare_db1
+DROP LOGIN babel_cross_db_vu_prepare_l1;
+GO
+
+DROP LOGIN babel_cross_db_vu_prepare_l2;
+GO
+
+DROP DATABASE my_babel_cross_db_vu_prepare_db1
 GO
 
 DROP PROCEDURE babel_cross_db_vu_prepare_myschema.babel_cross_db_vu_prepare_proc1

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
@@ -2,6 +2,12 @@
 USE master
 GO
 
+CREATE LOGIN babel_cross_db_vu_prepare_l1 WITH PASSWORD = '12345678';
+GO
+
+CREATE LOGIN babel_cross_db_vu_prepare_l2 WITH PASSWORD = '12345678';
+GO
+
 CREATE SCHEMA babel_cross_db_vu_prepare_myschema
 GO
 
@@ -40,26 +46,220 @@ AS
 SELECT 1/0;
 GO
 
-CREATE DATABASE babel_cross_db_vu_prepare_db1;
+CREATE DATABASE my_babel_cross_db_vu_prepare_db1;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 CREATE TABLE dbo.babel_cross_db_vu_prepare_db1_t1 (a int);
 GO
 
-CREATE TABLE dbo.babel_cross_db_vu_prepare_db1_t2 (a int);
+CREATE TABLE dbo.my_babel_cross_db_vu_prepare_db1_t2 (a int);
 GO
 
-CREATE PROCEDURE babel_cross_db_vu_prepare_db1_p1
+CREATE PROCEDURE my_babel_cross_db_vu_prepare_db1_p1
 AS
-EXEC('USE babel_cross_db_vu_prepare_db1');
+EXEC('USE my_babel_cross_db_vu_prepare_db1');
 SELECT 10;
 GO
 
-CREATE TABLE dbo.babel_cross_db_vu_prepare_db1_t3 (id int identity, a int);
+CREATE TABLE dbo.my_babel_cross_db_vu_prepare_db1_t3 (id int identity, a int);
+GO
+
+
+-- We have created a login and a user database so far, now let's create
+-- users and schemas for that login in both master a new databases to test
+-- cross-db access. Also create cross-db views and functions as well.
+USE master
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u1 FOR LOGIN babel_cross_db_vu_prepare_l1;
+GO
+
+CREATE SCHEMA babel_cross_db_vu_prepare_s1 AUTHORIZATION babel_cross_db_vu_prepare_u1;
+GO
+
+USE my_babel_cross_db_vu_prepare_db1;
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u2 FOR LOGIN babel_cross_db_vu_prepare_l1;
+GO
+
+CREATE SCHEMA babel_cross_db_vu_prepare_s2 AUTHORIZATION babel_cross_db_vu_prepare_u2;
+GO
+
+CREATE TABLE dbo.babel_cross_db_vu_prepare_t2 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+CREATE TABLE dbo.babel_cross_db_vu_prepare_t3 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+CREATE FUNCTION dbo.babel_cross_db_vu_prepare_f2 (@a int)
+    RETURNS INT AS
+    BEGIN
+        RETURN @a;
+    END;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
+USE my_babel_cross_db_vu_prepare_db1;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+INSERT INTO babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2(name) VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2 (@a int)
+    RETURNS INT AS
+    BEGIN
+        RETURN @a;
+    END;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 AS
+    SELECT id, babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(id), name
+    FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2
+    ORDER BY id;
+GO
+
+CREATE PROCEDURE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_p2
+AS
+    SELECT * FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 ORDER BY id;
+    SELECT * FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
 GO
 
 USE master;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+INSERT INTO babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1(name) VALUES('def');
+GO
+~~ROW COUNT: 1~~
+
+
+-- View containing cross-db table and function on which login babel_cross_db_vu_prepare_l1 has privilege
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1 AS
+    SELECT x.id,
+        my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(x.id),
+        x.name AS t1_name,
+        y.name AS t2_name
+    FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1 x INNER JOIN
+    my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 y
+    ON x.id = y.id
+    WHERE x.id = my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(x.id)
+    ORDER BY x.id;
+GO
+
+-- View containing cross-db table on which login babel_cross_db_vu_prepare_l1 does not have privilege
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2 AS
+    SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2
+    ORDER BY id;
+GO
+
+-- View containing cross-db function on which login babel_cross_db_vu_prepare_l1 does not have privilege
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3 AS
+    SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(id) AS id, name
+    FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1
+    ORDER BY id;
+GO
+
+-- View containing cross-db tables on which login babel_cross_db_vu_prepare_l1 does not have permission on either of joined tables
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4 AS
+    SELECT x.id,
+        x.name AS t1_name,
+        y.name AS t2_name
+    FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2 x INNER JOIN
+    my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t3 y
+    ON x.id = y.id
+    ORDER BY x.id;
+GO
+
+
+-- Procedure which accesses cross database objects
+CREATE PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1
+AS
+    SELECT * FROM master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1; -- SELECT from table in same database
+    SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2; -- SELECT from table in different database
+    SELECT * FROM master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1; -- SELECT from a view which accesses objects from different database
+    -- SELECT from a view which accesses objects from different database without permission
+    SELECT * FROM master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+-- Nested variants of all the objects above
+CREATE FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1 (@a int)
+    RETURNS INT AS
+    BEGIN
+        RETURN my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(@a);
+    END;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested AS
+    SELECT babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1(1) AS id;
+GO
+
+CREATE PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested
+AS
+    EXEC master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+
+-- tsql
+USE master;
+GO
+
+-- View containing union between two cross-db tables from different datababses.
+CREATE VIEW dbo.babel_cross_db_vu_prepare_v1 AS
+    SELECT id FROM master.dbo.babel_cross_db_vu_prepare_master_t1
+    UNION
+    SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2;
+GO
+
+USE master;
+GO
+
+-- psql
+
+-- CREATE a plpgsql function in master_dbo which accesses cross-db table from db1 database
+CREATE FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func() RETURNS INT AS $$
+DECLARE
+    schema_name TEXT;
+    res INT;
+BEGIN
+    -- Retrieve the schema name
+    SELECT ne.nspname 
+    INTO schema_name 
+    FROM sys.babelfish_namespace_ext ne 
+    INNER JOIN sys.babelfish_sysdatabases sd 
+    ON ne.dbid = sd.dbid 
+    WHERE sd.name = 'my_babel_cross_db_vu_prepare_db1'
+    AND ne.orig_name = 'babel_cross_db_vu_prepare_s2';
+    EXECUTE format('SELECT COUNT(*) FROM %I.babel_cross_db_vu_prepare_t2', schema_name) INTO res;
+    RETURN res;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+GRANT EXECUTE ON FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func to master_babel_cross_db_vu_prepare_u1;
 GO

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
@@ -1,5 +1,5 @@
 -- tsql
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 SELECT current_user;
@@ -69,7 +69,7 @@ int#!#int
 ~~END~~
 
 
-USE babel_cross_db_vu_prepare_db1
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 -- runtime error
@@ -124,22 +124,22 @@ dbo
 ~~END~~
 
 
-CREATE PROCEDURE babel_cross_db_vu_prepare_db1_p2
+CREATE PROCEDURE my_babel_cross_db_vu_prepare_db1_p2
 AS
 INSERT INTO master.dbo.babel_cross_db_vu_prepare_master_t1 VALUES (10);
 GO
 
-EXEC babel_cross_db_vu_prepare_db1_p2;
+EXEC my_babel_cross_db_vu_prepare_db1_p2;
 GO
 ~~ROW COUNT: 1~~
 
 
-EXEC babel_cross_db_vu_prepare_db1_p2;
+EXEC my_babel_cross_db_vu_prepare_db1_p2;
 GO
 ~~ROW COUNT: 1~~
 
 
-EXEC babel_cross_db_vu_prepare_db1_p2;
+EXEC my_babel_cross_db_vu_prepare_db1_p2;
 GO
 ~~ROW COUNT: 1~~
 
@@ -183,13 +183,13 @@ dbo
 ~~END~~
 
 
-INSERT INTO dbo.babel_cross_db_vu_prepare_db1_t2 VALUES (20);
+INSERT INTO dbo.my_babel_cross_db_vu_prepare_db1_t2 VALUES (20);
 GO
 ~~ROW COUNT: 1~~
 
 
 INSERT INTO master.dbo.babel_cross_db_vu_prepare_master_t1 (a)
-SELECT (a) FROM babel_cross_db_vu_prepare_db1_t2;
+SELECT (a) FROM my_babel_cross_db_vu_prepare_db1_t2;
 GO
 ~~ROW COUNT: 1~~
 
@@ -215,7 +215,7 @@ GO
 CREATE USER babel_cross_db_vu_prepare_master_janedoe FOR LOGIN babel_cross_db_vu_prepare_johndoe;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 CREATE USER babel_cross_db_vu_prepare_db1_janedoe FOR LOGIN babel_cross_db_vu_prepare_johndoe;
@@ -233,14 +233,14 @@ babel_cross_db_vu_prepare_master_janedoe
 ~~END~~
 
 
-SELECT * FROM babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t1 ORDER BY a;
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t1 ORDER BY a;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_db1_t1)~~
 
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 SELECT current_user;
@@ -268,7 +268,7 @@ GO
 GRANT EXECUTE ON dbo.babel_cross_db_vu_prepare_master_p2 TO babel_cross_db_vu_prepare_master_janedoe;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 GRANT SELECT ON dbo.babel_cross_db_vu_prepare_db1_t1 TO babel_cross_db_vu_prepare_db1_janedoe;
@@ -278,7 +278,7 @@ GO
 USE master
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 EXEC master.dbo.babel_cross_db_vu_prepare_master_p2
@@ -305,7 +305,7 @@ USE master;
 GO
 
 -- tsql
-USE babel_cross_db_vu_prepare_db1
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 REVOKE SELECT ON dbo.babel_cross_db_vu_prepare_db1_t1 FROM babel_cross_db_vu_prepare_db1_janedoe
@@ -355,14 +355,14 @@ GO
 USE master
 GO
 
-INSERT INTO babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t3 (a) VALUES (10);
+INSERT INTO my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_t3 (a) VALUES (10);
 GO
 ~~ROW COUNT: 1~~
 
 
 CREATE PROCEDURE babel_cross_db_vu_prepare_master_p4
 AS
-INSERT INTO babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t3 VALUES (1);
+INSERT INTO my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_t3 VALUES (1);
 GO
 
 EXEC babel_cross_db_vu_prepare_master_p4;
@@ -376,7 +376,7 @@ GO
 
 
 INSERT INTO dbo.babel_cross_db_vu_prepare_master_t2 (b)
-SELECT a FROM babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t3
+SELECT a FROM my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_t3
 WHERE id = 1;
 GO
 ~~ROW COUNT: 1~~
@@ -390,7 +390,7 @@ int
 ~~END~~
 
 
-EXEC babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_p1;
+EXEC my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_p1;
 GO
 ~~START~~
 int
@@ -401,11 +401,319 @@ int
 DROP PROCEDURE babel_cross_db_vu_prepare_master_p4
 GO
 
-USE babel_cross_db_vu_prepare_db1
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 USE master;
 GO
 
 DROP TABLE babel_cross_db_vu_prepare_tab1;
+GO
+
+-- reset the login password
+ALTER LOGIN babel_cross_db_vu_prepare_l1 with password = '12345678';
+GO
+
+ALTER LOGIN babel_cross_db_vu_prepare_l2 with password = '12345678';
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
+USE master;
+GO
+
+-- bare SELECT table/view from db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#abc
+~~END~~
+
+
+-- bare SELECT function from db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
+SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(1);
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- bare SELECT table from db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2 ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+-- bare SELECT function from db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_cross_db_vu_prepare_f2)~~
+
+
+-- SELECT from a view in db1 which references objects in db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+1#!#1#!#def#!#abc
+~~END~~
+
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+1#!#1#!#def#!#abc
+~~END~~
+
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- SELECT from a view in db1 which references tables in db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2_nested;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+-- SELECT from a view in db1 which references functions in db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_cross_db_vu_prepare_f2)~~
+
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3_nested;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_cross_db_vu_prepare_f2)~~
+
+
+-- View containing cross-db tables on which login babel_cross_db_vu_prepare_l1 does not have permission on either of joined tables, should throw error
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+-- Execute procedure from db1
+EXEC my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_p2;
+GO
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#abc
+~~END~~
+
+
+-- Execute procedure in db1 which accesses cross database objects
+EXEC babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+~~START~~
+int#!#varchar
+1#!#def
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+~~START~~
+int#!#int#!#varchar#!#varchar
+1#!#1#!#def#!#abc
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+EXEC babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
+GO
+~~START~~
+int#!#varchar
+1#!#def
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+~~START~~
+int#!#int#!#varchar#!#varchar
+1#!#1#!#def#!#abc
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+-- call procedure babel_cross_db_vu_prepare_p1 from a db1
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+EXEC master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+~~START~~
+int#!#varchar
+1#!#def
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+~~START~~
+int#!#int#!#varchar#!#varchar
+1#!#1#!#def#!#abc
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+-- call procedure babel_cross_db_vu_prepare_p1_nested from a db1
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+EXEC master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
+GO
+~~START~~
+int#!#varchar
+1#!#def
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#abc
+~~END~~
+
+~~START~~
+int#!#int#!#varchar#!#varchar
+1#!#1#!#def#!#abc
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t2)~~
+
+
+-- SELECT from a plpgsql which accesses cross-db table should be successful
+USE master
+GO
+
+SELECT dbo.babel_cross_db_vu_prepare_pg_func();
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- tsql
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+SELECT * FROM master.dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+~~END~~
+
+
+GRANT CONNECT TO guest;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+-- cross-db tests for guest user
+USE master
+GO
+
+-- expect error since guest user does not have permission on babel_cross_db_vu_prepare_v1
+SELECT * FROM dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v1)~~
+
+
+-- tsql
+-- now grant the SELECT privilege to guest
+USE master
+GO
+
+GRANT SELECT ON dbo.babel_cross_db_vu_prepare_v1 TO guest;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE master
+GO
+
+SELECT * FROM dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+~~END~~
+
+
+-- tsql
+USE master
 GO

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
@@ -77,7 +77,7 @@ select * from grant_connect_db1.dbo.grant_connect_t1
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: The server principal "grant_connect_abc" is not able to access the database "grant_connect_db1" under the current security context)~~
+~~ERROR (Message: permission denied for table grant_connect_t1)~~
 
 
 -- tsql

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -3449,11 +3449,12 @@ int
 1
 ~~END~~
 
-select db1.s1.f1(); -- Needs fix [BABEL-4841]
+select db1.s1.f1();
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: permission denied for function f1)~~
+~~START~~
+int
+1
+~~END~~
 
 
 -- tsql

--- a/test/JDBC/expected/TestTriggerInteroperability.out
+++ b/test/JDBC/expected/TestTriggerInteroperability.out
@@ -81,12 +81,10 @@ int
 begin tran;
 GO
 
--- should throw permission denied error
+-- should succeed as login is the owner of underlying table psql_tbl_2
 insert into test_tbl_trig_bbf_2 values (1);
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: permission denied for table psql_tbl_2)~~
+~~ROW COUNT: 1~~
 
 
 select @@trancount

--- a/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
+++ b/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
@@ -139,7 +139,6 @@ alter authorization on database::change_owner_db to dba_login
 go
 
 -- tsql user=new_owner_login password=12345678
--- previous owner is still in the DB and should still have access despite no longer being the owner
 select suser_name(), db_name()
 go
 ~~START~~
@@ -149,10 +148,9 @@ new_OWNER_login#!#change_owner_db
 
 select * from t
 go
-~~START~~
-int
-123
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t)~~
 
 create table t2(a int)
 go

--- a/test/JDBC/expected/single_db/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/single_db/GRANT_SCHEMA.out
@@ -3449,11 +3449,12 @@ int
 1
 ~~END~~
 
-select db1.s1.f1(); -- Needs fix [BABEL-4841]
+select db1.s1.f1();
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: permission denied for function f1)~~
+~~START~~
+int
+1
+~~END~~
 
 
 -- tsql

--- a/test/JDBC/expected/single_db/TestSpatialPoint-vu-verify.out
+++ b/test/JDBC/expected/single_db/TestSpatialPoint-vu-verify.out
@@ -3469,9 +3469,9 @@ SET @sql =
 -- Execute the dynamic SQL
 EXEC sp_executesql @sql;
 GO
-~~ERROR (Code: 911)~~
+~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: database "db2" does not exist)~~
+~~ERROR (Message: database "db2" does not exist. Make sure that the name is entered correctly.)~~
 
 
 USE master

--- a/test/JDBC/input/BABEL-5119-vu-verify.mix
+++ b/test/JDBC/input/BABEL-5119-vu-verify.mix
@@ -48,16 +48,16 @@ SELECT name FROM BABEL5119_db.sys.procedures WHERE name LIKE 'BABEL5119%'
 ORDER BY name
 GO
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
@@ -78,7 +78,7 @@ INSERT INTO #babel5119_tmp_table_2 SELECT name FROM BABEL5119_db.sys.databases W
 GO
 
 CREATE TABLE #babel5119_tmp_table_3(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_3 SELECT TABLE_NAME FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_3 SELECT TABLE_NAME FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 
 SELECT has_dbaccess(BABEL5119_db.sys.databases.name) FROM BABEL5119_db.sys.databases WHERE BABEL5119_db.sys.databases.name='BABEL5119_db'
@@ -100,16 +100,16 @@ SELECT name FROM master.sys.procedures WHERE name LIKE 'BABEL5119%'
 ORDER BY name
 GO
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
@@ -130,7 +130,7 @@ INSERT INTO #babel5119_tmp_table_5 SELECT name FROM master.sys.databases WHERE n
 GO
 
 CREATE TABLE #babel5119_tmp_table_6(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_6 SELECT TABLE_NAME FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_6 SELECT TABLE_NAME FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 
 SELECT has_dbaccess(master.sys.databases.name) FROM master.sys.databases WHERE master.sys.databases.name='BABEL5119_db'
@@ -156,16 +156,16 @@ SELECT name FROM BABEL5119_db.sys.procedures WHERE name LIKE 'BABEL5119%'
 ORDER BY name
 GO
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
@@ -186,7 +186,7 @@ INSERT INTO #babel5119_tmp_table_8 SELECT name FROM BABEL5119_db.sys.databases W
 GO
 
 CREATE TABLE #babel5119_tmp_table_9(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_9 SELECT TABLE_NAME FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_9 SELECT TABLE_NAME FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 
 SELECT has_dbaccess(BABEL5119_db.sys.databases.name) FROM BABEL5119_db.sys.databases WHERE BABEL5119_db.sys.databases.name='BABEL5119_db'
@@ -208,16 +208,16 @@ SELECT name FROM master.sys.procedures WHERE name LIKE 'BABEL5119%'
 ORDER BY name
 GO
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
@@ -238,7 +238,7 @@ INSERT INTO #babel5119_tmp_table_11 SELECT name FROM master.sys.databases WHERE 
 GO
 
 CREATE TABLE #babel5119_tmp_table_12(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_12 SELECT TABLE_NAME FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_12 SELECT TABLE_NAME FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 
 SELECT has_dbaccess(master.sys.databases.name) FROM master.sys.databases WHERE master.sys.databases.name='BABEL5119_db'
@@ -264,16 +264,16 @@ SELECT name FROM BABEL5119_db.sys.procedures WHERE name LIKE 'BABEL5119%'
 ORDER BY name
 GO
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM BABEL5119_db.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM BABEL5119_db.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
@@ -294,7 +294,7 @@ INSERT INTO #babel5119_tmp_table_14 SELECT name FROM BABEL5119_db.sys.databases 
 GO
 
 CREATE TABLE #babel5119_tmp_table_15(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_15 SELECT TABLE_NAME FROM BABEL5119_db.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_15 SELECT TABLE_NAME FROM BABEL5119_db.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 
 SELECT has_dbaccess(BABEL5119_db.sys.databases.name) FROM BABEL5119_db.sys.databases WHERE BABEL5119_db.sys.databases.name='BABEL5119_db'
@@ -312,16 +312,16 @@ SELECT name FROM master.sys.procedures WHERE name LIKE 'BABEL5119%'
 ORDER BY name
 GO
 
--- Checking crossdb for information_schema_tsql
-SELECT * FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+-- Checking crossdb for information_schema
+SELECT * FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema_tsql.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, COLUMN_NAME FROM master.information_schema.columns WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
-SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema_tsql.views WHERE TABLE_NAME LIKE 'BABEL5119%'
+SELECT TABLE_NAME, VIEW_DEFINITION FROM master.information_schema.views WHERE TABLE_NAME LIKE 'BABEL5119%'
 ORDER BY TABLE_NAME
 GO
 
@@ -335,7 +335,7 @@ INSERT INTO #babel5119_tmp_table_17 SELECT name FROM master.sys.databases WHERE 
 GO
 
 CREATE TABLE #babel5119_tmp_table_18(name VARCHAR(MAX))
-INSERT INTO #babel5119_tmp_table_18 SELECT TABLE_NAME FROM master.information_schema_tsql.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
+INSERT INTO #babel5119_tmp_table_18 SELECT TABLE_NAME FROM master.information_schema.tables WHERE TABLE_NAME LIKE 'BABEL5119%'
 GO
 
 SELECT has_dbaccess(master.sys.databases.name) FROM master.sys.databases WHERE master.sys.databases.name='BABEL5119_db'

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -1713,7 +1713,7 @@ select * from db1.s1.v1;
 go
 exec db1.s1.p1;
 go
-select db1.s1.f1(); -- Needs fix [BABEL-4841]
+select db1.s1.f1();
 go
 
 -- tsql

--- a/test/JDBC/input/alter_authorization_change_db_owner-vu-verify.mix
+++ b/test/JDBC/input/alter_authorization_change_db_owner-vu-verify.mix
@@ -81,7 +81,6 @@ alter authorization on database::change_owner_db to dba_login
 go
 
 -- tsql user=new_owner_login password=12345678
--- previous owner is still in the DB and should still have access despite no longer being the owner
 select suser_name(), db_name()
 go
 select * from t

--- a/test/JDBC/input/interoperability/TestTriggerInteroperability.mix
+++ b/test/JDBC/input/interoperability/TestTriggerInteroperability.mix
@@ -64,7 +64,7 @@ GO
 begin tran;
 GO
 
--- should throw permission denied error
+-- should succeed as login is the owner of underlying table psql_tbl_2
 insert into test_tbl_trig_bbf_2 values (1);
 GO
 

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
@@ -1,23 +1,111 @@
+-- psql
+DROP FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func;
+GO
+
 -- tsql
-USE babel_cross_db_vu_prepare_db1
+USE master
+GO
+
+DROP VIEW dbo.babel_cross_db_vu_prepare_v1;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4;
+GO
+
+DROP TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1;
+GO
+
+DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
+GO
+
+DROP PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
+GO
+
+DROP PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+
+DROP SCHEMA babel_cross_db_vu_prepare_s1;
+GO
+
+DROP USER babel_cross_db_vu_prepare_u1;
+GO
+
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 DROP TABLE dbo.babel_cross_db_vu_prepare_db1_t1
 GO
 
-DROP TABLE dbo.babel_cross_db_vu_prepare_db1_t2
+DROP TABLE dbo.my_babel_cross_db_vu_prepare_db1_t2
 GO
 
-DROP PROCEDURE babel_cross_db_vu_prepare_db1_p1
+DROP PROCEDURE my_babel_cross_db_vu_prepare_db1_p1
 GO
 
-DROP TABLE dbo.babel_cross_db_vu_prepare_db1_t3
+DROP TABLE dbo.my_babel_cross_db_vu_prepare_db1_t3
+GO
+
+DROP TABLE dbo.babel_cross_db_vu_prepare_t2;
+GO
+
+DROP TABLE dbo.babel_cross_db_vu_prepare_t3;
+GO
+
+DROP FUNCTION dbo.babel_cross_db_vu_prepare_f2;
+GO
+
+DROP VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
+GO
+
+DROP FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2;
+GO
+
+DROP TABLE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2;
+GO
+
+DROP PROCEDURE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_p2;
+GO
+
+DROP SCHEMA babel_cross_db_vu_prepare_s2;
+GO
+
+DROP USER babel_cross_db_vu_prepare_u2;
 GO
 
 USE master
 GO
 
-DROP DATABASE babel_cross_db_vu_prepare_db1
+DROP LOGIN babel_cross_db_vu_prepare_l1;
+GO
+
+DROP LOGIN babel_cross_db_vu_prepare_l2;
+GO
+
+DROP DATABASE my_babel_cross_db_vu_prepare_db1
 GO
 
 DROP PROCEDURE babel_cross_db_vu_prepare_myschema.babel_cross_db_vu_prepare_proc1

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
@@ -2,6 +2,12 @@
 USE master
 GO
 
+CREATE LOGIN babel_cross_db_vu_prepare_l1 WITH PASSWORD = '12345678';
+GO
+
+CREATE LOGIN babel_cross_db_vu_prepare_l2 WITH PASSWORD = '12345678';
+GO
+
 CREATE SCHEMA babel_cross_db_vu_prepare_myschema
 GO
 
@@ -40,26 +46,216 @@ AS
 SELECT 1/0;
 GO
 
-CREATE DATABASE babel_cross_db_vu_prepare_db1;
+CREATE DATABASE my_babel_cross_db_vu_prepare_db1;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 CREATE TABLE dbo.babel_cross_db_vu_prepare_db1_t1 (a int);
 GO
 
-CREATE TABLE dbo.babel_cross_db_vu_prepare_db1_t2 (a int);
+CREATE TABLE dbo.my_babel_cross_db_vu_prepare_db1_t2 (a int);
 GO
 
-CREATE PROCEDURE babel_cross_db_vu_prepare_db1_p1
+CREATE PROCEDURE my_babel_cross_db_vu_prepare_db1_p1
 AS
-EXEC('USE babel_cross_db_vu_prepare_db1');
+EXEC('USE my_babel_cross_db_vu_prepare_db1');
 SELECT 10;
 GO
 
-CREATE TABLE dbo.babel_cross_db_vu_prepare_db1_t3 (id int identity, a int);
+CREATE TABLE dbo.my_babel_cross_db_vu_prepare_db1_t3 (id int identity, a int);
+GO
+
+-- We have created a login and a user database so far, now let's create
+-- users and schemas for that login in both master a new databases to test
+-- cross-db access. Also create cross-db views and functions as well.
+
+USE master
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u1 FOR LOGIN babel_cross_db_vu_prepare_l1;
+GO
+
+CREATE SCHEMA babel_cross_db_vu_prepare_s1 AUTHORIZATION babel_cross_db_vu_prepare_u1;
+GO
+
+USE my_babel_cross_db_vu_prepare_db1;
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u2 FOR LOGIN babel_cross_db_vu_prepare_l1;
+GO
+
+CREATE SCHEMA babel_cross_db_vu_prepare_s2 AUTHORIZATION babel_cross_db_vu_prepare_u2;
+GO
+
+CREATE TABLE dbo.babel_cross_db_vu_prepare_t2 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+CREATE TABLE dbo.babel_cross_db_vu_prepare_t3 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+CREATE FUNCTION dbo.babel_cross_db_vu_prepare_f2 (@a int)
+    RETURNS INT AS
+    BEGIN
+        RETURN @a;
+    END;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
+USE my_babel_cross_db_vu_prepare_db1;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+INSERT INTO babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2(name) VALUES('abc');
+GO
+
+CREATE FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2 (@a int)
+    RETURNS INT AS
+    BEGIN
+        RETURN @a;
+    END;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 AS
+    SELECT id, babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(id), name
+    FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2
+    ORDER BY id;
+GO
+
+CREATE PROCEDURE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_p2
+AS
+    SELECT * FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 ORDER BY id;
+    SELECT * FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
 GO
 
 USE master;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1 (id INT IDENTITY PRIMARY KEY, name VARCHAR(20));
+GO
+
+INSERT INTO babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1(name) VALUES('def');
+GO
+
+-- View containing cross-db table and function on which login babel_cross_db_vu_prepare_l1 has privilege
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1 AS
+    SELECT x.id,
+        my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(x.id),
+        x.name AS t1_name,
+        y.name AS t2_name
+    FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1 x INNER JOIN
+    my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 y
+    ON x.id = y.id
+    WHERE x.id = my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(x.id)
+    ORDER BY x.id;
+GO
+
+-- View containing cross-db table on which login babel_cross_db_vu_prepare_l1 does not have privilege
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2 AS
+    SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2
+    ORDER BY id;
+GO
+
+-- View containing cross-db function on which login babel_cross_db_vu_prepare_l1 does not have privilege
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3 AS
+    SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(id) AS id, name
+    FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1
+    ORDER BY id;
+GO
+
+-- View containing cross-db tables on which login babel_cross_db_vu_prepare_l1 does not have permission on either of joined tables
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4 AS
+    SELECT x.id,
+        x.name AS t1_name,
+        y.name AS t2_name
+    FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2 x INNER JOIN
+    my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t3 y
+    ON x.id = y.id
+    ORDER BY x.id;
+GO
+
+-- Procedure which accesses cross database objects
+CREATE PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1
+AS
+    SELECT * FROM master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1; -- SELECT from table in same database
+    SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2; -- SELECT from table in different database
+    SELECT * FROM master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1; -- SELECT from a view which accesses objects from different database
+
+    -- SELECT from a view which accesses objects from different database without permission
+    SELECT * FROM master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+-- Nested variants of all the objects above
+CREATE FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1 (@a int)
+    RETURNS INT AS
+    BEGIN
+        RETURN my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(@a);
+    END;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested AS
+    SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4;
+GO
+
+CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested AS
+    SELECT babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1(1) AS id;
+GO
+
+CREATE PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested
+AS
+    EXEC master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+
+-- tsql
+USE master;
+GO
+
+-- View containing union between two cross-db tables from different datababses.
+CREATE VIEW dbo.babel_cross_db_vu_prepare_v1 AS
+    SELECT id FROM master.dbo.babel_cross_db_vu_prepare_master_t1
+    UNION
+    SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2;
+GO
+
+USE master;
+GO
+
+-- psql
+-- CREATE a plpgsql function in master_dbo which accesses cross-db table from db1 database
+CREATE FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func() RETURNS INT AS $$
+DECLARE
+    schema_name TEXT;
+    res INT;
+BEGIN
+    -- Retrieve the schema name
+    SELECT ne.nspname 
+    INTO schema_name 
+    FROM sys.babelfish_namespace_ext ne 
+    INNER JOIN sys.babelfish_sysdatabases sd 
+    ON ne.dbid = sd.dbid 
+    WHERE sd.name = 'my_babel_cross_db_vu_prepare_db1'
+    AND ne.orig_name = 'babel_cross_db_vu_prepare_s2';
+
+    EXECUTE format('SELECT COUNT(*) FROM %I.babel_cross_db_vu_prepare_t2', schema_name) INTO res;
+    RETURN res;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+GRANT EXECUTE ON FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func to master_babel_cross_db_vu_prepare_u1;
 GO

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
@@ -1,5 +1,5 @@
 -- tsql
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 SELECT current_user;
@@ -31,7 +31,7 @@ GO
 SELECT * from master.dbo.babel_cross_db_vu_prepare_tab1;
 GO
 
-USE babel_cross_db_vu_prepare_db1
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 -- runtime error
@@ -59,18 +59,18 @@ GO
 SELECT current_user;
 GO
 
-CREATE PROCEDURE babel_cross_db_vu_prepare_db1_p2
+CREATE PROCEDURE my_babel_cross_db_vu_prepare_db1_p2
 AS
 INSERT INTO master.dbo.babel_cross_db_vu_prepare_master_t1 VALUES (10);
 GO
 
-EXEC babel_cross_db_vu_prepare_db1_p2;
+EXEC my_babel_cross_db_vu_prepare_db1_p2;
 GO
 
-EXEC babel_cross_db_vu_prepare_db1_p2;
+EXEC my_babel_cross_db_vu_prepare_db1_p2;
 GO
 
-EXEC babel_cross_db_vu_prepare_db1_p2;
+EXEC my_babel_cross_db_vu_prepare_db1_p2;
 GO
 
 INSERT INTO dbo.babel_cross_db_vu_prepare_db1_t1 (a)
@@ -93,11 +93,11 @@ GO
 SELECT current_user;
 GO
 
-INSERT INTO dbo.babel_cross_db_vu_prepare_db1_t2 VALUES (20);
+INSERT INTO dbo.my_babel_cross_db_vu_prepare_db1_t2 VALUES (20);
 GO
 
 INSERT INTO master.dbo.babel_cross_db_vu_prepare_master_t1 (a)
-SELECT (a) FROM babel_cross_db_vu_prepare_db1_t2;
+SELECT (a) FROM my_babel_cross_db_vu_prepare_db1_t2;
 GO
 
 SELECT * FROM master.dbo.babel_cross_db_vu_prepare_master_t1 ORDER BY id;
@@ -112,7 +112,7 @@ GO
 CREATE USER babel_cross_db_vu_prepare_master_janedoe FOR LOGIN babel_cross_db_vu_prepare_johndoe;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 CREATE USER babel_cross_db_vu_prepare_db1_janedoe FOR LOGIN babel_cross_db_vu_prepare_johndoe;
@@ -125,10 +125,10 @@ GO
 SELECT current_user;
 GO
 
-SELECT * FROM babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t1 ORDER BY a;
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t1 ORDER BY a;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 SELECT current_user;
@@ -147,7 +147,7 @@ GO
 GRANT EXECUTE ON dbo.babel_cross_db_vu_prepare_master_p2 TO babel_cross_db_vu_prepare_master_janedoe;
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 GRANT SELECT ON dbo.babel_cross_db_vu_prepare_db1_t1 TO babel_cross_db_vu_prepare_db1_janedoe;
@@ -157,7 +157,7 @@ GO
 USE master
 GO
 
-USE babel_cross_db_vu_prepare_db1;
+USE my_babel_cross_db_vu_prepare_db1;
 GO
 
 EXEC master.dbo.babel_cross_db_vu_prepare_master_p2
@@ -170,7 +170,7 @@ USE master;
 GO
 
 -- tsql
-USE babel_cross_db_vu_prepare_db1
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 REVOKE SELECT ON dbo.babel_cross_db_vu_prepare_db1_t1 FROM babel_cross_db_vu_prepare_db1_janedoe
@@ -210,12 +210,12 @@ GO
 USE master
 GO
 
-INSERT INTO babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t3 (a) VALUES (10);
+INSERT INTO my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_t3 (a) VALUES (10);
 GO
 
 CREATE PROCEDURE babel_cross_db_vu_prepare_master_p4
 AS
-INSERT INTO babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t3 VALUES (1);
+INSERT INTO my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_t3 VALUES (1);
 GO
 
 EXEC babel_cross_db_vu_prepare_master_p4;
@@ -225,24 +225,155 @@ EXEC babel_cross_db_vu_prepare_master_p4;
 GO
 
 INSERT INTO dbo.babel_cross_db_vu_prepare_master_t2 (b)
-SELECT a FROM babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_t3
+SELECT a FROM my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_t3
 WHERE id = 1;
 GO
 
 SELECT * FROM dbo.babel_cross_db_vu_prepare_master_t2 ORDER BY b;
 GO
 
-EXEC babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_db1_p1;
+EXEC my_babel_cross_db_vu_prepare_db1.dbo.my_babel_cross_db_vu_prepare_db1_p1;
 GO
 
 DROP PROCEDURE babel_cross_db_vu_prepare_master_p4
 GO
 
-USE babel_cross_db_vu_prepare_db1
+USE my_babel_cross_db_vu_prepare_db1
 GO
 
 USE master;
 GO
 
 DROP TABLE babel_cross_db_vu_prepare_tab1;
+GO
+
+-- reset the login password
+ALTER LOGIN babel_cross_db_vu_prepare_l1 with password = '12345678';
+GO
+
+ALTER LOGIN babel_cross_db_vu_prepare_l2 with password = '12345678';
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
+USE master;
+GO
+
+-- bare SELECT table/view from db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2 ORDER BY id;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
+GO
+
+-- bare SELECT function from db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
+SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(1);
+GO
+
+-- bare SELECT table from db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2 ORDER BY id;
+GO
+
+-- bare SELECT function from db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(1);
+GO
+
+-- SELECT from a view in db1 which references objects in db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
+GO
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested;
+GO
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested;
+GO
+
+-- SELECT from a view in db1 which references tables in db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2;
+GO
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v2_nested;
+GO
+
+-- SELECT from a view in db1 which references functions in db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3;
+GO
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3_nested;
+GO
+
+-- View containing cross-db tables on which login babel_cross_db_vu_prepare_l1 does not have permission on either of joined tables, should throw error
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4;
+GO
+
+SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested;
+GO
+
+-- Execute procedure from db1
+EXEC my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_p2;
+GO
+
+-- Execute procedure in db1 which accesses cross database objects
+EXEC babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+
+EXEC babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
+GO
+
+-- call procedure babel_cross_db_vu_prepare_p1 from a db1
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+EXEC master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1;
+GO
+
+-- call procedure babel_cross_db_vu_prepare_p1_nested from a db1
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+EXEC master.babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
+GO
+
+-- SELECT from a plpgsql which accesses cross-db table should be successful
+USE master
+GO
+
+SELECT dbo.babel_cross_db_vu_prepare_pg_func();
+GO
+
+-- tsql
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+SELECT * FROM master.dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+
+GRANT CONNECT TO guest;
+GO
+
+-- cross-db tests for guest user
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE master
+GO
+
+-- expect error since guest user does not have permission on babel_cross_db_vu_prepare_v1
+SELECT * FROM dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+
+-- now grant the SELECT privilege to guest
+-- tsql
+USE master
+GO
+
+GRANT SELECT ON dbo.babel_cross_db_vu_prepare_v1 TO guest;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE master
+GO
+
+SELECT * FROM dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+
+-- tsql
+USE master
 GO

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -73,7 +73,6 @@ BABEL-889
 BABEL-APPLOCK
 babel_char
 BABEL-CHECK-CONSTRAINT-before-14_6
-BABEL-CROSS-DB
 babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -79,7 +79,6 @@ BABEL-889
 BABEL-APPLOCK
 babel_char
 BABEL-CHECK-CONSTRAINT-before-14_6
-BABEL-CROSS-DB
 babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -100,7 +100,6 @@ BABEL-889
 BABEL-APPLOCK
 babel_char
 BABEL-CHECK-CONSTRAINT-before-14_6
-BABEL-CROSS-DB
 babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -98,7 +98,6 @@ BABEL-889
 BABEL-APPLOCK
 babel_char
 BABEL-CHECK-CONSTRAINT-before-14_6
-BABEL-CROSS-DB
 babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -98,7 +98,6 @@ BABEL-889
 BABEL-APPLOCK
 babel_char
 BABEL-CHECK-CONSTRAINT-before-14_6
-BABEL-CROSS-DB
 babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -97,7 +97,6 @@ BABEL-889
 BABEL-APPLOCK
 babel_char
 BABEL-CHECK-CONSTRAINT-before-14_6
-BABEL-CROSS-DB
 babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext


### PR DESCRIPTION
### Description
Support execution of views which references objects (tables/views/functions) from across the databases. Here we are talking about Babelfish logical database (T-SQL database) which is different from a physical Postgres database. To support this, perform permission checks for cross database objects using session user (login) instead of current_user (user of current T-SQL database). The reason login can be used for permission check is since login is member of all it’s users, so it inherits all their permissions so it will be able execute any cross database objects owned by its users.

This commit handles functions and tables/views separately for cross database permission checks. For functions/procedures, a new hook `ExecFuncProc_AclCheck_hook` and for tables/views existing `ExecutorStart_hook` will be used to decide whether to use session user or current_user for permission check depending upon whether the object is from same or different database. We will be using `is_schema_from_db` function to identify if the object is from different database which performs a lookup into `babelfish_namespace_ext` catalog table which can be expensive as will be doing it pretty frequently. So, added this table into SYSCACHE for better performance. Tables/views permissions are handled slightly different than functions as we do not blindly want to check the permissions against session user (current login) since permissions of RTEs inside a view are checked against that view's owner which can very well be a user of some different database. So if we blindly check permission against session user instead of view's owner then it would break view's ownership chaining. Instead, we will replace `checkAsUser` with it's corresponding mapped login if present and only in cases where `checkAsUser` is not set, we will replace it with session user (login). We are using login to allow cross database queries since login can access all its objects across the databases. Getting mapped login to a user require lookup into sys.babelfish_authid_user_ext catalog table using its primary key column (rolname) so added this table is also into SYSCACHE.

Additionally, remove previous code to globally set current user to session user since newer logic takes care of the permission check now.

Task: BABEL-5206
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/443

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).