### PR TITLE
Modify APIs to return palloc'ed values and catalog lookup to validate the user in get_physical_user_name #2960

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1296,11 +1296,13 @@ schema_id(PG_FUNCTION_ARGS)
 	{
 		char	   *db_name = get_cur_db_name();
 		const char *user = get_user_for_database(db_name);
-		const char *guest_role_name = get_guest_role_name(db_name);
+		char 	   *guest_role_name = get_guest_role_name(db_name);
 
 		if (!user)
 		{
 			pfree(db_name);
+			pfree(guest_role_name);
+
 			PG_RETURN_NULL();
 		}
 		else if ((guest_role_name && strcmp(user, guest_role_name) == 0))
@@ -1313,6 +1315,7 @@ schema_id(PG_FUNCTION_ARGS)
 			physical_name = get_physical_schema_name(db_name, name);
 		}
 		pfree(db_name);
+		pfree(guest_role_name);
 	}
 	else
 	{
@@ -2026,15 +2029,18 @@ object_id(PG_FUNCTION_ARGS)
 		 * name
 		 */
 		const char *user = get_user_for_database(db_name);
-		const char *guest_role_name = get_guest_role_name(db_name);
+		char 	   *guest_role_name = get_guest_role_name(db_name);
 
 		if (!user)
 		{
 			pfree(db_name);
 			pfree(schema_name);
 			pfree(object_name);
+			pfree(guest_role_name);
+
 			if (object_type)
 				pfree(object_type);
+
 			PG_RETURN_NULL();
 		}
 		else if ((guest_role_name && strcmp(user, guest_role_name) == 0))
@@ -2047,6 +2053,8 @@ object_id(PG_FUNCTION_ARGS)
 			schema_name = get_authid_user_ext_schema_name((const char *) db_name, user);
 			physical_schema_name = get_physical_schema_name(db_name, schema_name);
 		}
+
+		pfree(guest_role_name);
 	}
 	else
 	{
@@ -2479,14 +2487,16 @@ type_id(PG_FUNCTION_ARGS)
         if (!OidIsValid(result))
         {
             /* find the default schema for current user and get physical schema name */
-            const char *user = get_user_for_database(db_name);
-            const char *guest_role_name = get_guest_role_name(db_name);
+            const char  *user = get_user_for_database(db_name);
+            char        *guest_role_name = get_guest_role_name(db_name);
 
             if (!user)
             {
                 pfree(db_name);
                 pfree(schema_name);
                 pfree(object_name);
+                pfree(guest_role_name);
+
                 PG_RETURN_NULL();
             }
             else if ((guest_role_name && strcmp(user, guest_role_name) == 0))
@@ -2499,6 +2509,8 @@ type_id(PG_FUNCTION_ARGS)
                 schema_name = get_authid_user_ext_schema_name((const char *) db_name, user);
                 physical_schema_name = get_physical_schema_name(db_name, schema_name);
             }
+			
+            pfree(guest_role_name);
         }
         else
         {
@@ -2605,20 +2617,20 @@ type_name(PG_FUNCTION_ARGS)
 Datum
 has_dbaccess(PG_FUNCTION_ARGS)
 {
-	char	   *db_name = text_to_cstring(PG_GETARG_TEXT_P(0));
+	char        *db_name = text_to_cstring(PG_GETARG_TEXT_P(0));
 
 	/*
 	 * Ensure the database name input argument is lower-case, as all Babel
 	 * table names are lower-case
 	 */
-	char	   *lowercase_db_name = lowerstr(db_name);
+	char        *lowercase_db_name = lowerstr(db_name);
 
 	/* Also strip trailing whitespace to mimic SQL Server behaviour */
-	int			i;
-	const char *user = NULL;
-	const char *login;
-	int16		db_id;
-	bool		login_is_db_owner;
+	int         i;
+	char        *user = NULL;
+	const char  *login;
+	int16       db_id;
+	bool        login_is_db_owner;
 
 	i = strlen(lowercase_db_name);
 	while (i > 0 && isspace((unsigned char) lowercase_db_name[i - 1]))
@@ -2664,7 +2676,10 @@ has_dbaccess(PG_FUNCTION_ARGS)
 	if (!user)
 		PG_RETURN_INT32(0);
 	else
+	{
+		pfree(user);
 		PG_RETURN_INT32(1);
+	}
 }
 
 Datum

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -158,6 +158,7 @@ extern void alter_user_can_connect(bool is_grant, char *user_name, char *db_name
 extern bool guest_role_exists_for_db(const char *dbname);
 extern void update_db_owner(const char *new_owner_name, const char *db_name);
 extern Oid get_login_for_user(Oid user_id, const char *physical_schema_name);
+extern bool user_exists_for_db(const char *db_name, const char *user_name);
 
 /* MUST comply with babelfish_authid_user_ext table */
 typedef struct FormData_authid_user_ext

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4671,8 +4671,8 @@ get_local_schema_for_bbf_functions(Oid proc_nsp_oid)
 	HeapTuple 	 	tuple;
 	char 			*func_schema_name = NULL,
 					*new_search_path = NULL;
-	const char  	*func_dbo_schema,
-					*cur_dbname = get_cur_db_name();
+	char  			*func_dbo_schema;
+	const char		*cur_dbname = get_cur_db_name();
 	
 	tuple = SearchSysCache1(NAMESPACEOID,
 						ObjectIdGetDatum(proc_nsp_oid));
@@ -4688,7 +4688,10 @@ get_local_schema_for_bbf_functions(Oid proc_nsp_oid)
 										quote_identifier(func_dbo_schema));
 		
 		ReleaseSysCache(tuple);
+		
+		pfree(func_dbo_schema);
 	}
+
 	return new_search_path;
 }
 

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -256,7 +256,7 @@ rewrite_object_refs(Node *stmt)
 				 * Try to get physical granted role name, see if it's an
 				 * existing db role
 				 */
-				physical_role_name = get_physical_user_name(db_name, role_name);
+				physical_role_name = get_physical_user_name(db_name, role_name, true);
 				if (get_role_oid(physical_role_name, true) == InvalidOid)
 					break;
 
@@ -275,7 +275,7 @@ rewrite_object_refs(Node *stmt)
 				pfree(granted->priv_name);
 				granted->priv_name = physical_role_name;
 
-				physical_principal_name = get_physical_user_name(db_name, principal_name);
+				physical_principal_name = get_physical_user_name(db_name, principal_name, true);
 				pfree(grantee->rolename);
 				grantee->rolename = physical_principal_name;
 
@@ -345,7 +345,7 @@ rewrite_object_refs(Node *stmt)
 						char	   *user_name;
 						char	   *db_name = get_cur_db_name();
 
-						user_name = get_physical_user_name(db_name, create_role->role);
+						user_name = get_physical_user_name(db_name, create_role->role, true);
 						pfree(create_role->role);
 						create_role->role = user_name;
 
@@ -396,7 +396,7 @@ rewrite_object_refs(Node *stmt)
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 									 errmsg("Cannot alter the user %s", user_name)));
 
-						physical_user_name = get_physical_user_name(db_name, user_name);
+						physical_user_name = get_physical_user_name(db_name, user_name, false);
 						pfree(alter_role->role->rolename);
 						alter_role->role->rolename = physical_user_name;
 					}
@@ -1088,8 +1088,11 @@ static void
 rewrite_role_name(RoleSpec *role)
 {
 	char	   *cur_db = get_cur_db_name();
+	char	   *temp_rolename = get_physical_user_name(cur_db, role->rolename, false);
 
-	role->rolename = get_physical_user_name(cur_db, role->rolename);
+	pfree(role->rolename);
+	role->rolename = temp_rolename;
+	pfree(cur_db);
 }
 
 bool
@@ -1325,11 +1328,13 @@ get_physical_schema_name(char *db_name, const char *schema_name)
  * Map the logical user name to its physical name in the database.
  */
 char *
-get_physical_user_name(char *db_name, char *user_name)
+get_physical_user_name(char *db_name, char *user_name, bool suppress_role_error)
 {
 	char	   *new_user_name;
 	char	   *result;
 	int			len;
+
+	Assert(db_name != NULL);
 
 	if (!user_name)
 		return NULL;
@@ -1363,8 +1368,9 @@ get_physical_user_name(char *db_name, char *user_name)
 			(strlen(db_name) != 6 || (strncmp(db_name, "tempdb", 6) != 0)) &&
 			(strlen(db_name) != 4 || (strncmp(db_name, "msdb", 4) != 0)))
 		{
-			if ((strlen(user_name) == 3 && strncmp(user_name, "dbo", 3) == 0) ||
-				(strlen(user_name) == 8 && strncmp(user_name, "db_owner", 8) == 0))
+			if (((strlen(user_name) == 3 && strncmp(user_name, "dbo", 3) == 0) ||
+				(strlen(user_name) == 8 && strncmp(user_name, "db_owner", 8) == 0)) 
+				&& (suppress_role_error || user_exists_for_db(db_name, new_user_name)))
 			{
 				return new_user_name;
 			}
@@ -1378,128 +1384,129 @@ get_physical_user_name(char *db_name, char *user_name)
 	/* Truncate final result to 64 bytes */
 	truncate_tsql_identifier(result);
 
+	/* 
+	 * If the user or role is not found in the sys.babelfish_authid_user_ext 
+	 * catalog, then an error is thrown. The 'suppress_role_error' flag indicates if 
+	 * it is ok for the user or role to be absent from the catalog.
+	 */
+	if(!suppress_role_error && !user_exists_for_db(db_name, result))
+	{
+		ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("User or role \"%s\" does not exist", new_user_name)));
+	}
+
+	pfree(new_user_name);
+
 	return result;
 }
 
-const char *
+char *
 get_dbo_schema_name(const char *dbname)
 {
-	if (0 == strcmp(dbname, "master"))
-		return "master_dbo";
-	if (0 == strcmp(dbname, "tempdb"))
-		return "tempdb_dbo";
-	if (0 == strcmp(dbname, "msdb"))
-		return "msdb_dbo";
-	if (SINGLE_DB == get_migration_mode())
-		return "dbo";
+	char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
+
+	Assert(dbname != NULL);
+
+	if (SINGLE_DB == get_migration_mode() && 0 != strcmp(dbname, "master") 
+		&& 0 != strcmp(dbname, "tempdb") && 0 != strcmp(dbname, "msdb"))
+	{	
+		snprintf(name, MAX_BBF_NAMEDATALEND, "%s", "dbo");
+	}
 	else
 	{
-		char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
-
 		snprintf(name, MAX_BBF_NAMEDATALEND, "%s_dbo", dbname);
 		truncate_identifier(name, strlen(name), false);
-		return name;
 	}
+	return name;
 }
 
-const char *
+char *
 get_dbo_role_name_by_mode(const char *dbname, MigrationMode mode)
 {
-	if (0 == strcmp(dbname, "master"))
-		return "master_dbo";
-	if (0 == strcmp(dbname, "tempdb"))
-		return "tempdb_dbo";
-	if (0 == strcmp(dbname, "msdb"))
-		return "msdb_dbo";
-	if (SINGLE_DB == mode)
-		return "dbo";
+	char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
+
+	Assert(dbname != NULL);
+
+	if (mode == SINGLE_DB && 0 != strcmp(dbname, "master") 
+		&& 0 != strcmp(dbname, "tempdb") && 0 != strcmp(dbname, "msdb"))
+	{	
+		snprintf(name, MAX_BBF_NAMEDATALEND, "%s", "dbo");
+	}
 	else
 	{
-		char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
-
 		snprintf(name, MAX_BBF_NAMEDATALEND, "%s_dbo", dbname);
 		truncate_identifier(name, strlen(name), false);
-		return name;
 	}
+	return name;
 }
 
-const char *
+char *
 get_dbo_role_name(const char *dbname)
 {
 	return get_dbo_role_name_by_mode(dbname, get_migration_mode());
 }
 
-const char *
+char *
 get_db_owner_name_by_mode(const char *dbname, MigrationMode mode)
 {
-	if (0 == strcmp(dbname, "master"))
-		return "master_db_owner";
-	if (0 == strcmp(dbname, "tempdb"))
-		return "tempdb_db_owner";
-	if (0 == strcmp(dbname, "msdb"))
-		return "msdb_db_owner";
-	if (SINGLE_DB == mode)
-		return "db_owner";
+	char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
+
+	Assert(dbname != NULL);
+
+	if (mode == SINGLE_DB && 0 != strcmp(dbname, "master") 
+		&& 0 != strcmp(dbname, "tempdb") && 0 != strcmp(dbname, "msdb"))
+	{	
+		snprintf(name, MAX_BBF_NAMEDATALEND, "%s", "db_owner");
+	}
 	else
 	{
-		char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
-
 		snprintf(name, MAX_BBF_NAMEDATALEND, "%s_db_owner", dbname);
 		truncate_identifier(name, strlen(name), false);
-		return name;
 	}
+	return name;
 }
 
-const char *
+char *
 get_db_owner_name(const char *dbname)
 {
 	return get_db_owner_name_by_mode(dbname, get_migration_mode());
 }
 
-const char *
+char *
 get_guest_role_name(const char *dbname)
 {
-	if (0 == strcmp(dbname, "master"))
-		return "master_guest";
-	if (0 == strcmp(dbname, "tempdb"))
-		return "tempdb_guest";
-	if (0 == strcmp(dbname, "msdb"))
-		return "msdb_guest";
+	char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
+
+	Assert(dbname != NULL);
 
 	/*
 	 * Always prefix with dbname regardless if single or multidb. Note that
 	 * dbo is an exception.
 	 */
-	else
-	{
-		char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
-
-		snprintf(name, MAX_BBF_NAMEDATALEND, "%s_guest", dbname);
-		truncate_identifier(name, strlen(name), false);
-		return name;
-	}
+	snprintf(name, MAX_BBF_NAMEDATALEND, "%s_guest", dbname);
+	truncate_identifier(name, strlen(name), false);
+	return name;
 }
 
-const char *
+char *
 get_guest_schema_name(const char *dbname)
 {
-	if (0 == strcmp(dbname, "master"))
-		return "master_guest";
-	if (0 == strcmp(dbname, "tempdb"))
-		return "tempdb_guest";
-	if (0 == strcmp(dbname, "msdb"))
-		return "msdb_guest";
+	char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
 
-	if (SINGLE_DB == get_migration_mode())
-		return "guest";
+	Assert(dbname != NULL);
+
+	if (SINGLE_DB == get_migration_mode() && 0 != strcmp(dbname, "master") 
+	                    && 0 != strcmp(dbname, "tempdb") && 0 != strcmp(dbname, "msdb"))
+	{	
+		snprintf(name, MAX_BBF_NAMEDATALEND, "%s", "guest");
+	}
 	else
 	{
-		char	   *name = palloc0(MAX_BBF_NAMEDATALEND);
-
 		snprintf(name, MAX_BBF_NAMEDATALEND, "%s_guest", dbname);
 		truncate_identifier(name, strlen(name), false);
-		return name;
 	}
+	return name;
 }
 
 bool

--- a/contrib/babelfishpg_tsql/src/multidb.h
+++ b/contrib/babelfishpg_tsql/src/multidb.h
@@ -17,16 +17,16 @@ extern void rewrite_object_refs(Node *stmt);
 extern List* rewrite_plain_name(List *name); /* Value Strings */
 
 /* helper functions */
-extern char *get_physical_user_name(char *db_name, char *user_name);
+extern char *get_physical_user_name(char *db_name, char *user_name, bool suppress_role_error);
 extern char *get_physical_schema_name(char *db_name, const char *schema_name);
 extern char *get_physical_schema_name_by_mode(char *db_name, const char *schema_name, MigrationMode mode);
-extern const char *get_dbo_schema_name(const char *dbname);
-extern const char *get_dbo_role_name(const char *dbname);
-extern const char *get_dbo_role_name_by_mode(const char *dbname, MigrationMode mode);
-extern const char *get_db_owner_name(const char *dbname);
-extern const char *get_db_owner_name_by_mode(const char *dbname, MigrationMode mode);
-extern const char *get_guest_role_name(const char *dbname);
-extern const char *get_guest_schema_name(const char *dbname);
+extern char *get_dbo_schema_name(const char *dbname);
+extern char *get_dbo_role_name(const char *dbname);
+extern char *get_dbo_role_name_by_mode(const char *dbname, MigrationMode mode);
+extern char *get_db_owner_name(const char *dbname);
+extern char *get_db_owner_name_by_mode(const char *dbname, MigrationMode mode);
+extern char *get_guest_role_name(const char *dbname);
+extern char *get_guest_schema_name(const char *dbname);
 extern bool is_shared_schema(const char *name);
 extern void truncate_tsql_identifier(char *ident);
 extern bool physical_schema_name_exists(char *phys_schema_name);

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3175,31 +3175,29 @@ void exec_stmt_dbcc_checkident(PLtsql_stmt_dbcc *stmt)
 	struct	dbcc_checkident dbcc_stmt = stmt->dbcc_stmt_data.dbcc_checkident;
 	Relation	rel;
 	TupleDesc	tupdesc;
-	char	*db_name = NULL;
-	char	*max_identity_value_str = NULL;
-	char	*query = NULL;
-	char	*attname;
-	char	*token;
+	char		*db_name = NULL;
+	char		*max_identity_value_str = NULL;
+	char		*query = NULL;
+	char		*attname;
+	char		*token;
 	const char	*schema_name;
-	const char	*nsp_name;
+	char		*nsp_name;
 	const char	*user;
-	const char	*guest_role_name;
-	const char	*dbo_role_name;
 	const char	*login;
-	int64	max_identity_value = 0;
-	int64	cur_identity_value = 0;
-	int	attnum;
-	int	rc = 0;
-	int64	reseed_value = 0;
-	Oid	nsp_oid;
-	Oid 	table_oid;
-	Oid	seqid = InvalidOid;
-	Oid	current_user_id = GetUserId();
-	volatile bool cur_value_is_null = true;
-	bool	login_is_db_owner;
+	int64		max_identity_value = 0;
+	int64		cur_identity_value = 0;
+	int		attnum;
+	int		rc = 0;
+	int64		reseed_value = 0;
+	Oid		nsp_oid;
+	Oid		table_oid;
+	Oid		seqid = InvalidOid;
+	Oid		current_user_id = GetUserId();
+	volatile bool	cur_value_is_null = true;
+	bool		login_is_db_owner;
 	StringInfoData msg;
-	bool	is_float_value;
-	bool    is_cross_db = false;
+	bool		is_float_value;
+	bool		is_cross_db = false;
 
 
 	if(dbcc_stmt.new_reseed_value)
@@ -3273,8 +3271,8 @@ void exec_stmt_dbcc_checkident(PLtsql_stmt_dbcc *stmt)
 		 * If schema_name is not provided, find default schema for current user
 		 * and get physical schema name
 		 */
-		guest_role_name = get_guest_role_name(db_name);
-		dbo_role_name = get_dbo_role_name(db_name);
+		char		*guest_role_name = get_guest_role_name(db_name);
+		char		*dbo_role_name = get_dbo_role_name(db_name);
 		
 		/* user will never be null here as cross-db calls are already handled */
 		Assert(user != NULL);
@@ -3292,6 +3290,9 @@ void exec_stmt_dbcc_checkident(PLtsql_stmt_dbcc *stmt)
 		{
 			nsp_name = get_physical_schema_name(db_name, schema_name);
 		}
+
+		pfree(guest_role_name);
+		pfree(dbo_role_name);
 	}
 	pfree(db_name);
 
@@ -3347,6 +3348,8 @@ void exec_stmt_dbcc_checkident(PLtsql_stmt_dbcc *stmt)
 			errmsg("'%s.%s' does not contain an identity column.",
 				nsp_name, dbcc_stmt.table_name)));
 	}
+	
+	pfree(nsp_name);
 
 	PG_TRY();
 	{
@@ -3723,7 +3726,7 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 		Oid	role_oid;
 		bool	is_public = 0 == strcmp(grantee_name, PUBLIC_ROLE_NAME);
 		if (!is_public)
-			rolname	= get_physical_user_name(dbname, grantee_name);
+			rolname	= get_physical_user_name(dbname, grantee_name, true);
 		else
 			rolname = pstrdup(PUBLIC_ROLE_NAME);
 		role_oid = get_role_oid(rolname, true);

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -10227,7 +10227,7 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 	char	   *cur_dbname = get_cur_db_name();
 	char	   *new_search_path;
 	char	   *physical_schema;
-	const char *dbo_schema;
+	char	   *dbo_schema = NULL;
 
 	top_es_entry = exec_state_call_stack->next;
 
@@ -10291,7 +10291,10 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 				(void) set_config_option("search_path", new_search_path,
 										 PGC_USERSET, PGC_S_SESSION,
 										 GUC_ACTION_SAVE, true, 0, false);
+										 
 				pfree(new_search_path);
+				pfree(dbo_schema);
+					
 				return true;
 			}
 			else if (top_es_entry->estate->db_name != NULL && stmt->is_ddl)
@@ -10343,6 +10346,8 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 											 PGC_USERSET, PGC_S_SESSION,
 											 GUC_ACTION_SAVE, true, 0, false);
 					pfree(new_search_path);
+					pfree(dbo_schema);
+					
 					return true;
 				}
 			}
@@ -10374,10 +10379,13 @@ reset_search_path(PLtsql_stmt_execsql *stmt, char **old_search_path, bool *reset
 								 PGC_USERSET, PGC_S_SESSION,
 								 GUC_ACTION_SAVE, true, 0, false);
 		pfree(new_search_path);
+		pfree(dbo_schema);
+			
 		return true;
 	}
 	
 	pfree(cur_dbname);
+	
 	return false;
 }
 

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -53,7 +53,7 @@ extern bool babelfish_dump_restore;
 extern char *get_cur_db_name(void);
 extern char *construct_unique_index_name(char *index_name, char *relation_name); 
 extern char *get_physical_schema_name(char *db_name, const char *schema_name);
-extern const char *get_dbo_schema_name(const char *dbname);
+extern char *get_dbo_schema_name(const char *dbname);
 PG_FUNCTION_INFO_V1(split_identifier_internal);
 
 /* To cache oid of sys.varchar */

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -1704,12 +1704,11 @@ create_xp_qv_in_master_dbo_internal(PG_FUNCTION_ARGS)
 	char	   *tempq = "CREATE OR REPLACE PROCEDURE %s.xp_qv(IN SYS.NVARCHAR(256), IN SYS.NVARCHAR(256))"
 	"AS \'babelfishpg_tsql\', \'xp_qv_internal\' LANGUAGE C";
 
-	const char *dbo_scm = get_dbo_schema_name("master");
-
-	if (dbo_scm == NULL)
-		elog(ERROR, "Failed to retrieve dbo schema name");
+	char	   *dbo_scm = get_dbo_schema_name("master");
 
 	query = psprintf(tempq, dbo_scm);
+
+	pfree(dbo_scm);
 
 	PG_TRY();
 	{
@@ -1794,13 +1793,12 @@ create_xp_instance_regread_in_master_dbo_internal(PG_FUNCTION_ARGS)
 	char	   *tempq2 = "CREATE OR REPLACE PROCEDURE %s.xp_instance_regread(IN p1 sys.nvarchar(512), IN p2 sys.sysname, IN p3 sys.nvarchar(512), INOUT out_param sys.nvarchar(512))"
 	"AS \'babelfishpg_tsql\', \'xp_instance_regread_internal\' LANGUAGE C";
 
-	const char *dbo_scm = get_dbo_schema_name("master");
-
-	if (dbo_scm == NULL)
-		elog(ERROR, "Failed to retrieve dbo schema name");
+	char	   *dbo_scm = get_dbo_schema_name("master");
 
 	query = psprintf(tempq, dbo_scm);
 	query2 = psprintf(tempq2, dbo_scm);
+
+	pfree(dbo_scm);
 
 	PG_TRY();
 	{
@@ -2136,8 +2134,9 @@ sp_addrole(PG_FUNCTION_ARGS)
 							errmsg("'%s' is not a valid name because it contains invalid characters.", rolname)));
 
 		/* Map the logical role name to its physical name in the database. */
-		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname, true);
 		role_oid = get_role_oid(physical_role_name, true);
+		pfree(physical_role_name);
 
 		/* Check if the user, group or role already exists */
 		if (role_oid)
@@ -2279,8 +2278,9 @@ sp_droprole(PG_FUNCTION_ARGS)
 							errmsg("Name cannot be NULL.")));
 
 		/* Map the logical role name to its physical name in the database. */
-		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname, true);
 		role_oid = get_role_oid(physical_role_name, true);
+		pfree(physical_role_name);
 
 		/* Check if the role does not exists */
 		if (role_oid == InvalidOid || !is_role(role_oid))
@@ -2429,7 +2429,7 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 					 errmsg("Cannot make a role a member of itself.")));
 
 		/* Map the logical member name to its physical name in the database. */
-		physical_member_name = get_physical_user_name(get_cur_db_name(), lowercase_membername);
+		physical_member_name = get_physical_user_name(get_cur_db_name(), lowercase_membername, true);
 		member_oid = get_role_oid(physical_member_name, true);
 
 		/*
@@ -2442,7 +2442,7 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 					 errmsg("User or role '%s' does not exist in this database.", membername)));
 
 		/* Map the logical role name to its physical name in the database. */
-		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		physical_role_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname, true);
 		role_oid = get_role_oid(physical_role_name, true);
 
 		/* Check if the role does not exists and given role name is an role */
@@ -2501,6 +2501,8 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+	pfree(physical_member_name);
+	pfree(physical_role_name);
 	PG_RETURN_VOID();
 }
 
@@ -2594,7 +2596,7 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 							errmsg("Name cannot be NULL.")));
 
 		/* Map the logical role name to its physical name in the database. */
-		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname);
+		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_rolname, true);
 		role_oid = get_role_oid(physical_name, true);
 
 		/* Throw an error id the given role name doesn't exist or isn't a role */
@@ -2604,7 +2606,8 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 					 errmsg("Cannot alter the role '%s', because it does not exist or you do not have permission.", rolname)));
 
 		/* Map the logical member name to its physical name in the database. */
-		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_membername);
+		pfree(physical_name);
+		physical_name = get_physical_user_name(get_cur_db_name(), lowercase_membername, true);
 		role_oid = get_role_oid(physical_name, true);
 
 		/*
@@ -2660,6 +2663,7 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 					  GUC_CONTEXT_CONFIG,
 					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
+	pfree(physical_name);
 	PG_RETURN_VOID();
 }
 
@@ -3357,7 +3361,7 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 		if (!strcmp(logical_schema_name, ""))
 		{
 			const char *user = get_user_for_database(db_name);
-			const char *guest_role_name = get_guest_role_name(db_name);
+			char	   *guest_role_name = get_guest_role_name(db_name);
 
 			if (!user)
 				ereport(ERROR,
@@ -3375,6 +3379,8 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 				physical_schema_name = get_physical_schema_name(db_name, logical_schema_name);
 				pfree(logical_schema_name);
 			}
+			
+			pfree(guest_role_name);
 		}
 		else
 		{

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -514,13 +514,16 @@ grant_guests_to_login(const char *login)
 												 &is_null);
 
 		const char *db_name = TextDatumGetCString(db_name_datum);
-		const char *guest_name = NULL;
+		char	   *guest_name = NULL;
 
 		if (guest_role_exists_for_db(db_name))
 			guest_name = get_guest_role_name(db_name);
 
 		if (guest_name)
+		{
 			guests = lappend(guests, make_accesspriv_node(guest_name));
+			pfree(guest_name);
+		}
 
 		tuple = heap_getnext(scan, ForwardScanDirection);
 	}
@@ -583,7 +586,7 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 	Node	   *stmt;
 	PlannedStmt *wrapper;
 
-	const char *dbo_role_name = get_dbo_role_name(db_name);
+	char 	   *dbo_role_name = get_dbo_role_name(db_name);
 
 	/*
 	 * If login i.e old_owner/new_owner is master user 
@@ -643,6 +646,7 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 	CommandCounterIncrement();
 
 	pfree(query.data);
+	pfree(dbo_role_name);
 }
 
 static List *
@@ -813,7 +817,7 @@ user_id(PG_FUNCTION_ARGS)
 	if (!db_name)
 		PG_RETURN_NULL();
 
-        user_name = get_physical_user_name(db_name, user_input);
+        user_name = get_physical_user_name(db_name, user_input, true);
 
         if (!user_name)
             PG_RETURN_NULL();
@@ -830,6 +834,7 @@ user_id(PG_FUNCTION_ARGS)
     }
 
     auth_tuple = SearchSysCache1(AUTHNAME, CStringGetDatum(user_name));
+    pfree(user_name);
 
     if (!HeapTupleIsValid(auth_tuple))
 	    PG_RETURN_NULL();
@@ -1307,10 +1312,10 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 	while (HeapTupleIsValid(tuple))
 	{
 		Datum		db_name_datum;
-		const char *db_name;
-		const char *dbo_role;
-		const char *db_owner_role;
-		const char *guest;
+		const char	*db_name;
+		char 		*dbo_role;
+		char 		*db_owner_role;
+		char 		*guest;
 
 		db_name_datum = heap_getattr(tuple,
 									 Anum_sysdatabases_name,
@@ -1327,9 +1332,13 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 		{
 			dbo_list = lappend(dbo_list, make_rolespec_node(dbo_role));
 			add_to_bbf_authid_user_ext(dbo_role, "dbo", db_name, "dbo", NULL, false, true, false);
+			pfree(dbo_role);
 		}
 		if (db_owner_role)
+		{
 			add_to_bbf_authid_user_ext(db_owner_role, "db_owner", db_name, NULL, NULL, true, true, false);
+			pfree(db_owner_role);
+		}
 		if (guest)
 		{
 			/*
@@ -1340,6 +1349,8 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 				add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false, true, false);
 			else
 				add_to_bbf_authid_user_ext(guest, "guest", db_name, NULL, NULL, false, false, false);
+				
+			pfree(guest);
 		}
 
 		tuple = heap_getnext(scan, ForwardScanDirection);
@@ -1507,7 +1518,7 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 	/* update user name */
 	if (new_user_name)
 	{
-		physical_name = get_physical_user_name(get_cur_db_name(), new_user_name);
+		physical_name = get_physical_user_name(get_cur_db_name(), new_user_name, true);
 		namestrcpy(&physical_name_namedata, physical_name);
 
 		new_record_user_ext[USER_EXT_ROLNAME] = NameGetDatum(&physical_name_namedata);
@@ -1600,6 +1611,7 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 					   NULL);
 
 		pfree(query.data);
+		pfree(physical_name);
 	}
 }
 
@@ -1842,9 +1854,10 @@ role_id(PG_FUNCTION_ARGS)
 	if (!get_cur_db_name())
 		PG_RETURN_NULL();
 
-	role_name = get_physical_user_name(get_cur_db_name(), user_input);
+	role_name = get_physical_user_name(get_cur_db_name(), user_input, true);
 
 	result = get_role_oid(role_name, true);
+	pfree(role_name);
 
 	if (result == InvalidOid)
 		PG_RETURN_NULL();
@@ -1864,14 +1877,14 @@ is_rolemember(PG_FUNCTION_ARGS)
 	Oid			cur_user_oid = GetUserId();
 	Oid			db_owner_oid;
 	Oid			dbo_role_oid;
-	char	   *role;
-	char	   *dc_role;
-	char	   *dc_principal = NULL;
-	char	   *physical_role_name;
-	char	   *physical_principal_name;
-	char	   *cur_db_name;
-	const char *db_owner_name;
-	const char *dbo_role_name;
+	char			*role;
+	char			*dc_role;
+	char			*dc_principal = NULL;
+	char			*physical_role_name;
+	char			*physical_principal_name;
+	char			*cur_db_name;
+	char			*db_owner_name;
+	char			*dbo_role_name;
 	int			idx;
 
 	if (PG_ARGISNULL(0))
@@ -1883,8 +1896,9 @@ is_rolemember(PG_FUNCTION_ARGS)
 	while (idx > 0 && isspace((unsigned char) role[idx - 1]))
 		role[--idx] = '\0';
 	dc_role = downcase_identifier(role, strlen(role), false, false);
-	physical_role_name = get_physical_user_name(get_cur_db_name(), dc_role);
+	physical_role_name = get_physical_user_name(get_cur_db_name(), dc_role, true);
 	role_oid = get_role_oid(physical_role_name, true);
+	pfree(physical_role_name);
 
 	/* If principal name is NULL, take current user instead */
 	if (PG_ARGISNULL(1))
@@ -1898,8 +1912,9 @@ is_rolemember(PG_FUNCTION_ARGS)
 		while (idx > 0 && isspace((unsigned char) principal[idx - 1]))
 			principal[--idx] = '\0';
 		dc_principal = downcase_identifier(principal, strlen(principal), false, false);
-		physical_principal_name = get_physical_user_name(get_cur_db_name(), dc_principal);
+		physical_principal_name = get_physical_user_name(get_cur_db_name(), dc_principal, true);
 		principal_oid = get_role_oid(physical_principal_name, true);
+		pfree(physical_principal_name);
 	}
 
 	/* Return 1 if given role is PUBLIC */
@@ -1936,6 +1951,10 @@ is_rolemember(PG_FUNCTION_ARGS)
 	dbo_role_name = get_dbo_role_name(cur_db_name);
 	db_owner_oid = get_role_oid(db_owner_name, false);
 	dbo_role_oid = get_role_oid(dbo_role_name, false);
+	
+	pfree(db_owner_name);
+	pfree(dbo_role_name);
+
 	if ((principal_oid == db_owner_oid) || (principal_oid == dbo_role_oid))
 		PG_RETURN_INT32(0);
 	else if (is_member_of_role_nosuper(principal_oid, role_oid))

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -160,11 +160,11 @@ set_cur_user_db_and_path(const char *db_name)
 static void
 set_search_path_for_user_schema(const char *db_name, const char *user)
 {
-	const char *path;
-	const char *buffer = "%s, \"$user\", sys, pg_catalog";
-	const char *physical_schema;
-	const char *dbo_role_name = get_dbo_role_name(db_name);
-	const char *guest_role_name = get_guest_role_name(db_name);
+	const char	*path;
+	const char	*buffer = "%s, \"$user\", sys, pg_catalog";
+	char		*physical_schema;
+	char		*dbo_role_name = get_dbo_role_name(db_name);
+	char		*guest_role_name = get_guest_role_name(db_name);
 
 	if ((dbo_role_name && strcmp(user, dbo_role_name) == 0))
 	{
@@ -191,6 +191,10 @@ set_search_path_for_user_schema(const char *db_name, const char *user)
 					path,
 					PGC_SUSET,
 					PGC_S_DATABASE_USER);
+	
+	pfree(dbo_role_name);
+	pfree(guest_role_name);
+	pfree(physical_schema);
 }
 
 /*


### PR DESCRIPTION
### Description
Earlier in babelfish,

The get_*_role_name() and get_*_schema_name() APIs returned constant values for a few cases.
The get_physical_user_name() used to return the user_name after appending the db_name to the user_name without any checks to verify its existence/validity.
With this change,

We return Palloc'ed values for the APIs instead of constant values.
In get_physical_user_name() if the user or role is not found in the sys.babelfish_authid_user_ext catalog, then an error is thrown.
Changes Made
In multidb.c, made changes to the APIs like get_role_name() and get_schema_name() to return palloc values instead of constant values.
Implemented a catalog lookup in get_physical_user_name() to verify if the user or role is found in the sys.babelfish_authid_user_ext catalog. The 'suppress_role_error' flag indicates if it is ok for the user or role to be absent from the catalog (required for cases when a new user/role is created and it can't be found in the catalog).
Checked all the functions where the APIs are called and pfree the variables containing values from the above APIs after they are no longer used.

### Issues Resolved

[BABEL-4933]

### Cherry picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2960

### Sign Off

Signed-off-by: P Aswini Kumar [aswinii@amazon.com](mailto:aswinii@amazon.com)

### Check List
 Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).