### PR TITLE
Reset db context at the time TDS resets the connection

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds_srv.c
@@ -198,6 +198,7 @@ pe_tds_init(void)
 	pltsql_plugin_handler_ptr->invalidate_stat_view = &invalidate_stat_table;
 	pltsql_plugin_handler_ptr->get_host_name = &get_tds_host_name;
 	pltsql_plugin_handler_ptr->set_reset_tds_connection_flag = &SetResetTDSConnectionFlag;
+	pltsql_plugin_handler_ptr->get_reset_tds_connection_flag = &GetResetTDSConnectionFlag;
 
 	invalidate_stat_table_hook = invalidate_stat_table;
 	guc_newval_hook = TdsSetGucStatVariable;

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -2146,7 +2146,6 @@ TdsSendLoginAck(Port *port)
 	uint8		temp8;
 	uint32_t	collationInfo;
 	char		collationBytesNew[5];
-	Oid			roleid = InvalidOid;
 	uint32_t	tdsVersion = pg_hton32(loginInfo->tdsVersion);
 	char		srvVersionBytes[4];
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -60,6 +60,7 @@
 
 #include "src/include/tds_debug.h"
 #include "src/include/tds_int.h"
+#include "src/include/tds_protocol.h"
 #include "src/include/tds_request.h"
 #include "src/include/tds_response.h"
 #include "src/include/guc.h"
@@ -2009,6 +2010,128 @@ TdsProcessLogin(Port *port, bool loadedSsl)
 }
 
 /*
+ * TdsSetDbContext:
+ *		Used to Set the Database Context during login
+ *		and during reset connection.
+ *		Note: We should not optimize the scenario during
+ *		reset connection to reset to the same database
+ *		which might be in use since the USE db command
+ *		will reset other configurations which might
+ *		have changed.
+ */
+void
+TdsSetDbContext()
+{
+	char *dbname				= NULL;
+	char *useDbCommand			= NULL;
+	char *user 					= NULL;
+	MemoryContext oldContext	= CurrentMemoryContext;
+
+	PG_TRY();
+	{
+		if (loginInfo->database != NULL && loginInfo->database[0] != '\0')
+		{
+			Oid			db_id;
+
+			/*
+			 * Before preparing the query, first check whether we got a valid
+			 * database name and it exists.  Otherwise, there'll be risk of
+			 * SQL injection.
+			 */
+			StartTransactionCommand();
+			db_id = pltsql_plugin_handler_ptr->pltsql_get_database_oid(loginInfo->database);
+			CommitTransactionCommand();
+			MemoryContextSwitchTo(oldContext);
+
+			if (!OidIsValid(db_id))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_DATABASE),
+							errmsg("database \"%s\" does not exist", loginInfo->database)));
+
+			/*
+			 * Any delimitated/quoted db name identifier requested in login
+			 * must be already handled before this point.
+			 */
+			useDbCommand = psprintf("USE [%s]", loginInfo->database);
+			dbname = pstrdup(loginInfo->database);
+		}
+		else
+		{
+			char	   *temp = NULL;
+
+			StartTransactionCommand();
+			temp = pltsql_plugin_handler_ptr->pltsql_get_login_default_db(loginInfo->username);
+			MemoryContextSwitchTo(oldContext);
+
+			if (temp == NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_DATABASE),
+							errmsg("could not find default database for user \"%s\"", loginInfo->username)));
+
+			useDbCommand = psprintf("USE [%s]", temp);
+			dbname = pstrdup(temp);
+			CommitTransactionCommand();
+			MemoryContextSwitchTo(oldContext);
+		}
+
+		StartTransactionCommand();
+		/*
+		 * Check if user has privileges to access current database.
+		 */
+		user = pltsql_plugin_handler_ptr->pltsql_get_user_for_database(dbname);
+		if (!user)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_DATABASE),
+						errmsg("Cannot open database \"%s\" requested by the login. The login failed", dbname)));
+
+		/*
+		 * loginInfo has a database name provided, so we execute a "USE
+		 * [<db_name>]" through pltsql inline handler.
+		 */
+		ExecuteSQLBatch(useDbCommand);
+		CommitTransactionCommand();
+	}
+	PG_CATCH();
+	{
+		/*
+		 * If this is during reset phase and we encounter an error
+		 * with mapped user or db not found then we should terminate
+		 * the connection.
+		 */
+		if (resetTdsConnectionFlag)
+		{
+			/* Before terminating the connection, send the response to the client. */
+			EmitErrorReport();
+			FlushErrorState();
+
+			/*
+			 * Client driver terminates the connection with a
+			 * dual error token and with error 596. Otherwise
+			 * it sends the next requests before realising the
+			 * session was terminated.
+			 */
+			TdsSendError(596, 1, ERROR,
+					"Cannot continue the execution because the session is in the kill state.", 1);
+
+			TdsSendDone(TDS_TOKEN_DONE, TDS_DONE_ERROR, 0, 0);
+			TdsFlush();
+
+			/* Terminate the connection. */
+			ereport(FATAL,
+					(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+					errmsg("Reset Connection Failed")));
+		}
+		/* Else rethrow the error. */
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+	if (useDbCommand)
+		pfree(useDbCommand);
+	if (dbname)
+		pfree(dbname);
+}
+
+/*
  * TdsSendLoginAck - Send a login acknowledgement to the client
  *
  * This function should be called in postmaster context.
@@ -2017,16 +2140,13 @@ void
 TdsSendLoginAck(Port *port)
 {
 	uint16_t	temp16;
-	char	   *dbname = NULL;
 	int			prognameLen = pg_mbstrlen(default_server_name);
 	LoginRequest request;
 	StringInfoData buf;
 	uint8		temp8;
 	uint32_t	collationInfo;
 	char		collationBytesNew[5];
-	char	   *useDbCommand = NULL;
-	char	   *user = NULL;
-	MemoryContext oldContext;
+	Oid			roleid = InvalidOid;
 	uint32_t	tdsVersion = pg_hton32(loginInfo->tdsVersion);
 	char		srvVersionBytes[4];
 
@@ -2138,75 +2258,7 @@ TdsSendLoginAck(Port *port)
 						 errmsg("\"%s\" is not a Babelfish user", port->user_name)));
 		}
 
-		oldContext = CurrentMemoryContext;
-
-		if (request->database != NULL && request->database[0] != '\0')
-		{
-			Oid			db_id;
-
-			/*
-			 * Before preparing the query, first check whether we got a valid
-			 * database name and it exists.  Otherwise, there'll be risk of
-			 * SQL injection.
-			 */
-			StartTransactionCommand();
-			db_id = pltsql_plugin_handler_ptr->pltsql_get_database_oid(request->database);
-			CommitTransactionCommand();
-			MemoryContextSwitchTo(oldContext);
-
-			if (!OidIsValid(db_id))
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_DATABASE),
-						 errmsg("database \"%s\" does not exist", request->database)));
-
-			/*
-			 * Any delimitated/quoted db name identifier requested in login
-			 * must be already handled before this point.
-			 */
-			useDbCommand = psprintf("USE [%s]", request->database);
-			dbname = pstrdup(request->database);
-		}
-		else
-		{
-			char	   *temp = NULL;
-
-			StartTransactionCommand();
-			temp = pltsql_plugin_handler_ptr->pltsql_get_login_default_db(port->user_name);
-			MemoryContextSwitchTo(oldContext);
-
-			if (temp == NULL)
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_DATABASE),
-						 errmsg("could not find default database for user \"%s\"", port->user_name)));
-
-			useDbCommand = psprintf("USE [%s]", temp);
-			dbname = pstrdup(temp);
-			CommitTransactionCommand();
-			MemoryContextSwitchTo(oldContext);
-		}
-
-		/*
-		 * Check if user has privileges to access current database
-		 */
-		StartTransactionCommand();
-		user = pltsql_plugin_handler_ptr->pltsql_get_user_for_database(dbname);
-		if (!user)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_DATABASE),
-					 errmsg("Cannot open database \"%s\" requested by the login. The login failed", dbname)));
-		CommitTransactionCommand();
-		if (dbname)
-			pfree(dbname);
-
-		/*
-		 * Request has a database name provided, so we execute a "USE
-		 * [<db_name>]" through pgtsql inline handler
-		 */
-		StartTransactionCommand();
-		ExecuteSQLBatch(useDbCommand);
-		CommitTransactionCommand();
-		if (useDbCommand)
-			pfree(useDbCommand);
+		TdsSetDbContext();
 
 		/*
 		 * Set the GUC for language, it will take care of changing the GUC,

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -295,6 +295,7 @@ extern int	TdsProcessLogin(Port *port, bool LoadSsl);
 extern void TdsSendLoginAck(Port *port);
 extern uint32_t GetClientTDSVersion(void);
 extern char *get_tds_login_domainname(void);
+extern void TdsSetDbContext(void);
 
 /* Functions in backend/tds/tdsprotocol.c */
 extern int	TdsSocketBackend(void);

--- a/contrib/babelfishpg_tds/src/include/tds_protocol.h
+++ b/contrib/babelfishpg_tds/src/include/tds_protocol.h
@@ -78,5 +78,8 @@ typedef struct
 
 extern TdsRequestCtrlData *TdsRequestCtrl;
 extern void SetResetTDSConnectionFlag(void);
+extern bool GetResetTDSConnectionFlag(void);
+
+extern bool resetTdsConnectionFlag;
 
 #endif							/* TDS_PROTOCOL_H */

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -2725,14 +2725,19 @@ exec_stmt_usedb(PLtsql_execstate *estate, PLtsql_stmt_usedb *stmt)
 			top_es_entry = top_es_entry->next;
 	}
 
-	snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
-	/* send env change token to user */
-	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change)
-		((*pltsql_protocol_plugin_ptr)->send_env_change) (1, stmt->db_name, old_db_name);
-	/* send message to user */
-	if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_info)
-		((*pltsql_protocol_plugin_ptr)->send_info) (0, 1, 0, message, 0);
-
+	/*
+	 * In case of reset-connection we do not need to send the environment change token.
+	 */
+	if (!((*pltsql_protocol_plugin_ptr) && (*pltsql_protocol_plugin_ptr)->get_reset_tds_connection_flag()))
+	{
+		snprintf(message, sizeof(message), "Changed database context to '%s'.", stmt->db_name);
+		/* send env change token to user */
+		if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_env_change)
+			((*pltsql_protocol_plugin_ptr)->send_env_change) (1, stmt->db_name, old_db_name);
+		/* send message to user */
+		if (*pltsql_protocol_plugin_ptr && (*pltsql_protocol_plugin_ptr)->send_info)
+			((*pltsql_protocol_plugin_ptr)->send_info) (0, 1, 0, message, 0);
+	}
 	return PLTSQL_RC_OK;
 }
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1666,6 +1666,8 @@ typedef struct PLtsql_protocol_plugin
 
 	void		(*set_reset_tds_connection_flag) ();
 
+	bool		(*get_reset_tds_connection_flag) ();
+
 	/* Session level GUCs */
 	bool		quoted_identifier;
 	bool		arithabort;

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -201,7 +201,6 @@ void
 reset_session_properties(void)
 {
 	reset_cached_batch();
-	set_session_properties(get_cur_db_name());
 }
 
 void

--- a/test/JDBC/expected/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/Test-sp_reset_connection.out
@@ -1,3 +1,4 @@
+-- tsql
 -- 1. Test resets GUC variables
 SET lock_timeout 0;
 GO
@@ -107,3 +108,78 @@ smallint
 2
 ~~END~~
 
+
+-- 6. Test Database Context being reset
+--      Tests include negative cases where db is dropped or renamed
+Create database reset_con_db1;
+GO
+Create database reset_con_db2;
+GO
+
+-- tsql database=reset_con_db1
+select db_name();
+GO
+~~START~~
+nvarchar
+reset_con_db1
+~~END~~
+
+exec sys.sp_reset_connection
+GO
+use master
+GO
+select db_name();
+GO
+~~START~~
+nvarchar
+master
+~~END~~
+
+exec sys.sp_reset_connection
+GO
+select db_name();
+GO
+~~START~~
+nvarchar
+reset_con_db1
+~~END~~
+
+-- test db being dropped before resetting to same db
+use master;
+drop database reset_con_db1;
+GO
+exec sys.sp_reset_connection
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "reset_con_db1" does not exist)~~
+
+-- tsql database=reset_con_db2
+select db_name();
+GO
+~~START~~
+nvarchar
+reset_con_db2
+~~END~~
+
+use master
+GO
+select db_name();
+GO
+~~START~~
+nvarchar
+master
+~~END~~
+
+ALTER DATABASE reset_con_db2 MODIFY NAME=reset_con_db3
+GO
+exec sys.sp_reset_connection
+GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "reset_con_db2" does not exist)~~
+
+
+-- tsql
+DROP DATABASE reset_con_db3
+GO

--- a/test/JDBC/expected/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/Test-sp_reset_connection.out
@@ -113,8 +113,6 @@ smallint
 --      Tests include negative cases where db is dropped or renamed
 Create database reset_con_db1;
 GO
-Create database reset_con_db2;
-GO
 
 -- tsql database=reset_con_db1
 select db_name();
@@ -154,32 +152,3 @@ GO
 
 ~~ERROR (Message: database "reset_con_db1" does not exist)~~
 
--- tsql database=reset_con_db2
-select db_name();
-GO
-~~START~~
-nvarchar
-reset_con_db2
-~~END~~
-
-use master
-GO
-select db_name();
-GO
-~~START~~
-nvarchar
-master
-~~END~~
-
-ALTER DATABASE reset_con_db2 MODIFY NAME=reset_con_db3
-GO
-exec sys.sp_reset_connection
-GO
-~~ERROR (Code: 911)~~
-
-~~ERROR (Message: database "reset_con_db2" does not exist)~~
-
-
--- tsql
-DROP DATABASE reset_con_db3
-GO

--- a/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
@@ -1,3 +1,4 @@
+-- tsql
 -- 1. Test resets GUC variables
 SET lock_timeout 0;
 GO
@@ -53,4 +54,46 @@ EXEC SP_EXECUTE @handle
 GO
 GO
 select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
+GO
+
+-- 6. Test Database Context being reset
+--      Tests include negative cases where db is dropped or renamed
+Create database reset_con_db1;
+GO
+Create database reset_con_db2;
+GO
+
+-- tsql database=reset_con_db1
+select db_name();
+GO
+exec sys.sp_reset_connection
+GO
+use master
+GO
+select db_name();
+GO
+exec sys.sp_reset_connection
+GO
+select db_name();
+GO
+-- test db being dropped before resetting to same db
+use master;
+drop database reset_con_db1;
+GO
+exec sys.sp_reset_connection
+GO
+-- tsql database=reset_con_db2
+select db_name();
+GO
+use master
+GO
+select db_name();
+GO
+ALTER DATABASE reset_con_db2 MODIFY NAME=reset_con_db3
+GO
+exec sys.sp_reset_connection
+GO
+
+-- tsql
+DROP DATABASE reset_con_db3
 GO

--- a/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
@@ -60,8 +60,6 @@ GO
 --      Tests include negative cases where db is dropped or renamed
 Create database reset_con_db1;
 GO
-Create database reset_con_db2;
-GO
 
 -- tsql database=reset_con_db1
 select db_name();
@@ -81,19 +79,4 @@ use master;
 drop database reset_con_db1;
 GO
 exec sys.sp_reset_connection
-GO
--- tsql database=reset_con_db2
-select db_name();
-GO
-use master
-GO
-select db_name();
-GO
-ALTER DATABASE reset_con_db2 MODIFY NAME=reset_con_db3
-GO
-exec sys.sp_reset_connection
-GO
-
--- tsql
-DROP DATABASE reset_con_db3
 GO

--- a/test/dotnet/ExpectedOutput/1_Setup.out
+++ b/test/dotnet/ExpectedOutput/1_Setup.out
@@ -1,0 +1,5 @@
+#Q#create database db1;
+#Q#use db1;
+#Q#Select db_name()
+#D#nvarchar
+db1

--- a/test/dotnet/ExpectedOutput/2_Successful_reset.out
+++ b/test/dotnet/ExpectedOutput/2_Successful_reset.out
@@ -1,0 +1,4 @@
+#Q#select db_name();
+#D#nvarchar
+master
+#Q#drop database db1;

--- a/test/dotnet/input/ResetConnection/1_Setup.txt
+++ b/test/dotnet/input/ResetConnection/1_Setup.txt
@@ -1,0 +1,3 @@
+create database db1;
+use db1;
+Select db_name()

--- a/test/dotnet/input/ResetConnection/2_Successful_reset.txt
+++ b/test/dotnet/input/ResetConnection/2_Successful_reset.txt
@@ -1,0 +1,2 @@
+select db_name();
+drop database db1;

--- a/test/dotnet/src/ExecuteTests.cs
+++ b/test/dotnet/src/ExecuteTests.cs
@@ -52,6 +52,8 @@ namespace BabelfishDotnetFramework
                 }
                 allFiles = tempList;
             }
+            allFiles = allFiles.OrderBy(file => file.DirectoryName)
+                   .ThenBy(file => file.Name);
             Task<bool>[] tasksInParallel = new Task<bool>[allFiles.Count()];
             bool [] result = new bool[allFiles.Count()];
             int i = 0;


### PR DESCRIPTION
T-SQL Behaviour suggests that if we connect to database db1 and if during the session we have changed the database context to db2 then at the time of reset connection, the server must reset the connection to db1. Earlier we were not resetting the database context to that of the database used to login, in the above example db1, this lead to clients being handed a stale connection.
To Fix this we reset the database context to that from the loginInfo which was maintained at time of login. Changes were also made to avoid sending the environment change token for the implicit "USE DB" being run at time of reset.

Issues Resolved
BABEL-5256

Signed off by: Kushaal Shroff <kushaal@amazon.com>
