### PR TITLE
Add QUOTED_IDENTIFIER OFF to prepare script in test case

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1825,7 +1825,6 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 
 	/* T-SQL doesn't allow procedure calls in a function */
 	if (estate->func && estate->func->fn_oid != InvalidOid && estate->func->fn_prokind == PROKIND_FUNCTION && estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER)
-	/* check EXEC is running in the body of function */
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -945,7 +945,7 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 
 		stmt->is_scalar_func = is_scalar_func;
 
-		/* T-SQL doesn't allow call procedure in function */
+		/* T-SQL doesn't allow procedure calls in a function */
 		if (estate->func && estate->func->fn_oid != InvalidOid && estate->func->fn_prokind == PROKIND_FUNCTION && estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER /* check EXEC is running
 																																									 * in the body of
 																																									 * function */
@@ -1822,6 +1822,15 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 	int32		restypmod;
 	char	   *querystr;
 	int			ret = 0;
+
+	/* T-SQL doesn't allow procedure calls in a function */
+	if (estate->func && estate->func->fn_oid != InvalidOid && estate->func->fn_prokind == PROKIND_FUNCTION && estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER)
+	/* check EXEC is running in the body of function */
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+				 errmsg("Only functions can be executed within a function")));
+	}
 
 	switch (stmt->sp_type_code)
 	{

--- a/test/JDBC/expected/exec_sp_in_udf-vu-cleanup.out
+++ b/test/JDBC/expected/exec_sp_in_udf-vu-cleanup.out
@@ -1,5 +1,9 @@
 use master
 go
+drop table t1_exec_sp_in_udf
+go
+drop table t2_exec_sp_in_udf
+go
 drop procedure sp_myproc
 go
 drop procedure p1_exec_sp_in_udf
@@ -16,6 +20,8 @@ drop function f5_exec_sp_in_udf
 go
 drop function f6_exec_sp_in_udf
 go
+drop function f6a_exec_sp_in_udf
+go
 drop function f7_exec_sp_in_udf
 go
 drop function f8_exec_sp_in_udf
@@ -27,8 +33,6 @@ go
 drop function f_tvf_exec_sp_in_udf
 go
 drop function f_itvf_exec_sp_in_udf
-go
-drop table t1_exec_sp_in_udf
 go
 use tempdb
 go

--- a/test/JDBC/expected/exec_sp_in_udf-vu-cleanup.out
+++ b/test/JDBC/expected/exec_sp_in_udf-vu-cleanup.out
@@ -1,0 +1,38 @@
+use master
+go
+drop procedure sp_myproc
+go
+drop procedure p1_exec_sp_in_udf
+go
+drop function f1_exec_sp_in_udf
+go
+drop function f2_exec_sp_in_udf
+go
+drop function f3_exec_sp_in_udf
+go
+drop function f4_exec_sp_in_udf
+go
+drop function f5_exec_sp_in_udf
+go
+drop function f6_exec_sp_in_udf
+go
+drop function f7_exec_sp_in_udf
+go
+drop function f8_exec_sp_in_udf
+go
+drop function f9_exec_sp_in_udf
+go
+drop function f_scalar_exec_sp_in_udf
+go
+drop function f_tvf_exec_sp_in_udf
+go
+drop function f_itvf_exec_sp_in_udf
+go
+drop table t1_exec_sp_in_udf
+go
+use tempdb
+go
+drop procedure p_tempdb_exec_sp_in_udf
+go
+use master
+go

--- a/test/JDBC/expected/exec_sp_in_udf-vu-prepare.out
+++ b/test/JDBC/expected/exec_sp_in_udf-vu-prepare.out
@@ -1,0 +1,32 @@
+use master
+go
+create table t1_exec_sp_in_udf (a int)
+go
+create procedure sp_myproc as return 0
+go
+create function f_scalar_exec_sp_in_udf(@p int) 
+returns int as
+begin
+return @p
+end
+go
+
+create function f_tvf_exec_sp_in_udf() 
+returns @tv table (a int)
+begin
+	insert @tv values(123)
+	return
+end
+go
+
+create function f_itvf_exec_sp_in_udf() 
+returns table 
+	return (select 123 as a)
+go
+
+use tempdb
+go
+create procedure p_tempdb_exec_sp_in_udf as return 0
+go
+use master
+go

--- a/test/JDBC/expected/exec_sp_in_udf-vu-verify.out
+++ b/test/JDBC/expected/exec_sp_in_udf-vu-verify.out
@@ -16,6 +16,67 @@ int
 
 ~~ERROR (Message: Only functions can be executed within a function)~~
 
+declare @v int = dbo.f1_exec_sp_in_udf()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+declare @v int 
+select @v = dbo.f1_exec_sp_in_udf()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+declare @v int
+set @v = dbo.f1_exec_sp_in_udf()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+select * from t1_exec_sp_in_udf where a = dbo.f1_exec_sp_in_udf()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+insert t1_exec_sp_in_udf values(dbo.f1_exec_sp_in_udf())
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+delete t1_exec_sp_in_udf where a = dbo.f1_exec_sp_in_udf()
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+declare @v int
+set @v = (select dbo.f1_exec_sp_in_udf())
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+select sqrt(dbo.f1_exec_sp_in_udf())
+go
+~~START~~
+float
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+create table t2_exec_sp_in_udf(a int, b int default dbo.f1_exec_sp_in_udf())
+go
+insert t2_exec_sp_in_udf(a) values(1)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
 
 create function f2_exec_sp_in_udf() 
 returns int as
@@ -96,6 +157,23 @@ int
 
 ~~ERROR (Message: Only functions can be executed within a function)~~
 
+
+-- do not allow calling with EXEC
+create function f6a_exec_sp_in_udf(@p int) 
+returns int as
+begin
+declare @v int
+exec @v = f1_exec_sp_in_udf
+return @v
+end
+go
+select dbo.f6a_exec_sp_in_udf(123)
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
 
 
 -- multi-statement TVF cannot be called with EXEC

--- a/test/JDBC/expected/exec_sp_in_udf-vu-verify.out
+++ b/test/JDBC/expected/exec_sp_in_udf-vu-verify.out
@@ -1,0 +1,206 @@
+use master
+go
+
+create function f1_exec_sp_in_udf() 
+returns int as
+begin
+exec sp_executesql 'select 123'
+return 0
+end
+go
+select dbo.f1_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+
+create function f2_exec_sp_in_udf() 
+returns int as
+begin
+exec dbo.sp_helpdb
+return 0
+end
+go
+select dbo.f2_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+
+create function f3_exec_sp_in_udf() 
+returns int as
+begin
+exec [sp_helpdb]
+return 0
+end
+go
+select dbo.f3_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+
+create function f4_exec_sp_in_udf() 
+returns @tv table(a int) as
+begin
+exec sp_myproc
+return
+end
+go
+select * from dbo.f4_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+
+create function f5_exec_sp_in_udf() 
+returns @tv table(a int) as
+begin
+exec dbo.[sp_myproc]
+return
+end
+go
+select * from dbo.f5_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+
+create function f6_exec_sp_in_udf() 
+returns @tv table(a int) as
+begin
+exec tempdb..p_tempdb_exec_sp_in_udf
+return
+end
+go
+select * from dbo.f6_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only functions can be executed within a function)~~
+
+
+
+-- multi-statement TVF cannot be called with EXEC
+exec dbo.f_tvf_exec_sp_in_udf
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: master_dbo.f_tvf_exec_sp_in_udf() is not a procedure)~~
+
+create function f7_exec_sp_in_udf() 
+returns int
+begin
+exec dbo.f_tvf_exec_sp_in_udf
+return
+end
+go
+select * from dbo.f7_exec_sp_in_udf()
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: master_dbo.f_tvf_exec_sp_in_udf() is not a procedure)~~
+
+
+-- inline TVF should not be callable with EXEC, but Babelfish currently allows this
+-- when this gets fixed so that an error is raised, the result of this test will change
+exec dbo.f_itvf_exec_sp_in_udf
+go
+create function f8_exec_sp_in_udf() 
+returns int
+begin
+exec dbo.f_itvf_exec_sp_in_udf
+return
+end
+go
+select * from dbo.f8_exec_sp_in_udf()
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+
+-- procedure and trigger are not affected:
+create trigger tr1 on t1_exec_sp_in_udf for insert as
+begin
+	exec sp_executesql 'select 123 as in_trigger'
+end
+go
+insert t1_exec_sp_in_udf values(456)
+go
+~~START~~
+int
+123
+~~END~~
+
+~~ROW COUNT: 1~~
+
+select * from t1_exec_sp_in_udf
+go
+~~START~~
+int
+456
+~~END~~
+
+
+create procedure p1_exec_sp_in_udf
+as
+begin
+	exec sp_executesql 'select 123 as in_procedure'
+end
+go
+exec p1_exec_sp_in_udf
+go
+~~START~~
+int
+123
+~~END~~
+
+
+-- scalar UDF can still be called with EXEC
+declare @v int
+exec @v = f_scalar_exec_sp_in_udf 123
+select @v as f_scalar_exec_sp_in_udf
+go
+~~START~~
+int
+123
+~~END~~
+
+
+create function f9_exec_sp_in_udf(@p int) 
+returns int as
+begin
+declare @v int
+exec @v = f_scalar_exec_sp_in_udf @p
+return @v
+end
+go
+select dbo.f9_exec_sp_in_udf(123)
+go
+~~START~~
+int
+123
+~~END~~
+

--- a/test/JDBC/expected/unary_plus_op_string-vu-prepare.out
+++ b/test/JDBC/expected/unary_plus_op_string-vu-prepare.out
@@ -1,3 +1,5 @@
+set quoted_identifier off
+go
 create table t1_unary_plus_op_string(i int, vc varchar(30))
 go
 

--- a/test/JDBC/input/exec_sp_in_udf-vu-cleanup.sql
+++ b/test/JDBC/input/exec_sp_in_udf-vu-cleanup.sql
@@ -1,5 +1,9 @@
 use master
 go
+drop table t1_exec_sp_in_udf
+go
+drop table t2_exec_sp_in_udf
+go
 drop procedure sp_myproc
 go
 drop procedure p1_exec_sp_in_udf
@@ -16,6 +20,8 @@ drop function f5_exec_sp_in_udf
 go
 drop function f6_exec_sp_in_udf
 go
+drop function f6a_exec_sp_in_udf
+go
 drop function f7_exec_sp_in_udf
 go
 drop function f8_exec_sp_in_udf
@@ -27,8 +33,6 @@ go
 drop function f_tvf_exec_sp_in_udf
 go
 drop function f_itvf_exec_sp_in_udf
-go
-drop table t1_exec_sp_in_udf
 go
 use tempdb
 go

--- a/test/JDBC/input/exec_sp_in_udf-vu-cleanup.sql
+++ b/test/JDBC/input/exec_sp_in_udf-vu-cleanup.sql
@@ -1,0 +1,38 @@
+use master
+go
+drop procedure sp_myproc
+go
+drop procedure p1_exec_sp_in_udf
+go
+drop function f1_exec_sp_in_udf
+go
+drop function f2_exec_sp_in_udf
+go
+drop function f3_exec_sp_in_udf
+go
+drop function f4_exec_sp_in_udf
+go
+drop function f5_exec_sp_in_udf
+go
+drop function f6_exec_sp_in_udf
+go
+drop function f7_exec_sp_in_udf
+go
+drop function f8_exec_sp_in_udf
+go
+drop function f9_exec_sp_in_udf
+go
+drop function f_scalar_exec_sp_in_udf
+go
+drop function f_tvf_exec_sp_in_udf
+go
+drop function f_itvf_exec_sp_in_udf
+go
+drop table t1_exec_sp_in_udf
+go
+use tempdb
+go
+drop procedure p_tempdb_exec_sp_in_udf
+go
+use master
+go

--- a/test/JDBC/input/exec_sp_in_udf-vu-prepare.sql
+++ b/test/JDBC/input/exec_sp_in_udf-vu-prepare.sql
@@ -1,0 +1,32 @@
+use master
+go
+create table t1_exec_sp_in_udf (a int)
+go
+create procedure sp_myproc as return 0
+go
+create function f_scalar_exec_sp_in_udf(@p int) 
+returns int as
+begin
+return @p
+end
+go
+
+create function f_tvf_exec_sp_in_udf() 
+returns @tv table (a int)
+begin
+	insert @tv values(123)
+	return
+end
+go
+
+create function f_itvf_exec_sp_in_udf() 
+returns table 
+	return (select 123 as a)
+go
+
+use tempdb
+go
+create procedure p_tempdb_exec_sp_in_udf as return 0
+go
+use master
+go

--- a/test/JDBC/input/exec_sp_in_udf-vu-verify.sql
+++ b/test/JDBC/input/exec_sp_in_udf-vu-verify.sql
@@ -1,0 +1,128 @@
+use master
+go
+
+create function f1_exec_sp_in_udf() 
+returns int as
+begin
+exec sp_executesql 'select 123'
+return 0
+end
+go
+select dbo.f1_exec_sp_in_udf()
+go
+
+create function f2_exec_sp_in_udf() 
+returns int as
+begin
+exec dbo.sp_helpdb
+return 0
+end
+go
+select dbo.f2_exec_sp_in_udf()
+go
+
+create function f3_exec_sp_in_udf() 
+returns int as
+begin
+exec [sp_helpdb]
+return 0
+end
+go
+select dbo.f3_exec_sp_in_udf()
+go
+
+create function f4_exec_sp_in_udf() 
+returns @tv table(a int) as
+begin
+exec sp_myproc
+return
+end
+go
+select * from dbo.f4_exec_sp_in_udf()
+go
+
+create function f5_exec_sp_in_udf() 
+returns @tv table(a int) as
+begin
+exec dbo.[sp_myproc]
+return
+end
+go
+select * from dbo.f5_exec_sp_in_udf()
+go
+
+create function f6_exec_sp_in_udf() 
+returns @tv table(a int) as
+begin
+exec tempdb..p_tempdb_exec_sp_in_udf
+return
+end
+go
+select * from dbo.f6_exec_sp_in_udf()
+go
+
+
+-- multi-statement TVF cannot be called with EXEC
+exec dbo.f_tvf_exec_sp_in_udf
+go
+create function f7_exec_sp_in_udf() 
+returns int
+begin
+exec dbo.f_tvf_exec_sp_in_udf
+return
+end
+go
+select * from dbo.f7_exec_sp_in_udf()
+go
+
+-- inline TVF should not be callable with EXEC, but Babelfish currently allows this
+-- when this gets fixed so that an error is raised, the result of this test will change
+exec dbo.f_itvf_exec_sp_in_udf
+go
+create function f8_exec_sp_in_udf() 
+returns int
+begin
+exec dbo.f_itvf_exec_sp_in_udf
+return
+end
+go
+select * from dbo.f8_exec_sp_in_udf()
+go
+
+
+-- procedure and trigger are not affected:
+create trigger tr1 on t1_exec_sp_in_udf for insert as
+begin
+	exec sp_executesql 'select 123 as in_trigger'
+end
+go
+insert t1_exec_sp_in_udf values(456)
+go
+select * from t1_exec_sp_in_udf
+go
+
+create procedure p1_exec_sp_in_udf
+as
+begin
+	exec sp_executesql 'select 123 as in_procedure'
+end
+go
+exec p1_exec_sp_in_udf
+go
+
+-- scalar UDF can still be called with EXEC
+declare @v int
+exec @v = f_scalar_exec_sp_in_udf 123
+select @v as f_scalar_exec_sp_in_udf
+go
+
+create function f9_exec_sp_in_udf(@p int) 
+returns int as
+begin
+declare @v int
+exec @v = f_scalar_exec_sp_in_udf @p
+return @v
+end
+go
+select dbo.f9_exec_sp_in_udf(123)
+go

--- a/test/JDBC/input/exec_sp_in_udf-vu-verify.sql
+++ b/test/JDBC/input/exec_sp_in_udf-vu-verify.sql
@@ -10,6 +10,29 @@ end
 go
 select dbo.f1_exec_sp_in_udf()
 go
+declare @v int = dbo.f1_exec_sp_in_udf()
+go
+declare @v int 
+select @v = dbo.f1_exec_sp_in_udf()
+go
+declare @v int
+set @v = dbo.f1_exec_sp_in_udf()
+go
+select * from t1_exec_sp_in_udf where a = dbo.f1_exec_sp_in_udf()
+go
+insert t1_exec_sp_in_udf values(dbo.f1_exec_sp_in_udf())
+go
+delete t1_exec_sp_in_udf where a = dbo.f1_exec_sp_in_udf()
+go
+declare @v int
+set @v = (select dbo.f1_exec_sp_in_udf())
+go
+select sqrt(dbo.f1_exec_sp_in_udf())
+go
+create table t2_exec_sp_in_udf(a int, b int default dbo.f1_exec_sp_in_udf())
+go
+insert t2_exec_sp_in_udf(a) values(1)
+go
 
 create function f2_exec_sp_in_udf() 
 returns int as
@@ -61,6 +84,17 @@ go
 select * from dbo.f6_exec_sp_in_udf()
 go
 
+-- do not allow calling with EXEC
+create function f6a_exec_sp_in_udf(@p int) 
+returns int as
+begin
+declare @v int
+exec @v = f1_exec_sp_in_udf
+return @v
+end
+go
+select dbo.f6a_exec_sp_in_udf(123)
+go
 
 -- multi-statement TVF cannot be called with EXEC
 exec dbo.f_tvf_exec_sp_in_udf

--- a/test/JDBC/input/unary_plus_op_string-vu-prepare.sql
+++ b/test/JDBC/input/unary_plus_op_string-vu-prepare.sql
@@ -1,3 +1,5 @@
+set quoted_identifier off
+go
 create table t1_unary_plus_op_string(i int, vc varchar(30))
 go
 

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -500,6 +500,7 @@ catalogs_dbo_sys_schema-upgrade
 unary_plus_op_string
 tabvar_in_function
 atatuservar
+exec_sp_in_udf
 BABEL-4217
 Test_ISNULL
 BABEL-4270


### PR DESCRIPTION
### Description

Adds SET QUOTED_IDENTIFIER OFF to the prepare script of test case `unary_plus_op_string-vu-prepare.sql.` This will make the test run correctly even when it is executed in a context where QUOTED_IDENTIFIER happens to be ON.

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** Yes

### Check List
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).