### PR TITLE
Login with mapped user should not use guest user privilege…

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
@@ -11,6 +11,15 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
  * final behaviour.
  */
 
+-- This is a temporary procedure which is only meant to be called during upgrade
+CREATE OR REPLACE PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'revoke_guest_from_mapped_logins';
+
+CALL sys.babelfish_revoke_guest_from_mapped_logins();
+
+-- Drop this procedure after it gets executed once.
+DROP PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins();
 
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -897,10 +897,10 @@ get_authid_user_ext_physical_name(const char *db_name, const char *login)
 {
 	Relation	bbf_authid_user_ext_rel;
 	HeapTuple	tuple_user_ext;
-	ScanKeyData key[3];
 	TableScanDesc scan;
 	char	   *user_name = NULL;
 	NameData   *login_name;
+	ScanKeyData key[2];
 
 	if (!db_name || !login)
 		return NULL;
@@ -910,20 +910,16 @@ get_authid_user_ext_physical_name(const char *db_name, const char *login)
 
 	login_name = (NameData *) palloc0(NAMEDATALEN);
 	snprintf(login_name->data, NAMEDATALEN, "%s", login);
-	ScanKeyInit(&key[0],
-				Anum_bbf_authid_user_ext_login_name,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				NameGetDatum(login_name));
-	ScanKeyInit(&key[1],
-				Anum_bbf_authid_user_ext_database_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
-				CStringGetTextDatum(db_name));
-	ScanKeyInit(&key[2],
-				Anum_bbf_authid_user_ext_user_can_connect,
-				BTEqualStrategyNumber, F_INT4EQ,
-				Int32GetDatum(1));
 
-	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 3, key);
+	ScanKeyInit(&key[0],
+			Anum_bbf_authid_user_ext_login_name,
+			BTEqualStrategyNumber, F_NAMEEQ,
+			NameGetDatum(login_name));
+	ScanKeyInit(&key[1],
+			Anum_bbf_authid_user_ext_database_name,
+			BTEqualStrategyNumber, F_TEXTEQ,
+			CStringGetTextDatum(db_name));
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
 
 	tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
 	if (HeapTupleIsValid(tuple_user_ext))
@@ -1028,6 +1024,28 @@ get_authid_user_ext_db_users(const char *db_name)
 	return db_users_list;
 }
 
+/* Checks if the user is enabled on a given database. */
+static bool
+user_has_dbaccess(const char *user)
+{
+	HeapTuple	tuple;
+	bool		has_access = false;
+	tuple = SearchSysCache1(AUTHIDUSEREXTROLENAME, CStringGetDatum(user));
+
+	if (HeapTupleIsValid(tuple))
+	{
+		bool	isnull = true;
+		int	user_can_connect = 0;
+		Datum	datum = SysCacheGetAttr(AUTHIDUSEREXTROLENAME, tuple, Anum_bbf_authid_user_ext_user_can_connect, &isnull);
+		Assert(!isnull);
+		user_can_connect = DatumGetInt32(datum);
+		if (user_can_connect == 1)
+			has_access = true;
+		ReleaseSysCache(tuple);
+	}
+	return has_access;
+}
+
 /*
  * Checks if there exists any user for respective database and login,
  * if there is not any then use dbo or guest user.
@@ -1044,6 +1062,9 @@ get_user_for_database(const char *db_name)
 	login = GetUserNameFromId(GetSessionUserId(), false);
 	user = get_authid_user_ext_physical_name(db_name, login);
 	login_is_db_owner = 0 == strncmp(login, get_owner_of_db(db_name), NAMEDATALEN);
+
+	if (user && !user_has_dbaccess(user) && !guest_has_dbaccess((char *) db_name))
+		user = NULL;
 
 	if (!user)
 	{

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3859,10 +3859,10 @@ exec_stmt_change_dbowner(PLtsql_execstate *estate, PLtsql_stmt_change_dbowner *s
 	}
 
 	/* Revoke dbo role from the previous owner */
-	grant_revoke_dbo_to_login(get_owner_of_db(stmt->db_name), stmt->db_name, false);
+	grant_revoke_role_to_login(get_owner_of_db(stmt->db_name), get_dbo_role_name(stmt->db_name), false);
 
 	/* Grant dbo role to the new owner */
-	grant_revoke_dbo_to_login(stmt->new_owner_name, stmt->db_name, true);
+	grant_revoke_role_to_login(stmt->new_owner_name, get_dbo_role_name(stmt->db_name), true);
 	update_db_owner(stmt->new_owner_name, stmt->db_name);
 
 	return PLTSQL_RC_OK;

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -82,6 +82,6 @@ extern bool windows_domain_contains_invalid_chars(char *input);
 extern bool check_windows_logon_length(char *input);
 extern char* get_windows_domain_name(char* input);
 extern bool windows_domain_is_not_supported(char* domain_name);
-extern void grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant);
+extern void grant_revoke_role_to_login(const char* login, const char *role_name, bool is_grant);
 
 #endif

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
@@ -39,6 +39,12 @@ GO
 DROP TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1;
 GO
 
+DROP TABLE babel_cross_db_vu_prepare_t4;
+GO
+
+DROP LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
 DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
 GO
 

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
@@ -263,3 +263,19 @@ GO
 
 GRANT EXECUTE ON FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func to master_babel_cross_db_vu_prepare_u1;
 GO
+
+-- tsql
+USE master;
+GO
+
+CREATE LOGIN babel_cross_db_vu_prepare_l3 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u3 FOR LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_t4 (a INT);
+GO
+
+GRANT SELECT ON babel_cross_db_vu_prepare_t4 TO guest;
+GO

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
@@ -417,6 +417,9 @@ GO
 ALTER LOGIN babel_cross_db_vu_prepare_l2 with password = '12345678';
 GO
 
+ALTER LOGIN babel_cross_db_vu_prepare_l3 with password = '12345678';
+GO
+
 -- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
 USE master;
 GO
@@ -673,8 +676,57 @@ int
 ~~END~~
 
 
+create user user_cannot_connect for login babel_cross_db_vu_prepare_l2;
+go
+
+revoke connect from user_cannot_connect;
+go
+
 GRANT CONNECT TO guest;
 GO
+
+grant select on babel_cross_db_vu_prepare_db1_t1 to guest;
+go
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+select current_user
+go
+~~START~~
+varchar
+user_cannot_connect
+~~END~~
+
+
+select has_dbaccess('my_babel_cross_db_vu_prepare_db1');
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select * from dbo.babel_cross_db_vu_prepare_db1_t1; -- should not use guest privilege
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_db1_t1)~~
+
+
+USE master
+GO
+
+-- tsql
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+revoke select on babel_cross_db_vu_prepare_db1_t1 from guest;
+go
+
+drop user user_cannot_connect;
+go
 
 -- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
 -- cross-db tests for guest user
@@ -711,6 +763,33 @@ int
 4
 5
 6
+~~END~~
+
+
+-- tsql user=babel_cross_db_vu_prepare_l3 password=12345678
+USE master
+GO
+
+-- login babel_cross_db_vu_prepare_l3 has mapped user in master
+-- database so following SELECT should fail.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t4)~~
+
+
+-- tsql
+-- now moreve mapped user from login babel_cross_db_vu_prepare_l3 in master database
+DROP USER babel_cross_db_vu_prepare_u3;
+GO
+
+-- now that login babel_cross_db_vu_prepare_l3 does not have a mapped user in master
+-- database so following SELECT should succeed as guest was granted SELECT privilege.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
+GO
+~~START~~
+int
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-USER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-USER-vu-cleanup.out
@@ -22,5 +22,8 @@ GO
 DROP LOGIN babel_user_vu_prepare_test5
 GO
 
+DROP LOGIN babel_user_vu_prepare_test6
+GO
+
 DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO

--- a/test/JDBC/expected/BABEL-USER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-USER-vu-prepare.out
@@ -13,6 +13,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 CREATE LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
 GO
 

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -239,6 +239,9 @@ babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
 ALTER LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+ALTER LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 -- tsql user=babel_user_vu_prepare_test5 password=abc
 SELECT CURRENT_USER;
 go
@@ -255,6 +258,45 @@ GO
 ~~START~~
 bool
 t
+~~END~~
+
+
+-- tsql
+-- Now map user babel_user_vu_prepare_test3 to a different login babel_user_vu_prepare_test6
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test6;
+GO
+
+-- psql
+-- Login babel_user_vu_prepare_test5 should no longer be a member of user babel_user_vu_prepare_test3
+SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- Login babel_user_vu_prepare_test6 should be a member of user babel_user_vu_prepare_test3
+SELECT pg_has_role('babel_user_vu_prepare_test6', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+-- Again map user babel_user_vu_prepare_test3 to login babel_user_vu_prepare_test5
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
+GO
+
+-- tsql user=babel_user_vu_prepare_test6 password=abc
+-- Login babel_user_vu_prepare_test6 should now be mapped to guest user
+SELECT CURRENT_USER;
+go
+~~START~~
+varchar
+guest
 ~~END~~
 
 
@@ -284,6 +326,7 @@ babel_user_vu_prepare_test2
 babel_user_vu_prepare_test3
 babel_user_vu_prepare_test4
 babel_user_vu_prepare_test5
+babel_user_vu_prepare_test6
 master_babel_user_vu_prepare_aacb2aa14e22b38c44e8614f1eae6949f8
 master_babel_user_vu_prepare_test1_new
 master_babel_user_vu_prepare_test2

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-cleanup.out
@@ -2,7 +2,7 @@
 use grant_connect_db1;
 go
 
-drop user grant_connect_abc
+drop user grant_connect_abc_new
 go
 
 drop table grant_connect_t1;

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-prepare.out
@@ -9,4 +9,3 @@ go
 
 create login grant_connect_abc with password = 'Babel123'
 go
-

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
@@ -92,6 +92,14 @@ go
 use grant_connect_db1;
 go
 
+select has_dbaccess('grant_connect_db1');
+go
+~~START~~
+int
+1
+~~END~~
+
+
 select user_name();
 go
 ~~START~~
@@ -182,6 +190,9 @@ go
 grant connect to grant_connect_abc
 go
 
+ALTER USER grant_connect_abc WITH NAME = grant_connect_abc_new;
+go
+
 -- tsql  user=grant_connect_abc password=Babel123
 -- should succeed because login has a user for grant_connect_db1 and it is enabled
 use grant_connect_db1
@@ -191,7 +202,14 @@ select user_name();
 go
 ~~START~~
 nvarchar
-grant_connect_abc
+grant_connect_abc_new
 ~~END~~
 
+
+select has_dbaccess('grant_connect_db1');
+go
+~~START~~
+int
+1
+~~END~~
 

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-cleanup.mix
@@ -2,7 +2,7 @@
 use grant_connect_db1;
 go
 
-drop user grant_connect_abc
+drop user grant_connect_abc_new
 go
 
 drop table grant_connect_t1;

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-prepare.sql
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-prepare.sql
@@ -9,4 +9,3 @@ go
 
 create login grant_connect_abc with password = 'Babel123'
 go
-

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-verify.mix
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-verify.mix
@@ -64,6 +64,9 @@ go
 use grant_connect_db1;
 go
 
+select has_dbaccess('grant_connect_db1');
+go
+
 select user_name();
 go
 
@@ -128,6 +131,9 @@ go
 grant connect to grant_connect_abc
 go
 
+ALTER USER grant_connect_abc WITH NAME = grant_connect_abc_new;
+go
+
 -- tsql  user=grant_connect_abc password=Babel123
 -- should succeed because login has a user for grant_connect_db1 and it is enabled
 use grant_connect_db1
@@ -136,3 +142,5 @@ go
 select user_name();
 go
 
+select has_dbaccess('grant_connect_db1');
+go

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
@@ -39,6 +39,12 @@ GO
 DROP TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1;
 GO
 
+DROP TABLE babel_cross_db_vu_prepare_t4;
+GO
+
+DROP LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
 DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
 GO
 

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
@@ -259,3 +259,19 @@ GO
 
 GRANT EXECUTE ON FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func to master_babel_cross_db_vu_prepare_u1;
 GO
+
+-- tsql
+USE master;
+GO
+
+CREATE LOGIN babel_cross_db_vu_prepare_l3 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u3 FOR LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_t4 (a INT);
+GO
+
+GRANT SELECT ON babel_cross_db_vu_prepare_t4 TO guest;
+GO

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
@@ -254,6 +254,9 @@ GO
 ALTER LOGIN babel_cross_db_vu_prepare_l2 with password = '12345678';
 GO
 
+ALTER LOGIN babel_cross_db_vu_prepare_l3 with password = '12345678';
+GO
+
 -- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
 USE master;
 GO
@@ -347,8 +350,43 @@ GO
 SELECT * FROM master.dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
 GO
 
+create user user_cannot_connect for login babel_cross_db_vu_prepare_l2;
+go
+
+revoke connect from user_cannot_connect;
+go
+
 GRANT CONNECT TO guest;
 GO
+
+grant select on babel_cross_db_vu_prepare_db1_t1 to guest;
+go
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+select current_user
+go
+
+select has_dbaccess('my_babel_cross_db_vu_prepare_db1');
+go
+
+select * from dbo.babel_cross_db_vu_prepare_db1_t1; -- should not use guest privilege
+go
+
+USE master
+GO
+
+-- tsql
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+revoke select on babel_cross_db_vu_prepare_db1_t1 from guest;
+go
+
+drop user user_cannot_connect;
+go
 
 -- cross-db tests for guest user
 -- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
@@ -372,6 +410,25 @@ USE master
 GO
 
 SELECT * FROM dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l3 password=12345678
+USE master
+GO
+
+-- login babel_cross_db_vu_prepare_l3 has mapped user in master
+-- database so following SELECT should fail.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
+GO
+
+-- now moreve mapped user from login babel_cross_db_vu_prepare_l3 in master database
+-- tsql
+DROP USER babel_cross_db_vu_prepare_u3;
+GO
+
+-- now that login babel_cross_db_vu_prepare_l3 does not have a mapped user in master
+-- database so following SELECT should succeed as guest was granted SELECT privilege.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
 GO
 
 -- tsql

--- a/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
@@ -22,5 +22,8 @@ GO
 DROP LOGIN babel_user_vu_prepare_test5
 GO
 
+DROP LOGIN babel_user_vu_prepare_test6
+GO
+
 DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
@@ -13,6 +13,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 CREATE LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
 GO
 

--- a/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
@@ -102,6 +102,9 @@ GO
 ALTER LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+ALTER LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 -- tsql user=babel_user_vu_prepare_test5 password=abc
 SELECT CURRENT_USER;
 go
@@ -110,6 +113,30 @@ go
 -- psql
 SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
 GO
+
+-- Now map user babel_user_vu_prepare_test3 to a different login babel_user_vu_prepare_test6
+-- tsql
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test6;
+GO
+
+-- Login babel_user_vu_prepare_test5 should no longer be a member of user babel_user_vu_prepare_test3
+-- psql
+SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+
+-- Login babel_user_vu_prepare_test6 should be a member of user babel_user_vu_prepare_test3
+SELECT pg_has_role('babel_user_vu_prepare_test6', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+
+-- Again map user babel_user_vu_prepare_test3 to login babel_user_vu_prepare_test5
+-- tsql
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
+GO
+
+-- Login babel_user_vu_prepare_test6 should now be mapped to guest user
+-- tsql user=babel_user_vu_prepare_test6 password=abc
+SELECT CURRENT_USER;
+go
 
 -- tsql
 -- both of the commands below should fail

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -65,7 +65,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file b
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--3.0.0--3.1.0.sql
-Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--4.4.0--4.5.0.sql
+Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--3.8.0--3.9.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.3.0--3.0.0.sql

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -65,6 +65,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file b
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--3.0.0--3.1.0.sql
+Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--4.4.0--4.5.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.3.0--3.0.0.sql


### PR DESCRIPTION
### Description
Previously, a guest users always remain member of a login even if login has a mapped user in a particular database. Due to this any database user is able to access the objects which are accessible to guest user which is undesirable.

Fixed this issue by only keeping one user member of a login at a time, which means, guest will be a member of login only if there is no mapped user to that login otherwise only that mapped user will be a member of login.

### Issue Resolved
Task: BABEL-5389

Co-authored-by: Rishabh Tanwar <ritanwar@amazon.com>
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).