### PR TITLE
Fix syntax error issue while using [primary] column name in DML/DDL statements

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -4831,6 +4831,7 @@ keyword
     | PREDICATE
     | PREDICT
     | PRIMARY_ROLE
+    | PRIMARY_SQBRACKET
     | PRIOR
     | PRIORITY
     | PRIORITY_LEVEL

--- a/test/JDBC/expected/BABEL-5422.out
+++ b/test/JDBC/expected/BABEL-5422.out
@@ -1,0 +1,205 @@
+-- Create tables
+CREATE TABLE babel_5422_table (
+    [primary] INT PRIMARY KEY,
+    Name VARCHAR(50)
+);
+GO
+
+CREATE TABLE babel_5422_table2 (
+    [PRIMARY] INT,
+    Age INT
+);
+GO
+
+CREATE TABLE #babel_5422_table3 (
+    [primary_column] INT,
+    Age INT
+);
+GO
+
+-- Insert sample data
+INSERT INTO babel_5422_table ([primary], Name)
+VALUES (1, 'John'), (2, 'Jane'), (3, 'Bob');
+GO
+~~ROW COUNT: 3~~
+
+
+INSERT INTO babel_5422_table2 ([primary], Age)
+VALUES (1, 25), (3, 30);
+GO
+~~ROW COUNT: 2~~
+
+
+INSERT INTO #babel_5422_table3 ([primary_column], Age)
+VALUES (1, 30), (3, 40);
+GO
+~~ROW COUNT: 2~~
+
+
+-- Aliasing
+SELECT [primary] AS PrimaryKey, Name
+FROM babel_5422_table;
+GO
+~~START~~
+int#!#varchar
+1#!#John
+2#!#Jane
+3#!#Bob
+~~END~~
+
+
+SELECT [primary_column] AS [Primary], Age
+FROM #babel_5422_table3;
+GO
+~~START~~
+int#!#int
+1#!#30
+3#!#40
+~~END~~
+
+
+-- Joining Tables
+SELECT t1.[primary], t1.Name, t2.Age
+FROM babel_5422_table t1
+JOIN babel_5422_table2 t2 ON t1.[primary] = t2.[primary];
+GO
+~~START~~
+int#!#varchar#!#int
+1#!#John#!#25
+3#!#Bob#!#30
+~~END~~
+
+
+-- Aggregation
+SELECT COUNT([primary]) AS TotalRows
+FROM babel_5422_table;
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Ordering
+SELECT *
+FROM babel_5422_table
+ORDER BY [primary] DESC;
+GO
+~~START~~
+int#!#varchar
+3#!#Bob
+2#!#Jane
+1#!#John
+~~END~~
+
+
+-- Checking for Existence
+IF EXISTS (SELECT 1 FROM babel_5422_table WHERE [primary] = 3)
+    PRINT 'Row with [primary] = 3 exists';
+ELSE
+    PRINT 'Row with [primary] = 3 does not exist';
+GO
+
+-- Using in a CASE Statement
+SELECT [primary],
+    CASE
+        WHEN [primary] = 1 THEN 'One'
+        WHEN [primary] = 2 THEN 'Two'
+        ELSE 'Other'
+    END AS PrimaryDescription
+FROM babel_5422_table;
+GO
+~~START~~
+int#!#varchar
+1#!#One
+2#!#Two
+3#!#Other
+~~END~~
+
+
+-- Using in a Subquery
+SELECT Name
+FROM babel_5422_table
+WHERE [primary] IN (SELECT [primary] FROM babel_5422_table2);
+GO
+~~START~~
+varchar
+John
+Bob
+~~END~~
+
+
+-- Using in a View
+CREATE VIEW babel_5422_view
+AS
+SELECT [primary], Name
+FROM babel_5422_table;
+GO
+
+SELECT * FROM babel_5422_view;
+GO
+~~START~~
+int#!#varchar
+1#!#John
+2#!#Jane
+3#!#Bob
+~~END~~
+
+
+-- Using in a Stored Procedure
+CREATE PROCEDURE babel_5422_proc
+    @PrimaryKey INT
+AS
+BEGIN
+    SELECT [primary], Name
+    FROM babel_5422_table
+    WHERE [primary] = @PrimaryKey;
+END
+GO
+
+EXEC babel_5422_proc 2;
+GO
+~~START~~
+int#!#varchar
+2#!#Jane
+~~END~~
+
+
+-- Using in a User-Defined Function
+CREATE FUNCTION babel_5422_func
+    (@PrimaryKey INT)
+RETURNS TABLE
+AS
+RETURN(
+    SELECT [primary], Name
+    FROM babel_5422_table
+    WHERE [primary] = @PrimaryKey
+)
+GO
+
+SELECT babel_5422_func(3);
+GO
+~~START~~
+varchar
+(3,Bob)
+~~END~~
+
+
+-- Cleanup
+DROP FUNCTION babel_5422_func;
+GO
+
+DROP PROCEDURE babel_5422_proc;
+GO
+
+DROP VIEW babel_5422_view;
+GO
+
+DROP TABLE #babel_5422_table3
+GO
+
+DROP TABLE babel_5422_table2;
+GO
+
+DROP TABLE babel_5422_table;
+GO

--- a/test/JDBC/input/BABEL-5422.sql
+++ b/test/JDBC/input/BABEL-5422.sql
@@ -1,0 +1,138 @@
+-- Create tables
+CREATE TABLE babel_5422_table (
+    [primary] INT PRIMARY KEY,
+    Name VARCHAR(50)
+);
+GO
+
+CREATE TABLE babel_5422_table2 (
+    [PRIMARY] INT,
+    Age INT
+);
+GO
+
+CREATE TABLE #babel_5422_table3 (
+    [primary_column] INT,
+    Age INT
+);
+GO
+
+-- Insert sample data
+INSERT INTO babel_5422_table ([primary], Name)
+VALUES (1, 'John'), (2, 'Jane'), (3, 'Bob');
+GO
+
+INSERT INTO babel_5422_table2 ([primary], Age)
+VALUES (1, 25), (3, 30);
+GO
+
+INSERT INTO #babel_5422_table3 ([primary_column], Age)
+VALUES (1, 30), (3, 40);
+GO
+
+-- Aliasing
+SELECT [primary] AS PrimaryKey, Name
+FROM babel_5422_table;
+GO
+
+SELECT [primary_column] AS [Primary], Age
+FROM #babel_5422_table3;
+GO
+
+-- Joining Tables
+SELECT t1.[primary], t1.Name, t2.Age
+FROM babel_5422_table t1
+JOIN babel_5422_table2 t2 ON t1.[primary] = t2.[primary];
+GO
+
+-- Aggregation
+SELECT COUNT([primary]) AS TotalRows
+FROM babel_5422_table;
+GO
+
+-- Ordering
+SELECT *
+FROM babel_5422_table
+ORDER BY [primary] DESC;
+GO
+
+-- Checking for Existence
+IF EXISTS (SELECT 1 FROM babel_5422_table WHERE [primary] = 3)
+    PRINT 'Row with [primary] = 3 exists';
+ELSE
+    PRINT 'Row with [primary] = 3 does not exist';
+GO
+
+-- Using in a CASE Statement
+SELECT [primary],
+    CASE
+        WHEN [primary] = 1 THEN 'One'
+        WHEN [primary] = 2 THEN 'Two'
+        ELSE 'Other'
+    END AS PrimaryDescription
+FROM babel_5422_table;
+GO
+
+-- Using in a Subquery
+SELECT Name
+FROM babel_5422_table
+WHERE [primary] IN (SELECT [primary] FROM babel_5422_table2);
+GO
+
+-- Using in a View
+CREATE VIEW babel_5422_view
+AS
+SELECT [primary], Name
+FROM babel_5422_table;
+GO
+
+SELECT * FROM babel_5422_view;
+GO
+
+-- Using in a Stored Procedure
+CREATE PROCEDURE babel_5422_proc
+    @PrimaryKey INT
+AS
+BEGIN
+    SELECT [primary], Name
+    FROM babel_5422_table
+    WHERE [primary] = @PrimaryKey;
+END
+GO
+
+EXEC babel_5422_proc 2;
+GO
+
+-- Using in a User-Defined Function
+CREATE FUNCTION babel_5422_func
+    (@PrimaryKey INT)
+RETURNS TABLE
+AS
+RETURN(
+    SELECT [primary], Name
+    FROM babel_5422_table
+    WHERE [primary] = @PrimaryKey
+)
+GO
+
+SELECT babel_5422_func(3);
+GO
+
+-- Cleanup
+DROP FUNCTION babel_5422_func;
+GO
+
+DROP PROCEDURE babel_5422_proc;
+GO
+
+DROP VIEW babel_5422_view;
+GO
+
+DROP TABLE #babel_5422_table3
+GO
+
+DROP TABLE babel_5422_table2;
+GO
+
+DROP TABLE babel_5422_table;
+GO


### PR DESCRIPTION
### Description
This commit resolves the syntax error issue that occurs when using '[primary]' as a column name in DML and DDL statements.


Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Issues Resolved

Task: BABEL-5422
Issue: https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/3127

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).