### PR TITLE
Remove babelfish formdata structures

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -1,5 +1,4 @@
 -- BBF_SYSDATABASES
--- Note: change here requires change in FormData_sysdatabases too
 CREATE TABLE sys.babelfish_sysdatabases (
 	dbid SMALLINT NOT NULL UNIQUE,
 	status INT NOT NULL,
@@ -324,7 +323,6 @@ END
 $$;
 
 -- LOGIN EXT
--- Note: change here requires change in FormData_authid_login_ext too
 CREATE TABLE sys.babelfish_authid_login_ext (
 rolname NAME NOT NULL, -- pg_authid.rolname
 is_disabled INT NOT NULL DEFAULT 0, -- to support enable/disable login

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2527,11 +2527,9 @@ get_perms_grantee_name(HeapTuple tuple, TupleDesc dsc)
 static Datum
 get_server_name(HeapTuple tuple, TupleDesc dsc)
 {
-	Form_bbf_servers_def	srv_def = ((Form_bbf_servers_def) GETSTRUCT(tuple));
-	const text 		*srv_name = &(srv_def->servername);
-	char 			*servername = text_to_cstring(srv_name);
+	bool	   isNull;
 
-	return CStringGetDatum(servername);
+	return heap_getattr(tuple, Anum_bbf_servers_def_servername, dsc, &isNull);
 }
 
 static Datum

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2444,17 +2444,17 @@ get_nspname(HeapTuple tuple, TupleDesc dsc)
 static Datum
 get_login_rolname(HeapTuple tuple, TupleDesc dsc)
 {
-	Form_authid_login_ext authid = ((Form_authid_login_ext) GETSTRUCT(tuple));
+	bool		isNull;
 
-	return NameGetDatum(&(authid->rolname));
+	return heap_getattr(tuple, Anum_bbf_authid_login_ext_rolname, dsc, &isNull);
 }
 
 static Datum
 get_default_database_name(HeapTuple tuple, TupleDesc dsc)
 {
-	Form_authid_login_ext authid = ((Form_authid_login_ext) GETSTRUCT(tuple));
+	bool		isNull;
 
-	return PointerGetDatum(&(authid->default_database_name));
+	return heap_getattr(tuple, Anum_bbf_authid_login_ext_default_database_name, dsc, &isNull);
 }
 
 static Datum

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2390,10 +2390,8 @@ static Datum
 get_owner(HeapTuple tuple, TupleDesc dsc)
 {
 	bool	   isNull;
-	Datum datum = heap_getattr(tuple, Anum_sysdatabases_owner,
-							   dsc, &isNull);
 
-	return datum;
+	return heap_getattr(tuple, Anum_sysdatabases_owner, dsc, &isNull);
 }
 
 static Datum
@@ -2534,9 +2532,11 @@ get_perms_grantee_name(HeapTuple tuple, TupleDesc dsc)
 static Datum
 get_server_name(HeapTuple tuple, TupleDesc dsc)
 {
-	bool	   isNull;
+	bool 	isNull;
+	Datum	datum = heap_getattr(tuple, Anum_bbf_servers_def_servername,
+								 dsc, &isNull);
 
-	return heap_getattr(tuple, Anum_bbf_servers_def_servername, dsc, &isNull);
+	return CStringGetDatum(TextDatumGetCString(datum));
 }
 
 static Datum

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -2477,17 +2477,17 @@ get_database_name(HeapTuple tuple, TupleDesc dsc)
 static Datum
 get_function_nspname(HeapTuple tuple, TupleDesc dsc)
 {
-	Form_bbf_function_ext func = ((Form_bbf_function_ext) GETSTRUCT(tuple));
+	bool	isNull;
 
-	return NameGetDatum(&(func->schema));
+	return heap_getattr(tuple, Anum_bbf_function_ext_nspname, dsc, &isNull);
 }
 
 static Datum
 get_function_name(HeapTuple tuple, TupleDesc dsc)
 {
-	Form_bbf_function_ext func = ((Form_bbf_function_ext) GETSTRUCT(tuple));
+	bool	isNull;
 
-	return NameGetDatum(&(func->funcname));
+	return heap_getattr(tuple, Anum_bbf_function_ext_funcname, dsc, &isNull);
 }
 
 static Datum

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -198,14 +198,6 @@ extern int get_timeout_from_server_name(char *servername, int attnum);
 extern int get_server_id_from_server_name(char *servername);
 extern void clean_up_bbf_server_def(void);
 
-typedef struct FormData_bbf_servers_def
-{
-	text		servername;
-	int32		query_timeout;
-	int32		connect_timeout;
-} FormData_bbf_servers_def;
-
-typedef FormData_bbf_servers_def *Form_bbf_servers_def;
 
 /*****************************************
  *			FUNCTION_EXT

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -107,6 +107,7 @@ extern Oid	get_authid_login_ext_idx_oid(void);
 #define BBF_AUTHID_USER_EXT_IDX_NAME "babelfish_authid_user_ext_pkey"
 #define Anum_bbf_authid_user_ext_rolname				1
 #define Anum_bbf_authid_user_ext_login_name				2
+#define Anum_bbf_authid_user_ext_type					3
 #define Anum_bbf_authid_user_ext_orig_username			11
 #define Anum_bbf_authid_user_ext_database_name			12
 #define Anum_bbf_authid_user_ext_default_schema_name	13
@@ -132,28 +133,6 @@ extern void rename_tsql_db(char *old_db_name, char *new_db_name);
 extern Oid get_login_for_user(Oid user_id, const char *physical_schema_name);
 extern bool user_exists_for_db(const char *db_name, const char *user_name);
 
-/* MUST comply with babelfish_authid_user_ext table */
-typedef struct FormData_authid_user_ext
-{
-	NameData	rolname;
-	NameData	login_name;
-	BpChar		type;
-	int32		owning_principal_id;
-	int32		is_fixed_role;
-	int32		authentication_type;
-	int32		default_language_lcid;
-	int32		allow_encrypted_value_modifications;
-	TimestampTz create_date;
-	TimestampTz modify_date;
-	VarChar		orig_username;
-	VarChar		database_name;
-	VarChar		default_schema_name;
-	VarChar		default_language_name;
-	VarChar		authentication_type_desc;
-	int32		user_can_connect;
-} FormData_authid_user_ext;
-
-typedef FormData_authid_user_ext *Form_authid_user_ext;
 
 /*****************************************
  *			VIEW_DEF

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -377,20 +377,6 @@ extern char	*get_partition_scheme_for_partitioned_table(int16 dbid, char *schema
 extern void	rename_table_update_bbf_partition_depend_catalog(RenameStmt *stmt, char *logical_schema_name, int16 dbid);
 
 
-typedef struct FormData_bbf_extended_properties
-{
-	int16		dbid;
-	NameData	schema_name;
-	NameData	major_name;
-	NameData	minor_name;
-	VarChar		type;
-	VarChar		name;
-	VarChar		orig_name;
-	bytea		value;
-} FormData_bbf_extended_properties;
-
-typedef FormData_bbf_extended_properties *Form_bbf_extended_properties;
-
 /*****************************************
  *			Metadata Check Rule
  *****************************************/

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -179,19 +179,6 @@ extern bool check_is_tsql_view(Oid relid);
 extern void clean_up_bbf_view_def(int16 dbid);
 extern void drop_bbf_schema_permission_entries(int16 dbid);
 
-typedef struct FormData_bbf_view_def
-{
-	int16		dbid;
-	VarChar		schema;
-	VarChar		object_name;
-	text		definition;
-	uint64		flag_validity;
-	uint64		flag_values;
-	Timestamp	create_date;
-	Timestamp	modify_date;
-}			FormData_bbf_view_def;
-
-typedef FormData_bbf_view_def * Form_bbf_view_def;
 
 /*****************************************
  *			LINKED_SERVERS_DEF

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -269,18 +269,6 @@ extern Oid bbf_schema_perms_idx_oid;
 
 extern Oid get_bbf_schema_perms_oid(void);
 
-typedef struct FormData_bbf_schema_perms
-{
-	int16		dbid;
-	VarChar	schema_name;
-	VarChar	object_name;
-	int32		permission;
-	VarChar	grantee;
-	char	object_type;
-	text	function_args;
-} FormData_bbf_schema_perms;
-
-typedef FormData_bbf_schema_perms *Form_bbf_schema_perms;
 
 extern void add_entry_to_bbf_schema_perms(const char *schema_name, const char *object_name, int permission, const char *grantee, const char *object_type, const char *func_args);
 extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee);

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -53,25 +53,6 @@ extern Oid	sysdatabaese_idx_name_oid;
 #define Anum_sysdatabases_name 6
 #define Anum_sysdatabases_crdate 7
 
-/* MUST comply with babelfish_authid_login_ext table */
-typedef struct FormData_authid_login_ext
-{
-	NameData	rolname;
-	int32		is_disabled;
-	char		type;
-	int32		credential_id;
-	int32		owning_principal_id;
-	int32		is_fixed_role;
-	TimestampTz create_date;
-	TimestampTz modify_date;
-	VarChar		default_database_name;
-	VarChar		default_language_name;
-	Jsonb		properties;
-	VarChar		orig_loginname;
-} FormData_authid_login_ext;
-
-typedef FormData_authid_login_ext *Form_authid_login_ext;
-
 #define InvalidDbid 0
 #define DbidIsValid(id)  ((bool) ((id) != InvalidDbid))
 
@@ -107,6 +88,7 @@ extern int16 get_dbid_from_physical_schema_name(const char *physical_schema_name
 #define BBF_AUTHID_LOGIN_EXT_IDX_NAME "babelfish_authid_login_ext_pkey"
 #define Anum_bbf_authid_login_ext_rolname 1
 #define Anum_bbf_authid_login_ext_type 3
+#define Anum_bbf_authid_login_ext_default_database_name 9
 #define Anum_bbf_authid_login_ext_orig_loginname 12
 
 extern Oid	bbf_authid_login_ext_oid;

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -49,23 +49,9 @@ extern Oid	sysdatabaese_idx_name_oid;
 #define SYSDATABASES_NUM_COLS 8
 #define Anum_sysdatabases_oid 1
 #define Anum_sysdatabases_owner 4
+#define Anum_sysdatabases_default_collation 5
 #define Anum_sysdatabases_name 6
 #define Anum_sysdatabases_crdate 7
-
-/* MUST comply with babelfish_sysdatabases table */
-typedef struct FormData_sysdatabases
-{
-	int16		dbid;
-	int32		status;
-	int32		status2;
-	NameData	owner;
-	NameData	default_collation;
-	text		name;
-	TimestampTz crdate;
-	text		properties;
-} FormData_sysdatabases;
-
-typedef FormData_sysdatabases *Form_sysdatabases;
 
 /* MUST comply with babelfish_authid_login_ext table */
 typedef struct FormData_authid_login_ext

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -267,21 +267,6 @@ extern void clean_up_bbf_function_ext(int16 dbid);
 extern bool is_created_with_recompile(Oid objectId);
 extern bool is_classic_catalog(const char *name);
 
-typedef struct FormData_bbf_function_ext
-{
-	NameData	schema;
-	NameData	funcname;
-	VarChar		orig_name;
-	text		function_signature;
-	text		default_positions;
-	uint64		flag_validity;
-	uint64		flag_values;
-	Timestamp	create_date;
-	Timestamp	modify_date;
-	text		definition;
-} FormData_bbf_function_ext;
-
-typedef FormData_bbf_function_ext *Form_bbf_function_ext;
 
 /*****************************************
  *			SCHEMA_PERMISSIONS

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1773,18 +1773,19 @@ char*
 get_collation_name_for_db(const char* dbname)
 {
 	HeapTuple	tuple;
-	Form_sysdatabases sysdb;
+	Datum datum;
+	bool  isnull;
 	char *collation_name;
 
-	tuple = SearchSysCache1(SYSDATABASENAME, PointerGetDatum(cstring_to_text(dbname)));
+	tuple = SearchSysCache1(SYSDATABASENAME, CStringGetTextDatum(dbname));
 
 	if (!HeapTupleIsValid(tuple))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_DATABASE),
 					 errmsg("Could not find database: \"%s\"", dbname)));
 
-	sysdb = ((Form_sysdatabases) GETSTRUCT(tuple));
-	collation_name = pstrdup(NameStr(sysdb->default_collation));
+	datum = SysCacheGetAttr(SYSDATABASENAME, tuple, Anum_sysdatabases_oid, &isnull);
+	collation_name = pstrdup(NameStr(*DatumGetName(datum)));
 
 	ReleaseSysCache(tuple);
 	return collation_name;

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1784,7 +1784,7 @@ get_collation_name_for_db(const char* dbname)
 					(errcode(ERRCODE_UNDEFINED_DATABASE),
 					 errmsg("Could not find database: \"%s\"", dbname)));
 
-	datum = SysCacheGetAttr(SYSDATABASENAME, tuple, Anum_sysdatabases_oid, &isnull);
+	datum = SysCacheGetAttr(SYSDATABASENAME, tuple, Anum_sysdatabases_default_collation, &isnull);
 	collation_name = pstrdup(NameStr(*DatumGetName(datum)));
 
 	ReleaseSysCache(tuple);

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1029,9 +1029,10 @@ drop_all_logins(PG_FUNCTION_ARGS)
 	/* Get all the login names beforehand. */
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
-		Form_authid_login_ext loginform = (Form_authid_login_ext) GETSTRUCT(tuple);
-
-		rolname = NameStr(loginform->rolname);
+		bool  isNull;
+		Datum datum = heap_getattr(tuple, Anum_bbf_authid_login_ext_rolname,
+								   RelationGetDescr(bbf_authid_login_ext_rel), &isNull);
+		rolname = pstrdup(NameStr(*DatumGetName(datum)));
 
 		/*
 		 * Remove SA from authid_login_ext now but do not add it to the list
@@ -2519,10 +2520,10 @@ remove_createrole_from_logins(PG_FUNCTION_ARGS)
 
 	while (HeapTupleIsValid(tuple))
 	{
-		Form_authid_login_ext loginform;
-		char *rolname;
-		loginform = (Form_authid_login_ext) GETSTRUCT(tuple);
-		rolname = pstrdup(NameStr(loginform->rolname));
+		bool  isNull;
+		Datum datum = heap_getattr(tuple, Anum_bbf_authid_login_ext_rolname,
+								   RelationGetDescr(rel), &isNull);
+		char *rolname = pstrdup(NameStr(*DatumGetName(datum)));
 
 		/*
 		 * For each login (except sysadmin and the member of sysadmin), remove

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-vu-verify.out
@@ -72,6 +72,25 @@ TYPE#!#babel_extended_property_v3_type#!#type property1#!#type property1 before
 ~~END~~
 
 
+-- BABEL-5087
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @level0type = N'SCHEMA',
+    @level0name = N'babel_extended_property_v3_schema',
+    @level1type = N'table',
+    @level1name = N'babel_extended_property_v3_table';
+GO
+
+SELECT  * FROM fn_listextendedproperty(NULL, 'SCHEMA', N'babel_extended_property_v3_schema', 'TABLE', N'babel_extended_property_v3_table', NULL, NULL);
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#sql_variant
+TABLE#!#babel_extended_property_v3_table#!#MS_Description#!#<NULL>
+TABLE#!#babel_extended_property_v3_table#!#table property1#!#table property1 value
+TABLE#!#babel_extended_property_v3_table#!#table property2#!#table property2 value
+~~END~~
+
+
 -- list all extended properties
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties ORDER BY class, class_desc, name, value;
 GO
@@ -81,6 +100,7 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 1#!#OBJECT_OR_COLUMN#!#1#!#1#!#column property1#!#column property1 value
 1#!#OBJECT_OR_COLUMN#!#1#!#1#!#COLUMN PROPERTY2 "{\)#!#COLUMN PROPERTY2 VALUE "{\)   
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#function property1#!#function property1 value
+1#!#OBJECT_OR_COLUMN#!#1#!#0#!#MS_Description#!#<NULL>
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#procedure property1#!#procedure property1 value
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#sequence property1#!#sequence property1 value
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#table property1#!#table property1 value

--- a/test/JDBC/input/BABEL-EXTENDEDPROPERTY-vu-verify.sql
+++ b/test/JDBC/input/BABEL-EXTENDEDPROPERTY-vu-verify.sql
@@ -25,6 +25,18 @@ GO
 SELECT * FROM fn_listextendedproperty(NULL, 'schema', 'babel_extended_property_v3_schema', 'type', NULL, NULL, NULL) ORDER BY objtype, objname, name, value;
 GO
 
+-- BABEL-5087
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @level0type = N'SCHEMA',
+    @level0name = N'babel_extended_property_v3_schema',
+    @level1type = N'table',
+    @level1name = N'babel_extended_property_v3_table';
+GO
+
+SELECT  * FROM fn_listextendedproperty(NULL, 'SCHEMA', N'babel_extended_property_v3_schema', 'TABLE', N'babel_extended_property_v3_table', NULL, NULL);
+GO
+
 -- list all extended properties
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties ORDER BY class, class_desc, name, value;
 GO


### PR DESCRIPTION
### Description

Form structure in postgres are only used for not null and non varlena columns. Additionally the valid columns should be before the invalid ones. Postgres handles it by declaring all their variable length and nullable columns as the last columns.
Babelfish system catalogs do not satisfy this, so remove these structures which are not even widely used in code except for code for metadata consistency.

Also fixed a crash in `fn_listextendedproperty`. We were fetching a tuple for the `value` column of `sys.babelfish_extended_properties` which could be null but did not account for this in code while copying its datum. As a fix handled the null datum properly and added test case for null value extended propery.


### Issues Resolved

[BABEL-5087][BABEL-5324]

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).