### PR TITLE
Fix flaky getdate tests (#2985)

### DIFF
--- a/test/JDBC/expected/getdate-vu-cleanup.out
+++ b/test/JDBC/expected/getdate-vu-cleanup.out
@@ -63,3 +63,6 @@ go
 
 DROP FUNCTION dbo.GetCurrTimestampDiffFunc
 go
+
+DROP FUNCTION dbo.checkDatetimeDiff
+go

--- a/test/JDBC/expected/getdate-vu-prepare.out
+++ b/test/JDBC/expected/getdate-vu-prepare.out
@@ -145,7 +145,11 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
 END;
 GO
 
@@ -156,7 +160,11 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
 END;
 GO
 
@@ -167,7 +175,11 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
 END;
 GO
 
@@ -178,7 +190,23 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
+END;
+GO
+
+-- Need this function to validate datetime difference spillover to avoid flakiness.
+CREATE FUNCTION dbo.checkDatetimeDiff(@value int, @expectedValue int, @expectedDiff int)
+RETURNS int
+AS
+BEGIN
+    IF @value = @expectedValue or @value = @expectedValue + @expectedDiff or @value = @expectedValue - @expectedDiff
+        RETURN 1;
+    ELSE
+        RETURN 0;
 END;
 GO
 
@@ -191,7 +219,7 @@ SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(),
 select set_config('timezone', 'US/Pacific', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), DATEDIFF(MINUTE, @getdate2, @getdate1), DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
 GO
 ~~START~~
 text
@@ -209,39 +237,39 @@ UTC
 CREATE VIEW dbo.datetimediffView AS SELECT * FROM datetimediffTable;
 GO
 
-CREATE FUNCTION dbo.GetSysDatetimeDiffFunc(@sysdatetime1 datetime2)
+CREATE FUNCTION dbo.GetSysDatetimeDiffFunc(@sysdatetime1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = SYSDATETIME();
-    RETURN DATEDIFF(MINUTE, @sysdatetime1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime1, @x), @expected, @diff);
 END;
 GO
 
-CREATE FUNCTION dbo.GetSysDatetimeOffsetDiffFunc(@sysdatetimeoffset1 datetime2)
+CREATE FUNCTION dbo.GetSysDatetimeOffsetDiffFunc(@sysdatetimeoffset1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = sysdatetimeoffset();
-    RETURN DATEDIFF(MINUTE, @sysdatetimeoffset1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset1, @x), @expected, @diff);
 END;
 GO
 
-CREATE FUNCTION dbo.GetDateDiffFunc(@getdate1 datetime2)
+CREATE FUNCTION dbo.GetDateDiffFunc(@getdate1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = getdate();
-    RETURN DATEDIFF(MINUTE, @getdate1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @getdate1, @x), @expected, @diff);
 END;
 GO
 
-CREATE FUNCTION dbo.GetCurrTimestampDiffFunc(@currtimestamp1 datetime2)
+CREATE FUNCTION dbo.GetCurrTimestampDiffFunc(@currtimestamp1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = CURRENT_TIMESTAMP;
-    RETURN DATEDIFF(MINUTE, @currtimestamp1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp1, @x), @expected, @diff);
 END;
 GO
 
@@ -259,6 +287,6 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), DATEDIFF(MINUTE, @getdate2, @getdate1), DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
 END;
 GO

--- a/test/JDBC/expected/getdate-vu-verify.out
+++ b/test/JDBC/expected/getdate-vu-verify.out
@@ -78,11 +78,16 @@ int
 ~~END~~
 
 
+-- all the tests have datetime difference spillover correction to avoid flakiness.
 declare @x datetime2 = sysdatetime()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 text
@@ -96,7 +101,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -104,7 +109,11 @@ declare @x datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 text
@@ -118,7 +127,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -126,7 +135,11 @@ declare @x datetime2 = getdate()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 text
@@ -140,7 +153,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -148,7 +161,11 @@ declare @x datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 text
@@ -162,47 +179,63 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
 declare @x datetime2 = sysdatetime() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = sysdatetime() AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 0 or @diff = -1
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
 declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = -420 or @diff = -421
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 int
--420
+1
 ~~END~~
 
 
 declare @x datetime2 = getdate() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = getdate() AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 0 or @diff = -1
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
 declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 0 or @diff = -1
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -220,7 +253,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -238,7 +271,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -256,7 +289,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -274,7 +307,7 @@ UTC
 
 ~~START~~
 int
-420
+1
 ~~END~~
 
 
@@ -282,13 +315,13 @@ SELECT * from dbo.datetimediffView;
 go
 ~~START~~
 int#!#int#!#int#!#int
-420#!#420#!#420#!#420
+1#!#1#!#1#!#1
 ~~END~~
 
 
 declare @x datetime2 = SYSDATETIME();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x)
+select dbo.GetSysDatetimeDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -298,7 +331,7 @@ US/Pacific
 
 ~~START~~
 int
--420
+1
 ~~END~~
 
 ~~START~~
@@ -309,7 +342,7 @@ UTC
 
 declare @x datetime2 = sysdatetimeoffset();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x)
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -319,7 +352,7 @@ US/Pacific
 
 ~~START~~
 int
--420
+1
 ~~END~~
 
 ~~START~~
@@ -330,7 +363,7 @@ UTC
 
 declare @x datetime2 = getdate();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x)
+select dbo.GetDateDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -340,7 +373,7 @@ US/Pacific
 
 ~~START~~
 int
--420
+1
 ~~END~~
 
 ~~START~~
@@ -351,7 +384,7 @@ UTC
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x)
+select dbo.GetCurrTimestampDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -361,7 +394,7 @@ US/Pacific
 
 ~~START~~
 int
--420
+1
 ~~END~~
 
 ~~START~~
@@ -391,254 +424,254 @@ SELECT * from trgdatetimediffTestTab;
 go
 ~~START~~
 int#!#int#!#int#!#int
-420#!#420#!#420#!#420
+1#!#1#!#1#!#1
 ~~END~~
 
 
 -- psql
 SET timezone = '+05:30';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
 GO
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 
 SET timezone = DEFAULT;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
 GO
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 
 SET timezone = 'Asia/Kolkata';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 
 SET timezone = +5.5;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 
 SET TIME ZONE '+05:30';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
 GO
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
--05:30:00
+int4
+1
 ~~END~~
 
 
 SET TIME ZONE DEFAULT;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
 GO
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-00:00:00
+int4
+1
 ~~END~~
 
 
 SET TIME ZONE +5.5;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 
 SET TIME ZONE 'Asia/Kolkata';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 
 SET timezone = DEFAULT;
 BEGIN; 
 SET LOCAL TIME ZONE 'Asia/Kolkata';
-SELECT sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 COMMIT;
 GO
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 ~~START~~
-interval
-05:30:00
+int4
+1
 ~~END~~
 
 
@@ -646,35 +679,35 @@ SELECT * from master_dbo.datetimediffView;
 GO
 ~~START~~
 int4#!#int4#!#int4#!#int4
-420#!#420#!#420#!#420
+1#!#1#!#1#!#1
 0#!#0#!#0#!#0
 ~~END~~
 
 
 SET TIME ZONE 'Asia/Kolkata';
-select master_dbo.GetSysDatetimeOffsetDiffFunc(CAST(sys.sysdatetimeoffset() AS sys.datetime2));
-select master_dbo.GetSysDatetimeDiffFunc(sys.SYSDATETIME());
-select master_dbo.GetDateDiffFunc(sys.getdate());
-select master_dbo.GetCurrTimestampDiffFunc(CAST(CURRENT_TIMESTAMP AS sys.datetime2));
+select master_dbo.GetSysDatetimeOffsetDiffFunc(CAST(sys.sysdatetimeoffset() AS sys.datetime2), 0, 1);
+select master_dbo.GetSysDatetimeDiffFunc(sys.SYSDATETIME(), 0, 1);
+select master_dbo.GetDateDiffFunc(sys.getdate(), 0, 1);
+select master_dbo.GetCurrTimestampDiffFunc(CAST(CURRENT_TIMESTAMP AS sys.datetime2), 0, 1);
 SET timezone = DEFAULT;
 GO
 ~~START~~
 int4
-0
+1
 ~~END~~
 
 ~~START~~
 int4
-0
+1
 ~~END~~
 
 ~~START~~
 int4
-0
+1
 ~~END~~
 
 ~~START~~
 int4
-0
+1
 ~~END~~
 

--- a/test/JDBC/input/getdate-vu-cleanup.sql
+++ b/test/JDBC/input/getdate-vu-cleanup.sql
@@ -63,3 +63,6 @@ go
 
 DROP FUNCTION dbo.GetCurrTimestampDiffFunc
 go
+
+DROP FUNCTION dbo.checkDatetimeDiff
+go

--- a/test/JDBC/input/getdate-vu-prepare.sql
+++ b/test/JDBC/input/getdate-vu-prepare.sql
@@ -145,7 +145,11 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
 END;
 GO
 
@@ -156,7 +160,11 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
 END;
 GO
 
@@ -167,7 +175,11 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
 END;
 GO
 
@@ -178,7 +190,23 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
-    SELECT DATEDIFF(MINUTE, @y, @x);
+    DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+    IF @diff = 420 or @diff = 419
+        SELECT 1;
+    ELSE
+        SELECT 0;
+END;
+GO
+
+-- Need this function to validate datetime difference spillover to avoid flakiness.
+CREATE FUNCTION dbo.checkDatetimeDiff(@value int, @expectedValue int, @expectedDiff int)
+RETURNS int
+AS
+BEGIN
+    IF @value = @expectedValue or @value = @expectedValue + @expectedDiff or @value = @expectedValue - @expectedDiff
+        RETURN 1;
+    ELSE
+        RETURN 0;
 END;
 GO
 
@@ -191,45 +219,45 @@ SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(),
 select set_config('timezone', 'US/Pacific', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), DATEDIFF(MINUTE, @getdate2, @getdate1), DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
 GO
 
 CREATE VIEW dbo.datetimediffView AS SELECT * FROM datetimediffTable;
 GO
 
-CREATE FUNCTION dbo.GetSysDatetimeDiffFunc(@sysdatetime1 datetime2)
+CREATE FUNCTION dbo.GetSysDatetimeDiffFunc(@sysdatetime1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = SYSDATETIME();
-    RETURN DATEDIFF(MINUTE, @sysdatetime1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime1, @x), @expected, @diff);
 END;
 GO
 
-CREATE FUNCTION dbo.GetSysDatetimeOffsetDiffFunc(@sysdatetimeoffset1 datetime2)
+CREATE FUNCTION dbo.GetSysDatetimeOffsetDiffFunc(@sysdatetimeoffset1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = sysdatetimeoffset();
-    RETURN DATEDIFF(MINUTE, @sysdatetimeoffset1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset1, @x), @expected, @diff);
 END;
 GO
 
-CREATE FUNCTION dbo.GetDateDiffFunc(@getdate1 datetime2)
+CREATE FUNCTION dbo.GetDateDiffFunc(@getdate1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = getdate();
-    RETURN DATEDIFF(MINUTE, @getdate1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @getdate1, @x), @expected, @diff);
 END;
 GO
 
-CREATE FUNCTION dbo.GetCurrTimestampDiffFunc(@currtimestamp1 datetime2)
+CREATE FUNCTION dbo.GetCurrTimestampDiffFunc(@currtimestamp1 datetime2, @expected int, @diff int)
 RETURNS int
 AS
 BEGIN
     DECLARE @x datetime2 = CURRENT_TIMESTAMP;
-    RETURN DATEDIFF(MINUTE, @currtimestamp1, @x);
+    RETURN checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp1, @x), @expected, @diff);
 END;
 GO
 
@@ -247,6 +275,6 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), DATEDIFF(MINUTE, @getdate2, @getdate1), DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
 END;
 GO

--- a/test/JDBC/input/getdate-vu-verify.mix
+++ b/test/JDBC/input/getdate-vu-verify.mix
@@ -28,52 +28,85 @@ go
 select * from getutcdate_dep_view
 go
 
+-- all the tests have datetime difference spillover correction to avoid flakiness.
 declare @x datetime2 = sysdatetime()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = getdate()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 420 or @diff = 419
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = sysdatetime() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = sysdatetime() AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 0 or @diff = -1
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = -420 or @diff = -421
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = getdate() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = getdate() AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 0 or @diff = -1
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
-select DATEDIFF(MINUTE, @y, @x)
+DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
+IF @diff = 0 or @diff = -1
+    SELECT 1;
+ELSE
+    SELECT 0;
 go
 
 EXEC dbo.GetSysDatetimeDiff;
@@ -93,25 +126,25 @@ go
 
 declare @x datetime2 = SYSDATETIME();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x)
+select dbo.GetSysDatetimeDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = sysdatetimeoffset();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x)
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = getdate();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x)
+select dbo.GetDateDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x)
+select dbo.GetCurrTimestampDiffFunc(@x, -420, 1)
 select set_config('timezone', 'UTC', false);
 go
 
@@ -123,68 +156,68 @@ go
 
 -- psql
 SET timezone = '+05:30';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
 GO
 
 SET timezone = DEFAULT;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
 GO
 
 SET timezone = 'Asia/Kolkata';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 
 SET timezone = +5.5;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 
 SET TIME ZONE '+05:30';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 330, 1);
 GO
 
 SET TIME ZONE DEFAULT;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), 0, 1);
 GO
 
 SET TIME ZONE +5.5;
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 
 SET TIME ZONE 'Asia/Kolkata';
-select sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 GO
 
 SET timezone = DEFAULT;
 BEGIN; 
 SET LOCAL TIME ZONE 'Asia/Kolkata';
-SELECT sys.SYSDATETIME() - sys.SYSDATETIME() AT TIME ZONE 'UTC';
-select sys.getdate() - sys.getdate() AT TIME ZONE 'UTC';
-select CURRENT_TIMESTAMP - CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
-select CAST(sys.sysdatetimeoffset() AS sys.datetime2) - CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC';
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.SYSDATETIME(), sys.SYSDATETIME() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', sys.getdate(), sys.getdate() AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(CURRENT_TIMESTAMP AS sys.datetime2), CAST(CURRENT_TIMESTAMP AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
+select master_dbo.checkDatetimeDiff(sys.DATEDIFF('MINUTE', CAST(sys.sysdatetimeoffset() AS sys.datetime2), CAST(sys.sysdatetimeoffset() AS sys.datetime2) AT TIME ZONE 'UTC'), -330, 1);
 COMMIT;
 GO
 
@@ -192,9 +225,9 @@ SELECT * from master_dbo.datetimediffView;
 GO
 
 SET TIME ZONE 'Asia/Kolkata';
-select master_dbo.GetSysDatetimeOffsetDiffFunc(CAST(sys.sysdatetimeoffset() AS sys.datetime2));
-select master_dbo.GetSysDatetimeDiffFunc(sys.SYSDATETIME());
-select master_dbo.GetDateDiffFunc(sys.getdate());
-select master_dbo.GetCurrTimestampDiffFunc(CAST(CURRENT_TIMESTAMP AS sys.datetime2));
+select master_dbo.GetSysDatetimeOffsetDiffFunc(CAST(sys.sysdatetimeoffset() AS sys.datetime2), 0, 1);
+select master_dbo.GetSysDatetimeDiffFunc(sys.SYSDATETIME(), 0, 1);
+select master_dbo.GetDateDiffFunc(sys.getdate(), 0, 1);
+select master_dbo.GetCurrTimestampDiffFunc(CAST(CURRENT_TIMESTAMP AS sys.datetime2), 0, 1);
 SET timezone = DEFAULT;
 GO


### PR DESCRIPTION
## Description
This commit fixes flaky getdate tests by validating for datetime difference spillover.

Cherry-picked: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2985
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)


### Test Scenarios Covered ###
* **Use case based -**   NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA

* **Memory tests -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).