### PR TITLE
release syscache in user_exists_for_db()

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -5011,6 +5011,7 @@ user_exists_for_db(const char *db_name, const char *user_name)
 			user_exists = true;
 		
 		pfree(db_name_from_cache);
+		ReleaseSysCache(tuple_cache);
 	}
 
 	return user_exists;


### PR DESCRIPTION
### Description

release syscache in user_exists_for_db()

Original PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2960

### Issues Resolved

[No JIRA]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).