### PR TITLE
Add support for sys.sp_reset_connection stored procedure

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -202,6 +202,7 @@ pe_tds_init(void)
 	pltsql_plugin_handler_ptr->set_context_info = &set_tds_context_info;
 	pltsql_plugin_handler_ptr->get_datum_from_byte_ptr = &TdsBytePtrToDatum;
 	pltsql_plugin_handler_ptr->get_datum_from_date_time_struct = &TdsDateTimeTypeToDatum;
+	pltsql_plugin_handler_ptr->set_reset_tds_connection_flag = &SetResetTDSConnectionFlag;
 
 	invalidate_stat_table_hook = invalidate_stat_table;
 	guc_newval_hook = TdsSetGucStatVariable;

--- a/contrib/babelfishpg_tds/src/include/tds_protocol.h
+++ b/contrib/babelfishpg_tds/src/include/tds_protocol.h
@@ -77,5 +77,6 @@ typedef struct
 } TdsRequestCtrlData;
 
 extern TdsRequestCtrlData *TdsRequestCtrl;
+extern void SetResetTDSConnectionFlag(void);
 
 #endif							/* TDS_PROTOCOL_H */

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -329,3 +329,7 @@ GRANT EXECUTE ON PROCEDURE sys.sp_dropextendedproperty TO PUBLIC;
 CREATE OR REPLACE PROCEDURE sys.sp_enum_oledb_providers()
 AS 'babelfishpg_tsql', 'sp_enum_oledb_providers_internal' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_enum_oledb_providers() TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_reset_connection()
+AS 'babelfishpg_tsql', 'sp_reset_connection_internal' LANGUAGE C;
+GRANT EXECUTE ON PROCEDURE sys.sp_reset_connection() TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
@@ -38,3 +38,7 @@ CALL sys.analyze_babelfish_catalogs();
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);
+
+CREATE OR REPLACE PROCEDURE sys.sp_reset_connection()
+AS 'babelfishpg_tsql', 'sp_reset_connection_internal' LANGUAGE C;
+GRANT EXECUTE ON PROCEDURE sys.sp_reset_connection() TO PUBLIC;

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1755,6 +1755,8 @@ typedef struct PLtsql_protocol_plugin
 
 	char	   *(*get_physical_schema_name) (char *db_name, const char *schema_name);
 
+	void		(*set_reset_tds_connection_flag) ();
+
 	/* Session level GUCs */
 	bool		quoted_identifier;
 	bool		arithabort;
@@ -1768,7 +1770,6 @@ typedef struct PLtsql_protocol_plugin
 	int			datefirst;
 	int			lock_timeout;
 	const char *language;
-
 } PLtsql_protocol_plugin;
 
 /*

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -78,6 +78,7 @@ PG_FUNCTION_INFO_V1(sp_babelfish_volatility);
 PG_FUNCTION_INFO_V1(sp_rename_internal);
 PG_FUNCTION_INFO_V1(sp_execute_postgresql);
 PG_FUNCTION_INFO_V1(sp_enum_oledb_providers_internal);
+PG_FUNCTION_INFO_V1(sp_reset_connection_internal);
 
 extern void delete_cached_batch(int handle);
 extern InlineCodeBlockArgs *create_args(int numargs);
@@ -4090,6 +4091,17 @@ sp_enum_oledb_providers_internal(PG_FUNCTION_ARGS)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	PG_RETURN_VOID();
+}
+
+Datum
+sp_reset_connection_internal(PG_FUNCTION_ARGS)
+{
+	if (*pltsql_protocol_plugin_ptr) 
+	{
+		(*pltsql_protocol_plugin_ptr)->set_reset_tds_connection_flag();
+	}
 
 	PG_RETURN_VOID();
 }

--- a/test/JDBC/expected/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/Test-sp_reset_connection.out
@@ -1,0 +1,109 @@
+-- 1. Test resets GUC variables
+SET lock_timeout 0;
+GO
+SELECT @@lock_timeout;
+GO
+~~START~~
+int
+0
+~~END~~
+
+EXEC sys.sp_reset_connection
+-- TODO: GUC is not resetting
+SELECT @@lock_timeout;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- 2. Test open transactions are aborted on reset
+DROP TABLE IF EXISTS sp_reset_connection_test_table;
+CREATE TABLE sp_reset_connection_test_table(id int);
+BEGIN TRANSACTION
+INSERT INTO sp_reset_connection_test_table VALUES(1)
+GO
+~~ROW COUNT: 1~~
+
+EXEC sys.sp_reset_connection
+GO
+COMMIT TRANSACTION
+GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
+SELECT * FROM sp_reset_connection_test_table
+GO
+~~START~~
+int
+~~END~~
+
+
+-- 3. Test temp tables are deleted on reset
+CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
+INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
+GO
+~~ROW COUNT: 3~~
+
+SELECT * from #babel_temp_table
+GO
+~~START~~
+int#!#int
+1#!#100
+2#!#200
+3#!#300
+~~END~~
+
+EXEC sys.sp_reset_connection
+GO
+SELECT * from #babel_temp_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#babel_temp_table" does not exist)~~
+
+
+-- 4. Test isolation level is reset
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+EXEC sys.sp_reset_connection
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+~~START~~
+smallint
+2
+~~END~~
+
+
+-- 5. Test sp_reset_connection called with sp_prepexec
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+~~START~~
+smallint
+1
+~~END~~
+
+DECLARE @handle int;
+EXEC SP_PREPARE @handle output, NULL, N'exec sys.sp_reset_connection'
+EXEC SP_EXECUTE @handle
+GO
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+~~START~~
+smallint
+2
+~~END~~
+

--- a/test/JDBC/input/storedProcedures/Test-sp_reset_connection.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_reset_connection.sql
@@ -1,0 +1,56 @@
+-- 1. Test resets GUC variables
+SET lock_timeout 0;
+GO
+SELECT @@lock_timeout;
+GO
+EXEC sys.sp_reset_connection
+-- TODO: GUC is not resetting
+SELECT @@lock_timeout;
+GO
+
+-- 2. Test open transactions are aborted on reset
+DROP TABLE IF EXISTS sp_reset_connection_test_table;
+CREATE TABLE sp_reset_connection_test_table(id int);
+BEGIN TRANSACTION
+INSERT INTO sp_reset_connection_test_table VALUES(1)
+GO
+EXEC sys.sp_reset_connection
+GO
+COMMIT TRANSACTION
+GO
+SELECT * FROM sp_reset_connection_test_table
+GO
+
+-- 3. Test temp tables are deleted on reset
+CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
+INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
+GO
+SELECT * from #babel_temp_table
+GO
+EXEC sys.sp_reset_connection
+GO
+SELECT * from #babel_temp_table
+GO
+
+-- 4. Test isolation level is reset
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+EXEC sys.sp_reset_connection
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+
+-- 5. Test sp_reset_connection called with sp_prepexec
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO
+DECLARE @handle int;
+EXEC SP_PREPARE @handle output, NULL, N'exec sys.sp_reset_connection'
+EXEC SP_EXECUTE @handle
+GO
+GO
+select transaction_isolation_level from sys.dm_exec_sessions where session_id=@@SPID
+GO

--- a/test/dotnet/ExpectedOutput/TestSpResetConnection.out
+++ b/test/dotnet/ExpectedOutput/TestSpResetConnection.out
@@ -1,0 +1,36 @@
+#Q#DROP TABLE IF EXISTS sp_reset_connection_test_table;
+#Q#CREATE TABLE sp_reset_connection_test_table(id int);
+#Q#INSERT INTO sp_reset_connection_test_table VALUES(1)
+#Q#INSERT INTO sp_reset_connection_test_table VALUES(2)
+#Q#sys.sp_reset_connection
+#Q#SELECT * FROM sp_reset_connection_test_table
+#D#int
+1
+#Q#CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
+#Q#INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
+#Q#SELECT * from #babel_temp_table
+#D#int#!#int
+1#!#100
+2#!#200
+3#!#300
+#Q#sys.sp_reset_connection
+#Q#SELECT * from #babel_temp_table
+#E#relation "#babel_temp_table" does not exist
+#Q#select current_setting('transaction_isolation')
+#D#text
+repeatable read
+#Q#sys.sp_reset_connection
+#Q#select current_setting('transaction_isolation')
+#D#text
+read committed
+#Q#CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
+#Q#INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
+#Q#SELECT * from #babel_temp_table
+#D#int#!#int
+1#!#100
+2#!#200
+3#!#300
+#Q#sys.sp_reset_connection
+#Q#sys.sp_reset_connection
+#Q#SELECT * from #babel_temp_table
+#E#relation "#babel_temp_table" does not exist

--- a/test/dotnet/ExpectedOutput/TestSpResetConnection.out
+++ b/test/dotnet/ExpectedOutput/TestSpResetConnection.out
@@ -16,13 +16,13 @@
 #Q#sys.sp_reset_connection
 #Q#SELECT * from #babel_temp_table
 #E#relation "#babel_temp_table" does not exist
-#Q#select current_setting('transaction_isolation')
-#D#text
-repeatable read
+#Q#select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
+#D#smallint
+5
 #Q#sys.sp_reset_connection
-#Q#select current_setting('transaction_isolation')
-#D#text
-read committed
+#Q#select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
+#D#smallint
+2
 #Q#CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
 #Q#INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
 #Q#SELECT * from #babel_temp_table

--- a/test/dotnet/input/Storedproc/TestSpResetConnection.txt
+++ b/test/dotnet/input/Storedproc/TestSpResetConnection.txt
@@ -1,0 +1,35 @@
+# Test (1): Test abort open transaction
+DROP TABLE IF EXISTS sp_reset_connection_test_table;
+CREATE TABLE sp_reset_connection_test_table(id int);
+INSERT INTO sp_reset_connection_test_table VALUES(1)
+txn#!#begin
+INSERT INTO sp_reset_connection_test_table VALUES(2)
+storedproc#!#prep#!#sys.sp_reset_connection#!#
+txn#!#commit
+SELECT * FROM sp_reset_connection_test_table
+# Test (1): End
+
+# Test (2): Test temp table deletion
+CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
+INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
+SELECT * from #babel_temp_table
+storedproc#!#prep#!#sys.sp_reset_connection#!#
+SELECT * from #babel_temp_table
+# Test (2): End
+
+# Test (3): Test reset of isolation level
+txn#!#begin#!#isolation#!#ss
+select current_setting('transaction_isolation')
+storedproc#!#prep#!#sys.sp_reset_connection#!#
+select current_setting('transaction_isolation')
+txn#!#commit 
+# Test (3): End
+
+# Test (4): Test prepexec sp_reset_connection
+CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
+INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
+SELECT * from #babel_temp_table
+prepst#!#sys.sp_reset_connection#!#
+prepst#!#exec#!#
+SELECT * from #babel_temp_table
+# Test (4): End

--- a/test/dotnet/input/Storedproc/TestSpResetConnection.txt
+++ b/test/dotnet/input/Storedproc/TestSpResetConnection.txt
@@ -19,9 +19,9 @@ SELECT * from #babel_temp_table
 
 # Test (3): Test reset of isolation level
 txn#!#begin#!#isolation#!#ss
-select current_setting('transaction_isolation')
+select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
 storedproc#!#prep#!#sys.sp_reset_connection#!#
-select current_setting('transaction_isolation')
+select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
 txn#!#commit 
 # Test (3): End
 

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -195,6 +195,7 @@ Could not find upgrade tests for procedure sys.sp_cursor_list
 Could not find upgrade tests for procedure sys.sp_describe_cursor
 Could not find upgrade tests for procedure sys.sp_oledb_ro_usrname
 Could not find upgrade tests for procedure sys.sp_prepare
+Could not find upgrade tests for procedure sys.sp_reset_connection
 Could not find upgrade tests for procedure sys.sp_unprepare
 Could not find upgrade tests for procedure sys.sp_updatestats
 Could not find upgrade tests for table sys.babelfish_configurations


### PR DESCRIPTION
Support sys.sp_reset_connection store procedure to reset tds connection

1. At the moment babelfish doesn't support sys.sp_reset_connection to reset the connection state. With this change it supports reset connection stored procedure.
2. This change is required for supporting RDS Proxy for Babelfish. RDS Proxy calls sys.sp_reset_connection before connection is reused by other clients.

Tasks:
BABEL-429

Signed off by: Sharath BP <sharatbp@amazon.com>

(cherry picked from commit 3997e2e88a60aa979eec950127162a8b3fa21f6c)

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).