### PR TITLE
Fix the issue about Like collation not properly transformed

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1010,6 +1010,7 @@ pltsql_predicate_transformer(Node *expr)
 
 	if (IsA(expr, OpExpr))
 	{
+		expr = expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
 		/* Singleton predicate */
 		return transform_likenode(expr);
 	}

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1010,9 +1010,12 @@ pltsql_predicate_transformer(Node *expr)
 
 	if (IsA(expr, OpExpr))
 	{
-		expr = expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
-		/* Singleton predicate */
-		return transform_likenode(expr);
+		Node *ret = transform_likenode(expr);
+		if (expr == ret)
+			return expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
+		else 
+			/* Singleton predicate */
+			return ret;
 	}
 	else
 	{

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1012,6 +1012,7 @@ pltsql_predicate_transformer(Node *expr)
 	{
 		Node *ret = transform_likenode(expr);
 		if (expr == ret)
+			/* If it's not a like Opexpr, then walk through args */
 			return expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
 		else 
 			/* Singleton predicate */

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -73,6 +73,13 @@ int#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-
-
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc = 'A'  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7839#!#KING#!#A
+~~END~~
 

--- a/test/JDBC/input/BABEL-4046-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4046-vu-verify.sql
@@ -35,6 +35,6 @@ GO
 	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4)  order by DM.empno
 GO
 
-
-
-
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc = 'A'  order by DM.empno
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -489,9 +489,6 @@ ignore#!#pgr_zzz_clean_up
 # Ignoring some test temporarily to get clean tests
 ignore#!#BABEL-3292
 ignore#!#BABEL-3512
-ignore#!#BABEL-4046-vu-prepare
-ignore#!#BABEL-4046-vu-verify
-ignore#!#BABEL-4046-vu-cleanup
 ignore#!#babel_collection
 ignore#!#four-part-names-vu-prepare
 ignore#!#four-part-names-vu-verify


### PR DESCRIPTION
There is a missing condition for transforming an OpExpr when the like node is in the arg list of OpExpr

Task: BABEL-5397, BABEL-5424

### Description

Previously we didn't transform args of OpExpr, it'll miss a condition when OpExpr is '=' OpExpr, with left arg is a Case When wrapped a like Expression and right arg is a Const Value. In such case the like node inside Case When will not be transformed and will lead to a non deterministic collation runtime error.

This fix will transform all the args of OpExpr before transform the OpExpr itself.

For APG 17, we noticed this error because the in subplan will be transformed into a Join.

### Issues Resolved

BABEL-5397, BABEL-5424

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).