### PR TITLE
Re-enable forjsonauto-before-16_5

### DIFF
--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -219,7 +219,7 @@ forjson
 forjson-datatypes
 forjson-subquery
 forjson-nesting
-#forjsonauto-before-16_5 TODO: BABEL-5413
+forjsonauto-before-16_5
 format
 format-dep
 forxml


### PR DESCRIPTION
### Description

Re-enable forjsonauto-before-16_5 in PG17 since the fix is merged as a part of https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/e47fa84c0a32a987f30fb9648d7885de88f27a4b 


### Issues Resolved

Task: BABEL-5413
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).