### PR TITLE
fixing the issue of select cast with invalid number of function argument

### DIFF
--- a/contrib/babelfishpg_common/src/sqlvariant.c
+++ b/contrib/babelfishpg_common/src/sqlvariant.c
@@ -276,6 +276,7 @@ do_cast(Oid source_type, Oid target_type, Datum value, int32_t typmod, Oid coll,
 	CoercionPathType path;
 	Oid			typioparam;
 	bool		isVarlena;
+	int 		nargs;
 
 	path = find_coercion_pathway(target_type, source_type, ccontext, &funcid);
 
@@ -284,7 +285,18 @@ do_cast(Oid source_type, Oid target_type, Datum value, int32_t typmod, Oid coll,
 	{
 		case COERCION_PATH_FUNC:
 			*cast_by_relabel = false;
-			return OidFunctionCall3Coll(funcid, coll, value, (Datum) typmod, (Datum) ccontext == COERCION_EXPLICIT);
+			nargs = get_func_nargs(funcid);
+			switch (nargs) 
+			{
+				case 1:
+					return OidFunctionCall1Coll(funcid, coll, value);
+				case 2:
+					return OidFunctionCall2Coll(funcid, coll, value, (Datum) typmod);
+				case 3:
+					return OidFunctionCall3Coll(funcid, coll, value, (Datum) typmod, (Datum) (ccontext == COERCION_EXPLICIT));
+				default:
+					elog(ERROR, "Unsupported number of arguments (%d) for function %u", nargs, funcid);
+			}
 			break;
 		case COERCION_PATH_COERCEVIAIO:
 			*cast_by_relabel = false;

--- a/test/JDBC/expected/babel_datatype_sqlvariant.out
+++ b/test/JDBC/expected/babel_datatype_sqlvariant.out
@@ -424,6 +424,29 @@ uniqueidentifier
 0E984725-C51C-4BF4-9960-E1C80E27ABA0
 ~~END~~
 
+-- fixeddecimal
+select cast(cast(cast('123.45' as fixeddecimal) as sql_variant) as fixeddecimal);
+go
+~~START~~
+money
+123.4500
+~~END~~
+
+-- bbf_varbinary
+select cast(cast(cast('abc' AS bbf_varbinary(5)) AS sql_variant) as bbf_varbinary(5));
+go
+~~START~~
+varbinary
+616263
+~~END~~
+
+-- bbf_binary
+select cast(cast(cast('abc' AS bbf_binary(5)) AS sql_variant) as bbf_binary(5));
+go
+~~START~~
+binary
+6162630000
+~~END~~
 
 select cast(cast(cast('0E984725-C51C-4BF4-9960-E1C80E27ABA0wrong' as uniqueidentifier) 
                  as sql_variant) as uniqueidentifier);
@@ -1428,6 +1451,32 @@ sql_variant#!#sql_variant
 200.0000#!#300
 ~~END~~
 
+
+-- User defined data-type
+CREATE TYPE sqlvariant_type from NVARCHAR(100)
+GO
+Select CAST(CAST('2023-05-01' AS sqlvariant_type) AS sqlvariant_type)
+go
+~~START~~
+nvarchar
+2023-05-01
+~~END~~
+
+DROP TYPE IF EXISTS sqlvariant_type;
+go
+
+--  User defined data-type with multiple cast
+CREATE TYPE sqlvariant_type from SQL_VARIANT;
+GO
+Select CAST(CAST(CAST('2023-05-01' AS sqlvariant_type) AS sqlvariant_type) AS VARCHAR(2))
+go
+~~START~~
+varchar
+20
+~~END~~
+
+DROP TYPE IF EXISTS sqlvariant_type;
+go
 
 -- Clean up
 drop table t1;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_datatype_sqlvariant.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_datatype_sqlvariant.out
@@ -424,6 +424,29 @@ uniqueidentifier
 0E984725-C51C-4BF4-9960-E1C80E27ABA0
 ~~END~~
 
+-- fixeddecimal
+select cast(cast(cast('123.45' as fixeddecimal) as sql_variant) as fixeddecimal);
+go
+~~START~~
+money
+123.4500
+~~END~~
+
+-- bbf_varbinary
+select cast(cast(cast('abc' AS bbf_varbinary(5)) AS sql_variant) as bbf_varbinary(5));
+go
+~~START~~
+varbinary
+616263
+~~END~~
+
+-- bbf_binary
+select cast(cast(cast('abc' AS bbf_binary(5)) AS sql_variant) as bbf_binary(5));
+go
+~~START~~
+binary
+6162630000
+~~END~~
 
 select cast(cast(cast('0E984725-C51C-4BF4-9960-E1C80E27ABA0wrong' as uniqueidentifier) 
                  as sql_variant) as uniqueidentifier);
@@ -1428,6 +1451,32 @@ sql_variant#!#sql_variant
 200.0000#!#300
 ~~END~~
 
+
+-- User defined data-type
+CREATE TYPE sqlvariant_type from NVARCHAR(100)
+GO
+Select CAST(CAST('2023-05-01' AS sqlvariant_type) AS sqlvariant_type)
+go
+~~START~~
+nvarchar
+2023-05-01
+~~END~~
+
+DROP TYPE IF EXISTS sqlvariant_type;
+go
+
+--  User defined data-type with multiple cast
+CREATE TYPE sqlvariant_type from SQL_VARIANT;
+GO
+Select CAST(CAST(CAST('2023-05-01' AS sqlvariant_type) AS sqlvariant_type) AS VARCHAR(2))
+go
+~~START~~
+varchar
+20
+~~END~~
+
+DROP TYPE IF EXISTS sqlvariant_type;
+go
 
 -- Clean up
 drop table t1;

--- a/test/JDBC/input/babel_datatype_sqlvariant.sql
+++ b/test/JDBC/input/babel_datatype_sqlvariant.sql
@@ -198,7 +198,15 @@ go
 select cast(cast(cast('0E984725-C51C-4BF4-9960-E1C80E27ABA0' as uniqueidentifier) 
                  as sql_variant) as uniqueidentifier);
 go
-
+-- fixeddecimal
+select cast(cast(cast('123.45' as fixeddecimal) as sql_variant) as fixeddecimal);
+go
+-- bbf_varbinary
+select cast(cast(cast('abc' AS bbf_varbinary(5)) AS sql_variant) as bbf_varbinary(5));
+go
+-- bbf_binary
+select cast(cast(cast('abc' AS bbf_binary(5)) AS sql_variant) as bbf_binary(5));
+go
 select cast(cast(cast('0E984725-C51C-4BF4-9960-E1C80E27ABA0wrong' as uniqueidentifier) 
                  as sql_variant) as uniqueidentifier);
 go
@@ -678,6 +686,22 @@ go
 select * from t7 where a >= b order by 1,2;
 go
 select * from t7 where a <= b order by 1,2;
+go
+
+-- User defined data-type
+CREATE TYPE sqlvariant_type from NVARCHAR(100)
+GO
+Select CAST(CAST('2023-05-01' AS sqlvariant_type) AS sqlvariant_type)
+go
+DROP TYPE IF EXISTS sqlvariant_type;
+go
+
+--  User defined data-type with multiple cast
+CREATE TYPE sqlvariant_type from SQL_VARIANT;
+GO
+Select CAST(CAST(CAST('2023-05-01' AS sqlvariant_type) AS sqlvariant_type) AS VARCHAR(2))
+go
+DROP TYPE IF EXISTS sqlvariant_type;
 go
 
 -- Clean up


### PR DESCRIPTION
### Description
Cherry pick from : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3005
* Problem - cache lookup failed error when we run cast query with extensions like PgAudit, Valgrind enabled.
* RCA - we blindly trying to call cast function with three arguments every time where as in postgres the number of function arguments can vary from 1 to 3.
* Fix - Adding the handling cases as per the number of arguments(nargs) passed via cast query.

### Issues Resolved
[BABEL-5272] [BABEL-4476]
### Sign Off
Signed-off-by: Pranav Jain [pranavjc@amazon.com](mailto:pranavjc@amazon.com)

### Test Scenarios Covered ###

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).