### PR TITLE
Additional tests for UPDATE/DELETE of table variable in function

### DIFF
--- a/test/JDBC/expected/tabvar_in_function-vu-cleanup.out
+++ b/test/JDBC/expected/tabvar_in_function-vu-cleanup.out
@@ -12,5 +12,17 @@ drop function f4_tabvar_in_function_del
 go
 drop function f4_tabvar_in_function_upd
 go
+drop function f6_tabvar_in_function_del
+go
+drop function f6_tabvar_in_function_upd
+go
+drop function f6a_tabvar_in_function_del
+go
+drop function f6a_tabvar_in_function_upd
+go
+drop function f7_tabvar_in_function_del
+go
+drop function f7_tabvar_in_function_upd
+go
 drop table t1_tabvar_in_function_ins
 go

--- a/test/JDBC/expected/tabvar_in_function-vu-verify.out
+++ b/test/JDBC/expected/tabvar_in_function-vu-verify.out
@@ -195,3 +195,170 @@ go
 ~~ERROR (Message: 'DELETE' cannot be used within a function)~~
 
 
+create function f6_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as t join t1_tabvar_in_function_ins as tv on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6_tabvar_in_function_upd(123)
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f6_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as t inner join t1_tabvar_in_function_ins as tv on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6_tabvar_in_function_del(123)
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f6a_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from t1_tabvar_in_function_ins as tv join @tv as t on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6a_tabvar_in_function_upd(123)
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f6a_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from t1_tabvar_in_function_ins as tv join @tv as t on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6a_tabvar_in_function_del(123)
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f7_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from t1_tabvar_in_function_ins as t1 left join t1_tabvar_in_function_ins as tv on tv.a = t1.a right join @tv t on tv.a = t.a 
+    return
+end
+go
+select * from dbo.f7_tabvar_in_function_upd(123)
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f7_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from t1_tabvar_in_function_ins as t1 join t1_tabvar_in_function_ins as tv on tv.a = t1.a join @tv t on tv.a = t.a 
+    return
+end
+go
+select * from dbo.f7_tabvar_in_function_del(123)
+go
+~~START~~
+int
+124
+~~END~~
+
+
+create function f8_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as tv cross join t1_tabvar_in_function_ins as t
+    return
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'UPDATE' cannot be used within a function)~~
+
+
+create function f8_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as tv inner join t1_tabvar_in_function_ins as t on tv.a = t.a
+    return
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DELETE' cannot be used within a function)~~
+
+
+create function f9_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as t1 full outer join t1_tabvar_in_function_ins as tv on tv.a = t1.a cross join t1_tabvar_in_function_ins t
+    return
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'UPDATE' cannot be used within a function)~~
+
+
+create function f9_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as t1 right join t1_tabvar_in_function_ins as tv on tv.a = t1.a full outer join t1_tabvar_in_function_ins t on tv.a = t.a 
+    return
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'DELETE' cannot be used within a function)~~
+

--- a/test/JDBC/input/tabvar_in_function-vu-cleanup.sql
+++ b/test/JDBC/input/tabvar_in_function-vu-cleanup.sql
@@ -12,5 +12,17 @@ drop function f4_tabvar_in_function_del
 go
 drop function f4_tabvar_in_function_upd
 go
+drop function f6_tabvar_in_function_del
+go
+drop function f6_tabvar_in_function_upd
+go
+drop function f6a_tabvar_in_function_del
+go
+drop function f6a_tabvar_in_function_upd
+go
+drop function f7_tabvar_in_function_del
+go
+drop function f7_tabvar_in_function_upd
+go
 drop table t1_tabvar_in_function_ins
 go

--- a/test/JDBC/input/tabvar_in_function-vu-verify.sql
+++ b/test/JDBC/input/tabvar_in_function-vu-verify.sql
@@ -140,3 +140,124 @@ begin
 end
 go
 
+create function f6_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as t join t1_tabvar_in_function_ins as tv on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6_tabvar_in_function_upd(123)
+go
+
+create function f6_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as t inner join t1_tabvar_in_function_ins as tv on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6_tabvar_in_function_del(123)
+go
+
+create function f6a_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from t1_tabvar_in_function_ins as tv join @tv as t on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6a_tabvar_in_function_upd(123)
+go
+
+create function f6a_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from t1_tabvar_in_function_ins as tv join @tv as t on tv.a = t.a
+    return
+end
+go
+select * from dbo.f6a_tabvar_in_function_del(123)
+go
+
+create function f7_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from t1_tabvar_in_function_ins as t1 left join t1_tabvar_in_function_ins as tv on tv.a = t1.a right join @tv t on tv.a = t.a 
+    return
+end
+go
+select * from dbo.f7_tabvar_in_function_upd(123)
+go
+
+create function f7_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from t1_tabvar_in_function_ins as t1 join t1_tabvar_in_function_ins as tv on tv.a = t1.a join @tv t on tv.a = t.a 
+    return
+end
+go
+select * from dbo.f7_tabvar_in_function_del(123)
+go
+
+create function f8_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as tv cross join t1_tabvar_in_function_ins as t
+    return
+end
+go
+
+create function f8_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as tv inner join t1_tabvar_in_function_ins as t on tv.a = t.a
+    return
+end
+go
+
+create function f9_tabvar_in_function_upd(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update t set a = t.a + 1 from @tv as t1 full outer join t1_tabvar_in_function_ins as tv on tv.a = t1.a cross join t1_tabvar_in_function_ins t
+    return
+end
+go
+
+create function f9_tabvar_in_function_del(@p1 int)
+returns @tv table(a int)
+as
+begin
+    insert @tv values(@p1)
+    update @tv set a = a + 1
+    insert @tv values(@p1)
+    delete t from @tv as t1 right join t1_tabvar_in_function_ins as tv on tv.a = t1.a full outer join t1_tabvar_in_function_ins t on tv.a = t.a 
+    return
+end
+go


### PR DESCRIPTION
### Description

Additional tests and test cases for detecting allowed UPDATE/DELETE on a table variables inside a T-SQL function, for cases where the FROM-clause contains an ANSI join. 

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-5357 Table variable UPDATE/DELETE in function is incorrectly rejected with multi-table FROM-clause

### Test Scenarios Covered ###
- Use case based - Yes

- Boundary conditions - N/A

- Arbitrary inputs - N/A

- Negative test cases - Yes

- Minor version upgrade tests - N/A

- Major version upgrade tests - N/A

- Performance tests - N/A

- Tooling impact - N/A

- Client tests - N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).