### PR TITLE
Replaced schedule file for 15_9 to BABEL-2736 instead of BABEL-2736-before-16_5

### DIFF
--- a/test/JDBC/upgrade/15_9/schedule
+++ b/test/JDBC/upgrade/15_9/schedule
@@ -549,5 +549,5 @@ xml_exist-before-16_5
 BABEL-5119_before_16_5
 BABEL-CASE_EXPR
 BABEL-5186
-BABEL-2736-before-16_5
+BABEL-2736
 


### PR DESCRIPTION
### Description

This pull request updates the schedule file in the BABEL_4_X_DEV branch for version 15_9. The change involves replacing the schedule file "BABEL-2736-before-16_5" with "BABEL-2736" to align with the latest version in the 3x DEV branch.

Changes made:
- In file: /babelfish_extensions/test/JDBC/upgrade/15_9/schedule
- Changed "BABEL-2736-before-16_5" to "BABEL-2736"

Reason for change:
To maintain consistency with the latest version in the 3x DEV branch, which uses "BABEL-2736".

Reference PR: #3042 

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).