### PR TITLE
Add support for Alter Function on multi-line table value functions.

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
@@ -51,6 +51,9 @@ static void tsql_check_param_readonly(const char *paramname, TypeName *typename,
 static ResTarget *TsqlForXMLMakeFuncCall(TSQL_ForClause *forclause);
 static ResTarget *TsqlForJSONMakeFuncCall(TSQL_ForClause *forclause);
 static RangeSubselect *TsqlForClauseSubselect(Node *selectstmt);
+static Node * buildTsqlMultiLineTvfNode(int create_loc, bool replace, List *func_name, int func_name_loc, 
+										List *tsql_createfunc_args, char *param_name, int table_loc, List *table_elts, 
+										char *tokens_remaining, int tokens_loc, bool alter, core_yyscan_t yyscanner);
 static Node *tsql_pivot_select_transformation(List *target_list, List *from_clause, List *pivot_clause, Alias *alias_clause, SelectStmt *pivot_sl);
 
 static Node *TsqlOpenJSONSimpleMakeFuncCall(Node *jsonExpr, Node *path);

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -3901,54 +3901,7 @@ tsql_CreateFunctionStmt:
 			| CREATE opt_or_replace FUNCTION func_name tsql_createfunc_args
 			  RETURNS param_name TABLE '(' OptTableElementList ')' opt_as tokens_remaining
 				{
-					CreateStmt *n1 = makeNode(CreateStmt);
-					CreateFunctionStmt *n2 = makeNode(CreateFunctionStmt);
-					char *tbltyp_name = psprintf("%s_%s", $7, strVal(llast($4)));
-					List *tbltyp = list_copy($4);
-					FunctionParameter *out_param;
-
-					DefElem *lang = makeDefElem("language", (Node *) makeString("pltsql"), @1);
-					DefElem *body = makeDefElem("as", (Node *) list_make1(makeString($13)), @13);
-					DefElem *tbltypStmt = makeDefElem("tbltypStmt", (Node *) n1, @1);
-					DefElem *location = makeDefElem("location", (Node *) makeInteger(@4), @4);
-					TSQLInstrumentation(INSTR_TSQL_CREATE_FUNCTION_RETURNS_TABLE);
-					if (sql_dialect != SQL_DIALECT_TSQL)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("This syntax is only valid when babelfishpg_tsql.sql_dialect is TSQL"),
-								 parser_errposition(@1)));
-
-					tbltyp = list_truncate(tbltyp, list_length(tbltyp) - 1);
-					tbltyp = lappend(tbltyp, makeString(downcase_truncate_identifier(tbltyp_name, strlen(tbltyp_name), true)));
-					n1->relation = makeRangeVarFromAnyName(tbltyp, @4, yyscanner);
-					n1->tableElts = $10;
-					n1->inhRelations = NIL;
-					n1->partspec = NULL;
-					n1->ofTypename = NULL;
-					n1->constraints = NIL;
-					n1->options = NIL;
-					n1->oncommit = ONCOMMIT_NOOP;
-					n1->tablespacename = NULL;
-					n1->if_not_exists = false;
-					n1->tsql_tabletype = true;
-
-					/* Add a param for the output table variable */
-					out_param = makeNode(FunctionParameter);
-					out_param->name = $7;
-					out_param->argType = makeTypeNameFromNameList(tbltyp);
-					out_param->mode = FUNC_PARAM_TABLE;
-					out_param->defexpr = NULL;
-
-					n2->is_procedure = false;
-					n2->replace = $2;
-					n2->funcname = $4;
-					n2->parameters = lappend($5, out_param);
-					n2->returnType = makeTypeNameFromNameList(tbltyp);
-					n2->returnType->setof = true;
-					n2->returnType->location = @8;
-					n2->options = list_make4(lang, body, tbltypStmt, location);
-
-					$$ = (Node *)n2;
+					$$ = buildTsqlMultiLineTvfNode(@1, $2, $4, @4, $5, $7, @8, $10, $13, @13, false, yyscanner);
 				}
 			/* TSQL inline table-valued function */
 			| CREATE opt_or_replace FUNCTION func_name tsql_createfunc_args
@@ -4067,6 +4020,11 @@ tsql_AlterFunctionStmt:
 					n->actions = list_make4(lang, body, location, ret); // piggy-back on actions to just put the new proc body instead
 					$$ = (Node *)n;
 				}
+			| TSQL_ALTER FUNCTION func_name tsql_createfunc_args
+              RETURNS param_name TABLE '(' OptTableElementList ')' opt_as tokens_remaining
+                {
+					$$ = buildTsqlMultiLineTvfNode(@1, false, $3, @3, $4, $6, @7, $9, $12, @12, true, yyscanner);
+                }
 		;
 
 /*

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -291,9 +291,6 @@ antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitKill_statement(TSqlParser:
 
 antlrcpp::Any TsqlUnsupportedFeatureHandlerImpl::visitCreate_or_alter_function(TSqlParser::Create_or_alter_functionContext *ctx)
 {
-	if (ctx->ALTER() && ctx->func_body_returns_table())
-    	handle(INSTR_UNSUPPORTED_TSQL_ALTER_FUNCTION, "ALTER FUNCTION on multi-statement table valued functions", getLineAndPos(ctx->ALTER()));
-
 	std::vector<TSqlParser::Function_optionContext *> options;
 	if (ctx->func_body_returns_select())
 		options = ctx->func_body_returns_select()->function_option();

--- a/test/JDBC/expected/alter-function-vu-cleanup.out
+++ b/test/JDBC/expected/alter-function-vu-cleanup.out
@@ -16,7 +16,14 @@ go
 drop function alter_func_f6;
 go
 
+drop function alter_func_prep_schema1.alter_func_f5
+go
+
 drop table alter_func_users
 go
 drop table alter_func_orders
 go
+
+drop schema alter_func_prep_schema1
+go
+

--- a/test/JDBC/expected/alter-function-vu-prepare.out
+++ b/test/JDBC/expected/alter-function-vu-prepare.out
@@ -1,7 +1,7 @@
 
 CREATE TABLE alter_func_users ([Id] int, [firstname] varchar(50), [lastname] varchar(50), [email] varchar(50));
 CREATE TABLE alter_func_orders ([Id] int, [userid] int, [productid] int, [quantity] int, [orderdate] Date);
-INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (1, 'e', 'l', 'testemail2');
+INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (2, 'e', 'l', 'testemail2');
 INSERT INTO alter_func_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
 GO
 ~~ROW COUNT: 2~~
@@ -48,4 +48,7 @@ create function alter_func_f5() returns @result TABLE([Id] int) as begin insert 
 go
 
 create function alter_func_f6(@p1 int, @p2 int=123, @p3 int) returns int as begin return @p1 + @p2 + @p3 end
+go
+
+create schema alter_func_prep_schema1
 go

--- a/test/JDBC/expected/alter-function-vu-verify.out
+++ b/test/JDBC/expected/alter-function-vu-verify.out
@@ -91,7 +91,7 @@ varchar
 ~~END~~
 
 
--- Confirm information schema is correctly updated with "CREATE FUNC [new definition]" 
+-- Confirm information schema is correctly updated with "CREATE FUNC [new definition]"
 select ROUTINE_NAME, ROUTINE_BODY, ROUTINE_DEFINITION from information_schema.routines where SPECIFIC_NAME LIKE 'alter_func_f2';
 go
 ~~START~~
@@ -157,7 +157,7 @@ go
 ~~START~~
 int#!#varchar#!#varchar#!#varchar
 1#!#j#!#o#!#testemail
-1#!#e#!#l#!#testemail2
+2#!#e#!#l#!#testemail2
 3#!#newuser#!#lastname#!#testemail3
 ~~END~~
 
@@ -201,7 +201,7 @@ go
 ~~START~~
 int#!#varchar#!#varchar#!#varchar
 1#!#j#!#o#!#testemail
-1#!#e#!#l#!#testemail2
+2#!#e#!#l#!#testemail2
 3#!#newuser#!#lastname#!#testemail3
 ~~END~~
 
@@ -219,17 +219,132 @@ go
 ~~ERROR (Message: column "address" does not exist)~~
 
 
--- Test Case 9: Expect error for attempting to alter multi statement tvf
--- Alter Func Multi-statement tvf support will be added after BABEL-5149 is resolved
+-- Test Case 9: Alter multi statement tvf
 alter function alter_func_f5()
 returns @result TABLE(Id int) as begin
 insert into @result values (2)
 return
 end
 go
+
+select Id from alter_func_f5()
+go
+~~START~~
+int
+2
+~~END~~
+
+
+-- Add column with different type
+alter function alter_func_f5()
+returns @result TABLE(Id int, Name varchar(max)) as begin
+insert into @result values (2, 'Grace Hopper')
+return
+end
+go
+
+select Id, Name from alter_func_f5()
+go
+~~START~~
+int#!#varchar
+2#!#Grace Hopper
+~~END~~
+
+
+-- Remove a column
+alter function alter_func_f5()
+returns @result TABLE(Name varchar(max)) as begin
+insert into @result values ('Grace Hopper')
+return
+end
+go
+
+-- Expect error for Id column not existing
+select Id, Name from alter_func_f5()
+go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: 'ALTER FUNCTION on multi-statement table valued functions' is not currently supported in Babelfish)~~
+~~ERROR (Message: column "id" does not exist)~~
+
+
+select Name from alter_func_f5()
+go
+~~START~~
+varchar
+Grace Hopper
+~~END~~
+
+
+-- Add column and update condition
+alter function alter_func_f5()
+returns @result TABLE([Id] int, [email] varchar(50), [Status] varchar(50)) as begin
+insert into @result select Id, email, NULL from alter_func_users
+update @result set Status =
+    case when Id = 1 then 'Owner'
+    else 'Normal'
+end
+return
+end
+go
+
+select * from alter_func_f5()
+go
+~~START~~
+int#!#varchar#!#varchar
+1#!#testemail#!#Owner
+2#!#testemail2#!#Normal
+3#!#testemail3#!#Normal
+~~END~~
+
+
+
+-- Create same multiline function on schema
+create function alter_func_prep_schema1.alter_func_f5() 
+returns @result TABLE([Id] int, [email] varchar(50), [Status] varchar(50)) as 
+begin 
+insert into @result select Id, email, NULL from alter_func_users update @result set Status = case when Id = 1 then 'Owner' else 'Normal' end 
+return 
+end
+go
+
+select * from alter_func_prep_schema1.alter_func_f5()
+go
+~~START~~
+int#!#varchar#!#varchar
+1#!#testemail#!#Owner
+2#!#testemail2#!#Normal
+3#!#testemail3#!#Normal
+~~END~~
+
+
+-- Alter function on schema
+alter function alter_func_prep_schema1.alter_func_f5() 
+returns @result TABLE(Name varchar(max)) as begin insert into @result values ('Grace Hopper') 
+return 
+end
+go
+
+select * from alter_func_prep_schema1.alter_func_f5()
+go
+~~START~~
+varchar
+Grace Hopper
+~~END~~
+
+
+-- Alter function on schema with parameters
+alter function alter_func_prep_schema1.alter_func_f5(@name varchar(max)) 
+returns @result TABLE(Name varchar(max)) as begin insert into @result values (@name) 
+return 
+end
+go
+
+select * from alter_func_prep_schema1.alter_func_f5('Ada Lovelace')
+go
+~~START~~
+varchar
+Ada Lovelace
+~~END~~
 
 
 -- Test Case 10: Expect error for altering function in an illegal way

--- a/test/JDBC/input/alter/alter-function-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-function-vu-cleanup.sql
@@ -16,7 +16,14 @@ go
 drop function alter_func_f6;
 go
 
+drop function alter_func_prep_schema1.alter_func_f5
+go
+
 drop table alter_func_users
 go
 drop table alter_func_orders
 go
+
+drop schema alter_func_prep_schema1
+go
+

--- a/test/JDBC/input/alter/alter-function-vu-prepare.sql
+++ b/test/JDBC/input/alter/alter-function-vu-prepare.sql
@@ -1,7 +1,7 @@
 CREATE TABLE alter_func_users ([Id] int, [firstname] varchar(50), [lastname] varchar(50), [email] varchar(50));
 CREATE TABLE alter_func_orders ([Id] int, [userid] int, [productid] int, [quantity] int, [orderdate] Date);
 
-INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (1, 'e', 'l', 'testemail2');
+INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (2, 'e', 'l', 'testemail2');
 INSERT INTO alter_func_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
 GO
 
@@ -38,4 +38,7 @@ create function alter_func_f5() returns @result TABLE([Id] int) as begin insert 
 go
 
 create function alter_func_f6(@p1 int, @p2 int=123, @p3 int) returns int as begin return @p1 + @p2 + @p3 end
+go
+
+create schema alter_func_prep_schema1
 go


### PR DESCRIPTION
### Description

This commit adds the grammar rules and logic to support alter function for multi-statement table value functions cases. The additional grammar rule is included with the other tsql_AlterFunctionStmt cases, and follows the syntax for creating multi line tvfs. The logic is the same as the other alter function cases, with the addition of handling for tabletypstmt, which represents the underlying relationship of these functions.

### Issues Resolved

BABEL-5247

### Test Scenarios Covered ###
see https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2999 for test cases
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).