### PR TITLE
Update tap-tests and dump/restore github actions

### DIFF
--- a/.github/configuration/dump-restore-test-configuration.yml
+++ b/.github/configuration/dump-restore-test-configuration.yml
@@ -94,37 +94,4 @@ dump-restore-version: [[
     type: schema-cum-data-only
   }
 ]
-# TODO: 
-# [
-#   {
-#     version: 15.5,
-#     dump-data-as: copy,
-#     dump-format: tar,
-#     database-level: true,
-#     type: full
-#   },
-#   {
-#     version: 15.5,
-#     dump-data-as: copy,
-#     dump-format: tar,
-#     database-level: true,
-#     type: full
-#   }
-# ],
-# [
-#   {
-#     version: 16.1,
-#     dump-data-as: inserts,
-#     dump-format: custom,
-#     database-level: true,
-#     type: full
-#   },
-#   {
-#     version: 16.1,
-#     dump-data-as: inserts,
-#     dump-format: custom,
-#     database-level: true,
-#     type: full
-#   }
-# ]
 ]

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -8,6 +8,8 @@ jobs:
       NEW_INSTALL_DIR: psql_target
       ENGINE_BRANCH_OLD: BABEL_2_6_STABLE__PG_14_9
       EXTENSION_BRANCH_OLD: BABEL_2_6_STABLE
+      INSTALL_DIR_16: psql16
+      ENGINE_BRANCH_16: BABEL_4_X_DEV__PG_16_X
 
     runs-on: ubuntu-20.04
     steps:
@@ -44,54 +46,24 @@ jobs:
           engine_branch: ${{env.ENGINE_BRANCH_OLD}}
           install_dir: ${{env.OLD_INSTALL_DIR}}
 
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_16}}
+        id: build-modified-postgres-16
+        if: always() && steps.build-modified-postgres-old.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_BRANCH_16}}
+          install_dir: ${{env.INSTALL_DIR_16}}
+
       - name: Compile ANTLR
         id: compile-antlr
-        if: always() && steps.build-modified-postgres-old.outcome == 'success'
+        if: always() && steps.build-modified-postgres-16.outcome == 'success'
         uses: ./.github/composite-actions/compile-antlr
         with:
           install_dir: ${{env.OLD_INSTALL_DIR}}
 
-      - name: Build PostGIS Extension using ${{env.EXTENSION_BRANCH_OLD}}
-        id: build-postgis-extension-old
-        if: always() && steps.compile-antlr.outcome == 'success'
-        run: |
-          cd ..
-          export CC='ccache gcc'
-          export CMAKE_C_COMPILER_LAUNCHER=ccache
-          export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
-          sudo apt-get install wget
-          max_retries=20
-          retries=0
-          until [ $retries -ge $max_retries ]
-          do
-            wget http://postgis.net/stuff/postgis-3.5.0.tar.gz && break
-            retries=$((retries+1))
-          done
-          tar -xvzf postgis-3.5.0.tar.gz
-          retries1=0
-          until [ $retries1 -ge $max_retries ]
-          do
-            wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
-            retries1=$((retries1+1))
-          done
-          tar -xvzf proj-9.2.1.tar.gz
-          cd proj-9.2.1
-          if [ ! -d "build" ]; then
-            mkdir build
-          fi
-          cd build
-          cmake -DCMAKE_INSTALL_LIBDIR="lib/x86_64-linux-gnu" -DCMAKE_INSTALL_PREFIX="/usr" ..
-          cmake --build .
-          sudo cmake --build . --target install
-          cd ../../postgis-3.5.0
-          ./configure --without-protobuf --without-raster --with-pgconfig=$HOME/psql_source/bin/pg_config
-          make USE_PGXS=1 PG_CONFIG=~/psql_source/bin/pg_config
-          sudo make USE_PGXS=1 PG_CONFIG=~/psql_source/bin/pg_config install
-        shell: bash
-
       - name: Build Extensions using ${{env.EXTENSION_BRANCH_OLD}}
         id: build-extensions-old
-        if: always() && steps.build-postgis-extension-old.outcome == 'success'
+        if: always() && steps.compile-antlr.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions
         with:
           install_dir: ${{env.OLD_INSTALL_DIR}}
@@ -132,9 +104,10 @@ jobs:
           export PG_CONFIG=~/${{env.NEW_INSTALL_DIR}}/bin/pg_config
           export PATH=/opt/mssql-tools/bin:$PATH
           export oldinstall=$HOME/${{env.OLD_INSTALL_DIR}}
+          export installdir16=$HOME/${{env.INSTALL_DIR_16}}
 
           cd contrib/babelfishpg_tds
-          make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/002_tdskerberos.pl t/003_bbfextnotloaded.pl"
+          make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/002_tdskerberos.pl t/003_bbfextnotloaded.pl t/004_bbfdumprestore.pl"
 
       - name: Upload Logs
         if: always() && steps.tap.outcome == 'failure'

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -38,32 +38,70 @@ jobs:
           sudo -E apt-get install krb5-admin-server krb5-kdc krb5-user libkrb5-dev -y -qq
         shell: bash
 
-      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_OLD}}
-        id: build-modified-postgres-old
-        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
-        uses: ./.github/composite-actions/build-modified-postgres
-        with:
-          engine_branch: ${{env.ENGINE_BRANCH_OLD}}
-          install_dir: ${{env.OLD_INSTALL_DIR}}
-
       - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_16}}
         id: build-modified-postgres-16
-        if: always() && steps.build-modified-postgres-old.outcome == 'success'
+        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
         uses: ./.github/composite-actions/build-modified-postgres
         with:
           engine_branch: ${{env.ENGINE_BRANCH_16}}
           install_dir: ${{env.INSTALL_DIR_16}}
 
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_OLD}}
+        id: build-modified-postgres-old
+        if: always() && steps.build-modified-postgres-16.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_BRANCH_OLD}}
+          install_dir: ${{env.OLD_INSTALL_DIR}}
+
       - name: Compile ANTLR
         id: compile-antlr
-        if: always() && steps.build-modified-postgres-16.outcome == 'success'
+        if: always() && steps.build-modified-postgres-old.outcome == 'success'
         uses: ./.github/composite-actions/compile-antlr
         with:
           install_dir: ${{env.OLD_INSTALL_DIR}}
 
+      - name: Build PostGIS Extension using ${{env.EXTENSION_BRANCH_OLD}}
+        id: build-postgis-extension-old
+        if: always() && steps.compile-antlr.outcome == 'success'
+        run: |
+          cd ..
+          export CC='ccache gcc'
+          export CMAKE_C_COMPILER_LAUNCHER=ccache
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache 
+          sudo apt-get install wget
+          max_retries=20
+          retries=0
+          until [ $retries -ge $max_retries ]
+          do
+            wget http://postgis.net/stuff/postgis-3.5.0.tar.gz && break
+            retries=$((retries+1))
+          done
+          tar -xvzf postgis-3.5.0.tar.gz
+          retries1=0
+          until [ $retries1 -ge $max_retries ]
+          do
+            wget https://download.osgeo.org/proj/proj-9.2.1.tar.gz && break
+            retries1=$((retries1+1))
+          done
+          tar -xvzf proj-9.2.1.tar.gz
+          cd proj-9.2.1
+          if [ ! -d "build" ]; then
+            mkdir build
+          fi
+          cd build
+          cmake -DCMAKE_INSTALL_LIBDIR="lib/x86_64-linux-gnu" -DCMAKE_INSTALL_PREFIX="/usr" ..
+          cmake --build .
+          sudo cmake --build . --target install
+          cd ../../postgis-3.5.0
+          ./configure --without-protobuf --without-raster --with-pgconfig=$HOME/psql_source/bin/pg_config
+          make USE_PGXS=1 PG_CONFIG=~/psql_source/bin/pg_config
+          sudo make USE_PGXS=1 PG_CONFIG=~/psql_source/bin/pg_config install
+        shell: bash
+
       - name: Build Extensions using ${{env.EXTENSION_BRANCH_OLD}}
         id: build-extensions-old
-        if: always() && steps.compile-antlr.outcome == 'success'
+        if: always() && steps.build-postgis-extension-old.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions
         with:
           install_dir: ${{env.OLD_INSTALL_DIR}}

--- a/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
+++ b/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
@@ -70,17 +70,21 @@ my $node16 =
   PostgreSQL::Test::Cluster->new('node_16',
 	install_path => $ENV{installdir16});
 
+my $newbindir = $newnode->config_data('--bindir');
+my $oldbindir = $oldnode->config_data('--bindir');
+my $bindir16 = $node16->config_data('--bindir');
+
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 $oldnode->start;
 my @dumpall_command = (
-	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
+	$bindir16 . '/pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $oldnode->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump1_file);
 $node16->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 my @dump_command = (
-	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
+	$bindir16 . '/pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $oldnode->port, '--verbose', '--dbname', 'testdb',
 	'--file', $dump2_file);
 $node16->command_ok(\@dump_command, 'Dump Babelfish database.');
@@ -93,7 +97,7 @@ $newnode->start;
 # dump/restore is not yet supported.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -106,7 +110,7 @@ $newnode->command_fails_like(
 # Similarly, restore of dump file should also cause a failure.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -122,7 +126,7 @@ $oldnode->start;
 
 $oldnode->command_fails_like(
 	[
-		'psql',
+		$oldbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $oldnode->port,
@@ -134,7 +138,7 @@ $oldnode->command_fails_like(
 
 $oldnode->command_fails_like(
 	[
-		'psql',
+		$oldbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $oldnode->port,
@@ -167,14 +171,14 @@ $tsql_newnode2->init_tsql('test_master', 'testdb', 'multi-db');
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 @dumpall_command = (
-	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
+	$newbindir . '/pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $newnode2->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump3_file);
 $newnode2->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump. Let's dump with the custom format
 # this time so that we cover pg_restore as well.
 @dump_command = (
-	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
+	$newbindir . '/pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $newnode2->port, '--verbose', '--dbname', 'testdb',
 	'--format', 'custom', '--file', $dump4_file);
 $newnode2->command_ok(\@dump_command, 'Dump Babelfish database.');
@@ -187,7 +191,7 @@ $newnode->start;
 # dump/restore is not yet supported.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -200,7 +204,7 @@ $newnode->command_fails_like(
 # Similarly, restore of dump file should also cause a failure.
 $newnode->command_fails_like(
 	[
-		'pg_restore',
+		$newbindir . '/pg_restore',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -218,13 +222,13 @@ $newnode->start;
 
 # Dump global objects using pg_dumpall.
 @dumpall_command = (
-	'pg_dumpall', '--database', 'postgres', '--port', $newnode->port,
+	$newbindir . '/pg_dumpall', '--database', 'postgres', '--port', $newnode->port,
 	'--roles-only', '--quote-all-identifiers', '--verbose',
 	'--no-role-passwords', '--file', $dump1_file);
 $newnode->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 @dump_command = (
-	'pg_dump', '--quote-all-identifiers', '--port', $newnode->port,
+	$newbindir . '/pg_dump', '--quote-all-identifiers', '--port', $newnode->port,
 	'--verbose', '--dbname', 'postgres',
 	'--file', $dump2_file);
 $newnode->command_ok(\@dump_command, 'Dump non-Babelfish (postgres db) database.');

--- a/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
+++ b/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
@@ -65,6 +65,11 @@ my $tsql_newnode = new TDSNode($newnode);
 $tsql_newnode->init_tsql('test_master', 'testdb');
 $newnode->stop;
 
+# Setup pg16 node
+my $node16 =
+  PostgreSQL::Test::Cluster->new('node_16',
+	install_path => $ENV{installdir16});
+
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 $oldnode->start;
@@ -72,13 +77,13 @@ my @dumpall_command = (
 	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $oldnode->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump1_file);
-$newnode->command_ok(\@dumpall_command, 'Dump global objects.');
+$node16->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 my @dump_command = (
 	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $oldnode->port, '--verbose', '--dbname', 'testdb',
 	'--file', $dump2_file);
-$newnode->command_ok(\@dump_command, 'Dump Babelfish database.');
+$node16->command_ok(\@dump_command, 'Dump Babelfish database.');
 $oldnode->stop;
 
 # Retore the dumped files on the new server.

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-cleanup.out
@@ -58,7 +58,7 @@ go
 DROP SCHEMA babel_4768_s2
 GO
 
-DROP TABLE babel_4768ログインαιώνια.t1
+DROP TABLE babel_4768ログイαιώνια.t1
 go
 
 
@@ -68,7 +68,7 @@ go
 DROP TABLE [babel_4768유니코드스키마👻].t1
 go
 
-DROP SCHEMA babel_4768ログインαιώνια
+DROP SCHEMA babel_4768ログイαιώνια
 GO
 
 DROP SCHEMA [babel_4768 😎$chem@ #123 🌍rder]

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-prepare.out
@@ -152,7 +152,7 @@ GRANT EXECUTE ON babel_4768_s2.p1 TO babel_4768_u1
 go
 
 -- to test consistency in case of special characters in schema name
-CREATE SCHEMA babel_4768ログインαιώνια
+CREATE SCHEMA babel_4768ログイαιώνια
 GO
 
 CREATE SCHEMA [babel_4768 😎$chem@ #123 🌍rder]
@@ -161,10 +161,10 @@ GO
 CREATE SCHEMA [babel_4768유니코드스키마👻]
 GO
 
-CREATE TABLE babel_4768ログインαιώνια.t1 (a int)
+CREATE TABLE babel_4768ログイαιώνια.t1 (a int)
 go
 
-GRANT SELECT ON  babel_4768ログインαιώνια.t1 TO babel_4768_u1
+GRANT SELECT ON  babel_4768ログイαιώνια.t1 TO babel_4768_u1
 go
 
 CREATE TABLE "babel_4768 😎$chem@ #123 🌍rder".t1 (a int)

--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -181,7 +181,7 @@ go
 REVOKE EXECUTE ON babel_4768_s2.p1 FROM babel_4768_u1
 go
 
-REVOKE SELECT ON babel_4768ログインαιώνια.t1 FROM babel_4768_u1
+REVOKE SELECT ON babel_4768ログイαιώνια.t1 FROM babel_4768_u1
 go
 
 REVOKE SELECT ON "babel_4768 😎$chem@ #123 🌍rder".t1 FROM babel_4768_u1

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-cleanup.mix
@@ -58,7 +58,7 @@ go
 DROP SCHEMA babel_4768_s2
 GO
 
-DROP TABLE babel_4768ログインαιώνια.t1
+DROP TABLE babel_4768ログイαιώνια.t1
 go
 
 
@@ -68,7 +68,7 @@ go
 DROP TABLE [babel_4768유니코드스키마👻].t1
 go
 
-DROP SCHEMA babel_4768ログインαιώνια
+DROP SCHEMA babel_4768ログイαιώνια
 GO
 
 DROP SCHEMA [babel_4768 😎$chem@ #123 🌍rder]

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-prepare.mix
@@ -130,7 +130,7 @@ GRANT EXECUTE ON babel_4768_s2.p1 TO babel_4768_u1
 go
 
 -- to test consistency in case of special characters in schema name
-CREATE SCHEMA babel_4768ログインαιώνια
+CREATE SCHEMA babel_4768ログイαιώνια
 GO
 
 CREATE SCHEMA [babel_4768 😎$chem@ #123 🌍rder]
@@ -139,10 +139,10 @@ GO
 CREATE SCHEMA [babel_4768유니코드스키마👻]
 GO
 
-CREATE TABLE babel_4768ログインαιώνια.t1 (a int)
+CREATE TABLE babel_4768ログイαιώνια.t1 (a int)
 go
 
-GRANT SELECT ON  babel_4768ログインαιώνια.t1 TO babel_4768_u1
+GRANT SELECT ON  babel_4768ログイαιώνια.t1 TO babel_4768_u1
 go
 
 CREATE TABLE "babel_4768 😎$chem@ #123 🌍rder".t1 (a int)

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
@@ -112,7 +112,7 @@ go
 REVOKE EXECUTE ON babel_4768_s2.p1 FROM babel_4768_u1
 go
 
-REVOKE SELECT ON babel_4768ログインαιώνια.t1 FROM babel_4768_u1
+REVOKE SELECT ON babel_4768ログイαιώνια.t1 FROM babel_4768_u1
 go
 
 REVOKE SELECT ON "babel_4768 😎$chem@ #123 🌍rder".t1 FROM babel_4768_u1


### PR DESCRIPTION
### Description
This commit brings the following changes:
* Removed dump/restore tests for older versions since they require
corresponding older dump utility.
* Updated dump/restore tap-tests to use v16 dump utility to dump older versions.
* Updated schema name in GRANT_SCHEMA test so that it doesn't cause crash
during restore.

Task: BABEL-5421
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).