### PR TITLE
test fix for 25d639e

### DIFF
--- a/test/JDBC/expected/TestInteropProcedures.out
+++ b/test/JDBC/expected/TestInteropProcedures.out
@@ -251,3 +251,132 @@ GO
 -- psql     currentSchema=master_dbo,public
 DROP PROCEDURE psql_interop_proc
 GO
+
+
+-- psql     currentSchema=master_dbo,public
+CREATE FUNCTION pg_stable_func()
+RETURNS INT 
+AS $$ 
+BEGIN 
+    RETURN (SELECT id FROM t); END; 
+$$ LANGUAGE plpgsql STABLE;
+GO
+
+CREATE PROCEDURE pg_proc_inner(i INT)
+AS $$ 
+BEGIN 
+    INSERT INTO TEMP VALUES (i); 
+END; 
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE OR REPLACE PROCEDURE pg_proc_outer() 
+AS $$
+BEGIN 
+    BEGIN
+        UPDATE t SET id = 2; 
+        CALL pg_proc_inner(pg_stable_func()); 
+    EXCEPTION WHEN DIVISION_BY_ZERO THEN 
+        RAISE NOTICE '%', SQLERRM;
+    END; 
+END; 
+$$ LANGUAGE plpgsql;
+GO
+
+-- tsql
+CREATE TABLE t(id INT)
+GO
+CREATE TABLE temp(id INT)
+GO
+INSERT INTO t VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE PROC ptsql_proc AS EXEC pg_proc_outer; UPDATE t SET id = 1;
+GO
+
+
+-- BEGIN TRAN -> tsql proc -> pg_proc_outer -> pg_proc_inner with a plpgsql stable function in argument
+BEGIN TRAN
+GO
+EXEC ptsql_proc
+GO
+~~ROW COUNT: 1~~
+
+COMMIT
+GO
+
+-- tsql proc -> pg_proc_outer -> pg_proc_inner with a plpgsql stable function in argument
+-- same test as above but no explicit transaction block
+EXEC ptsql_proc
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- psql     currentSchema=master_dbo,public
+CREATE FUNCTION pltsql_stable_func()
+RETURNS INT 
+AS $$
+BEGIN 
+    RETURN (SELECT id FROM t);
+END; 
+$$ LANGUAGE PLTSQL STABLE;
+GO
+
+CREATE OR REPLACE PROCEDURE pg_proc_outer()
+AS $$
+BEGIN
+    BEGIN
+        UPDATE t SET id = 2;
+        CALL pg_proc_inner(pltsql_stable_func());
+    EXCEPTION WHEN DIVISION_BY_ZERO THEN
+        RAISE NOTICE '%', SQLERRM;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+-- tsql
+-- BEGIN TRAN -> tsql proc -> pg_proc_outer -> pg_proc_inner with a pltsql stable function in argument
+BEGIN TRAN
+GO
+EXEC ptsql_proc
+GO
+~~ROW COUNT: 1~~
+
+COMMIT
+GO
+
+-- tsql proc -> pg_proc_outer -> pg_proc_inner with a pltsql stable function in argument
+-- same test as above but no explicit transaction block
+EXEC ptsql_proc
+GO
+~~ROW COUNT: 1~~
+
+
+-- we should only see "2" since we always update value before inserting
+SELECT * FROM temp
+GO
+~~START~~
+int
+2
+2
+2
+2
+~~END~~
+
+
+DROP PROCEDURE ptsql_proc
+GO
+
+DROP TABLE t, temp
+GO
+
+-- psql     currentSchema=master_dbo,public
+DROP PROCEDURE IF EXISTS pg_proc_inner, pg_proc_outer;
+GO
+
+DROP FUNCTION IF EXISTS pg_stable_func, pltsql_stable_func;
+GO

--- a/test/JDBC/input/interoperability/TestInteropProcedures.mix
+++ b/test/JDBC/input/interoperability/TestInteropProcedures.mix
@@ -192,3 +192,114 @@ GO
 -- psql     currentSchema=master_dbo,public
 DROP PROCEDURE psql_interop_proc
 GO
+
+
+-- psql     currentSchema=master_dbo,public
+CREATE FUNCTION pg_stable_func()
+RETURNS INT 
+AS $$ 
+BEGIN 
+    RETURN (SELECT id FROM t); END; 
+$$ LANGUAGE plpgsql STABLE;
+GO
+
+CREATE PROCEDURE pg_proc_inner(i INT)
+AS $$ 
+BEGIN 
+    INSERT INTO TEMP VALUES (i); 
+END; 
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE OR REPLACE PROCEDURE pg_proc_outer() 
+AS $$
+BEGIN 
+    BEGIN
+        UPDATE t SET id = 2; 
+        CALL pg_proc_inner(pg_stable_func()); 
+    EXCEPTION WHEN DIVISION_BY_ZERO THEN 
+        RAISE NOTICE '%', SQLERRM;
+    END; 
+END; 
+$$ LANGUAGE plpgsql;
+GO
+
+-- tsql
+CREATE TABLE t(id INT)
+GO
+CREATE TABLE temp(id INT)
+GO
+INSERT INTO t VALUES (1)
+GO
+
+CREATE PROC ptsql_proc AS EXEC pg_proc_outer; UPDATE t SET id = 1;
+GO
+
+
+-- BEGIN TRAN -> tsql proc -> pg_proc_outer -> pg_proc_inner with a plpgsql stable function in argument
+BEGIN TRAN
+GO
+EXEC ptsql_proc
+GO
+COMMIT
+GO
+
+-- same test as above but no explicit transaction block
+-- tsql proc -> pg_proc_outer -> pg_proc_inner with a plpgsql stable function in argument
+EXEC ptsql_proc
+GO
+
+
+-- psql     currentSchema=master_dbo,public
+CREATE FUNCTION pltsql_stable_func()
+RETURNS INT 
+AS $$
+BEGIN 
+    RETURN (SELECT id FROM t);
+END; 
+$$ LANGUAGE PLTSQL STABLE;
+GO
+
+CREATE OR REPLACE PROCEDURE pg_proc_outer()
+AS $$
+BEGIN
+    BEGIN
+        UPDATE t SET id = 2;
+        CALL pg_proc_inner(pltsql_stable_func());
+    EXCEPTION WHEN DIVISION_BY_ZERO THEN
+        RAISE NOTICE '%', SQLERRM;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+-- tsql
+-- BEGIN TRAN -> tsql proc -> pg_proc_outer -> pg_proc_inner with a pltsql stable function in argument
+BEGIN TRAN
+GO
+EXEC ptsql_proc
+GO
+COMMIT
+GO
+
+-- same test as above but no explicit transaction block
+-- tsql proc -> pg_proc_outer -> pg_proc_inner with a pltsql stable function in argument
+EXEC ptsql_proc
+GO
+
+-- we should only see "2" since we always update value before inserting
+SELECT * FROM temp
+GO
+
+DROP PROCEDURE ptsql_proc
+GO
+
+DROP TABLE t, temp
+GO
+
+-- psql     currentSchema=master_dbo,public
+DROP PROCEDURE IF EXISTS pg_proc_inner, pg_proc_outer;
+GO
+
+DROP FUNCTION IF EXISTS pg_stable_func, pltsql_stable_func;
+GO


### PR DESCRIPTION
### Description

Test fix for community commit https://github.com/postgres/postgres/commit/25d639e.

Pushing the patch first since this commit is not yet merged in babelfish engine fork and they trying out the fix.

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).