### PR TITLE
Refactor code under create schema in bbf_ProcessUtility and remove unnecessary hook chaining in tsql extension

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2130,6 +2130,8 @@ extern bool check_fulltext_exist(const char *schema_name, const char *table_name
 extern char *replace_special_chars_fts_impl(char *input_str);
 extern bool is_unique_index(Oid relid, const char *index_name);
 extern void exec_grantschema_subcmds(const char *schema, const char *rolname, bool is_grant, bool with_grant_option, AclMode privilege, bool is_create_schema);
+extern void exec_grant_usage_to_public_on_schema(const char *schema, const char *queryString, bool readOnlyTree,
+											ParamListInfo params, PlannedStmt *pstmt);
 extern int	TsqlUTF8LengthInUTF16(const void *vin, int len);
 extern void TsqlCheckUTF16Length_bpchar(const char *s, int32 len, int32 maxlen, int charlen, bool isExplicit);
 extern void TsqlCheckUTF16Length_varchar(const char *s, int32 len, int32 maxlen, bool isExplicit);


### PR DESCRIPTION
### Description

1. Move the grant usage on schema subcommand execution into an another helper functions in favour of keeping process utility hook more readable.

2. tsql extensions sets the `object_access_hook` twice for no reason. Merge them into one.

3. CREATE SCHEMA schema AUTHORIZATION  role & schema is NULL leads to crash in babelfish, fix it making it no-op which is the correct tsql behaviour.

### Issues Resolved

[no jira]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).