### PR TITLE
Fix Current_user being NULL after reset connection

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -100,7 +100,6 @@ TdsDiscardAll()
 
 	/* Closing portals might run user-defined code, so do that first. */
 	PortalHashTableDeleteAll();
-	SetPGVariable("session_authorization", NIL, false);
 	ResetAllOptions();
 	DropAllPreparedStatements();
 	Async_UnlistenAll();

--- a/test/dotnet/ExpectedOutput/2_Successful_reset.out
+++ b/test/dotnet/ExpectedOutput/2_Successful_reset.out
@@ -1,4 +1,7 @@
 #Q#select db_name();
 #D#nvarchar
 master
+#Q#select current_user;
+#D#varchar
+dbo
 #Q#drop database db1;

--- a/test/dotnet/input/ResetConnection/2_Successful_reset.txt
+++ b/test/dotnet/input/ResetConnection/2_Successful_reset.txt
@@ -1,2 +1,3 @@
 select db_name();
+select current_user;
 drop database db1;

--- a/test/dotnet/utils/ConfigSetup.cs
+++ b/test/dotnet/utils/ConfigSetup.cs
@@ -9,8 +9,6 @@ namespace BabelfishDotnetFramework
 		/* Declaring variables required for a Test Run. */
 		static readonly Dictionary<string, string> Dictionary = LoadConfig();
 		public static readonly string BblConnectionString = Dictionary["bblConnectionString"];
-
-		public static readonly string BCPConnectionString = Dictionary["BCPConnectionString"];
 		public static readonly string QueryFolder = Dictionary["queryFolder"];
 		public static readonly string TestName = Dictionary["testName"];
 		public static readonly bool RunInParallel = bool.Parse(Dictionary["runInParallel"]);
@@ -47,9 +45,6 @@ namespace BabelfishDotnetFramework
 
 			/* Creating Server Connection String and Query. */
 			dictionary["bblConnectionString"] = BuildConnectionString(dictionary["babel_URL"], dictionary["babel_port"],
-				dictionary["babel_databaseName"],
-				dictionary["babel_user"], dictionary["babel_password"]) + "pooling=false;";
-			dictionary["BCPConnectionString"] = BuildConnectionString(dictionary["babel_URL"], dictionary["babel_port"],
 				dictionary["babel_databaseName"],
 				dictionary["babel_user"], dictionary["babel_password"]);
 			return dictionary;

--- a/test/dotnet/utils/TestUtils.cs
+++ b/test/dotnet/utils/TestUtils.cs
@@ -42,7 +42,7 @@ namespace BabelfishDotnetFramework
 				/* To Enforce Reset Connection. */
 				reader = bblCmd.ExecuteReader();
 				using (SqlConnection destinationConnection =
-                       new SqlConnection(ConfigSetup.BCPConnectionString))
+                       new SqlConnection(ConfigSetup.BblConnectionString))
 				{
 					destinationConnection.Open();
 


### PR DESCRIPTION
Before this commit, if the current session had triggered a Tds Reset Connection then the current_user of the session would be set to NULL instead of the databases' default user. This was happening since we were resetting session_authorization which was initially copied from PG's Discard All function. This is not needed since we have fixed the Database Context being reset in an earlier commit, removing this redundant line of code will maintain the user being set after the "USE DB" execution for DbContextReset.
With this commit we also enable pooling=true for the dotnet framework.

### Check List
-[x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).