### PR TITLE
Extend the function of eliminating unnecessary CAST function for integer

### DIFF
--- a/test/JDBC/expected/cast_eliminate-vu-prepare.out
+++ b/test/JDBC/expected/cast_eliminate-vu-prepare.out
@@ -1,6 +1,5 @@
-CREATE TABLE cast_eliminate( [ROID] [int] NOT NULL PRIMARY KEY );
+CREATE TABLE cast_eliminate( [ROID] [int] NOT NULL PRIMARY KEY, s_int SMALLINT, b_int BIGINT );
 GO
 
 CREATE TABLE cast_eliminate2( [ROID] [bigint] NOT NULL PRIMARY KEY );
 GO
-

--- a/test/JDBC/expected/cast_eliminate-vu-verify.out
+++ b/test/JDBC/expected/cast_eliminate-vu-verify.out
@@ -1,3 +1,7 @@
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs', 'off'
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_timing', 'off'
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_summary', 'off'
 set babelfish_showplan_all on
 GO
 
@@ -6,13 +10,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = 1)
-Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
   Index Cond: (roid = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 280.159 ms
 ~~END~~
 
 
@@ -21,13 +20,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS int) = 1)
-Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
   Index Cond: (roid = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 8.415 ms
 ~~END~~
 
 
@@ -36,13 +30,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (ROID = cast(1 as bigint))
-Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
   Index Cond: (roid = '1'::bigint)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 11.041 ms
 ~~END~~
 
 
@@ -51,13 +40,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = cast( 1 as bigint ))
-Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
   Index Cond: (roid = '1'::bigint)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.232 ms
 ~~END~~
 
 
@@ -66,13 +50,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (CAST(ROID AS BIGINT) = 1)
-Index Only Scan using cast_eliminate2_pkey on cast_eliminate2  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate2_pkey on cast_eliminate2
   Index Cond: (roid = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.206 ms
 ~~END~~
 
 
@@ -81,13 +60,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (CAST(ROID AS int) = 1)
-Seq Scan on cast_eliminate2  (cost=0.00..43.90 rows=11 width=4)
+Seq Scan on cast_eliminate2
   Filter: ((roid)::integer = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.188 ms
 ~~END~~
 
 
@@ -96,13 +70,8 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (ROID = cast(1 as bigint))
-Index Only Scan using cast_eliminate2_pkey on cast_eliminate2  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate2_pkey on cast_eliminate2
   Index Cond: (roid = '1'::bigint)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.270 ms
 ~~END~~
 
 
@@ -111,12 +80,316 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = cast( 1 as bigint ))
-Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
   Index Cond: (roid = '1'::bigint)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) OR (CAST(ROID AS BIGINT) = 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) OR (CAST(ROID AS BIGINT) = 2)
+Bitmap Heap Scan on cast_eliminate
+  Recheck Cond: ((roid = 1) OR (roid = 2))
+  ->  BitmapOr
+        ->  Bitmap Index Scan on cast_eliminate_pkey
+              Index Cond: (roid = 1)
+        ->  Bitmap Index Scan on cast_eliminate_pkey
+              Index Cond: (roid = 2)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) AND (CAST(s_int AS BIGINT) = 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) AND (CAST(s_int AS BIGINT) = 2)
+Index Scan using cast_eliminate_pkey on cast_eliminate
+  Index Cond: (roid = 1)
+  Filter: (s_int = 2)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE 1 = (CAST(ROID AS BIGINT))
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE 1 = (CAST(ROID AS BIGINT))
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
+  Index Cond: (roid = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as INT) = 1
+Index Only Scan using cast_eliminate_pkey on cast_eliminate
+  Index Cond: (roid = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(s_int AS INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(s_int AS INT) = 1
+Seq Scan on cast_eliminate
+  Filter: (s_int = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(s_int AS BIGINT) as INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(s_int AS BIGINT) as INT) = 1
+Seq Scan on cast_eliminate
+  Filter: (s_int = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1
+Seq Scan on cast_eliminate
+  Filter: (s_int = 1)
+~~END~~
+
+
+-- NOT clause supported
+SELECT 1 AS [C1] FROM cast_eliminate WHERE b_int = 10 AND NOT ((CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1 OR CAST(ROID AS BIGINT) > 10) AND ROID NOT IN (12, 34))
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE b_int = 10 AND NOT ((CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1 OR CAST(ROID AS BIGINT) > 10) AND ROID NOT IN (12, 34))
+Bitmap Heap Scan on cast_eliminate
+  Recheck Cond: ((roid <= 10) OR (roid = ANY ('{12,34}'::integer[])))
+  Filter: ((b_int = 10) AND (((s_int <> 1) AND (roid <= 10)) OR (roid = ANY ('{12,34}'::integer[]))))
+  ->  BitmapOr
+        ->  Bitmap Index Scan on cast_eliminate_pkey
+              Index Cond: (roid <= 10)
+        ->  Bitmap Index Scan on cast_eliminate_pkey
+              Index Cond: (roid = ANY ('{12,34}'::integer[]))
+~~END~~
+
+
+-- Bad case: cannot remove CAST if a column is typecasted into a type with less precision
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = 1
+Seq Scan on cast_eliminate
+  Filter: (((roid)::bigint)::smallint = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS SMALLINT) as BIGINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS SMALLINT) as BIGINT) = 1
+Seq Scan on cast_eliminate
+  Filter: (((roid)::smallint)::bigint = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS BIGINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS BIGINT) = 1
+Seq Scan on cast_eliminate
+  Filter: (b_int = 1)
+~~END~~
+
+
+-- Bad case: cannot remove CAST if a column is typecasted into a type with less precision
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS INT) = 1
+Seq Scan on cast_eliminate
+  Filter: ((b_int)::integer = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = CAST(s_int AS INT)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = CAST(s_int AS INT)
+Seq Scan on cast_eliminate
+  Filter: (((roid)::bigint)::smallint = s_int)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS numeric) as int) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS numeric) as int) = 1
+Seq Scan on cast_eliminate
+  Filter: (((roid)::numeric(18,0))::integer = 1)
+~~END~~
+
+
+-- Other operators like >/</<=/>= are also supported
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) < 1) OR (CAST(ROID AS BIGINT) > 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) < 1) OR (CAST(ROID AS BIGINT) > 2)
+Seq Scan on cast_eliminate
+  Filter: ((roid < 1) OR (roid > 2))
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) >= 1) AND (CAST(ROID AS BIGINT) <= 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) >= 1) AND (CAST(ROID AS BIGINT) <= 2)
+Bitmap Heap Scan on cast_eliminate
+  Recheck Cond: ((roid >= 1) AND (roid <= 2))
+  ->  Bitmap Index Scan on cast_eliminate_pkey
+        Index Cond: ((roid >= 1) AND (roid <= 2))
+~~END~~
+
+
+set babelfish_showplan_all off
+GO
+
+-- Verify executions
+INSERT INTO cast_eliminate VALUES (1, 1, 1), (2, 2938, 2), (3, 32767, 9223372036854775807), (-2147483648, -32768, -9223372036854775808), (2147483647, 2393, 1111111111111111);
+GO
+~~ROW COUNT: 5~~
+
+
+set BABELFISH_STATISTICS PROFILE on
+GO
+
+-- Operators like !=/<> cannot make use of index, so we don't bother to elimiate the unnecessary CAST
+SELECT * FROM cast_eliminate WHERE (CAST(CAST(ROID AS BIGINT) AS BIGINT) = 3 OR CAST(CAST(ROID AS INT) AS BIGINT) = 2147483647) AND CAST(CAST(s_int AS INT) AS BIGINT) != 32767
+GO
+~~START~~
+int#!#smallint#!#bigint
+2147483647#!#2393#!#1111111111111111
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.317 ms
+Query Text: SELECT * FROM cast_eliminate WHERE (CAST(CAST(ROID AS BIGINT) AS BIGINT) = 3 OR CAST(CAST(ROID AS INT) AS BIGINT) = 2147483647) AND CAST(CAST(s_int AS INT) AS BIGINT) != 32767
+Bitmap Heap Scan on cast_eliminate (actual rows=1 loops=1)
+  Recheck Cond: ((roid = 3) OR (roid = 2147483647))
+  Filter: (((s_int)::integer)::bigint <> 32767)
+  Rows Removed by Filter: 1
+  Heap Blocks: exact=1
+  ->  BitmapOr (actual rows=0 loops=1)
+        ->  Bitmap Index Scan on cast_eliminate_pkey (actual rows=1 loops=1)
+              Index Cond: (roid = 3)
+        ->  Bitmap Index Scan on cast_eliminate_pkey (actual rows=1 loops=1)
+              Index Cond: (roid = 2147483647)
 ~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE CAST(CAST(s_int AS INT) AS BIGINT) >= 2394 AND CAST(CAST(ROID AS BIGINT) AS SMALLINT) >= 3
+GO
+~~START~~
+int#!#smallint#!#bigint
+3#!#32767#!#9223372036854775807
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE CAST(CAST(s_int AS INT) AS BIGINT) >= 2394 AND CAST(CAST(ROID AS BIGINT) AS SMALLINT) >= 3
+Seq Scan on cast_eliminate (actual rows=1 loops=1)
+  Filter: ((s_int >= 2394) AND (((roid)::bigint)::smallint >= 3))
+  Rows Removed by Filter: 4
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -32768 = CAST(s_int AS INT);
+GO
+~~START~~
+int#!#smallint#!#bigint
+-2147483648#!#-32768#!#-9223372036854775808
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -32768 = CAST(s_int AS INT)
+Seq Scan on cast_eliminate (actual rows=1 loops=1)
+  Filter: ('-32768'::integer = s_int)
+  Rows Removed by Filter: 4
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -32768 = CAST(CAST(s_int AS INT) AS BIGINT);
+GO
+~~START~~
+int#!#smallint#!#bigint
+-2147483648#!#-32768#!#-9223372036854775808
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -32768 = CAST(CAST(s_int AS INT) AS BIGINT)
+Seq Scan on cast_eliminate (actual rows=1 loops=1)
+  Filter: ('-32768'::integer = s_int)
+  Rows Removed by Filter: 4
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR CAST(ROID AS BIGINT) = -2147483648
+GO
+~~START~~
+int#!#smallint#!#bigint
+1#!#1#!#1
+2#!#2938#!#2
+3#!#32767#!#9223372036854775807
+-2147483648#!#-32768#!#-9223372036854775808
+2147483647#!#2393#!#1111111111111111
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR CAST(ROID AS BIGINT) = -2147483648
+Seq Scan on cast_eliminate (actual rows=5 loops=1)
+  Filter: (('-32768'::integer < s_int) OR (roid = '-2147483648'::integer))
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -9223372036854775808 = CAST(s_int AS BIGINT)
+GO
+~~START~~
+int#!#smallint#!#bigint
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -9223372036854775808 = CAST(s_int AS BIGINT)
+Seq Scan on cast_eliminate (actual rows=0 loops=1)
+  Filter: ('-9223372036854775808'::bigint = s_int)
+  Rows Removed by Filter: 5
+~~END~~
+
+
+-- Throws an error due to overflow. If we wrongly eliminate the CAST function, the error won't be thrown
+SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR -9223372036854775808 = CAST(CAST(b_int AS BIGINT) AS INT)
+GO
+~~START~~
+int#!#smallint#!#bigint
+1#!#1#!#1
+2#!#2938#!#2
+3#!#32767#!#9223372036854775807
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
 

--- a/test/JDBC/expected/parallel_query/cast_eliminate-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/cast_eliminate-vu-verify.out
@@ -1,3 +1,7 @@
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs', 'off'
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_timing', 'off'
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_summary', 'off'
 set babelfish_showplan_all on
 GO
 
@@ -6,16 +10,11 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = 1)
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
         Index Cond: (roid = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 282.491 ms
 ~~END~~
 
 
@@ -24,16 +23,11 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS int) = 1)
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
         Index Cond: (roid = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 8.364 ms
 ~~END~~
 
 
@@ -42,16 +36,11 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (ROID = cast(1 as bigint))
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
         Index Cond: (roid = '1'::bigint)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 10.825 ms
 ~~END~~
 
 
@@ -60,16 +49,11 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = cast( 1 as bigint ))
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
         Index Cond: (roid = '1'::bigint)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.225 ms
 ~~END~~
 
 
@@ -78,16 +62,11 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (CAST(ROID AS BIGINT) = 1)
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate2_pkey on cast_eliminate2  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate2_pkey on cast_eliminate2
         Index Cond: (roid = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.192 ms
 ~~END~~
 
 
@@ -96,15 +75,10 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (CAST(ROID AS int) = 1)
-Gather  (cost=0.00..20.94 rows=11 width=4)
+Gather
   Workers Planned: 3
-  ->  Parallel Seq Scan on cast_eliminate2  (cost=0.00..20.94 rows=4 width=4)
+  ->  Parallel Seq Scan on cast_eliminate2
         Filter: ((roid)::integer = 1)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.180 ms
 ~~END~~
 
 
@@ -113,16 +87,11 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (ROID = cast(1 as bigint))
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate2_pkey on cast_eliminate2  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate2_pkey on cast_eliminate2
         Index Cond: (roid = '1'::bigint)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.178 ms
 ~~END~~
 
 
@@ -131,15 +100,366 @@ GO
 ~~START~~
 text
 Query Text: SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = cast( 1 as bigint ))
-Gather  (cost=0.15..8.17 rows=1 width=4)
+Gather
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate  (cost=0.15..8.17 rows=1 width=4)
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
         Index Cond: (roid = '1'::bigint)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) OR (CAST(ROID AS BIGINT) = 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) OR (CAST(ROID AS BIGINT) = 2)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on cast_eliminate
+        Recheck Cond: ((roid = 1) OR (roid = 2))
+        ->  BitmapOr
+              ->  Bitmap Index Scan on cast_eliminate_pkey
+                    Index Cond: (roid = 1)
+              ->  Bitmap Index Scan on cast_eliminate_pkey
+                    Index Cond: (roid = 2)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) AND (CAST(s_int AS BIGINT) = 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) AND (CAST(s_int AS BIGINT) = 2)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Index Scan using cast_eliminate_pkey on cast_eliminate
+        Index Cond: (roid = 1)
+        Filter: (s_int = 2)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE 1 = (CAST(ROID AS BIGINT))
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE 1 = (CAST(ROID AS BIGINT))
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
+        Index Cond: (roid = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as INT) = 1
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Index Only Scan using cast_eliminate_pkey on cast_eliminate
+        Index Cond: (roid = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(s_int AS INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(s_int AS INT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (s_int = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(s_int AS BIGINT) as INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(s_int AS BIGINT) as INT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (s_int = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (s_int = 1)
+~~END~~
+
+
+-- NOT clause supported
+SELECT 1 AS [C1] FROM cast_eliminate WHERE b_int = 10 AND NOT ((CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1 OR CAST(ROID AS BIGINT) > 10) AND ROID NOT IN (12, 34))
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE b_int = 10 AND NOT ((CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1 OR CAST(ROID AS BIGINT) > 10) AND ROID NOT IN (12, 34))
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: ((b_int = 10) AND (((s_int <> 1) AND (roid <= 10)) OR (roid = ANY ('{12,34}'::integer[]))))
+~~END~~
+
+
+-- Bad case: cannot remove CAST if a column is typecasted into a type with less precision
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (((roid)::bigint)::smallint = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS SMALLINT) as BIGINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS SMALLINT) as BIGINT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (((roid)::smallint)::bigint = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS BIGINT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS BIGINT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (b_int = 1)
+~~END~~
+
+
+-- Bad case: cannot remove CAST if a column is typecasted into a type with less precision
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS INT) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS INT) = 1
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: ((b_int)::integer = 1)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = CAST(s_int AS INT)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = CAST(s_int AS INT)
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: (((roid)::bigint)::smallint = s_int)
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS numeric) as int) = 1
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS numeric) as int) = 1
+Seq Scan on cast_eliminate
+  Filter: (((roid)::numeric(18,0))::integer = 1)
+~~END~~
+
+
+-- Other operators like >/</<=/>= are also supported
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) < 1) OR (CAST(ROID AS BIGINT) > 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) < 1) OR (CAST(ROID AS BIGINT) > 2)
+Gather
+  Workers Planned: 3
+  ->  Parallel Seq Scan on cast_eliminate
+        Filter: ((roid < 1) OR (roid > 2))
+~~END~~
+
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) >= 1) AND (CAST(ROID AS BIGINT) <= 2)
+GO
+~~START~~
+text
+Query Text: SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) >= 1) AND (CAST(ROID AS BIGINT) <= 2)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on cast_eliminate
+        Recheck Cond: ((roid >= 1) AND (roid <= 2))
+        ->  Bitmap Index Scan on cast_eliminate_pkey
+              Index Cond: ((roid >= 1) AND (roid <= 2))
+~~END~~
+
+
+set babelfish_showplan_all off
+GO
+
+-- Verify executions
+INSERT INTO cast_eliminate VALUES (1, 1, 1), (2, 2938, 2), (3, 32767, 9223372036854775807), (-2147483648, -32768, -9223372036854775808), (2147483647, 2393, 1111111111111111);
+GO
+~~ROW COUNT: 5~~
+
+
+set BABELFISH_STATISTICS PROFILE on
+GO
+
+-- Operators like !=/<> cannot make use of index, so we don't bother to elimiate the unnecessary CAST
+SELECT * FROM cast_eliminate WHERE (CAST(CAST(ROID AS BIGINT) AS BIGINT) = 3 OR CAST(CAST(ROID AS INT) AS BIGINT) = 2147483647) AND CAST(CAST(s_int AS INT) AS BIGINT) != 32767
+GO
+~~START~~
+int#!#smallint#!#bigint
+2147483647#!#2393#!#1111111111111111
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.206 ms
+Query Text: SELECT * FROM cast_eliminate WHERE (CAST(CAST(ROID AS BIGINT) AS BIGINT) = 3 OR CAST(CAST(ROID AS INT) AS BIGINT) = 2147483647) AND CAST(CAST(s_int AS INT) AS BIGINT) != 32767
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on cast_eliminate (actual rows=1 loops=1)
+        Recheck Cond: ((roid = 3) OR (roid = 2147483647))
+        Filter: (((s_int)::integer)::bigint <> 32767)
+        Rows Removed by Filter: 1
+        ->  BitmapOr (actual rows=0 loops=1)
+              ->  Bitmap Index Scan on cast_eliminate_pkey (actual rows=1 loops=1)
+                    Index Cond: (roid = 3)
+              ->  Bitmap Index Scan on cast_eliminate_pkey (actual rows=1 loops=1)
+                    Index Cond: (roid = 2147483647)
 ~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE CAST(CAST(s_int AS INT) AS BIGINT) >= 2394 AND CAST(CAST(ROID AS BIGINT) AS SMALLINT) >= 3
+GO
+~~START~~
+int#!#smallint#!#bigint
+3#!#32767#!#9223372036854775807
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE CAST(CAST(s_int AS INT) AS BIGINT) >= 2394 AND CAST(CAST(ROID AS BIGINT) AS SMALLINT) >= 3
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
+        Filter: ((s_int >= 2394) AND (((roid)::bigint)::smallint >= 3))
+        Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -32768 = CAST(s_int AS INT);
+GO
+~~START~~
+int#!#smallint#!#bigint
+-2147483648#!#-32768#!#-9223372036854775808
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -32768 = CAST(s_int AS INT)
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
+        Filter: ('-32768'::integer = s_int)
+        Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -32768 = CAST(CAST(s_int AS INT) AS BIGINT);
+GO
+~~START~~
+int#!#smallint#!#bigint
+-2147483648#!#-32768#!#-9223372036854775808
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -32768 = CAST(CAST(s_int AS INT) AS BIGINT)
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
+        Filter: ('-32768'::integer = s_int)
+        Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR CAST(ROID AS BIGINT) = -2147483648
+GO
+~~START~~
+int#!#smallint#!#bigint
+1#!#1#!#1
+2#!#2938#!#2
+3#!#32767#!#9223372036854775807
+-2147483648#!#-32768#!#-9223372036854775808
+2147483647#!#2393#!#1111111111111111
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR CAST(ROID AS BIGINT) = -2147483648
+Gather (actual rows=5 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=1 loops=4)
+        Filter: (('-32768'::integer < s_int) OR (roid = '-2147483648'::integer))
+~~END~~
+
+
+SELECT * FROM cast_eliminate WHERE -9223372036854775808 = CAST(s_int AS BIGINT)
+GO
+~~START~~
+int#!#smallint#!#bigint
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM cast_eliminate WHERE -9223372036854775808 = CAST(s_int AS BIGINT)
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
+        Filter: ('-9223372036854775808'::bigint = s_int)
+        Rows Removed by Filter: 1
+~~END~~
+
+
+-- Throws an error due to overflow. If we wrongly eliminate the CAST function, the error won't be thrown
+SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR -9223372036854775808 = CAST(CAST(b_int AS BIGINT) AS INT)
+GO
+~~START~~
+int#!#smallint#!#bigint
+1#!#1#!#1
+2#!#2938#!#2
+3#!#32767#!#9223372036854775807
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
 

--- a/test/JDBC/input/cast_eliminate-vu-prepare.sql
+++ b/test/JDBC/input/cast_eliminate-vu-prepare.sql
@@ -1,6 +1,5 @@
-CREATE TABLE cast_eliminate( [ROID] [int] NOT NULL PRIMARY KEY );
+CREATE TABLE cast_eliminate( [ROID] [int] NOT NULL PRIMARY KEY, s_int SMALLINT, b_int BIGINT );
 GO
 
 CREATE TABLE cast_eliminate2( [ROID] [bigint] NOT NULL PRIMARY KEY );
 GO
-

--- a/test/JDBC/input/cast_eliminate-vu-verify.sql
+++ b/test/JDBC/input/cast_eliminate-vu-verify.sql
@@ -1,4 +1,8 @@
 -- parallel_query_expected
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_costs', 'off'
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_timing', 'off'
+EXEC sp_babelfish_configure 'babelfishpg_tsql.explain_summary', 'off'
+
 set babelfish_showplan_all on
 GO
 
@@ -24,4 +28,89 @@ SELECT 1 AS [C1] FROM cast_eliminate2  WHERE (ROID = cast(1 as bigint))
 GO
 
 SELECT 1 AS [C1] FROM cast_eliminate  WHERE (CAST(ROID AS BIGINT) = cast( 1 as bigint ))
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) OR (CAST(ROID AS BIGINT) = 2)
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) = 1) AND (CAST(s_int AS BIGINT) = 2)
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE 1 = (CAST(ROID AS BIGINT))
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as INT) = 1
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(s_int AS INT) = 1
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(s_int AS BIGINT) as INT) = 1
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1
+GO
+
+-- NOT clause supported
+SELECT 1 AS [C1] FROM cast_eliminate WHERE b_int = 10 AND NOT ((CAST(CAST(CAST(s_int AS BIGINT) as INT) as SMALLINT) = 1 OR CAST(ROID AS BIGINT) > 10) AND ROID NOT IN (12, 34))
+GO
+
+-- Bad case: cannot remove CAST if a column is typecasted into a type with less precision
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = 1
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS SMALLINT) as BIGINT) = 1
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS BIGINT) = 1
+GO
+
+-- Bad case: cannot remove CAST if a column is typecasted into a type with less precision
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(b_int AS INT) = 1
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS BIGINT) as SMALLINT) = CAST(s_int AS INT)
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE CAST(CAST(ROID AS numeric) as int) = 1
+GO
+
+-- Other operators like >/</<=/>= are also supported
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) < 1) OR (CAST(ROID AS BIGINT) > 2)
+GO
+
+SELECT 1 AS [C1] FROM cast_eliminate WHERE (CAST(ROID AS BIGINT) >= 1) AND (CAST(ROID AS BIGINT) <= 2)
+GO
+
+set babelfish_showplan_all off
+GO
+
+-- Verify executions
+INSERT INTO cast_eliminate VALUES (1, 1, 1), (2, 2938, 2), (3, 32767, 9223372036854775807), (-2147483648, -32768, -9223372036854775808), (2147483647, 2393, 1111111111111111);
+GO
+
+set BABELFISH_STATISTICS PROFILE on
+GO
+
+-- Operators like !=/<> cannot make use of index, so we don't bother to elimiate the unnecessary CAST
+SELECT * FROM cast_eliminate WHERE (CAST(CAST(ROID AS BIGINT) AS BIGINT) = 3 OR CAST(CAST(ROID AS INT) AS BIGINT) = 2147483647) AND CAST(CAST(s_int AS INT) AS BIGINT) != 32767
+GO
+
+SELECT * FROM cast_eliminate WHERE CAST(CAST(s_int AS INT) AS BIGINT) >= 2394 AND CAST(CAST(ROID AS BIGINT) AS SMALLINT) >= 3
+GO
+
+SELECT * FROM cast_eliminate WHERE -32768 = CAST(s_int AS INT);
+GO
+
+SELECT * FROM cast_eliminate WHERE -32768 = CAST(CAST(s_int AS INT) AS BIGINT);
+GO
+
+SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR CAST(ROID AS BIGINT) = -2147483648
+GO
+
+SELECT * FROM cast_eliminate WHERE -9223372036854775808 = CAST(s_int AS BIGINT)
+GO
+
+-- Throws an error due to overflow. If we wrongly eliminate the CAST function, the error won't be thrown
+SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR -9223372036854775808 = CAST(CAST(b_int AS BIGINT) AS INT)
 GO


### PR DESCRIPTION
### Description

Some unnecessary CAST functions for integer type exist in the SQL preventing the optimizer making use of the indexes on those columns. By removing those functions, we can give the optimizer an option to choose index.

This patch extends the following supported scenarios:
1. Functions nested in AND/OR clauses.
2. Functions appear in both sides of the operator.
3. Nested CAST functions.
4. CASTs among SMAILLINT, INT, BIGINT.
5. Apart from '=', more operators are supported: </>/<=/>=


### Issues Resolved

Unnecessary CAST function in above scenarios cannot be removed. So the optimizer doesn't have a chance to consider index scan.

BABEL-4550


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).