### PR TITLE
Support PgAudit with Babelfish and addition of PgAudit github action …

### DIFF
--- a/.github/composite-actions/build-install-pgaudit-extension/action.yml
+++ b/.github/composite-actions/build-install-pgaudit-extension/action.yml
@@ -1,0 +1,28 @@
+name: 'Build and Install PgAudit'
+
+inputs:
+  install_dir:
+    description: 'Engine install directory'
+    required: no
+    default: psql
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build and Install PgAudit
+      run: |
+        cd ~
+        rm -rf pgaudit
+        git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
+        cd pgaudit
+        make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
+        cd ../psql
+        sudo sed -i "s/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'	# (change requires restart)/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements,pgaudit'/g" data/postgresql.conf
+        echo "everything set"
+
+        ~/${{ inputs.install_dir }}/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
+        sudo PGPASSWORD=12345678 ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "CREATE EXTENSION pgaudit;"
+        sudo PGPASSWORD=12345678 ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "ALTER SYSTEM SET pgaudit.log = 'all';"
+
+      shell: bash
+      

--- a/.github/composite-actions/build-install-pgaudit-extension/action.yml
+++ b/.github/composite-actions/build-install-pgaudit-extension/action.yml
@@ -13,7 +13,7 @@ runs:
       run: |
         cd ~
         rm -rf pgaudit
-        git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
+        git clone --depth 1 --branch REL_15_STABLE https://github.com/pgaudit/pgaudit.git
         cd pgaudit
         make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
         cd ../psql

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,0 +1,163 @@
+name: JDBC Tests With PG AUDIT Enable
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs every midnight
+
+jobs:
+  run-babelfish-jdbc-tests-with-pg-audit:
+    env:
+      INSTALL_DIR: psql
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        uses: ./.github/composite-actions/install-dependencies
+
+      - name: Build Modified Postgres
+        id: build-modified-postgres
+        if: always() && steps.install-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          install_dir: 'psql'
+      
+      - name: Compile ANTLR
+        id: compile-antlr
+        if: always() && steps.build-modified-postgres.outcome == 'success'
+        uses: ./.github/composite-actions/compile-antlr
+      
+      - name: Build Extensions
+        id: build-extensions
+        if: always() && steps.compile-antlr.outcome == 'success'
+        uses: ./.github/composite-actions/build-extensions
+
+      - name: Build tds_fdw Extension
+        id: build-tds_fdw-extension
+        if: always() && steps.build-extensions.outcome == 'success'
+        uses: ./.github/composite-actions/build-tds_fdw-extension
+
+      - name: Build vector Extension
+        id: build-vector-extension
+        if: always() &&  steps.build-tds_fdw-extension.outcome == 'success'
+        uses: ./.github/composite-actions/build-vector-extension
+
+      - name: Build PostGIS Extension
+        id: build-postgis-extension
+        if: always() &&  steps.build-vector-extension.outcome == 'success'
+        uses: ./.github/composite-actions/build-postgis-extension
+        
+      - name: Install Extensions
+        id: install-extensions
+        if: always() && steps.build-postgis-extension.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
+        with:
+          wal_level: logical
+
+      - name: Build and Install PgAudit
+        uses: ./.github/composite-actions/build-install-pgaudit-extension
+        with:
+          install_dir: 'psql'
+
+      - name: Ignore some JDBC files 
+        run: |
+          export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
+          export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
+          export inputFilesPath=${{inputs.input_dir}}
+          cd test
+          # ignoring BABEL-2843 test file BABEL-2843,as in this file we are enabling the babelfish_statistics profile On for DDL, which is not giving any error but just adding the query under Query Text  which is being passed from pg_audit and hence getting a diff file
+          sudo sed -i '$a\ignore#!#BABEL-2843' JDBC/jdbc_schedule
+          # ignoring below files as we will fix this issue in BABEL-5272
+          sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant' JDBC/jdbc_schedule
+          sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-prepare' JDBC/jdbc_schedule
+          sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-verify' JDBC/jdbc_schedule
+          sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-cleanup' JDBC/jdbc_schedule
+
+      - name: Run JDBC Tests
+        id: jdbc
+        if: always() && steps.install-extensions.outcome == 'success'
+        timeout-minutes: 60
+        uses: ./.github/composite-actions/run-jdbc-tests
+
+      - name: Start secondary server
+        id: start-secondary
+        if: always() && steps.jdbc.outcome == 'success'
+        uses: ./.github/composite-actions/install-extensions
+        with:
+          psql_port: 5433
+          tsql_port: 8199
+          wal_level: logical
+
+      - name: Setup Publication and Subscription
+        id: setup-pub-sub
+        if: always() && steps.start-secondary.outcome == 'success'
+        run: |
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=jdbc_testdb password=12345678' PUBLICATION my_pub;"
+
+      - name: Run Replication Tests
+        id: replication
+        if: always() && steps.setup-pub-sub.outcome == 'success'
+        timeout-minutes: 60
+        uses: ./.github/composite-actions/run-jdbc-tests
+        with:
+          input_dir: 'replication'
+
+      - name: Cleanup babelfish database
+        id: cleanup
+        if: always() && steps.replication.outcome == 'success'
+        run: |
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+
+      - name: Upload Log
+        if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgres-log-jdbc
+          path: |
+            ~/psql/data/logfile
+            ~/psql/data_5433/logfile
+
+      # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
+      - name: Rename Test Summary Files
+        id: test-file-rename
+        if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')
+        run: |
+          cd test/JDBC/Info
+          timestamp=`ls -Art | tail -n 1`
+          cd $timestamp
+          mv $timestamp.diff ../output-diff.diff
+          mv "$timestamp"_runSummary.log ../run-summary.log
+          cd ..
+          # get the replication output diff as well if it is present
+          dir_count=`ls | wc -l`
+          if [[ $dir_count -eq 2 ]];then
+            timestamp=`ls -rt | tail -n 2 | sort -r | tail -n 1`
+            cd $timestamp
+            mv $timestamp.diff ../replication-output-diff.diff
+            mv "$timestamp"_runSummary.log ../replication-run-summary.log
+
+      - name: Upload Run Summary 
+        if: always() && steps.test-file-rename.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-summary.log
+          path: |
+            test/JDBC/Info/run-summary.log
+            test/JDBC/Info/replication-run-summary.log
+
+      - name: Upload Output Diff
+        if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')
+        uses: actions/upload-artifact@v4
+        with:
+          name: jdbc-output-diff.diff
+          path: |
+            test/JDBC/Info/output-diff.diff
+            test/JDBC/Info/replication-output-diff.diff
+
+      - name: Check and upload coredumps
+        if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')
+        uses: ./.github/composite-actions/upload-coredump
+        

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,7 +1,8 @@
 name: JDBC Tests With PG AUDIT Enable
-on:
-  schedule:
-    - cron: '0 0 * * *'  # runs every midnight
+# on:
+#   schedule:
+#     - cron: '0 0 * * *'  # runs every midnight
+on: [workflow_call]
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -2,7 +2,7 @@ name: JDBC Tests With PG AUDIT Enable
 # on:
 #   schedule:
 #     - cron: '0 0 * * *'  # runs every midnight
-on: [workflow_call]
+on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,8 +1,7 @@
 name: JDBC Tests With PG AUDIT Enable
-# on:
-#   schedule:
-#     - cron: '0 0 * * *'  # runs every midnight
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs every midnight
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -154,7 +154,7 @@ static bool pltsql_bbfCustomProcessUtility(ParseState *pstate,
 									  ProcessUtilityContext context,
 									  ParamListInfo params, QueryCompletion *qc);
 extern void pltsql_bbfSelectIntoUtility(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, 
-					QueryEnvironment *queryEnv, ParamListInfo params, QueryCompletion *qc);
+					QueryEnvironment *queryEnv, ParamListInfo params, QueryCompletion *qc, ObjectAddress *address);
 
 /*****************************************
  * 			Executor Hooks
@@ -195,6 +195,7 @@ static void revoke_func_permission_from_public(Oid objectId);
  * 			Planner Hook
  *****************************************/
 static PlannedStmt *pltsql_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams);
+static char* pltsql_get_object_identity_event_trigger(ObjectAddress *addr);
 
 /* Save hook values in case of unload */
 static core_yylex_hook_type prev_core_yylex_hook = NULL;
@@ -435,6 +436,8 @@ InstallExtendedHooks(void)
 
 	prev_ExecFuncProc_AclCheck_hook  = ExecFuncProc_AclCheck_hook;
 	ExecFuncProc_AclCheck_hook = pltsql_ExecFuncProc_AclCheck;
+	
+	pltsql_get_object_identity_event_trigger_hook = pltsql_get_object_identity_event_trigger;
 }
 
 void
@@ -506,6 +509,7 @@ UninstallExtendedHooks(void)
 
 	bbf_InitializeParallelDSM_hook = NULL;
 	bbf_ParallelWorkerMain_hook = NULL;
+	pltsql_get_object_identity_event_trigger_hook = NULL;
 }
 
 /*****************************************
@@ -5025,4 +5029,42 @@ unique_constraint_nulls_ordering(ConstrType constraint_type, SortByDir ordering)
 	}
 
 	return SORTBY_NULLS_DEFAULT;
+}
+
+/*
+ * Postgres event triggers can call pg_event_trigger_ddl_commands
+ * which in turn does a syscache lookup for the object that fired
+ * the event trigger. If the event is create babelfish temp table
+ * or table variable then the syscahe lookup will fail since ENR
+ * sys table scan is only allowed when dialect is TSQL but when
+ * executing pg_event_trigger_ddl_commands() dialect will be PSQL.
+ * As a fix we will temporarily switch the dialect to TSQL when
+ * doing a syscahe lookup inside pg_event_trigger_ddl_commands()
+ */
+static char*
+pltsql_get_object_identity_event_trigger(ObjectAddress* address)
+{
+    char *identity = NULL;
+    if (getObjectClass(address) == OCLASS_CLASS)
+    {
+        int save_nestlevel = 0;
+        save_nestlevel = pltsql_new_guc_nest_level();
+        PG_TRY();
+        {
+            set_config_option("babelfishpg_tsql.sql_dialect", "tsql",                                       
+                GUC_CONTEXT_CONFIG,     \
+                PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+            identity = getObjectIdentity(address,true);
+        }
+        PG_FINALLY();
+        {
+            pltsql_revert_guc(save_nestlevel);
+        }
+        PG_END_TRY();
+    }
+    else
+    {
+        identity = getObjectIdentity(address,true); 
+    }
+    return identity;
 }

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -32,7 +32,7 @@ extern Oid  get_tsql_trigger_oid(List *object,
                                  const char *tsql_trigger_name,
                                  bool object_from_input);
 extern void pltsql_bbfSelectIntoUtility(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, 
-                    QueryEnvironment *queryEnv, ParamListInfo params, QueryCompletion *qc);
+                    QueryEnvironment *queryEnv, ParamListInfo params, QueryCompletion *qc, ObjectAddress *address);
 
 extern char *update_delete_target_alias;
 extern bool sp_describe_first_result_set_inprogress;

--- a/test/JDBC/input/views/sys-syscolumns.sql
+++ b/test/JDBC/input/views/sys-syscolumns.sql
@@ -1,4 +1,4 @@
--- sla 13000
+-- sla 20000
 create database db1;
 go
 


### PR DESCRIPTION
### Description
Cherry Pick from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2903

Extension PR link: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2981
Engine PR link: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/453
### Issues Resolved

Issues while testing of JDBC tests with pgaudit extension enabled.

[BABEL-5269]:
Problem: Some crashes and diff files with the error as undefined objectId or classId.
RCA: Main issue was to over-write the address for the case T_CreateTableAsStmt. In this case we are setting the address via bbfSelectIntoUtility_hook and passing it further from there only.
But due to improper check we are also over-writing that address with a random initialised variable in ProcessUtilitySlow.
Fix is to pass the correct address once, so we can set address in bbfSelectIntoUtility_hook but instead of passing it there we can set the pointer to address which is allotted in hook and pass that address in ProcessUtilitySlow function itself.
[BABEL-5233]:
Problem: there were some files which were giving diff file upon running with pgaudit as: "ERROR (Message: cache lookup failed for relation 24553)".
RCA: we were not initialising the cache when we enter ENRgetSystableScan() function for table object type.
Fix is to change the dialect to tsql and then initialise the cache and then again change the dialect to earlier dialect via introducing a hook.
[BABEL-5281]:
Problem: Diff files with the error unexpected command tag "???"
RCA: mainly this issue arises when we call the identity() function via select into query. Upon debugging found that we
were not setting the object type while making the identity node (AlterTableStmt).
Fix was to set the object type to object_table while making the identity node.

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**
### Task
 [BABEL-5269], [BABEL-5233], [BABEL-5281]

Signed-off-by: Pranav Jain [pranavjc@amazon.com](mailto:pranavjc@amazon.com)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).