### PR TITLE
Changing time difference for non daylight saving period in getdate test file.

### DIFF
--- a/test/JDBC/expected/getdate-vu-prepare.out
+++ b/test/JDBC/expected/getdate-vu-prepare.out
@@ -142,11 +142,11 @@ CREATE PROCEDURE dbo.GetSysDatetimeDiff
 AS
 BEGIN
     DECLARE @x datetime2 = SYSDATETIME();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -157,11 +157,11 @@ CREATE PROCEDURE dbo.GetSysDatetimeOffsetDiff
 AS
 BEGIN
     DECLARE @x datetime2 = sysdatetimeoffset();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -172,11 +172,11 @@ CREATE PROCEDURE dbo.GetDateDiff
 AS
 BEGIN
     DECLARE @x datetime2 = getdate();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -187,11 +187,11 @@ CREATE PROCEDURE dbo.GetCurrTimestampDiff
 AS
 BEGIN
     DECLARE @x datetime2 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -216,14 +216,14 @@ GO
 DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
 DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
 SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 GO
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -284,9 +284,9 @@ BEGIN
     DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
     DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
     SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 END;
 GO

--- a/test/JDBC/expected/getdate-vu-verify.out
+++ b/test/JDBC/expected/getdate-vu-verify.out
@@ -80,18 +80,18 @@ int
 
 -- all the tests have datetime difference spillover correction to avoid flakiness.
 declare @x datetime2 = sysdatetime()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -106,18 +106,18 @@ int
 
 
 declare @x datetime2 = sysdatetimeoffset()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -132,18 +132,18 @@ int
 
 
 declare @x datetime2 = getdate()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -158,18 +158,18 @@ int
 
 
 declare @x datetime2 = CURRENT_TIMESTAMP
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -183,7 +183,7 @@ int
 ~~END~~
 
 
-declare @x datetime2 = sysdatetime() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetime() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetime() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -197,10 +197,10 @@ int
 ~~END~~
 
 
-declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = -420 or @diff = -421
+IF @diff = 330 or @diff = 329
     SELECT 1;
 ELSE
     SELECT 0;
@@ -211,7 +211,7 @@ int
 ~~END~~
 
 
-declare @x datetime2 = getdate() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = getdate() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = getdate() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -225,7 +225,7 @@ int
 ~~END~~
 
 
-declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -243,7 +243,7 @@ EXEC dbo.GetSysDatetimeDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -261,7 +261,7 @@ EXEC dbo.GetSysDatetimeOffsetDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -279,7 +279,7 @@ EXEC dbo.GetDateDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -297,7 +297,7 @@ EXEC dbo.GetCurrTimestampDiff;
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -320,13 +320,13 @@ int#!#int#!#int#!#int
 
 
 declare @x datetime2 = SYSDATETIME();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -341,13 +341,13 @@ UTC
 
 
 declare @x datetime2 = sysdatetimeoffset();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -362,13 +362,13 @@ UTC
 
 
 declare @x datetime2 = getdate();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetDateDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -383,13 +383,13 @@ UTC
 
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetCurrTimestampDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~
@@ -407,7 +407,7 @@ INSERT INTO datetimediffTable values (0, 0, 0, 0)
 go
 ~~START~~
 text
-US/Pacific
+Asia/Kolkata
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/input/getdate-vu-prepare.sql
+++ b/test/JDBC/input/getdate-vu-prepare.sql
@@ -142,11 +142,11 @@ CREATE PROCEDURE dbo.GetSysDatetimeDiff
 AS
 BEGIN
     DECLARE @x datetime2 = SYSDATETIME();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = SYSDATETIME()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -157,11 +157,11 @@ CREATE PROCEDURE dbo.GetSysDatetimeOffsetDiff
 AS
 BEGIN
     DECLARE @x datetime2 = sysdatetimeoffset();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = sysdatetimeoffset()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -172,11 +172,11 @@ CREATE PROCEDURE dbo.GetDateDiff
 AS
 BEGIN
     DECLARE @x datetime2 = getdate();
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = getdate()
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -187,11 +187,11 @@ CREATE PROCEDURE dbo.GetCurrTimestampDiff
 AS
 BEGIN
     DECLARE @x datetime2 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     DECLARE @y datetime2 = CURRENT_TIMESTAMP
     select set_config('timezone', 'UTC', false);
     DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-    IF @diff = 420 or @diff = 419
+    IF @diff = -330 or @diff = -331
         SELECT 1;
     ELSE
         SELECT 0;
@@ -216,10 +216,10 @@ GO
 DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
 DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
 SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
 select set_config('timezone', 'UTC', false);
-INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+INSERT INTO datetimediffTable values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 GO
 
 CREATE VIEW dbo.datetimediffView AS SELECT * FROM datetimediffTable;
@@ -272,9 +272,9 @@ BEGIN
     DECLARE @sysdatetime1 datetime2, @sysdatetimeoffset1 datetime2, @getdate1 datetime2, @currtimestamp1 datetime2;
     DECLARE @sysdatetime2 datetime2, @sysdatetimeoffset2 datetime2, @getdate2 datetime2, @currtimestamp2 datetime2;
     SELECT @sysdatetime1 = SYSDATETIME(), @sysdatetimeoffset1 = sysdatetimeoffset(), @getdate1 = getdate(), @currtimestamp1 = CURRENT_TIMESTAMP;
-    select set_config('timezone', 'US/Pacific', false);
+    select set_config('timezone', 'Asia/Kolkata', false);
     SELECT @sysdatetime2 = SYSDATETIME(), @sysdatetimeoffset2 = sysdatetimeoffset(), @getdate2 = getdate(), @currtimestamp2 = CURRENT_TIMESTAMP;
     select set_config('timezone', 'UTC', false);
-    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), 420, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), 420, -1))
+    INSERT INTO trgdatetimediffTestTab values (dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetime2, @sysdatetime1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @sysdatetimeoffset2, @sysdatetimeoffset1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @getdate2, @getdate1), -330, -1), dbo.checkDatetimeDiff(DATEDIFF(MINUTE, @currtimestamp2, @currtimestamp1), -330, -1))
 END;
 GO

--- a/test/JDBC/input/getdate-vu-verify.mix
+++ b/test/JDBC/input/getdate-vu-verify.mix
@@ -30,50 +30,50 @@ go
 
 -- all the tests have datetime difference spillover correction to avoid flakiness.
 declare @x datetime2 = sysdatetime()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetime()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
 declare @x datetime2 = sysdatetimeoffset()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = sysdatetimeoffset()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
 declare @x datetime2 = getdate()
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = getdate()
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP
-select set_config('timezone', 'US/Pacific', false);
+select set_config('timezone', 'Asia/Kolkata', false);
 declare @y datetime2 = CURRENT_TIMESTAMP
 select set_config('timezone', 'UTC', false);
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = 420 or @diff = 419
+IF @diff = -330 or @diff = -331
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = sysdatetime() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetime() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetime() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -82,16 +82,16 @@ ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = sysdatetimeoffset() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = sysdatetimeoffset() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
-IF @diff = -420 or @diff = -421
+IF @diff = 330 or @diff = 329
     SELECT 1;
 ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = getdate() AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = getdate() AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = getdate() AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -100,7 +100,7 @@ ELSE
     SELECT 0;
 go
 
-declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'Pacific Standard Time'
+declare @x datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'India Standard Time'
 declare @y datetime2 = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 DECLARE @diff int = DATEDIFF(MINUTE, @y, @x);
 IF @diff = 0 or @diff = -1
@@ -125,26 +125,26 @@ SELECT * from dbo.datetimediffView;
 go
 
 declare @x datetime2 = SYSDATETIME();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = sysdatetimeoffset();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetSysDatetimeOffsetDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetSysDatetimeOffsetDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = getdate();
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetDateDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetDateDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 
 declare @x datetime2 = CURRENT_TIMESTAMP;
-select set_config('timezone', 'US/Pacific', false);
-select dbo.GetCurrTimestampDiffFunc(@x, -420, 1)
+select set_config('timezone', 'Asia/Kolkata', false);
+select dbo.GetCurrTimestampDiffFunc(@x, 330, 1)
 select set_config('timezone', 'UTC', false);
 go
 


### PR DESCRIPTION
### Description

As daylight saving period ends Minute difference between 'UTC' and 'US/Pacific' is changed from 420 to 480. So changed the time zone from 'US/Pacific' to 'Asia/Kolkata' making it independent from daylight saving period.


### Issues Resolved

getdate tests were failing because of this issue.

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).