### PR TITLE
Fix build warning in sys_functions.sql (#3030)

### DIFF
--- a/contrib/babelfishpg_common/Makefile
+++ b/contrib/babelfishpg_common/Makefile
@@ -102,7 +102,7 @@ FLAG_TO_CHECK := -DENABLE_SPATIAL_TYPES
 ifeq (,$(filter $(FLAG_TO_CHECK),$(PG_CPPFLAGS)))
 # The flag is not present then build the .in file not including the spatial type files
     sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).in
-		cpp $< | sed 's/^# /-- /g' > $@
+		cpp -Werror $< | sed 's/^# /-- /g' > $@
 
     sql/$(EXTENSION)--3.2.0--3.3.0.sql: sql/upgrades/babelfishpg_upgrades.in
 		cpp -D PREV_VERSION=3.2.0 -D CUR_VERSION=3.3.0 $< | sed 's/^# /-- /g' > $@
@@ -122,7 +122,7 @@ ifeq (,$(filter $(FLAG_TO_CHECK),$(PG_CPPFLAGS)))
 else
 # The flag is present build the .in file including the spatial type files
     sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).in
-		cpp -D ENABLE_SPATIAL_TYPES=1 $< | sed 's/^# /-- /g' > $@
+		cpp -Werror -D ENABLE_SPATIAL_TYPES=1 $< | sed 's/^# /-- /g' > $@
 
     sql/$(EXTENSION)--3.2.0--3.3.0.sql: sql/upgrades/babelfishpg_upgrades.in
 		cpp -D ENABLE_SPATIAL_TYPES=1 -D PREV_VERSION=3.2.0 -D CUR_VERSION=3.3.0 $< | sed 's/^# /-- /g' > $@

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -148,7 +148,7 @@ $(EXTENSION).control: $(EXTENSION).control.in
 		> $@
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).in
-	cpp $< | sed 's/^# /-- /g' > $@
+	cpp -Werror $< | sed 's/^# /-- /g' > $@
 
 sql/%.sql: sql/upgrades/%.sql
 	cp $< $@

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -4423,7 +4423,7 @@ CREATE OR REPLACE FUNCTION sys.is_member(IN role sys.SYSNAME)
 RETURNS INT AS
 $$
 DECLARE
-    is_windows_grp boolean := (CHARINDEX('\', role) != 0);
+    is_windows_grp boolean := (CHARINDEX('\', role) != 0); -- '  adding quote in comment to suppress build warning
 BEGIN
     -- Always return 1 for 'public'
     IF (role = 'public')


### PR DESCRIPTION
In sys_functions.sql file, we have defined the sys.is_member() function which internally calls CHARINDEX('\', ...). During build, the compiler treats \' as an escaped quote and thus complains that there is unterminated quote. To fix this, added a single quote as a comment.

Task: BABEL-5359
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).