### PR TITLE
Fix detection of table variable UPDATE/DELETE in function

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1942,7 +1942,6 @@ public:
 			if (ctx->select_statement_standalone() && stmt->need_to_push_result)
 				throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "SELECT statement returning result to a client cannot be used in a function", getLineAndPos(ctx->select_statement_standalone()));
 
-			/* T-SQL doens't allow side-effecting operations in CREATE FUNCTION */
 			/* T-SQL doesn't allow side-effecting operations in CREATE FUNCTION */
 			if (ctx->insert_statement())
 			{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1943,20 +1943,86 @@ public:
 				throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "SELECT statement returning result to a client cannot be used in a function", getLineAndPos(ctx->select_statement_standalone()));
 
 			/* T-SQL doens't allow side-effecting operations in CREATE FUNCTION */
+			/* T-SQL doesn't allow side-effecting operations in CREATE FUNCTION */
 			if (ctx->insert_statement())
 			{
 				auto ddl_object = ctx->insert_statement()->ddl_object();
 				if (stmt->insert_exec && ddl_object && !ddl_object->local_id()) /* insert into non-local object */
+				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
+				}
 				else if (ddl_object && !ddl_object->local_id()) /* insert into non-local object */
+				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT' cannot be used within a function", getLineAndPos(ddl_object));
+				}
 			}
-			else if (ctx->update_statement() && ctx->update_statement()->ddl_object() && !ctx->update_statement()->ddl_object()->local_id() && 
-					(ctx->update_statement()->table_sources() ? ::getFullText(ctx->update_statement()->table_sources()).c_str()[0] != '@' : true)) /* update non-local object, table variables are allowed */
-				throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'UPDATE' cannot be used within a function", getLineAndPos(ctx->update_statement()->ddl_object()));
-			else if (ctx->delete_statement() && ctx->delete_statement()->delete_statement_from()->ddl_object() && !ctx->delete_statement()->delete_statement_from()->ddl_object()->local_id()  &&
-					(ctx->delete_statement()->table_sources() ? ::getFullText(ctx->delete_statement()->table_sources()).c_str()[0] != '@' : true)) /* delete non-local object, table variables are allowed */
-				throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'DELETE' cannot be used within a function", getLineAndPos(ctx->delete_statement()->delete_statement_from()->ddl_object()));
+			else if (ctx->update_statement() || ctx->delete_statement())
+			{
+				std::string dmlType = "";
+				TSqlParser::Ddl_objectContext *ddl_object = nullptr;
+				TSqlParser::Table_sourcesContext * table_sources = nullptr;
+				std::pair<int,int> line_and_pos;
+
+				if (ctx->update_statement())
+				{
+					ddl_object = ctx->update_statement()->ddl_object();
+					table_sources = ctx->update_statement()->table_sources();
+					dmlType = "UPDATE";
+				}
+				else
+				{
+					ddl_object = ctx->delete_statement()->delete_statement_from()->ddl_object();
+					table_sources = ctx->delete_statement()->table_sources();
+					dmlType = "DELETE";
+				}
+
+				bool dmlTargetAllowed = false;
+				if (ddl_object && ddl_object->local_id())
+				{
+					// DML target is a table variable
+					dmlTargetAllowed = true;
+				}
+				else if (ddl_object && !ddl_object->local_id())
+				{
+					if (ddl_object && ddl_object->full_object_name())
+					{
+						line_and_pos = getLineAndPos(ddl_object);
+						// DML target can be an alias: verify that the alias is for a table variable
+						bool aliasIsTabVar = false;
+						if (table_sources)
+						{
+							std::string dmlTarget = getFullText(ddl_object->full_object_name());
+							line_and_pos = getLineAndPos(ddl_object->full_object_name());
+							std::vector<TSqlParser::Table_source_itemContext *> table_source_item;
+							if (ctx->update_statement())
+								table_source_item = table_sources->table_source_item();
+							else
+								table_source_item = table_sources->table_source_item();
+
+							for (size_t i=0; i<table_source_item.size(); ++i)
+							{
+								// Find FROM-clause alias matching the DML target
+								if (table_source_item[i]->as_table_alias().size() == 0)
+									continue;  // No alias found in this FROM-clause item
+
+								std::string alias = getFullText(table_source_item[i]->as_table_alias()[0]->table_alias());
+								if (pg_strcasecmp(alias.c_str(), dmlTarget.c_str()) != 0)
+									continue;  // This alias is not matching the DML target
+
+								if (table_source_item[i]->local_id())
+								{
+									// Table variable, with alias matching the DML target
+									aliasIsTabVar = true;
+									break;
+								}
+							}
+							dmlTargetAllowed = aliasIsTabVar;
+						}
+					}
+				}
+				if (!dmlTargetAllowed)
+					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, format_errmsg("'%s' cannot be used within a function", dmlType.c_str()), line_and_pos);
+			}
 
 			/*
 			 * Reject if OUTPUT clause is missing INTO (returning to client) or OUTPUT INTO non local object
@@ -8460,7 +8526,7 @@ rewrite_dot_func_ref_args_query_helper(T ctx, TSqlParser::Method_callContext *me
 	std::vector<std::pair<int, int>> arg_offset_list;
 	int local_id_end_offset = 0;
 	
-	/* writting the previously rewritten XML and/or Geospatial context */
+	/* writing the previously rewritten XML and/or Geospatial context */
 	for (auto &entry : rewritten_query_fragment)
 	{
 		if(entry.first >= ctx->start->getStartIndex() && entry.first <= method->stop->getStopIndex())
@@ -8539,7 +8605,7 @@ rewrite_geospatial_col_ref_query_helper(T ctx, TSqlParser::Method_callContext *m
 	int index = 0;
 	int offset1 = 0;
 	
-	/* writting the previously rewritten Geospatial context */
+	/* writing the previously rewritten Geospatial context */
 	for (auto &entry : rewritten_query_fragment)
 	{
 		if(entry.first >= ctx->start->getStartIndex() && entry.first <= method->stop->getStopIndex())
@@ -8577,7 +8643,7 @@ rewrite_geospatial_func_ref_no_arg_query_helper(T ctx, TSqlParser::Method_callCo
 	int index = 0;
 	int offset1 = 0;
 	
-	/* writting the previously rewritten Geospatial context */
+	/* writing the previously rewritten Geospatial context */
 	for (auto &entry : rewritten_query_fragment)
 	{
 		if(entry.first >= ctx->start->getStartIndex() && entry.first <= method->stop->getStopIndex())
@@ -8693,7 +8759,7 @@ rewrite_function_call_dot_func_ref_args(T ctx)
 	std::vector<std::pair<int, int>> arg_offset_list;
 	int local_id_end_offset = 0;
 	
-	/* writting the previously rewritten Dot Function context */
+	/* writing the previously rewritten Dot Function context */
 	for (auto &entry : rewritten_query_fragment)
 	{
 		if(entry.first >= ctx->start->getStartIndex() && entry.first <= ctx->stop->getStopIndex())

--- a/test/JDBC/expected/tabvar_in_function-vu-cleanup.out
+++ b/test/JDBC/expected/tabvar_in_function-vu-cleanup.out
@@ -1,0 +1,16 @@
+drop function f2_tabvar_in_function_del
+go
+drop function f2_tabvar_in_function_ins
+go
+drop function f2_tabvar_in_function_upd
+go
+drop function f3_tabvar_in_function_del
+go
+drop function f3_tabvar_in_function_upd
+go
+drop function f4_tabvar_in_function_del
+go
+drop function f4_tabvar_in_function_upd
+go
+drop table t1_tabvar_in_function_ins
+go

--- a/test/JDBC/expected/tabvar_in_function-vu-prepare.out
+++ b/test/JDBC/expected/tabvar_in_function-vu-prepare.out
@@ -1,0 +1,5 @@
+create table t1_tabvar_in_function_ins (a int)
+insert t1_tabvar_in_function_ins values(123)
+go
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/tabvar_in_function-vu-verify.out
+++ b/test/JDBC/expected/tabvar_in_function-vu-verify.out
@@ -1,0 +1,197 @@
+create function f1_tabvar_in_function_ins(@p1 int)
+returns int
+as
+begin
+    insert t1_tabvar_in_function_ins values(@p1)
+    return 0
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'INSERT' cannot be used within a function)~~
+
+
+create function f1_tabvar_in_function_upd(@p1 int)
+returns int
+as
+begin
+    update t1_tabvar_in_function_ins set a = a + 1
+    return 0
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'UPDATE' cannot be used within a function)~~
+
+
+create function f1_tabvar_in_function_del(@p1 int)
+returns int
+as
+begin
+    delete t1_tabvar_in_function_ins 
+    return 0
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DELETE' cannot be used within a function)~~
+
+
+create function f2_tabvar_in_function_ins(@p1 int)
+returns int
+as
+begin
+	declare @tv table(a int)
+    insert @tv values(@p1)
+    return (select sum(a) from @tv)
+end
+go
+select dbo. f2_tabvar_in_function_ins(123) 
+go
+~~START~~
+int
+123
+~~END~~
+
+
+create function f2_tabvar_in_function_upd(@p1 int)
+returns int
+as
+begin
+	declare @tv table(a int)
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    return (select sum(a) from @tv)
+end
+go
+select dbo. f2_tabvar_in_function_upd(123) 
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f2_tabvar_in_function_del(@p1 int)
+returns int
+as
+begin
+	declare @tv table(a int)
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    delete @tv where a = 124
+    return (select sum(a) from @tv)
+end
+go
+select dbo. f2_tabvar_in_function_del(123) 
+go
+~~START~~
+int
+125
+~~END~~
+
+
+create function f3_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as t
+    return
+end
+go
+select * from dbo. f3_tabvar_in_function_upd(123) order by 1
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f3_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as t where a = 124 
+    return
+end
+go
+select * from dbo. f3_tabvar_in_function_del(123) order by 1
+go
+~~START~~
+int
+123
+~~END~~
+
+
+create function f4_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from t1_tabvar_in_function_ins, @tv as t where t1_tabvar_in_function_ins.a = t.a
+    return
+end
+go
+select * from dbo. f4_tabvar_in_function_upd(123) order by 1
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f4_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from t1_tabvar_in_function_ins, @tv as t where t1_tabvar_in_function_ins.a = t.a
+    return
+end
+go
+select * from dbo. f4_tabvar_in_function_del(123) order by 1
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f5_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as tv, t1_tabvar_in_function_ins as t where tv.a = t.a
+    return
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'UPDATE' cannot be used within a function)~~
+
+
+create function f5_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as tv, t1_tabvar_in_function_ins as t where tv.a = t.a
+    return
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DELETE' cannot be used within a function)~~
+
+

--- a/test/JDBC/input/tabvar_in_function-vu-cleanup.sql
+++ b/test/JDBC/input/tabvar_in_function-vu-cleanup.sql
@@ -1,0 +1,16 @@
+drop function f2_tabvar_in_function_del
+go
+drop function f2_tabvar_in_function_ins
+go
+drop function f2_tabvar_in_function_upd
+go
+drop function f3_tabvar_in_function_del
+go
+drop function f3_tabvar_in_function_upd
+go
+drop function f4_tabvar_in_function_del
+go
+drop function f4_tabvar_in_function_upd
+go
+drop table t1_tabvar_in_function_ins
+go

--- a/test/JDBC/input/tabvar_in_function-vu-prepare.sql
+++ b/test/JDBC/input/tabvar_in_function-vu-prepare.sql
@@ -1,0 +1,3 @@
+create table t1_tabvar_in_function_ins (a int)
+insert t1_tabvar_in_function_ins values(123)
+go

--- a/test/JDBC/input/tabvar_in_function-vu-verify.sql
+++ b/test/JDBC/input/tabvar_in_function-vu-verify.sql
@@ -1,0 +1,142 @@
+create function f1_tabvar_in_function_ins(@p1 int)
+returns int
+as
+begin
+    insert t1_tabvar_in_function_ins values(@p1)
+    return 0
+end
+go
+
+create function f1_tabvar_in_function_upd(@p1 int)
+returns int
+as
+begin
+    update t1_tabvar_in_function_ins set a = a + 1
+    return 0
+end
+go
+
+create function f1_tabvar_in_function_del(@p1 int)
+returns int
+as
+begin
+    delete t1_tabvar_in_function_ins 
+    return 0
+end
+go
+
+create function f2_tabvar_in_function_ins(@p1 int)
+returns int
+as
+begin
+	declare @tv table(a int)
+    insert @tv values(@p1)
+    return (select sum(a) from @tv)
+end
+go
+select dbo. f2_tabvar_in_function_ins(123) 
+go
+
+create function f2_tabvar_in_function_upd(@p1 int)
+returns int
+as
+begin
+	declare @tv table(a int)
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    return (select sum(a) from @tv)
+end
+go
+select dbo. f2_tabvar_in_function_upd(123) 
+go
+
+create function f2_tabvar_in_function_del(@p1 int)
+returns int
+as
+begin
+	declare @tv table(a int)
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    delete @tv where a = 124
+    return (select sum(a) from @tv)
+end
+go
+select dbo. f2_tabvar_in_function_del(123) 
+go
+
+create function f3_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as t
+    return
+end
+go
+select * from dbo. f3_tabvar_in_function_upd(123) order by 1
+go
+
+create function f3_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as t where a = 124 
+    return
+end
+go
+select * from dbo. f3_tabvar_in_function_del(123) order by 1
+go
+
+create function f4_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from t1_tabvar_in_function_ins, @tv as t where t1_tabvar_in_function_ins.a = t.a
+    return
+end
+go
+select * from dbo. f4_tabvar_in_function_upd(123) order by 1
+go
+
+create function f4_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from t1_tabvar_in_function_ins, @tv as t where t1_tabvar_in_function_ins.a = t.a
+    return
+end
+go
+select * from dbo. f4_tabvar_in_function_del(123) order by 1
+go
+
+create function f5_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as tv, t1_tabvar_in_function_ins as t where tv.a = t.a
+    return
+end
+go
+
+create function f5_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as tv, t1_tabvar_in_function_ins as t where tv.a = t.a
+    return
+end
+go
+

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -498,6 +498,7 @@ with_recompile
 alter_proc_recompile
 catalogs_dbo_sys_schema-upgrade
 unary_plus_op_string
+tabvar_in_function
 BABEL-4217
 Test_ISNULL
 BABEL-4270


### PR DESCRIPTION
### Description

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1471  fixed the issue of catching the case where a table variable was modified in a function, but referenced via an alias. 
However, that fix only handled the case where the FROM clause consists of a single table variable, i.e. it does not contain a join.
This fix checks that the alias actually corresponds to a table variable in the FROM-clause. 

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-5357 Table variable UPDATE/DELETE in function is incorrectly rejected with multi-table FROM-clause

### Test Scenarios Covered ###
- Use case based - Yes

- Boundary conditions - N/A

- Arbitrary inputs - N/A

- Negative test cases - Yes

- Minor version upgrade tests - N/A

- Major version upgrade tests - N/A

- Performance tests - N/A

- Tooling impact - N/A

- Client tests - N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).