### PR TITLE
Exclude grant/revoke dbo to master user while creating database/alter authorization on database

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -588,6 +588,14 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 	PlannedStmt *wrapper;
 
 	const char *dbo_role_name = get_dbo_role_name(db_name);
+
+	/*
+	 * If login i.e old_owner/new_owner is master user 
+	 * then skip grant/revoke dbo to login
+	 * since it will always be the member of sysadmin.
+	 */
+	if (role_is_sa(get_role_oid(login, true)))
+		return;
 	
 	initStringInfo(&query);
 


### PR DESCRIPTION
### Description
Earlier with the fix for BABEL-5119, BABEL-5218, we were granting dbo to the login while creating the database and granting/revoking dbo to/from login while alter authorization on database but it is not required to grant/revoke dbo to/from master user since it will always be member of sysadmin.

With this commit, we have excluded granting/revoking dbo to/from master user while creating database or doing alter authorization on database.

### Issues Resolved

Regression of BABEL-5119, BABEL-5218

### Test Scenarios Covered ###
Tested the code in Gitfarm
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).