### PR TITLE
fix valgrind warning in pltsql_store_view_definition

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4633,8 +4633,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 						  (estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER) &&
 						  (strcmp(estate->func->fn_signature, "inline_code_block") != 0);
 
-	if (stmt->original_query)
-		original_query_string = stmt->original_query;
+	original_query_string = stmt->original_query ? stmt->original_query : NULL;
 
 	if (stmt->is_cross_db)
 	{
@@ -4668,14 +4667,14 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		{
 			int			ret = exec_stmt_insert_execute_select(estate, expr);
 
-			if (stmt->is_cross_db)
-			{
-				if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
-					set_session_properties(cur_dbname);
-			}
 			if (reset_session_properties)
 			{
 				set_session_properties(cur_dbname);
+			}
+			else if (stmt->is_cross_db)
+			{
+				if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
+					set_session_properties(cur_dbname);
 			}
 			return ret;
 		}
@@ -5070,8 +5069,10 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 				restore_session_properties();
 		}
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
+		original_query_string = NULL;
+
 		if (need_path_reset)
 			(void) set_config_option("search_path", old_search_path,
 									 PGC_USERSET, PGC_S_SESSION,
@@ -5080,28 +5081,15 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		{
 			set_session_properties(cur_dbname);
 		}
-		if (stmt->is_cross_db)
+		else if (stmt->is_cross_db)
 		{
 			if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
 				set_session_properties(cur_dbname);
 		}
-		PG_RE_THROW();
+
+		pfree(cur_dbname);
 	}
 	PG_END_TRY();
-
-	if (need_path_reset)
-		(void) set_config_option("search_path", old_search_path,
-								 PGC_USERSET, PGC_S_SESSION,
-								 GUC_ACTION_SAVE, true, 0, false);
-	if (reset_session_properties)
-	{
-		set_session_properties(cur_dbname);
-	}
-	if (stmt->is_cross_db)
-	{
-		if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
-			set_session_properties(cur_dbname);
-	}
 
 	return PLTSQL_RC_OK;
 }


### PR DESCRIPTION
### Description

Reset static variable original_query_string back to NULL after use otherwise next queries which do not set original_query_string in ANLTR will read already freed memory.

before this change valgrind reports the following error
Root cause here was calls to `sp_describe_first_result_set` internally creates a view in tsql dialect but we did not set original query string in anltr, which means it will read old already freed value.
```
==00:04:42:31.158 8517== VALGRINDERROR-BEGIN
==00:04:42:31.158 8517== Invalid read of size 1
==00:04:42:31.158 8517==    at 0x4C32D82: strlen (vg_replace_strmem.c:494)
==00:04:42:31.158 8517==    by 0xB4D3A4: cstring_to_text (varlena.c:187)
==00:04:42:31.158 8517==    by 0x12A2B8F2: pltsql_store_view_definition (hooks.c:3166)
==00:04:42:31.158 8517==    by 0x728494: DefineView (view.c:517)
==00:04:42:31.158 8517==    by 0x9D21C0: ProcessUtilitySlow (utility.c:1666)
==00:04:42:31.158 8517==    by 0x9D0F95: standard_ProcessUtility (utility.c:1095)
==00:04:42:31.158 8517==    by 0x89EC165: call_next_ProcessUtility (tdsutils.c:756)
==00:04:42:31.158 8517==    by 0x89EC0DC: tdsutils_ProcessUtility (tdsutils.c:731)
==00:04:42:31.158 8517==    by 0x8C0C7B3: pgss_ProcessUtility (pg_stat_statements.c:1202)
==00:04:42:31.158 8517==    by 0x12939404: call_prev_ProcessUtility (pl_handler.c:4196)
==00:04:42:31.158 8517==    by 0x129392CD: bbf_ProcessUtility (pl_handler.c:4168)
==00:04:42:31.158 8517==    by 0x9D00B3: ProcessUtility (utility.c:529)
==00:04:42:31.158 8517==  Address 0x17163480 is 2,208 bytes inside a block of size 8,192 alloc'd
==00:04:42:31.158 8517==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==00:04:42:31.158 8517==    by 0xBC25CF: AllocSetContextCreateInternal (aset.c:438)
==00:04:42:31.158 8517==    by 0xB9D50E: hash_create (dynahash.c:385)
==00:04:42:31.159 8517==    by 0x129AA76D: create_compile_context (compile_context.c:25)
==00:04:42:31.159 8517==    by 0x12942D5C: pltsql_compile_inline (pl_comp.c:1035)
==00:04:42:31.159 8517==    by 0x1293C51F: pltsql_inline_handler (pl_handler.c:5253)
==00:04:42:31.159 8517==    by 0x89DEFF5: ExecuteSQLBatch (tdssqlbatch.c:94)
==00:04:42:31.159 8517==    by 0x89DF20C: ProcessSQLBatchRequest (tdssqlbatch.c:142)
==00:04:42:31.159 8517==    by 0x89C943A: ProcessTDSRequest (tdsprotocol.c:392)
==00:04:42:31.159 8517==    by 0x89C9F42: TdsSocketBackend (tdsprotocol.c:636)
==00:04:42:31.159 8517==    by 0x89BDF47: pe_process_command (tds_srv.c:450)
==00:04:42:31.159 8517==    by 0x9CC548: PostgresMain (postgres.c:4729)
==00:04:42:31.159 8517== 
==00:04:42:31.159 8517== VALGRINDERROR-END 
```

### Issues Resolved

[BABEL-5246]

### Test Scenarios Covered ###

test_db_collation-* test cases now run clean with valgrind

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).