### PR TITLE
Fix crash when trying to alter temp table column type.

### DIFF
--- a/test/JDBC/expected/temp_table.out
+++ b/test/JDBC/expected/temp_table.out
@@ -48,6 +48,7 @@ int#!#varchar#!#int
 ~~END~~
 
 
+-- should throw error due to generated column
 ALTER TABLE #t1 DROP COLUMN a
 GO
 ~~ERROR (Code: 33557097)~~
@@ -61,6 +62,176 @@ GO
 int#!#varchar#!#int
 1#!#<NULL>#!#2
 ~~END~~
+
+
+-- BABEL-5273 ALTER COLUMN to another type
+ALTER TABLE #t1 ALTER COLUMN b CHAR(5)
+GO
+
+INSERT INTO #t1 (b) VALUES ('hello')
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#char#!#int
+1#!#<NULL>#!#2
+2#!#hello#!#3
+~~END~~
+
+
+-- should fail due to possible truncation
+ALTER TABLE #t1 ALTER COLUMN b CHAR(4)
+GO
+~~ERROR (Code: 8152)~~
+
+~~ERROR (Message: value too long for type character(4))~~
+
+
+DELETE FROM #t1 WHERE b = 'hello'
+GO
+~~ROW COUNT: 1~~
+
+
+-- try all other TSQL types
+ALTER TABLE #t1 ALTER COLUMN b TINYINT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b SMALLINT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b INT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b BIGINT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b BIT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b DECIMAL
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NUMERIC
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b MONEY
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b SMALLMONEY
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b FLOAT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b REAL
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b DATE
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type date)~~
+
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b TIME
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type time without time zone)~~
+
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b DATETIME2
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type datetime2)~~
+
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b DATETIMEOFFSET
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type datetimeoffset)~~
+
+
+ALTER TABLE #t1 ALTER COLUMN b DATETIME
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b SMALLDATETIME
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b CHAR
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b VARCHAR
+GO
+
+-- TODO: fix this, it should work and not raise a syntax error
+ALTER TABLE #t1 ALTER COLUMN b TEXT
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "TEXT")~~
+
+
+ALTER TABLE #t1 ALTER COLUMN b NCHAR
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NVARCHAR
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NTEXT
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b BINARY
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: type "BINARY" does not exist)~~
+
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b VARBINARY
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type varbinary)~~
+
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b IMAGE
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type image)~~
+
+
+-- TODO: should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b GEOGRAPHY
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b GEOMETRY
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" cannot be cast automatically to type geometry)~~
+
+
+-- TODO: fix this, it should work and not raise a syntax error
+ALTER TABLE #t1 ALTER COLUMN b XML
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "XML")~~
 
 
 ALTER TABLE #t1 DROP COLUMN b

--- a/test/JDBC/input/temp_tables/temp_table.sql
+++ b/test/JDBC/input/temp_tables/temp_table.sql
@@ -26,10 +26,127 @@ GO
 SELECT * FROM #t1
 GO
 
+-- should throw error due to generated column
 ALTER TABLE #t1 DROP COLUMN a
 GO
 
 SELECT * FROM #t1
+GO
+
+-- BABEL-5273 ALTER COLUMN to another type
+ALTER TABLE #t1 ALTER COLUMN b CHAR(5)
+GO
+
+INSERT INTO #t1 (b) VALUES ('hello')
+GO
+
+SELECT * FROM #t1
+GO
+
+-- should fail due to possible truncation
+ALTER TABLE #t1 ALTER COLUMN b CHAR(4)
+GO
+
+DELETE FROM #t1 WHERE b = 'hello'
+GO
+
+-- try all other TSQL types
+ALTER TABLE #t1 ALTER COLUMN b TINYINT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b SMALLINT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b INT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b BIGINT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b BIT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b DECIMAL
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NUMERIC
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b MONEY
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b SMALLMONEY
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b FLOAT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b REAL
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b DATE
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b TIME
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b DATETIME2
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b DATETIMEOFFSET
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b DATETIME
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b SMALLDATETIME
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b CHAR
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b VARCHAR
+GO
+
+-- TODO: fix this, it should work and not raise a syntax error
+ALTER TABLE #t1 ALTER COLUMN b TEXT
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NCHAR
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NVARCHAR
+GO
+
+ALTER TABLE #t1 ALTER COLUMN b NTEXT
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b BINARY
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b VARBINARY
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b IMAGE
+GO
+
+-- TODO: should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b GEOGRAPHY
+GO
+
+-- should raise error due to incompatible types
+ALTER TABLE #t1 ALTER COLUMN b GEOMETRY
+GO
+
+-- TODO: fix this, it should work and not raise a syntax error
+ALTER TABLE #t1 ALTER COLUMN b XML
 GO
 
 ALTER TABLE #t1 DROP COLUMN b


### PR DESCRIPTION
### Description
In cases where a temp table column is being altered so that only the size changes (e.g. char(20) -> char(5)), the code path needs to drop the pg_depend entry from the normal catalog table (to be later recreated using the new target type). However, for ENR temp tables all catalog tuples are stored in currentQueryEnv and not actually in the catalogs themselves. Thus, the code would not be able to find the tuple for deletion, leading to an assertion error. Fix the issue by using ENRDropTuple() instead of CatalogTupleDelete() so that the code drops the tuple in the correct place.

Backport of https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/442

Note that there are additional changes compared to the original commit from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/442 to allow this change to work with pg15, as there are commits which are present in pg16 which have not been backported to pg15 which are required for this change to work properly.


### Issues Resolved

BABEL-5273

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).