### PR TITLE
use PG_CATALOG.RIGHT in upgrade scripts to mVU issues

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -844,7 +844,7 @@ GRANT SELECT ON information_schema_tsql.key_column_usage TO PUBLIC;
  */
 CREATE OR REPLACE VIEW information_schema_tsql.schemata AS
 	SELECT CAST(sys.db_name() AS sys.sysname) AS "CATALOG_NAME",
-	CAST(CASE WHEN np.nspname LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN RIGHT(np.nspname, LENGTH(np.nspname) - LENGTH(sys.db_name()) - 1)
+	CAST(CASE WHEN np.nspname LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN PG_CATALOG.RIGHT(np.nspname, LENGTH(np.nspname) - LENGTH(sys.db_name()) - 1)
 	     ELSE np.nspname END AS sys.nvarchar(128)) AS "SCHEMA_NAME",
 	-- For system-defined schemas, schema-owner name will be same as schema_name
 	-- For user-defined schemas having default owner, schema-owner will be dbo
@@ -852,8 +852,8 @@ CREATE OR REPLACE VIEW information_schema_tsql.schemata AS
 	-- by owner name, so need to extract the owner name from rolname always.
 	CAST(CASE WHEN sys.bbf_is_shared_schema(np.nspname) = TRUE THEN np.nspname
 		  WHEN r.rolname LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN
-			CASE WHEN RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) = 'db_owner' THEN 'dbo'
-			     ELSE RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) END ELSE 'dbo' END
+			CASE WHEN PG_CATALOG.RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) = 'db_owner' THEN 'dbo'
+			     ELSE PG_CATALOG.RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) END ELSE 'dbo' END
 			AS sys.nvarchar(128)) AS "SCHEMA_OWNER",
 	CAST(null AS sys.varchar(6)) AS "DEFAULT_CHARACTER_SET_CATALOG",
 	CAST(null AS sys.varchar(3)) AS "DEFAULT_CHARACTER_SET_SCHEMA",

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
@@ -5803,7 +5803,7 @@ GRANT EXECUTE ON PROCEDURE sys.sp_procedure_params_100_managed TO PUBLIC;
 
 CREATE OR REPLACE VIEW information_schema_tsql.schemata AS
 	SELECT CAST(sys.db_name() AS sys.sysname) AS "CATALOG_NAME",
-	CAST(CASE WHEN np.nspname LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN RIGHT(np.nspname, LENGTH(np.nspname) - LENGTH(sys.db_name()) - 1)
+	CAST(CASE WHEN np.nspname LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN PG_CATALOG.RIGHT(np.nspname, LENGTH(np.nspname) - LENGTH(sys.db_name()) - 1)
 	     ELSE np.nspname END AS sys.nvarchar(128)) AS "SCHEMA_NAME",
 	-- For system-defined schemas, schema-owner name will be same as schema_name
 	-- For user-defined schemas having default owner, schema-owner will be dbo
@@ -5811,8 +5811,8 @@ CREATE OR REPLACE VIEW information_schema_tsql.schemata AS
 	-- by owner name, so need to extract the owner name from rolname always.
 	CAST(CASE WHEN sys.bbf_is_shared_schema(np.nspname) = TRUE THEN np.nspname
 		  WHEN r.rolname LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN
-			CASE WHEN RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) = 'db_owner' THEN 'dbo'
-			     ELSE RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) END ELSE 'dbo' END
+			CASE WHEN PG_CATALOG.RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) = 'db_owner' THEN 'dbo'
+			     ELSE PG_CATALOG.RIGHT(r.rolname, LENGTH(r.rolname) - LENGTH(sys.db_name()) - 1) END ELSE 'dbo' END
 			AS sys.nvarchar(128)) AS "SCHEMA_OWNER",
 	CAST(null AS sys.varchar(6)) AS "DEFAULT_CHARACTER_SET_CATALOG",
 	CAST(null AS sys.varchar(3)) AS "DEFAULT_CHARACTER_SET_SCHEMA",


### PR DESCRIPTION
### Description
use PG_CATALOG.RIGHT in upgrade scripts to fix mVU issues

Signed-off-by: Anikait Agrawal <agraani@amazon.com>

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3078

### Test Scenarios Covered ###
in upgrade script, `SELECT set_config('search_path', 'sys, pg_catalog', false);`

Ran the upgrade script without these changes:
```
dev-dsk-agraani-1c-be0732c3 % sudo ~/postgres/bin/psql -d postgres -U agraani -d jdbc_testdb -f ./contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
   set_config    
-----------------
 sys, pg_catalog
(1 row)

psql:contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql:53: WARNING:  function sys.bbf_pivot() does not exist

psql:contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql:72: WARNING:  could not find a function named "sys.bbf_pivot_deprecated_in_3_8_0"

psql:contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql:5827: ERROR:  CASE/WHEN could not convert type "varchar" to name
LINE 3: ...me LIKE PG_CATALOG.CONCAT(sys.db_name(),'%') THEN RIGHT(np.n...
                                                             ^
```
Ran the upgrade script with these changes:
```
dev-dsk-agraani-1c-be0732c3 % sudo ~/postgres/bin/psql -d postgres -U agraani -d jdbc_testdb -f ./contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql
   set_config    
-----------------
 sys, pg_catalog
(1 row)

psql:contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql:53: WARNING:  function sys.bbf_pivot() does not exist

psql:contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.7.0--3.8.0.sql:72: WARNING:  could not find a function named "sys.bbf_pivot_deprecated_in_3_8_0"
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).