### PR TITLE
Update dev-tools.sh script to install extension and run JDBC tests in multi-db migration mode by default

### DIFF
--- a/INSTALLING.md.tmpl
+++ b/INSTALLING.md.tmpl
@@ -240,14 +240,16 @@ ${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "CREATE EXTENSION IF N
 ${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "GRANT ALL ON SCHEMA sys to babelfish_user;"
 ${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "ALTER USER babelfish_user CREATEDB;"
 ${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';"
+${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
 ${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "SELECT pg_reload_conf();"
 ```
 
 
-By default, the `migration_mode` is `single-db`. To deploy in `multi-db` mode, you need to modify the Babelfish configuration file before initializing the database:
+The recommended `migration_mode` is `multi-db`. To run in `single-db` mode, you need to modify the Babelfish configuration file before initializing the database:
 
 ```sh
-${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "ALTER DATABASE babelfish_db SET babelfishpg_tsql.migration_mode = 'multi-db';"
+${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'single-db';"
+${BABELFISH_HOME}/bin/psql -d babelfish_db -U postgres -c "SELECT pg_reload_conf();"
 ```
 
 > For more information about the `migration_mode`, see [Single vs. multiple instances](https://babelfishpg.org/docs/installation/single-multiple/) and [Choosing a migration mode](https://babelfishpg.org/docs/installation/single-multiple/#choosing-a-migration-mode).

--- a/contrib/babelfishpg_tds/test/TDSNode.pm
+++ b/contrib/babelfishpg_tds/test/TDSNode.pm
@@ -65,7 +65,7 @@ sub init_tsql {
 
 	if (!defined($migration_mode) or ($migration_mode eq ""))
 	{
-		$migration_mode = "multi-db";
+		$migration_mode = "single-db";
 	}
 
 	$self->{_tsql_master_role} = $role;

--- a/contrib/babelfishpg_tds/test/TDSNode.pm
+++ b/contrib/babelfishpg_tds/test/TDSNode.pm
@@ -65,7 +65,7 @@ sub init_tsql {
 
 	if (!defined($migration_mode) or ($migration_mode eq ""))
 	{
-		$migration_mode = "single-db";
+		$migration_mode = "multi-db";
 	}
 
 	$self->{_tsql_master_role} = $role;

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,7 +33,7 @@ if [ ! $1 ]; then
     echo "      run pg_upgrade from SOURCE_WS to TARGET_WS"
     echo ""
     echo "  test normal [MIGRATION_MODE] [TEST_BASE_DIR]"
-    echo "      run a normal JDBC test, default migration mode and test dir are single-db and input, respectively"
+    echo "      run a normal JDBC test, default migration mode and test dir are multi-db and input, respectively"
     echo ""
     echo "  test TEST_MODE MIGRATION_MODE TEST_BASE_DIR"
     echo "      run a prepare/verify JDBC test using a schedule file in TEST_BASE_DIR"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -89,7 +89,7 @@ elif [ "$1" == "test" ]; then
     MIGRATION_MODE=$3
     if [ ! ${MIGRATION_MODE} ]; then
         if [ "${TEST_MODE?}" == "normal" ]; then
-            MIGRATION_MODE="single-db"
+            MIGRATION_MODE="multi-db"
         else
             echo "Error: MIGRATION_MODE should be specified, single-db or multi-db" 1>&2
             exit 1

--- a/test/JDBC/cleanup.sh
+++ b/test/JDBC/cleanup.sh
@@ -3,6 +3,7 @@ psql -d postgres -U "$USER" << EOF
 \c jdbc_testdb
 CALL sys.remove_babelfish();
 ALTER SYSTEM RESET babelfishpg_tsql.database_name;
+ALTER SYSTEM RESET babelfishpg_tsql.migration_mode;
 SELECT pg_reload_conf();
 \c postgres
 DROP DATABASE jdbc_testdb WITH (FORCE);

--- a/test/JDBC/init.sh
+++ b/test/JDBC/init.sh
@@ -30,6 +30,7 @@ GRANT ALL ON SCHEMA sys to jdbc_user;
 ALTER USER jdbc_user CREATEDB;
 \c jdbc_testdb
 ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 SELECT pg_reload_conf();
 \c jdbc_testdb
 show babelfishpg_tsql.database_name;
@@ -51,6 +52,7 @@ GRANT ALL ON SCHEMA sys to jdbc_user;
 ALTER USER jdbc_user CREATEDB;
 \c jdbc_testdb
 ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';
+ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 ALTER SYSTEM SET parallel_setup_cost = 0;
 ALTER SYSTEM SET parallel_tuple_cost = 0;
 ALTER SYSTEM SET min_parallel_index_scan_size = 0;


### PR DESCRIPTION

### Description
This commit updates `dev-tools.sh` script to install Babelfish extension and run JDBC tests in multi-db migration mode by default.


Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).