### PR TITLE
Fix Individual AD crash in TdsSetDbContext

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1614,6 +1614,9 @@ CheckGSSAuth(Port *port)
 	oldContext = MemoryContextSwitchTo(TopMemoryContext);
 	pfree(port->user_name);
 	port->user_name = convertUsernameToCanonicalform(gbuf.value);
+
+	/* Assign canonical form username to loginInfo->username. */
+	loginInfo->username = pstrdup(port->user_name);
 	if ((at_pos = strchr(gbuf.value, '@')) != NULL && loginInfo)
 	{
 		/* skip '@' */


### PR DESCRIPTION
### Description
Earlier we were not assigning value for loginInfo->username in case of AD session.

This commit assigns value for loginInfo->username when GSS enabled.

### Issues Resolved

BABEL-5380

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).