### PR TITLE
Changing time difference for non daylight saving period in getdate test file.

### DIFF
--- a/test/JDBC/expected/getdate-vu-prepare.out
+++ b/test/JDBC/expected/getdate-vu-prepare.out
@@ -138,6 +138,7 @@ AS
     WHERE min_getdate = sys.getutcdate()
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeDiff
 AS
 BEGIN
@@ -146,13 +147,14 @@ BEGIN
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeOffsetDiff
 AS
 BEGIN
@@ -161,13 +163,14 @@ BEGIN
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetDateDiff
 AS
 BEGIN
@@ -176,13 +179,14 @@ BEGIN
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetCurrTimestampDiff
 AS
 BEGIN
@@ -191,7 +195,7 @@ BEGIN
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
@@ -213,13 +217,14 @@ GO
 CREATE TABLE datetimediffTable(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
 DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
 SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'US/Pacific', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
 GO
 ~~START~~
 text
@@ -276,6 +281,7 @@ GO
 CREATE TABLE trgdatetimediffTestTab(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 
 CREATE TRIGGER trgdatetimediff
 ON datetimediffTable
 AFTER INSERT
@@ -287,6 +293,6 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
 END;
 GO

--- a/test/JDBC/expected/getdate-vu-prepare.out
+++ b/test/JDBC/expected/getdate-vu-prepare.out
@@ -138,64 +138,60 @@ AS
     WHERE min_getdate = sys.getutcdate()
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeDiff
 AS
 BEGIN
     DECLARE @x datetime2 = SYSDATETIME();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeOffsetDiff
 AS
 BEGIN
     DECLARE @x datetime2 = sysdatetimeoffset();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetDateDiff
 AS
 BEGIN
     DECLARE @x datetime2 = getdate();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetCurrTimestampDiff
 AS
 BEGIN
     DECLARE @x datetime2 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -217,18 +213,17 @@ GO
 CREATE TABLE datetimediffTable(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
 DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
 SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 GO
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -290,9 +285,9 @@ BEGIN
     DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
     DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
     SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 END;
 GO

--- a/test/JDBC/expected/getdate-vu-prepare.out
+++ b/test/JDBC/expected/getdate-vu-prepare.out
@@ -276,7 +276,6 @@ GO
 CREATE TABLE trgdatetimediffTestTab(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 
 CREATE TRIGGER trgdatetimediff
 ON datetimediffTable
 AFTER INSERT

--- a/test/JDBC/expected/getdate-vu-verify.out
+++ b/test/JDBC/expected/getdate-vu-verify.out
@@ -79,20 +79,19 @@ int
 
 
 -- all the tests have datetime difference spillover correction to avoid flakiness.
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = sysdatetime()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -107,18 +106,18 @@ int
 
 
 declare @x datetime2 = sysdatetimeoffset()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -133,18 +132,18 @@ int
 
 
 declare @x datetime2 = getdate()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -159,18 +158,18 @@ int
 
 
 declare @x datetime2 = CURRENT_TIMESTAMP
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -184,7 +183,7 @@ int
 ~~END~~
 
 
-declare @x datetime2 = sysdatetime() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetime() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetime() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -198,10 +197,10 @@ int
 ~~END~~
 
 
-declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = -480 or @diff = -481
+IF @diff = 330 or @diff = 329
     SELECT 1;
 ELSE
     SELECT 0;
@@ -212,7 +211,7 @@ int
 ~~END~~
 
 
-declare @x datetime2 = getdate() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = getdate() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = getdate() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -226,7 +225,7 @@ int
 ~~END~~
 
 
-declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -244,7 +243,7 @@ EXEC dbo.GetSysDatetimeDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -262,7 +261,7 @@ EXEC dbo.GetSysDatetimeOffsetDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -280,7 +279,7 @@ EXEC dbo.GetDateDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -298,7 +297,7 @@ EXEC dbo.GetCurrTimestampDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -320,15 +319,14 @@ int#!#int#!#int#!#int
 ~~END~~
 
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = SYSDATETIME();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -343,13 +341,13 @@ UTC
 
 
 declare @x datetime2 = sysdatetimeoffset();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -364,13 +362,13 @@ UTC
 
 
 declare @x datetime2 = getdate();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetDateDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -385,13 +383,13 @@ UTC
 
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetCurrTimestampDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -409,7 +407,7 @@ INSERT INTO datetimediffTable values (0, 0, 0, 0)
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/getdate-vu-verify.out
+++ b/test/JDBC/expected/getdate-vu-verify.out
@@ -79,12 +79,13 @@ int
 
 
 -- all the tests have datetime difference spillover correction to avoid flakiness.
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = sysdatetime()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -110,7 +111,7 @@ select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -136,7 +137,7 @@ select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -162,7 +163,7 @@ select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -200,7 +201,7 @@ int
 declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = -420 or @diff = -421
+IF @diff = -480 or @diff = -481
     SELECT 1;
 ELSE
     SELECT 0;
@@ -319,9 +320,10 @@ int#!#int#!#int#!#int
 ~~END~~
 
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = SYSDATETIME();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x, -420, 1)
+select dbo.GetSysDatetimeDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -342,7 +344,7 @@ UTC
 
 declare @x datetime2 = sysdatetimeoffset();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x, -420, 1)
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -363,7 +365,7 @@ UTC
 
 declare @x datetime2 = getdate();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x, -420, 1)
+select dbo.GetDateDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
@@ -384,7 +386,7 @@ UTC
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x, -420, 1)
+select dbo.GetCurrTimestampDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~

--- a/test/JDBC/input/getdate-vu-prepare.sql
+++ b/test/JDBC/input/getdate-vu-prepare.sql
@@ -264,7 +264,6 @@ GO
 CREATE TABLE trgdatetimediffTestTab(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 
 CREATE TRIGGER trgdatetimediff
 ON datetimediffTable
 AFTER INSERT

--- a/test/JDBC/input/getdate-vu-prepare.sql
+++ b/test/JDBC/input/getdate-vu-prepare.sql
@@ -138,6 +138,7 @@ AS
     WHERE min_getdate = sys.getutcdate()
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeDiff
 AS
 BEGIN
@@ -146,13 +147,14 @@ BEGIN
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeOffsetDiff
 AS
 BEGIN
@@ -161,13 +163,14 @@ BEGIN
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetDateDiff
 AS
 BEGIN
@@ -176,13 +179,14 @@ BEGIN
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetCurrTimestampDiff
 AS
 BEGIN
@@ -191,7 +195,7 @@ BEGIN
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = 480 or @diff = 479
         SELECT 1;
     ELSE
         SELECT 0;
@@ -213,13 +217,14 @@ GO
 CREATE TABLE datetimediffTable(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
 DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
 SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'US/Pacific', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
 GO
 
 CREATE VIEW dbo.datetimediffView AS SELECT * FROM datetimediffTable;
@@ -264,6 +269,7 @@ GO
 CREATE TABLE trgdatetimediffTestTab(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 
 CREATE TRIGGER trgdatetimediff
 ON datetimediffTable
 AFTER INSERT
@@ -275,6 +281,6 @@ BEGIN
     select set_config('timezone', 'US/Pacific', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
 END;
 GO

--- a/test/JDBC/input/getdate-vu-prepare.sql
+++ b/test/JDBC/input/getdate-vu-prepare.sql
@@ -138,64 +138,60 @@ AS
     WHERE min_getdate = sys.getutcdate()
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeDiff
 AS
 BEGIN
     DECLARE @x datetime2 = SYSDATETIME();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetSysDatetimeOffsetDiff
 AS
 BEGIN
     DECLARE @x datetime2 = sysdatetimeoffset();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetDateDiff
 AS
 BEGIN
     DECLARE @x datetime2 = getdate();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
 END;
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 CREATE PROCEDURE dbo.GetCurrTimestampDiff
 AS
 BEGIN
     DECLARE @x datetime2 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 480 or @diff = 479
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -217,14 +213,13 @@ GO
 CREATE TABLE datetimediffTable(sysdatetime int, sysdatetimeoffset int, getdate int, currtimestamp int)
 GO
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
 DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
 SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 GO
 
 CREATE VIEW dbo.datetimediffView AS SELECT * FROM datetimediffTable;
@@ -278,9 +273,9 @@ BEGIN
     DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
     DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
     SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 480, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 480, -1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 END;
 GO

--- a/test/JDBC/input/getdate-vu-verify.mix
+++ b/test/JDBC/input/getdate-vu-verify.mix
@@ -29,12 +29,13 @@ select * from getutcdate_dep_view
 go
 
 -- all the tests have datetime difference spillover correction to avoid flakiness.
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = sysdatetime()
 select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -45,7 +46,7 @@ select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -56,7 +57,7 @@ select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -67,7 +68,7 @@ select set_config('timezone', 'US/Pacific', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = 480 or @diff = 479
     SELECT 1;
 ELSE
     SELECT 0;
@@ -85,7 +86,7 @@ go
 declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = -420 or @diff = -421
+IF @diff = -480 or @diff = -481
     SELECT 1;
 ELSE
     SELECT 0;
@@ -124,27 +125,28 @@ go
 SELECT * from dbo.datetimediffView;
 go
 
+-- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = SYSDATETIME();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x, -420, 1)
+select dbo.GetSysDatetimeDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = sysdatetimeoffset();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x, -420, 1)
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = getdate();
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x, -420, 1)
+select dbo.GetDateDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x, -420, 1)
+select dbo.GetCurrTimestampDiffFunc(@x, -480, 1)
 select set_config('timezone', 'UTC', false);
 go
 

--- a/test/JDBC/input/getdate-vu-verify.mix
+++ b/test/JDBC/input/getdate-vu-verify.mix
@@ -29,52 +29,51 @@ select * from getutcdate_dep_view
 go
 
 -- all the tests have datetime difference spillover correction to avoid flakiness.
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = sysdatetime()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
 declare @x datetime2 = sysdatetimeoffset()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
 declare @x datetime2 = getdate()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 480 or @diff = 479
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = sysdatetime() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetime() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetime() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -83,16 +82,16 @@ ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = -480 or @diff = -481
+IF @diff = 330 or @diff = 329
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = getdate() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = getdate() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = getdate() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -101,7 +100,7 @@ ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -125,28 +124,27 @@ go
 SELECT * from dbo.datetimediffView;
 go
 
--- For daylight saving period DIFF will be 420, For non daylight saving period DIFF will be 480
 declare @x datetime2 = SYSDATETIME();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = sysdatetimeoffset();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = getdate();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetDateDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x, -480, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetCurrTimestampDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 


### PR DESCRIPTION
### Description

As daylight saving period ends Minute difference between 'UTC' and 'US/Pacific' is changed from 420 to 480. So changed the time zone from 'US/Pacific' to 'Asia/Kolkata' making it independent from daylight saving period.


### Issues Resolved

getdate tests were failing because of this issue.

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).