### PR TITLE
Add sleep in restrict_drop_user_role file (#3027)

### DIFF
--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -289,6 +289,14 @@ t
 ~~END~~
 
 
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
 drop login no_priv_login1
@@ -302,6 +310,15 @@ go
 ~~START~~
 bool
 t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
 ~~END~~
 
 
@@ -359,6 +376,15 @@ WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client b
 go
 ~~START~~
 bool
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
 ~~END~~
 
 

--- a/test/JDBC/expected/single_db/restrict_drop_user_role.out
+++ b/test/JDBC/expected/single_db/restrict_drop_user_role.out
@@ -289,6 +289,14 @@ t
 ~~END~~
 
 
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
+~~END~~
+
 
 -- tsql
 drop login no_priv_login1
@@ -302,6 +310,15 @@ go
 ~~START~~
 bool
 t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
 ~~END~~
 
 
@@ -363,6 +380,15 @@ WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client b
 go
 ~~START~~
 bool
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
+~~START~~
+void
+
 ~~END~~
 
 

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -188,6 +188,9 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'no_priv_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 go
 
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+go
 
 -- tsql
 drop login no_priv_login1
@@ -197,6 +200,10 @@ go
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'no_priv_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
 go
 
 -- tsql
@@ -242,6 +249,10 @@ go
 -- Need to terminate active session before cleaning up the login
 SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'restrict_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+go
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
 go
 
 -- tsql


### PR DESCRIPTION
### Description
Add sleep in restrict_drop_user_role testfile after termination the active session to give time to sync.

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).