### PR TITLE
[OSS-ONLY] Execute CREATE/GRANT ROLE statements using bbf_role_admin during restore

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -10,6 +10,49 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+-- Update all grants to babelfish users to make bbf_role_admin as grantor.
+DO
+LANGUAGE plpgsql
+$$
+DECLARE
+    temprow RECORD;
+    query TEXT;
+    init_user NAME;
+BEGIN
+    SELECT r.rolname
+    INTO init_user
+    FROM pg_roles r
+    INNER JOIN pg_database d
+    ON r.oid = d.datdba
+    WHERE d.datname = current_database();
+
+    FOR temprow IN
+        WITH bbf_catalog AS (
+            SELECT r.oid AS roleid, ext1.rolname
+            FROM sys.babelfish_authid_login_ext ext1
+            INNER JOIN pg_roles r ON ext1.rolname = r.rolname
+            WHERE r.rolname != init_user
+            UNION
+            SELECT r.oid AS roleid, ext2.rolname
+            FROM sys.babelfish_authid_user_ext ext2
+            INNER JOIN pg_roles r ON ext2.rolname = r.rolname
+        )
+        SELECT cat.rolname AS rolname, cat2.rolname AS member, am.grantor::regrole
+        FROM pg_auth_members am
+        INNER JOIN bbf_catalog cat ON am.roleid = cat.roleid
+        INNER JOIN bbf_catalog cat2 ON am.member = cat2.roleid
+        WHERE am.admin_option = 'f'
+        AND am.grantor != 'bbf_role_admin'::regrole
+    LOOP
+        -- First revoke the existing grant
+        query := pg_catalog.format('REVOKE %I FROM %I GRANTED BY %s;', temprow.rolname, temprow.member, temprow.grantor);
+        EXECUTE query;
+        -- Now create the grant with bbf_role_admin as grantor
+        query := pg_catalog.format('GRANT %I TO %I GRANTED BY bbf_role_admin;', temprow.rolname, temprow.member);
+        EXECUTE query;
+    END LOOP;
+END;
+$$;
 
 
 -- After upgrade, always run analyze for all babelfish catalogs.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -37,6 +37,49 @@ LANGUAGE plpgsql;
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+-- Update all grants to babelfish users to make bbf_role_admin as grantor.
+DO
+LANGUAGE plpgsql
+$$
+DECLARE
+    temprow RECORD;
+    query TEXT;
+    init_user NAME;
+BEGIN
+    SELECT r.rolname
+    INTO init_user
+    FROM pg_roles r
+    INNER JOIN pg_database d
+    ON r.oid = d.datdba
+    WHERE d.datname = current_database();
+
+    FOR temprow IN
+        WITH bbf_catalog AS (
+            SELECT r.oid AS roleid, ext1.rolname
+            FROM sys.babelfish_authid_login_ext ext1
+            INNER JOIN pg_roles r ON ext1.rolname = r.rolname
+            WHERE r.rolname != init_user
+            UNION
+            SELECT r.oid AS roleid, ext2.rolname
+            FROM sys.babelfish_authid_user_ext ext2
+            INNER JOIN pg_roles r ON ext2.rolname = r.rolname
+        )
+        SELECT cat.rolname AS rolname, cat2.rolname AS member, am.grantor::regrole
+        FROM pg_auth_members am
+        INNER JOIN bbf_catalog cat ON am.roleid = cat.roleid
+        INNER JOIN bbf_catalog cat2 ON am.member = cat2.roleid
+        WHERE am.admin_option = 'f'
+        AND am.grantor != 'bbf_role_admin'::regrole
+    LOOP
+        -- First revoke the existing grant
+        query := pg_catalog.format('REVOKE %I FROM %I GRANTED BY %s;', temprow.rolname, temprow.member, temprow.grantor);
+        EXECUTE query;
+        -- Now create the grant with bbf_role_admin as grantor
+        query := pg_catalog.format('GRANT %I TO %I GRANTED BY bbf_role_admin;', temprow.rolname, temprow.member);
+        EXECUTE query;
+    END LOOP;
+END;
+$$;
 
 /*
  * Do this so that whenever we run grant statements during create logical database

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3030,6 +3030,35 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 					return;
 				}
+				/*
+				 * Set current user to bbf_role_admin while restoring babelfish roles/grants
+				 * so that it becomes their admin/GRANTOR. We will do this only if the current
+				 * user is superuser since only superuser is allowed to perform dump/restore.
+				 * Note that no additional permission checks are needed as superusers can
+				 * anyway perform this action.
+				 */
+				else if (!IsBinaryUpgrade && babelfish_dump_restore && superuser())
+				{
+					Oid 		save_userid;
+					int 		save_sec_context;
+
+					/* Save the previous user to be restored after creating the user. */
+					GetUserIdAndSecContext(&save_userid, &save_sec_context);
+					PG_TRY();
+					{
+						SetUserIdAndSecContext(get_bbf_role_admin_oid(), save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+
+						call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, context,
+												params, queryEnv, dest,
+												qc);
+					}
+					PG_FINALLY();
+					{
+						SetUserIdAndSecContext(save_userid, save_sec_context);
+					}
+					PG_END_TRY();
+					return;
+				}
 				break;
 			}
 		case T_AlterRoleStmt:
@@ -3928,6 +3957,53 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					PG_END_TRY();
 					return;
 				}
+			}
+			/*
+			 * Set current user to bbf_role_admin while restoring babelfish roles/grants
+			 * so that it becomes their admin/GRANTOR. We will do this only if the current
+			 * user is superuser since only superuser is allowed to perform dump/restore.
+			 * Note that no additional permission checks are needed as superusers can
+			 * anyway perform this action.
+			 */
+			else if (!IsBinaryUpgrade && babelfish_dump_restore && superuser())
+			{
+				Oid 			save_userid;
+				int 			save_sec_context;
+				ListCell		*item;
+				bool			isadmin = false;
+				GrantRoleStmt	*stmt = (GrantRoleStmt *) parsetree;
+
+				foreach(item, stmt->opt)
+				{
+					DefElem    *opt = (DefElem *) lfirst(item);
+					char	   *optval = defGetString(opt);
+
+					if (strcmp(opt->defname, "admin") == 0)
+					{
+						parse_bool(optval, &isadmin);
+						break;
+					}
+				}
+				/* Grantor of admin grants is always BOOTSTRAP_SUPERUSER so no need to update them */
+				if (isadmin)
+					break;
+
+				/* Save the previous user to be restored after executing the grant. */
+				GetUserIdAndSecContext(&save_userid, &save_sec_context);
+				PG_TRY();
+				{
+					SetUserIdAndSecContext(get_bbf_role_admin_oid(), save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+
+					call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, context,
+											params, queryEnv, dest,
+											qc);
+				}
+				PG_FINALLY();
+				{
+					SetUserIdAndSecContext(save_userid, save_sec_context);
+				}
+				PG_END_TRY();
+				return;
 			}
 			break;
 		case T_RenameStmt:

--- a/test/JDBC/expected/Test-Role-Member-vu-cleanup.out
+++ b/test/JDBC/expected/Test-Role-Member-vu-cleanup.out
@@ -1,0 +1,11 @@
+DROP TABLE test_role_member_t1;
+GO
+
+DROP USER test_role_member_u1;
+GO
+
+DROP ROLE test_role_member_r1;
+GO
+
+DROP LOGIN test_role_member_l1;
+GO

--- a/test/JDBC/expected/Test-Role-Member-vu-prepare.out
+++ b/test/JDBC/expected/Test-Role-Member-vu-prepare.out
@@ -1,0 +1,38 @@
+CREATE LOGIN test_role_member_l1 WITH PASSWORD = '12345678';
+GO
+
+CREATE ROLE test_role_member_r1;
+GO
+
+CREATE USER test_role_member_u1 FOR LOGIN test_role_member_l1;
+GO
+
+CREATE TABLE test_role_member_t1(a INT);
+GO
+
+GRANT SELECT ON OBJECT::test_role_member_t1 to test_role_member_r1;
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table test_role_member_t1)~~
+
+
+-- tsql
+ALTER ROLE test_role_member_r1 ADD MEMBER test_role_member_u1;
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+~~START~~
+int
+~~END~~
+
+
+-- tsql
+use master
+GO

--- a/test/JDBC/expected/Test-Role-Member-vu-verify.out
+++ b/test/JDBC/expected/Test-Role-Member-vu-verify.out
@@ -1,0 +1,24 @@
+-- tsql
+-- reset the login password
+ALTER LOGIN test_role_member_l1 WITH PASSWORD = '12345678'
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+~~START~~
+int
+~~END~~
+
+
+-- tsql
+ALTER ROLE test_role_member_r1 DROP MEMBER test_role_member_u1;
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table test_role_member_t1)~~
+

--- a/test/JDBC/input/Test-Role-Member-vu-cleanup.mix
+++ b/test/JDBC/input/Test-Role-Member-vu-cleanup.mix
@@ -1,0 +1,11 @@
+DROP TABLE test_role_member_t1;
+GO
+
+DROP USER test_role_member_u1;
+GO
+
+DROP ROLE test_role_member_r1;
+GO
+
+DROP LOGIN test_role_member_l1;
+GO

--- a/test/JDBC/input/Test-Role-Member-vu-prepare.mix
+++ b/test/JDBC/input/Test-Role-Member-vu-prepare.mix
@@ -1,0 +1,30 @@
+CREATE LOGIN test_role_member_l1 WITH PASSWORD = '12345678';
+GO
+
+CREATE ROLE test_role_member_r1;
+GO
+
+CREATE USER test_role_member_u1 FOR LOGIN test_role_member_l1;
+GO
+
+CREATE TABLE test_role_member_t1(a INT);
+GO
+
+GRANT SELECT ON OBJECT::test_role_member_t1 to test_role_member_r1;
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+
+-- tsql
+ALTER ROLE test_role_member_r1 ADD MEMBER test_role_member_u1;
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+
+-- tsql
+use master
+GO

--- a/test/JDBC/input/Test-Role-Member-vu-verify.mix
+++ b/test/JDBC/input/Test-Role-Member-vu-verify.mix
@@ -1,0 +1,16 @@
+-- tsql
+-- reset the login password
+ALTER LOGIN test_role_member_l1 WITH PASSWORD = '12345678'
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO
+
+-- tsql
+ALTER ROLE test_role_member_r1 DROP MEMBER test_role_member_u1;
+GO
+
+-- tsql		user=test_role_member_l1		password=12345678
+SELECT * FROM test_role_member_t1;
+GO

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -167,6 +167,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -168,6 +168,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -166,6 +166,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -166,6 +166,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/14_14/schedule
+++ b/test/JDBC/upgrade/14_14/schedule
@@ -166,6 +166,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -166,6 +166,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -340,6 +340,7 @@ Test-sp_helprole-dep
 Test-sp_helprolemember-dep
 Test-sp_helpsrvrolemember
 Test-sp_helpuser
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -375,6 +375,7 @@ Test-sp_helprole-dep
 Test-sp_helprolemember-dep
 Test-sp_helpsrvrolemember
 Test-sp_helpuser
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -397,6 +397,7 @@ Test-sp_helpuser
 Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -395,6 +395,7 @@ Test-sp_helpuser
 Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -167,6 +167,7 @@ Test-sp_helpsrvrolemember
 Test-sp_helpuser
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestTableType
 BABEL-CROSS-DB
 BABEL-LOGIN

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -444,6 +444,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -403,6 +403,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -422,6 +422,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -430,6 +430,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -439,6 +439,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -446,6 +446,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -447,6 +447,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -444,6 +444,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/15_9/schedule
+++ b/test/JDBC/upgrade/15_9/schedule
@@ -444,6 +444,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -444,6 +444,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -448,6 +448,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -449,6 +449,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -451,6 +451,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/16_5/schedule
+++ b/test/JDBC/upgrade/16_5/schedule
@@ -452,6 +452,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -452,6 +452,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+Test-Role-Member
 TestSQLVariant
 TestTableType
 TestText


### PR DESCRIPTION
### Description
Execute CREATE/GRANT ROLE statements using bbf_role_admin during restore
so that bbf_role_admin becomes the admin/GRANTOR. We will do this only if the
current is superuser since only superuser is allowed to perform dump/restore.
Note that no additional permission checks are needed as superusers can anyway
perform this action.

Additionally, update GRATOR of grants from previous versions from BOOTSTRAP_SUPERUSER
to bbf_role_admin.

Task: BABEL-5309
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).