### PR TITLE
[OSS-ONLY] Login with mapped user should not use guest user privileges (#3088)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -37,6 +37,16 @@ LANGUAGE plpgsql;
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+
+-- This is a temporary procedure which is only meant to be called during upgrade
+CREATE OR REPLACE PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'revoke_guest_from_mapped_logins';
+
+CALL sys.babelfish_revoke_guest_from_mapped_logins();
+
+-- Drop this procedure after it gets executed once.
+
 DO $$
 DECLARE
     exception_message text;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -46,6 +46,7 @@ AS 'babelfishpg_tsql', 'revoke_guest_from_mapped_logins';
 CALL sys.babelfish_revoke_guest_from_mapped_logins();
 
 -- Drop this procedure after it gets executed once.
+DROP PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins();
 
 DO $$
 DECLARE

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -943,10 +943,10 @@ get_authid_user_ext_physical_name(const char *db_name, const char *login)
 {
 	Relation	bbf_authid_user_ext_rel;
 	HeapTuple	tuple_user_ext;
-	ScanKeyData key[3];
 	TableScanDesc scan;
 	char	   *user_name = NULL;
 	NameData   *login_name;
+	ScanKeyData key[2];
 
 	if (!db_name || !login)
 		return NULL;
@@ -956,20 +956,16 @@ get_authid_user_ext_physical_name(const char *db_name, const char *login)
 
 	login_name = (NameData *) palloc0(NAMEDATALEN);
 	snprintf(login_name->data, NAMEDATALEN, "%s", login);
+	
 	ScanKeyInit(&key[0],
-				Anum_bbf_authid_user_ext_login_name,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				NameGetDatum(login_name));
+			Anum_bbf_authid_user_ext_login_name,
+			BTEqualStrategyNumber, F_NAMEEQ,
+			NameGetDatum(login_name));
 	ScanKeyInit(&key[1],
-				Anum_bbf_authid_user_ext_database_name,
-				BTEqualStrategyNumber, F_TEXTEQ,
-				CStringGetTextDatum(db_name));
-	ScanKeyInit(&key[2],
-				Anum_bbf_authid_user_ext_user_can_connect,
-				BTEqualStrategyNumber, F_INT4EQ,
-				Int32GetDatum(1));
-
-	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 3, key);
+			Anum_bbf_authid_user_ext_database_name,
+			BTEqualStrategyNumber, F_TEXTEQ,
+			CStringGetTextDatum(db_name));
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 2, key);
 
 	tuple_user_ext = heap_getnext(scan, ForwardScanDirection);
 	if (HeapTupleIsValid(tuple_user_ext))
@@ -1074,6 +1070,28 @@ get_authid_user_ext_db_users(const char *db_name)
 	return db_users_list;
 }
 
+/* Checks if the user is enabled on a given database. */
+static bool
+user_has_dbaccess(const char *user)
+{
+	HeapTuple	tuple;
+	bool		has_access = false;
+	tuple = SearchSysCache1(AUTHIDUSEREXTROLENAME, CStringGetDatum(user));
+
+	if (HeapTupleIsValid(tuple))
+	{
+		bool	isnull = true;
+		int	user_can_connect = 0;
+		Datum	datum = SysCacheGetAttr(AUTHIDUSEREXTROLENAME, tuple, Anum_bbf_authid_user_ext_user_can_connect, &isnull);
+		Assert(!isnull);
+		user_can_connect = DatumGetInt32(datum);
+		if (user_can_connect == 1)
+			has_access = true;
+		ReleaseSysCache(tuple);
+	}
+	return has_access;
+}
+
 /*
  * Checks if there exists any user for respective database and login,
  * if there is not any then use dbo or guest user.
@@ -1090,6 +1108,9 @@ get_user_for_database(const char *db_name)
 	login = GetUserNameFromId(GetSessionUserId(), false);
 	user = get_authid_user_ext_physical_name(db_name, login);
 	login_is_db_owner = 0 == strncmp(login, get_owner_of_db(db_name), NAMEDATALEN);
+
+	if (user && !user_has_dbaccess(user) && !guest_has_dbaccess((char *) db_name))
+		user = NULL;
 
 	if (!user)
 	{
@@ -3139,7 +3160,7 @@ create_guest_role_for_db(const char *dbname)
 	if (list_length(logins) > 0)
 	{
 		stmt = parsetree_nth_stmt(res, i++);
-		update_GrantRoleStmt(stmt, list_make1(make_accesspriv_node(guest)), logins);
+		update_GrantRoleStmt(stmt, list_make1(make_accesspriv_node(guest)), logins, NULL);
 	}
 
 	GetUserIdAndSecContext(&save_userid, &save_sec_context);

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -167,7 +167,7 @@ gen_createdb_subcmds(const char *dbname, const char *owner)
 		/* Grant dbo role to owner */
 		stmt = parsetree_nth_stmt(res, i++);
 		update_GrantRoleStmt(stmt, list_make1(make_accesspriv_node(dbo)),
-							list_make1(make_rolespec_node(owner)));
+							list_make1(make_rolespec_node(owner)), NULL);
 	}
 
 	if (guest)
@@ -178,7 +178,7 @@ gen_createdb_subcmds(const char *dbname, const char *owner)
 		if (list_length(logins) > 0)
 		{
 			stmt = parsetree_nth_stmt(res, i++);
-			update_GrantRoleStmt(stmt, list_make1(make_accesspriv_node(guest)), logins);
+			update_GrantRoleStmt(stmt, list_make1(make_accesspriv_node(guest)), logins, NULL);
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3908,10 +3908,10 @@ exec_stmt_change_dbowner(PLtsql_execstate *estate, PLtsql_stmt_change_dbowner *s
 		SetUserIdAndSecContext(get_bbf_role_admin_oid(), save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
 		
 		/* Revoke dbo role from the previous owner */
-		grant_revoke_dbo_to_login(get_owner_of_db(stmt->db_name), stmt->db_name, false);
+		grant_revoke_role_to_login(get_owner_of_db(stmt->db_name), get_dbo_role_name(stmt->db_name), NULL, false);
 
 		/* Grant dbo role to the new owner */
-		grant_revoke_dbo_to_login(stmt->new_owner_name, stmt->db_name, true);
+		grant_revoke_role_to_login(stmt->new_owner_name, get_dbo_role_name(stmt->db_name), NULL, true);
 		update_db_owner(stmt->new_owner_name, stmt->db_name);	
 	}
 	PG_FINALLY();

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2168,7 +2168,7 @@ extern void update_CreateSchemaStmt(Node *n, const char *schemaname, const char 
 extern void update_DropOwnedStmt(Node *n, List *role_list);
 extern void update_DropRoleStmt(Node *n, const char *role);
 extern void update_DropStmt(Node *n, const char *object);
-extern void update_GrantRoleStmt(Node *n, List *privs, List *roles);
+extern void update_GrantRoleStmt(Node *n, List *privs, List *roles, const char *grantor);
 extern void update_GrantStmt(Node *n, const char *object, const char *obj_schema, const char *grantee, const char *priv);
 extern void update_RenameStmt(Node *n, const char *old_name, const char *new_name);
 extern void update_ViewStmt(Node *n, const char *view_schema);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1082,7 +1082,7 @@ update_DropStmt(Node *n, const char *object)
 }
 
 void
-update_GrantRoleStmt(Node *n, List *privs, List *roles)
+update_GrantRoleStmt(Node *n, List *privs, List *roles, const char *grantor)
 {
 	GrantRoleStmt *stmt = (GrantRoleStmt *) n;
 
@@ -1091,6 +1091,11 @@ update_GrantRoleStmt(Node *n, List *privs, List *roles)
 
 	stmt->granted_roles = privs;
 	stmt->grantee_roles = roles;
+
+	if (grantor && stmt->grantor)
+	{
+		stmt->grantor->rolename = pstrdup(grantor);
+	}
 }
 
 void

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -439,8 +439,24 @@ drop_bbf_authid_user_ext(ObjectAccessType access,
 	tuple = systable_getnext(scan);
 
 	if (HeapTupleIsValid(tuple))
+	{
+		bool  is_null;
+
+		Datum datum = heap_getattr(tuple,
+								   Anum_bbf_authid_user_ext_login_name,
+								   RelationGetDescr(bbf_authid_user_ext_rel),
+								   &is_null);
+		if (!is_null)
+		{
+			char *login = NameStr(*DatumGetName(datum));
+
+			/* Grant guest user to login if it's mapped user is being dropped. */
+			if (strlen(login) > 0)
+				grant_revoke_role_to_login(login, get_guest_role_name(get_cur_db_name()), "bbf_role_admin", true);
+		}
 		CatalogTupleDelete(bbf_authid_user_ext_rel,
 						   &tuple->t_self);
+	}
 
 	systable_endscan(scan);
 	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
@@ -550,7 +566,7 @@ grant_guests_to_login(const char *login)
 
 	/* Update the dummy statement with real values */
 	stmt = parsetree_nth_stmt(parsetree_list, 0);
-	update_GrantRoleStmt(stmt, guests, list_make1(make_rolespec_node(login)));
+	update_GrantRoleStmt(stmt, guests, list_make1(make_rolespec_node(login)), NULL);
 
 	/* Run the built query */
 	/* need to make a wrapper PlannedStmt */
@@ -578,19 +594,18 @@ grant_guests_to_login(const char *login)
 }
 
 /* 
- * Grant/revoke dbo role from the login.
+ * Grant/revoke given role from the login.
+ * If grantor is provided then only GRANT/REVOKE specific to it will be affected.
  * The 'is_grant' flag determines if the action is grant/revoke.
  */
 void
-grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
+grant_revoke_role_to_login(const char* login, const char *role_name, const char *grantor, bool is_grant)
 {
 	StringInfoData query;
 	List	   *parsetree_list;
-	List	   *dbo = NIL;
+	List	   *rolelist = NIL;
 	Node	   *stmt;
 	PlannedStmt *wrapper;
-
-	char 	   *dbo_role_name = get_dbo_role_name(db_name);
 
 	/*
 	 * If login i.e old_owner/new_owner is master user 
@@ -602,18 +617,22 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 	
 	initStringInfo(&query);
 
-	dbo = lappend(dbo, make_accesspriv_node(dbo_role_name));
+	rolelist = lappend(rolelist, make_accesspriv_node(role_name));
 
 	if (is_grant)
 	{
 		/* Build dummy GRANT statement to grant membership to login  */
-		appendStringInfo(&query, "GRANT dummy TO dummy; ");
+		appendStringInfo(&query, "GRANT dummy TO dummy");
 	}
 	else
 	{
 		/* Build dummy REVOKE statement to revoke membership from login */
-		appendStringInfo(&query, "REVOKE dummy FROM dummy; ");
+		appendStringInfo(&query, "REVOKE dummy FROM dummy");
 	}
+	if (grantor)
+		appendStringInfo(&query, " GRANTED BY dummy; ");
+	else
+		appendStringInfo(&query, "; ");
 
 	parsetree_list = raw_parser(query.data, RAW_PARSE_DEFAULT);
 
@@ -625,7 +644,7 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 
 	/* Update the dummy statement with real values */
 	stmt = parsetree_nth_stmt(parsetree_list, 0);
-	update_GrantRoleStmt(stmt, dbo, list_make1(make_rolespec_node(login)));
+	update_GrantRoleStmt(stmt, rolelist, list_make1(make_rolespec_node(login)), grantor);
 
 	/* Run the built query */
 	/* need to make a wrapper PlannedStmt */
@@ -638,7 +657,7 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 
 	/* do this step */
 	ProcessUtility(wrapper,
-				   "(ALTER DATABASE OWNER )",
+				   "GRANT/REVOKE ROLE TO LOGIN",
 				   false,
 				   PROCESS_UTILITY_SUBCOMMAND,
 				   NULL,
@@ -650,7 +669,6 @@ grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant)
 	CommandCounterIncrement();
 
 	pfree(query.data);
-	pfree(dbo_role_name);
 }
 
 static List *
@@ -801,7 +819,7 @@ user_name(PG_FUNCTION_ARGS)
 
 	datum = heap_getattr(tuple,
 						 Anum_bbf_authid_user_ext_orig_username,
-						 bbf_authid_user_ext_rel->rd_att,
+						 RelationGetDescr(bbf_authid_user_ext_rel),
 						 &is_null);
 	user = pstrdup(TextDatumGetCString(datum));
 
@@ -1286,8 +1304,32 @@ create_bbf_authid_user_ext(CreateRoleStmt *stmt, bool has_schema, bool has_login
 
 	if (has_login)
 	{
+		char *db_name = get_cur_db_name();
+		int         save_sec_context;
+		Oid         save_userid;
+
 		verify_login_for_bbf_authid_user_ext(login);
 		login_name_str = login->rolename;
+		/* Revoke guest user from login as login now has a mapped user in current database. */
+		GetUserIdAndSecContext(&save_userid, &save_sec_context);
+		PG_TRY();
+		{
+			/*
+			 * Older version before APG16 did not store grantor information.
+			 * After MVU to APG16, the grantor for these GRANTs on older roles
+			 * becomes BOOTSTRAP_SUPERUSER. We need SA privilege to revoke the guest
+			 * membership from these roles.
+			 */
+			SetUserIdAndSecContext(get_sa_role_oid(), save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+			grant_revoke_role_to_login(login_name_str, get_guest_role_name(db_name), NULL, false);
+		}
+		PG_FINALLY();
+		{
+			SetUserIdAndSecContext(save_userid, save_sec_context);
+		}
+		PG_END_TRY();
+		grant_revoke_role_to_login(login_name_str, get_guest_role_name(db_name), "bbf_role_admin", false); /* revoke even membership granted by bbf_role_admin */
+		pfree(db_name);
 	}
 
 	/* Add to the catalog table. Adds current database name by default */
@@ -1442,6 +1484,58 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(0);
 }
 
+PG_FUNCTION_INFO_V1(revoke_guest_from_mapped_logins);
+Datum
+revoke_guest_from_mapped_logins(PG_FUNCTION_ARGS)
+{
+	Relation	bbf_authid_user_ext_rel;
+	TableScanDesc scan;
+	HeapTuple	tuple;
+	bool		is_null;
+
+	/* We only allow this to be called from an extension's SQL script. */
+	if (!creating_extension)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("%s can only be called from an SQL script executed by CREATE/ALTER EXTENSION",
+						"add_existing_users_to_catalog()")));
+
+	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(), AccessShareLock);
+	scan = table_beginscan_catalog(bbf_authid_user_ext_rel, 0, NULL);
+	tuple = heap_getnext(scan, ForwardScanDirection);
+
+	while (HeapTupleIsValid(tuple))
+	{
+		Datum datum = heap_getattr(tuple,
+								   Anum_bbf_authid_user_ext_login_name,
+								   RelationGetDescr(bbf_authid_user_ext_rel),
+								   &is_null);
+		if (!is_null)
+		{
+			char *login = NameStr(*DatumGetName(datum));
+
+			/* Revoke guest user from login as login already has a mapped database user. */
+			if (strlen(login) > 0)
+			{
+				Datum name = heap_getattr(tuple,
+									Anum_bbf_authid_user_ext_database_name,
+									RelationGetDescr(bbf_authid_user_ext_rel),
+									&is_null);
+
+				char *db_name = TextDatumGetCString(name);
+				grant_revoke_role_to_login(login, get_guest_role_name(db_name), NULL, false);
+				grant_revoke_role_to_login(login, get_guest_role_name(db_name), "bbf_role_admin", false); /* revoke even membership granted by bbf_role_admin */
+				pfree(db_name);
+			}
+		}
+		tuple = heap_getnext(scan, ForwardScanDirection);
+	}
+
+	table_endscan(scan);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
+	PG_RETURN_INT32(0);
+}
+
 void
 alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 {
@@ -1463,6 +1557,7 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 	char	   *new_user_name = NULL;
 	char	   *physical_name = NULL;
 	char	   *login_name_str = NULL;
+	char	   *old_login_name = NULL;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
@@ -1558,8 +1653,16 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 
 	if (login_name_str)
 	{
-		namestrcpy(&login_name_str_namedata, login_name_str);
+		bool is_null;
+		Datum old_login = heap_getattr(tuple,
+									   Anum_bbf_authid_user_ext_login_name,
+									   bbf_authid_user_ext_dsc,
+									   &is_null);
+		/* Fetch the login name which was previously mapped to this user. */
+		if (!is_null)
+			old_login_name = pstrdup(NameStr(*DatumGetName(old_login)));
 
+		namestrcpy(&login_name_str_namedata, login_name_str);
 		new_record_user_ext[USER_EXT_LOGIN_NAME] = NameGetDatum(&login_name_str_namedata);
 		new_record_repl_user_ext[USER_EXT_LOGIN_NAME] = true;
 	}
@@ -1579,6 +1682,40 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 	heap_freetuple(new_tuple);
 
 	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+
+	if (login_name_str)
+	{
+		int         save_sec_context;
+		Oid         save_userid;
+		if (old_login_name && strlen(old_login_name) > 0)
+		{
+			/* First revoke this user from old login as the user is being mapped to a new login. */
+			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, NULL, false);
+			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, "bbf_role_admin", false);
+			/* Now grant guest user to old login as it's mapped user is being removed. */
+			grant_revoke_role_to_login(old_login_name, get_guest_role_name(get_cur_db_name()), "bbf_role_admin", true);
+		}
+
+		/* Revoke guest user from new login as login now has a mapped user in current database. */
+		GetUserIdAndSecContext(&save_userid, &save_sec_context);
+		PG_TRY();
+		{
+			/*
+			 * Older version before APG16 did not store grantor information.
+			 * After MVU to APG16, the grantor for these GRANTs on older roles
+			 * becomes BOOTSTRAP_SUPERUSER. We need SA privilege to revoke the guest
+			 * membership from these roles.
+			 */
+			SetUserIdAndSecContext(get_sa_role_oid(), save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+			grant_revoke_role_to_login(login_name_str, get_guest_role_name(get_cur_db_name()), NULL, false);
+		}
+		PG_FINALLY();
+		{
+			SetUserIdAndSecContext(save_userid, save_sec_context);
+		}
+		PG_END_TRY();
+		grant_revoke_role_to_login(login_name_str, get_guest_role_name(get_cur_db_name()), "bbf_role_admin", false); /* revoke even membership granted by bbf_role_admin */
+	}
 
 	if (new_user_name)
 	{
@@ -2036,7 +2173,7 @@ has_user_in_db(const char *login, char **db_name)
 	{
 
 		Datum		name = heap_getattr(tuple_user_ext, Anum_bbf_authid_user_ext_database_name,
-										bbf_authid_user_ext_rel->rd_att, &is_null);
+										RelationGetDescr(bbf_authid_user_ext_rel), &is_null);
 
 		*db_name = pstrdup(TextDatumGetCString(name));
 

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -83,6 +83,6 @@ extern bool windows_domain_contains_invalid_chars(char *input);
 extern bool check_windows_logon_length(char *input);
 extern char* get_windows_domain_name(char* input);
 extern bool windows_domain_is_not_supported(char* domain_name);
-extern void grant_revoke_dbo_to_login(const char* login, const char* db_name, bool is_grant);
+extern void grant_revoke_role_to_login(const char* login, const char *role_name, const char *grantor, bool is_grant);
 
 #endif

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
@@ -39,6 +39,12 @@ GO
 DROP TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1;
 GO
 
+DROP TABLE babel_cross_db_vu_prepare_t4;
+GO
+
+DROP LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
 DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
 GO
 

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
@@ -263,3 +263,19 @@ GO
 
 GRANT EXECUTE ON FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func to master_babel_cross_db_vu_prepare_u1;
 GO
+
+-- tsql
+USE master;
+GO
+
+CREATE LOGIN babel_cross_db_vu_prepare_l3 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u3 FOR LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_t4 (a INT);
+GO
+
+GRANT SELECT ON babel_cross_db_vu_prepare_t4 TO guest;
+GO

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
@@ -417,6 +417,9 @@ GO
 ALTER LOGIN babel_cross_db_vu_prepare_l2 with password = '12345678';
 GO
 
+ALTER LOGIN babel_cross_db_vu_prepare_l3 with password = '12345678';
+GO
+
 -- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
 USE master;
 GO
@@ -673,8 +676,57 @@ int
 ~~END~~
 
 
+create user user_cannot_connect for login babel_cross_db_vu_prepare_l2;
+go
+
+revoke connect from user_cannot_connect;
+go
+
 GRANT CONNECT TO guest;
 GO
+
+grant select on babel_cross_db_vu_prepare_db1_t1 to guest;
+go
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+select current_user
+go
+~~START~~
+varchar
+user_cannot_connect
+~~END~~
+
+
+select has_dbaccess('my_babel_cross_db_vu_prepare_db1');
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select * from dbo.babel_cross_db_vu_prepare_db1_t1; -- should not use guest privilege
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_db1_t1)~~
+
+
+USE master
+GO
+
+-- tsql
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+revoke select on babel_cross_db_vu_prepare_db1_t1 from guest;
+go
+
+drop user user_cannot_connect;
+go
 
 -- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
 -- cross-db tests for guest user
@@ -711,6 +763,33 @@ int
 4
 5
 6
+~~END~~
+
+
+-- tsql user=babel_cross_db_vu_prepare_l3 password=12345678
+USE master
+GO
+
+-- login babel_cross_db_vu_prepare_l3 has mapped user in master
+-- database so following SELECT should fail.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table babel_cross_db_vu_prepare_t4)~~
+
+
+-- tsql
+-- now moreve mapped user from login babel_cross_db_vu_prepare_l3 in master database
+DROP USER babel_cross_db_vu_prepare_u3;
+GO
+
+-- now that login babel_cross_db_vu_prepare_l3 does not have a mapped user in master
+-- database so following SELECT should succeed as guest was granted SELECT privilege.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
+GO
+~~START~~
+int
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-USER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-USER-vu-cleanup.out
@@ -22,5 +22,8 @@ GO
 DROP LOGIN babel_user_vu_prepare_test5
 GO
 
+DROP LOGIN babel_user_vu_prepare_test6
+GO
+
 DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO

--- a/test/JDBC/expected/BABEL-USER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-USER-vu-prepare.out
@@ -13,6 +13,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 CREATE LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
 GO
 

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -239,6 +239,9 @@ babel_user_vu_prepare_test3#!#babel_user_vu_prepare_sch
 ALTER LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+ALTER LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 -- tsql user=babel_user_vu_prepare_test5 password=abc
 SELECT CURRENT_USER;
 go
@@ -255,6 +258,45 @@ GO
 ~~START~~
 bool
 t
+~~END~~
+
+
+-- tsql
+-- Now map user babel_user_vu_prepare_test3 to a different login babel_user_vu_prepare_test6
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test6;
+GO
+
+-- psql
+-- Login babel_user_vu_prepare_test5 should no longer be a member of user babel_user_vu_prepare_test3
+SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- Login babel_user_vu_prepare_test6 should be a member of user babel_user_vu_prepare_test3
+SELECT pg_has_role('babel_user_vu_prepare_test6', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- tsql
+-- Again map user babel_user_vu_prepare_test3 to login babel_user_vu_prepare_test5
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
+GO
+
+-- tsql user=babel_user_vu_prepare_test6 password=abc
+-- Login babel_user_vu_prepare_test6 should now be mapped to guest user
+SELECT CURRENT_USER;
+go
+~~START~~
+varchar
+guest
 ~~END~~
 
 
@@ -284,6 +326,7 @@ babel_user_vu_prepare_test2
 babel_user_vu_prepare_test3
 babel_user_vu_prepare_test4
 babel_user_vu_prepare_test5
+babel_user_vu_prepare_test6
 master_babel_user_vu_prepare_aacb2aa14e22b38c44e8614f1eae6949f8
 master_babel_user_vu_prepare_test1_new
 master_babel_user_vu_prepare_test2

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-cleanup.out
@@ -2,7 +2,7 @@
 use grant_connect_db1;
 go
 
-drop user grant_connect_abc
+drop user grant_connect_abc_new
 go
 
 drop table grant_connect_t1;

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-prepare.out
@@ -9,4 +9,3 @@ go
 
 create login grant_connect_abc with password = 'Babel123'
 go
-

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
@@ -92,6 +92,14 @@ go
 use grant_connect_db1;
 go
 
+select has_dbaccess('grant_connect_db1');
+go
+~~START~~
+int
+1
+~~END~~
+
+
 select user_name();
 go
 ~~START~~
@@ -182,6 +190,9 @@ go
 grant connect to grant_connect_abc
 go
 
+ALTER USER grant_connect_abc WITH NAME = grant_connect_abc_new;
+go
+
 -- tsql  user=grant_connect_abc password=Babel123
 -- should succeed because login has a user for grant_connect_db1 and it is enabled
 use grant_connect_db1
@@ -191,7 +202,14 @@ select user_name();
 go
 ~~START~~
 nvarchar
-grant_connect_abc
+grant_connect_abc_new
 ~~END~~
 
+
+select has_dbaccess('grant_connect_db1');
+go
+~~START~~
+int
+1
+~~END~~
 

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-cleanup.mix
@@ -2,7 +2,7 @@
 use grant_connect_db1;
 go
 
-drop user grant_connect_abc
+drop user grant_connect_abc_new
 go
 
 drop table grant_connect_t1;

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-prepare.sql
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-prepare.sql
@@ -9,4 +9,3 @@ go
 
 create login grant_connect_abc with password = 'Babel123'
 go
-

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-verify.mix
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-verify.mix
@@ -64,6 +64,9 @@ go
 use grant_connect_db1;
 go
 
+select has_dbaccess('grant_connect_db1');
+go
+
 select user_name();
 go
 
@@ -128,6 +131,9 @@ go
 grant connect to grant_connect_abc
 go
 
+ALTER USER grant_connect_abc WITH NAME = grant_connect_abc_new;
+go
+
 -- tsql  user=grant_connect_abc password=Babel123
 -- should succeed because login has a user for grant_connect_db1 and it is enabled
 use grant_connect_db1
@@ -136,3 +142,5 @@ go
 select user_name();
 go
 
+select has_dbaccess('grant_connect_db1');
+go

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
@@ -39,6 +39,12 @@ GO
 DROP TABLE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1;
 GO
 
+DROP TABLE babel_cross_db_vu_prepare_t4;
+GO
+
+DROP LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
 DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
 GO
 

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
@@ -259,3 +259,19 @@ GO
 
 GRANT EXECUTE ON FUNCTION master_dbo.babel_cross_db_vu_prepare_pg_func to master_babel_cross_db_vu_prepare_u1;
 GO
+
+-- tsql
+USE master;
+GO
+
+CREATE LOGIN babel_cross_db_vu_prepare_l3 WITH PASSWORD = '12345678';
+GO
+
+CREATE USER babel_cross_db_vu_prepare_u3 FOR LOGIN babel_cross_db_vu_prepare_l3;
+GO
+
+CREATE TABLE babel_cross_db_vu_prepare_t4 (a INT);
+GO
+
+GRANT SELECT ON babel_cross_db_vu_prepare_t4 TO guest;
+GO

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
@@ -254,6 +254,9 @@ GO
 ALTER LOGIN babel_cross_db_vu_prepare_l2 with password = '12345678';
 GO
 
+ALTER LOGIN babel_cross_db_vu_prepare_l3 with password = '12345678';
+GO
+
 -- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
 USE master;
 GO
@@ -347,8 +350,43 @@ GO
 SELECT * FROM master.dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
 GO
 
+create user user_cannot_connect for login babel_cross_db_vu_prepare_l2;
+go
+
+revoke connect from user_cannot_connect;
+go
+
 GRANT CONNECT TO guest;
 GO
+
+grant select on babel_cross_db_vu_prepare_db1_t1 to guest;
+go
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+select current_user
+go
+
+select has_dbaccess('my_babel_cross_db_vu_prepare_db1');
+go
+
+select * from dbo.babel_cross_db_vu_prepare_db1_t1; -- should not use guest privilege
+go
+
+USE master
+GO
+
+-- tsql
+USE my_babel_cross_db_vu_prepare_db1
+GO
+
+revoke select on babel_cross_db_vu_prepare_db1_t1 from guest;
+go
+
+drop user user_cannot_connect;
+go
 
 -- cross-db tests for guest user
 -- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
@@ -372,6 +410,25 @@ USE master
 GO
 
 SELECT * FROM dbo.babel_cross_db_vu_prepare_v1 ORDER BY id;
+GO
+
+-- tsql user=babel_cross_db_vu_prepare_l3 password=12345678
+USE master
+GO
+
+-- login babel_cross_db_vu_prepare_l3 has mapped user in master
+-- database so following SELECT should fail.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
+GO
+
+-- now moreve mapped user from login babel_cross_db_vu_prepare_l3 in master database
+-- tsql
+DROP USER babel_cross_db_vu_prepare_u3;
+GO
+
+-- now that login babel_cross_db_vu_prepare_l3 does not have a mapped user in master
+-- database so following SELECT should succeed as guest was granted SELECT privilege.
+SELECT * FROM babel_cross_db_vu_prepare_t4;
 GO
 
 -- tsql

--- a/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
@@ -22,5 +22,8 @@ GO
 DROP LOGIN babel_user_vu_prepare_test5
 GO
 
+DROP LOGIN babel_user_vu_prepare_test6
+GO
+
 DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
@@ -13,6 +13,9 @@ GO
 CREATE LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+CREATE LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 CREATE LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA WITH PASSWORD = 'abc';
 GO
 

--- a/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
@@ -102,6 +102,9 @@ GO
 ALTER LOGIN babel_user_vu_prepare_test5 WITH PASSWORD = 'abc';
 GO
 
+ALTER LOGIN babel_user_vu_prepare_test6 WITH PASSWORD = 'abc';
+GO
+
 -- tsql user=babel_user_vu_prepare_test5 password=abc
 SELECT CURRENT_USER;
 go
@@ -110,6 +113,30 @@ go
 -- psql
 SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
 GO
+
+-- Now map user babel_user_vu_prepare_test3 to a different login babel_user_vu_prepare_test6
+-- tsql
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test6;
+GO
+
+-- Login babel_user_vu_prepare_test5 should no longer be a member of user babel_user_vu_prepare_test3
+-- psql
+SELECT pg_has_role('babel_user_vu_prepare_test5', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+
+-- Login babel_user_vu_prepare_test6 should be a member of user babel_user_vu_prepare_test3
+SELECT pg_has_role('babel_user_vu_prepare_test6', 'master_babel_user_vu_prepare_test3', 'member')
+GO
+
+-- Again map user babel_user_vu_prepare_test3 to login babel_user_vu_prepare_test5
+-- tsql
+ALTER USER babel_user_vu_prepare_test3 WITH LOGIN = babel_user_vu_prepare_test5;
+GO
+
+-- Login babel_user_vu_prepare_test6 should now be mapped to guest user
+-- tsql user=babel_user_vu_prepare_test6 password=abc
+SELECT CURRENT_USER;
+go
 
 -- tsql
 -- both of the commands below should fail

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -72,7 +72,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file b
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--3.0.0--3.1.0.sql
-Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--4.4.0--4.5.0.sql
+Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--4.3.0--4.4.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.3.0--3.0.0.sql

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -72,6 +72,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file b
 Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--3.0.0--3.1.0.sql
+Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--4.4.0--4.5.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.3.0--3.0.0.sql


### PR DESCRIPTION
### Description
Previously, a guest users always remain member of a login even if login has a mapped user in a particular database. Due to this any database user is able to access the objects which are accessible to guest user which is undesirable.

Fixed this issue by only keeping one user member of a login at a time, which means, guest will be a member of login only if there is no mapped user to that login otherwise only that mapped user will be a member of login.

Task: BABEL-5389
Co-authored-by: Rishabh Tanwar <ritanwar@amazon.com>
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).