### PR TITLE
Fix protocol violation in USE DB when database name contains multibyte characters

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2635,7 +2635,7 @@ TdsSendInfoOrError(int token, int number, int state, int class,
 	int			messageLen = strlen(message);
 	int			serverNameLen = strlen(serverName);
 	int			procNameLen = strlen(procName);
-	int16_t		messageLen_16 = pg_mbstrlen(message);
+	int16_t		messageLen_16;
 	int32_t		number_32 = (int32_t) number;
 	int32_t		lineNo_32 = (int32_t) lineNo;
 	int16_t		totalLen;
@@ -2658,6 +2658,8 @@ TdsSendInfoOrError(int token, int number, int state, int class,
 	TdsUTF8toUTF16StringInfo(&messageUtf16, message, messageLen);
 	TdsUTF8toUTF16StringInfo(&serverNameUtf16, serverName, serverNameLen);
 	TdsUTF8toUTF16StringInfo(&procNameUtf16, procName, procNameLen);
+
+	messageLen_16 = messageUtf16.len / 2;
 
 	SendPendingDone(true);
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2516,7 +2516,7 @@ TdsSendEnvChange(int envid, const char *new_val, const char *old_val)
 
 	if (new_val)
 	{
-		temp8 = strlen(new_val);
+		temp8 = newUtf16.len / 2;
 		TdsPutbytes(&temp8, sizeof(temp8));
 		TdsPutbytes(newUtf16.data, newUtf16.len);
 	}
@@ -2528,7 +2528,7 @@ TdsSendEnvChange(int envid, const char *new_val, const char *old_val)
 
 	if (old_val)
 	{
-		temp8 = strlen(old_val);
+		temp8 = oldUtf16.len / 2;
 		TdsPutbytes(&temp8, sizeof(temp8));
 		TdsPutbytes(oldUtf16.data, oldUtf16.len);
 	}

--- a/test/JDBC/expected/BABEL-4792.out
+++ b/test/JDBC/expected/BABEL-4792.out
@@ -1,0 +1,137 @@
+-- Initialize Procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+
+-- Expect error for duplicate procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
+
+
+-- Expect error for duplicate function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
+
+
+-- Cleanup
+drop proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Expect error for duplicate function 
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: Function '%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8' already exists with the same name)~~
+
+
+-- Cleanup
+drop function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize View
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+
+-- Expect error for duplicate view
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~
+
+
+-- Expect error for duplicate relation
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~
+
+
+-- Cleanup
+drop view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Expect error for duplicate table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+~~ERROR (Code: 2714)~~
+
+~~ERROR (Message: relation "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" already exists)~~
+
+
+-- Cleanup
+drop table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+create table t1 (
+    col1 int
+);
+go
+
+-- Initialize Trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+
+-- Expect error for duplicate trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: trigger "%%#%@$^$姓氏すず🤬🤯86d3db6066be0016789ff9cd274595b8" for relation "t1" already exists)~~
+
+
+-- Cleanup
+drop trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+drop table t1
+go

--- a/test/JDBC/expected/BABEL-4792.out
+++ b/test/JDBC/expected/BABEL-4792.out
@@ -135,3 +135,19 @@ go
 
 drop table t1
 go
+
+-- database name with multi byte characters
+CREATE DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO
+CREATE DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Database '"龙漫远; 龍漫😃😄漫遠.¢£€¥"' already exists. Choose a different database name.)~~
+
+USE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO
+USE master
+GO
+DROP DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO

--- a/test/JDBC/input/BABEL-4792.sql
+++ b/test/JDBC/input/BABEL-4792.sql
@@ -1,0 +1,109 @@
+-- Initialize Procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+
+-- Expect error for duplicate procedure
+create proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] @in INT AS SELECT @in;
+go
+
+-- Expect error for duplicate function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Cleanup
+drop proc [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Function
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Expect error for duplicate function 
+create function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (@input int)
+returns varchar(250)
+as begin
+    return "test"
+end
+go
+
+-- Cleanup
+drop function [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize View
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+
+-- Expect error for duplicate view
+create view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] 
+as
+    select 1
+go
+
+-- Expect error for duplicate relation
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Cleanup
+drop view [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+-- Initialize Table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Expect error for duplicate table
+create table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##] (
+    col1 int
+);
+go
+
+-- Cleanup
+drop table [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+create table t1 (
+    col1 int
+);
+go
+
+-- Initialize Trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+
+-- Expect error for duplicate trigger
+create trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+on t1
+for
+insert
+as
+print 'Table blocked from insert'
+rollback;
+go
+
+-- Cleanup
+drop trigger [%%#%@$^$姓氏すず🤬🤯🫣🤗🫡🤔🫢🤭き,😀 鈴木##]
+go
+
+drop table t1
+go

--- a/test/JDBC/input/BABEL-4792.sql
+++ b/test/JDBC/input/BABEL-4792.sql
@@ -107,3 +107,15 @@ go
 
 drop table t1
 go
+
+-- database name with multi byte characters
+CREATE DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO
+CREATE DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO
+USE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO
+USE master
+GO
+DROP DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -563,4 +563,4 @@ binary-datatype-operators
 cast-varchar-to-time
 SELECT_INTO_TEST
 BABEL-5119
-
+BABEL-4869

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -563,4 +563,4 @@ binary-datatype-operators
 cast-varchar-to-time
 SELECT_INTO_TEST
 BABEL-5119
-BABEL-4869
+

--- a/test/python/expected/pyodbc/TestAuth.out
+++ b/test/python/expected/pyodbc/TestAuth.out
@@ -32,3 +32,8 @@ py_auth#!#database|-|test1 SELECT 1
 ~~ERROR (Code: 911)~~
 ~~ERROR (Message: [08004] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]database "test1 select 1" does not exist (911) (SQLDriverConnect))~~
 
+
+CREATE DATABASE ["龙漫远龍漫😃😄漫遠.¢£€¥"]
+py_auth#!#database|-|"龙漫远龍漫😃😄漫遠.¢£€¥"
+~~SUCCESS~~
+DROP DATABASE ["龙漫远龍漫😃😄漫遠.¢£€¥"]

--- a/test/python/input/authentication/TestAuth.txt
+++ b/test/python/input/authentication/TestAuth.txt
@@ -11,3 +11,7 @@ py_auth#!#others|-|packetSize=0
 py_auth#!#others|-|packetSize=-1
 py_auth#!#others|-|packetSize=4096
 py_auth#!#database|-|test1 SELECT 1
+
+CREATE DATABASE ["龙漫远龍漫😃😄漫遠.¢£€¥"]
+py_auth#!#database|-|"龙漫远龍漫😃😄漫遠.¢£€¥"
+DROP DATABASE ["龙漫远龍漫😃😄漫遠.¢£€¥"]


### PR DESCRIPTION
### Description

When database name contains a character which is multi byte encoded in UTF8
then USE DB with that database name throws protocol error in SQLCMD.
```
-- SQL CMD connection
1> CREATE DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
2> go
1> USE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
2> go
SqlState HY000, Protocol error in TDS stream.
```
This does not show up in our JDBC framework since we ignore such notice message and do not flush it to output file.

Length of string in TDS stream should be in UTF-16 characters length and not number of bytes.
Hence replaced strlen() with UTF16 number of chars.

### Issues Resolved

[BABEL-5153]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Test Scenarios Covered ###
Post change sql cmd driver does not throw any protocol error when we switch to a database with multi byte character in its name.
```
-- SQL CMD connection
1> CREATE DATABASE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
2> go
1> USE ["龙漫远; 龍漫😃😄漫遠.¢£€¥"]
2> go
Changed database context to '"龙漫远; 龍漫😃😄漫遠.¢£€¥"'.
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).