### PR TITLE
Fix sp_reset_connection test

### DIFF
--- a/test/JDBC/expected/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/Test-sp_reset_connection.out
@@ -1,5 +1,12 @@
 -- tsql
 -- 1. Test resets GUC variables
+SELECT @@lock_timeout;
+GO
+~~START~~
+int
+-1
+~~END~~
+
 SET lock_timeout 0;
 GO
 SELECT @@lock_timeout;
@@ -10,12 +17,12 @@ int
 ~~END~~
 
 EXEC sys.sp_reset_connection
--- TODO: GUC is not resetting
+GO
 SELECT @@lock_timeout;
 GO
 ~~START~~
 int
-0
+-1
 ~~END~~
 
 

--- a/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
@@ -1,11 +1,13 @@
 -- tsql
 -- 1. Test resets GUC variables
+SELECT @@lock_timeout;
+GO
 SET lock_timeout 0;
 GO
 SELECT @@lock_timeout;
 GO
 EXEC sys.sp_reset_connection
--- TODO: GUC is not resetting
+GO
 SELECT @@lock_timeout;
 GO
 


### PR DESCRIPTION
### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]
- "GO" statement was missing after sys.sp_reset_connection in Test-sp_reset_connection test due to which GUC was not resetting. Adding it to fix the test.

### Issues Resolved

BABEL-429

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
NA

* **Arbitrary inputs -**
NA

* **Negative test cases -**
NA

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).