### PR TITLE
Fix resetting some GUCs at the time of TDSResetConnection

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1135,6 +1135,17 @@ ProcessLoginFlags(LoginRequest loginInfo)
 }
 
 /*
+ * TdsResetLoginFlags - Resets the session properties which
+ * we provided during login time.
+ * Wrapper of ProcessLoginFlags, since we do not expose loginInfo.
+ */
+void
+TdsResetLoginFlags()
+{
+	ProcessLoginFlags(loginInfo);
+}
+
+/*
  * ProcessLoginInternal - internal workhorse for processing login
  * request.
  *

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -154,6 +154,8 @@ ResetTDSConnection(void)
 	TdsResetCache();
 	TdsResponseReset();
 	TdsResetBcpOffset();
+	TdsResetLoginFlags();
+
 	/* Retore previous isolation level when not called by sys.sp_reset_connection. */
 	if (!resetTdsConnectionFlag)
 	{

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -296,6 +296,7 @@ extern void TdsSendLoginAck(Port *port);
 extern uint32_t GetClientTDSVersion(void);
 extern char *get_tds_login_domainname(void);
 extern void TdsSetDbContext(void);
+extern void TdsResetLoginFlags(void);
 
 /* Functions in backend/tds/tdsprotocol.c */
 extern int	TdsSocketBackend(void);

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -13,6 +13,7 @@
 
 #define PLTSQL_SESSION_ISOLATION_LEVEL "default_transaction_isolation"
 #define PLTSQL_TRANSACTION_ISOLATION_LEVEL "transaction_isolation"
+#define PLTSQL_MIGRATION_MODE "babelfishpg_tsql.migration_mode"
 #define PLTSQL_DEFAULT_LANGUAGE "us_english"
 
 static int migration_mode = SINGLE_DB;
@@ -1509,6 +1510,7 @@ pltsql_validate_set_config_function(char *name, char *value)
 {
 	if (strncmp(name, PLTSQL_SESSION_ISOLATION_LEVEL, strlen(PLTSQL_SESSION_ISOLATION_LEVEL)) == 0 ||
 		strncmp(name, PLTSQL_TRANSACTION_ISOLATION_LEVEL, strlen(PLTSQL_TRANSACTION_ISOLATION_LEVEL)) == 0 ||
+		strncmp(name, PLTSQL_MIGRATION_MODE, strlen(PLTSQL_MIGRATION_MODE)) == 0 ||
 		strncmp(name, "role", strlen("role")) == 0)
 	{
 		ereport(ERROR,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1508,7 +1508,8 @@ void
 pltsql_validate_set_config_function(char *name, char *value)
 {
 	if (strncmp(name, PLTSQL_SESSION_ISOLATION_LEVEL, strlen(PLTSQL_SESSION_ISOLATION_LEVEL)) == 0 ||
-		strncmp(name, PLTSQL_TRANSACTION_ISOLATION_LEVEL, strlen(PLTSQL_TRANSACTION_ISOLATION_LEVEL)) == 0)
+		strncmp(name, PLTSQL_TRANSACTION_ISOLATION_LEVEL, strlen(PLTSQL_TRANSACTION_ISOLATION_LEVEL)) == 0 ||
+		strncmp(name, "role", strlen("role")) == 0)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -725,6 +725,17 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	else
 		estate->schema_name = NULL;
 
+	/*
+	 * We need to disable the explain gucs incase of sp_reset_connection
+	 * execution otherwise we will get explain output for it which is
+	 * not intended.
+	 */
+	if (strcmp(stmt->proc_name, "sp_reset_connection") == 0)
+	{
+		pltsql_explain_only = false;
+		pltsql_explain_analyze = false;
+	}
+
 	/* PG_TRY to ensure we clear the plan link, if needed, on failure */
 	PG_TRY();
 	{

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -14,6 +14,7 @@
 #include "dbcmds.h"
 #include "multidb.h"
 #include "session.h"
+#include "pl_explain.h"
 #include "pltsql.h"
 #include "guc.h"
 #include "storage/shm_toc.h"
@@ -202,6 +203,8 @@ reset_session_properties(void)
 {
 	reset_cached_batch();
 	reset_cached_cursor();
+	pltsql_explain_only = false;
+	pltsql_explain_analyze = false;
 }
 
 void

--- a/test/JDBC/expected/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/Test-sp_reset_connection.out
@@ -621,11 +621,6 @@ Query Text: SELECT 1
 Result  (cost=0.00..0.01 rows=1 width=4)
 ~~END~~
 
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.085 ms
-~~END~~
-
 
 -- reset
 exec sys.sp_reset_connection

--- a/test/JDBC/expected/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/Test-sp_reset_connection.out
@@ -483,3 +483,212 @@ int
 
 drop table babel_cursor_t1;
 GO
+
+
+-- GUCs testing
+-- 1. Ansi defaults
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_null_dflt_on', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+SET ANSI_DEFAULTS ON
+GO
+
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_null_dflt_on', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+-- reset
+exec sys.sp_reset_connection
+GO
+
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_null_dflt_on', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+-- babelfish_showplan_all
+SET babelfish_showplan_all ON
+GO
+
+-- explain output
+SELECT 1;
+GO
+~~START~~
+text
+Query Text: SELECT 1
+Result  (cost=0.00..0.01 rows=1 width=4)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
+~~END~~
+
+
+-- reset
+exec sys.sp_reset_connection
+GO
+
+-- 1 output
+SELECT 1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+-- set_config testing.
+-- search_path has source < PGC_S_SESSION in TSQL but it gets reset during ResetAll Gucs.
+-- Whereas role does not get reset since it uses GUC_NO_RESET_ALL, so we should not allow
+-- set_config for this option.
+SELECT CURRENT_SETTING('search_path', true)
+SELECT CURRENT_SETTING('role', true)
+GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+text
+master_dbo
+~~END~~
+
+
+SELECT set_config('search_path', 'sys', false);
+GO
+~~START~~
+text
+sys
+~~END~~
+
+SELECT set_config('role', 'jdbc_user', false);
+GO
+~~START~~
+text
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: set_config not allowed for option role)~~
+
+
+-- reset
+exec sp_reset_connection
+GO
+
+SELECT CURRENT_SETTING('search_path', true)
+SELECT CURRENT_SETTING('role', true)
+GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+text
+master_dbo
+~~END~~
+

--- a/test/JDBC/expected/parallel_query/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/parallel_query/Test-sp_reset_connection.out
@@ -1,16 +1,30 @@
--- parallel_query_expected
 -- tsql
 -- 1. Test resets GUC variables
 SELECT @@lock_timeout;
 GO
+~~START~~
+int
+-1
+~~END~~
+
 SET lock_timeout 0;
 GO
 SELECT @@lock_timeout;
 GO
+~~START~~
+int
+0
+~~END~~
+
 EXEC sys.sp_reset_connection
 GO
 SELECT @@lock_timeout;
 GO
+~~START~~
+int
+-1
+~~END~~
+
 
 -- 2. Test open transactions are aborted on reset
 DROP TABLE IF EXISTS sp_reset_connection_test_table;
@@ -18,39 +32,77 @@ CREATE TABLE sp_reset_connection_test_table(id int);
 BEGIN TRANSACTION
 INSERT INTO sp_reset_connection_test_table VALUES(1)
 GO
+~~ROW COUNT: 1~~
+
 EXEC sys.sp_reset_connection
 GO
 COMMIT TRANSACTION
 GO
+~~ERROR (Code: 3902)~~
+
+~~ERROR (Message: COMMIT can only be used in transaction blocks)~~
+
 SELECT * FROM sp_reset_connection_test_table
 GO
+~~START~~
+int
+~~END~~
+
 
 -- 3. Test temp tables are deleted on reset
 CREATE TABLE #babel_temp_table (ID INT identity(1,1), Data INT)
 INSERT INTO #babel_temp_table (Data) VALUES (100), (200), (300)
 GO
+~~ROW COUNT: 3~~
+
 SELECT * from #babel_temp_table
 GO
+~~START~~
+int#!#int
+1#!#100
+2#!#200
+3#!#300
+~~END~~
+
 EXEC sys.sp_reset_connection
 GO
 SELECT * from #babel_temp_table
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#babel_temp_table" does not exist)~~
+
 
 -- 4. Test isolation level is reset
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 GO
 select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
 GO
+~~START~~
+smallint
+1
+~~END~~
+
 EXEC sys.sp_reset_connection
 GO
 select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
 GO
+~~START~~
+smallint
+2
+~~END~~
+
 
 -- 5. Test sp_reset_connection called with sp_prepexec
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 GO
 select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
 GO
+~~START~~
+smallint
+1
+~~END~~
+
 DECLARE @handle int;
 EXEC SP_PREPARE @handle output, NULL, N'exec sys.sp_reset_connection'
 EXEC SP_EXECUTE @handle
@@ -58,6 +110,11 @@ GO
 GO
 select transaction_isolation_level from sys.dm_exec_sessions where session_id = @@SPID
 GO
+~~START~~
+smallint
+2
+~~END~~
+
 
 -- 6. Test Database Context being reset
 --      Tests include negative cases where db is dropped or renamed
@@ -67,22 +124,41 @@ GO
 -- tsql database=reset_con_db1
 select db_name();
 GO
+~~START~~
+nvarchar
+reset_con_db1
+~~END~~
+
 exec sys.sp_reset_connection
 GO
 use master
 GO
 select db_name();
 GO
+~~START~~
+nvarchar
+master
+~~END~~
+
 exec sys.sp_reset_connection
 GO
 select db_name();
 GO
+~~START~~
+nvarchar
+reset_con_db1
+~~END~~
+
 -- test db being dropped before resetting to same db
 use master;
 drop database reset_con_db1;
 GO
 exec sys.sp_reset_connection
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "reset_con_db1" does not exist)~~
+
 
 -- tsql
 -- Cursor reset testing
@@ -93,17 +169,39 @@ INSERT INTO babel_cursor_t1 VALUES (3, 333.333, 'cccc', '3E984725-C51C-4BF4-9960
 INSERT INTO babel_cursor_t1 VALUES (4, 4444.4444, 'dddddd', '4E984725-C51C-4BF4-9960-E1C80E27ABA0', cast('4E984725-C51C-4BF4-9960-E1C80E27ABA0' as uniqueidentifier));
 INSERT INTO babel_cursor_t1 VALUES (NULL, NULL, NULL, NULL, NULL);
 GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
 
 -- check the status of the cursor
 DECLARE @Report CURSOR;
 EXEC sys.sp_cursor_list @cursor_return = @Report OUTPUT,@cursor_scope = 2; FETCH NEXT from @Report; WHILE (@@FETCH_STATUS <> -1) BEGIN FETCH NEXT from @Report; END;
 go
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
 
 -- This will work since we declared 180150001 handle
 EXEC sp_cursorfetch 180150001, 2, 0, 1;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor "180150001" does not exist)~~
+
 EXEC sp_cursor 180150001, 40, 1, 0;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor "180150001" does not exist)~~
+
 
 exec sys.sp_reset_connection
 GO
@@ -116,11 +214,38 @@ SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 SELECT sys.babelfish_pltsql_get_last_cursor_handle();
 SELECT @@cursor_rows;
 GO
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
+~~START~~
+int
+1073741824
+~~END~~
+
+~~START~~
+int
+180150000
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
 -- This will not work since we 80150001 handle should have been cleaned up
 EXEC sp_cursorfetch 180150001, 2, 0, 1;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor "180150001" does not exist)~~
+
 EXEC sp_cursor 180150001, 40, 1, 0;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cursor "180150001" does not exist)~~
+
 
 -- Testing with only Cursor Open
 DECLARE @cursor_handle int;
@@ -131,6 +256,15 @@ GO
 DECLARE @Report CURSOR;
 EXEC sys.sp_cursor_list @cursor_return = @Report OUTPUT,@cursor_scope = 2; FETCH NEXT from @Report; WHILE (@@FETCH_STATUS <> -1) BEGIN FETCH NEXT from @Report; END;
 go
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+NULL#!#NULL#!#2#!#1#!#1#!#1#!#1#!#1#!#-1#!#0#!#4#!#0#!#1#!#180150001
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
 
 exec sys.sp_reset_connection
 GO
@@ -143,6 +277,25 @@ SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 SELECT sys.babelfish_pltsql_get_last_cursor_handle();
 SELECT @@cursor_rows;
 GO
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
+~~START~~
+int
+1073741824
+~~END~~
+
+~~START~~
+int
+180150000
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
 
 -- Testing with only Cursor Prepare
 DECLARE @stmt_handle int;
@@ -153,6 +306,11 @@ GO
 SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 exec sys.sp_reset_connection
 GO
+~~START~~
+int
+1073741825
+~~END~~
+
 
 -- Check cursor being cleaned up
 DECLARE @Report CURSOR;
@@ -162,6 +320,25 @@ SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 SELECT sys.babelfish_pltsql_get_last_cursor_handle();
 SELECT @@cursor_rows;
 GO
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
+~~START~~
+int
+1073741824
+~~END~~
+
+~~START~~
+int
+180150000
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
 
 -- Testing with only Cursor Prepare and Fetch
 DECLARE @stmt_handle int;
@@ -172,15 +349,39 @@ EXEC sp_cursorexecute @stmt_handle, @cursor_handle OUTPUT, 2, 1;
 EXEC sp_cursorfetch @cursor_handle, 2, 0, 1;
 EXEC sp_cursorexecute @stmt_handle, @cursor_handle2 OUTPUT, 2, 1;
 GO
+~~START~~
+int#!#float#!#varchar#!#uniqueidentifier
+1#!#1.1#!#a#!#1E984725-C51C-4BF4-9960-E1C80E27ABA0
+~~END~~
+
 
 -- check the status of the cursor
 DECLARE @Report CURSOR;
 EXEC sys.sp_cursor_list @cursor_return = @Report OUTPUT,@cursor_scope = 2; FETCH NEXT from @Report; WHILE (@@FETCH_STATUS <> -1) BEGIN FETCH NEXT from @Report; END;
 go
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+NULL#!#NULL#!#2#!#1#!#1#!#1#!#1#!#1#!#-1#!#0#!#4#!#1#!#2#!#180150001
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+NULL#!#NULL#!#2#!#1#!#1#!#1#!#1#!#1#!#-1#!#0#!#4#!#0#!#1#!#180150002
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
 -- check the status of the cursor should give 1073741825
 SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 exec sys.sp_reset_connection
 GO
+~~START~~
+int
+1073741825
+~~END~~
+
 
 exec sys.sp_reset_connection
 GO
@@ -193,6 +394,25 @@ SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 SELECT sys.babelfish_pltsql_get_last_cursor_handle();
 SELECT @@cursor_rows;
 GO
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
+~~START~~
+int
+1073741824
+~~END~~
+
+~~START~~
+int
+180150000
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
 
 -- Testing with only Cursor Prepare and Fetch but this time calling cursor close
 DECLARE @stmt_handle int;
@@ -206,15 +426,29 @@ EXEC sp_cursorclose @cursor_handle;
 EXEC sp_cursorclose @cursor_handle2;
 EXEC sp_cursorunprepare @stmt_handle;
 GO
+~~START~~
+int#!#float#!#varchar#!#uniqueidentifier
+1#!#1.1#!#a#!#1E984725-C51C-4BF4-9960-E1C80E27ABA0
+~~END~~
+
 
 -- check the status of the cursor
 DECLARE @Report CURSOR;
 EXEC sys.sp_cursor_list @cursor_return = @Report OUTPUT,@cursor_scope = 2; FETCH NEXT from @Report; WHILE (@@FETCH_STATUS <> -1) BEGIN FETCH NEXT from @Report; END;
 go
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
 -- check the status of the cursor should give 1073741825
 SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 exec sys.sp_reset_connection
 GO
+~~START~~
+int
+1073741825
+~~END~~
+
 
 exec sys.sp_reset_connection
 GO
@@ -227,12 +461,31 @@ SELECT sys.babelfish_pltsql_get_last_stmt_handle();
 SELECT sys.babelfish_pltsql_get_last_cursor_handle()
 SELECT @@cursor_rows;
 GO
+~~START~~
+varchar#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#smallint#!#numeric#!#smallint#!#smallint#!#numeric#!#smallint#!#int
+~~END~~
+
+~~START~~
+int
+1073741824
+~~END~~
+
+~~START~~
+int
+180150000
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
 
 drop table babel_cursor_t1;
 GO
 
--- GUCs testing
 
+-- GUCs testing
 -- 1. Ansi defaults
 SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
@@ -241,6 +494,36 @@ SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
 GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
 
 SET ANSI_DEFAULTS ON
 GO
@@ -252,6 +535,36 @@ SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
 GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
 
 -- reset
 exec sys.sp_reset_connection
@@ -264,6 +577,36 @@ SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
 SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
 GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
 
 -- babelfish_showplan_all
 SET babelfish_showplan_all ON
@@ -272,6 +615,15 @@ GO
 -- explain output
 SELECT 1;
 GO
+~~START~~
+text
+Query Text: SELECT 1
+Gather  (cost=0.00..0.01 rows=1 width=4)
+  Workers Planned: 1
+  Single Copy: true
+  ->  Result  (cost=0.00..0.01 rows=1 width=4)
+~~END~~
+
 
 -- reset
 exec sys.sp_reset_connection
@@ -280,20 +632,46 @@ GO
 -- 1 output
 SELECT 1;
 GO
+~~START~~
+int
+1
+~~END~~
+
+
 
 -- set_config testing.
-
 -- search_path has source < PGC_S_SESSION in TSQL but it gets reset during ResetAll Gucs.
 -- Whereas role does not get reset since it uses GUC_NO_RESET_ALL, so we should not allow
 -- set_config for this option.
 SELECT CURRENT_SETTING('search_path', true)
 SELECT CURRENT_SETTING('role', true)
 GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+text
+none
+~~END~~
+
 
 SELECT set_config('search_path', 'sys', false);
 GO
+~~START~~
+text
+sys
+~~END~~
+
 SELECT set_config('role', 'jdbc_user', false);
 GO
+~~START~~
+text
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: set_config not allowed for option role)~~
+
 
 -- reset
 exec sp_reset_connection
@@ -302,3 +680,13 @@ GO
 SELECT CURRENT_SETTING('search_path', true)
 SELECT CURRENT_SETTING('role', true)
 GO
+~~START~~
+text
+master_dbo, "$user", sys, pg_catalog
+~~END~~
+
+~~START~~
+text
+none
+~~END~~
+

--- a/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
+++ b/test/JDBC/input/storedProcedures/Test-sp_reset_connection.mix
@@ -229,3 +229,75 @@ GO
 
 drop table babel_cursor_t1;
 GO
+
+-- GUCs testing
+
+-- 1. Ansi defaults
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_null_dflt_on', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
+GO
+
+SET ANSI_DEFAULTS ON
+GO
+
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_null_dflt_on', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
+GO
+
+-- reset
+exec sys.sp_reset_connection
+GO
+
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_nulls', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_warnings', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_null_dflt_on', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.ansi_padding', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.implicit_transactions', true);
+SELECT CURRENT_SETTING('babelfishpg_tsql.quoted_identifier', true);
+GO
+
+-- babelfish_showplan_all
+SET babelfish_showplan_all ON
+GO
+
+-- explain output
+SELECT 1;
+GO
+
+-- reset
+exec sys.sp_reset_connection
+GO
+
+-- 1 output
+SELECT 1;
+GO
+
+-- set_config testing.
+
+-- search_path has source < PGC_S_SESSION in TSQL but it gets reset during ResetAll Gucs.
+-- Whereas role does not get reset since it uses GUC_NO_RESET_ALL, so we should not allow
+-- set_config for this option.
+SELECT CURRENT_SETTING('search_path', true)
+SELECT CURRENT_SETTING('role', true)
+GO
+
+SELECT set_config('search_path', 'sys', false);
+GO
+SELECT set_config('role', 'jdbc_user', false);
+GO
+
+-- reset
+exec sp_reset_connection
+GO
+
+SELECT CURRENT_SETTING('search_path', true)
+SELECT CURRENT_SETTING('role', true)
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -10,6 +10,14 @@
 
 all
 
+ignore#!#BABEL-1435
+ignore#!#BABEL-1446
+ignore#!#BABEL-4279
+ignore#!#babelfish_migration_mode-vu-prepare
+ignore#!#babelfish_migration_mode-vu-verify
+ignore#!#babelfish_migration_mode-vu-cleanup
+ignore#!#test_search_path
+
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
 ignore#!#insertbulk
 ignore#!#BABEL-SQLvariant

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -124,7 +124,6 @@ BABEL-ROLE
 babelfish_sysdatabases
 babelfish_namespace_ext
 babelfish_authid_login_ext
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 babel_char

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -185,7 +185,6 @@ BABEL-ROLE
 babelfish_sysdatabases
 babelfish_namespace_ext
 babelfish_authid_login_ext
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 BABEL-EXTENDEDPROPERTY

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -215,7 +215,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -214,7 +214,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -214,7 +214,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -211,7 +211,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -174,7 +174,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -173,7 +173,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -171,7 +171,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 collation_tests_arabic
 collation_tests_greek

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -174,7 +174,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -174,7 +174,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -215,7 +215,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -152,7 +152,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 select-strip-parens-before-14-10
 BABEL-3147-before-16_3-or-15_7-or-14_12

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -163,7 +163,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -172,7 +172,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -172,7 +172,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -173,7 +173,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -174,7 +174,6 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
-babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic


### PR DESCRIPTION
### Description
Some GUCs had an issue with being reset at time of TDSResetConnection:

1. Explain GUCs, they were not getting setting reset after TDSResetConnection. To fix this we need to reset it at time TDSResetConnection AND also at time of sys.sp_reset_connection execution(which would otherwise have given explain output).
2. ANSI_DEFAULTS and IMPLICIT_TRANSACTION related GUCs. These were getting set when driver sends some TDS flags. But after ResetConnection they were being rolled-back. To avoid this we implement TdsResetLoginFlags a wrapper to Re-ProcessLoginFlags.
3. We restrict the setting and re-setting of important GUCs like "babelfishpg_tsql.migration_mode" and "role", since once set, cannot be reset.

NOTE: point 3 was being used as a hack to test single/multi-db tests in the same JDBC workflow. Since we now prohibit this, the tests need to be rewritten for single-db and multi-db, 2 separate github actions.
For now we ignore them until individual authors fix this and undo the commit added to ignore.

```
ignore#!#BABEL-1435 @ahmed-shameem 
ignore#!#BABEL-1446 @ahmed-shameem / @sumitj824 
ignore#!#BABEL-4279 @anju15bharti 
ignore#!#TestSpatialPoint-vu-prepare/verify/cleanup @Anikait143 
ignore#!#babelfish_migration_mode-vu-prepare/verfiy/cleanup @ahmed-shameem / @xhfanhe 
ignore#!#test_search_path @ahmed-shameem / @anju15bharti 
```


### Issues Resolved

BABEL-5280, BABEL-5276, BABEL-5278

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).