### PR TITLE
Clean up temp table naming, introduce new functions for readability

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2474,7 +2474,7 @@ object_name(PG_FUNCTION_ARGS)
 	 * search in list of ENRs registered in the current query environment by
 	 * object_id
 	 */
-	enr = get_ENR_withoid(currentQueryEnv, object_id, ENR_TSQL_TEMP);
+	enr = OidBelongsToENRTempTable(object_id);
 	if (enr != NULL && enr->md.enrtype == ENR_TSQL_TEMP)
 	{
 		PG_RETURN_VARCHAR_P((VarChar *) cstring_to_text(enr->md.name));

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2474,7 +2474,7 @@ object_name(PG_FUNCTION_ARGS)
 	 * search in list of ENRs registered in the current query environment by
 	 * object_id
 	 */
-	enr = OidBelongsToENRTempTable(object_id);
+	enr = GetENRTempTableWithOid(object_id);
 	if (enr != NULL && enr->md.enrtype == ENR_TSQL_TEMP)
 	{
 		PG_RETURN_VARCHAR_P((VarChar *) cstring_to_text(enr->md.name));

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -373,8 +373,7 @@ bool IsPltsqlToastClassHook(Form_pg_class pg_class_tup)
 void pltsql_drop_relation_refcnt_hook(Relation relation)
 {
 	int expected_refcnt = 0;
-	if (sql_dialect != SQL_DIALECT_TSQL ||
-		!RelationIsBBFTableVariable(relation))
+	if (!IsTsqlTableVariable(relation))
 		return;
 
 	expected_refcnt = relation->rd_isnailed ? 2 : 1;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4800,7 +4800,7 @@ pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg)
 static EphemeralNamedRelation
 pltsql_get_tsql_enr_from_oid(const Oid oid)
 {
-	return temp_oid_buffer_size > 0 ? OidBelongsToENRTempTable(oid) : NULL;
+	return temp_oid_buffer_size > 0 ? GetENRTempTableWithOid(oid) : NULL;
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -89,12 +89,6 @@ extern char *babelfish_dump_restore_min_oid;
 extern bool pltsql_quoted_identifier;
 extern bool pltsql_ansi_nulls;
 
-#define OID_TO_BUFFER_START(oid) 		((oid) + INT_MIN)
-#define BUFFER_START_TO_OID 			((Oid) (temp_oid_buffer_start) - INT_MIN)
-
-/* For unit testing, to avoid concurrent heap update issues. */
-bool TEST_persist_temp_oid_buffer_start_disable_catalog_update = false;
-
 /*****************************************
  * 			Catalog Hooks
  *****************************************/
@@ -162,12 +156,6 @@ static void preserve_view_constraints_from_base_table(ColumnDef *col, Oid tableO
 static bool pltsql_detect_numeric_overflow(int weight, int dscale, int first_block, int numeric_base);
 static void insert_pltsql_function_defaults(HeapTuple func_tuple, List *defaults, Node **argarray);
 static int	print_pltsql_function_arguments(StringInfo buf, HeapTuple proctup, bool print_table_args, bool print_defaults);
-static void pltsql_GetNewObjectId(VariableCache variableCache);
-static Oid  pltsql_GetNewTempObjectId(void);
-static Oid 	pltsql_GetNewTempOidWithIndex(Relation relation, Oid indexId, AttrNumber oidcolumn);
-static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
-static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
-static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
 static void pltsql_validate_var_datatype_scale(const TypeName *typeName, Type typ);
 static bool pltsql_bbfCustomProcessUtility(ParseState *pstate,
 									  PlannedStmt *pstmt,
@@ -221,6 +209,22 @@ static PlannedStmt *pltsql_planner_hook(Query *parse, const char *query_string, 
 static Oid set_param_collation(Param *param);
 static Oid default_collation_for_builtin_type(Type typ, bool handle_text);
 static char* pltsql_get_object_identity_event_trigger(ObjectAddress *addr);
+
+/***************************************************
+ * 			Temp Table Related Declarations + Hooks
+ ***************************************************/
+#define OID_TO_BUFFER_START(oid) 		((oid) + INT_MIN)
+#define BUFFER_START_TO_OID 			((Oid) (temp_oid_buffer_start) - INT_MIN)
+
+/* For unit testing, to avoid concurrent heap update issues. */
+bool TEST_persist_temp_oid_buffer_start_disable_catalog_update = false;
+
+static void pltsql_GetNewObjectId(VariableCache variableCache);
+static Oid  pltsql_GetNewTempObjectId(void);
+static Oid 	pltsql_GetNewTempOidWithIndex(Relation relation, Oid indexId, AttrNumber oidcolumn);
+static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
+static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
+static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
 
 /* Save hook values in case of unload */
 static core_yylex_hook_type prev_core_yylex_hook = NULL;
@@ -4796,7 +4800,7 @@ pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg)
 static EphemeralNamedRelation
 pltsql_get_tsql_enr_from_oid(const Oid oid)
 {
-	return temp_oid_buffer_size > 0 ? get_ENR_withoid(currentQueryEnv, oid, ENR_TSQL_TEMP) : NULL;
+	return temp_oid_buffer_size > 0 ? OidBelongsToENRTempTable(oid) : NULL;
 }
 
 /*


### PR DESCRIPTION
### Description

BABEL-5128

- Reorganize `queryenvironment.c` to have better separation of different families of functions (ENR catalog search/insertion, cleanup, invalidation messages, rollback handling). 
- Refactored some function names to have consistent naming
- Introduced new functions to clean up commonly used temp table checks across engine code

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).