### PR TITLE
Dump physical database aclprivs for fixed database roles

### DIFF
--- a/test/JDBC/expected/BABEL-5119-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5119-vu-verify.out
@@ -748,7 +748,7 @@ GO
 CREATE SCHEMA S1;
 GO
 
-SELECT u.orig_username, SUBSTRING(a.datacl, CHARINDEX('/', a.datacl), CHARINDEX('/', a.datacl) - CHARINDEX('=', a.datacl))
+SELECT u.orig_username, SUBSTRING(a.datacl, strpos(a.datacl, '='), strpos(a.datacl, '/') - strpos(a.datacl, '='))
     FROM (
         SELECT CAST(unnest(datacl) AS TEXT) AS datacl FROM pg_database WHERE datname = CURRENT_DATABASE()
     ) AS a
@@ -758,7 +758,7 @@ SELECT u.orig_username, SUBSTRING(a.datacl, CHARINDEX('/', a.datacl), CHARINDEX(
 GO
 ~~START~~
 nvarchar#!#varchar
-dbo#!#/jdb
+dbo#!#=CTc
 ~~END~~
 
 -- terminate-tsql-conn database=BABEL5119_db

--- a/test/JDBC/expected/BABEL-5119-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5119-vu-verify.out
@@ -745,7 +745,7 @@ GO
 -- terminate-tsql-conn user=login_babel5119_2 password=12345678
 
 -- tsql database=BABEL5119_db
-CREATE SCHEMA S1;
+CREATE SCHEMA BABEL5119_schema;
 GO
 
 SELECT u.orig_username, SUBSTRING(a.datacl, strpos(a.datacl, '='), strpos(a.datacl, '/') - strpos(a.datacl, '='))

--- a/test/JDBC/expected/BABEL-5119-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5119-vu-verify.out
@@ -743,3 +743,22 @@ GO
 ~~ROW COUNT: 1~~
 
 -- terminate-tsql-conn user=login_babel5119_2 password=12345678
+
+-- tsql database=BABEL5119_db
+CREATE SCHEMA S1;
+GO
+
+SELECT u.orig_username, SUBSTRING(a.datacl, CHARINDEX('/', a.datacl), CHARINDEX('/', a.datacl) - CHARINDEX('=', a.datacl))
+    FROM (
+        SELECT CAST(unnest(datacl) AS TEXT) AS datacl FROM pg_database WHERE datname = CURRENT_DATABASE()
+    ) AS a
+    JOIN sys.babelfish_authid_user_ext u ON (left(datacl, charindex('=', datacl) - 1) = u.rolname)
+    WHERE u.database_name = 'BABEL5119_db'
+    ORDER BY u.orig_username;
+GO
+~~START~~
+nvarchar#!#varchar
+dbo#!#/jdb
+~~END~~
+
+-- terminate-tsql-conn database=BABEL5119_db

--- a/test/JDBC/input/BABEL-5119-vu-verify.mix
+++ b/test/JDBC/input/BABEL-5119-vu-verify.mix
@@ -364,3 +364,17 @@ GO
 INSERT INTO BABEL5119_t1 VALUES(1)
 GO
 -- terminate-tsql-conn user=login_babel5119_2 password=12345678
+
+-- tsql database=BABEL5119_db
+CREATE SCHEMA S1;
+GO
+
+SELECT u.orig_username, SUBSTRING(a.datacl, CHARINDEX('/', a.datacl), CHARINDEX('/', a.datacl) - CHARINDEX('=', a.datacl))
+    FROM (
+        SELECT CAST(unnest(datacl) AS TEXT) AS datacl FROM pg_database WHERE datname = CURRENT_DATABASE()
+    ) AS a
+    JOIN sys.babelfish_authid_user_ext u ON (left(datacl, charindex('=', datacl) - 1) = u.rolname)
+    WHERE u.database_name = 'BABEL5119_db'
+    ORDER BY u.orig_username;
+GO
+-- terminate-tsql-conn database=BABEL5119_db

--- a/test/JDBC/input/BABEL-5119-vu-verify.mix
+++ b/test/JDBC/input/BABEL-5119-vu-verify.mix
@@ -366,7 +366,7 @@ GO
 -- terminate-tsql-conn user=login_babel5119_2 password=12345678
 
 -- tsql database=BABEL5119_db
-CREATE SCHEMA S1;
+CREATE SCHEMA BABEL5119_schema;
 GO
 
 SELECT u.orig_username, SUBSTRING(a.datacl, strpos(a.datacl, '='), strpos(a.datacl, '/') - strpos(a.datacl, '='))

--- a/test/JDBC/input/BABEL-5119-vu-verify.mix
+++ b/test/JDBC/input/BABEL-5119-vu-verify.mix
@@ -369,7 +369,7 @@ GO
 CREATE SCHEMA S1;
 GO
 
-SELECT u.orig_username, SUBSTRING(a.datacl, CHARINDEX('/', a.datacl), CHARINDEX('/', a.datacl) - CHARINDEX('=', a.datacl))
+SELECT u.orig_username, SUBSTRING(a.datacl, strpos(a.datacl, '='), strpos(a.datacl, '/') - strpos(a.datacl, '='))
     FROM (
         SELECT CAST(unnest(datacl) AS TEXT) AS datacl FROM pg_database WHERE datname = CURRENT_DATABASE()
     ) AS a


### PR DESCRIPTION
### Description

We were not dumping the acls on physical database granted to fixed database roles of user defined databases in babelfish dump and restore. As a result after bbf dump CREATE SCHEMA. would fail we permission denied error.

As a fix, dump a DO block which will run all the grant statements again for the fixed database roles for user defined logical databases. While running these grants we will switch to sysadmin because it has all the necessary permissions to grant and so that DROP DATABASE also works correctly. We internally switch to sysadmin when executing revoke commands during drop db commands, which would only work if grantor was also sysadmin.


#### Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/456
#### Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3003 

### Issues Resolved

[BABEL-5294]

### Test Scenarios Covered ###
CREATE SCEHMA works for dbo user after babelfish dump restore.
Added future proofing, when new fixed db roles are supported there will be test failures if physical database aclprivs are not dumped.

#### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com> 


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).